### PR TITLE
implement viewer and editor roles

### DIFF
--- a/cmd/revad/svcs/grpcsvcs/usershareprovidersvc/usershareprovidersvc.go
+++ b/cmd/revad/svcs/grpcsvcs/usershareprovidersvc/usershareprovidersvc.go
@@ -99,6 +99,8 @@ func (s *service) CreateShare(ctx context.Context, req *usershareproviderv0alpha
 		Permissions: req.Grant.Permissions.Permissions,
 	}
 
+	// TODO try to read role?
+
 	log.Debug().Str("path", ref.String()).Msg("list shares")
 	// check if path exists
 	err := s.storage.AddGrant(ctx, ref, grant)
@@ -370,16 +372,9 @@ func (s *service) UpdateShare(ctx context.Context, req *usershareproviderv0alpha
 		return nil, err
 	}
 
-	rPerm := sPerm.Permissions
 	grant := &storageproviderv0alphapb.Grant{
-		Grantee: grantee,
-		Permissions: &storageproviderv0alphapb.ResourcePermissions{
-			//AddGrant:        rPerm.AddGrand, // TODO map more permissions
-			ListContainer:   rPerm.ListContainer,
-			CreateContainer: rPerm.CreateContainer,
-			Move:            rPerm.Move,
-			Delete:          rPerm.Delete,
-		},
+		Grantee:     grantee,
+		Permissions: sPerm.Permissions,
 	}
 
 	ref := &storageproviderv0alphapb.Reference{Spec: &storageproviderv0alphapb.Reference_Path{Path: path}}

--- a/pkg/eosclient/eosclient.go
+++ b/pkg/eosclient/eosclient.go
@@ -319,9 +319,10 @@ func (c *Client) ListACLs(ctx context.Context, username, path string) ([]*acl.En
 	acls := []*acl.Entry{}
 	for _, acl := range parsedACLs.Entries {
 		// since EOS Citrine ACLs are is stored with uid, we need to convert uid to userame
+		// TODO map group names as well if acl.Type == "g" ...
 		acl.Qualifier, err = getUsername(acl.Qualifier)
 		if err != nil {
-			log.Warn().Err(err).Str("username", username).Msg("acl entry for user is invalid")
+			log.Warn().Err(err).Str("path", path).Str("username", username).Str("qualifier", acl.Qualifier).Msg("cannot map qualifier to name")
 			continue
 		}
 		acls = append(acls, acl)

--- a/pkg/storage/fs/eos/eos.go
+++ b/pkg/storage/fs/eos/eos.go
@@ -297,7 +297,9 @@ func getEosACLPerm(set *storageproviderv0alphapb.ResourcePermissions) (string, e
 		b.WriteString("x")
 	}
 
-	if !set.Delete {
+	if set.Delete {
+		b.WriteString("+d")
+	} else {
 		b.WriteString("!d")
 	}
 
@@ -442,6 +444,8 @@ func (fs *eosStorage) getGrantPermissionSet(mode string) *storageproviderv0alpha
 	}
 	if strings.Contains(mode, "!d") {
 		p.Delete = false
+	} else if strings.Contains(mode, "+d") {
+		p.Delete = true
 	}
 	// x
 	if strings.Contains(mode, "x") {

--- a/pkg/storage/fs/eos/eos.go
+++ b/pkg/storage/fs/eos/eos.go
@@ -284,12 +284,27 @@ func getEosACLType(gt storageproviderv0alphapb.GranteeType) (string, error) {
 }
 
 // TODO(labkode): fine grained permission controls.
-func getEosACLPerm(rp *storageproviderv0alphapb.ResourcePermissions) (string, error) {
-	if rp.Delete {
-		return "rwx!d", nil
+func getEosACLPerm(set *storageproviderv0alphapb.ResourcePermissions) (string, error) {
+	var b strings.Builder
+
+	if set.Stat || set.InitiateFileDownload {
+		b.WriteString("r")
+	}
+	if set.CreateContainer || set.InitiateFileUpload || set.Delete || set.Move {
+		b.WriteString("w")
+	}
+	if set.ListContainer {
+		b.WriteString("x")
 	}
 
-	return "rx", nil
+	if !set.Delete {
+		b.WriteString("!d")
+	}
+
+	// TODO sharing
+	// TODO trash
+	// TODO versions
+	return b.String(), nil
 }
 
 func (fs *eosStorage) getEosACL(g *storageproviderv0alphapb.Grant) (*acl.Entry, error) {
@@ -340,7 +355,7 @@ func (fs *eosStorage) UpdateGrant(ctx context.Context, ref *storageproviderv0alp
 
 	eosACL, err := fs.getEosACL(g)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "storage_eos: error mapping acl")
 	}
 
 	fn, err := fs.resolve(ctx, u, ref)
@@ -398,26 +413,60 @@ func (fs *eosStorage) getGranteeType(aclType string) storageproviderv0alphapb.Gr
 }
 
 // TODO(labkode): add more fine grained controls.
+// EOS acls are a mix of ACLs and POSIX permissions. More details can be found in
+// https://github.com/cern-eos/eos/blob/master/doc/configuration/permission.rst
+// TODO we need to evaluate all acls in the list at once to properly forbid (!) and overwrite (+) permissons
+// This is ugly, because those are actually negative permissions ...
 func (fs *eosStorage) getGrantPermissionSet(mode string) *storageproviderv0alphapb.ResourcePermissions {
-	// TODO(labkode) map other permissions.
-	switch mode {
-	case "rx":
-		return &storageproviderv0alphapb.ResourcePermissions{
-			ListContainer: true,
-			//InitiateFileDownload: true,
-			//Stat:          true,
-		}
-	case "rwx!d":
-		return &storageproviderv0alphapb.ResourcePermissions{
-			Move:            true,
-			CreateContainer: true,
-			ListContainer:   true,
-		}
-	default:
-		// return no permissions are we do not know
-		// what acl is this one.
-		return &storageproviderv0alphapb.ResourcePermissions{} // default values are false
+
+	// TODO also check unix permissions for read access
+	p := &storageproviderv0alphapb.ResourcePermissions{}
+	// r
+	if strings.Contains(mode, "r") {
+		p.Stat = true
+		p.InitiateFileDownload = true
 	}
+	// w
+	if strings.Contains(mode, "w") {
+		p.CreateContainer = true
+		p.InitiateFileUpload = true
+		p.Delete = true
+		if p.InitiateFileDownload {
+			p.Move = true
+		}
+	}
+	if strings.Contains(mode, "wo") {
+		p.CreateContainer = true
+		//	p.InitiateFileUpload = false // TODO only when the file exists
+		p.Delete = false
+	}
+	if strings.Contains(mode, "!d") {
+		p.Delete = false
+	}
+	// x
+	if strings.Contains(mode, "x") {
+		p.ListContainer = true
+	}
+
+	// sharing
+	// TODO AddGrant
+	// TODO ListGrants
+	// TODO RemoveGrant
+	// TODO UpdateGrant
+
+	// trash
+	// TODO ListRecycle
+	// TODO RestoreRecycleItem
+	// TODO PurgeRecycle
+
+	// versions
+	// TODO ListFileVersions
+	// TODO RestoreFileVersion
+
+	// ?
+	// TODO GetPath
+	// TODO GetQuota
+	return p
 }
 
 func (fs *eosStorage) GetMD(ctx context.Context, ref *storageproviderv0alphapb.Reference) (*storageproviderv0alphapb.ResourceInfo, error) {


### PR DESCRIPTION
together with https://github.com/owncloud/phoenix/pull/1332 this allows updating share permissions to viewer and editor roles, reflected in eos as `rx!d` and `rwx`. I also map all the permissions between the permission set and the cs2 resource permissions ... although that seems awkward ...

implementing something like a co owner needs a beter understanding of how eos acls work. we need to change the way acls are processed anyway because there might be user.acl and sys.acls as well as posix permissions. at least that needs to be written down and specified somewhere. the official docs for EOS were quite revealing: https://github.com/cern-eos/eos/blob/master/doc/configuration/permission.rst

I don't yet know what to make of acls not being available on files ... or that only the direct parent dir acls are taken into account, not all in the tree to the root ... weird ...