### PR TITLE
add json based user and auth manager

### DIFF
--- a/cmd/revad/users.json
+++ b/cmd/revad/users.json
@@ -1,0 +1,10 @@
+[
+	{
+		"sub": "a48cb0ed-3375-4b94-bdcd-3cac6e201b7b",
+		"iss": "example.com",
+		"username": "admin",
+		"secret": "secret",
+		"mail": "admin@example.com",
+		"displayname": "Admin"
+	}
+]

--- a/pkg/auth/manager/json/json.go
+++ b/pkg/auth/manager/json/json.go
@@ -1,0 +1,98 @@
+// Copyright 2018-2019 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package json
+
+import (
+	"context"
+	"encoding/json"
+	"io/ioutil"
+
+	"github.com/cs3org/reva/pkg/auth"
+	"github.com/cs3org/reva/pkg/auth/manager/registry"
+	"github.com/mitchellh/mapstructure"
+	"github.com/pkg/errors"
+)
+
+func init() {
+	registry.Register("json", New)
+}
+
+// Credentials holds a pair of username and secret
+// TOTDO id?
+type Credentials struct {
+	Username string `mapstructure:"username"`
+	Secret   string `mapstructure:"secret"`
+}
+
+type manager struct {
+	credentials map[string]string
+}
+
+type config struct {
+	// Users holds a path to a file containing json conforming the Users struct
+	Users string `mapstructure:"users"`
+}
+
+func parseConfig(m map[string]interface{}) (*config, error) {
+	c := &config{}
+	if err := mapstructure.Decode(m, c); err != nil {
+		err = errors.Wrap(err, "error decoding conf")
+		return nil, err
+	}
+	return c, nil
+}
+
+// New returns a new auth Manager.
+func New(m map[string]interface{}) (auth.Manager, error) {
+	c, err := parseConfig(m)
+	if err != nil {
+		return nil, err
+	}
+
+	manager := &manager{credentials: map[string]string{}}
+
+	credentials := []*Credentials{}
+	f, err := ioutil.ReadFile(c.Users)
+	if err != nil {
+		return nil, err
+	}
+	err = json.Unmarshal([]byte(f), &credentials)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, c := range credentials {
+		manager.credentials[c.Username] = c.Secret
+	}
+
+	return manager, nil
+}
+
+func (m *manager) Authenticate(ctx context.Context, username string, secret string) (context.Context, error) {
+	if s, ok := m.credentials[username]; ok {
+		if s == secret {
+			return ctx, nil
+		}
+	}
+	return ctx, invalidCredentialsError(username)
+}
+
+type invalidCredentialsError string
+
+func (e invalidCredentialsError) Error() string { return string(e) }

--- a/pkg/auth/manager/loader/loader.go
+++ b/pkg/auth/manager/loader/loader.go
@@ -22,6 +22,7 @@ import (
 	// Load core authentication managers.
 	_ "github.com/cs3org/reva/pkg/auth/manager/demo"
 	_ "github.com/cs3org/reva/pkg/auth/manager/impersonator"
+	_ "github.com/cs3org/reva/pkg/auth/manager/json"
 	_ "github.com/cs3org/reva/pkg/auth/manager/ldap"
 	_ "github.com/cs3org/reva/pkg/auth/manager/oidc"
 	// Add your own here

--- a/pkg/user/manager/json/json.go
+++ b/pkg/user/manager/json/json.go
@@ -16,38 +16,88 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-package demo
+package json
 
 import (
 	"context"
+	"encoding/json"
+	"io/ioutil"
+	"strings"
 
 	"github.com/cs3org/reva/pkg/user"
 	"github.com/cs3org/reva/pkg/user/manager/registry"
+	"github.com/mitchellh/mapstructure"
+	"github.com/pkg/errors"
 )
 
 func init() {
-	registry.Register("demo", New)
+	registry.Register("json", New)
 }
 
 type manager struct {
-	catalog map[string]*user.User
+	users []*user.User
 }
 
-// New returns a new user manager.
+type config struct {
+	// Users holds a path to a file containing json conforming the Users struct
+	Users string `mapstructure:"users"`
+}
+
+func parseConfig(m map[string]interface{}) (*config, error) {
+	c := &config{}
+	if err := mapstructure.Decode(m, c); err != nil {
+		err = errors.Wrap(err, "error decoding conf")
+		return nil, err
+	}
+	return c, nil
+}
+
+// New returns a user manager implementation that reads a json file to provide user metadata.
 func New(m map[string]interface{}) (user.Manager, error) {
-	cat := getUsers()
-	return &manager{catalog: cat}, nil
+	c, err := parseConfig(m)
+	if err != nil {
+		return nil, err
+	}
+
+	f, err := ioutil.ReadFile(c.Users)
+	if err != nil {
+		return nil, err
+	}
+
+	users := []*user.User{}
+
+	err = json.Unmarshal([]byte(f), &users)
+	if err != nil {
+		return nil, err
+	}
+
+	return &manager{
+		users: users,
+	}, nil
 }
 
 func (m *manager) GetUser(ctx context.Context, username string) (*user.User, error) {
-	if user, ok := m.catalog[username]; ok {
-		return user, nil
+	for _, u := range m.users {
+		if u.Username == username {
+			return u, nil
+		}
 	}
 	return nil, userNotFoundError(username)
 }
 
+// TODO search Opaque? compare sub?
+func userContains(u *user.User, query string) bool {
+	return strings.Contains(u.Username, query) || strings.Contains(u.DisplayName, query) || strings.Contains(u.Mail, query)
+}
+
 func (m *manager) FindUsers(ctx context.Context, query string) ([]*user.User, error) {
-	return []*user.User{}, nil // FIXME implement FindUsers for demo user manager
+	users := []*user.User{}
+	for _, u := range m.users {
+		if userContains(u, query) {
+			users = append(users, u)
+		}
+	}
+	return users, nil
 }
 
 func (m *manager) GetUserGroups(ctx context.Context, username string) ([]string, error) {
@@ -75,28 +125,3 @@ func (m *manager) IsInGroup(ctx context.Context, username, group string) (bool, 
 type userNotFoundError string
 
 func (e userNotFoundError) Error() string { return string(e) }
-
-func getUsers() map[string]*user.User {
-	return map[string]*user.User{
-		// TODO sub
-		// TODO iss
-		"einstein": &user.User{
-			Username:    "einstein",
-			Groups:      []string{"sailing-lovers", "violin-haters"},
-			Mail:        "einstein@example.org",
-			DisplayName: "Albert Einstein",
-		},
-		"marie": &user.User{
-			Username:    "marie",
-			Groups:      []string{"radium-lovers", "polonium-lovers"},
-			Mail:        "marie@example.org",
-			DisplayName: "Marie Curie",
-		},
-		"richard": &user.User{
-			Username:    "richard",
-			Groups:      []string{"quantum-lovers", "philosophy-haters"},
-			Mail:        "richard@example.org",
-			DisplayName: "Richard Feynman",
-		},
-	}
-}

--- a/pkg/user/manager/loader/loader.go
+++ b/pkg/user/manager/loader/loader.go
@@ -21,6 +21,7 @@ package loader
 import (
 	// Load core user manager drivers.
 	_ "github.com/cs3org/reva/pkg/user/manager/demo"
+	_ "github.com/cs3org/reva/pkg/user/manager/json"
 	_ "github.com/cs3org/reva/pkg/user/manager/ldap"
 	_ "github.com/cs3org/reva/pkg/user/manager/oidc"
 	// Add your own here


### PR DESCRIPTION
This PR allows using a simple json file to provision users for development.

Configure like this (unrelated omitted):
```
[http.services.ocssvc]
user_manager = "json"

[http.services.ocssvc.user_managers.json]
users = "users.json"

[grpc.services.authsvc]
auth_manager = "json"
user_manager = "json"

[grpc.services.authsvc.auth_managers.json]
users = "users.json"

[grpc.services.authsvc.user_managers.json]
users = "users.json"
```

secrets are not yet stored encrypted. I would propose using prefixes like `{plain}`, `{md5}` or `{sha256}` to indicate the secret encoding.