### PR TITLE
fix the key retrieval method in preferencessvc

### DIFF
--- a/cmd/revad/svcs/httpsvcs/preferencessvc/get.go
+++ b/cmd/revad/svcs/httpsvcs/preferencessvc/get.go
@@ -23,7 +23,6 @@ import (
 
 	preferencesv0alphapb "github.com/cs3org/go-cs3apis/cs3/preferences/v0alpha"
 	rpcpb "github.com/cs3org/go-cs3apis/cs3/rpc"
-	"github.com/cs3org/reva/cmd/revad/svcs/httpsvcs"
 	"github.com/cs3org/reva/pkg/appctx"
 	"github.com/cs3org/reva/pkg/user"
 )
@@ -38,8 +37,7 @@ func (s *svc) doGet(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var key string
-	key, r.URL.Path = httpsvcs.ShiftPath(r.URL.Path)
+	key := r.URL.Path
 
 	client, err := s.getClient()
 	if err != nil {

--- a/cmd/revad/svcs/httpsvcs/preferencessvc/set.go
+++ b/cmd/revad/svcs/httpsvcs/preferencessvc/set.go
@@ -25,7 +25,6 @@ import (
 
 	preferencesv0alphapb "github.com/cs3org/go-cs3apis/cs3/preferences/v0alpha"
 	rpcpb "github.com/cs3org/go-cs3apis/cs3/rpc"
-	"github.com/cs3org/reva/cmd/revad/svcs/httpsvcs"
 	"github.com/cs3org/reva/pkg/appctx"
 	"github.com/cs3org/reva/pkg/user"
 )
@@ -44,8 +43,7 @@ func (s *svc) doSet(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var key string
-	key, r.URL.Path = httpsvcs.ShiftPath(r.URL.Path)
+	key := r.URL.Path
 
 	body, err := ioutil.ReadAll(r.Body)
 	if err != nil {


### PR DESCRIPTION
The previous implementation of preferences service uses httpsvc.ShiftPath to retrieve key from url. But the mime types contain a '/' character in them. Hence the key retrieved was just the substring before '/'. This pull request fixes this.