### PR TITLE
revad: print build information on startup

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,3 +1,4 @@
+- Felix Hillingshaeuser <felix@mxcore.de>
 - Hugo Gonzalez Labrador <github@hugo.labkode.com>
 - Jörn Friedrich Dreyer <jfd@butonic.de>
 - Mohitty <mohitt@iitk.ac.in>

--- a/cmd/revad/main.go
+++ b/cmd/revad/main.go
@@ -78,6 +78,7 @@ func main() {
 		log.Error().Err(err).Msg("error adjusting number of cpus")
 		watcher.Exit(1)
 	}
+	log.Info().Msgf("%s", getVersionString())
 	log.Info().Msgf("running on %d cpus", ncpus)
 
 	servers := []grace.Server{}
@@ -161,16 +162,20 @@ func getWriter(out string) (io.Writer, error) {
 	return fd, nil
 }
 
+func getVersionString() string {
+	msg := "version=%s "
+	msg += "commit=%s "
+	msg += "branch=%s "
+	msg += "go_version=%s "
+	msg += "build_date=%s "
+	msg += "build_platform=%s\n"
+
+	return fmt.Sprintf(msg, version, gitCommit, gitBranch, goVersion, buildDate, buildPlatform)
+}
+
 func handleVersionFlag() {
 	if *versionFlag {
-		msg := "version=%s "
-		msg += "commit=%s "
-		msg += "branch=%s "
-		msg += "go_version=%s "
-		msg += "build_date=%s "
-		msg += "build_platform=%s\n"
-
-		fmt.Fprintf(os.Stderr, msg, version, gitCommit, gitBranch, goVersion, buildDate, buildPlatform)
+		fmt.Fprintf(os.Stderr, getVersionString())
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
From Issue https://github.com/cs3org/reva/issues/67.

To avoid code redundancy, I moved the generation of the version string to a new function.
This function is called from `handleVersionFlag()` and in the normal startup process.