### PR TITLE
fix panic when disabling http server

### DIFF
--- a/cmd/revad/main.go
+++ b/cmd/revad/main.go
@@ -128,11 +128,6 @@ func main() {
 				watcher.Exit(1)
 			}
 		}(servers[0], listeners[0])
-		// shift servers and listeners array
-		if len(servers) > 1 {
-			servers = servers[1:]
-			listeners = listeners[1:]
-		}
 	}
 
 	// wait for signal to close servers


### PR DESCRIPTION
fix for issue https://github.com/cs3org/reva/issues/163

Proposal: we always use the elements with index 0 and shift the arrays after each server.
Because the code runs in a go routine and therefore runs async, we need to push the variables into the function.