### PR TITLE
revad: move line-break from getVersionString() to actual printing

### DIFF
--- a/cmd/revad/main.go
+++ b/cmd/revad/main.go
@@ -177,14 +177,14 @@ func getVersionString() string {
 	msg += "branch=%s "
 	msg += "go_version=%s "
 	msg += "build_date=%s "
-	msg += "build_platform=%s\n"
+	msg += "build_platform=%s"
 
 	return fmt.Sprintf(msg, version, gitCommit, gitBranch, goVersion, buildDate, buildPlatform)
 }
 
 func handleVersionFlag() {
 	if *versionFlag {
-		fmt.Fprintf(os.Stderr, getVersionString())
+		fmt.Fprintf(os.Stderr, "%s\n", getVersionString())
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
Move line-break from `getVersionString()` to actual printing.

This ensures that the log message itself do not contain any line-breaks.
For logging to stdout/stderr the logger append a line-break.
For logging as json objects we do not want a line-break in the json element.