### PR TITLE
introduce trash-bin endpoint, fix propfind parsing

### DIFF
--- a/cmd/revad/svcs/httpsvcs/ocdavsvc/dav.go
+++ b/cmd/revad/svcs/httpsvcs/ocdavsvc/dav.go
@@ -26,22 +26,27 @@ import (
 
 // DavHandler routes to the different sub handlers
 type DavHandler struct {
-	FilesHandler   *FilesHandler
-	AvatarsHandler *AvatarsHandler
-	MetaHandler    *MetaHandler
+	AvatarsHandler  *AvatarsHandler
+	FilesHandler    *FilesHandler
+	MetaHandler     *MetaHandler
+	TrashbinHandler *TrashbinHandler
 }
 
 func (h *DavHandler) init(c *Config) error {
-	h.FilesHandler = new(FilesHandler)
-	if err := h.FilesHandler.init(c); err != nil {
-		return err
-	}
 	h.AvatarsHandler = new(AvatarsHandler)
 	if err := h.AvatarsHandler.init(c); err != nil {
 		return err
 	}
+	h.FilesHandler = new(FilesHandler)
+	if err := h.FilesHandler.init(c); err != nil {
+		return err
+	}
 	h.MetaHandler = new(MetaHandler)
-	return h.MetaHandler.init(c)
+	if err := h.MetaHandler.init(c); err != nil {
+		return err
+	}
+	h.TrashbinHandler = new(TrashbinHandler)
+	return h.TrashbinHandler.init(c)
 }
 
 // Handler handles requests
@@ -50,12 +55,14 @@ func (h *DavHandler) Handler(s *svc) http.Handler {
 		var head string
 		head, r.URL.Path = httpsvcs.ShiftPath(r.URL.Path)
 		switch head {
-		case "files":
-			h.FilesHandler.Handler(s).ServeHTTP(w, r)
 		case "avatars":
 			h.AvatarsHandler.Handler(s).ServeHTTP(w, r)
+		case "files":
+			h.FilesHandler.Handler(s).ServeHTTP(w, r)
 		case "meta":
 			h.MetaHandler.Handler(s).ServeHTTP(w, r)
+		case "trash-bin":
+			h.TrashbinHandler.Handler(s).ServeHTTP(w, r)
 		default:
 			w.WriteHeader(http.StatusNotFound)
 		}

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/rs/zerolog v1.15.0
 	go.opencensus.io v0.22.0
 	golang.org/x/crypto v0.0.0-20190411191339-88737f569e3a
-	golang.org/x/net v0.0.0-20190620200207-3b0461eec859 // indirect
+	golang.org/x/net v0.0.0-20190827160401-ba9fcec4b297 // indirect
 	golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421
 	google.golang.org/grpc v1.23.0
 	gopkg.in/asn1-ber.v1 v1.0.0-20181015200546-f715ec2f112d // indirect

--- a/go.sum
+++ b/go.sum
@@ -193,8 +193,8 @@ golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190501004415-9ce7a6920f09 h1:KaQtG+aDELoNmXYas3TVkGNYRuq8JQ1aa7LJt8EXVyo=
 golang.org/x/net v0.0.0-20190501004415-9ce7a6920f09/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
-golang.org/x/net v0.0.0-20190620200207-3b0461eec859 h1:R/3boaszxrf1GEUWTVDzSKVwLmSJpwZ1yqXm8j0v2QI=
-golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20190827160401-ba9fcec4b297 h1:k7pJ2yAPLPgbskkFdhRCsA77k2fySZ1zf2zCjvQCiIM=
+golang.org/x/net v0.0.0-20190827160401-ba9fcec4b297/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be h1:vEDujvNQGv4jgYKudGeI/+DAX4Jffq6hpD55MmoEvKs=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20181003184128-c57b0facaced h1:4oqSq7eft7MdPKBGQK11X9WYUxmj6ZLgGTqYIbY1kyw=


### PR DESCRIPTION
I was working on the trashbin endpoint and had to fix a few propfind issues. This PR makes the ocdevsvc return only the requested properties. The trashbin will render a completely different set of properties, which is why I had to go and fix this. I want to bring this in in its unfinished state because I now need the gateway to implement the *Recycle calls ... or I need to have a config that allows me to run reva without the gatway ... something I havent looked into.