### PR TITLE
store the userid in the context when authenticating credentials

### DIFF
--- a/cmd/revad/svcs/grpcsvcs/authsvc/authsvc.go
+++ b/cmd/revad/svcs/grpcsvcs/authsvc/authsvc.go
@@ -130,7 +130,6 @@ func (s *service) GenerateAccessToken(ctx context.Context, req *authv0alphapb.Ge
 	log := appctx.GetLogger(ctx)
 	username := req.ClientId
 	password := req.ClientSecret
-	uid := &typespb.UserId{OpaqueId: username}
 
 	ctx, err := s.authmgr.Authenticate(ctx, username, password)
 	if err != nil {
@@ -139,6 +138,15 @@ func (s *service) GenerateAccessToken(ctx context.Context, req *authv0alphapb.Ge
 			Status: status.NewUnauthenticated(ctx, err, "error authenticating user"),
 		}
 		return res, nil
+	}
+
+	uid, ok := user.ContextGetUserID(ctx)
+	if !ok {
+		// try to look up user by username
+		// TODO log warning or should we fail?
+		uid = &typespb.UserId{
+			OpaqueId: username,
+		}
 	}
 
 	user, err := s.usermgr.GetUser(ctx, uid)

--- a/cmd/revad/users.demo.json
+++ b/cmd/revad/users.demo.json
@@ -1,8 +1,8 @@
 [
 	{
 		"id": {
-			"opaque_id": "37a08ed30093a133b1bb4ae0b8f3601f",
-			"idp": "localhost"
+			"opaque_id": "4c510ada-c86b-4815-8820-42cdf82c3d51",
+			"idp": "http://localhost:9998"
 		},
 		"username": "einstein",
 		"secret": "relativity",
@@ -11,8 +11,8 @@
 	},
 	{
 		"id": {
-			"opaque_id": "b3725122c9d3bfef5664619e08e31877",
-			"idp": "localhost"
+			"opaque_id": "f7fbf8c8-139b-4376-b307-cf0a8c2d0d9c",
+			"idp": "http://localhost:9998"
 		},
 		"username": "marie",
 		"secret": "radioactivity",
@@ -21,8 +21,8 @@
 	},
 	{
 		"id": {
-			"opaque_id": "6ae199a93c381bf6d5de27491139d3f9",
-			"idp": "localhost"
+			"opaque_id": "932b4540-8d16-481e-8ef4-588e4b6b151c",
+			"idp": "http://localhost:9998"
 		},
 		"username": "richard",
 		"secret": "superfluidity",

--- a/pkg/auth/manager/demo/demo.go
+++ b/pkg/auth/manager/demo/demo.go
@@ -21,9 +21,11 @@ package demo
 import (
 	"context"
 
+	typespb "github.com/cs3org/go-cs3apis/cs3/types"
 	"github.com/cs3org/reva/pkg/auth"
 	"github.com/cs3org/reva/pkg/auth/manager/registry"
 	"github.com/cs3org/reva/pkg/errtypes"
+	"github.com/cs3org/reva/pkg/user"
 )
 
 func init() {
@@ -31,7 +33,13 @@ func init() {
 }
 
 type manager struct {
-	credentials map[string]string
+	credentials map[string]Credentials
+}
+
+// Credentials holds a pair of secret and userid
+type Credentials struct {
+	ID     *typespb.UserId
+	Secret string
 }
 
 // New returns a new auth Manager.
@@ -42,18 +50,36 @@ func New(m map[string]interface{}) (auth.Manager, error) {
 }
 
 func (m *manager) Authenticate(ctx context.Context, clientID, clientSecret string) (context.Context, error) {
-	if secret, ok := m.credentials[clientID]; ok {
-		if secret == clientSecret {
-			return ctx, nil
+	if c, ok := m.credentials[clientID]; ok {
+		if c.Secret == clientSecret {
+			return user.ContextSetUserID(ctx, c.ID), nil
 		}
 	}
 	return ctx, errtypes.InvalidCredentials(clientID)
 }
 
-func getCredentials() map[string]string {
-	return map[string]string{
-		"einstein": "relativity",
-		"marie":    "radioactivity",
-		"richard":  "superfluidity",
+func getCredentials() map[string]Credentials {
+	return map[string]Credentials{
+		"einstein": Credentials{
+			Secret: "relativity",
+			ID: &typespb.UserId{
+				OpaqueId: "4c510ada-c86b-4815-8820-42cdf82c3d51",
+				Idp:      "http://localhost:9998",
+			},
+		},
+		"marie": Credentials{
+			Secret: "radioactivity",
+			ID: &typespb.UserId{
+				OpaqueId: "f7fbf8c8-139b-4376-b307-cf0a8c2d0d9c",
+				Idp:      "http://localhost:9998",
+			},
+		},
+		"richard": Credentials{
+			Secret: "superfluidity",
+			ID: &typespb.UserId{
+				OpaqueId: "932b4540-8d16-481e-8ef4-588e4b6b151c",
+				Idp:      "http://localhost:9998",
+			},
+		},
 	}
 }

--- a/pkg/auth/manager/impersonator/impersonator.go
+++ b/pkg/auth/manager/impersonator/impersonator.go
@@ -20,9 +20,12 @@ package impersonator
 
 import (
 	"context"
+	"strings"
 
+	typespb "github.com/cs3org/go-cs3apis/cs3/types"
 	"github.com/cs3org/reva/pkg/auth"
 	"github.com/cs3org/reva/pkg/auth/manager/registry"
+	"github.com/cs3org/reva/pkg/user"
 )
 
 func init() {
@@ -37,5 +40,14 @@ func New(c map[string]interface{}) (auth.Manager, error) {
 }
 
 func (m *mgr) Authenticate(ctx context.Context, clientID, clientSecret string) (context.Context, error) {
-	return ctx, nil
+	// allow passing in uid as <opaqueid>@<idp>
+	at := strings.LastIndex(clientID, "@")
+	uid := &typespb.UserId{}
+	if at < 0 {
+		uid.OpaqueId = clientID
+	} else {
+		uid.OpaqueId = clientID[:at]
+		uid.Idp = clientID[at+1:]
+	}
+	return user.ContextSetUserID(ctx, uid), nil
 }

--- a/pkg/auth/manager/impersonator/impersonator_test.go
+++ b/pkg/auth/manager/impersonator/impersonator_test.go
@@ -21,13 +21,41 @@ package impersonator
 import (
 	"context"
 	"testing"
+
+	"github.com/cs3org/reva/pkg/user"
 )
 
 func TestImpersonator(t *testing.T) {
 	ctx := context.Background()
 	i, _ := New(nil)
-	_, err := i.Authenticate(ctx, "admin", "pwd")
+	ctx, err := i.Authenticate(ctx, "admin", "pwd")
 	if err != nil {
 		t.Fatal(err)
+	}
+	uid, ok := user.ContextGetUserID(ctx)
+	if !ok {
+		t.Fatal("no userid in context")
+	}
+	if uid.OpaqueId != "admin" {
+		t.Errorf("%#v, wanted %#v", uid.OpaqueId, "admin")
+	}
+	if uid.Idp != "" {
+		t.Errorf("%#v, wanted %#v", uid.Idp, "")
+	}
+
+	ctx = context.Background()
+	ctx, err = i.Authenticate(ctx, "opaqueid@idp", "pwd")
+	if err != nil {
+		t.Fatal(err)
+	}
+	uid, ok = user.ContextGetUserID(ctx)
+	if !ok {
+		t.Fatal("no userid in context")
+	}
+	if uid.OpaqueId != "opaqueid" {
+		t.Errorf("%#v, wanted %#v", uid.OpaqueId, "opaqueid")
+	}
+	if uid.Idp != "idp" {
+		t.Errorf("%#v, wanted %#v", uid.Idp, "idp")
 	}
 }

--- a/pkg/auth/manager/json/json.go
+++ b/pkg/auth/manager/json/json.go
@@ -36,7 +36,7 @@ func init() {
 	registry.Register("json", New)
 }
 
-// Credentials holds a pair of userid and secret
+// Credentials holds a pair of secret and userid
 type Credentials struct {
 	ID       *typespb.UserId `mapstructure:"id"`
 	Username string          `mapstructure:"username"`

--- a/pkg/auth/manager/json/json.go
+++ b/pkg/auth/manager/json/json.go
@@ -23,9 +23,11 @@ import (
 	"encoding/json"
 	"io/ioutil"
 
+	typespb "github.com/cs3org/go-cs3apis/cs3/types"
 	"github.com/cs3org/reva/pkg/auth"
 	"github.com/cs3org/reva/pkg/auth/manager/registry"
 	"github.com/cs3org/reva/pkg/errtypes"
+	"github.com/cs3org/reva/pkg/user"
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
 )
@@ -34,15 +36,15 @@ func init() {
 	registry.Register("json", New)
 }
 
-// Credentials holds a pair of username and secret
-// TOTDO id?
+// Credentials holds a pair of userid and secret
 type Credentials struct {
-	Username string `mapstructure:"username"`
-	Secret   string `mapstructure:"secret"`
+	ID       *typespb.UserId `mapstructure:"id"`
+	Username string          `mapstructure:"username"`
+	Secret   string          `mapstructure:"secret"`
 }
 
 type manager struct {
-	credentials map[string]string
+	credentials map[string]*Credentials
 }
 
 type config struct {
@@ -66,29 +68,31 @@ func New(m map[string]interface{}) (auth.Manager, error) {
 		return nil, err
 	}
 
-	manager := &manager{credentials: map[string]string{}}
+	manager := &manager{credentials: map[string]*Credentials{}}
 
-	credentials := []*Credentials{}
 	f, err := ioutil.ReadFile(c.Users)
 	if err != nil {
 		return nil, err
 	}
+
+	credentials := []*Credentials{}
+
 	err = json.Unmarshal(f, &credentials)
 	if err != nil {
 		return nil, err
 	}
 
 	for _, c := range credentials {
-		manager.credentials[c.Username] = c.Secret
+		manager.credentials[c.Username] = c
 	}
 
 	return manager, nil
 }
 
 func (m *manager) Authenticate(ctx context.Context, username string, secret string) (context.Context, error) {
-	if s, ok := m.credentials[username]; ok {
-		if s == secret {
-			return ctx, nil
+	if c, ok := m.credentials[username]; ok {
+		if c.Secret == secret {
+			return user.ContextSetUserID(ctx, c.ID), nil
 		}
 	}
 	return ctx, errtypes.InvalidCredentials(username)

--- a/pkg/auth/manager/oidc/oidc.go
+++ b/pkg/auth/manager/oidc/oidc.go
@@ -29,9 +29,11 @@ import (
 	"time"
 
 	oidc "github.com/coreos/go-oidc"
+	typespb "github.com/cs3org/go-cs3apis/cs3/types"
 	"github.com/cs3org/reva/pkg/appctx"
 	"github.com/cs3org/reva/pkg/auth"
 	"github.com/cs3org/reva/pkg/auth/manager/registry"
+	"github.com/cs3org/reva/pkg/user"
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
 	"golang.org/x/oauth2"
@@ -221,6 +223,11 @@ func (am *mgr) Authenticate(ctx context.Context, clientID, token string) (contex
 
 	// store claims in context
 	ctx = context.WithValue(ctx, ClaimsKey, claims)
+	uid := &typespb.UserId{
+		Idp:      claims.Iss,
+		OpaqueId: claims.Sub,
+	}
+	ctx = user.ContextSetUserID(ctx, uid)
 
 	return ctx, nil
 }

--- a/pkg/user/manager/demo/demo.go
+++ b/pkg/user/manager/demo/demo.go
@@ -20,6 +20,7 @@ package demo
 
 import (
 	"context"
+	"strings"
 
 	authv0alphapb "github.com/cs3org/go-cs3apis/cs3/auth/v0alpha"
 	typespb "github.com/cs3org/go-cs3apis/cs3/types"
@@ -49,8 +50,19 @@ func (m *manager) GetUser(ctx context.Context, uid *typespb.UserId) (*authv0alph
 	return nil, errtypes.NotFound(uid.OpaqueId)
 }
 
+// TODO(jfd) search Opaque? compare sub?
+func userContains(u *authv0alphapb.User, query string) bool {
+	return strings.Contains(u.Username, query) || strings.Contains(u.DisplayName, query) || strings.Contains(u.Mail, query)
+}
+
 func (m *manager) FindUsers(ctx context.Context, query string) ([]*authv0alphapb.User, error) {
-	return []*authv0alphapb.User{}, nil // FIXME implement FindUsers for demo user manager
+	users := []*authv0alphapb.User{}
+	for _, u := range m.catalog {
+		if userContains(u, query) {
+			users = append(users, u)
+		}
+	}
+	return users, nil
 }
 
 func (m *manager) GetUserGroups(ctx context.Context, uid *typespb.UserId) ([]string, error) {
@@ -77,32 +89,30 @@ func (m *manager) IsInGroup(ctx context.Context, uid *typespb.UserId, group stri
 
 func getUsers() map[string]*authv0alphapb.User {
 	return map[string]*authv0alphapb.User{
-		// TODO sub
-		// TODO iss
-		"einstein": &authv0alphapb.User{
+		"4c510ada-c86b-4815-8820-42cdf82c3d51": &authv0alphapb.User{
 			Id: &typespb.UserId{
-				Idp:      "localhost",
-				OpaqueId: "einstein",
+				Idp:      "http://localhost:9998",
+				OpaqueId: "4c510ada-c86b-4815-8820-42cdf82c3d51",
 			},
 			Username:    "einstein",
 			Groups:      []string{"sailing-lovers", "violin-haters", "physics-lovers"},
 			Mail:        "einstein@example.org",
 			DisplayName: "Albert Einstein",
 		},
-		"marie": &authv0alphapb.User{
+		"f7fbf8c8-139b-4376-b307-cf0a8c2d0d9c": &authv0alphapb.User{
 			Id: &typespb.UserId{
-				Idp:      "localhost",
-				OpaqueId: "marie",
+				Idp:      "http://localhost:9998",
+				OpaqueId: "f7fbf8c8-139b-4376-b307-cf0a8c2d0d9c",
 			},
 			Username:    "marie",
 			Groups:      []string{"radium-lovers", "polonium-lovers", "physics-lovers"},
 			Mail:        "marie@example.org",
 			DisplayName: "Marie Curie",
 		},
-		"richard": &authv0alphapb.User{
+		"932b4540-8d16-481e-8ef4-588e4b6b151c": &authv0alphapb.User{
 			Id: &typespb.UserId{
-				Idp:      "localhost",
-				OpaqueId: "richard",
+				Idp:      "http://localhost:9998",
+				OpaqueId: "932b4540-8d16-481e-8ef4-588e4b6b151c",
 			},
 			Username:    "richard",
 			Groups:      []string{"quantum-lovers", "philosophy-haters", "physics-lovers"},

--- a/pkg/user/user.go
+++ b/pkg/user/user.go
@@ -27,7 +27,10 @@ import (
 
 type key int
 
-const userKey key = iota
+const (
+	userKey key = iota
+	idKey
+)
 
 // ContextGetUser returns the user if set in the given context.
 func ContextGetUser(ctx context.Context) (*authv0alphapb.User, bool) {
@@ -47,6 +50,17 @@ func ContextMustGetUser(ctx context.Context) *authv0alphapb.User {
 // ContextSetUser stores the user in the context.
 func ContextSetUser(ctx context.Context, u *authv0alphapb.User) context.Context {
 	return context.WithValue(ctx, userKey, u)
+}
+
+// ContextGetUserID returns the user if set in the given context.
+func ContextGetUserID(ctx context.Context) (*typespb.UserId, bool) {
+	u, ok := ctx.Value(idKey).(*typespb.UserId)
+	return u, ok
+}
+
+// ContextSetUserID stores the userid in the context.
+func ContextSetUserID(ctx context.Context, id *typespb.UserId) context.Context {
+	return context.WithValue(ctx, idKey, id)
 }
 
 // Manager is the interface to implement to manipulate users.


### PR DESCRIPTION
Authenticating credentials is used to establish the identity of a user. The credentials can be
* username & password - demo, ldap and json auth managers do this
* a clientid & token - the oidc auth manager does this, in the future we also need basic oauth tokens for device specific authentication

All of the above establish the identity of a user, which is why we should either return a UserID struct or put it into the context.

This PR for now implements how this works when using the json auth provider.

@labkode Do you agree that the result of the auth should be a userid or nil? Should we use a return parameter or the context? I prefer a return parameter ... which can be nil or a UserID struct.

I ran into this because the current reva login command only works with userids, not usernames. but a login is the process of identifying a user, so the login should imo work with usernames.
  