### PR TITLE
use correct id property, fileid is not used by the desktop client

### DIFF
--- a/cmd/revad/svcs/httpsvcs/ocdavsvc/propfind.go
+++ b/cmd/revad/svcs/httpsvcs/ocdavsvc/propfind.go
@@ -209,7 +209,7 @@ func (s *svc) mdToPropResponse(ctx context.Context, pf *propfindXML, md *storage
 			Status: "HTTP/1.1 200 OK",
 			Prop:   []*propertyXML{},
 		})
-		response.Propstat[0].Prop = append(response.Propstat[0].Prop, s.newProp("oc:fileid", wrapResourceID(md.Id)))
+		response.Propstat[0].Prop = append(response.Propstat[0].Prop, s.newProp("oc:id", wrapResourceID(md.Id)))
 		if md.Etag != "" {
 			response.Propstat[0].Prop = append(response.Propstat[0].Prop, s.newProp("d:getetag", md.Etag))
 		}
@@ -251,11 +251,11 @@ func (s *svc) mdToPropResponse(ctx context.Context, pf *propfindXML, md *storage
 			switch pf.Prop[i].Space {
 			case "http://owncloud.org/ns":
 				switch pf.Prop[i].Local {
-				case "fileid": // TODO upper lowercase sensivity?
+				case "id": // TODO upper lowercase sensivity?
 					if md.Id != nil {
-						propstatOK.Prop = append(propstatOK.Prop, s.newProp("oc:fileid", wrapResourceID(md.Id)))
+						propstatOK.Prop = append(propstatOK.Prop, s.newProp("oc:id", wrapResourceID(md.Id)))
 					} else {
-						propstatNotFound.Prop = append(propstatNotFound.Prop, s.newProp("oc:fileid", ""))
+						propstatNotFound.Prop = append(propstatNotFound.Prop, s.newProp("oc:id", ""))
 					}
 				case "permissions":
 					if md.PermissionSet != nil {


### PR DESCRIPTION
tested with owncloudcmd ... i refactored that away ... turns out the current owncloud client uses id ... not fileid .... hmmmm but phoenix might use file id ... should we make phoenix use the id?

yuck they have different meaning ... fileid is the oc10 numeric fileid ... id is a unique string. 