### PR TITLE
Feature/ocisprovider use backend

### DIFF
--- a/cmd/revad/svcs/httpsvcs/oidcprovider/auth.go
+++ b/cmd/revad/svcs/httpsvcs/oidcprovider/auth.go
@@ -76,7 +76,6 @@ func (s *svc) doAuth(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
-	// TODO(jfd): use reva sepcific implementation that uses existing auth managers
 	actx, err := s.authmgr.Authenticate(ctx, username, password)
 	if err != nil {
 		s.oauth2.WriteAuthorizeError(w, ar, err)

--- a/cmd/revad/svcs/httpsvcs/oidcprovider/auth.go
+++ b/cmd/revad/svcs/httpsvcs/oidcprovider/auth.go
@@ -73,7 +73,7 @@ func (s *svc) doAuth(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
-	// use reva sepcific implementation that uses existing auth managers
+	// TODO(jfd): use reva sepcific implementation that uses existing auth managers
 	if err := store.Authenticate(ctx, username, password); err != nil {
 		oauth2.WriteAuthorizeError(w, ar, err)
 	}

--- a/cmd/revad/svcs/httpsvcs/oidcprovider/home.go
+++ b/cmd/revad/svcs/httpsvcs/oidcprovider/home.go
@@ -62,6 +62,9 @@ func (s *svc) doHome(w http.ResponseWriter, r *http.Request) {
 			<a href="%s">Make an invalid request</a>
 		</li>
 	</ul>`,
+	// TODO(jfd): make sure phoenix uses random state and nonce, see https://tools.ietf.org/html/rfc6819#section-4.4.1.8
+	// - nonce vs jti https://security.stackexchange.com/a/188171
+	// - state vs nonce https://stackoverflow.com/a/46859861
 		clientConf.AuthCodeURL("some-random-state-foobar")+"&nonce=some-random-nonce",
 		"http://localhost:9998/oauth2/auth?client_id=my-client&redirect_uri=http%3A%2F%2Flocalhost%3A9998%2Fcallback&response_type=token%20id_token&scope=fosite%20openid&state=some-random-state-foobar&nonce=some-random-nonce",
 		clientConf.AuthCodeURL("some-random-state-foobar")+"&nonce=some-random-nonce",

--- a/cmd/revad/svcs/httpsvcs/oidcprovider/home.go
+++ b/cmd/revad/svcs/httpsvcs/oidcprovider/home.go
@@ -62,9 +62,9 @@ func (s *svc) doHome(w http.ResponseWriter, r *http.Request) {
 			<a href="%s">Make an invalid request</a>
 		</li>
 	</ul>`,
-	// TODO(jfd): make sure phoenix uses random state and nonce, see https://tools.ietf.org/html/rfc6819#section-4.4.1.8
-	// - nonce vs jti https://security.stackexchange.com/a/188171
-	// - state vs nonce https://stackoverflow.com/a/46859861
+		// TODO(jfd): make sure phoenix uses random state and nonce, see https://tools.ietf.org/html/rfc6819#section-4.4.1.8
+		// - nonce vs jti https://security.stackexchange.com/a/188171
+		// - state vs nonce https://stackoverflow.com/a/46859861
 		clientConf.AuthCodeURL("some-random-state-foobar")+"&nonce=some-random-nonce",
 		"http://localhost:9998/oauth2/auth?client_id=my-client&redirect_uri=http%3A%2F%2Flocalhost%3A9998%2Fcallback&response_type=token%20id_token&scope=fosite%20openid&state=some-random-state-foobar&nonce=some-random-nonce",
 		clientConf.AuthCodeURL("some-random-state-foobar")+"&nonce=some-random-nonce",

--- a/cmd/revad/svcs/httpsvcs/oidcprovider/introspect.go
+++ b/cmd/revad/svcs/httpsvcs/oidcprovider/introspect.go
@@ -27,12 +27,12 @@ import (
 func (s *svc) doIntrospect(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	log := appctx.GetLogger(ctx)
-	ir, err := oauth2.NewIntrospectionRequest(ctx, r, emptySession())
+	ir, err := s.oauth2.NewIntrospectionRequest(ctx, r, emptySession())
 	if err != nil {
 		log.Error().Err(err).Msg("Error occurred in NewIntrospectionRequest")
-		oauth2.WriteIntrospectionError(w, err)
+		s.oauth2.WriteIntrospectionError(w, err)
 		return
 	}
 
-	oauth2.WriteIntrospectionResponse(w, ir)
+	s.oauth2.WriteIntrospectionResponse(w, ir)
 }

--- a/cmd/revad/svcs/httpsvcs/oidcprovider/oidcprovider.go
+++ b/cmd/revad/svcs/httpsvcs/oidcprovider/oidcprovider.go
@@ -75,7 +75,7 @@ func newExampleStore() *storage.MemoryStore {
 				Scopes:        []string{"openid", "profile", "email", "offline"},
 			},
 		},
-		// TODO implement reva specific user store that uses existing user managers
+		// TODO(jfd): implement reva specific user store that uses existing user managers
 		Users: map[string]storage.MemoryUserRelation{
 			"aaliyah_abernathy": {
 				Username: "aaliyah_abernathy",
@@ -107,6 +107,7 @@ var fconfig = new(compose.Config)
 var start = compose.CommonStrategy{
 	// alternatively you could use:
 	//  OAuth2Strategy: compose.NewOAuth2JWTStrategy(mustRSAKey())
+	// TODO(jfd): generate / read proper secret from config
 	CoreStrategy: compose.NewOAuth2HMACStrategy(fconfig, []byte("some-super-cool-secret-that-nobody-knows"), nil),
 
 	// open id connect strategy
@@ -173,13 +174,13 @@ func emptySession() *openid.DefaultSession {
 func mustRSAKey() *rsa.PrivateKey {
 	key, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
-		// TODO really panic?
+		// TODO(jfd): don't panic!
 		panic(err)
 	}
 	return key
 }
 
-// TODO currently we fake a sub. it would change when tha username changes ...
+// TODO(jfd): do not fake the sub like tkis. it would change when the username changes ...
 func getSub(ctx context.Context, username string) string {
 	hasher := md5.New()
 	_, err := hasher.Write([]byte(username))
@@ -190,7 +191,7 @@ func getSub(ctx context.Context, username string) string {
 	return hex.EncodeToString(hasher.Sum(nil))
 }
 
-// New returns a new webuisvc
+// New returns a new oidcprovidersvc
 func New(m map[string]interface{}) (httpsvcs.Service, error) {
 	conf := &config{}
 	if err := mapstructure.Decode(m, conf); err != nil {
@@ -240,7 +241,7 @@ func (s *svc) setHandler() {
 		case "userinfo":
 			s.doUserinfo(w, r)
 		case "sessions":
-			// TODO only for development
+			// TODO(jfd) make session lookup configurable? only for development?
 			s.doSessions(w, r)
 		default:
 			w.WriteHeader(http.StatusNotFound)

--- a/cmd/revad/svcs/httpsvcs/oidcprovider/oidcprovider.go
+++ b/cmd/revad/svcs/httpsvcs/oidcprovider/oidcprovider.go
@@ -66,6 +66,7 @@ type svc struct {
 func newExampleStore() *storage.MemoryStore {
 	return &storage.MemoryStore{
 		IDSessions: make(map[string]fosite.Requester),
+		// TODO(jfd): read clients from a json file
 		Clients: map[string]fosite.Client{
 			"phoenix": &fosite.DefaultClient{
 				ID:            "phoenix",

--- a/cmd/revad/svcs/httpsvcs/oidcprovider/revoke.go
+++ b/cmd/revad/svcs/httpsvcs/oidcprovider/revoke.go
@@ -31,7 +31,7 @@ func (s *svc) doRevoke(w http.ResponseWriter, r *http.Request) {
 	log := appctx.GetLogger(ctx)
 
 	// This will create an access request object and iterate through the registered TokenEndpointHandlers to validate the request.
-	accessRequest, err := oauth2.NewAccessRequest(ctx, r, emptySession())
+	accessRequest, err := s.oauth2.NewAccessRequest(ctx, r, emptySession())
 
 	// Catch any errors, e.g.:
 	// * unknown client
@@ -39,7 +39,7 @@ func (s *svc) doRevoke(w http.ResponseWriter, r *http.Request) {
 	// * ...
 	if err != nil {
 		log.Error().Err(err).Msg("Error occurred in NewAccessRequest")
-		oauth2.WriteAccessError(w, accessRequest, err)
+		s.oauth2.WriteAccessError(w, accessRequest, err)
 		return
 	}
 
@@ -54,15 +54,15 @@ func (s *svc) doRevoke(w http.ResponseWriter, r *http.Request) {
 
 	// Next we create a response for the access request. Again, we iterate through the TokenEndpointHandlers
 	// and aggregate the result in response.
-	response, err := oauth2.NewAccessResponse(ctx, accessRequest)
+	response, err := s.oauth2.NewAccessResponse(ctx, accessRequest)
 	if err != nil {
 		log.Error().Err(err).Msg("Error occurred in NewAccessResponse")
-		oauth2.WriteAccessError(w, accessRequest, err)
+		s.oauth2.WriteAccessError(w, accessRequest, err)
 		return
 	}
 
 	// All done, send the response.
-	oauth2.WriteAccessResponse(w, accessRequest, response)
+	s.oauth2.WriteAccessResponse(w, accessRequest, response)
 
 	// The client now has a valid access token
 }

--- a/cmd/revad/svcs/httpsvcs/oidcprovider/sessions.go
+++ b/cmd/revad/svcs/httpsvcs/oidcprovider/sessions.go
@@ -34,7 +34,7 @@ func (s *svc) doSessions(w http.ResponseWriter, r *http.Request) {
 		log.Error().Err(err).Msg("Error writing response")
 		return
 	}
-	for id, c := range store.Clients {
+	for id, c := range s.store.Clients {
 		c := c
 		_, err := w.Write([]byte(fmt.Sprintf(`
 			<li>
@@ -53,7 +53,7 @@ func (s *svc) doSessions(w http.ResponseWriter, r *http.Request) {
 		log.Error().Err(err).Msg("Error writing response")
 		return
 	}
-	for id, c := range store.AuthorizeCodes {
+	for id, c := range s.store.AuthorizeCodes {
 		c := c
 		_, err := w.Write([]byte(fmt.Sprintf(`
 			<li>
@@ -73,7 +73,7 @@ func (s *svc) doSessions(w http.ResponseWriter, r *http.Request) {
 		log.Error().Err(err).Msg("Error writing response")
 		return
 	}
-	for id, c := range store.IDSessions {
+	for id, c := range s.store.IDSessions {
 		c := c
 		_, err := w.Write([]byte(fmt.Sprintf(`
 			<li>
@@ -93,7 +93,7 @@ func (s *svc) doSessions(w http.ResponseWriter, r *http.Request) {
 		log.Error().Err(err).Msg("Error writing response")
 		return
 	}
-	for id, c := range store.AccessTokens {
+	for id, c := range s.store.AccessTokens {
 		_, err := w.Write([]byte(fmt.Sprintf(`
 			<li>
 				%s: %#v
@@ -112,7 +112,7 @@ func (s *svc) doSessions(w http.ResponseWriter, r *http.Request) {
 		log.Error().Err(err).Msg("Error writing response")
 		return
 	}
-	for id, c := range store.Implicit {
+	for id, c := range s.store.Implicit {
 		c := c
 		_, err := w.Write([]byte(fmt.Sprintf(`
 			<li>
@@ -132,7 +132,7 @@ func (s *svc) doSessions(w http.ResponseWriter, r *http.Request) {
 		log.Error().Err(err).Msg("Error writing response")
 		return
 	}
-	for id, c := range store.RefreshTokens {
+	for id, c := range s.store.RefreshTokens {
 		c := c
 		_, err := w.Write([]byte(fmt.Sprintf(`
 			<li>
@@ -152,27 +152,7 @@ func (s *svc) doSessions(w http.ResponseWriter, r *http.Request) {
 		log.Error().Err(err).Msg("Error writing response")
 		return
 	}
-	for id, c := range store.PKCES {
-		c := c
-		_, err := w.Write([]byte(fmt.Sprintf(`
-			<li>
-				%s: %#v
-			</li>`,
-
-			id, c,
-		)))
-		if err != nil {
-			log.Error().Err(err).Msg("Error writing response")
-			return
-		}
-	}
-	// Users
-	_, err = w.Write([]byte(`</ul><p>Users</p><ul>`))
-	if err != nil {
-		log.Error().Err(err).Msg("Error writing response")
-		return
-	}
-	for id, c := range store.Users {
+	for id, c := range s.store.PKCES {
 		c := c
 		_, err := w.Write([]byte(fmt.Sprintf(`
 			<li>
@@ -192,7 +172,7 @@ func (s *svc) doSessions(w http.ResponseWriter, r *http.Request) {
 		log.Error().Err(err).Msg("Error writing response")
 		return
 	}
-	for id, c := range store.AccessTokenRequestIDs {
+	for id, c := range s.store.AccessTokenRequestIDs {
 		c := c
 		_, err := w.Write([]byte(fmt.Sprintf(`
 			<li>
@@ -212,7 +192,7 @@ func (s *svc) doSessions(w http.ResponseWriter, r *http.Request) {
 		log.Error().Err(err).Msg("Error writing response")
 		return
 	}
-	for id, c := range store.RefreshTokenRequestIDs {
+	for id, c := range s.store.RefreshTokenRequestIDs {
 		c := c
 		_, err := w.Write([]byte(fmt.Sprintf(`
 			<li>

--- a/cmd/revad/svcs/httpsvcs/oidcprovider/token.go
+++ b/cmd/revad/svcs/httpsvcs/oidcprovider/token.go
@@ -31,7 +31,7 @@ func (s *svc) doToken(w http.ResponseWriter, r *http.Request) {
 	log := appctx.GetLogger(ctx)
 
 	// This will create an access request object and iterate through the registered TokenEndpointHandlers to validate the request.
-	accessRequest, err := oauth2.NewAccessRequest(ctx, r, emptySession())
+	accessRequest, err := s.oauth2.NewAccessRequest(ctx, r, emptySession())
 
 	// Catch any errors, e.g.:
 	// * unknown client
@@ -39,7 +39,7 @@ func (s *svc) doToken(w http.ResponseWriter, r *http.Request) {
 	// * ...
 	if err != nil {
 		log.Error().Err(err).Msg("Error occurred in NewAccessRequest")
-		oauth2.WriteAccessError(w, accessRequest, err)
+		s.oauth2.WriteAccessError(w, accessRequest, err)
 		return
 	}
 
@@ -54,15 +54,15 @@ func (s *svc) doToken(w http.ResponseWriter, r *http.Request) {
 
 	// Next we create a response for the access request. Again, we iterate through the TokenEndpointHandlers
 	// and aggregate the result in response.
-	response, err := oauth2.NewAccessResponse(ctx, accessRequest)
+	response, err := s.oauth2.NewAccessResponse(ctx, accessRequest)
 	if err != nil {
 		log.Error().Err(err).Msg("Error occurred in NewAccessResponse")
-		oauth2.WriteAccessError(w, accessRequest, err)
+		s.oauth2.WriteAccessError(w, accessRequest, err)
 		return
 	}
 
 	// All done, send the response.
-	oauth2.WriteAccessResponse(w, accessRequest, response)
+	s.oauth2.WriteAccessResponse(w, accessRequest, response)
 
 	// The client now has a valid access token
 }

--- a/cmd/revad/svcs/httpsvcs/oidcprovider/userinfo.go
+++ b/cmd/revad/svcs/httpsvcs/oidcprovider/userinfo.go
@@ -45,7 +45,7 @@ func (s *svc) doUserinfo(w http.ResponseWriter, r *http.Request) {
 
 	var sc *oidc.StandardClaims
 	switch ar.GetSession().GetUsername() {
-	//TODO use reva specific implementation that uses existing user managers
+	// TODO(jfd): use reva specific implementation that uses existing user managers
 	case "aaliyah_abernathy":
 		sc = &oidc.StandardClaims{
 			Name: "Aaliyah Abernathy",

--- a/cmd/revad/svcs/httpsvcs/oidcprovider/userinfo.go
+++ b/cmd/revad/svcs/httpsvcs/oidcprovider/userinfo.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/ory/fosite"
 
+	typespb "github.com/cs3org/go-cs3apis/cs3/types"
 	"github.com/cs3org/reva/pkg/appctx"
 	"github.com/cs3org/reva/pkg/auth/manager/oidc"
 )
@@ -35,7 +36,7 @@ func (s *svc) doUserinfo(w http.ResponseWriter, r *http.Request) {
 
 	requiredScope := "openid"
 
-	_, ar, err := oauth2.IntrospectToken(ctx, fosite.AccessTokenFromRequest(r), fosite.AccessToken, emptySession(), requiredScope)
+	_, ar, err := s.oauth2.IntrospectToken(ctx, fosite.AccessTokenFromRequest(r), fosite.AccessToken, emptySession(), requiredScope)
 	if err != nil {
 		fmt.Fprintf(w, "<h1>An error occurred!</h1><p>Could not perform introspection: %v</p>", err)
 		return
@@ -43,30 +44,26 @@ func (s *svc) doUserinfo(w http.ResponseWriter, r *http.Request) {
 
 	log.Debug().Interface("ar", ar).Msg("introspected")
 
-	var sc *oidc.StandardClaims
-	switch ar.GetSession().GetUsername() {
-	// TODO(jfd): use reva specific implementation that uses existing user managers
-	case "aaliyah_abernathy":
-		sc = &oidc.StandardClaims{
-			Name: "Aaliyah Abernathy",
-		}
-	case "aaliyah_adams":
-		sc = &oidc.StandardClaims{
-			Name: "Aaliyah Adams",
-		}
-	case "aaliyah_anderson":
-		sc = &oidc.StandardClaims{
-			Name: "Aaliyah Anderson",
-		}
-	default:
-		log.Error().Err(err).Msg("unknown user")
+	sub := ar.GetSession().GetSubject()
+
+	uid := &typespb.UserId{
+		// TODO(jfd): also fill the idp if possible.
+		OpaqueId: sub,
+	}
+	user, err := s.usermgr.GetUser(ctx, uid)
+	if err != nil {
+		log.Error().Err(err).Str("sub", sub).Msg("unknown user")
 		w.WriteHeader(http.StatusNotFound)
 		return
 	}
-	sc.Sub = ar.GetSession().GetSubject()
-	sc.PreferredUsername = ar.GetSession().GetUsername()
-	sc.EmailVerified = true
-	sc.Email = sc.PreferredUsername + "@owncloudqa.com"
+
+	sc := &oidc.StandardClaims{
+		Sub:               user.Id.OpaqueId,
+		Iss:               user.Id.Idp,
+		PreferredUsername: user.Username,
+		Name:              user.DisplayName,
+		Email:             user.Mail,
+	}
 
 	b, err := json.Marshal(sc)
 	if err != nil {

--- a/cmd/revad/svcs/httpsvcs/oidcprovider/userinfo.go
+++ b/cmd/revad/svcs/httpsvcs/oidcprovider/userinfo.go
@@ -47,7 +47,16 @@ func (s *svc) doUserinfo(w http.ResponseWriter, r *http.Request) {
 	sub := ar.GetSession().GetSubject()
 
 	uid := &typespb.UserId{
-		// TODO(jfd): also fill the idp if possible.
+		// TODO(jfd): also fill the idp, if possible.
+		// well .. that might be hard, because in this case we are the idp
+		// we should put oar hostname into the Iss field
+		// - only an oidc provider would be able to provide an iss
+		// - maybe for ldap the uidNumber attribute makes more sense as sub?
+		//    - this is still a tricky question. ms eg uses sid - security identifiers
+		//      but they change when a usename changes or he moves to a new node in the tree
+		//      to mitigate this they keep track of past ids in the sidHistory attribute
+		//      so the filesystem might use an outdated sid in the permissions but the system
+		//      can still resolve the user using the sidhistory attribute
 		OpaqueId: sub,
 	}
 	user, err := s.usermgr.GetUser(ctx, uid)


### PR DESCRIPTION
This PR makes the oidc provider use an auth and user manager.

Configure like this (only oidc relevant properties shown):
```toml
[http]
enabled_services = [
    "oidcprovider",
    "wellknown"
]

# HTTP middlewares

[http.middlewares.auth]
credential_strategy = "oidc"
skip_methods = [
    "/oauth2",
    "/oauth2/auth", 
    "/oauth2/token", 
    "/oauth2/introspect",
    "/oauth2/userinfo", 
    "/oauth2/sessions", 
    "/.well-known/openid-configuration",
]

[http.services.oidcprovider]
prefix = "oauth2"
auth_manager = "json"
user_manager = "json"

[http.services.oidcprovider.auth_managers.json]
users = "/data/users.json"

[http.services.oidcprovider.user_managers.json]
users = "/data/users.json"
```