### PR TITLE
capabilities: revert change from boolean to string

### DIFF
--- a/cmd/revad/svcs/httpsvcs/ocssvc/capabilities.go
+++ b/cmd/revad/svcs/httpsvcs/ocssvc/capabilities.go
@@ -117,20 +117,13 @@ func (h *CapabilitiesHandler) init(c *Config) {
 		h.c.Capabilities.FilesSharing = &CapabilitiesFilesSharing{}
 	}
 
-	// h.c.Capabilities.FilesSharing.APIEnabled is string ... with a boolean flag
+	// h.c.Capabilities.FilesSharing.APIEnabled is boolean
 
-	if h.c.Capabilities.FilesSharing.APIEnabled == "" {
-		h.c.Capabilities.FilesSharing.APIEnabled = "1"
-	}
 	if h.c.Capabilities.FilesSharing.Public == nil {
 		h.c.Capabilities.FilesSharing.Public = &CapabilitiesFilesSharingPublic{}
 	}
 
-	// h.c.Capabilities.FilesSharing.Public.Enabled is string ... with a boolean flag
-
-	if h.c.Capabilities.FilesSharing.Public.Enabled == "" {
-		h.c.Capabilities.FilesSharing.Public.Enabled = "1"
-	}
+	// h.c.Capabilities.FilesSharing.Public.Enabled is boolean
 
 	if h.c.Capabilities.FilesSharing.Public.Password == nil {
 		h.c.Capabilities.FilesSharing.Public.Password = &CapabilitiesFilesSharingPublicPassword{}
@@ -280,7 +273,7 @@ type CapabilitiesDav struct {
 
 // CapabilitiesFilesSharing TODO document
 type CapabilitiesFilesSharing struct {
-	APIEnabled                    string                                   `json:"api_enabled" xml:"api_enabled" mapstructure:"api_enabled"`
+	APIEnabled                    bool                                     `json:"api_enabled" xml:"api_enabled" mapstructure:"api_enabled"`
 	Resharing                     bool                                     `json:"resharing" xml:"resharing"`
 	GroupSharing                  bool                                     `json:"group_sharing" xml:"group_sharing" mapstructure:"group_sharing"`
 	AutoAcceptShare               bool                                     `json:"auto_accept_share" xml:"auto_accept_share" mapstructure:"auto_accept_share"`
@@ -296,7 +289,7 @@ type CapabilitiesFilesSharing struct {
 
 // CapabilitiesFilesSharingPublic TODO document
 type CapabilitiesFilesSharingPublic struct {
-	Enabled            string                                    `json:"enabled" xml:"enabled"`
+	Enabled            bool                                      `json:"enabled" xml:"enabled"`
 	SendMail           bool                                      `json:"send_mail" xml:"send_mail" mapstructure:"send_mail"`
 	SocialShare        bool                                      `json:"social_share" xml:"social_share" mapstructure:"social_share"`
 	Upload             bool                                      `json:"upload" xml:"upload"`


### PR DESCRIPTION
It was committed accidentially. And actually this is a bug in phoenix. oc10 renders booleans in ocs json responses properly, not as strings.