### PR TITLE
allow running authsvc and the gateway an the same process

### DIFF
--- a/cmd/revad/svcs/grpcsvcs/gatewaysvc/gatewaysvc.go
+++ b/cmd/revad/svcs/grpcsvcs/gatewaysvc/gatewaysvc.go
@@ -53,7 +53,9 @@ func New(m map[string]interface{}, ss *grpc.Server) (io.Closer, error) {
 	}
 
 	storageproviderv0alphapb.RegisterStorageProviderServiceServer(ss, s)
-	authv0alphapb.RegisterAuthServiceServer(ss, s)
+	if c.AuthEndpoint != "" {
+		authv0alphapb.RegisterAuthServiceServer(ss, s)
+	}
 	usershareproviderv0alphapb.RegisterUserShareProviderServiceServer(ss, s)
 	appregistryv0alphapb.RegisterAppRegistryServiceServer(ss, s)
 	appproviderv0alphapb.RegisterAppProviderServiceServer(ss, s)


### PR DESCRIPTION
This pr allows running the authsvc along the gatewaysvc. That enables a setup where twe gatweys handle the configuration in different ways: one with basic auth, one with openid connect. The backend then relies on tokens. An example is given in https://github.com/cs3org/reva/issues/65#issuecomment-530846477