### PR TITLE
WebDAV service update + Leftover erroneous config parameter check

### DIFF
--- a/cmd/revad/svcs/httpsvcs/ocdavsvc/options.go
+++ b/cmd/revad/svcs/httpsvcs/ocdavsvc/options.go
@@ -33,7 +33,7 @@ func (s *svc) doOptions(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Access-Control-Allow-Origin", "*")
 	w.Header().Set("Access-Control-Allow-Credentials", "true")
 	w.Header().Set("Access-Control-Allow-Methods", allow)
-	w.Header().Set("Access-Control-Allow-Headers", "Authorization, Content-Type, Depth, Ocs-Apirequest, If-Match, If-None-Match, Destination")
+	w.Header().Set("Access-Control-Allow-Headers", "Authorization, X-Requested-With, Content-Type, Depth, Ocs-Apirequest, If-Match, If-None-Match, Destination")
 	w.Header().Set("Content-Type", "application/xml")
 	w.Header().Set("Allow", allow)
 	w.Header().Set("DAV", "1, 2")

--- a/pkg/storage/fs/owncloud/owncloud.go
+++ b/pkg/storage/fs/owncloud/owncloud.go
@@ -169,7 +169,7 @@ func (c *config) init(m map[string]interface{}) {
 		c.Scan = true
 	}
 	// default to autocreate if not configured
-	if _, ok := m["scan"]; !ok {
+	if _, ok := m["autocreate"]; !ok {
 		c.Autocreate = true
 	}
 }


### PR DESCRIPTION
A bit of housekeeping for the dav service and the owncloud storage provider. Point 2 is currently preventing phoenix from loading files.

- update leftover typo
- add missing phoenix header `x-requested-with` ([as per this PR](https://github.com/owncloud/phoenix/pull/1984))