### PR TITLE
Update Makefile, so that git describe works

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ BUILD_DATE=`date +%FT%T%z`
 GIT_COMMIT=`git rev-parse --short HEAD`
 GIT_BRANCH=`git rev-parse --symbolic-full-name --abbrev-ref HEAD`
 GIT_DIRTY=`git diff-index --quiet HEAD -- || echo "dirty-"`
-VERSION=`git describe`
+VERSION=`git describe --always`
 GO_VERSION=`go version | awk '{print $$3}'`
 BUILD_PLATFORM=`go version | awk '{print $$4}'`
 


### PR DESCRIPTION
Was getting: `fatal: No names found, cannot describe anything.` with command:
go build -o ./cmd/revad/revad -ldflags "-s -X main.buildDate=`date +%FT%T%z` -X main.gitCommit=`git diff-index --quiet HEAD -- || echo "dirty-"``git rev-parse --short HEAD` -X main.gitBranch=`git rev-parse --symbolic-full-name --abbrev-ref HEAD` -X main.version=`git describe` -X main.goVersion=`go version | awk '{print $3}'` -X main.buildPlatform=`go version | awk '{print $4}'`" ./cmd/revad