### PR TITLE
WIP: List Outgoing Shares

### DIFF
--- a/cmd/reva/share-create.go
+++ b/cmd/reva/share-create.go
@@ -36,7 +36,7 @@ func shareCreateCommand() *command {
 	cmd.Description = func() string { return "create share to a user or group" }
 	cmd.Usage = func() string { return "Usage: share create [-flags] <path>" }
 	grantType := cmd.String("type", "user", "grantee type (user or group)")
-	grantee := cmd.String("grantee", "", "the grantee")
+	grantee := cmd.String("grantee", "", "the opaqueId of the grantee")
 	idp := cmd.String("idp", "", "the idp of the grantee, default to same idp as the user triggering the action")
 	rol := cmd.String("rol", "viewer", "the permission for the share (viewer or editor)")
 	cmd.Action = func() error {

--- a/cmd/revad/svcs/grpcsvcs/gatewaysvc/gatewaysvc.go
+++ b/cmd/revad/svcs/grpcsvcs/gatewaysvc/gatewaysvc.go
@@ -53,16 +53,16 @@ func New(m map[string]interface{}, ss *grpc.Server) (io.Closer, error) {
 		c: c,
 	}
 
-	storageproviderv0alphapb.RegisterStorageProviderServiceServer(ss, s)
 	if c.AuthEndpoint != "" {
 		authv0alphapb.RegisterAuthServiceServer(ss, s)
 	}
+	storageproviderv0alphapb.RegisterStorageProviderServiceServer(ss, s)
 	usershareproviderv0alphapb.RegisterUserShareProviderServiceServer(ss, s)
-	publicshareproviderv0alphapb.RegisterPublicShareProviderServiceServer(ss, s)
+	storageregv0alphapb.RegisterStorageRegistryServiceServer(ss, s)
 	appregistryv0alphapb.RegisterAppRegistryServiceServer(ss, s)
 	appproviderv0alphapb.RegisterAppProviderServiceServer(ss, s)
 	preferencesv0alphapb.RegisterPreferencesServiceServer(ss, s)
-	storageregv0alphapb.RegisterStorageRegistryServiceServer(ss, s)
+	publicshareproviderv0alphapb.RegisterPublicShareProviderServiceServer(ss, s)
 
 	return s, nil
 }

--- a/cmd/revad/svcs/grpcsvcs/gatewaysvc/storageprovidersvc.go
+++ b/cmd/revad/svcs/grpcsvcs/gatewaysvc/storageprovidersvc.go
@@ -475,6 +475,27 @@ func (s *svc) GetQuota(ctx context.Context, req *storageproviderv0alphapb.GetQuo
 	return res, nil
 }
 
+func (s *svc) CreateReference(ctx context.Context, req *storageproviderv0alphapb.CreateReferenceRequest) (*storageproviderv0alphapb.CreateReferenceResponse, error) {
+	res := &storageproviderv0alphapb.CreateReferenceResponse{
+		Status: status.NewUnimplemented(ctx, nil, "CreateReference not yet implemented"),
+	}
+	return res, nil
+}
+
+func (s *svc) SetArbitraryMetadata(ctx context.Context, req *storageproviderv0alphapb.SetArbitraryMetadataRequest) (*storageproviderv0alphapb.SetArbitraryMetadataResponse, error) {
+	res := &storageproviderv0alphapb.SetArbitraryMetadataResponse{
+		Status: status.NewUnimplemented(ctx, nil, "SetArbitraryMetadata not yet implemented"),
+	}
+	return res, nil
+}
+
+func (s *svc) UnsetArbitraryMetadata(ctx context.Context, rq *storageproviderv0alphapb.UnsetArbitraryMetadataRequest) (*storageproviderv0alphapb.UnsetArbitraryMetadataResponse, error) {
+	res := &storageproviderv0alphapb.UnsetArbitraryMetadataResponse{
+		Status: status.NewUnimplemented(ctx, nil, "UnsetArbitraryMetadataResponse not yet implemented"),
+	}
+	return res, nil
+}
+
 func (s *svc) find(ctx context.Context, ref *storageproviderv0alphapb.Reference) (*storagetypespb.ProviderInfo, error) {
 	c, err := pool.GetStorageRegistryClient(s.c.StorageRegistryEndpoint)
 	if err != nil {

--- a/cmd/revad/svcs/grpcsvcs/gatewaysvc/storageregistrysvc.go
+++ b/cmd/revad/svcs/grpcsvcs/gatewaysvc/storageregistrysvc.go
@@ -60,3 +60,10 @@ func (s *svc) GetStorageProvider(ctx context.Context, req *storageregv0alphapb.G
 
 	return res, nil
 }
+
+func (s *svc) GetHome(ctx context.Context, req *storageregv0alphapb.GetHomeRequest) (*storageregv0alphapb.GetHomeResponse, error) {
+	res := &storageregv0alphapb.GetHomeResponse{
+		Status: status.NewUnimplemented(ctx, nil, "(gateway) GetHome not yet implemented"),
+	}
+	return res, nil
+}

--- a/cmd/revad/svcs/grpcsvcs/gatewaysvc/usershareprovidersvc.go
+++ b/cmd/revad/svcs/grpcsvcs/gatewaysvc/usershareprovidersvc.go
@@ -286,3 +286,10 @@ func (s *svc) UpdateReceivedShare(ctx context.Context, req *usershareproviderv0a
 
 	return res, nil
 }
+
+func (s *svc) GetReceivedShare(ctx context.Context, req *usershareproviderv0alphapb.GetReceivedShareRequest) (*usershareproviderv0alphapb.GetReceivedShareResponse, error) {
+	res := &usershareproviderv0alphapb.GetReceivedShareResponse{
+		Status: status.NewUnimplemented(ctx, nil, "(gateway) GetReceivedShare not yet implemented"),
+	}
+	return res, nil
+}

--- a/cmd/revad/svcs/grpcsvcs/publicshareprovidersvc/publicshareprovidersvc.go
+++ b/cmd/revad/svcs/grpcsvcs/publicshareprovidersvc/publicshareprovidersvc.go
@@ -26,6 +26,7 @@ import (
 	publicshareproviderv0alphapb "github.com/cs3org/go-cs3apis/cs3/publicshareprovider/v0alpha"
 	storageproviderv0alphapb "github.com/cs3org/go-cs3apis/cs3/storageprovider/v0alpha"
 	"github.com/cs3org/reva/cmd/revad/grpcserver"
+	"github.com/cs3org/reva/cmd/revad/svcs/grpcsvcs/pool"
 	"github.com/cs3org/reva/cmd/revad/svcs/grpcsvcs/status"
 	"github.com/cs3org/reva/pkg/appctx"
 	"github.com/cs3org/reva/pkg/publicshare"
@@ -97,9 +98,47 @@ func (s *service) CreatePublicShare(ctx context.Context, req *publicshareprovide
 	log := appctx.GetLogger(ctx)
 	log.Info().Msg("create public share")
 
+	// TODO(refs) this is just for testing purposes until the update of the cs3apis: https://github.com/cs3org/cs3apis/pull/34
+	endpoint := "localhost:9999"
+	// TODO(refs) wait until [] is merged and get rid of this hardcoded url
+	_, err := pool.GetStorageProviderServiceClient(endpoint)
+	if err != nil {
+		log.Debug().Err(errors.New("error getting a connection to a storage provider")).Msgf("address: %v", endpoint)
+	}
+
+	// TODO(refs) until https://github.com/cs3org/cs3apis/pull/34 is merged, we need a stat call to get the ResourceInfo
+	// build stat request. We have the ID from the CreatePublicShareRequest
+	statReq := storageproviderv0alphapb.StatRequest{
+		Ref: &storageproviderv0alphapb.Reference{
+			Spec: &storageproviderv0alphapb.Reference_Id{
+				Id: req.GetResourceId(),
+			},
+		},
+	}
+
+	// get user from context
+	u, _ := user.ContextGetUser(ctx) // TODO(refs) handle error
+
+	// do stat
+	spConn, err := pool.GetStorageProviderServiceClient(endpoint)
+	if err != nil {
+		log.Debug().Err(err).Str("createShare", "shares").Msg("error connecting to storage provider")
+	}
+
+	statRes, err := spConn.Stat(ctx, &statReq)
+	if err != nil {
+		log.Debug().Err(err).Str("createShare", "shares").Msg("error on stat call")
+	}
+
+	share, err := s.sm.CreatePublicShare(ctx, u, statRes.GetInfo(), req.Grant)
+	if err != nil {
+		log.Debug().Err(err).Str("createShare", "shares").Msg("error connecting to storage provider")
+	}
+
+	// TODO(refs) where does the 1970 come from?
 	res := &publicshareproviderv0alphapb.CreatePublicShareResponse{
 		Status: status.NewOK(ctx),
-		// Share:  share,
+		Share:  share,
 	}
 	return res, nil
 }

--- a/cmd/revad/svcs/grpcsvcs/publicshareprovidersvc/publicshareprovidersvc.go
+++ b/cmd/revad/svcs/grpcsvcs/publicshareprovidersvc/publicshareprovidersvc.go
@@ -46,8 +46,8 @@ type config struct {
 }
 
 type service struct {
-	conf *config
-	sm   publicshare.Manager
+	conf         *config
+	shareManager publicshare.Manager
 }
 
 func getShareManager(c *config) (publicshare.Manager, error) {
@@ -58,7 +58,7 @@ func getShareManager(c *config) (publicshare.Manager, error) {
 }
 
 // TODO(labkode): add ctx to Close.
-func (s *service) Close() error {
+func (svc *service) Close() error {
 	return nil
 }
 
@@ -85,25 +85,24 @@ func New(m map[string]interface{}, ss *grpc.Server) (io.Closer, error) {
 	}
 
 	service := &service{
-		conf: c,
-		sm:   sm,
+		conf:         c,
+		shareManager: sm,
 	}
 
 	publicshareproviderv0alphapb.RegisterPublicShareProviderServiceServer(ss, service)
 	return service, nil
 }
 
-func (s *service) CreatePublicShare(ctx context.Context, req *publicshareproviderv0alphapb.CreatePublicShareRequest) (*publicshareproviderv0alphapb.CreatePublicShareResponse, error) {
+func (svc *service) CreatePublicShare(ctx context.Context, req *publicshareproviderv0alphapb.CreatePublicShareRequest) (*publicshareproviderv0alphapb.CreatePublicShareResponse, error) {
 	log := appctx.GetLogger(ctx)
 	log.Info().Msg("create public share")
 
-	// get user from context
 	u, ok := user.ContextGetUser(ctx)
 	if !ok {
 		log.Error().Msg("error getting user from context")
 	}
 
-	share, err := s.sm.CreatePublicShare(ctx, u, req.ResourceInfo, req.Grant)
+	share, err := svc.shareManager.CreatePublicShare(ctx, u, req.ResourceInfo, req.Grant)
 	if err != nil {
 		log.Debug().Err(err).Str("createShare", "shares").Msg("error connecting to storage provider")
 	}
@@ -116,7 +115,7 @@ func (s *service) CreatePublicShare(ctx context.Context, req *publicshareprovide
 	return res, nil
 }
 
-func (s *service) RemovePublicShare(ctx context.Context, req *publicshareproviderv0alphapb.RemovePublicShareRequest) (*publicshareproviderv0alphapb.RemovePublicShareResponse, error) {
+func (svc *service) RemovePublicShare(ctx context.Context, req *publicshareproviderv0alphapb.RemovePublicShareRequest) (*publicshareproviderv0alphapb.RemovePublicShareResponse, error) {
 	log := appctx.GetLogger(ctx)
 	log.Info().Msg("remove public share")
 
@@ -125,7 +124,8 @@ func (s *service) RemovePublicShare(ctx context.Context, req *publicshareprovide
 	}, nil
 }
 
-func (s *service) GetPublicShareByToken(ctx context.Context, req *publicshareproviderv0alphapb.GetPublicShareByTokenRequest) (*publicshareproviderv0alphapb.GetPublicShareByTokenResponse, error) {
+// TODO(refs) implement
+func (svc *service) GetPublicShareByToken(ctx context.Context, req *publicshareproviderv0alphapb.GetPublicShareByTokenRequest) (*publicshareproviderv0alphapb.GetPublicShareByTokenResponse, error) {
 	log := appctx.GetLogger(ctx)
 	log.Info().Msg("remove public share")
 
@@ -134,7 +134,8 @@ func (s *service) GetPublicShareByToken(ctx context.Context, req *publicsharepro
 	}, nil
 }
 
-func (s *service) GetPublicShare(ctx context.Context, req *publicshareproviderv0alphapb.GetPublicShareRequest) (*publicshareproviderv0alphapb.GetPublicShareResponse, error) {
+// TODO(refs) implement
+func (svc *service) GetPublicShare(ctx context.Context, req *publicshareproviderv0alphapb.GetPublicShareRequest) (*publicshareproviderv0alphapb.GetPublicShareResponse, error) {
 	log := appctx.GetLogger(ctx)
 	log.Info().Msg("get public share")
 
@@ -144,12 +145,12 @@ func (s *service) GetPublicShare(ctx context.Context, req *publicshareproviderv0
 	}, nil
 }
 
-func (s *service) ListPublicShares(ctx context.Context, req *publicshareproviderv0alphapb.ListPublicSharesRequest) (*publicshareproviderv0alphapb.ListPublicSharesResponse, error) {
+func (svc *service) ListPublicShares(ctx context.Context, req *publicshareproviderv0alphapb.ListPublicSharesRequest) (*publicshareproviderv0alphapb.ListPublicSharesResponse, error) {
 	log := appctx.GetLogger(ctx)
 	log.Info().Msg("list public share")
 	user, _ := user.ContextGetUser(ctx)
 
-	shares, err := s.sm.ListPublicShares(ctx, user, &storageproviderv0alphapb.ResourceInfo{})
+	shares, err := svc.shareManager.ListPublicShares(ctx, user, &storageproviderv0alphapb.ResourceInfo{})
 	if err != nil {
 		log.Err(err).Msg("error listing shares")
 		return &publicshareproviderv0alphapb.ListPublicSharesResponse{
@@ -164,7 +165,7 @@ func (s *service) ListPublicShares(ctx context.Context, req *publicshareprovider
 	return res, nil
 }
 
-func (s *service) UpdatePublicShare(ctx context.Context, req *publicshareproviderv0alphapb.UpdatePublicShareRequest) (*publicshareproviderv0alphapb.UpdatePublicShareResponse, error) {
+func (svc *service) UpdatePublicShare(ctx context.Context, req *publicshareproviderv0alphapb.UpdatePublicShareRequest) (*publicshareproviderv0alphapb.UpdatePublicShareResponse, error) {
 	log := appctx.GetLogger(ctx)
 	log.Info().Msg("list public share")
 

--- a/cmd/revad/svcs/grpcsvcs/storageprovidersvc/storageprovidersvc.go
+++ b/cmd/revad/svcs/grpcsvcs/storageprovidersvc/storageprovidersvc.go
@@ -40,6 +40,8 @@ import (
 	"github.com/pkg/errors"
 	"go.opencensus.io/trace"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	grpcStatus "google.golang.org/grpc/status"
 )
 
 func init() {
@@ -615,6 +617,18 @@ func (s *service) GetQuota(ctx context.Context, req *storageproviderv0alphapb.Ge
 		UsedBytes:  uint64(used),
 	}
 	return res, nil
+}
+
+func (s *service) CreateReference(ctx context.Context, req *storageproviderv0alphapb.CreateReferenceRequest) (*storageproviderv0alphapb.CreateReferenceResponse, error) {
+	return nil, grpcStatus.Error(codes.Unimplemented, "method CreateReference is not yet implemented")
+}
+
+func (s *service) SetArbitraryMetadata(ctx context.Context, req *storageproviderv0alphapb.SetArbitraryMetadataRequest) (*storageproviderv0alphapb.SetArbitraryMetadataResponse, error) {
+	return nil, grpcStatus.Error(codes.Unimplemented, "method SetArbitraryMetadata is not yet implemented")
+}
+
+func (s *service) UnsetArbitraryMetadata(ctx context.Context, rq *storageproviderv0alphapb.UnsetArbitraryMetadataRequest) (*storageproviderv0alphapb.UnsetArbitraryMetadataResponse, error) {
+	return nil, grpcStatus.Error(codes.Unimplemented, "method UnsetArbitraryMetadata is not yet implemented")
 }
 
 func (s *service) unwrap(ctx context.Context, ref *storageproviderv0alphapb.Reference) (*storageproviderv0alphapb.Reference, error) {

--- a/cmd/revad/svcs/grpcsvcs/storageregistrysvc/storageregistrysvc.go
+++ b/cmd/revad/svcs/grpcsvcs/storageregistrysvc/storageregistrysvc.go
@@ -26,6 +26,7 @@ import (
 	storagetypespb "github.com/cs3org/go-cs3apis/cs3/storagetypes"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 
 	storageregv0alphapb "github.com/cs3org/go-cs3apis/cs3/storageregistry/v0alpha"
 	"github.com/cs3org/reva/cmd/revad/grpcserver"
@@ -33,6 +34,7 @@ import (
 	"github.com/cs3org/reva/pkg/storage"
 	"github.com/cs3org/reva/pkg/storage/registry/registry"
 	"github.com/mitchellh/mapstructure"
+	grpcStatus "google.golang.org/grpc/status"
 )
 
 func init() {
@@ -122,6 +124,10 @@ func (s *service) GetStorageProvider(ctx context.Context, req *storageregv0alpha
 		Provider: p,
 	}
 	return res, nil
+}
+
+func (s *service) GetHome(ctx context.Context, req *storageregv0alphapb.GetHomeRequest) (*storageregv0alphapb.GetHomeResponse, error) {
+	return nil, grpcStatus.Error(codes.Unimplemented, "method GetHome is not yet implemented")
 }
 
 // TODO(labkode): fix

--- a/cmd/revad/svcs/grpcsvcs/usershareprovidersvc/usershareprovidersvc.go
+++ b/cmd/revad/svcs/grpcsvcs/usershareprovidersvc/usershareprovidersvc.go
@@ -31,6 +31,8 @@ import (
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	grpcStatus "google.golang.org/grpc/status"
 )
 
 func init() {
@@ -193,4 +195,8 @@ func (s *service) UpdateReceivedShare(ctx context.Context, req *usershareprovide
 		Status: status.NewOK(ctx),
 	}
 	return res, nil
+}
+
+func (s *service) GetReceivedShare(ctx context.Context, req *usershareproviderv0alphapb.GetReceivedShareRequest) (*usershareproviderv0alphapb.GetReceivedShareResponse, error) {
+	return nil, grpcStatus.Error(codes.Unimplemented, "method GetReceivedShare is not yet implemented")
 }

--- a/cmd/revad/svcs/httpsvcs/ocdavsvc/meta.go
+++ b/cmd/revad/svcs/httpsvcs/ocdavsvc/meta.go
@@ -21,7 +21,6 @@ package ocdavsvc
 import (
 	"net/http"
 
-	storageproviderv0alphapb "github.com/cs3org/go-cs3apis/cs3/storageprovider/v0alpha"
 	"github.com/cs3org/reva/cmd/revad/svcs/httpsvcs"
 )
 
@@ -39,23 +38,22 @@ func (h *MetaHandler) init(c *Config) error {
 func (h *MetaHandler) Handler(s *svc) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 
-		var id string
-		id, r.URL.Path = httpsvcs.ShiftPath(r.URL.Path)
-		if id == "" {
+		// encodedResourceID - base64 encoded resource id:
+		// http://localhost:9998/remote.php/dav/meta/MTIzZTQ1NjctZTg5Yi0xMmQzLWE0NTYtNDI2NjU1NDQwMDAwOmVmY2RmZGQ3LTdjZGEtNGI4My1hNDI2LTFmYWRlNjEwZjE5MQ%3D%3D/v
+		var encodedResourceID string
+		encodedResourceID, r.URL.Path = httpsvcs.ShiftPath(r.URL.Path)
+		if encodedResourceID == "" {
 			http.Error(w, "400 Bad Request", http.StatusBadRequest)
 			return
 		}
 
-		// did := unwrap(id)
-		did := &storageproviderv0alphapb.ResourceId{
-			OpaqueId: id,
-		}
+		decodedResourceID := decode(encodedResourceID)
 
 		var head string
 		head, r.URL.Path = httpsvcs.ShiftPath(r.URL.Path)
 		switch head {
 		case "v":
-			h.VersionsHandler.Handler(s, did).ServeHTTP(w, r)
+			h.VersionsHandler.Handler(s, decodedResourceID).ServeHTTP(w, r)
 		default:
 			w.WriteHeader(http.StatusNotFound)
 		}

--- a/cmd/revad/svcs/httpsvcs/ocdavsvc/meta.go
+++ b/cmd/revad/svcs/httpsvcs/ocdavsvc/meta.go
@@ -21,6 +21,7 @@ package ocdavsvc
 import (
 	"net/http"
 
+	storageproviderv0alphapb "github.com/cs3org/go-cs3apis/cs3/storageprovider/v0alpha"
 	"github.com/cs3org/reva/cmd/revad/svcs/httpsvcs"
 )
 
@@ -45,7 +46,10 @@ func (h *MetaHandler) Handler(s *svc) http.Handler {
 			return
 		}
 
-		did := unwrap(id)
+		// did := unwrap(id)
+		did := &storageproviderv0alphapb.ResourceId{
+			OpaqueId: id,
+		}
 
 		var head string
 		head, r.URL.Path = httpsvcs.ShiftPath(r.URL.Path)

--- a/cmd/revad/svcs/httpsvcs/ocdavsvc/ocdavsvc.go
+++ b/cmd/revad/svcs/httpsvcs/ocdavsvc/ocdavsvc.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"strings"
 
 	storageproviderv0alphapb "github.com/cs3org/go-cs3apis/cs3/storageprovider/v0alpha"
 	"github.com/cs3org/reva/cmd/revad/httpserver"
@@ -127,6 +126,7 @@ func (s *svc) Handler() http.Handler {
 			}
 
 			// the new `/dav/files` endpoint uses remote.php/dav/files/$user/$path style paths
+			// http://localhost:9998/remote.php/dav/meta/efcdfdd7-7cda-4b83-a426-1fade610f191/v
 			if head2 == "dav" {
 				s.davHandler.Handler(s).ServeHTTP(w, r)
 				return
@@ -153,17 +153,18 @@ func wrap(sid string, oid string) string {
 	return base64.URLEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", sid, oid)))
 }
 
-func unwrap(rid string) *storageproviderv0alphapb.ResourceId {
-	decodedID, err := base64.URLEncoding.DecodeString(rid)
-	if err != nil {
-		return nil
-	}
-	parts := strings.SplitN(string(decodedID), ":", 2)
-	if len(parts) != 2 {
-		return nil
-	}
-	return &storageproviderv0alphapb.ResourceId{
-		StorageId: parts[0],
-		OpaqueId:  parts[1],
-	}
-}
+// TODO(refs): is this needed?
+// func unwrap(rid string) *storageproviderv0alphapb.ResourceId {
+// 	decodedID, err := base64.URLEncoding.DecodeString(rid)
+// 	if err != nil {
+// 		return nil
+// 	}
+// 	parts := strings.SplitN(string(decodedID), ":", 2)
+// 	if len(parts) != 2 {
+// 		return nil
+// 	}
+// 	return &storageproviderv0alphapb.ResourceId{
+// 		StorageId: parts[0],
+// 		OpaqueId:  parts[1],
+// 	}
+// }

--- a/cmd/revad/svcs/httpsvcs/ocdavsvc/ocdavsvc.go
+++ b/cmd/revad/svcs/httpsvcs/ocdavsvc/ocdavsvc.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"strings"
 
 	storageproviderv0alphapb "github.com/cs3org/go-cs3apis/cs3/storageprovider/v0alpha"
 	"github.com/cs3org/reva/cmd/revad/httpserver"
@@ -153,18 +154,20 @@ func wrap(sid string, oid string) string {
 	return base64.URLEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", sid, oid)))
 }
 
-// TODO(refs): is this needed?
-// func unwrap(rid string) *storageproviderv0alphapb.ResourceId {
-// 	decodedID, err := base64.URLEncoding.DecodeString(rid)
-// 	if err != nil {
-// 		return nil
-// 	}
-// 	parts := strings.SplitN(string(decodedID), ":", 2)
-// 	if len(parts) != 2 {
-// 		return nil
-// 	}
-// 	return &storageproviderv0alphapb.ResourceId{
-// 		StorageId: parts[0],
-// 		OpaqueId:  parts[1],
-// 	}
-// }
+// unwrap accepts base64 encoded url's like: MTIzZTQ1NjctZTg5Yi0xMmQzLWE0NTYtNDI2NjU1NDQwMDAwOmVmY2RmZGQ3LTdjZGEtNGI4My1hNDI2LTFmYWRlNjEwZjE5MQ==
+// decodes them: 123e4567-e89b-12d3-a456-426655440000:efcdfdd7-7cda-4b83-a426-1fade610f191
+// where parts[0] = storageID, parts[1] = opaqueID
+func decode(rid string) *storageproviderv0alphapb.ResourceId {
+	decodedID, err := base64.URLEncoding.DecodeString(rid)
+	if err != nil {
+		return nil
+	}
+	parts := strings.SplitN(string(decodedID), ":", 2)
+	if len(parts) != 2 {
+		return nil
+	}
+	return &storageproviderv0alphapb.ResourceId{
+		StorageId: parts[0],
+		OpaqueId:  parts[1],
+	}
+}

--- a/cmd/revad/svcs/httpsvcs/ocdavsvc/versions.go
+++ b/cmd/revad/svcs/httpsvcs/ocdavsvc/versions.go
@@ -72,6 +72,15 @@ func (h *VersionsHandler) Handler(s *svc, rid *storageproviderv0alphapb.Resource
 }
 
 func (h *VersionsHandler) doListVersions(w http.ResponseWriter, r *http.Request, s *svc, rid *storageproviderv0alphapb.ResourceId) {
+	// read propfinds
+	// get a client to the storage provider
+	// prepare a reference
+	// prepare a request to use the reference in
+	// do a stat call on the reference to get resource info
+	// prepare a list file version request
+	// do list file versions request
+	// get versions from the response (GetVersions())
+
 	ctx := r.Context()
 	log := appctx.GetLogger(ctx)
 

--- a/cmd/revad/svcs/httpsvcs/ocssvc/conversions/conversions.go
+++ b/cmd/revad/svcs/httpsvcs/ocssvc/conversions/conversions.go
@@ -16,5 +16,5 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-// The conversions package provides a series of glue code that converts cs3api types into OCS data structures
+// Package conversions package provides a series of glue code that converts cs3api types into OCS data structures
 package conversions

--- a/cmd/revad/svcs/httpsvcs/ocssvc/conversions/conversions.go
+++ b/cmd/revad/svcs/httpsvcs/ocssvc/conversions/conversions.go
@@ -1,0 +1,20 @@
+// Copyright 2018-2019 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+// The conversions package provides a series of glue code that converts cs3api types into OCS data structures
+package conversions

--- a/cmd/revad/svcs/httpsvcs/ocssvc/conversions/shares.go
+++ b/cmd/revad/svcs/httpsvcs/ocssvc/conversions/shares.go
@@ -73,6 +73,11 @@ const (
 	// ShareTypeFederatedCloudShare shareType = 6
 )
 
+// Element is a commodity type wraps members of any interface (as per Owncloud's OCS V1 Spec)f
+type Element struct {
+	Data interface{} `json:"element" xml:"element"`
+}
+
 // ShareData represents https://doc.owncloud.com/server/developer_manual/core/ocs-share-api.html#response-attributes-1
 type ShareData struct {
 	// TODO int?
@@ -134,10 +139,10 @@ type ShareData struct {
 	ShareWith string `json:"share_with" xml:"share_with"`
 	// The display name of the receiver of the file.
 	ShareWithDisplayname string `json:"share_with_displayname" xml:"share_with_displayname"`
+	// sharee Additional info
+	ShareWithAdditionalInfo string `json:"share_with_additional_info" xml:"share_with_additional_info"`
 	// Whether the recipient was notified, by mail, about the share being shared with them.
 	MailSend string `json:"mail_send" xml:"mail_send"`
-	// A (human-readable) name for the share, which can be up to 64 characters in length
-	Name string `json:"name" xml:"name"`
 }
 
 // ShareeData holds share recipient search results
@@ -275,7 +280,7 @@ func AsCS3Permissions(p int, rp *storageproviderv0alphapb.ResourcePermissions) *
 
 // PublicShare2ShareData converts a cs3api public share into shareData data model
 func PublicShare2ShareData(share *publicshareproviderv0alphapb.PublicShare) *ShareData {
-	sd := &ShareData{
+	return &ShareData{
 		// TODO map share.resourceId to path and storage ... requires a stat call
 		// share.permissions ar mapped below
 		// TODO lookup user metadata
@@ -293,7 +298,6 @@ func PublicShare2ShareData(share *publicshareproviderv0alphapb.PublicShare) *Sha
 	}
 	// actually clients should be able to GET and cache the user info themselves ...
 	// TODO check grantee type for user vs group
-	return sd
 }
 
 // UserIDToString transforms a cs3api user id into an ocs data model

--- a/cmd/revad/svcs/httpsvcs/ocssvc/conversions/shares.go
+++ b/cmd/revad/svcs/httpsvcs/ocssvc/conversions/shares.go
@@ -1,0 +1,387 @@
+// Copyright 2018-2019 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package conversions
+
+import (
+	"fmt"
+	"time"
+
+	publicshareproviderv0alphapb "github.com/cs3org/go-cs3apis/cs3/publicshareprovider/v0alpha"
+	storageproviderv0alphapb "github.com/cs3org/go-cs3apis/cs3/storageprovider/v0alpha"
+	typespb "github.com/cs3org/go-cs3apis/cs3/types"
+	usershareproviderv0alphapb "github.com/cs3org/go-cs3apis/cs3/usershareprovider/v0alpha"
+	"github.com/cs3org/reva/pkg/publicshare"
+	publicsharemgr "github.com/cs3org/reva/pkg/publicshare/manager/registry"
+	"github.com/cs3org/reva/pkg/user"
+	usermgr "github.com/cs3org/reva/pkg/user/manager/registry"
+)
+
+// Types
+
+type ResourceType int
+
+func (rt ResourceType) String() (s string) {
+	switch rt {
+	case 0:
+		s = "invalid"
+	case 1:
+		s = "file"
+	case 2:
+		s = "folder"
+	case 3:
+		s = "reference"
+	default:
+		s = "invalid"
+	}
+	return
+}
+
+// Permissions reflects the CRUD permissions used in the OCS sharing API
+type Permissions uint
+
+type ShareType int
+
+const (
+	ShareTypeUser ShareType = 0
+	// shareTypeGroup shareType = 1
+	ShareTypePublicLink ShareType = 3
+	//	shareTypeFederatedCloudShare shareType = 6
+)
+
+// ShareData represents https://doc.owncloud.com/server/developer_manual/core/ocs-share-api.html#response-attributes-1
+type ShareData struct {
+	// TODO int?
+	ID string `json:"id" xml:"id"`
+	// The share’s type. This can be one of:
+	// 0 = user
+	// 1 = group
+	// 3 = public link
+	// 6 = federated cloud share
+	ShareType ShareType `json:"share_type" xml:"share_type"`
+	// The username of the owner of the share.
+	UIDOwner string `json:"uid_owner" xml:"uid_owner"`
+	// The display name of the owner of the share.
+	DisplaynameOwner string `json:"displayname_owner" xml:"displayname_owner"`
+	// The permission attribute set on the file. Options are:
+	// * 1 = Read
+	// * 2 = Update
+	// * 4 = Create
+	// * 8 = Delete
+	// * 16 = Share
+	// * 31 = All permissions
+	// The default is 31, and for public shares is 1.
+	// TODO we should change the default to read only
+	Permissions Permissions `json:"permissions" xml:"permissions"`
+	// The UNIX timestamp when the share was created.
+	STime uint64 `json:"stime" xml:"stime"`
+	// ?
+	Parent string `json:"parent" xml:"parent"`
+	// The UNIX timestamp when the share expires.
+	Expiration string `json:"expiration" xml:"expiration"`
+	// The public link to the item being shared.
+	Token string `json:"token" xml:"token"`
+	// The unique id of the user that owns the file or folder being shared.
+	UIDFileOwner string `json:"uid_file_owner" xml:"uid_file_owner"`
+	// The display name of the user that owns the file or folder being shared.
+	DisplaynameFileOwner string `json:"displayname_file_owner" xml:"displayname_file_owner"`
+	// The path to the shared file or folder.
+	Path string `json:"path" xml:"path"`
+	// The type of the object being shared. This can be one of file or folder.
+	ItemType string `json:"item_type" xml:"item_type"`
+	// The RFC2045-compliant mimetype of the file.
+	MimeType  string `json:"mimetype" xml:"mimetype"`
+	StorageID string `json:"storage_id" xml:"storage_id"`
+	Storage   uint64 `json:"storage" xml:"storage"`
+	// The unique node id of the item being shared.
+	// TODO int?
+	ItemSource string `json:"item_source" xml:"item_source"`
+	// The unique node id of the item being shared. For legacy reasons item_source and file_source attributes have the same value.
+	// TODO int?
+	FileSource string `json:"file_source" xml:"file_source"`
+	// The unique node id of the parent node of the item being shared.
+	// TODO int?
+	FileParent string `json:"file_parent" xml:"file_parent"`
+	// The name of the shared file.
+	FileTarget string `json:"file_target" xml:"file_target"`
+	// The uid of the receiver of the file. This is either
+	// - a GID (group id) if it is being shared with a group or
+	// - a UID (user id) if the share is shared with a user.
+	ShareWith string `json:"share_with" xml:"share_with"`
+	// The display name of the receiver of the file.
+	ShareWithDisplayname string `json:"share_with_displayname" xml:"share_with_displayname"`
+	// Whether the recipient was notified, by mail, about the share being shared with them.
+	MailSend string `json:"mail_send" xml:"mail_send"`
+	// A (human-readable) name for the share, which can be up to 64 characters in length
+	Name string `json:"name" xml:"name"`
+}
+
+// ShareeData holds share recipient search results
+type ShareeData struct {
+	Exact   *ExactMatchesData `json:"exact" xml:"exact"`
+	Users   []*MatchData      `json:"users" xml:"users"`
+	Groups  []*MatchData      `json:"groups" xml:"groups"`
+	Remotes []*MatchData      `json:"remotes" xml:"remotes"`
+}
+
+// ExactMatchesData hold exact matches
+type ExactMatchesData struct {
+	Users   []*MatchData `json:"users" xml:"users"`
+	Groups  []*MatchData `json:"groups" xml:"groups"`
+	Remotes []*MatchData `json:"remotes" xml:"remotes"`
+}
+
+// MatchData describes a single match
+type MatchData struct {
+	Label string          `json:"label" xml:"label"`
+	Value *MatchValueData `json:"value" xml:"value"`
+}
+
+// MatchValueData holds the type and actual value
+type MatchValueData struct {
+	ShareType int    `json:"shareType" xml:"shareType"`
+	ShareWith string `json:"shareWith" xml:"shareWith"`
+}
+
+// Conversion functions. From cs3api types => ocs
+
+func Role2CS3Permissions(r string) (*storageproviderv0alphapb.ResourcePermissions, error) {
+	switch r {
+	case RoleViewer:
+		return &storageproviderv0alphapb.ResourcePermissions{
+			ListContainer:        true,
+			ListGrants:           true,
+			ListFileVersions:     true,
+			ListRecycle:          true,
+			Stat:                 true,
+			GetPath:              true,
+			GetQuota:             true,
+			InitiateFileDownload: true,
+		}, nil
+	case RoleEditor:
+		return &storageproviderv0alphapb.ResourcePermissions{
+			ListContainer:        true,
+			ListGrants:           true,
+			ListFileVersions:     true,
+			ListRecycle:          true,
+			Stat:                 true,
+			GetPath:              true,
+			GetQuota:             true,
+			InitiateFileDownload: true,
+
+			Move:               true,
+			InitiateFileUpload: true,
+			RestoreFileVersion: true,
+			RestoreRecycleItem: true,
+			CreateContainer:    true,
+			Delete:             true,
+			PurgeRecycle:       true,
+		}, nil
+	case RoleCoowner:
+		return &storageproviderv0alphapb.ResourcePermissions{
+			ListContainer:        true,
+			ListGrants:           true,
+			ListFileVersions:     true,
+			ListRecycle:          true,
+			Stat:                 true,
+			GetPath:              true,
+			GetQuota:             true,
+			InitiateFileDownload: true,
+
+			Move:               true,
+			InitiateFileUpload: true,
+			RestoreFileVersion: true,
+			RestoreRecycleItem: true,
+			CreateContainer:    true,
+			Delete:             true,
+			PurgeRecycle:       true,
+
+			AddGrant:    true,
+			RemoveGrant: true, // TODO when are you able to unshare / delete
+			UpdateGrant: true,
+		}, nil
+	default:
+		return nil, fmt.Errorf("unknown role: %s", r)
+	}
+}
+
+// TODO sort out mapping, this is just a first guess
+// TODO use roles to make this configurable
+func AsCS3Permissions(p int, rp *storageproviderv0alphapb.ResourcePermissions) *storageproviderv0alphapb.ResourcePermissions {
+	if rp == nil {
+		rp = &storageproviderv0alphapb.ResourcePermissions{}
+	}
+
+	if p&int(PermissionRead) != 0 {
+		rp.ListContainer = true
+		rp.ListGrants = true
+		rp.ListFileVersions = true
+		rp.ListRecycle = true
+		rp.Stat = true
+		rp.GetPath = true
+		rp.GetQuota = true
+		rp.InitiateFileDownload = true
+	}
+	if p&int(PermissionWrite) != 0 {
+		rp.InitiateFileUpload = true
+		rp.RestoreFileVersion = true
+		rp.RestoreRecycleItem = true
+	}
+	if p&int(PermissionCreate) != 0 {
+		rp.CreateContainer = true
+		// FIXME permissions mismatch: double check create vs write file
+		rp.InitiateFileUpload = true
+		if p&int(PermissionWrite) != 0 {
+			rp.Move = true // TODO move only when create and write?
+		}
+	}
+	if p&int(PermissionDelete) != 0 {
+		rp.Delete = true
+		rp.PurgeRecycle = true
+	}
+	if p&int(PermissionShare) != 0 {
+		rp.AddGrant = true
+		rp.RemoveGrant = true // TODO when are you able to unshare / delete
+		rp.UpdateGrant = true
+	}
+	return rp
+}
+
+// TODO(refs) helper function, move to a mixins
+func PublicShare2ShareData(share *publicshareproviderv0alphapb.PublicShare) *ShareData {
+	sd := &ShareData{
+		// TODO map share.resourceId to path and storage ... requires a stat call
+		// share.permissions ar mapped below
+		// TODO lookup user metadata
+		//DisplaynameOwner:     creator.DisplayName,
+		// TODO lookup user metadata
+		// DisplaynameFileOwner: owner.DisplayName,
+		ID:           share.Id.OpaqueId,
+		Permissions:  publicSharePermissions2OCSPermissions(share.GetPermissions()),
+		ShareType:    ShareTypePublicLink,
+		UIDOwner:     UserIDToString(share.Creator),
+		STime:        share.Ctime.Seconds, // TODO CS3 api birth time = btime
+		UIDFileOwner: UserIDToString(share.Owner),
+		Token:        share.Token,
+		Expiration:   timestampToExpiration(share.Expiration),
+	}
+	// actually clients should be able to GET and cache the user info themselves ...
+	// TODO check grantee type for user vs group
+	return sd
+}
+
+func UserIDToString(userID *typespb.UserId) string {
+	if userID == nil || userID.OpaqueId == "" {
+		return ""
+	}
+	if userID.Idp == "" {
+		return userID.OpaqueId
+	}
+	return userID.OpaqueId + "@" + userID.Idp
+}
+
+func UserSharePermissions2OCSPermissions(sp *usershareproviderv0alphapb.SharePermissions) Permissions {
+	if sp != nil {
+		return permissions2OCSPermissions(sp.GetPermissions())
+	}
+	return PermissionInvalid
+}
+
+func publicSharePermissions2OCSPermissions(sp *publicshareproviderv0alphapb.PublicSharePermissions) Permissions {
+	if sp != nil {
+		return permissions2OCSPermissions(sp.GetPermissions())
+	}
+	return PermissionInvalid
+}
+
+// TODO sort out mapping, this is just a first guess
+func permissions2OCSPermissions(p *storageproviderv0alphapb.ResourcePermissions) Permissions {
+	permissions := PermissionInvalid
+	if p != nil {
+		if p.ListContainer {
+			permissions += PermissionRead
+		}
+		if p.InitiateFileUpload {
+			permissions += PermissionWrite
+		}
+		if p.CreateContainer {
+			permissions += PermissionCreate
+		}
+		if p.Delete {
+			permissions += PermissionDelete
+		}
+		if p.AddGrant {
+			permissions += PermissionShare
+		}
+	}
+	return permissions
+}
+
+// TODO(refs) this doesn't belong here
+func GetUserManager(manager string, m map[string]map[string]interface{}) (user.Manager, error) {
+	if f, ok := usermgr.NewFuncs[manager]; ok {
+		return f(m[manager])
+	}
+
+	return nil, fmt.Errorf("driver %s not found for user manager", manager)
+}
+
+func GetPublicShareManager(manager string, m map[string]map[string]interface{}) (publicshare.Manager, error) {
+	if f, ok := publicsharemgr.NewFuncs[manager]; ok {
+		return f(m[manager])
+	}
+
+	return nil, fmt.Errorf("driver %s not found for public shares manager", manager)
+}
+
+// timestamp is assumed to be UTC ... just human readable ...
+// FIXME and ambiguous / error prone because there is no time zone ...
+func timestampToExpiration(t *typespb.Timestamp) string {
+	return time.Unix(int64(t.Seconds), int64(t.Nanos)).Format("2006-01-02 15:05:05")
+}
+
+const (
+	RoleLegacy  string = "legacy"
+	RoleViewer  string = "viewer"
+	RoleEditor  string = "editor"
+	RoleCoowner string = "coowner"
+)
+
+const (
+	PermissionInvalid Permissions = 0
+	PermissionRead    Permissions = 1
+	PermissionWrite   Permissions = 2
+	PermissionCreate  Permissions = 4
+	PermissionDelete  Permissions = 8
+	PermissionShare   Permissions = 16
+	//PermissionAll     Permissions = 31
+)
+
+func Permissions2Role(p int) string {
+	role := RoleLegacy
+	if p == int(PermissionRead) {
+		role = RoleViewer
+	}
+	if p&int(PermissionWrite) == 1 {
+		role = RoleEditor
+	}
+	if p&int(PermissionShare) == 1 {
+		role = RoleCoowner
+	}
+	return role
+}

--- a/cmd/revad/svcs/httpsvcs/ocssvc/conversions/shares.go
+++ b/cmd/revad/svcs/httpsvcs/ocssvc/conversions/shares.go
@@ -73,7 +73,7 @@ const (
 	// ShareTypeFederatedCloudShare shareType = 6
 )
 
-// Element is a commodity type wraps members of any interface (as per Owncloud's OCS V1 Spec)f
+// Element is a commodity type wraps members of any interface (as per Owncloud's OCS V1 Spec)
 type Element struct {
 	Data interface{} `json:"element" xml:"element"`
 }

--- a/cmd/revad/svcs/httpsvcs/ocssvc/ocs.go
+++ b/cmd/revad/svcs/httpsvcs/ocssvc/ocs.go
@@ -94,6 +94,7 @@ func WriteOCSResponse(w http.ResponseWriter, r *http.Request, res *Response, err
 		appctx.GetLogger(r.Context()).Error().Err(err).Msg(res.OCS.Meta.Message)
 	}
 
+	// TODO is this assumption true? default to xml?
 	if r.URL.Query().Get("format") == "json" {
 		w.Header().Set("Content-Type", "application/json")
 		encoded, err = json.Marshal(res)

--- a/cmd/revad/svcs/httpsvcs/ocssvc/ocssvc.go
+++ b/cmd/revad/svcs/httpsvcs/ocssvc/ocssvc.go
@@ -33,12 +33,14 @@ func init() {
 
 // Config holds the config options that need to be passed down to all ocs handlers
 type Config struct {
-	Prefix       string                            `mapstructure:"prefix"`
-	Config       ConfigData                        `mapstructure:"config"`
-	Capabilities CapabilitiesData                  `mapstructure:"capabilities"`
-	GatewaySvc   string                            `mapstructure:"gatewaysvc"`
-	UserManager  string                            `mapstructure:"user_manager"`
-	UserManagers map[string]map[string]interface{} `mapstructure:"user_managers"`
+	Prefix              string                            `mapstructure:"prefix"`
+	Config              ConfigData                        `mapstructure:"config"`
+	Capabilities        CapabilitiesData                  `mapstructure:"capabilities"`
+	GatewaySvc          string                            `mapstructure:"gatewaysvc"`
+	UserManager         string                            `mapstructure:"user_manager"`
+	UserManagers        map[string]map[string]interface{} `mapstructure:"user_managers"`
+	PublicShareManager  string                            `mapstructure:"public_manager"`
+	PublicShareManagers map[string]map[string]interface{} `mapstructure:"publicshare_managers"`
 }
 
 type svc struct {

--- a/cmd/revad/svcs/httpsvcs/ocssvc/ocssvc.go
+++ b/cmd/revad/svcs/httpsvcs/ocssvc/ocssvc.go
@@ -90,6 +90,7 @@ func (s *svc) Handler() http.Handler {
 			s.V1Handler.Handler().ServeHTTP(w, r)
 			return
 		}
+		// TODO(refs) perhaps it's a good time to start with the v2.php now.
 
 		WriteOCSError(w, r, MetaNotFound.StatusCode, "Not found", nil)
 	})

--- a/cmd/revad/svcs/httpsvcs/ocssvc/ocssvc.go
+++ b/cmd/revad/svcs/httpsvcs/ocssvc/ocssvc.go
@@ -39,7 +39,7 @@ type Config struct {
 	GatewaySvc          string                            `mapstructure:"gatewaysvc"`
 	UserManager         string                            `mapstructure:"user_manager"`
 	UserManagers        map[string]map[string]interface{} `mapstructure:"user_managers"`
-	PublicShareManager  string                            `mapstructure:"public_manager"`
+	PublicShareManager  string                            `mapstructure:"publicshare_manager"`
 	PublicShareManagers map[string]map[string]interface{} `mapstructure:"publicshare_managers"`
 }
 

--- a/cmd/revad/svcs/httpsvcs/ocssvc/shares.go
+++ b/cmd/revad/svcs/httpsvcs/ocssvc/shares.go
@@ -311,8 +311,7 @@ func (h *SharesHandler) createShare(w http.ResponseWriter, r *http.Request) {
 		// TODO(refs) phoenix is not setting expiration. Default to (now + 1 year?)
 		// create public share request.
 		req := publicshareproviderv0alphapb.CreatePublicShareRequest{
-			// where do we get the ResourceID from? - from a stat call
-			ResourceId: statRes.Info.GetId(),
+			ResourceInfo: statRes.GetInfo(),
 			Grant: &publicshareproviderv0alphapb.Grant{
 				Expiration: &typespb.Timestamp{
 					Nanos:   uint32(time.Now().Add(time.Duration(31536000)).Nanosecond()),

--- a/cmd/revad/svcs/httpsvcs/ocssvc/shares.go
+++ b/cmd/revad/svcs/httpsvcs/ocssvc/shares.go
@@ -518,7 +518,6 @@ func (h *SharesHandler) listShares(w http.ResponseWriter, r *http.Request) {
 	shares = append(shares, append(userShares, publicShares...)...)
 
 	if isReshare(r) {
-		// this request expects a V1 response - we need to wrap it on an <element> node
 		WriteOCSSuccess(w, r, &conversions.Element{Data: shares})
 		return
 	}

--- a/cmd/revad/svcs/httpsvcs/ocssvc/shares.go
+++ b/cmd/revad/svcs/httpsvcs/ocssvc/shares.go
@@ -172,7 +172,6 @@ func (h *SharesHandler) createShare(w http.ResponseWriter, r *http.Request) {
 		}
 
 		// map role to permissions
-
 		var permissions *storageproviderv0alphapb.ResourcePermissions
 		permissions, err = h.role2CS3Permissions(role)
 		if err != nil {
@@ -569,19 +568,19 @@ func (h *SharesHandler) listUserShares(w http.ResponseWriter, r *http.Request) (
 	var rInfo *storageproviderv0alphapb.ResourceInfo
 	ctx := r.Context()
 	log := appctx.GetLogger(ctx)
-	filters := []*usershareproviderv0alphapb.ListSharesRequest_Filter{}
+
+	lsUserSharesRequest := usershareproviderv0alphapb.ListSharesRequest{}
 
 	if h.gatewaySvc != "" {
+		// get a connection to the users share provider
 		userShareProviderClient, err := pool.GetUserShareProviderClient(h.gatewaySvc)
 		if err != nil {
 			WriteOCSError(w, r, MetaServerError.StatusCode, "error getting grpc user share handler client", err)
 			return
 		}
 
-		// list of shares with other users
-		lsUserSharesResponse, err := userShareProviderClient.ListShares(ctx, &usershareproviderv0alphapb.ListSharesRequest{
-			Filters: filters,
-		})
+		// do list shares request. unfiltered
+		lsUserSharesResponse, err := userShareProviderClient.ListShares(ctx, &lsUserSharesRequest)
 		if err != nil {
 			WriteOCSError(w, r, MetaServerError.StatusCode, "error sending a grpc list shares request", err)
 			return

--- a/cmd/revad/svcs/httpsvcs/ocssvc/shares.go
+++ b/cmd/revad/svcs/httpsvcs/ocssvc/shares.go
@@ -26,10 +26,8 @@ import (
 	"path"
 	"strconv"
 	"strings"
-	"time"
 
 	authv0alphapb "github.com/cs3org/go-cs3apis/cs3/auth/v0alpha"
-	publicshareproviderv0alphapb "github.com/cs3org/go-cs3apis/cs3/publicshareprovider/v0alpha"
 	rpcpb "github.com/cs3org/go-cs3apis/cs3/rpc"
 	storageproviderv0alphapb "github.com/cs3org/go-cs3apis/cs3/storageprovider/v0alpha"
 	typespb "github.com/cs3org/go-cs3apis/cs3/types"
@@ -572,12 +570,12 @@ func userSharePermissions2OCSPermissions(sp *usershareproviderv0alphapb.SharePer
 	return permissionInvalid
 }
 
-func publicSharePermissions2OCSPermissions(sp *publicshareproviderv0alphapb.PublicSharePermissions) Permissions {
-	if sp != nil {
-		return permissions2OCSPermissions(sp.GetPermissions())
-	}
-	return permissionInvalid
-}
+// func publicSharePermissions2OCSPermissions(sp *publicshareproviderv0alphapb.PublicSharePermissions) Permissions {
+// 	if sp != nil {
+// 		return permissions2OCSPermissions(sp.GetPermissions())
+// 	}
+// 	return permissionInvalid
+// }
 
 // TODO(refs): uncomment when working on public shares
 // func (h *SharesHandler) publicShare2ShareData(share *publicshareproviderv0alphapb.PublicShare) *shareData {
@@ -604,9 +602,9 @@ func publicSharePermissions2OCSPermissions(sp *publicshareproviderv0alphapb.Publ
 
 // timestamp is assumed to be UTC ... just human readable ...
 // FIXME and ambiguous / error prone because there is no time zone ...
-func timestampToExpiration(t *typespb.Timestamp) string {
-	return time.Unix(int64(t.Seconds), int64(t.Nanos)).Format("2006-01-02 15:05:05")
-}
+// func timestampToExpiration(t *typespb.Timestamp) string {
+// 	return time.Unix(int64(t.Seconds), int64(t.Nanos)).Format("2006-01-02 15:05:05")
+// }
 
 // TODO sort out mapping, this is just a first guess
 func permissions2OCSPermissions(p *storageproviderv0alphapb.ResourcePermissions) Permissions {

--- a/cmd/revad/svcs/httpsvcs/ocssvc/shares.go
+++ b/cmd/revad/svcs/httpsvcs/ocssvc/shares.go
@@ -757,7 +757,7 @@ type shareType int
 const (
 	shareTypeUser shareType = 0
 	//	shareTypeGroup               ShareType = 1
-	shareTypePublicLink shareType = 3
+	// shareTypePublicLink shareType = 3
 	//	shareTypeFederatedCloudShare ShareType = 6
 )
 

--- a/cmd/revad/svcs/httpsvcs/ocssvc/shares.go
+++ b/cmd/revad/svcs/httpsvcs/ocssvc/shares.go
@@ -579,27 +579,28 @@ func publicSharePermissions2OCSPermissions(sp *publicshareproviderv0alphapb.Publ
 	return permissionInvalid
 }
 
-func (h *SharesHandler) publicShare2ShareData(share *publicshareproviderv0alphapb.PublicShare) *shareData {
-	sd := &shareData{
-		ID: share.Id.OpaqueId,
-		// TODO map share.resourceId to path and storage ... requires a stat call
-		// share.permissions ar mapped below
-		Permissions: publicSharePermissions2OCSPermissions(share.GetPermissions()),
-		ShareType:   shareTypePublicLink,
-		UIDOwner:    UserIDToString(share.Creator),
-		// TODO lookup user metadata
-		//DisplaynameOwner:     creator.DisplayName,
-		STime:        share.Ctime.Seconds, // TODO CS3 api birth time = btime
-		UIDFileOwner: UserIDToString(share.Owner),
-		// TODO lookup user metadata
-		//DisplaynameFileOwner: owner.DisplayName,
-		Token:      share.Token,
-		Expiration: timestampToExpiration(share.Expiration),
-	}
-	// actually clients should be able to GET and cache the user info themselves ...
-	// TODO check grantee type for user vs group
-	return sd
-}
+// TODO(refs): uncomment when working on public shares
+// func (h *SharesHandler) publicShare2ShareData(share *publicshareproviderv0alphapb.PublicShare) *shareData {
+// 	sd := &shareData{
+// 		ID: share.Id.OpaqueId,
+// 		// TODO map share.resourceId to path and storage ... requires a stat call
+// 		// share.permissions ar mapped below
+// 		Permissions: publicSharePermissions2OCSPermissions(share.GetPermissions()),
+// 		ShareType:   shareTypePublicLink,
+// 		UIDOwner:    UserIDToString(share.Creator),
+// 		// TODO lookup user metadata
+// 		//DisplaynameOwner:     creator.DisplayName,
+// 		STime:        share.Ctime.Seconds, // TODO CS3 api birth time = btime
+// 		UIDFileOwner: UserIDToString(share.Owner),
+// 		// TODO lookup user metadata
+// 		//DisplaynameFileOwner: owner.DisplayName,
+// 		Token:      share.Token,
+// 		Expiration: timestampToExpiration(share.Expiration),
+// 	}
+// 	// actually clients should be able to GET and cache the user info themselves ...
+// 	// TODO check grantee type for user vs group
+// 	return sd
+// }
 
 // timestamp is assumed to be UTC ... just human readable ...
 // FIXME and ambiguous / error prone because there is no time zone ...
@@ -875,13 +876,6 @@ type MatchValueData struct {
 }
 
 type resourceType int
-
-const (
-	invalid resourceType = iota
-	file
-	folder
-	reference
-)
 
 func (rt resourceType) String() (s string) {
 	switch rt {

--- a/cmd/revad/svcs/httpsvcs/ocssvc/shares.go
+++ b/cmd/revad/svcs/httpsvcs/ocssvc/shares.go
@@ -436,18 +436,6 @@ func isReshare(req *http.Request) bool {
 	return req.URL.Query().Get("reshares") != ""
 }
 
-// reshare requests require to be wrapped around <elements>
-func (h *SharesHandler) doReshareResponse(w http.ResponseWriter, r *http.Request, shares []*conversions.ShareData) {
-	out := make([]*conversions.Element, 0)
-
-	// wrap every item on an <element> type
-	for _, share := range shares {
-		out = append(out, &conversions.Element{Data: share})
-	}
-	WriteOCSSuccess(w, r, out)
-}
-
-// listShares bundles user and public shares
 func (h *SharesHandler) listShares(w http.ResponseWriter, r *http.Request) {
 	shares := make([]*conversions.ShareData, 0)
 
@@ -464,9 +452,9 @@ func (h *SharesHandler) listShares(w http.ResponseWriter, r *http.Request) {
 	// TODO(refs) horrendous syntax. Abstract it to a variadic function that uses the unpack operator on every argument and appends to result.
 	shares = append(shares, append(userShares, publicShares...)...)
 
-	// do something if reshares is present
 	if isReshare(r) {
-		h.doReshareResponse(w, r, shares)
+		// this request expects a V1 response - we need to wrap it on an <element> node
+		WriteOCSSuccess(w, r, &conversions.Element{Data: shares})
 		return
 	}
 

--- a/cmd/revad/svcs/httpsvcs/ocssvc/shares.go
+++ b/cmd/revad/svcs/httpsvcs/ocssvc/shares.go
@@ -1005,11 +1005,11 @@ type exactMatchesData struct {
 // matchData describes a single match
 type matchData struct {
 	Label string          `json:"label" xml:"label"`
-	Value *MatchValueData `json:"value" xml:"value"`
+	Value *matchValueData `json:"value" xml:"value"`
 }
 
-// MatchValueData holds the type and actual value
-type MatchValueData struct {
+// matchValueData holds the type and actual value
+type matchValueData struct {
 	ShareType int    `json:"shareType" xml:"shareType"`
 	ShareWith string `json:"shareWith" xml:"shareWith"`
 }
@@ -1078,7 +1078,7 @@ func getPublicShareManager(manager string, m map[string]map[string]interface{}) 
 func (h *SharesHandler) userAsMatch(u *authv0alphapb.User) *matchData {
 	return &matchData{
 		Label: u.DisplayName,
-		Value: &MatchValueData{
+		Value: &matchValueData{
 			ShareType: int(shareTypeUser),
 			// TODO(jfd) find more robust userid
 			// username might be ok as it is uniqe at a given point in time

--- a/cmd/revad/svcs/httpsvcs/ocssvc/shares.go
+++ b/cmd/revad/svcs/httpsvcs/ocssvc/shares.go
@@ -499,9 +499,13 @@ func (h *SharesHandler) listPublicShares(w http.ResponseWriter, r *http.Request)
 			return
 		}
 
-		fmt.Println(lst)
+		// transform into an ocs payload
+		ocsDataPayload := make([]*shareData, 0)
+		for _, share := range lst.Share {
+			ocsDataPayload = append(ocsDataPayload, h.publicShare2ShareData(share))
+		}
 
-		// convert the list of public shares into a ocs valid response
+		return ocsDataPayload
 	}
 
 	return

--- a/cmd/revad/svcs/httpsvcs/ocssvc/shares.go
+++ b/cmd/revad/svcs/httpsvcs/ocssvc/shares.go
@@ -431,7 +431,6 @@ func (h *SharesHandler) updateShare(w http.ResponseWriter, r *http.Request) {
 	WriteOCSSuccess(w, r, share)
 }
 
-// this probablt has to be handled at the handler level. v1 != v2. check ocssvc.go:87
 func isReshare(req *http.Request) bool {
 	return req.URL.Query().Get("reshares") != ""
 }

--- a/cmd/revad/svcs/httpsvcs/ocssvc/shares.go
+++ b/cmd/revad/svcs/httpsvcs/ocssvc/shares.go
@@ -486,7 +486,6 @@ func (h *SharesHandler) listPublicShares(w http.ResponseWriter, r *http.Request)
 	log := appctx.GetLogger(ctx)
 
 	if h.gatewaySvc != "" {
-		// get the public shares provider (pool?)
 		publicSharesProvider, err := pool.GetPublicShareProviderClient(h.gatewaySvc)
 		if err != nil {
 			log.Debug().Err(err).Str("service", "publicshareprovidersvc").Msg("error connecting to public shares provider")
@@ -494,9 +493,7 @@ func (h *SharesHandler) listPublicShares(w http.ResponseWriter, r *http.Request)
 			return
 		}
 
-		// get the public shares for the given user ([]*shareData)
-
-		// prepare a listPublicShares request. for which we need filters -> for which we'll use the ResourceId
+		// prepare a listPublicShares request
 		filters := []*publicshareproviderv0alphapb.ListPublicSharesRequest_Filter{}
 		req := publicshareproviderv0alphapb.ListPublicSharesRequest{
 			Filters: filters,
@@ -515,7 +512,7 @@ func (h *SharesHandler) listPublicShares(w http.ResponseWriter, r *http.Request)
 
 			// TODO(refs) abstract this boilerplate to a function
 			// at this point we are missing file info on the shareData. do stat and call h.addFileInfo
-			// check if the resource exists
+
 			sClient, err := pool.GetStorageProviderServiceClient(h.gatewaySvc)
 			if err != nil {
 				WriteOCSError(w, r, MetaServerError.StatusCode, "error getting grpc storage provider client", err)

--- a/cmd/revad/svcs/httpsvcs/ocssvc/shares.go
+++ b/cmd/revad/svcs/httpsvcs/ocssvc/shares.go
@@ -425,7 +425,6 @@ func (h *SharesHandler) updateShare(w http.ResponseWriter, r *http.Request) {
 func (h *SharesHandler) listShares(w http.ResponseWriter, r *http.Request) {
 	// TODO fetch group shares
 	// TODO fetch federated shares
-	// TODO fetch public link shares
 	shares := make([]*shareData, 0) // we need a zero value here, and new() is not a good practice
 	shares = append(shares, h.listUserShares(w, r)...)
 	shares = append(shares, h.listPublicShares(w, r)...)

--- a/cmd/revad/svcs/httpsvcs/oidcprovider/auth.go
+++ b/cmd/revad/svcs/httpsvcs/oidcprovider/auth.go
@@ -59,7 +59,7 @@ func (s *svc) doAuth(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
 		_, err := w.Write([]byte(fmt.Sprintf(`
 			<h1>Login page</h1>
-			<p>Howdy! This is the log in page. For this example, it is enough to supply the username.</p>
+			<p>Howdy! This is the log in page. It requires username and password</p>
 			<form method="post">
 				<p>
 					By logging in, you consent to grant these scopes:

--- a/cmd/revad/svcs/httpsvcs/oidcprovider/oidcprovider.go
+++ b/cmd/revad/svcs/httpsvcs/oidcprovider/oidcprovider.go
@@ -119,7 +119,7 @@ var start = compose.CommonStrategy{
 //
 //  session = new(fosite.DefaultSession)
 func newSession(username string, uid *typespb.UserId) *openid.DefaultSession {
-	return &openid.DefaultSession{
+	s := openid.DefaultSession{
 		Claims: &jwt.IDTokenClaims{
 			Issuer:  uid.Idp,
 			Subject: uid.OpaqueId,
@@ -135,10 +135,12 @@ func newSession(username string, uid *typespb.UserId) *openid.DefaultSession {
 		Subject:  uid.OpaqueId,
 		Username: username,
 	}
+	return &s
 }
 
 // emptySession creates a session object and fills it with safe defaults
 func emptySession() *openid.DefaultSession {
+	// why not getting user from context?
 	return newSession("", &typespb.UserId{})
 }
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/aws/aws-sdk-go v1.23.13
 	github.com/cheggaaa/pb v1.0.28
 	github.com/coreos/go-oidc v2.1.0+incompatible
-	github.com/cs3org/go-cs3apis v0.0.0-20190809124338-bd2fb913922c
+	github.com/cs3org/go-cs3apis v0.0.0-20191007135719-8a3d0e8a9e18
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/fatih/color v1.7.0 // indirect
 	github.com/go-openapi/strfmt v0.19.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -30,6 +30,8 @@ github.com/coreos/go-oidc v2.1.0+incompatible/go.mod h1:CgnwVTmzoESiwO9qyAFEMiHo
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/cs3org/go-cs3apis v0.0.0-20190809124338-bd2fb913922c h1:A2tEKdOhmucueGcaSNpzl3iJJTdGBsLjqXG2uYoWqxw=
 github.com/cs3org/go-cs3apis v0.0.0-20190809124338-bd2fb913922c/go.mod h1:xXet4ZmuUWqr/LATX9EGUIp8xq6Lk9wZK5dK8BZDCu4=
+github.com/cs3org/go-cs3apis v0.0.0-20191007135719-8a3d0e8a9e18 h1:G+AzVD66pAj0eSgVdim6fqu7ceAWg9LIqdN7fjdJwEU=
+github.com/cs3org/go-cs3apis v0.0.0-20191007135719-8a3d0e8a9e18/go.mod h1:+SahswLd+p4bLlXXG+UuNiWSgRin4dSQQOgPXCsdiTM=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/pkg/auth/manager/oidc/oidc.go
+++ b/pkg/auth/manager/oidc/oidc.go
@@ -193,6 +193,7 @@ func (am *mgr) Authenticate(ctx context.Context, clientID, token string) (contex
 			if err := json.Unmarshal(body, &ir); err != nil {
 				return ctx, fmt.Errorf("failed to parse claims: %v", err)
 			}
+
 			// verify the auth token is still active
 			if !ir.Active {
 				log.Debug().Interface("ir", ir).Str("body", string(body)).Msg("token no longer active")
@@ -209,7 +210,6 @@ func (am *mgr) Authenticate(ctx context.Context, clientID, token string) (contex
 			if err := userInfo.Claims(&claims); err != nil {
 				return ctx, fmt.Errorf("failed to unmarshal userinfo claims: %v", err)
 			}
-			claims.Iss = ir.Iss
 			log.Debug().Interface("claims", claims).Interface("userInfo", userInfo).Msg("unmarshalled userinfo")
 
 		default:

--- a/pkg/storage/fs/owncloud/owncloud.go
+++ b/pkg/storage/fs/owncloud/owncloud.go
@@ -149,7 +149,7 @@ func init() {
 type config struct {
 	DataDirectory string `mapstructure:"datadirectory"`
 	Scan          bool   `mapstructure:"scan"`
-	// Autocreate creates the neccessary folders for the file system to operate.
+	// Autocreate creates the necessary folders for the file system to operate.
 	// TODO(refs) if autocreate is set to false we need defensive code
 	Autocreate bool   `mapstructure:"autocreate"`
 	Redis      string `mapstructure:"redis"`
@@ -422,10 +422,18 @@ func readOrCreateID(ctx context.Context, np string, conn redis.Conn) string {
 
 // TODO(refs) this function assumes too much...
 func (fs *ocFS) autocreate(ctx context.Context, p string) {
+	log := appctx.GetLogger(ctx)
 	segments := strings.Split(p, "/") // TODO(refs) add defensive code at this point
 	home := path.Join("/", segments[1], segments[2])
-	fs.bootstrapDir(path.Join(home, filesDir))
-	fs.bootstrapDir(path.Join(home, filesVersionDir))
+	if err := fs.bootstrapDir(path.Join(home, filesDir)); err != nil {
+		log.Error().Err(err).Msg("error bootstraping /files dir")
+		return
+	}
+
+	if err := fs.bootstrapDir(path.Join(home, filesVersionDir)); err != nil {
+		log.Error().Err(err).Msg("error bootstraping /files_versions dir")
+		return
+	}
 }
 
 // bootstrap oC directories


### PR DESCRIPTION
see https://github.com/owncloud/ocis/issues/16. Once the logic runs, a refactor would be nice.

Features:
- [x] ~User shares~
- [x] ~Public shares~

Extras:
- [ ] Add reva command for listing public shares (hook it into `reva share-list` or create a new subcommand?)

new directive added: `publicshare_manager`

```toml
[http.services.ocssvc]
    publicshare_manager = "memory"
```