### PR TITLE
owncloud driver: Close files before we rename them

### DIFF
--- a/pkg/storage/fs/owncloud/owncloud.go
+++ b/pkg/storage/fs/owncloud/owncloud.go
@@ -959,10 +959,10 @@ func (fs *ocFS) Upload(ctx context.Context, ref *storageproviderv0alphapb.Refere
 	if err != nil {
 		return errors.Wrap(err, "ocFS: error creating tmp fn at "+path.Dir(np))
 	}
-	defer tmp.Close()
 	defer os.RemoveAll(tmp.Name())
 
 	_, err = io.Copy(tmp, r)
+	tmp.Close()
 	if err != nil {
 		return errors.Wrap(err, "ocFS: error writing to tmp file "+tmp.Name())
 	}


### PR DESCRIPTION
This fixes renaming on operation systems with file locking

@butonic 