### PR TITLE
fix path rewriting from CS3 to webdav if mounted with namespace

### DIFF
--- a/internal/http/services/owncloud/ocdav/ocdav.go
+++ b/internal/http/services/owncloud/ocdav/ocdav.go
@@ -114,7 +114,8 @@ func (s *svc) Handler() http.Handler {
 		}
 
 		// to build correct href prop urls we need to keep track of the base path
-		base := s.Prefix()
+		// always starts with /
+		base := path.Join("/", s.Prefix())
 
 		var head string
 		head, r.URL.Path = rhttp.ShiftPath(r.URL.Path)

--- a/internal/http/services/owncloud/ocdav/versions.go
+++ b/internal/http/services/owncloud/ocdav/versions.go
@@ -166,7 +166,7 @@ func (h *VersionsHandler) doListVersions(w http.ResponseWriter, r *http.Request,
 		infos = append(infos, vi)
 	}
 
-	propRes, err := s.formatPropfind(ctx, &pf, infos)
+	propRes, err := s.formatPropfind(ctx, &pf, infos, "")
 	if err != nil {
 		log.Error().Err(err).Msg("error formatting propfind")
 		w.WriteHeader(http.StatusInternalServerError)

--- a/internal/http/services/owncloud/ocdav/webdav.go
+++ b/internal/http/services/owncloud/ocdav/webdav.go
@@ -20,6 +20,7 @@ package ocdav
 
 import (
 	"net/http"
+	"path"
 )
 
 // WebDavHandler implements a dav endpoint
@@ -28,10 +29,7 @@ type WebDavHandler struct {
 }
 
 func (h *WebDavHandler) init(ns string) error {
-	h.namespace = ns
-	if h.namespace == "" {
-		h.namespace = "/"
-	}
+	h.namespace = path.Join("/", ns)
 	return nil
 }
 


### PR DESCRIPTION
when prefixing paths from the webdav to the cs3 namespace, the prefix needs to be removed again in propfind responses.