### PR TITLE
on import: allow specifying namespace prefix, trim '/files/' from files.jsonl

### DIFF
--- a/cmd/reva/import.go
+++ b/cmd/reva/import.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"path"
 
 	"github.com/cs3org/reva/pkg/storage/migrate"
 )
@@ -30,6 +31,9 @@ func importCommand() *command {
 	cmd := newCommand("import")
 	cmd.Description = func() string { return "import metadata" }
 	cmd.Usage = func() string { return "Usage: import [-flags] <user export folder>" }
+
+	namespaceFlag := cmd.String("n", "/", "CS3 namespace prefix")
+
 	cmd.Action = func() error {
 		if cmd.NArg() < 1 {
 			fmt.Println(cmd.Usage())
@@ -42,7 +46,14 @@ func importCommand() *command {
 		if err != nil {
 			return err
 		}
-		if err := migrate.ImportShares(ctx, client, exportPath); err != nil {
+
+		ns := path.Join("/", *namespaceFlag)
+
+		if err := migrate.ImportMetadata(ctx, client, exportPath, ns); err != nil {
+			log.Fatal(err)
+			return err
+		}
+		if err := migrate.ImportShares(ctx, client, exportPath, ns); err != nil {
 			log.Fatal(err)
 			return err
 		}

--- a/pkg/storage/migrate/shares.go
+++ b/pkg/storage/migrate/shares.go
@@ -49,7 +49,7 @@ type share struct {
 }
 
 //ImportShares from a shares.jsonl file in exportPath. The files must already be present on the storage
-func ImportShares(ctx context.Context, client gatewayv0alphapb.GatewayServiceClient, exportPath string) error {
+func ImportShares(ctx context.Context, client gatewayv0alphapb.GatewayServiceClient, exportPath string, ns string) error {
 
 	sharesJSONL, err := os.Open(path.Join(exportPath, "shares.jsonl"))
 	if err != nil {
@@ -66,7 +66,7 @@ func ImportShares(ctx context.Context, client gatewayv0alphapb.GatewayServiceCli
 		}
 
 		//Stat file, skip share creation if it does not exist on the target system
-		resourcePath := path.Join("/", path.Base(exportPath), shareData.Path)
+		resourcePath := path.Join(ns, path.Base(exportPath), shareData.Path)
 		statReq := &storageproviderv0alphapb.StatRequest{
 			Ref: &storageproviderv0alphapb.Reference{
 				Spec: &storageproviderv0alphapb.Reference_Path{Path: resourcePath},


### PR DESCRIPTION
the import file layout is expected to match the data_exporter export format described in https://github.com/owncloud/data_exporter/issues/118

it currently exports paths with an unnecessary `/files/` prefix. Tracked in https://github.com/owncloud/data_exporter/issues/111


