### PR TITLE
repair unquoted etags

### DIFF
--- a/internal/http/services/owncloud/ocdav/propfind.go
+++ b/internal/http/services/owncloud/ocdav/propfind.go
@@ -210,7 +210,11 @@ func (s *svc) mdToPropResponse(ctx context.Context, pf *propfindXML, md *storage
 		)
 
 		if md.Etag != "" {
-			response.Propstat[0].Prop = append(response.Propstat[0].Prop, s.newProp("d:getetag", md.Etag))
+			// etags must be enclosed in double quotes and cannot contain them.
+			// See https://tools.ietf.org/html/rfc7232#section-2.3 for details
+			// TODO(jfd) handle weak tags that start with 'W/'
+			etag := fmt.Sprintf("\"%s\"", strings.Trim(md.Etag, "\""))
+			response.Propstat[0].Prop = append(response.Propstat[0].Prop, s.newProp("d:getetag", etag))
 		}
 
 		if md.PermissionSet != nil {


### PR DESCRIPTION
repairs bad etags by stripping them of excess double quotes and enclosing them properly. helps with storage drivers that don't quote them or when they have been quoted too often.