### PR TITLE
move auth providers to corresponding frontends, clarify users instance

### DIFF
--- a/examples/separate/frontend-basic.toml
+++ b/examples/separate/frontend-basic.toml
@@ -4,12 +4,27 @@
 #   - /owncloud - ocdav
 #   - /ocs - ocs
 #   - TODO ocm
+# - authenticates requests using basic auth
+# - serves the grpc services on port 18001
 [core]
 max_cpus = "2"
-disable_grpc = true
 
 [log]
 level = "debug"
+
+[grpc]
+network = "tcp"
+address = "0.0.0.0:18001"
+enabled_services = [
+    "authprovider", # provides basic auth
+]
+enabled_interceptors = ["auth"]
+
+[grpc.services.authprovider]
+auth_manager = "json"
+
+[grpc.services.authprovider.auth_managers.json]
+users = "./examples/separate/users.demo.json"
 
 [http]
 enabled_services = ["ocdav", "ocs"]
@@ -23,13 +38,14 @@ credential_strategy = "basic"
 token_strategy = "header"
 token_writer = "header"
 token_manager = "jwt"
-skip_methods = ["/owncloud/status.php"]
+skip_methods = ["/status.php"]
 
 [http.middlewares.auth.token_managers.jwt]
 secret = "Pive-Fumkiu4"
 
 [http.services.ocdav]
-prefix = "owncloud"
+# serve ocdav on the root path
+prefix = ""
 chunk_folder = "/var/tmp/revad/chunks"
 # for user lookups
 gateway = "localhost:19000"

--- a/examples/separate/frontend-oidc.toml
+++ b/examples/separate/frontend-oidc.toml
@@ -1,11 +1,13 @@
-# This frontend.toml config file will start a reva service that:
-# - serves as the entypoint for all legacy owncloud requests
+# This frontend-oidc.toml config file will start a reva service that:
+# - serves as the entypoint for legacy owncloud requests
 # - serves http endpoints on port 20080
 #   - /owncloud - ocdav
 #   - /ocs - ocs
 #   - /oauth2 - oidcprovider
 #   - /.well-known - wellknown service to announce openid-configuration
 #   - TODO ocm
+# - authenticates requests using oidc bearer auth
+# - serves the grpc services on port 18002
 [core]
 max_cpus = "2"
 
@@ -13,14 +15,13 @@ max_cpus = "2"
 level = "debug"
 
 [grpc]
-address = "0.0.0.0:18001"
+address = "0.0.0.0:18002"
 enabled_services = [
     "authprovider"
 ]
 
 [grpc.services.authprovider]
 auth_manager = "oidc"
-userprovidersvc = "http://localhost:20080"
 
 [grpc.services.authprovider.auth_managers.oidc]
 # If you want to use your own openid provider change this config
@@ -111,6 +112,7 @@ client_secret = "$2a$10$IxMdI6d.LIRZPpSfEwNoeu4rY3FhDREsxFJXikcgdRRAStxUlsuEO"  
 scopes = ["openid", "profile", "email", "offline"]
 
 [http.services.ocdav]
+# serve ocdav on the root path
 prefix = ""
 chunk_folder = "/var/tmp/revad/chunks"
 # for user lookups

--- a/examples/separate/gateway.toml
+++ b/examples/separate/gateway.toml
@@ -41,9 +41,10 @@ secret = "Pive-Fumkiu4"
 authregistrysvc = "localhost:19000"
 storageregistrysvc = "localhost:19000"
 appregistrysvc = "localhost:19000"
-# auth and user metadata
+# user metadata
 preferencessvc = "localhost:18000"
 userprovidersvc = "localhost:18000"
+# an approvider lives on "localhost:18000" as well, see users.toml
 # sharing
 usershareprovidersvc = "localhost:17000"
 publicshareprovidersvc = "localhost:17000"
@@ -62,23 +63,18 @@ secret = "Pive-Fumkiu4"
 driver = "static"
 
 [grpc.services.appregistry.static.rules]
-# TODO 
-".txt" = "localhost:16000"
-"text/plain" = "localhost:16000"
-
-# TODO move to a dedicated approvider.toml
-#[grpc.services.appprovider]
-#driver = "demo"
-#[grpc.services.appprovider.demo]
-#iframe_ui_provider = "http://localhost:16000/iframeuisvc"
+# TODO implement user specifir app registry
+".txt" = "localhost:18000"
+"text/plain" = "localhost:18000"
 
 [grpc.services.authregistry]
 driver = "static"
 
 [grpc.services.authregistry.drivers.static.rules]
-basic = "localhost:18000"
-# needs to be started as a second service using the frontend-oidc.toml
-oidc = "localhost:18001"
+# started with the frontend-basic.toml
+basic = "localhost:18001"
+# started with the frontend-oidc.toml
+oidc = "localhost:18002"
 
 [grpc.services.storageregistry]
 driver = "static"

--- a/examples/separate/shares.toml
+++ b/examples/separate/shares.toml
@@ -1,0 +1,28 @@
+# This storage.toml config file will start a reva service that:
+# - authenticates grpc storage provider requests using the internal jwt token
+# - authenticates http upload and download requests requests using basic auth
+# - serves the storage provider on grpc port 11000
+# - serves http dataprovider for this storage on port 11001
+#   - /data - dataprovider: file up and download
+[core]
+max_cpus = "2"
+
+[log]
+level = "debug"
+
+[grpc]
+address = "0.0.0.0:17000"
+enabled_services = ["usershareprovider", "publicshareprovider"] # TODO ocmshareprovider
+enabled_interceptors = ["auth"]
+
+[grpc.services.usershareprovider]
+driver = "memory"
+
+[grpc.services.publicshareprovider]
+driver = "memory"
+
+[grpc.interceptors.auth]
+token_manager = "jwt"
+
+[grpc.interceptors.auth.token_managers.jwt]
+secret = "Pive-Fumkiu4"

--- a/examples/separate/storage-home.toml
+++ b/examples/separate/storage-home.toml
@@ -23,6 +23,7 @@ enabled_interceptors = ["auth"]
 # This is a storage proider that grants direct acces to the wrapped storage
 [grpc.services.storageprovider]
 driver = "owncloud"
+# the context path wrapper reads tho username from the context and prefixes the relative storage path with it
 path_wrapper = "context"
 mount_path = "/home/"
 # TODO same storage id as the /oc/ storage provider

--- a/examples/separate/users.toml
+++ b/examples/separate/users.toml
@@ -1,5 +1,5 @@
-# This auth.toml config file will start a reva service that:
-# - handles authentication, users and user preferences
+# This users.toml config file will start a reva service that:
+# - handles user metadata and user preferences
 # - serves the grpc services on port 18000
 [core]
 max_cpus = "2"
@@ -12,18 +12,17 @@ level = "debug"
 network = "tcp"
 address = "0.0.0.0:18000"
 enabled_services = [
-    "authprovider", # provides basic auth
+    "approvider",
     "userprovider", # provides user matadata (used to look up email, displayname etc after a login)
     "preferences",  # provides user preferences
 ]
 enabled_interceptors = ["auth"]
 
-[grpc.services.authprovider]
-auth_manager = "json"
-userprovidersvc = "localhost:18000"
+[grpc.services.appprovider]
+driver = "demo"
 
-[grpc.services.authprovider.auth_managers.json]
-users = "./examples/separate/users.demo.json"
+[grpc.services.appprovider.demo]
+iframe_ui_provider = "http://localhost:19500/iframeui"
 
 [grpc.services.userprovider]
 driver = "json"
@@ -35,9 +34,13 @@ users = "./examples/separate/users.demo.json"
 token_manager = "jwt"
 skip_methods = [
     # we need to allow calls that happen during authentication
-	"/cs3.authproviderv0alpha.AuthProviderService/Authenticate",
 	"/cs3.userproviderv0alpha.UserProviderService/GetUser",
 ]
 
 [grpc.interceptors.auth.token_managers.jwt]
 secret = "Pive-Fumkiu4"
+
+# TODO bring back iframe app ui demo
+#[http]
+#address = "0.0.0.0:19500"
+#enabled_services = ["iframeui"]

--- a/internal/grpc/services/authprovider/authprovider.go
+++ b/internal/grpc/services/authprovider/authprovider.go
@@ -39,9 +39,8 @@ func init() {
 }
 
 type config struct {
-	AuthManager          string                            `mapstructure:"auth_manager"`
-	AuthManagers         map[string]map[string]interface{} `mapstructure:"auth_managers"`
-	UserProviderEndpoint string                            `mapstructure:"userprovidersvc"`
+	AuthManager  string                            `mapstructure:"auth_manager"`
+	AuthManagers map[string]map[string]interface{} `mapstructure:"auth_managers"`
 }
 
 type service struct {


### PR DESCRIPTION
- move auth providers to corresponding frontends
- rename auth.toml to users.toml
- start approvider in users.toml
- add shares.toml
-get rid of unneded config

should clarify a few things. will add a drawio diagram to clean this up ... or hope that @refs  has an automatic way to render a nice graph ;-)