### PR TITLE
allow eos to use keytab for authentication rather than gw

### DIFF
--- a/pkg/eosclient/eosclient.go
+++ b/pkg/eosclient/eosclient.go
@@ -52,6 +52,9 @@ type Options struct {
 	// This is the case when access to EOS is done from FUSE under apache or www-data.
 	ForceSingleUserMode bool
 
+	// UseKeyTabAuth changes will authenticate requests by using an EOS keytab.
+	UseKeytab bool
+
 	// SingleUsername is the username to use when connecting to EOS.
 	// Defaults to apache
 	SingleUsername string
@@ -71,6 +74,13 @@ type Options struct {
 	// Location on the local fs where to store reads.
 	// Defaults to os.TempDir()
 	CacheDirectory string
+
+	// Keytab is the location of the EOS keytab file.
+	Keytab string
+
+	// SecProtocol is the comma separated list of security protocols used by xrootd.
+	// For example: "sss, unix"
+	SecProtocol string
 }
 
 func (opt *Options) init() {
@@ -126,6 +136,11 @@ func (c *Client) execute(ctx context.Context, cmd *exec.Cmd) (string, string, er
 	cmd.Stderr = errBuf
 	cmd.Env = []string{
 		"EOS_MGM_URL=" + c.opt.URL,
+	}
+
+	if c.opt.UseKeytab {
+		cmd.Env = append(cmd.Env, "XrdSecPROTOCOL="+c.opt.SecProtocol)
+		cmd.Env = append(cmd.Env, "XrdSecSSSKT="+c.opt.Keytab)
 	}
 
 	err := cmd.Run()

--- a/pkg/storage/fs/eos/eos.go
+++ b/pkg/storage/fs/eos/eos.go
@@ -162,6 +162,14 @@ func New(m map[string]interface{}) (storage.FS, error) {
 	}
 	c.init()
 
+	// bail out if keytab is not found.
+	if c.UseKeytab {
+		if _, err := os.Stat(c.Keytab); err != nil {
+			err = errors.Wrapf(err, "eos: keytab not accesible at location: %s", err)
+			return nil, err
+		}
+	}
+
 	eosClientOpts := &eosclient.Options{
 		XrdcopyBinary:       c.XrdcopyBinary,
 		URL:                 c.MasterURL,

--- a/pkg/storage/fs/eos/eos.go
+++ b/pkg/storage/fs/eos/eos.go
@@ -105,6 +105,15 @@ type config struct {
 	// ForceSingleUserMode will force connections to EOS to use SingleUsername
 	ForceSingleUserMode bool `mapstructure:"force_single_user_mode"`
 
+	// UseKeyTabAuth changes will authenticate requests by using an EOS keytab.
+	UseKeytab bool `mapstrucuture:"use_keytab"`
+
+	// SecProtocol specifies the xrootd security protocol to use between the server and EOS.
+	SecProtocol string `mapstructure:"sec_protocol"`
+
+	// Keytab specifies the location of the keytab to use to authenticate to EOS.
+	Keytab string `mapstructure:"keytab"`
+
 	// SingleUsername is the username to use when SingleUserMode is enabled
 	SingleUsername string `mapstructure:"single_username"`
 }
@@ -160,6 +169,9 @@ func New(m map[string]interface{}) (storage.FS, error) {
 		CacheDirectory:      c.CacheDirectory,
 		ForceSingleUserMode: c.ForceSingleUserMode,
 		SingleUsername:      c.SingleUsername,
+		UseKeytab:           c.UseKeytab,
+		Keytab:              c.Keytab,
+		SecProtocol:         c.SecProtocol,
 	}
 
 	eosClient := eosclient.New(eosClientOpts)


### PR DESCRIPTION
Current EOS authentication relies on trusted gateways.

This change allows the connection from the storage provider to EOS by relying on EOS shared secrets, known as keytabs.