### PR TITLE
sort out namespaces, fake root storage

### DIFF
--- a/examples/separate/frontend.toml
+++ b/examples/separate/frontend.toml
@@ -128,9 +128,26 @@ gateway = "localhost:19000"
 # can prefix the path to jail the requests to the correct CS3 namespace.
 # In this deployment we mounted the owncloud storage provider at /oc. It
 # expects a username as the first path segment.
-files_namespace = "/oc/"
+files_namespace = "/"
+# currently, only the desktop client will use this endpoint, but only if
+# the dav.chunking capability is available
+# TODO implement a path wrapper that rewrites `<username>` into the path
+# layout for the users home?
+# no, use GetHome?
+# for eos we need to rewrite the path
+# TODO strip the username from the path so the CS3 namespace can be mounted
+# at the files/<username> endpoint? what about migration? separate reva instance
+
 # similar to the dav/files endpoint we can configure a prefix for the old webdav endpoint
-webdav_namespace = "/home/"
+# we use the old webdav endpoint to present the cs3 namespace
+webdav_namespace = "/"
+# note: this changes the tree that is rendered at remote.php/webdav from the users home to the cs3 namespace
+# use webdav_namespace = "/home" to use the old namespace that only exposes the users files
+# this endpoint should not affect the desktop client sync but will present different folders for the other clients:
+# - the desktop clients use a hardcoded remote.php/dav/files/<username> if the dav.chunkung capability is present
+# - the ios ios uses the core.webdav-root capability which points to remote.php/webdav in oc10
+# - the oc js sdk is hardcoded to the remote.php/webdav so it will see the new tree
+# - TODO android? no sync ... but will see different tree
 
 [http.services.ocs]
 # prefix = "ocs"

--- a/examples/separate/gateway.toml
+++ b/examples/separate/gateway.toml
@@ -80,6 +80,9 @@ bearer = "localhost:20099"
 driver = "static"
 
 [grpc.services.storageregistry.drivers.static.rules]
+# this is the list of namespaces that build the cs3 namespace
+# - every storage as mounted in the root
+
 # mount a home storage provider that uses a context based path wrapper
 # to jail users into their home dir
 "/home" = "localhost:12000"
@@ -89,6 +92,8 @@ driver = "static"
 # mount a storage provider without a path wrapper for direct access to files
 "/oc" = "localhost:11000"
 "123e4567-e89b-12d3-a456-426655440000" = "localhost:11000"
+"/" = "localhost:11100"
+"123e4567-e89b-12d3-a456-426655440001" = "localhost:11100"
 
 # another mount point might be "/projects/" 
 
@@ -104,8 +109,7 @@ transfer_shared_secret = "replace-me-with-a-transfer-secret"
 
 [http.middlewares.auth]
 gatewaysvc = "0.0.0.0:19000"
-auth_type = "basic"
-credential_strategy = "basic"
+credential_chain = ["basic", "bearer"]
 token_strategy = "header"
 token_writer = "header"
 token_manager = "jwt"

--- a/examples/separate/storage-home.toml
+++ b/examples/separate/storage-home.toml
@@ -57,8 +57,7 @@ enabled_middlewares = ["auth"]
 
 [http.middlewares.auth]
 gatewaysvc = "localhost:19000"
-auth_type = "basic"
-credential_strategy = "basic"
+credential_chain = ["basic", "bearer"]
 token_strategy = "header"
 token_writer = "header"
 token_manager = "jwt"

--- a/examples/separate/storage-oc.toml
+++ b/examples/separate/storage-oc.toml
@@ -46,8 +46,7 @@ enabled_middlewares = ["auth"]
 
 [http.middlewares.auth]
 gatewaysvc = "localhost:19000"
-auth_type = "basic"
-credential_strategy = "basic"
+credential_chain = ["basic", "bearer"]
 token_strategy = "header"
 token_writer = "header"
 token_manager = "jwt"

--- a/examples/separate/storage-root.toml
+++ b/examples/separate/storage-root.toml
@@ -1,0 +1,49 @@
+# This storage-root.toml config file will start a reva service that:
+# - authenticates grpc storage provider requests using the internal jwt token
+# - serves a root storage provider on grpc port 11100
+
+# it is used to render the root namespace. you need to create a folder
+# layout in "/var/tmp/reva/root" that matches the storage registry:
+# tree /var/tmp/reva/root should give for this example
+# /var/tmp/reva/root
+# ├── home
+# └── oc
+# that will allow you to list the existing namespaces.
+# TODO either make the gateway return a proper ListCollection for the root,
+# TODO or implement a virtual storage that implements this
+
+[core]
+max_cpus = "2"
+disable_http = true
+
+[log]
+level = "debug"
+
+[grpc]
+network = "tcp"
+address = "0.0.0.0:11100"
+enabled_services = ["storageprovider"]
+enabled_interceptors = ["auth"]
+
+# This is a storage proider that grants direct acces to the wrapped storage
+[grpc.services.storageprovider]
+driver = "local"
+mount_path = "/"
+# if we have an id, we can directly go to that storage, no need to wrap paths
+mount_id = "123e4567-e89b-12d3-a456-426655440001"
+
+[grpc.services.storageprovider.available_checksums]
+md5   = 100
+unset = 1000
+
+[grpc.services.storageprovider.drivers.local]
+root = "/var/tmp/reva/root"
+
+[grpc.services.storageprovider.path_wrappers.context]
+prefix = ""
+
+[grpc.interceptors.auth]
+token_manager = "jwt"
+
+[grpc.interceptors.auth.token_managers.jwt]
+secret = "Pive-Fumkiu4"

--- a/pkg/storage/fs/owncloud/owncloud.go
+++ b/pkg/storage/fs/owncloud/owncloud.go
@@ -269,19 +269,24 @@ func (fs *ocFS) scanFiles(ctx context.Context, conn redis.Conn) {
 // and prefix the datadirectory
 // TODO the path handed to a storage provider should not contain the username
 func (fs *ocFS) getInternalPath(ctx context.Context, fn string) string {
-	// p = /<username> or
-	// p = /<username>/foo/bar.txt
-	parts := strings.SplitN(fn, "/", 3)
+	// trim all /
+	fn = strings.Trim(fn, "/")
+	// p = "" or
+	// p = <username> or
+	// p = <username>/foo/bar.txt
+	parts := strings.SplitN(fn, "/", 2)
 
 	switch len(parts) {
-	case 2:
-		// parts = "", "<username>"
-		return path.Join(fs.c.DataDirectory, parts[1], "files")
-	case 3:
-		// parts = "", "<username>", "foo/bar.txt"
-		return path.Join(fs.c.DataDirectory, parts[1], "files", parts[2])
+	case 1:
+		// parts = "" or "<username>"
+		if parts[0] == "" {
+			return fs.c.DataDirectory
+		}
+		// parts = "<username>"
+		return path.Join(fs.c.DataDirectory, parts[0], "files")
 	default:
-		return "" // TODO Must not happen?
+		// parts = "<username>", "foo/bar.txt"
+		return path.Join(fs.c.DataDirectory, parts[0], "files", parts[1])
 	}
 }
 

--- a/pkg/storage/pw/context/context.go
+++ b/pkg/storage/pw/context/context.go
@@ -21,6 +21,7 @@ package context
 import (
 	"context"
 	"path"
+	"strings"
 
 	"github.com/cs3org/reva/pkg/errtypes"
 	"github.com/cs3org/reva/pkg/storage"
@@ -82,5 +83,12 @@ func (pw *pw) Unwrap(ctx context.Context, rp string) (string, error) {
 	return path.Join("/", pw.prefix, u.Username, rp), nil
 }
 func (pw *pw) Wrap(ctx context.Context, rp string) (string, error) {
-	return rp, nil
+	u, ok := user.ContextGetUser(ctx)
+	if !ok {
+		return "", errors.Wrap(errtypes.UserRequired("userrequired"), "error getting user from ctx")
+	}
+	if u.Username == "" {
+		return "", errors.Wrap(errtypes.UserRequired("userrequired"), "user has no username")
+	}
+	return strings.TrimPrefix(rp, path.Join("/", u.Username)), nil
 }


### PR DESCRIPTION
working towards https://github.com/owncloud/ocis/issues/44

- mounts the cs3 namespace on both webdav endpoints
- fakes a root storage provider to be able to list the mounted storages
  - read the storage-root.toml to set this up properly
- [x] navigating into /home works
- [x] navigating into /oc does not work because the oc storage expects the username in the path.
  - we could enable the path wrapper, but then it would behave exactly like the /home storage
  - it should list the existing users ... 
- [x] fixes navigating into folders
- [ ] check if sharing now uses absolute paths, cc @refs 
  - after making sharing work again ...

@labkode I currently fake a root storage with a local storage, because the gateway can currently not list the root of the namespace if nothing is mounted there. But for an example this works nicely. One thing I realized is that the etag will not be propagated to the root in the CS3 namespace. I'll add that to https://github.com/owncloud/ocis/issues/44