### PR TITLE
hardcode basic auth for openidconnect internal authentication

### DIFF
--- a/examples/separate/frontend.toml
+++ b/examples/separate/frontend.toml
@@ -88,7 +88,6 @@ userinfo_endpoint = "http://localhost:20080/oauth2/userinfo"
 [http.services.oidcprovider]
 prefix = "oauth2"
 gateway = "localhost:19000"
-auth_type = "basic"
 issuer = "http://localhost:20080"
 
 [http.services.oidcprovider.clients.phoenix]

--- a/internal/http/services/oidcprovider/auth.go
+++ b/internal/http/services/oidcprovider/auth.go
@@ -57,8 +57,6 @@ func (s *svc) doAuth(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// TODO(labkode): this should be a flexible mechanism to
-	// use any kind of authentication, basic auth, SSO, anything ...
 	username := r.PostForm.Get("username")
 	password := r.PostForm.Get("password")
 	// No username we ask to give one, here we provide only a form validation.
@@ -92,7 +90,7 @@ func (s *svc) doAuth(w http.ResponseWriter, r *http.Request) {
 	}
 
 	genReq := &gatewayv0alphapb.AuthenticateRequest{
-		Type:         s.conf.AuthType,
+		Type:         "basic", // we are sending username and password -> basic auth
 		ClientId:     username,
 		ClientSecret: password,
 	}

--- a/internal/http/services/oidcprovider/oidcprovider.go
+++ b/internal/http/services/oidcprovider/oidcprovider.go
@@ -21,7 +21,6 @@ package oidcprovider
 import (
 	"crypto/rand"
 	"crypto/rsa"
-	"fmt"
 	"net/http"
 	"time"
 
@@ -44,7 +43,6 @@ func init() {
 
 type config struct {
 	Prefix          string                            `mapstructure:"prefix"`
-	AuthType        string                            `mapstructure:"auth_type"`
 	GatewayEndpoint string                            `mapstructure:"gateway"`
 	Clients         map[string]map[string]interface{} `mapstructure:"clients"`
 	Issuer          string                            `mapstructure:"issuer"`
@@ -81,9 +79,6 @@ func New(m map[string]interface{}) (rhttp.Service, error) {
 		c.Prefix = "oauth2"
 	}
 
-	if c.AuthType == "" {
-		return nil, fmt.Errorf("oidcprovidersvc: auth_type cannot be empty")
-	}
 	// parse clients
 	clients := map[string]fosite.Client{}
 	for id, val := range c.Clients {


### PR DESCRIPTION
The openidconnect provider always uses a simple basic auth to verify credentials. Let us not confuse people by providing an unused config option. The build in oidc provider is NOT secure. It only works for development and testing. In production a proper oidc provider should be used. No need to add fancy stuff here.