### PR TITLE
Fix auth skip

### DIFF
--- a/internal/http/interceptors/auth/auth.go
+++ b/internal/http/interceptors/auth/auth.go
@@ -76,9 +76,11 @@ func parseConfig(m map[string]interface{}) (*config, error) {
 	return c, nil
 }
 
-func skip(url string, skipped []string) bool {
-	for i := range skipped {
-		if strings.HasPrefix(skipped[i], url) {
+// skip evaluates whether a source url is a subpath of base
+// i.e: /a/b/c/d/e is a subpath of /a/b/c
+func skip(source string, base []string) bool {
+	for i := range base {
+		if strings.HasPrefix(source, base[i]) {
 			return true
 		}
 	}

--- a/internal/http/interceptors/auth/auth_test.go
+++ b/internal/http/interceptors/auth/auth_test.go
@@ -1,0 +1,44 @@
+// Copyright 2018-2019 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package auth
+
+import "testing"
+
+var skipTests = []struct {
+	name string
+	url  string
+	base []string
+	out  bool
+}{
+	{"valid subpath", "/a/b/c/d", []string{"/a/b/"}, true},
+	{"invalid subpath", "/a/b/c", []string{"/a/b/c/d"}, false},
+	{"equal values", "/a/b/c", []string{"/a/b/c"}, true},
+}
+
+func TestSkip(t *testing.T) {
+	for _, tt := range skipTests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			r := skip(tt.url, tt.base)
+			if r != tt.out {
+				t.Errorf("expected %v, want %v", r, tt.out)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# What?

The `auth` package does url (sub)path comparison the other way around. Introduced [here](https://github.com/cs3org/reva/commit/fa6c31c69dd5fb3048bdda0486d73475b547c763#diff-5ce7cebb8069150f098ace199a6ac9bbR79-R84).

Behavior captured on unit tests.