### PR TITLE
return user on auth

### DIFF
--- a/internal/grpc/services/authprovider/authprovider.go
+++ b/internal/grpc/services/authprovider/authprovider.go
@@ -106,7 +106,7 @@ func (s *service) Authenticate(ctx context.Context, req *authproviderv0alphapb.A
 	log.Info().Msgf("user %s authenticated", uid.String())
 	res := &authproviderv0alphapb.AuthenticateResponse{
 		Status: status.NewOK(ctx),
-		UserId: uid,
+		User:   uid,
 	}
 	return res, nil
 }

--- a/internal/http/services/oidcprovider/auth.go
+++ b/internal/http/services/oidcprovider/auth.go
@@ -111,7 +111,7 @@ func (s *svc) doAuth(w http.ResponseWriter, r *http.Request) {
 	// Once the authentication is successful, we have a user id that has been
 	// validated, to fill other fields we need the user information also.
 
-	uid := genRes.UserId
+	uid := genRes.User.Id
 
 	getUserReq := &userproviderv0alphapb.GetUserRequest{
 		UserId: uid,

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -23,12 +23,12 @@ import (
 	"net/http"
 
 	authregistryv0alphapb "github.com/cs3org/go-cs3apis/cs3/authregistry/v0alpha"
-	typespb "github.com/cs3org/go-cs3apis/cs3/types"
+	userproviderv0alphapb "github.com/cs3org/go-cs3apis/cs3/userprovider/v0alpha"
 )
 
 // Manager is the interface to implement to authenticate users
 type Manager interface {
-	Authenticate(ctx context.Context, clientID, clientSecret string) (*typespb.UserId, error)
+	Authenticate(ctx context.Context, clientID, clientSecret string) (*userproviderv0alphapb.User, error)
 }
 
 // Credentials contains the auth type, client id and secret.

--- a/pkg/auth/manager/demo/demo.go
+++ b/pkg/auth/manager/demo/demo.go
@@ -22,6 +22,7 @@ import (
 	"context"
 
 	typespb "github.com/cs3org/go-cs3apis/cs3/types"
+	userproviderv0alphapb "github.com/cs3org/go-cs3apis/cs3/userprovider/v0alpha"
 	"github.com/cs3org/reva/pkg/auth"
 	"github.com/cs3org/reva/pkg/auth/manager/registry"
 	"github.com/cs3org/reva/pkg/errtypes"
@@ -37,7 +38,7 @@ type manager struct {
 
 // Credentials holds a pair of secret and userid
 type Credentials struct {
-	ID     *typespb.UserId
+	User   *userproviderv0alphapb.User
 	Secret string
 }
 
@@ -48,10 +49,10 @@ func New(m map[string]interface{}) (auth.Manager, error) {
 	return &manager{credentials: creds}, nil
 }
 
-func (m *manager) Authenticate(ctx context.Context, clientID, clientSecret string) (*typespb.UserId, error) {
+func (m *manager) Authenticate(ctx context.Context, clientID, clientSecret string) (*userproviderv0alphapb.User, error) {
 	if c, ok := m.credentials[clientID]; ok {
 		if c.Secret == clientSecret {
-			return c.ID, nil
+			return c.User, nil
 		}
 	}
 	return nil, errtypes.InvalidCredentials(clientID)
@@ -61,23 +62,41 @@ func getCredentials() map[string]Credentials {
 	return map[string]Credentials{
 		"einstein": Credentials{
 			Secret: "relativity",
-			ID: &typespb.UserId{
-				OpaqueId: "4c510ada-c86b-4815-8820-42cdf82c3d51",
-				Idp:      "http://localhost:9998",
+			User: &userproviderv0alphapb.User{
+				Id: &typespb.UserId{
+					Idp:      "http://localhost:9998",
+					OpaqueId: "4c510ada-c86b-4815-8820-42cdf82c3d51",
+				},
+				Username:    "einstein",
+				Groups:      []string{"sailing-lovers", "violin-haters", "physics-lovers"},
+				Mail:        "einstein@example.org",
+				DisplayName: "Albert Einstein",
 			},
 		},
 		"marie": Credentials{
 			Secret: "radioactivity",
-			ID: &typespb.UserId{
-				OpaqueId: "f7fbf8c8-139b-4376-b307-cf0a8c2d0d9c",
-				Idp:      "http://localhost:9998",
+			User: &userproviderv0alphapb.User{
+				Id: &typespb.UserId{
+					Idp:      "http://localhost:9998",
+					OpaqueId: "f7fbf8c8-139b-4376-b307-cf0a8c2d0d9c",
+				},
+				Username:    "marie",
+				Groups:      []string{"radium-lovers", "polonium-lovers", "physics-lovers"},
+				Mail:        "marie@example.org",
+				DisplayName: "Marie Curie",
 			},
 		},
 		"richard": Credentials{
 			Secret: "superfluidity",
-			ID: &typespb.UserId{
-				OpaqueId: "932b4540-8d16-481e-8ef4-588e4b6b151c",
-				Idp:      "http://localhost:9998",
+			User: &userproviderv0alphapb.User{
+				Id: &typespb.UserId{
+					Idp:      "http://localhost:9998",
+					OpaqueId: "932b4540-8d16-481e-8ef4-588e4b6b151c",
+				},
+				Username:    "richard",
+				Groups:      []string{"quantum-lovers", "philosophy-haters", "physics-lovers"},
+				Mail:        "richard@example.org",
+				DisplayName: "Richard Feynman",
 			},
 		},
 	}

--- a/pkg/auth/manager/impersonator/impersonator.go
+++ b/pkg/auth/manager/impersonator/impersonator.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	typespb "github.com/cs3org/go-cs3apis/cs3/types"
+	userproviderv0alphapb "github.com/cs3org/go-cs3apis/cs3/userprovider/v0alpha"
 	"github.com/cs3org/reva/pkg/auth"
 	"github.com/cs3org/reva/pkg/auth/manager/registry"
 )
@@ -38,7 +39,7 @@ func New(c map[string]interface{}) (auth.Manager, error) {
 	return &mgr{}, nil
 }
 
-func (m *mgr) Authenticate(ctx context.Context, clientID, clientSecret string) (*typespb.UserId, error) {
+func (m *mgr) Authenticate(ctx context.Context, clientID, clientSecret string) (*userproviderv0alphapb.User, error) {
 	// allow passing in uid as <opaqueid>@<idp>
 	at := strings.LastIndex(clientID, "@")
 	uid := &typespb.UserId{}
@@ -48,5 +49,8 @@ func (m *mgr) Authenticate(ctx context.Context, clientID, clientSecret string) (
 		uid.OpaqueId = clientID[:at]
 		uid.Idp = clientID[at+1:]
 	}
-	return uid, nil
+	return &userproviderv0alphapb.User{
+		Id: uid,
+		// not much else to provide
+	}, nil
 }

--- a/pkg/auth/manager/impersonator/impersonator_test.go
+++ b/pkg/auth/manager/impersonator/impersonator_test.go
@@ -26,27 +26,27 @@ import (
 func TestImpersonator(t *testing.T) {
 	ctx := context.Background()
 	i, _ := New(nil)
-	uid, err := i.Authenticate(ctx, "admin", "pwd")
+	u, err := i.Authenticate(ctx, "admin", "pwd")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if uid.OpaqueId != "admin" {
-		t.Errorf("%#v, wanted %#v", uid.OpaqueId, "admin")
+	if u.Id.OpaqueId != "admin" {
+		t.Errorf("%#v, wanted %#v", u.Id.OpaqueId, "admin")
 	}
-	if uid.Idp != "" {
-		t.Errorf("%#v, wanted %#v", uid.Idp, "")
+	if u.Id.Idp != "" {
+		t.Errorf("%#v, wanted %#v", u.Id.Idp, "")
 	}
 
 	ctx = context.Background()
-	uid, err = i.Authenticate(ctx, "opaqueid@idp", "pwd")
+	u, err = i.Authenticate(ctx, "opaqueid@idp", "pwd")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if uid.OpaqueId != "opaqueid" {
-		t.Errorf("%#v, wanted %#v", uid.OpaqueId, "opaqueid")
+	if u.Id.OpaqueId != "opaqueid" {
+		t.Errorf("%#v, wanted %#v", u.Id.OpaqueId, "opaqueid")
 	}
-	if uid.Idp != "idp" {
-		t.Errorf("%#v, wanted %#v", uid.Idp, "idp")
+	if u.Id.Idp != "idp" {
+		t.Errorf("%#v, wanted %#v", u.Id.Idp, "idp")
 	}
 }

--- a/pkg/auth/manager/json/json.go
+++ b/pkg/auth/manager/json/json.go
@@ -24,6 +24,7 @@ import (
 	"io/ioutil"
 
 	typespb "github.com/cs3org/go-cs3apis/cs3/types"
+	userproviderv0alphapb "github.com/cs3org/go-cs3apis/cs3/userprovider/v0alpha"
 	"github.com/cs3org/reva/pkg/auth"
 	"github.com/cs3org/reva/pkg/auth/manager/registry"
 	"github.com/cs3org/reva/pkg/errtypes"
@@ -37,9 +38,13 @@ func init() {
 
 // Credentials holds a pair of secret and userid
 type Credentials struct {
-	ID       *typespb.UserId `mapstructure:"id"`
-	Username string          `mapstructure:"username"`
-	Secret   string          `mapstructure:"secret"`
+	ID           *typespb.UserId `mapstructure:"id"`
+	Username     string          `mapstructure:"username"`
+	Mail         string          `mapstructure:"mail"`
+	MailVerified bool            `mapstructure:"mail_verified"`
+	DisplayName  string          `mapstructure:"display_name"`
+	Secret       string          `mapstructure:"secret"`
+	Groups       []string        `mapstructure:"groups"`
 }
 
 type manager struct {
@@ -88,10 +93,18 @@ func New(m map[string]interface{}) (auth.Manager, error) {
 	return manager, nil
 }
 
-func (m *manager) Authenticate(ctx context.Context, username string, secret string) (*typespb.UserId, error) {
+func (m *manager) Authenticate(ctx context.Context, username string, secret string) (*userproviderv0alphapb.User, error) {
 	if c, ok := m.credentials[username]; ok {
 		if c.Secret == secret {
-			return c.ID, nil
+			return &userproviderv0alphapb.User{
+				Id:           c.ID,
+				Username:     c.Username,
+				Mail:         c.Mail,
+				MailVerified: c.MailVerified,
+				DisplayName:  c.DisplayName,
+				Groups:       c.Groups,
+				// TODO add arbitrary keys as opaque data
+			}, nil
 		}
 	}
 	return nil, errtypes.InvalidCredentials(username)


### PR DESCRIPTION
This PR makes the AuthManagers implementations return a full user object instead of just the id.
- oidc and ldap already provide the user metadata as part of the authentication process
  - more specifically:
    - the credentials are extracted using a credential strategy in the chain
    - they are passed to the gateway which will handle basic or bearer auth with the configured auth provider
    - the auth provider returns all user metadata
      - before this PR the auth provider would only return an id, which the gateway then used to look up a user in the user provider
    - this allows us to authenticate user with oidc bearer auth (and fetch the user metadata from the userinfo endpoint) as well as ldap basic auth (and fetching the user metadata from ldap)
    - if the metadata needs to be extended, or only users should be allowed in via oidc that are also avaliable in ldap a separate middleware / inspector should handle that. 
- the user manager is only used to search users for sharing

- [x] update json & demo auth manager to return all metadata
- [ ] update examples
- [ ] requires https://github.com/cs3org/cs3apis/pull/46 / https://github.com/cs3org/go-cs3apis/pull/20