### PR TITLE
WIP: Make revad start on a per directory basis

### DIFF
--- a/cmd/revad/internal/grace/grace.go
+++ b/cmd/revad/internal/grace/grace.go
@@ -35,7 +35,7 @@ import (
 )
 
 // Watcher watches a process for a graceful restart
-// preserving open network sockets to avoid packets.
+// preserving open network sockets to avoid packet loss.
 type Watcher struct {
 	log       zerolog.Logger
 	graceful  bool

--- a/cmd/revad/main.go
+++ b/cmd/revad/main.go
@@ -56,7 +56,7 @@ var (
 	signalFlag  = flag.String("s", "", "send signal to a master process: stop, quit, reload")
 	configFlag  = flag.String("c", "/etc/revad/revad.toml", "set configuration file")
 	pidFlag     = flag.String("p", "", "pid file. If empty defaults to a random file in the OS temporary directory")
-	dirFlag     = flag.String("dir", "", "runs any toml file in the directory specified")
+	dirFlag     = flag.String("dev-dir", "", "runs any toml file in the specified directory. Intended for development use only")
 	// Compile time variables initialized with gcc flags.
 	gitCommit, buildDate, version, goVersion string
 )

--- a/examples/separate/users.toml
+++ b/examples/separate/users.toml
@@ -40,13 +40,13 @@ iframe_ui_provider = "http://localhost:19500/iframeui"
 auth_manager = "json"
 
 [grpc.services.authprovider.auth_managers.json]
-users = "./examples/separate/users.demo.json"
+users = "users.demo.json"
 
 [grpc.services.userprovider]
 driver = "json"
 
 [grpc.services.userprovider.drivers.json]
-users = "./examples/separate/users.demo.json"
+users = "users.demo.json"
 
 
 # TODO bring back iframe app ui demo

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/fatih/color v1.7.0 // indirect
 	github.com/go-openapi/strfmt v0.19.2 // indirect
 	github.com/gofrs/uuid v3.2.0+incompatible
-	github.com/gogo/protobuf v1.2.0 // indirect
 	github.com/golang/protobuf v1.3.2
 	github.com/gomodule/redigo v2.0.0+incompatible
 	github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4
@@ -25,12 +24,10 @@ require (
 	github.com/pkg/errors v0.8.1
 	github.com/pkg/xattr v0.4.1
 	github.com/pquerna/cachecontrol v0.0.0-20180517163645-1555304b9b35 // indirect
-	github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829 // indirect
 	github.com/rs/cors v1.7.0
 	github.com/rs/zerolog v1.17.2
 	go.opencensus.io v0.22.1
 	golang.org/x/crypto v0.0.0-20190411191339-88737f569e3a
-	golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3 // indirect
 	golang.org/x/net v0.0.0-20190827160401-ba9fcec4b297 // indirect
 	golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421
 	google.golang.org/grpc v1.25.1
@@ -38,7 +35,6 @@ require (
 	gopkg.in/cheggaaa/pb.v1 v1.0.27 // indirect
 	gopkg.in/ldap.v2 v2.5.1
 	gopkg.in/square/go-jose.v2 v2.2.2 // indirect
-	honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc // indirect
 )
 
 go 1.13


### PR DESCRIPTION
Added a new `--dir` flag that allows for starting `revad` on any directory with a set of config files.

Having a directory like so:

```
~/code/reva
❯ tree ~/automation/reva/separate
/Users/aunger/automation/reva/separate
├── auth.toml
├── frontend-oidc.toml
├── frontend.toml
├── gateway.toml
├── phoenix.oidc.config.json
├── storage-home.toml
├── storage.toml
└── users.demo.json
```

Would allow for `revad` to launch every service defined on each config file on the given folder like:

`> revad --dir ~/automation/reva/separate`

This is a preliminary implementation.

It all lives under the same terminal session so all logs are printed on STDOUT. This is more intended to speed up development as it does not handle graceful shutdown just yet.