### PR TITLE
misc: skip contrib makefile step

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,12 +1,11 @@
 - Alex Unger <zyxancf@gmail.com>
+- Aritz Brosa <aritz.brosa.iartza@cern.ch>
 - Diogo Castro <diogo.castro@cern.ch>
 - Felix Hillingshaeuser <felix@mxcore.de>
-- Giuseppe <giuseppe.lopresti@cern.ch>
 - Giuseppe Lo Presti <giuseppe.lopresti@cern.ch>
 - Hannah von Reth <vonreth@kde.org>
 - Hugo Gonzalez Labrador <github@hugo.labkode.com>
 - Ilja Neumann <ineumann@owncloud.com>
 - Jörn Friedrich Dreyer <jfd@butonic.de>
-- Michael D'Silva <md@aarnet.edu.au>
+- Michael DSilva <md@aarnet.edu.au>
 - Mohitty <mohitt@iitk.ac.in>
-- zazola <aritz.brosa@gmail.com>

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: build
-default: build test lint contrib
+default: build test lint vendor contrib-sort
 
 BUILD_DATE=`date +%FT%T%z`
 GIT_COMMIT=`git rev-parse --short HEAD`
@@ -38,9 +38,13 @@ test: off
 lint:
 	go run tools/check-license/check-license.go
 	`go env GOPATH`/bin/golangci-lint run
+vendor:
+	go mod vendor
 
-contrib:
-	git log --pretty="%an <%ae>" | sort -n | uniq  | sort -n | awk '{print "-", $$0}' | grep -v 'users.noreply.github.com' > CONTRIBUTORS.md 
+#contrib:
+#	git log --pretty="%an <%ae>" | sort -n | uniq  | sort -n | awk '{print "-", $$0}' | grep -v 'users.noreply.github.com' > CONTRIBUTORS.md 
+contrib-sort:
+	cat CONTRIBUTORS.md | sort -o CONTRIBUTORS.md 
 
 # for manual building only
 deps: 


### PR DESCRIPTION
Some people use different git usernames and mails and once the PR is accepted into master is impossible without rewriting history to change the author name.

This PR removes the automatic creation of the CONTRIBUTORS.md file by analyzing the git log and instead relies on every author to put their username and mail accordingly in the file.
