### PR TITLE
Add an initial mailmap config

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,2 @@
+Aritz Brosa <aritz.brosa.iartza@cern.ch> zazola <aritz.brosa@gmail.com>
+Giuseppe Lo Presti <giuseppe.lopresti@cern.ch> Giuseppe <giuseppe.lopresti@cern.ch>

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -9,3 +9,4 @@
 - Jörn Friedrich Dreyer <jfd@butonic.de>
 - Michael D'Silva <md@aarnet.edu.au>
 - Mohitty <mohitt@iitk.ac.in>
+- Thomas Boerger <thomas@webhippie.de>

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: build
-default: build test lint vendor contrib-sort
+default: build test lint vendor contrib
 
 BUILD_DATE=`date +%FT%T%z`
 GIT_COMMIT=`git rev-parse --short HEAD`
@@ -8,7 +8,7 @@ GIT_DIRTY=`git diff-index --quiet HEAD -- || echo "dirty-"`
 VERSION=`git describe --always`
 GO_VERSION=`go version | awk '{print $$3}'`
 
-off: 
+off:
 	GORPOXY=off
 	echo BUILD_DATE=${BUILD_DATE}
 	echo GIT_COMMIT=${GIT_COMMIT}
@@ -20,20 +20,20 @@ imports: off
 	`go env GOPATH`/bin/goimports -w tools pkg internal cmd
 
 build: imports
-	go build -mod=vendor -o ./cmd/revad/revad ./cmd/revad 
+	go build -mod=vendor -o ./cmd/revad/revad ./cmd/revad
 	go build -mod=vendor -o ./cmd/reva/reva ./cmd/reva
-	
+
 tidy:
 	go mod tidy
 
 build-revad: imports
-	go build -mod=vendor -o ./cmd/revad/revad ./cmd/revad 
+	go build -mod=vendor -o ./cmd/revad/revad ./cmd/revad
 
 build-reva: imports
 	go build -mod=vendor -o ./cmd/reva/reva ./cmd/reva
-	
+
 test: off
-	go test -mod=vendor -race ./... 
+	go test -mod=vendor -race ./...
 
 lint:
 	go run tools/check-license/check-license.go
@@ -41,18 +41,16 @@ lint:
 vendor:
 	go mod vendor
 
-#contrib:
-#	git log --pretty="%an <%ae>" | sort -n | uniq  | sort -n | awk '{print "-", $$0}' | grep -v 'users.noreply.github.com' > CONTRIBUTORS.md 
-contrib-sort:
-	cat CONTRIBUTORS.md | sort -o CONTRIBUTORS.md 
+contrib:
+	git shortlog -se | cut -c8- | sort -u | awk '{print "-", $$0}' | grep -v 'users.noreply.github.com' > CONTRIBUTORS.md
 
 # for manual building only
-deps: 
+deps:
 	cd /tmp && rm -rf golangci-lint &&  git clone --quiet -b 'v1.21.0' --single-branch --depth 1 https://github.com/golangci/golangci-lint &> /dev/null && cd golangci-lint/cmd/golangci-lint && go install
 	cd /tmp && go get golang.org/x/tools/cmd/goimports
 
 build-ci: off
-	go build -mod=vendor -o ./cmd/revad/revad ./cmd/revad 
+	go build -mod=vendor -o ./cmd/revad/revad ./cmd/revad
 	go build -mod=vendor -o ./cmd/reva/reva ./cmd/reva
 
 lint-ci:
@@ -64,7 +62,7 @@ ci: build-ci test  lint-ci
 
 # to be run in Docker build
 build-revad-docker: off
-	go build -mod=vendor -o ./cmd/revad/revad ./cmd/revad 
+	go build -mod=vendor -o ./cmd/revad/revad ./cmd/revad
 build-reva-docker: off
 	go build -mod=vendor -o ./cmd/revad/reva ./cmd/reva
 clean:


### PR DESCRIPTION
The contributors file gets automatically generated from the commit
history, to avoid duplicates within that contributors file it's common
to add a `.mailmap` file to the root of the repository to remove the
duplicates. For further reference you can read
https://git-scm.com/docs/git-check-mailmap#_mapping_authors.

Signed-off-by: Thomas Boerger <thomas@webhippie.de>