### PR TITLE
Update beginner's guide added path to start command for revad

### DIFF
--- a/docs/content/en/docs/Getting started/begginers-guide.md
+++ b/docs/content/en/docs/Getting started/begginers-guide.md
@@ -29,7 +29,7 @@ enabled_services = ["helloworld"]
 To start revad, run the executable file:
 
 ```
-revad -c revad.toml -p /var/tmp/revad.pid
+cmd/revad/revad -c revad.toml -p /var/tmp/revad.pid
 ```
 
 {{% alert title="The pid flag" color="warning" %}}


### PR DESCRIPTION
This is just a small update in the beginner's guide (it took us some time to figure out why things didnät work when we first tried to start revad).