### PR TITLE
Fix golangci-lint

### DIFF
--- a/internal/http/services/oidcprovider/revoke.go
+++ b/internal/http/services/oidcprovider/revoke.go
@@ -43,7 +43,7 @@ func (s *svc) doRevoke(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// If this is a client_credentials grant, grant all scopes the client is allowed to perform.
-	if accessRequest.GetGrantTypes().Exact("client_credentials") {
+	if accessRequest.GetGrantTypes().ExactOne("client_credentials") {
 		for _, scope := range accessRequest.GetRequestedScopes() {
 			if fosite.HierarchicScopeStrategy(accessRequest.GetClient().GetScopes(), scope) {
 				accessRequest.GrantScope(scope)

--- a/internal/http/services/oidcprovider/token.go
+++ b/internal/http/services/oidcprovider/token.go
@@ -43,7 +43,7 @@ func (s *svc) doToken(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// If this is a client_credentials grant, grant all scopes the client is allowed to perform.
-	if accessRequest.GetGrantTypes().Exact("client_credentials") {
+	if accessRequest.GetGrantTypes().ExactOne("client_credentials") {
 		for _, scope := range accessRequest.GetRequestedScopes() {
 			if fosite.HierarchicScopeStrategy(accessRequest.GetClient().GetScopes(), scope) {
 				accessRequest.GrantScope(scope)


### PR DESCRIPTION
replace deprecated `.Exact` -> `.ExactOne`

Failing builds:

https://cloud.drone.io/cs3org/reva/651/1/4
https://cloud.drone.io/cs3org/reva/652/1/4
https://cloud.drone.io/cs3org/reva/653/1/4
https://cloud.drone.io/cs3org/reva/658/1/4