### PR TITLE
Teach the owncloud storage driver home handling

### DIFF
--- a/examples/oc-phoenix/frontend.toml
+++ b/examples/oc-phoenix/frontend.toml
@@ -67,7 +67,7 @@ chunk_folder = "/var/tmp/reva/chunks"
 # for eos we need to rewrite the path
 # TODO strip the username from the path so the CS3 namespace can be mounted
 # at the files/<username> endpoint? what about migration? separate reva instance
-files_namespace = "/"
+files_namespace = "/oc"
 
 # similar to the dav/files endpoint we can configure a prefix for the old webdav endpoint
 # we use the old webdav endpoint to present the cs3 namespace

--- a/examples/oc-phoenix/storage-home.toml
+++ b/examples/oc-phoenix/storage-home.toml
@@ -26,17 +26,13 @@ driver = "owncloud"
 mount_path = "/home"
 mount_id = "123e4567-e89b-12d3-a456-426655440000"
 expose_data_server = true
-path_wrapper = "context"
 data_server_url = "http://localhost:12001/data"
 enable_home_creation = true
 
 [grpc.services.storageprovider.drivers.owncloud]
 datadirectory = "/var/tmp/reva/data"
-layout = "{{.Username}}"
+enable_home = true
 
-[grpc.services.storageprovider.path_wrappers.context]
-prefix = ""
-layout = "{{.Username}}"
 
 [http]
 address = "0.0.0.0:12001"


### PR DESCRIPTION
fixes path mappings for phoenix and oc10 acceptance tests and changes the `layout` config option to `user_layout` to align it with eos and local