### PR TITLE
escape special xml characters in propfind response

### DIFF
--- a/internal/http/services/owncloud/ocdav/propfind.go
+++ b/internal/http/services/owncloud/ocdav/propfind.go
@@ -19,6 +19,7 @@
 package ocdav
 
 import (
+	"bytes"
 	"context"
 	"encoding/xml"
 	"fmt"
@@ -169,10 +170,12 @@ func (s *svc) formatPropfind(ctx context.Context, pf *propfindXML, mds []*provid
 }
 
 func (s *svc) newProp(key, val string) *propertyXML {
+	escaped := new(bytes.Buffer)
+	xml.Escape(escaped, []byte(val))
 	return &propertyXML{
 		XMLName:  xml.Name{Space: "", Local: key},
 		Lang:     "",
-		InnerXML: []byte(val),
+		InnerXML: escaped.Bytes(),
 	}
 }
 


### PR DESCRIPTION
When the propfind response contained a character that is a special xml character then if a client tried to parse the xml it would fail. Therefore we needed to escape the characters.

Fixes https://github.com/owncloud/ocis-reva/issues/122