### PR TITLE
Revert "escape special xml characters in propfind response"

### DIFF
--- a/internal/http/services/owncloud/ocdav/propfind.go
+++ b/internal/http/services/owncloud/ocdav/propfind.go
@@ -19,7 +19,6 @@
 package ocdav
 
 import (
-	"bytes"
 	"context"
 	"encoding/xml"
 	"fmt"
@@ -170,12 +169,10 @@ func (s *svc) formatPropfind(ctx context.Context, pf *propfindXML, mds []*provid
 }
 
 func (s *svc) newProp(key, val string) *propertyXML {
-	escaped := new(bytes.Buffer)
-	xml.Escape(escaped, []byte(val))
 	return &propertyXML{
 		XMLName:  xml.Name{Space: "", Local: key},
 		Lang:     "",
-		InnerXML: escaped.Bytes(),
+		InnerXML: []byte(val),
 	}
 }
 


### PR DESCRIPTION
Reverts cs3org/reva#627, it broke propfinds: `<d:resourcetype>&lt;d:collection/&gt;</d:resourcetype>` so all directories are now broken ...