### PR TITLE
ocm: Check for ID provider match as well when creating shares

### DIFF
--- a/examples/ocmd/users.demo.json
+++ b/examples/ocmd/users.demo.json
@@ -2,7 +2,7 @@
 	{
 		"id": {
 			"opaque_id": "4c510ada-c86b-4815-8820-42cdf82c3d51",
-			"idp": "http://localhost:20080"
+			"idp": "http://cernbox.cern.ch"
 		},
 		"username": "einstein",
 		"secret": "relativity",
@@ -13,7 +13,7 @@
 	{
 		"id": {
 			"opaque_id": "f7fbf8c8-139b-4376-b307-cf0a8c2d0d9c",
-			"idp": "http://localhost:20080"
+			"idp": "http://cesnet.cz"
 		},
 		"username": "marie",
 		"secret": "radioactivity",

--- a/internal/http/services/ocmd/shares.go
+++ b/internal/http/services/ocmd/shares.go
@@ -85,15 +85,19 @@ func (h *sharesHandler) createShare(w http.ResponseWriter, r *http.Request) {
 	}
 	prefix := hRes.GetPath()
 
-	shareWith := r.FormValue("shareWith")
-	if shareWith == "" {
-		WriteError(w, r, APIErrorInvalidParameter, "missing shareWith", nil)
+	shareWithUser := r.FormValue("shareWithUser")
+	shareWithProvider := r.FormValue("shareWithProvider")
+
+	if shareWithUser == "" || shareWithProvider == "" {
+		WriteError(w, r, APIErrorInvalidParameter, "missing shareWith parameters", nil)
 		return
 	}
 
 	userRes, err := gatewayClient.GetUser(ctx, &userpb.GetUserRequest{
-		UserId: &userpb.UserId{OpaqueId: shareWith},
+		UserId: &userpb.UserId{OpaqueId: shareWithUser, Idp: shareWithProvider},
 	})
+
+	log.Info().Msg(fmt.Sprintf("userRes %+v", userRes))
 
 	if err != nil {
 		WriteError(w, r, APIErrorInvalidParameter, "error searching recipient", err)

--- a/pkg/user/manager/json/json.go
+++ b/pkg/user/manager/json/json.go
@@ -81,8 +81,7 @@ func New(m map[string]interface{}) (user.Manager, error) {
 
 func (m *manager) GetUser(ctx context.Context, uid *userpb.UserId) (*userpb.User, error) {
 	for _, u := range m.users {
-		// TODO(jfd) we should also compare idp / iss? labkode: yes we should
-		if u.Id.GetOpaqueId() == uid.OpaqueId || u.Username == uid.OpaqueId {
+		if (u.Id.GetOpaqueId() == uid.OpaqueId || u.Username == uid.OpaqueId) && (uid.Idp == "" || uid.Idp == u.Id.GetIdp()) {
 			return u, nil
 		}
 	}


### PR DESCRIPTION
When creating OCM shares, we need to take both the user ID as well as the provider ID as input, as the same user ID can be present across mesh providers, but the combination of the provider ID and user ID would be unique. I changed the logic for the JSON driver, but for ldap, there's a [comment](https://github.com/ishank011/reva/blob/master/pkg/user/manager/ldap/ldap.go#L131) that says ` this is screaming for errors if filter contains >1 %s`, tracked in https://github.com/cs3org/reva/issues/326. So that needs to be corrected.