### PR TITLE
Point GitHub ref in docs to cs3org/reva

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -135,7 +135,7 @@ no = 'Sorry to hear that. Please <a href="https://github.com/USERNAME/REPOSITORY
 # Developer relevant links. These will show up on right side of footer and in the community page if you have one.
 [[params.links.developer]]
 	name = "GitHub"
-	url = "https://github.com/google/docsy"
+	url = "https://github.com/cs3org/reva"
 	icon = "fab fa-github"
         desc = "Development takes place here!"
 #[[params.links.developer]]


### PR DESCRIPTION
While I was playing around with the theme, I noticed the GitHub link in `config.toml` was pointing to Docsy repo instead of this one, causing both the link in the footer and the one in https://reva.link/community to point there instead. 