### PR TITLE
Add ocm core to gateway

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/aws/aws-sdk-go v1.30.7
 	github.com/cheggaaa/pb v1.0.28
 	github.com/coreos/go-oidc v2.2.1+incompatible
-	github.com/cs3org/go-cs3apis v0.0.0-20200408065125-6e23f3ecec0a
+	github.com/cs3org/go-cs3apis v0.0.0-20200422090600-d9e5166bebfe
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/fatih/color v1.7.0 // indirect
 	github.com/go-openapi/strfmt v0.19.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -46,6 +46,8 @@ github.com/cs3org/go-cs3apis v0.0.0-20200403073321-0519c6823b48 h1:iR2JGsyZwRg6N
 github.com/cs3org/go-cs3apis v0.0.0-20200403073321-0519c6823b48/go.mod h1:UXha4TguuB52H14EMoSsCqDj7k8a/t7g4gVP+bgY5LY=
 github.com/cs3org/go-cs3apis v0.0.0-20200408065125-6e23f3ecec0a h1:+enFdliTCV/aaLAvLmeka/r9wUoEypngV4JD5Gy92Uc=
 github.com/cs3org/go-cs3apis v0.0.0-20200408065125-6e23f3ecec0a/go.mod h1:UXha4TguuB52H14EMoSsCqDj7k8a/t7g4gVP+bgY5LY=
+github.com/cs3org/go-cs3apis v0.0.0-20200422090600-d9e5166bebfe h1:gQgullcz2/nn1epVPhX3805nszWkSolM8m6CYLF9Y04=
+github.com/cs3org/go-cs3apis v0.0.0-20200422090600-d9e5166bebfe/go.mod h1:UXha4TguuB52H14EMoSsCqDj7k8a/t7g4gVP+bgY5LY=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/internal/grpc/services/gateway/gateway.go
+++ b/internal/grpc/services/gateway/gateway.go
@@ -47,6 +47,7 @@ type config struct {
 	OCMShareProviderEndpoint      string `mapstructure:"ocmshareprovidersvc"`
 	OCMInviteManagerEndpoint      string `mapstructure:"ocminvitemanagersvc"`
 	OCMProviderAuthorizerEndpoint string `mapstructure:"ocmproviderauthorizersvc"`
+	OCMCoreEndpoint               string `mapstructure:"ocmcoresvc"`
 	UserProviderEndpoint          string `mapstructure:"userprovidersvc"`
 	CommitShareToStorageGrant     bool   `mapstructure:"commit_share_to_storage_grant"`
 	CommitShareToStorageRef       bool   `mapstructure:"commit_share_to_storage_ref"`

--- a/internal/grpc/services/gateway/ocmcore.go
+++ b/internal/grpc/services/gateway/ocmcore.go
@@ -1,0 +1,44 @@
+// Copyright 2018-2020 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package gateway
+
+import (
+	"context"
+
+	ocmcore "github.com/cs3org/go-cs3apis/cs3/ocm/core/v1beta1"
+	"github.com/cs3org/reva/pkg/rgrpc/status"
+	"github.com/cs3org/reva/pkg/rgrpc/todo/pool"
+	"github.com/pkg/errors"
+)
+
+func (s *svc) CreateOCMCoreShare(ctx context.Context, req *ocmcore.CreateOCMCoreShareRequest) (*ocmcore.CreateOCMCoreShareResponse, error) {
+	c, err := pool.GetOCMCoreClient(s.c.OCMCoreEndpoint)
+	if err != nil {
+		return &ocmcore.CreateOCMCoreShareResponse{
+			Status: status.NewInternal(ctx, err, "error getting ocm authorizer provider client"),
+		}, nil
+	}
+
+	res, err := c.CreateOCMCoreShare(ctx, req)
+	if err != nil {
+		return nil, errors.Wrap(err, "gateway: error calling IsProviderAllowed")
+	}
+
+	return res, nil
+}

--- a/internal/grpc/services/gateway/ocmcore.go
+++ b/internal/grpc/services/gateway/ocmcore.go
@@ -31,13 +31,45 @@ func (s *svc) CreateOCMCoreShare(ctx context.Context, req *ocmcore.CreateOCMCore
 	c, err := pool.GetOCMCoreClient(s.c.OCMCoreEndpoint)
 	if err != nil {
 		return &ocmcore.CreateOCMCoreShareResponse{
-			Status: status.NewInternal(ctx, err, "error getting ocm authorizer provider client"),
+			Status: status.NewInternal(ctx, err, "error getting ocm core client"),
 		}, nil
 	}
 
 	res, err := c.CreateOCMCoreShare(ctx, req)
 	if err != nil {
-		return nil, errors.Wrap(err, "gateway: error calling IsProviderAllowed")
+		return nil, errors.Wrap(err, "gateway: error calling CreateOCMCoreShare")
+	}
+
+	return res, nil
+}
+
+func (s *svc) GetOCMCoreShare(ctx context.Context, req *ocmcore.GetOCMCoreShareRequest) (*ocmcore.GetOCMCoreShareResponse, error) {
+	c, err := pool.GetOCMCoreClient(s.c.OCMCoreEndpoint)
+	if err != nil {
+		return &ocmcore.GetOCMCoreShareResponse{
+			Status: status.NewInternal(ctx, err, "error getting ocm core client"),
+		}, nil
+	}
+
+	res, err := c.GetOCMCoreShare(ctx, req)
+	if err != nil {
+		return nil, errors.Wrap(err, "gateway: error calling GetOCMCoreShare")
+	}
+
+	return res, nil
+}
+
+func (s *svc) ListOCMCoreShares(ctx context.Context, req *ocmcore.ListOCMCoreSharesRequest) (*ocmcore.ListOCMCoreSharesResponse, error) {
+	c, err := pool.GetOCMCoreClient(s.c.OCMCoreEndpoint)
+	if err != nil {
+		return &ocmcore.ListOCMCoreSharesResponse{
+			Status: status.NewInternal(ctx, err, "error getting ocm core client"),
+		}, nil
+	}
+
+	res, err := c.CreateOCMCoreShare(ctx, req)
+	if err != nil {
+		return nil, errors.Wrap(err, "gateway: error calling ListOCMCoreShares")
 	}
 
 	return res, nil

--- a/internal/grpc/services/gateway/ocmcore.go
+++ b/internal/grpc/services/gateway/ocmcore.go
@@ -42,35 +42,3 @@ func (s *svc) CreateOCMCoreShare(ctx context.Context, req *ocmcore.CreateOCMCore
 
 	return res, nil
 }
-
-func (s *svc) GetOCMCoreShare(ctx context.Context, req *ocmcore.GetOCMCoreShareRequest) (*ocmcore.GetOCMCoreShareResponse, error) {
-	c, err := pool.GetOCMCoreClient(s.c.OCMCoreEndpoint)
-	if err != nil {
-		return &ocmcore.GetOCMCoreShareResponse{
-			Status: status.NewInternal(ctx, err, "error getting ocm core client"),
-		}, nil
-	}
-
-	res, err := c.GetOCMCoreShare(ctx, req)
-	if err != nil {
-		return nil, errors.Wrap(err, "gateway: error calling GetOCMCoreShare")
-	}
-
-	return res, nil
-}
-
-func (s *svc) ListOCMCoreShares(ctx context.Context, req *ocmcore.ListOCMCoreSharesRequest) (*ocmcore.ListOCMCoreSharesResponse, error) {
-	c, err := pool.GetOCMCoreClient(s.c.OCMCoreEndpoint)
-	if err != nil {
-		return &ocmcore.ListOCMCoreSharesResponse{
-			Status: status.NewInternal(ctx, err, "error getting ocm core client"),
-		}, nil
-	}
-
-	res, err := c.CreateOCMCoreShare(ctx, req)
-	if err != nil {
-		return nil, errors.Wrap(err, "gateway: error calling ListOCMCoreShares")
-	}
-
-	return res, nil
-}

--- a/pkg/rgrpc/todo/pool/pool.go
+++ b/pkg/rgrpc/todo/pool/pool.go
@@ -47,7 +47,7 @@ var userShareProviders = map[string]collaboration.CollaborationAPIClient{}
 var ocmShareProviders = map[string]ocm.OcmAPIClient{}
 var ocmInviteManagers = map[string]invitepb.InviteAPIClient{}
 var ocmProviderAuthorizers = map[string]ocmprovider.ProviderAPIClient{}
-var ocmCores = map[string]ocmcore.OCMCoreClient{}
+var ocmCores = map[string]ocmcore.OcmCoreAPIClient{}
 var publicShareProviders = map[string]link.LinkAPIClient{}
 var preferencesProviders = map[string]preferences.PreferencesAPIClient{}
 var appRegistries = map[string]appregistry.RegistryAPIClient{}
@@ -293,7 +293,7 @@ func GetOCMProviderAuthorizerClient(endpoint string) (ocmprovider.ProviderAPICli
 }
 
 // GetOCMCoreClient returns a new OCMCoreClient.
-func GetOCMCoreClient(endpoint string) (ocmcore.ProviderAPIClient, error) {
+func GetOCMCoreClient(endpoint string) (ocmcore.OcmCoreAPIClient, error) {
 	if val, ok := ocmCores[endpoint]; ok {
 		return val, nil
 	}
@@ -303,7 +303,7 @@ func GetOCMCoreClient(endpoint string) (ocmcore.ProviderAPIClient, error) {
 		return nil, err
 	}
 
-	ocmCores[endpoint] = ocmcore.NewProviderAPIClient(conn)
+	ocmCores[endpoint] = ocmcore.NewOcmCoreAPIClient(conn)
 
 	return ocmCores[endpoint], nil
 }

--- a/pkg/rgrpc/todo/pool/pool.go
+++ b/pkg/rgrpc/todo/pool/pool.go
@@ -25,6 +25,7 @@ import (
 	authregistry "github.com/cs3org/go-cs3apis/cs3/auth/registry/v1beta1"
 	gateway "github.com/cs3org/go-cs3apis/cs3/gateway/v1beta1"
 	user "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
+	ocmcore "github.com/cs3org/go-cs3apis/cs3/ocm/core/v1beta1"
 	invitepb "github.com/cs3org/go-cs3apis/cs3/ocm/invite/v1beta1"
 	ocmprovider "github.com/cs3org/go-cs3apis/cs3/ocm/provider/v1beta1"
 	preferences "github.com/cs3org/go-cs3apis/cs3/preferences/v1beta1"
@@ -46,6 +47,7 @@ var userShareProviders = map[string]collaboration.CollaborationAPIClient{}
 var ocmShareProviders = map[string]ocm.OcmAPIClient{}
 var ocmInviteManagers = map[string]invitepb.InviteAPIClient{}
 var ocmProviderAuthorizers = map[string]ocmprovider.ProviderAPIClient{}
+var ocmCores = map[string]ocmcore.OCMCoreClient{}
 var publicShareProviders = map[string]link.LinkAPIClient{}
 var preferencesProviders = map[string]preferences.PreferencesAPIClient{}
 var appRegistries = map[string]appregistry.RegistryAPIClient{}
@@ -288,4 +290,20 @@ func GetOCMProviderAuthorizerClient(endpoint string) (ocmprovider.ProviderAPICli
 	ocmProviderAuthorizers[endpoint] = ocmprovider.NewProviderAPIClient(conn)
 
 	return ocmProviderAuthorizers[endpoint], nil
+}
+
+// GetOCMCoreClient returns a new OCMCoreClient.
+func GetOCMCoreClient(endpoint string) (ocmcore.ProviderAPIClient, error) {
+	if val, ok := ocmCores[endpoint]; ok {
+		return val, nil
+	}
+
+	conn, err := NewConn(endpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	ocmCores[endpoint] = ocmcore.NewProviderAPIClient(conn)
+
+	return ocmCores[endpoint], nil
 }


### PR DESCRIPTION
Adds the method described in https://github.com/cs3org/cs3apis/pull/65 to the gateway. Note: This cannot be merged before https://github.com/cs3org/cs3apis/pull/65 is merged (build will fail until the mentioned PR is merged).