### PR TITLE
implement another Run function in runtime to be able to pass options

### DIFF
--- a/cmd/revad/runtime/option.go
+++ b/cmd/revad/runtime/option.go
@@ -1,0 +1,49 @@
+// Copyright 2018-2020 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package runtime
+
+import (
+	"github.com/rs/zerolog"
+)
+
+// Option defines a single option function.
+type Option func(o *Options)
+
+// Options defines the available options for this package.
+type Options struct {
+	Logger *zerolog.Logger
+}
+
+// newOptions intializes the available default options.
+func newOptions(opts ...Option) Options {
+	opt := Options{}
+
+	for _, o := range opts {
+		o(&opt)
+	}
+
+	return opt
+}
+
+// WithLogger provides a function to set the logger option.
+func WithLogger(logger *zerolog.Logger) Option {
+	return func(o *Options) {
+		o.Logger = logger
+	}
+}

--- a/cmd/revad/runtime/runtime.go
+++ b/cmd/revad/runtime/runtime.go
@@ -45,11 +45,18 @@ import (
 
 // Run runs a reva server with the given config file and pid file.
 func Run(mainConf map[string]interface{}, pidFile string) {
+	logConf := parseLogConfOrDie(mainConf["log"])
+	logger := initLogger(logConf)
+	RunWithOptions(mainConf, pidFile, WithLogger(logger))
+}
+
+// RunWithOptions runs a reva server with the given config file, pid file and options.
+func RunWithOptions(mainConf map[string]interface{}, pidFile string, opts ...Option) {
+	options := newOptions(opts...)
 	parseSharedConfOrDie(mainConf["shared"])
 	coreConf := parseCoreConfOrDie(mainConf["core"])
-	logConf := parseLogConfOrDie(mainConf["log"])
 
-	run(mainConf, coreConf, logConf, pidFile)
+	run(mainConf, coreConf, options.Logger, pidFile)
 }
 
 type coreConf struct {
@@ -60,9 +67,7 @@ type coreConf struct {
 	TracingServiceName string `mapstructure:"tracing_service_name"`
 }
 
-func run(mainConf map[string]interface{}, coreConf *coreConf, logConf *logConf, filename string) {
-	logger := initLogger(logConf)
-
+func run(mainConf map[string]interface{}, coreConf *coreConf, logger *zerolog.Logger, filename string) {
 	host, _ := os.Hostname()
 	logger.Info().Msgf("host info: %s", host)
 


### PR DESCRIPTION
In https://github.com/owncloud/ocis-reva we want to be able to pass down our own logger.
This change makes that possible.
Closes #659 