### PR TITLE
Disable chunking v1 by default

### DIFF
--- a/cmd/reva/gen/gen.go
+++ b/cmd/reva/gen/gen.go
@@ -173,7 +173,7 @@ blacklisted_files = ["foo"]
 undelete = true
 versioning = true
 [http.services.ocssvc.capabilities.capabilities.dav]
-chunking = "1.0"
+chunking = "" # set to "1.0" for experimental support
 [http.services.ocssvc.capabilities.capabilities.files_sharing]
 api_enabled = true
 resharing = true

--- a/internal/http/services/owncloud/ocdav/put.go
+++ b/internal/http/services/owncloud/ocdav/put.go
@@ -37,6 +37,7 @@ import (
 )
 
 func isChunked(fn string) (bool, error) {
+	// FIXME: also need to check whether the OC-Chunked header is set
 	return regexp.MatchString(`-chunking-\w+-[0-9]+-[0-9]+$`, fn)
 }
 
@@ -127,6 +128,15 @@ func (s *svc) handlePut(w http.ResponseWriter, r *http.Request, ns string) {
 	}
 
 	if ok {
+		// TODO: disable if chunking capability is turned off in config
+		/**
+		if s.c.Capabilities.Dav.Chunking == "1.0" {
+			s.handlePutChunked(w, r)
+		} else {
+			log.Error().Err(err).Msg("chunking 1.0 is not enabled")
+			w.WriteHeader(http.StatusBadRequest)
+		}
+		*/
 		s.handlePutChunked(w, r)
 		return
 	}

--- a/internal/http/services/owncloud/ocs/handlers/cloud/capabilities/capabilities.go
+++ b/internal/http/services/owncloud/ocs/handlers/cloud/capabilities/capabilities.go
@@ -106,9 +106,6 @@ func (h *Handler) Init(c *config.Config) {
 	if h.c.Capabilities.Dav == nil {
 		h.c.Capabilities.Dav = &data.CapabilitiesDav{}
 	}
-	if h.c.Capabilities.Dav.Chunking == "" {
-		h.c.Capabilities.Dav.Chunking = "1.0"
-	}
 	if h.c.Capabilities.Dav.Trashbin == "" {
 		h.c.Capabilities.Dav.Trashbin = "1.0"
 	}


### PR DESCRIPTION
This is because chunking v1 is [not working correctly](https://github.com/owncloud/ocis/issues/195) currently with desktop clients, so we better not advertise the capability until it's stable. That is, if there is interest at all to make it stable considering that we're moving to TUS: https://github.com/cs3org/reva/pull/661

In this PR I've set the default config to not set version 1 for the chunking capabilitiy.

Now:
- [ ] how to access the capabilities from inside ocdav to disable the chunking logic ? (see TODO in code)

@butonic 
