### PR TITLE
return correct status code for api v2

### DIFF
--- a/internal/http/services/owncloud/ocs/conversions/permissions.go
+++ b/internal/http/services/owncloud/ocs/conversions/permissions.go
@@ -40,11 +40,18 @@ const (
 	PermissionAll Permissions = (1 << (iota - 1)) - 1
 )
 
+var (
+	// ErrPermissionAboveRange defines a permission specific error.
+	ErrPermissionAboveRange = fmt.Errorf("The provided permission is higher than %d", PermissionAll)
+)
+
 // NewPermissions creates a new Permissions instanz.
 // The value must be in the valid range.
 func NewPermissions(val int) (Permissions, error) {
-	if val <= int(PermissionInvalid) || int(PermissionAll) < val {
+	if val <= int(PermissionInvalid) {
 		return PermissionInvalid, fmt.Errorf("permissions %d out of range %d - %d", val, PermissionRead, PermissionAll)
+	} else if int(PermissionAll) < val {
+		return PermissionInvalid, ErrPermissionAboveRange
 	}
 	return Permissions(val), nil
 }

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/shares.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/shares.go
@@ -193,7 +193,11 @@ func (h *Handler) createShare(w http.ResponseWriter, r *http.Request) {
 				}
 				permissions, err = conversions.NewPermissions(pint)
 				if err != nil {
-					response.WriteOCSError(w, r, response.MetaBadRequest.StatusCode, err.Error(), nil)
+					if err == conversions.ErrPermissionAboveRange {
+						response.WriteOCSError(w, r, http.StatusNotFound, err.Error(), nil)
+					} else {
+						response.WriteOCSError(w, r, response.MetaBadRequest.StatusCode, err.Error(), nil)
+					}
 					return
 				}
 				role = conversions.Permissions2Role(permissions)


### PR DESCRIPTION
API v2 returns HTTP 404 instead of HTTP 400.
Fixes some tests related to https://github.com/owncloud/ocis-reva/issues/45