### PR TITLE
Always return size in ocdav

### DIFF
--- a/internal/http/services/owncloud/ocdav/propfind.go
+++ b/internal/http/services/owncloud/ocdav/propfind.go
@@ -246,11 +246,15 @@ func (s *svc) mdToPropResponse(ctx context.Context, pf *propfindXML, md *provide
 				s.newProp("d:getcontenttype", "httpd/unix-directory"),
 				s.newProp("oc:size", size),
 			)
-		} else if md.MimeType != "" {
+		} else {
 			response.Propstat[0].Prop = append(response.Propstat[0].Prop,
-				s.newProp("d:getcontenttype", md.MimeType),
 				s.newProp("d:getcontentlength", size),
 			)
+			if md.MimeType != "" {
+				response.Propstat[0].Prop = append(response.Propstat[0].Prop,
+					s.newProp("d:getcontenttype", md.MimeType),
+				)
+			}
 		}
 		// Finder needs the the getLastModified property to work.
 		t := utils.TSToTime(md.Mtime).UTC()


### PR DESCRIPTION
Return the file size in ocdav regardless whether the mime type was
detected or not

See https://github.com/owncloud/ocis-reva/issues/67#issuecomment-623944982 for context.

Separately, we might also want to default to "application/octet-stream" instead of an empty string when the mime type was not detectable.

@butonic @labkode 