### PR TITLE
Default mime when none detected

### DIFF
--- a/pkg/mime/mime.go
+++ b/pkg/mime/mime.go
@@ -52,6 +52,10 @@ func Detect(isDir bool, fn string) string {
 		mimeType = gomime.TypeByExtension(ext)
 	}
 
+	if mimeType == "" {
+		mimeType = "application/octet-stream"
+	}
+
 	return mimeType
 }
 


### PR DESCRIPTION
Whenever the mime type could not be detected, default to
"application/octet-stream"