### PR TITLE
Fix arbitrary namespace in PROPFIND

### DIFF
--- a/internal/http/services/owncloud/ocdav/propfind.go
+++ b/internal/http/services/owncloud/ocdav/propfind.go
@@ -184,6 +184,14 @@ func (s *svc) xmlEscaped(val string) string {
 	return buf.String()
 }
 
+func (s *svc) newPropNS(namespace string, local string, val string) *propertyXML {
+	return &propertyXML{
+		XMLName:  xml.Name{Space: namespace, Local: local},
+		Lang:     "",
+		InnerXML: []byte(val),
+	}
+}
+
 func (s *svc) newProp(key, val string) *propertyXML {
 	return &propertyXML{
 		XMLName:  xml.Name{Space: "", Local: key},
@@ -419,11 +427,15 @@ func (s *svc) mdToPropResponse(ctx context.Context, pf *propfindXML, md *provide
 					propstatNotFound.Prop = append(propstatNotFound.Prop, s.newProp("d:"+pf.Prop[i].Local, ""))
 				}
 			default:
-				// TODO (jfd) lookup shortname for unknown namespaces?
-				propstatNotFound.Prop = append(propstatNotFound.Prop, s.newProp(pf.Prop[i].Space+":"+pf.Prop[i].Local, ""))
+				propstatNotFound.Prop = append(propstatNotFound.Prop, s.newPropNS(pf.Prop[i].Space, pf.Prop[i].Local, ""))
 			}
 		}
-		response.Propstat = append(response.Propstat, propstatOK, propstatNotFound)
+		if len(propstatOK.Prop) > 0 {
+			response.Propstat = append(response.Propstat, propstatOK)
+		}
+		if len(propstatNotFound.Prop) > 0 {
+			response.Propstat = append(response.Propstat, propstatNotFound)
+		}
 	}
 
 	return &response, nil


### PR DESCRIPTION
Arbitrary namespaces can usually be URLs, so we have to properly
pass them into the formatter instead of concatenating it as an alias.

Also fixed PROPFIND response to not contain empty status blocks.

Discovered while debugging PROPPATCH here: https://github.com/owncloud/ocis-reva/issues/57#issuecomment-624523683

Steps to reproduce: use the steps from https://github.com/owncloud/core/issues/32660 against a resource on the API backend (port 9140)

Before this fix, broken namespaces:
```
<?xml version="1.0" encoding="utf-8"?>
<d:multistatus xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns" xmlns:oc="http://owncloud.org/ns">
<d:response>
   <d:href>/remote.php/webdav/litmus/</d:href>
   <d:propstat>
      <d:prop></d:prop>
      <d:status>HTTP/1.1 200 OK</d:status>
   </d:propstat>
   <d:propstat>
      <d:prop>
         <http://example.com/alpha:somename></http://example.com/alpha:somename>
         <http://example.com/beta:somename></http://example.com/beta:somename>
         <http://example.com/gamma:somename></http://example.com/gamma:somename>
         <http://example.com/delta:somename></http://example.com/delta:somename>
         <http://example.com/epsilon:somename></http://example.com/epsilon:somename>
         <http://example.com/zeta:somename></http://example.com/zeta:somename>
         <http://example.com/eta:somename></http://example.com/eta:somename>
         <http://example.com/theta:somename></http://example.com/theta:somename>
         <http://example.com/iota:somename></http://example.com/iota:somename>
         <http://example.com/kappa:somename></http://example.com/kappa:somename>
   </d:prop>
   <d:status>HTTP/1.1 404 Not Found</d:status>
   </d:propstat>
</d:response>
</d:multistatus>
```

After this fix:
```
<?xml version="1.0" encoding="utf-8"?>
<d:multistatus xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns" xmlns:oc="http://owncloud.org/ns">
  <d:response>
    <d:href>/remote.php/webdav/litmus/</d:href>
    <d:propstat>
      <d:prop>
        <somename xmlns="http://example.com/alpha"/>
        <somename xmlns="http://example.com/beta"/>
        <somename xmlns="http://example.com/gamma"/>
        <somename xmlns="http://example.com/delta"/>
        <somename xmlns="http://example.com/epsilon"/>
        <somename xmlns="http://example.com/zeta"/>
        <somename xmlns="http://example.com/eta"/>
        <somename xmlns="http://example.com/theta"/>
        <somename xmlns="http://example.com/iota"/>
        <somename xmlns="http://example.com/kappa"/>
      </d:prop>
      <d:status>HTTP/1.1 404 Not Found</d:status>
    </d:propstat>
  </d:response>
</d:multistatus>
```

Note: I don't think this will fix litmus tests as it expects custom properties to be settable while here they are returned as 404. Still, it's a step forward to at least make the response properly parse-able.

@butonic 