### PR TITLE
Returning custom Webdav properties

### DIFF
--- a/internal/http/services/owncloud/ocdav/propfind.go
+++ b/internal/http/services/owncloud/ocdav/propfind.go
@@ -427,7 +427,16 @@ func (s *svc) mdToPropResponse(ctx context.Context, pf *propfindXML, md *provide
 					propstatNotFound.Prop = append(propstatNotFound.Prop, s.newProp("d:"+pf.Prop[i].Local, ""))
 				}
 			default:
-				propstatNotFound.Prop = append(propstatNotFound.Prop, s.newPropNS(pf.Prop[i].Space, pf.Prop[i].Local, ""))
+				// handle custom properties
+				if k := md.GetArbitraryMetadata(); k == nil {
+					propstatNotFound.Prop = append(propstatNotFound.Prop, s.newPropNS(pf.Prop[i].Space, pf.Prop[i].Local, ""))
+				} else if amd := k.GetMetadata(); amd == nil {
+					propstatNotFound.Prop = append(propstatNotFound.Prop, s.newPropNS(pf.Prop[i].Space, pf.Prop[i].Local, ""))
+				} else if v, ok := amd[fmt.Sprintf("%s/%s", pf.Prop[i].Space, pf.Prop[i].Local)]; ok && v != "" {
+					propstatOK.Prop = append(propstatOK.Prop, s.newPropNS(pf.Prop[i].Space, pf.Prop[i].Local, v))
+				} else {
+					propstatNotFound.Prop = append(propstatNotFound.Prop, s.newPropNS(pf.Prop[i].Space, pf.Prop[i].Local, ""))
+				}
 			}
 		}
 		if len(propstatOK.Prop) > 0 {


### PR DESCRIPTION
Adjust PROPFIND to process custom properties

Adjust storage provider to read custom properties from extended
attributes

- [x] check whether we want to allow owncloud-namespaced dead properties (non-processed)
- [x] add filter to xattr property list
- [x] debug xattr code
- [ ] add todo/ticket for optimizing and providing a way to query specific properties from the storage instead of all
