### PR TITLE
OCFS properly process empty file upload

### DIFF
--- a/internal/http/services/owncloud/ocdav/put.go
+++ b/internal/http/services/owncloud/ocdav/put.go
@@ -254,6 +254,7 @@ func (s *svc) handlePut(w http.ResponseWriter, r *http.Request, ns string) {
 
 	tusc, err := tus.NewClient(dataServerURL, c)
 	if err != nil {
+		log.Error().Err(err).Msg("Could not get TUS client")
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
@@ -273,10 +274,12 @@ func (s *svc) handlePut(w http.ResponseWriter, r *http.Request, ns string) {
 	// start the uploading process.
 	err = uploader.Upload()
 	if err != nil {
+		log.Error().Err(err).Msg("Could not start TUS upload")
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 
+	// stat again to check the new file's metadata
 	sRes, err = client.Stat(ctx, sReq)
 	if err != nil {
 		log.Error().Err(err).Msg("error sending grpc stat request")
@@ -285,6 +288,7 @@ func (s *svc) handlePut(w http.ResponseWriter, r *http.Request, ns string) {
 	}
 
 	if sRes.Status.Code != rpc.Code_CODE_OK {
+		log.Error().Err(err).Msgf("error status %d when sending grpc stat request", sRes.Status.Code)
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}


### PR DESCRIPTION
We should fix the two TUS layers to properly process uploads with 0 bytes to automatically finish:

Fixes https://github.com/owncloud/ocis-reva/issues/188

- [x] Fix scenario 1: Webdav PUT upload of empty file
- [ ] Fix scenario 2: Webdav TUS upload of empty file

### Scenario 1: Webdav PUT upload of empty file

In Phoenix when creating a new file, it uses a PUT with empty payload to create the file.
The PUT goes to ocdav/put.go and gets converted to a TUS upload to the backend.
In this PR the backend has a new shortcut to automatically finish the upload.

### Scenario 2: TUS upload of empty file

In Phoenix, try uploading an empty file that exists on local disk.

In this scenario, the code flow goes into tus.go and initiates the upload in the backend storage.
However it doesn't create the file automatically despite the fix for scenario 1.
I tried to debug this and somehow it seems that it doesn't even reach owncloud/upload.go for the upload and aborts earlier.
I'm a bit confused about the code path between the file upload initiation and finishing the upload in the case of TUS. Maybe it's in the storage provider.

I also tried to make it send an empty PATCH to the backend but that makes it return 400 bad request.

Also: it is likely that we'll need a similar fix for EOS.

@butonic thoughts ?
