### PR TITLE
ocdav: Adjust propstat response for removed properties

### DIFF
--- a/internal/http/services/owncloud/ocdav/proppatch.go
+++ b/internal/http/services/owncloud/ocdav/proppatch.go
@@ -19,10 +19,12 @@
 package ocdav
 
 import (
+	"context"
 	"encoding/xml"
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"path"
 	"strings"
 
@@ -39,6 +41,9 @@ func (s *svc) handleProppatch(w http.ResponseWriter, r *http.Request, ns string)
 	ctx, span := trace.StartSpan(ctx, "proppatch")
 	defer span.End()
 	log := appctx.GetLogger(ctx)
+
+	acceptedProps := []xml.Name{}
+	removedProps := []xml.Name{}
 
 	ns = applyLayout(ctx, ns)
 
@@ -58,11 +63,29 @@ func (s *svc) handleProppatch(w http.ResponseWriter, r *http.Request, ns string)
 		return
 	}
 
-	mkeys := []string{}
-
-	pf := &propfindXML{
-		Prop: propfindProps{},
+	// check if resource exists
+	statReq := &provider.StatRequest{
+		Ref: &provider.Reference{
+			Spec: &provider.Reference_Path{Path: fn},
+		},
 	}
+	statRes, err := c.Stat(ctx, statReq)
+	if err != nil {
+		log.Error().Err(err).Msg("error sending a grpc stat request")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	if statRes.Status.Code != rpc.Code_CODE_OK {
+		if statRes.Status.Code == rpc.Code_CODE_NOT_FOUND {
+			log.Warn().Str("path", fn).Msg("resource not found")
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
 	rreq := &provider.UnsetArbitraryMetadataRequest{
 		Ref: &provider.Reference{
 			Spec: &provider.Reference_Path{Path: fn},
@@ -82,7 +105,7 @@ func (s *svc) handleProppatch(w http.ResponseWriter, r *http.Request, ns string)
 			continue
 		}
 		for j := range pp[i].Props {
-			pf.Prop = append(pf.Prop, pp[i].Props[j].XMLName)
+			propNameXml := pp[i].Props[j].XMLName
 			// don't use path.Join. It removes the double slash! concatenate with a /
 			key := fmt.Sprintf("%s/%s", pp[i].Props[j].XMLName.Space, pp[i].Props[j].XMLName.Local)
 			value := string(pp[i].Props[j].InnerXML)
@@ -95,13 +118,21 @@ func (s *svc) handleProppatch(w http.ResponseWriter, r *http.Request, ns string)
 					remove = true
 				}
 			}
+			// FIXME: Webdav spec requires the operations to be executed in the order
+			// specified in the PROPPATCH request
+			// http://www.webdav.org/specs/rfc2518.html#rfc.section.8.2
 			if remove {
 				rreq.ArbitraryMetadataKeys = append(rreq.ArbitraryMetadataKeys, key)
+				removedProps = append(removedProps, propNameXml)
 			} else {
+				acceptedProps = append(acceptedProps, propNameXml)
 				sreq.ArbitraryMetadata.Metadata[key] = value
 			}
-			mkeys = append(mkeys, key)
 		}
+		// FIXME: in case of error, need to set all properties back to the original state,
+		// and return the error in the matching propstat block, if applicable
+		// http://www.webdav.org/specs/rfc2518.html#rfc.section.8.2
+
 		// what do we need to unset
 		if len(rreq.ArbitraryMetadataKeys) > 0 {
 			res, err := c.UnsetArbitraryMetadata(ctx, rreq)
@@ -141,35 +172,15 @@ func (s *svc) handleProppatch(w http.ResponseWriter, r *http.Request, ns string)
 		}
 	}
 
-	req := &provider.StatRequest{
-		Ref: &provider.Reference{
-			Spec: &provider.Reference_Path{Path: fn},
-		},
-		ArbitraryMetadataKeys: mkeys,
+	ref := strings.TrimPrefix(fn, ns)
+	ref = path.Join(ctx.Value(ctxKeyBaseURI).(string), ref)
+	if statRes.Info.Type == provider.ResourceType_RESOURCE_TYPE_CONTAINER {
+		ref += "/"
 	}
-	res, err := c.Stat(ctx, req)
+
+	propRes, err := s.formatProppatchResponse(ctx, acceptedProps, removedProps, ref)
 	if err != nil {
-		log.Error().Err(err).Msg("error sending a grpc stat request")
-		w.WriteHeader(http.StatusInternalServerError)
-		return
-	}
-
-	if res.Status.Code != rpc.Code_CODE_OK {
-		if res.Status.Code == rpc.Code_CODE_NOT_FOUND {
-			log.Warn().Str("path", fn).Msg("resource not found")
-			w.WriteHeader(http.StatusNotFound)
-			return
-		}
-		w.WriteHeader(http.StatusInternalServerError)
-		return
-	}
-
-	info := res.Info
-	infos := []*provider.ResourceInfo{info}
-
-	propRes, err := s.formatPropfind(ctx, pf, infos, ns)
-	if err != nil {
-		log.Error().Err(err).Msg("error formatting propfind")
+		log.Error().Err(err).Msg("error formatting proppatch response")
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
@@ -179,6 +190,47 @@ func (s *svc) handleProppatch(w http.ResponseWriter, r *http.Request, ns string)
 	if _, err := w.Write([]byte(propRes)); err != nil {
 		log.Err(err).Msg("error writing response")
 	}
+}
+
+func (s *svc) formatProppatchResponse(ctx context.Context, acceptedProps []xml.Name, removedProps []xml.Name, ref string) (string, error) {
+	responses := make([]responseXML, 0, 1)
+	response := responseXML{
+		Href:     (&url.URL{Path: ref}).EscapedPath(), // url encode response.Href
+		Propstat: []propstatXML{},
+	}
+
+	if len(acceptedProps) > 0 {
+		propstatBody := []*propertyXML{}
+		for i := range acceptedProps {
+			propstatBody = append(propstatBody, s.newPropNS(acceptedProps[i].Space, acceptedProps[i].Local, ""))
+		}
+		response.Propstat = append(response.Propstat, propstatXML{
+			Status: "HTTP/1.1 200 OK",
+			Prop:   propstatBody,
+		})
+	}
+
+	if len(removedProps) > 0 {
+		propstatBody := []*propertyXML{}
+		for i := range removedProps {
+			propstatBody = append(propstatBody, s.newPropNS(removedProps[i].Space, removedProps[i].Local, ""))
+		}
+		response.Propstat = append(response.Propstat, propstatXML{
+			Status: "HTTP/1.1 204 No Content",
+			Prop:   propstatBody,
+		})
+	}
+
+	responses = append(responses, response)
+	responsesXML, err := xml.Marshal(&responses)
+	if err != nil {
+		return "", err
+	}
+
+	msg := `<?xml version="1.0" encoding="utf-8"?><d:multistatus xmlns:d="DAV:" `
+	msg += `xmlns:s="http://sabredav.org/ns" xmlns:oc="http://owncloud.org/ns">`
+	msg += string(responsesXML) + `</d:multistatus>`
+	return msg, nil
 }
 
 func (s *svc) isBooleanProperty(prop string) bool {


### PR DESCRIPTION
Removed properties now appear in a propstat block with status 204.
The list of properties appearing in propstat blocks now depend on the
request and no more on the values returned by the Stat call.

This fixes the propdeletes and popreplace test cases from Litmus.

Former result is https://github.com/owncloud/ocis-reva/issues/183
Current result after the fix:
```
docker run -e LITMUS_URL="http://172.17.0.1:9140/remote.php/webdav" -e LITMUS_USERNAME="einstein" -e LITMUS_PASSWORD="relativity" -e TESTS="props" owncloud/litmus:latest
-> running `props':
 0. init.................. pass
 1. begin................. pass
 2. propfind_invalid...... pass
 3. propfind_invalid2..... pass
 4. propfind_d0........... pass
 5. propinit.............. pass
 6. propset............... pass
 7. propget............... pass
 8. propextended.......... pass
 9. propmove.............. pass
10. propget............... pass
11. propdeletes........... pass
12. propget............... pass
13. propreplace........... pass
14. propget............... pass
15. propnullns............ pass
16. propget............... pass
17. propremoveset......... pass
18. propget............... pass
19. propsetremove......... pass
20. propget............... FAIL (Deleted property `{http://example.com/neon/litmus/}removeset' was still present)
21. propvalnspace......... pass
22. propwformed........... FAIL (PROPFIND on `/remote.php/webdav/litmus/prop2': 207 Multi-Status)
23. propinit.............. pass
24. propmanyns............ pass
25. propget............... pass
26. propcleanup........... pass
27. finish................ pass
<- summary for `props': of 28 tests run: 26 passed, 2 failed. 92.9%
See debug.log for network/debug traces.
```

Next up I'll look into those additional issues.