### PR TITLE
Point the 'Edit this page' link to the docs subdir

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -78,10 +78,10 @@ github_repo = "https://github.com/cs3org/reva"
 github_project_repo = "https://github.com/cs3org/reva"
 
 # Specify a value here if your content directory is not in your repo's root directory
-# github_subdir = ""
+github_subdir = "docs"
 
 # Google Custom Search Engine ID. Remove or comment out to disable search.
- gcs_engine_id = "010913146518163072247:tinkle2veql"
+gcs_engine_id = "010913146518163072247:tinkle2veql"
 
 # Enable Algolia DocSearch
 algolia_docsearch = false


### PR DESCRIPTION
I've just noticed the link to "_Edit this page_" link on the right sidebar of the docs was pointing to the wrong URL:

![imagen](https://user-images.githubusercontent.com/2644445/81953479-fe15cb00-9607-11ea-8d49-3c6230ae8a84.png)

e.g. https://github.com/cs3org/reva/edit/master/content/en/docs/Config/_index.md