### PR TITLE
Make sharing behavior consitent with the behavior of the old backend

### DIFF
--- a/internal/http/services/owncloud/ocs/conversions/permissions.go
+++ b/internal/http/services/owncloud/ocs/conversions/permissions.go
@@ -41,17 +41,17 @@ const (
 )
 
 var (
-	// ErrPermissionAboveRange defines a permission specific error.
-	ErrPermissionAboveRange = fmt.Errorf("The provided permission is higher than %d", PermissionAll)
+	// ErrPermissionNotInRange defines a permission specific error.
+	ErrPermissionNotInRange = fmt.Errorf("The provided permission is not between %d and %d", PermissionInvalid, PermissionAll)
 )
 
 // NewPermissions creates a new Permissions instanz.
 // The value must be in the valid range.
 func NewPermissions(val int) (Permissions, error) {
-	if val <= int(PermissionInvalid) {
+	if val == int(PermissionInvalid) {
 		return PermissionInvalid, fmt.Errorf("permissions %d out of range %d - %d", val, PermissionRead, PermissionAll)
-	} else if int(PermissionAll) < val {
-		return PermissionInvalid, ErrPermissionAboveRange
+	} else if val < int(PermissionInvalid) || int(PermissionAll) < val {
+		return PermissionInvalid, ErrPermissionNotInRange
 	}
 	return Permissions(val), nil
 }

--- a/internal/http/services/owncloud/ocs/response/response.go
+++ b/internal/http/services/owncloud/ocs/response/response.go
@@ -188,10 +188,7 @@ func UserIDToString(userID *user.UserId) string {
 	if userID == nil || userID.OpaqueId == "" {
 		return ""
 	}
-	if userID.Idp == "" {
-		return userID.OpaqueId
-	}
-	return userID.OpaqueId + "@" + userID.Idp
+	return userID.OpaqueId
 }
 
 func encodeXML(res Response) ([]byte, error) {


### PR DESCRIPTION
This pull request fixes the behavior of the createShare api.
It includes fixes for the return status codes, correct mapping of the permissions, correct response content.

Partially fixed
- https://github.com/owncloud/ocis-reva/issues/20
- https://github.com/owncloud/ocis-reva/issues/46

Fixed:
- https://github.com/owncloud/ocis-reva/issues/26
- https://github.com/owncloud/ocis-reva/issues/43
- https://github.com/owncloud/ocis-reva/issues/44
- https://github.com/owncloud/ocis-reva/issues/94