### PR TITLE
WIP prevent creating dir in another home

### DIFF
--- a/internal/http/services/owncloud/ocdav/mkcol.go
+++ b/internal/http/services/owncloud/ocdav/mkcol.go
@@ -19,6 +19,7 @@
 package ocdav
 
 import (
+	"fmt"
 	"io"
 	"net/http"
 	"path"
@@ -69,6 +70,8 @@ func (s *svc) handleMkcol(w http.ResponseWriter, r *http.Request, ns string) {
 		return
 	}
 
+	log.Debug().Msg("#### Before client.CreateContainer")
+
 	req := &provider.CreateContainerRequest{Ref: ref}
 	res, err := client.CreateContainer(ctx, req)
 	if err != nil {
@@ -77,8 +80,20 @@ func (s *svc) handleMkcol(w http.ResponseWriter, r *http.Request, ns string) {
 		return
 	}
 
+	log.Debug().Str("res.Status.Code", fmt.Sprintf("%d", res.Status.Code)).Msg("After client.CreateContainer")
+
 	if res.Status.Code == rpc.Code_CODE_NOT_FOUND {
 		w.WriteHeader(http.StatusConflict)
+		return
+	}
+
+	if res.Status.Code == rpc.Code_CODE_ALREADY_EXISTS {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+
+	if res.Status.Code == rpc.Code_CODE_PERMISSION_DENIED {
+		w.WriteHeader(http.StatusForbidden)
 		return
 	}
 


### PR DESCRIPTION
Context is here: https://github.com/owncloud/ocis-reva/issues/197
It's about preventing access to other user's homes.

Currently the OCFS propagator fails because it is performing said check and assuming we work only in the current user's home.

I tried to reuse that logic to enforce a "permission denied" in CreateDir (and later also in other calls). I'm unsure if this check is overkill and whether it should or should not include both cases where EnableHome is set and unset.

However what doesn't work correctly here is that even though [a "permission denied" error is created and returned](https://github.com/PVince81/butonic-reva/blob/ocfs-forbid-cross-home-access/pkg/storage/fs/owncloud/owncloud.go#L948), it still gets converted to an "internal server error" RPC code.

@butonic let me know if this POC makes sense at all and if yes, give me some advice about the RPC code issue
