### PR TITLE
meshdirectory: add mentix driver for gocdb sites integration

### DIFF
--- a/docs/content/en/docs/Config/HTTP/Services/MeshDirectory/_index.md
+++ b/docs/content/en/docs/Config/HTTP/Services/MeshDirectory/_index.md
@@ -1,0 +1,83 @@
+---
+title: "meshdirectory"
+linkTitle: "meshdirectory"
+weight: 10
+description: >
+  Configuration for the Mesh Directory service
+---
+
+{{% dir name="static" type="string" default="static" %}}
+Path to a static directory containing a UI frontend for the service.
+This directory must contain an **index.html** file at least.
+{{< highlight toml >}}
+[http.services.meshdirectory]
+static = "/path/to/static"
+{{< /highlight >}}
+{{% /dir %}}
+
+{{% dir name="driver" type="string" default="json" %}}
+Which driver to use as a source of Mesh Provider data. Currently supported drivers are: **mentix**, **json**.
+{{< highlight toml >}}
+[http.services.meshdirectory]
+driver = "mentix"
+{{< /highlight >}}
+{{% /dir %}}
+
+{{% dir name="url" type="string" default="http://localhost:9600/" %}}
+URL of Mentix HTTP service when using the Mentix driver to query for Mesh Providers.
+{{< highlight toml >}}
+[http.services.meshdirectory.drivers.mentix]
+url = "http://localhost:9600/"
+{{< /highlight >}}
+{{% /dir %}}
+
+{{% dir name="providers" type="string" default="" %}}
+Source file containing Mesh Provider data when using the JSON driver.
+{{< highlight toml >}}
+[http.services.meshdirectory.drivers.json]
+providers = "providers.json"
+{{< /highlight >}}
+{{% /dir %}}
+
+The expected format of the JSON source file is:
+{{< highlight json >}}
+{
+  "providers": [
+    {
+      "Name": "cernbox",
+      "FullName": "CERNBox",
+      "Organization": "CERN",
+      "Domain": "cernbox.cern.ch",
+      "Homepage": "https://cernbox.cern.ch",
+      "Description": "CERNBox provides cloud data storage to all CERN users.",
+      "Services": [
+        {
+          "Type": {
+            "Name": "OCM",
+            "Description": "CERNBox Open Cloud Mesh API"
+          },
+          "Name": "CERNBox - OCM API",
+          "Path": "",
+          "IsMonitored": true,
+          "Properties": {},
+          "Host": "",
+          "AdditionalEndpoints": [
+            {
+              "IsMonitored": true,
+              "Name": "OCM API",
+              "Path": "https://cernbox.cern.ch/ocm",
+              "Properties": {},
+              "Type": {
+                "Description": "Open Cloud Mesh",
+                "Name": "OCM"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+{{< /highlight >}}
+
+

--- a/examples/meshdirectory/meshdirectory.toml
+++ b/examples/meshdirectory/meshdirectory.toml
@@ -6,7 +6,10 @@ address = "0.0.0.0:19001"
 enabled_services = ["meshdirectory"]
 
 [http.services.meshdirectory]
-driver = "json"
+driver = "mentix"
 
-[http.services.meshdirectory.drivers.json]
-providers = "providers.demo.json"
+#[http.services.meshdirectory.drivers.json]
+#providers = "providers.demo.json"
+
+[http.services.meshdirectory.drivers.mentix]
+url = "http://localhost:9600/gocdb/"

--- a/examples/meshdirectory/meshdirectory.toml
+++ b/examples/meshdirectory/meshdirectory.toml
@@ -10,6 +10,6 @@ driver = "mentix"
 
 #[http.services.meshdirectory.drivers.json]
 #providers = "providers.demo.json"
-
-[http.services.meshdirectory.drivers.mentix]
-url = "http://localhost:9600/gocdb/"
+#
+#[http.services.meshdirectory.drivers.mentix]
+#url = "http://localhost:9600/"

--- a/examples/meshdirectory/providers.demo.json
+++ b/examples/meshdirectory/providers.demo.json
@@ -1,37 +1,103 @@
 {
   "providers": [
     {
-      "id": "cernbox",
-      "org": "CERN",
-      "name": "CERNBox",
-      "description": "CERNBox provides cloud data storage to all CERN users.You can store your data,share it and synchronise it across devices - smartphones, tablets, laptops, desktops, the lot!",
-      "domain": "cernbox.cern.ch",
-      "logo": "https://github.com/cernbox/branding/blob/master/cernbox-lrg.svg",
-      "homepage": "https://cernbox.cern.ch",
-      "ocm_api": "ocm/",
-      "api_version": "0.0.1"
+      "Name": "cernbox",
+      "FullName": "CERNBox",
+      "Organization": "CERN",
+      "Domain": "cernbox.cern.ch",
+      "Homepage": "https://cernbox.cern.ch",
+      "Description": "CERNBox provides cloud data storage to all CERN users.You can store your data,share it and synchronise it across devices - smartphones, tablets, laptops, desktops, the lot!",
+      "Services": [
+        {
+          "Type": {
+            "Name": "OCM",
+            "Description": "CERNBox Open Cloud Mesh API"
+          },
+          "Name": "CERNBox - OCM API",
+          "Path": "",
+          "IsMonitored": true,
+          "Properties": {},
+          "Host": "",
+          "AdditionalEndpoints": [
+            {
+              "IsMonitored": true,
+              "Name": "OCM API",
+              "Path": "https://cernbox.cern.ch/ocm",
+              "Properties": {},
+              "Type": {
+                "Description": "Open Cloud Mesh",
+                "Name": "OCM"
+              }
+            }
+          ]
+        }
+      ]
     },
     {
-      "id": "oc-cesnet",
-      "org": "CESNET",
-      "name": "ownCloud@CESNET",
-      "description": "OwnCloud has been designed for individual users. It enables automatic data synchronisation between various computers and mobile devices of the user. Data are also available through the web interface. Data can be easily shared with colleagues.",
-      "domain": "owncloud.cesnet.cz",
-      "logo": "",
-      "homepage": "https://owncloud.cesnet.cz",
-      "ocm_api": "ocm/",
-      "api_version": "0.0.1"
+      "Name": "oc-cesnet",
+      "FullName": "ownCloud@CESNET",
+      "Organization": "CESNET",
+      "Domain": "owncloud.cesnet.cz",
+      "Homepage": "https://owncloud.cesnet.cz",
+      "Description": "OwnCloud has been designed for individual users. It enables automatic data synchronisation between various computers and mobile devices of the user. Data are also available through the web interface. Data can be easily shared with colleagues.",
+      "Services": [
+        {
+          "Type": {
+            "Name": "OCM",
+            "Description": "CESNET Open Cloud Mesh API"
+          },
+          "Name": "CESNET - OCM API",
+          "Path": "",
+          "IsMonitored": true,
+          "Properties": {},
+          "Host": "",
+          "AdditionalEndpoints": [
+            {
+              "IsMonitored": true,
+              "Name": "OCM API",
+              "Path": "https://owncloud.cesnet.cz/ocm",
+              "Properties": {},
+              "Type": {
+                "Description": "Open Cloud Mesh",
+                "Name": "OCM"
+              }
+            }
+          ]
+        }
+      ]
     },
     {
-      "id": "catbox",
-      "org": "Erwin Schrödinger",
-      "name": "CatBox",
-      "description": "A nondeterministic storage of cats.",
-      "domain": "catbox.example.org",
-      "logo": "",
-      "homepage": "https://catbox.example.org/dead",
-      "ocm_api": "alive/ocm/",
-      "api_version": "0.0.1"
+      "Name": "catbox",
+      "FullName": "CatBox",
+      "Organization": "Erwin Schrödinger",
+      "Domain": "catbox.example.org",
+      "Homepage": "https://catbox.example.org/dead",
+      "Description": "A nondeterministic storage of cats.",
+      "Services": [
+        {
+          "Type": {
+            "Name": "OCM",
+            "Description": "CatBox Open Cloud Mesh API"
+          },
+          "Name": "CatBox - OCM API",
+          "Path": "",
+          "IsMonitored": true,
+          "Properties": {},
+          "Host": "",
+          "AdditionalEndpoints": [
+            {
+              "IsMonitored": true,
+              "Name": "OCM API",
+              "Path": "https://catbox.example.org/alive/ocm",
+              "Properties": {},
+              "Type": {
+                "Description": "Open Cloud Mesh",
+                "Name": "OCM"
+              }
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/examples/meshdirectory/static/index.html
+++ b/examples/meshdirectory/static/index.html
@@ -44,15 +44,15 @@
     <div class="provider-container">
         <div class="input-group">
             <select v-model="selected" class="provider-list">
-                <option v-for="provider in providers" :value="provider.id" :key="provider.id">
-                    {{ provider.name }}
+                <option v-for="provider in providers" :value="provider.Name" :key="provider.Name">
+                    {{ provider.FullName }}
                 </option>
             </select>
             <div class="provider-details" v-if="selected">
                 <h5>Operator:</h5>
-                <span>{{ providerDetails.org }}</span>
+                <span>{{ providerDetails.Organization }}</span>
                 <h5>Service description:</h5>
-                <p>{{ providerDetails.description }}</p>
+                <p>{{ providerDetails.Description }}</p>
             </div>
             <div class="provider-navigate" v-if="selected">
                 <a class="provider-btn button"  :href="providerLink(providerDetails)">Go!</a>
@@ -76,13 +76,18 @@
         },
         methods: {
             providerLink(provider) {
-                return `https://${provider.domain}/${provider.ocm_api}?${this.queryParams}`;
+                return this.ocmService(provider).AdditionalEndpoints[0].Path
+            },
+            ocmService(provider) {
+                return provider.Services.find(s => {
+                    return s.Type.Name === 'OCM'
+                })
             }
         },
         computed: {
             providerDetails: function () {
                 return this.providers.find(p => {
-                    return p.id === this.selected
+                    return p.Name === this.selected
                 })
             },
             baseUrl: function () {
@@ -96,7 +101,10 @@
             axios
                 .get(this.baseUrl)
                 .then(response => {
-                    this.providers = response.data;
+                    this.providers = response.data.providers;
+                })
+                .catch(err => {
+                    console.log(err)
                 });
         }
     });

--- a/pkg/meshdirectory/manager/json/json.go
+++ b/pkg/meshdirectory/manager/json/json.go
@@ -45,7 +45,7 @@ func New(m map[string]interface{}) (meshdirectory.Manager, error) {
 	// load mesh providers file
 	model, err := load(c.File)
 	if err != nil {
-		err = errors.Wrap(err, "error loading the file containing the shares")
+		err = errors.Wrap(err, "error loading the file containing the providers")
 		return nil, err
 	}
 
@@ -83,7 +83,7 @@ func load(file string) (*meshDirectoryModel, error) {
 
 type meshDirectoryModel struct {
 	file          string
-	MeshProviders []*meshdirectory.MeshProvider `json:"providers"`
+	MeshProviders *[]meshdirectory.MeshProvider `json:"providers"`
 }
 
 type config struct {
@@ -104,6 +104,6 @@ func parseConfig(m map[string]interface{}) (*config, error) {
 	return c, nil
 }
 
-func (m *mgr) GetMeshProviders() []*meshdirectory.MeshProvider {
-	return m.model.MeshProviders
+func (m *mgr) GetMeshProviders() (*[]meshdirectory.MeshProvider, error) {
+	return m.model.MeshProviders, nil
 }

--- a/pkg/meshdirectory/manager/loader/loader.go
+++ b/pkg/meshdirectory/manager/loader/loader.go
@@ -21,5 +21,6 @@ package loader
 import (
 	// Load core share manager drivers.
 	_ "github.com/cs3org/reva/pkg/meshdirectory/manager/json"
+	_ "github.com/cs3org/reva/pkg/meshdirectory/manager/mentix"
 	// Add your own here
 )

--- a/pkg/meshdirectory/manager/mentix/mentix.go
+++ b/pkg/meshdirectory/manager/mentix/mentix.go
@@ -33,6 +33,7 @@ func init() {
 	registry.Register("mentix", New)
 }
 
+// Client is a Mentix API client
 type Client struct {
 	BaseURL    string
 	HTTPClient *http.Client

--- a/pkg/meshdirectory/manager/mentix/mentix.go
+++ b/pkg/meshdirectory/manager/mentix/mentix.go
@@ -19,14 +19,16 @@
 package mentix
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
+
 	"github.com/cs3org/reva/pkg/meshdirectory"
 	"github.com/cs3org/reva/pkg/meshdirectory/manager/registry"
 	"github.com/cs3org/reva/pkg/rhttp"
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
-	"net/http"
 )
 
 func init() {
@@ -47,13 +49,18 @@ func New(m map[string]interface{}) (meshdirectory.Manager, error) {
 		return nil, err
 	}
 
+	if c.URL == "" {
+		c.URL = "http://localhost:9600/"
+	}
+
 	client := &Client{
-		BaseURL:    c.URL,
-		HTTPClient: rhttp.GetHTTPClient(nil),
+		BaseURL: c.URL,
+		// TODO: pass/create context once it is required by GetHTTPClient
+		HTTPClient: rhttp.GetHTTPClient(context.TODO()),
 	}
 
 	mgr := &mgr{
-		cfg: c,
+		cfg:    c,
 		client: client,
 	}
 

--- a/pkg/meshdirectory/manager/mentix/mentix.go
+++ b/pkg/meshdirectory/manager/mentix/mentix.go
@@ -1,0 +1,130 @@
+// Copyright 2018-2020 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package mentix
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/cs3org/reva/pkg/meshdirectory"
+	"github.com/cs3org/reva/pkg/meshdirectory/manager/registry"
+	"github.com/cs3org/reva/pkg/rhttp"
+	"github.com/mitchellh/mapstructure"
+	"github.com/pkg/errors"
+	"net/http"
+)
+
+func init() {
+	registry.Register("mentix", New)
+}
+
+type Client struct {
+	BaseURL    string
+	HTTPClient *http.Client
+}
+
+// New returns a new mesh directory manager object.
+func New(m map[string]interface{}) (meshdirectory.Manager, error) {
+	c, err := parseConfig(m)
+	if err != nil {
+		err = errors.Wrap(err, "error creating a new manager")
+		return nil, err
+	}
+
+	client := &Client{
+		BaseURL:    c.URL,
+		HTTPClient: rhttp.GetHTTPClient(nil),
+	}
+
+	mgr := &mgr{
+		cfg: c,
+		client: client,
+	}
+
+	return mgr, nil
+}
+
+type config struct {
+	URL string `mapstructure:"url"`
+}
+
+type mgr struct {
+	client *Client
+	cfg    *config
+}
+
+func parseConfig(m map[string]interface{}) (*config, error) {
+	c := &config{}
+	if err := mapstructure.Decode(m, c); err != nil {
+		return nil, err
+	}
+	return c, nil
+}
+
+func (c *Client) sendRequest(req *http.Request) (*meshdirectory.MentixResponse, error) {
+	req.Header.Set("Accept", "application/json; charset=utf-8")
+	req.Header.Set("Content-Type", "application/json; charset=utf-8")
+
+	res, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	defer res.Body.Close()
+
+	if res.StatusCode < http.StatusOK || res.StatusCode >= http.StatusBadRequest {
+		var errRes meshdirectory.MentixErrorResponse
+		if err = json.NewDecoder(res.Body).Decode(&errRes); err == nil {
+			return nil, errors.New(errRes.Message)
+		}
+
+		return nil, fmt.Errorf("unknown api error, status code: %d", res.StatusCode)
+	}
+
+	var mr meshdirectory.MentixResponse
+	if err = json.NewDecoder(res.Body).Decode(&mr); err != nil {
+		return nil, err
+	}
+
+	return &mr, nil
+}
+
+// GetMeshProviders gets the available mesh providers data.
+func (m *mgr) GetMeshProviders() (*[]meshdirectory.MeshProvider, error) {
+	req, err := http.NewRequest("GET", m.client.BaseURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := m.client.sendRequest(req)
+	if err != nil {
+		return nil, err
+	}
+
+	// Filter out providers without OCM API service
+	var providers []meshdirectory.MeshProvider
+	for _, p := range res.Sites {
+		for _, s := range p.Services {
+			if s.Type.Name == "OCM" {
+				providers = append(providers, p)
+			}
+		}
+	}
+
+	return &providers, nil
+}

--- a/pkg/meshdirectory/meshdirectory.go
+++ b/pkg/meshdirectory/meshdirectory.go
@@ -21,5 +21,5 @@ package meshdirectory
 // Manager is the interface that manages the Sync'n'Share providers directory.
 type Manager interface {
 	// GetMeshProviders gets the available Sync'n'Share providers list.
-	GetMeshProviders() []*MeshProvider
+	GetMeshProviders() (*[]MeshProvider, error)
 }

--- a/pkg/meshdirectory/meshprovider.go
+++ b/pkg/meshdirectory/meshprovider.go
@@ -59,7 +59,7 @@ type MentixErrorResponse struct {
 	Message string `json:"error"`
 }
 
-// MeshDirectoryResponse service response
+// Response service response
 type Response struct {
 	Status        int             `json:"status"`
 	StatusMessage string          `json:"message"`

--- a/pkg/meshdirectory/meshprovider.go
+++ b/pkg/meshdirectory/meshprovider.go
@@ -18,15 +18,50 @@
 
 package meshdirectory
 
-// MeshProvider holds provider metadata
+// ServiceType describes a type of provided service
+type ServiceType struct {
+	Name        string `json:"Name"`
+	Description string `json:"Description"`
+}
+
+// Service holds a service definition
+type Service struct {
+	Type                ServiceType `json:"Type"`
+	Name                string      `json:"Name"`
+	Path                string      `json:"Path"`
+	IsMonitored         bool        `json:"IsMonitored"`
+	Properties          interface{} `json:"Properties"`
+	Host                string      `json:"Host"`
+	AdditionalEndpoints interface{} `json:"AdditionalEndpoints"`
+}
+
+// MeshProvider contains information about a mesh provider site
 type MeshProvider struct {
-	ID          string `json:"id" mapstructure:"id"`
-	Org         string `json:"org" mapstructure:"org"`
-	Name        string `json:"name" mapstructure:"description"`
-	Description string `json:"description" mapstructure:"description"`
-	Domain      string `json:"domain" mapstructure:"domain"`
-	Logo        string `json:"logo" mapstructure:"logo"`
-	Homepage    string `json:"homepage" mapstructure:"homepage"`
-	OCM         string `json:"ocm_api" mapstructure:"ocm_api"`
-	Version     string `json:"api_version" mapstructure:"api_version"`
+	Name         string      `json:"Name"`
+	FullName     string      `json:"FullName"`
+	Organization string      `json:"Organization"`
+	Domain       string      `json:"Domain"`
+	Homepage     string      `json:"Homepage"`
+	Email        string      `json:"Email"`
+	Description  string      `json:"Description"`
+	Services     []Service   `json:"Services"`
+	Properties   interface{} `json:"Properties"`
+}
+
+// MentixResponse holds Mentix API response
+type MentixResponse struct {
+	Sites        []MeshProvider `json:"Sites"`
+	ServiceTypes []ServiceType  `json:"ServiceTypes"`
+}
+
+// MentixErrorResponse holds Mentix API errors
+type MentixErrorResponse struct {
+	Message string `json:"error"`
+}
+
+// MeshDirectoryResponse service response
+type Response struct {
+	Status        int             `json:"status"`
+	StatusMessage string          `json:"message"`
+	Providers     *[]MeshProvider `json:"providers"`
 }


### PR DESCRIPTION
This pull request adds a new driver to meshdirectory service for querying a configurable Mentix REST API for mesh provider site data

Fixes #753 