### PR TITLE
Remove Implicit data member from memory store

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -8,7 +8,6 @@
 - Hugo Gonzalez Labrador <github@hugo.labkode.com>
 - Ilja Neumann <ineumann@owncloud.com>
 - Ilja Neumann <node512@gmail.com>
-- Ishank Arora <ishank.arora@cern.ch>
 - Ishank Arora <ishank011@gmail.com>
 - Jörn Friedrich Dreyer <jfd@butonic.de>
 - LovisaLugnegard <lovisa.lugnegard@gmail.com>

--- a/internal/http/services/oidcprovider/oidcprovider.go
+++ b/internal/http/services/oidcprovider/oidcprovider.go
@@ -197,7 +197,6 @@ func getStore(clients map[string]fosite.Client) *storage.MemoryStore {
 		IDSessions:             make(map[string]fosite.Requester),
 		Clients:                clients,
 		AuthorizeCodes:         map[string]storage.StoreAuthorizeCode{},
-		Implicit:               map[string]fosite.Requester{},
 		AccessTokens:           map[string]fosite.Requester{},
 		RefreshTokens:          map[string]fosite.Requester{},
 		PKCES:                  map[string]fosite.Requester{},

--- a/internal/http/services/oidcprovider/sessions.go
+++ b/internal/http/services/oidcprovider/sessions.go
@@ -106,26 +106,6 @@ func (s *svc) doSessions(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	// Implicit
-	_, err = w.Write([]byte(`</ul><p>Implicit</p><ul>`))
-	if err != nil {
-		log.Error().Err(err).Msg("Error writing response")
-		return
-	}
-	for id, c := range s.store.Implicit {
-		c := c
-		_, err := w.Write([]byte(fmt.Sprintf(`
-			<li>
-				%s: %#v
-			</li>`,
-
-			id, c,
-		)))
-		if err != nil {
-			log.Error().Err(err).Msg("Error writing response")
-			return
-		}
-	}
 	// RefreshTokens
 	_, err = w.Write([]byte(`</ul><p>RefreshTokens</p><ul>`))
 	if err != nil {


### PR DESCRIPTION
In the new fosite package #773, they have removed the Implicit data member from the Memory Store struct, but they still support implicit grants and authentication flow, and since we don't explicitly use it in our code, we can safely remove it as well. Tested with the oc-phoenix example.