### PR TITLE
Add TUS global capabilities

### DIFF
--- a/cmd/reva/gen/gen.go
+++ b/cmd/reva/gen/gen.go
@@ -172,6 +172,12 @@ bigfilechunking = true
 blacklisted_files = ["foo"]
 undelete = true
 versioning = true
+[http.services.ocssvc.capabilities.capabilities.files.tus_support]
+version = "1.0.0"
+resumable = "1.0.0"
+extension = "creation,creation-with-upload"
+http_method_override = ""
+max_chunk_size = 0
 [http.services.ocssvc.capabilities.capabilities.dav]
 chunking = "" # set to "1.0" for experimental support
 [http.services.ocssvc.capabilities.capabilities.files_sharing]

--- a/internal/http/services/owncloud/ocs/data/capabilities.go
+++ b/internal/http/services/owncloud/ocs/data/capabilities.go
@@ -52,7 +52,7 @@ type CapabilitiesData struct {
 type Capabilities struct {
 	Core          *CapabilitiesCore          `json:"core" xml:"core"`
 	Checksums     *CapabilitiesChecksums     `json:"checksums" xml:"checksums"`
-	Files         *CapabilitiesFiles         `json:"files" xml:"files"`
+	Files         *CapabilitiesFiles         `json:"files" xml:"files" mapstructure:"files"`
 	Dav           *CapabilitiesDav           `json:"dav" xml:"dav"`
 	FilesSharing  *CapabilitiesFilesSharing  `json:"files_sharing" xml:"files_sharing" mapstructure:"files_sharing"`
 	Notifications *CapabilitiesNotifications `json:"notifications" xml:"notifications"`
@@ -83,13 +83,23 @@ type CapabilitiesChecksums struct {
 	PreferredUploadType string   `json:"preferredUploadType" xml:"preferredUploadType" mapstructure:"preferred_upload_type"`
 }
 
+// CapabilitiesFilesTusSupport TODO this must be a summry of storages
+type CapabilitiesFilesTusSupport struct {
+	Version            string `json:"version" xml:"version"`
+	Resumable          string `json:"resumable" xml:"resumable"`
+	Extension          string `json:"extension" xml:"extension"`
+	MaxChunkSize       int    `json:"max_chunk_size" xml:"max_chunk_size" mapstructure:"max_chunk_size"`
+	HTTPMethodOverride string `json:"http_method_override" xml:"http_method_override" mapstructure:"http_method_override"`
+}
+
 // CapabilitiesFiles TODO this is storage specific, not global. What effect do these options have on the clients?
 type CapabilitiesFiles struct {
-	PrivateLinks     ocsBool  `json:"privateLinks" xml:"privateLinks" mapstructure:"private_links"`
-	BigFileChunking  ocsBool  `json:"bigfilechunking" xml:"bigfilechunking"`
-	Undelete         ocsBool  `json:"undelete" xml:"undelete"`
-	Versioning       ocsBool  `json:"versioning" xml:"versioning"`
-	BlacklistedFiles []string `json:"blacklisted_files" xml:"blacklisted_files>element" mapstructure:"blacklisted_files"`
+	PrivateLinks     ocsBool                      `json:"privateLinks" xml:"privateLinks" mapstructure:"private_links"`
+	BigFileChunking  ocsBool                      `json:"bigfilechunking" xml:"bigfilechunking"`
+	Undelete         ocsBool                      `json:"undelete" xml:"undelete"`
+	Versioning       ocsBool                      `json:"versioning" xml:"versioning"`
+	BlacklistedFiles []string                     `json:"blacklisted_files" xml:"blacklisted_files>element" mapstructure:"blacklisted_files"`
+	TusSupport       *CapabilitiesFilesTusSupport `json:"tus_support" xml:"tus_support" mapstructure:"tus_support"`
 }
 
 // CapabilitiesDav holds dav endpoint config

--- a/internal/http/services/owncloud/ocs/handlers/cloud/capabilities/capabilities.go
+++ b/internal/http/services/owncloud/ocs/handlers/cloud/capabilities/capabilities.go
@@ -101,6 +101,18 @@ func (h *Handler) Init(c *config.Config) {
 	// h.c.Capabilities.Files.Undelete is boolean
 	// h.c.Capabilities.Files.Versioning is boolean
 
+	if h.c.Capabilities.Files.TusSupport == nil {
+		// these are global capabilities
+		// TODO: infer from various TUS handlers from all known storages
+		h.c.Capabilities.Files.TusSupport = &data.CapabilitiesFilesTusSupport{
+			Version:            "1.0.0",
+			Resumable:          "1.0.0",
+			Extension:          "creation,creation-with-upload",
+			MaxChunkSize:       0,
+			HTTPMethodOverride: "",
+		}
+	}
+
 	// dav
 
 	if h.c.Capabilities.Dav == nil {


### PR DESCRIPTION
Advertise global TUS capabilities so that clients can check whether they
should load their TUS functionality.

This is in addition to the existing advertisement using headers on
Webdav PROPFINDS or OPTIONS depending on the underlying storage.

Note that storages could have different TUS capabilities so in the
future we should look into ways to aggregate the capabilities from
configured storages in these global capability attributes.

For https://github.com/owncloud/ocis-reva/issues/177