### PR TITLE
Disable OIDC HTTP-KeepAlives to reduce fd count

### DIFF
--- a/pkg/auth/manager/oidc/oidc.go
+++ b/pkg/auth/manager/oidc/oidc.go
@@ -147,7 +147,10 @@ func (am *mgr) getOAuthCtx(ctx context.Context) context.Context {
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: am.c.Insecure,
 		},
+		// Fixes connection fd leak which might be caused by provider-caching
+		DisableKeepAlives: true,
 	}
+
 	customHTTPClient := &http.Client{
 		Transport: tr,
 		Timeout:   time.Second * 10,


### PR DESCRIPTION
The oidc-client opens a new connection (file-descriptor) on each request. Those fds are not getting cleaned up because default IdleConnTimeout = 0 (unlimited). 

While those timeouts could be defined I see no value in using Keep-Alive because it only works on HTTP-Level and does not reuse TCP-Connections.