### PR TITLE
Fix Link roles and permissions regression (second edition)

### DIFF
--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/shares.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/shares.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"mime"
 	"net/http"
 	"path"
 	"strconv"
@@ -57,14 +58,6 @@ type Handler struct {
 func (h *Handler) Init(c *config.Config) error {
 	h.gatewayAddr = c.GatewaySvc
 	return nil
-}
-
-// Maps oc10 permissions to roles
-var ocPermToRole = map[int]string{
-	1:  "viewer",
-	15: "coowner",
-	31: "editor",
-	// 5: contributor (?)
 }
 
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -123,15 +116,15 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	default:
 		switch r.Method {
-		case "PUT": // TODO this implementation does NOT differenciates between public vs user shares. A distinction has to be made.
-			// update share needs to make a distinction between public / user shares
+		case "PUT":
 			if h.isPublicShare(r, strings.ReplaceAll(head, "/", "")) {
 				h.updatePublicShare(w, r, strings.ReplaceAll(head, "/", ""))
+				return
 			} else {
 				h.updateShare(w, r, head) // TODO PUT is used with incomplete data to update a share
+				return
 			}
 		case "DELETE":
-			// All CRUD operations on shares need to make a distinction between public shares and user shares.
 			h.removeShare(w, r, head)
 		default:
 			response.WriteOCSError(w, r, response.MetaBadRequest.StatusCode, "Only GET, POST and PUT are allowed", nil)
@@ -139,187 +132,32 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func permissionFromRequest(r *http.Request, h *Handler) *provider.ResourcePermissions {
-	// phoenix sends: {"permissions": 15}. See ocPermToRole struct for mapping
-	permKey, err := strconv.Atoi(r.FormValue("permissions"))
-	if err != nil {
-		log.Error().Str("permissionFromRequest", "shares").Msgf("invalid type: %T", permKey)
-	}
-
-	perm, ok := ocPermToRole[permKey]
-	if !ok {
-		log.Error().Str("permissionFromRequest", "shares").Msgf("invalid oC permission: %v", perm)
-	}
-
-	p, err := h.role2CS3Permissions(perm)
-	if err != nil {
-		log.Error().Str("permissionFromRequest", "shares").Msgf("role to cs3permission %v", perm)
-	}
-
-	return p
-}
-
-func expirationTimestampFromRequest(r *http.Request, h *Handler) *types.Timestamp {
-	var expireTime time.Time
-	var err error
-
-	expireDate := r.FormValue("expireDate")
-	if expireDate != "" {
-		expireTime, err = time.Parse("2006-01-02T15:04:05Z0700", expireDate)
-		if err != nil {
-			log.Error().Str("expiration", "create public share").Msgf("date format invalid: %v", expireDate)
-		}
-		final := expireTime.UnixNano()
-
-		return &types.Timestamp{
-			Seconds: uint64(final / 1000000000),
-			Nanos:   uint32(final % 1000000000),
-		}
-	}
-
-	return nil
-}
-
-func (h *Handler) updatePublicShare(w http.ResponseWriter, r *http.Request, token string) {
-	updates := []*link.UpdatePublicShareRequest_Update{}
-	shares := make([]*conversions.ShareData, 0)
-	logger := appctx.GetLogger(r.Context())
-
-	gwC, err := pool.GetGatewayServiceClient(h.gatewayAddr)
-	if err != nil {
-		log.Err(err).Str("updatePublicShare ref:", token).Msg("updating")
-		response.WriteOCSError(w, r, response.MetaBadRequest.StatusCode, "error getting a connection to the gateway service", nil)
-		return
-	}
-
-	before, err := gwC.GetPublicShare(r.Context(), &link.GetPublicShareRequest{
-		Ref: &link.PublicShareReference{
-			Spec: &link.PublicShareReference_Id{
-				Id: &link.PublicShareId{
-					OpaqueId: token,
-				},
-			},
-		},
-	})
-	if err != nil {
-		response.WriteOCSError(w, r, response.MetaBadRequest.StatusCode, "failed to get public share", nil)
-		return
-	}
-
-	if r.FormValue("name") != before.GetShare().DisplayName {
-		updates = append(updates, &link.UpdatePublicShareRequest_Update{
-			Type:        link.UpdatePublicShareRequest_Update_TYPE_DISPLAYNAME,
-			DisplayName: r.FormValue("name"),
-		})
-	}
-
-	// Permissions
-	publicSharePermissions := &link.PublicSharePermissions{
-		Permissions: permissionFromRequest(r, h),
-	}
-	beforePerm, _ := json.Marshal(before.GetShare().Permissions)
-	afterPerm, _ := json.Marshal(publicSharePermissions)
-	if string(beforePerm) != string(afterPerm) {
-		logger.Info().Str("shares", "update").Msgf("updating permissions from %v to: %v", string(beforePerm), string(afterPerm))
-		updates = append(updates, &link.UpdatePublicShareRequest_Update{
-			Type: link.UpdatePublicShareRequest_Update_TYPE_PERMISSIONS,
-			Grant: &link.Grant{
-				Permissions: publicSharePermissions,
-			},
-		})
-	}
-
-	// ExpireDate
-	newExpiration := expirationTimestampFromRequest(r, h)
-	beforeExpiration, _ := json.Marshal(before.Share.Expiration)
-	afterExpiration, _ := json.Marshal(newExpiration)
-	if newExpiration != nil || (string(afterExpiration) != string(beforeExpiration)) {
-		logger.Info().Str("shares", "update").Msgf("updating expire date from %v to: %v", string(beforeExpiration), string(afterExpiration))
-		updates = append(updates, &link.UpdatePublicShareRequest_Update{
-			Type: link.UpdatePublicShareRequest_Update_TYPE_EXPIRATION,
-			Grant: &link.Grant{
-				Expiration: newExpiration,
-			},
-		})
-	}
-
-	// Password
-	if len(r.FormValue("password")) > 0 {
-		logger.Info().Str("shares", "update").Msg("password updated")
-		updates = append(updates, &link.UpdatePublicShareRequest_Update{
-			Type: link.UpdatePublicShareRequest_Update_TYPE_PASSWORD,
-			Grant: &link.Grant{
-				Password: r.FormValue("password"),
-			},
-		})
-	}
-
-	// Updates are atomical. See: https://github.com/cs3org/cs3apis/pull/67#issuecomment-617651428 so in order to get the latest updated version
-	if len(updates) == 0 {
-		response.WriteOCSError(w, r, response.MetaBadRequest.StatusCode, "There is nothing to update.", nil) // TODO(refs) error? a simple noop might suffice
-		return
-	}
-
-	req := &link.UpdatePublicShareResponse{}
-	for k := range updates {
-		req, err = gwC.UpdatePublicShare(r.Context(), &link.UpdatePublicShareRequest{
-			Ref: &link.PublicShareReference{
-				Spec: &link.PublicShareReference_Id{
-					Id: &link.PublicShareId{
-						OpaqueId: token,
-					},
-				},
-			},
-			Update: updates[k],
-		})
-		if err != nil {
-			log.Err(err).Str("updatePublicShare ref:", token).Msg("sending update request to public link provider")
-		}
-	}
-
-	statReq := provider.StatRequest{
-		Ref: &provider.Reference{
-			Spec: &provider.Reference_Id{
-				Id: req.GetShare().GetResourceId(),
-			},
-		},
-	}
-
-	statRes, err := gwC.Stat(r.Context(), &statReq)
-	if err != nil {
-		log.Debug().Err(err).Str("shares", "update public share").Msg("error during stat")
-		response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "missing resource information", fmt.Errorf("error getting resource information"))
-		return
-	}
-
-	s := conversions.PublicShare2ShareData(req.Share, r)
-	err = h.addFileInfo(r.Context(), s, statRes.Info)
-
-	if err != nil {
-		response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "error enhancing response with share data", err)
-		return
-	}
-
-	shares = append(shares, s)
-	response.WriteOCSSuccess(w, r, shares)
-}
-
 func (h *Handler) createShare(w http.ResponseWriter, r *http.Request) {
-	ctx := r.Context()
-	log := appctx.GetLogger(ctx)
-
 	shareType, err := strconv.Atoi(r.FormValue("shareType"))
 	if err != nil {
 		response.WriteOCSError(w, r, response.MetaBadRequest.StatusCode, "shareType must be an integer", nil)
 		return
 	}
 
+	switch shareType {
+	case int(conversions.ShareTypeUser):
+		h.createUserShare(w, r)
+	case int(conversions.ShareTypePublicLink):
+		h.createPublicLinkShare(w, r)
+	case int(conversions.ShareTypeFederatedCloudShare):
+		h.createFederatedCloudShare(w, r)
+	default:
+		response.WriteOCSError(w, r, response.MetaBadRequest.StatusCode, "unknown share type", nil)
+	}
+}
+
+func (h *Handler) createUserShare(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
 	c, err := pool.GetGatewayServiceClient(h.gatewayAddr)
 	if err != nil {
 		response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "error getting grpc gateway client", err)
 		return
 	}
-
 	// prefix the path with the owners home, because ocs share requests are relative to the home dir
 	// TODO the path actually depends on the configured webdav_namespace
 	hRes, err := c.GetHome(ctx, &provider.GetHomeRequest{})
@@ -327,269 +165,50 @@ func (h *Handler) createShare(w http.ResponseWriter, r *http.Request) {
 		response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "error sending a grpc get home request", err)
 		return
 	}
+
 	prefix := hRes.GetPath()
-
-	if shareType == int(conversions.ShareTypeUser) {
-
-		// if user sharing is disabled
-		if h.gatewayAddr == "" {
-			response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "user sharing service not configured", nil)
-			return
-		}
-
-		shareWith := r.FormValue("shareWith")
-		if shareWith == "" {
-			response.WriteOCSError(w, r, response.MetaBadRequest.StatusCode, "missing shareWith", nil)
-			return
-		}
-
-		userRes, err := c.GetUser(ctx, &userpb.GetUserRequest{
-			UserId: &userpb.UserId{OpaqueId: shareWith},
-		})
-		if err != nil {
-			response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "error searching recipient", err)
-			return
-		}
-
-		if userRes.Status.Code != rpc.Code_CODE_OK {
-			response.WriteOCSError(w, r, response.MetaNotFound.StatusCode, "user not found", err)
-			return
-		}
-
-		var permissions conversions.Permissions
-
-		role := r.FormValue("role")
-		// 2. if we don't have a role try to map the permissions
-		if role == "" {
-			pval := r.FormValue("permissions")
-			if pval == "" {
-				// by default only allow read permissions / assign viewer role
-				role = conversions.RoleViewer
-			} else {
-				pint, err := strconv.Atoi(pval)
-				if err != nil {
-					response.WriteOCSError(w, r, response.MetaBadRequest.StatusCode, "permissions must be an integer", nil)
-					return
-				}
-				permissions, err = conversions.NewPermissions(pint)
-				if err != nil {
-					if err == conversions.ErrPermissionNotInRange {
-						response.WriteOCSError(w, r, http.StatusNotFound, err.Error(), nil)
-					} else {
-						response.WriteOCSError(w, r, response.MetaBadRequest.StatusCode, err.Error(), nil)
-					}
-					return
-				}
-				role = conversions.Permissions2Role(permissions)
-			}
-		}
-
-		var resourcePermissions *provider.ResourcePermissions
-		resourcePermissions, err = h.role2CS3Permissions(role)
-		if err != nil {
-			log.Warn().Err(err).Msg("unknown role, mapping legacy permissions")
-			resourcePermissions = asCS3Permissions(permissions, nil)
-		}
-
-		roleMap := map[string]string{"name": role}
-		val, err := json.Marshal(roleMap)
-		if err != nil {
-			response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "could not encode role", err)
-			return
-		}
-
-		statReq := &provider.StatRequest{
-			Ref: &provider.Reference{
-				Spec: &provider.Reference_Path{
-					Path: path.Join(prefix, r.FormValue("path")),
-				},
-			},
-		}
-
-		statRes, err := c.Stat(ctx, statReq)
-		if err != nil {
-			response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "error sending a grpc stat request", err)
-			return
-		}
-
-		if statRes.Status.Code != rpc.Code_CODE_OK {
-			if statRes.Status.Code == rpc.Code_CODE_NOT_FOUND {
-				response.WriteOCSError(w, r, response.MetaNotFound.StatusCode, "not found", nil)
-				return
-			}
-			response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "grpc stat request failed", err)
-			return
-		}
-
-		createShareReq := &collaboration.CreateShareRequest{
-			Opaque: &types.Opaque{
-				Map: map[string]*types.OpaqueEntry{
-					"role": &types.OpaqueEntry{
-						Decoder: "json",
-						Value:   val,
-					},
-				},
-			},
-			ResourceInfo: statRes.Info,
-			Grant: &collaboration.ShareGrant{
-				Grantee: &provider.Grantee{
-					Type: provider.GranteeType_GRANTEE_TYPE_USER,
-					Id:   userRes.User.GetId(),
-				},
-				Permissions: &collaboration.SharePermissions{
-					Permissions: resourcePermissions,
-				},
-			},
-		}
-
-		createShareResponse, err := c.CreateShare(ctx, createShareReq)
-		if err != nil {
-			response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "error sending a grpc create share request", err)
-			return
-		}
-		if createShareResponse.Status.Code != rpc.Code_CODE_OK {
-			if createShareResponse.Status.Code == rpc.Code_CODE_NOT_FOUND {
-				response.WriteOCSError(w, r, response.MetaNotFound.StatusCode, "not found", nil)
-				return
-			}
-			response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "grpc create share request failed", err)
-			return
-		}
-		s, err := h.userShare2ShareData(ctx, createShareResponse.Share)
-		if err != nil {
-			response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "error mapping share data", err)
-			return
-		}
-		s.Path = r.FormValue("path") // use path without user prefix
-		// s.MailSend = "0"
-		response.WriteOCSSuccess(w, r, s)
+	sharepath := r.FormValue("path")
+	// if user sharing is disabled
+	if h.gatewayAddr == "" {
+		response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "user sharing service not configured", nil)
 		return
 	}
 
-	// create a public link share
-	if shareType == int(conversions.ShareTypePublicLink) {
-
-		statReq := provider.StatRequest{
-			Ref: &provider.Reference{
-				Spec: &provider.Reference_Path{
-					Path: path.Join(prefix, r.FormValue("path")), // TODO replace path with target
-				},
-			},
-		}
-
-		statRes, err := c.Stat(ctx, &statReq)
-		if err != nil {
-			log.Debug().Err(err).Str("createShare", "shares").Msg("error on stat call")
-			response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "missing resource information", fmt.Errorf("error getting resource information"))
-			return
-		}
-
-		// phoenix sends: {"permissions": 15}. See ocPermToRole struct for mapping
-		permKey, err := strconv.Atoi(r.FormValue("permissions"))
-		if err != nil {
-			log.Error().Str("createShare", "shares").Msgf("invalid type: %T", permKey)
-		}
-
-		perm, ok := ocPermToRole[permKey]
-		if !ok {
-			log.Error().Str("createShare", "shares").Msgf("invalid oC permission: %v", perm)
-		}
-
-		p, err := h.role2CS3Permissions(perm)
-		if err != nil {
-			response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "invalid role", err)
-			return
-		}
-
-		req := link.CreatePublicShareRequest{
-			ResourceInfo: statRes.GetInfo(),
-			Grant: &link.Grant{
-				Permissions: &link.PublicSharePermissions{
-					Permissions: p,
-				},
-				Password: r.FormValue("password"),
-			},
-		}
-
-		expireDate := r.FormValue("expireDate")
-		if expireDate != "" {
-			if err != nil {
-				response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "invalid date format", err)
-				return
-			}
-			req.Grant.Expiration = expirationTimestampFromRequest(r, h)
-		}
-
-		// set displayname and password protected as arbitrary metadata
-		req.ResourceInfo.ArbitraryMetadata = &provider.ArbitraryMetadata{
-			Metadata: map[string]string{
-				"name":     r.FormValue("name"),
-				"password": r.FormValue("password"),
-			},
-		}
-
-		createRes, err := c.CreatePublicShare(ctx, &req)
-		if err != nil {
-			log.Debug().Err(err).Str("createShare", "shares").Msgf("error creating a public share to resource id: %v", statRes.Info.GetId())
-			response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "error creating public share", fmt.Errorf("error creating a public share to resource id: %v", statRes.Info.GetId()))
-			return
-		}
-
-		if createRes.Status.Code != rpc.Code_CODE_OK {
-			log.Debug().Err(errors.New("create public share failed")).Str("shares", "createShare").Msgf("create public share failed with status code: %v", createRes.Status.Code.String())
-			response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "grpc create public share request failed", err)
-			return
-		}
-
-		s := conversions.PublicShare2ShareData(createRes.Share, r)
-		err = h.addFileInfo(ctx, s, statRes.Info)
-
-		if err != nil {
-			response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "error enhancing response with share data", err)
-			return
-		}
-
-		response.WriteOCSSuccess(w, r, s)
-
+	shareWith := r.FormValue("shareWith")
+	if shareWith == "" {
+		response.WriteOCSError(w, r, response.MetaBadRequest.StatusCode, "missing shareWith", nil)
 		return
 	}
 
-	if shareType == int(conversions.ShareTypeFederatedCloudShare) {
+	userRes, err := c.GetUser(ctx, &userpb.GetUserRequest{
+		UserId: &userpb.UserId{OpaqueId: shareWith},
+	})
+	if err != nil {
+		response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "error searching recipient", err)
+		return
+	}
 
-		shareWithUser, shareWithProvider := r.FormValue("shareWithUser"), r.FormValue("shareWithProvider")
-		if shareWithUser == "" || shareWithProvider == "" {
-			response.WriteOCSError(w, r, response.MetaBadRequest.StatusCode, "missing shareWith parameters", nil)
-			return
-		}
+	if userRes.Status.Code != rpc.Code_CODE_OK {
+		response.WriteOCSError(w, r, response.MetaNotFound.StatusCode, "user not found", err)
+		return
+	}
 
-		providerInfoResp, err := c.GetInfoByDomain(ctx, &ocmprovider.GetInfoByDomainRequest{
-			Domain: shareWithProvider,
-		})
-		if err != nil {
-			response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "error sending a grpc get invite by domain info request", err)
-			return
-		}
+	statRes, err := h.stat(ctx, path.Join(prefix, sharepath))
+	if err != nil {
+		response.WriteOCSError(w, r, response.MetaBadRequest.StatusCode, fmt.Sprintf("stat on file %s failed", sharepath), err)
+		return
+	}
 
-		remoteUserRes, err := c.GetRemoteUser(ctx, &invitepb.GetRemoteUserRequest{
-			RemoteUserId: &userpb.UserId{OpaqueId: shareWithUser, Idp: shareWithProvider},
-		})
-		if err != nil {
-			response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "error searching recipient", err)
-			return
-		}
-		if remoteUserRes.Status.Code != rpc.Code_CODE_OK {
-			response.WriteOCSError(w, r, response.MetaNotFound.StatusCode, "user not found", err)
-			return
-		}
+	var permissions conversions.Permissions
 
-		var permissions conversions.Permissions
-		var role string
-
+	role := r.FormValue("role")
+	// 2. if we don't have a role try to map the permissions
+	if role == "" {
 		pval := r.FormValue("permissions")
 		if pval == "" {
-			// by default only allow read permissions / assign viewer role
-			permissions = conversions.PermissionRead
-			role = conversions.RoleViewer
+			// default is all permissions / role coowner
+			permissions = conversions.PermissionAll
+			role = conversions.RoleCoowner
 		} else {
 			pint, err := strconv.Atoi(pval)
 			if err != nil {
@@ -598,88 +217,359 @@ func (h *Handler) createShare(w http.ResponseWriter, r *http.Request) {
 			}
 			permissions, err = conversions.NewPermissions(pint)
 			if err != nil {
-				response.WriteOCSError(w, r, response.MetaBadRequest.StatusCode, err.Error(), nil)
+				if err == conversions.ErrPermissionNotInRange {
+					response.WriteOCSError(w, r, http.StatusNotFound, err.Error(), nil)
+				} else {
+					response.WriteOCSError(w, r, response.MetaBadRequest.StatusCode, err.Error(), nil)
+				}
 				return
 			}
 			role = conversions.Permissions2Role(permissions)
 		}
+	}
 
-		var resourcePermissions *provider.ResourcePermissions
-		resourcePermissions, err = h.role2CS3Permissions(role)
-		if err != nil {
-			log.Warn().Err(err).Msg("unknown role, mapping legacy permissions")
-			resourcePermissions = asCS3Permissions(permissions, nil)
-		}
+	if statRes.Info != nil && statRes.Info.Type == provider.ResourceType_RESOURCE_TYPE_FILE {
+		// Single file shares should never have delete or create permissions
+		permissions &^= conversions.PermissionCreate
+		permissions &^= conversions.PermissionDelete
+	}
 
-		permissionMap := map[string]string{"name": strconv.Itoa(int(permissions))}
-		val, err := json.Marshal(permissionMap)
-		if err != nil {
-			response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "could not encode role", err)
-			return
-		}
+	var resourcePermissions *provider.ResourcePermissions
+	resourcePermissions = asCS3Permissions(permissions, resourcePermissions)
 
-		statReq := &provider.StatRequest{
-			Ref: &provider.Reference{
-				Spec: &provider.Reference_Path{
-					Path: path.Join(prefix, r.FormValue("path")),
-				},
-			},
-		}
-		statRes, err := c.Stat(ctx, statReq)
-		if err != nil {
-			response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "error sending a grpc stat request", err)
-			return
-		}
-		if statRes.Status.Code != rpc.Code_CODE_OK {
-			if statRes.Status.Code == rpc.Code_CODE_NOT_FOUND {
-				response.WriteOCSError(w, r, response.MetaNotFound.StatusCode, "not found", nil)
-				return
-			}
-			response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "grpc stat request failed", err)
-			return
-		}
-
-		createShareReq := &ocm.CreateOCMShareRequest{
-			Opaque: &types.Opaque{
-				Map: map[string]*types.OpaqueEntry{
-					"permissions": &types.OpaqueEntry{
-						Decoder: "json",
-						Value:   val,
-					},
-				},
-			},
-			ResourceId: statRes.Info.Id,
-			Grant: &ocm.ShareGrant{
-				Grantee: &provider.Grantee{
-					Type: provider.GranteeType_GRANTEE_TYPE_USER,
-					Id:   remoteUserRes.RemoteUser.GetId(),
-				},
-				Permissions: &ocm.SharePermissions{
-					Permissions: resourcePermissions,
-				},
-			},
-			RecipientMeshProvider: providerInfoResp.ProviderInfo,
-		}
-
-		createShareResponse, err := c.CreateOCMShare(ctx, createShareReq)
-		if err != nil {
-			response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "error sending a grpc create ocm share request", err)
-			return
-		}
-		if createShareResponse.Status.Code != rpc.Code_CODE_OK {
-			if createShareResponse.Status.Code == rpc.Code_CODE_NOT_FOUND {
-				response.WriteOCSError(w, r, response.MetaNotFound.StatusCode, "not found", nil)
-				return
-			}
-			response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "grpc create ocm share request failed", err)
-			return
-		}
-
-		response.WriteOCSSuccess(w, r, "OCM Share created")
+	roleMap := map[string]string{"name": role}
+	val, err := json.Marshal(roleMap)
+	if err != nil {
+		response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "could not encode role", err)
 		return
 	}
 
-	response.WriteOCSError(w, r, response.MetaBadRequest.StatusCode, "unknown share type", nil)
+	if statRes.Status.Code != rpc.Code_CODE_OK {
+		if statRes.Status.Code == rpc.Code_CODE_NOT_FOUND {
+			response.WriteOCSError(w, r, response.MetaNotFound.StatusCode, "not found", nil)
+			return
+		}
+		response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "grpc stat request failed", err)
+		return
+	}
+
+	createShareReq := &collaboration.CreateShareRequest{
+		Opaque: &types.Opaque{
+			Map: map[string]*types.OpaqueEntry{
+				"role": &types.OpaqueEntry{
+					Decoder: "json",
+					Value:   val,
+				},
+			},
+		},
+		ResourceInfo: statRes.Info,
+		Grant: &collaboration.ShareGrant{
+			Grantee: &provider.Grantee{
+				Type: provider.GranteeType_GRANTEE_TYPE_USER,
+				Id:   userRes.User.GetId(),
+			},
+			Permissions: &collaboration.SharePermissions{
+				Permissions: resourcePermissions,
+			},
+		},
+	}
+
+	createShareResponse, err := c.CreateShare(ctx, createShareReq)
+	if err != nil {
+		response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "error sending a grpc create share request", err)
+		return
+	}
+	if createShareResponse.Status.Code != rpc.Code_CODE_OK {
+		if createShareResponse.Status.Code == rpc.Code_CODE_NOT_FOUND {
+			response.WriteOCSError(w, r, response.MetaNotFound.StatusCode, "not found", nil)
+			return
+		}
+		response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "grpc create share request failed", err)
+		return
+	}
+	s, err := h.userShare2ShareData(ctx, createShareResponse.Share)
+	if err != nil {
+		response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "error mapping share data", err)
+		return
+	}
+	err = h.addFileInfo(ctx, s, statRes.Info)
+	if err != nil {
+		response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "error adding fileinfo to share", err)
+		return
+	}
+	response.WriteOCSSuccess(w, r, s)
+}
+
+func (h *Handler) createPublicLinkShare(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	log := appctx.GetLogger(ctx)
+
+	c, err := pool.GetGatewayServiceClient(h.gatewayAddr)
+	if err != nil {
+		response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "error getting grpc gateway client", err)
+		return
+	}
+	// prefix the path with the owners home, because ocs share requests are relative to the home dir
+	// TODO the path actually depends on the configured webdav_namespace
+	hRes, err := c.GetHome(ctx, &provider.GetHomeRequest{})
+	if err != nil {
+		response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "error sending a grpc get home request", err)
+		return
+	}
+
+	prefix := hRes.GetPath()
+
+	statReq := provider.StatRequest{
+		Ref: &provider.Reference{
+			Spec: &provider.Reference_Path{
+				Path: path.Join(prefix, r.FormValue("path")), // TODO replace path with target
+			},
+		},
+	}
+
+	statRes, err := c.Stat(ctx, &statReq)
+	if err != nil {
+		log.Debug().Err(err).Str("createShare", "shares").Msg("error on stat call")
+		response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "missing resource information", fmt.Errorf("error getting resource information"))
+		return
+	}
+
+	// phoenix sends: {"permissions": 15}. See ocPermToRole struct for mapping
+	permKey, err := strconv.Atoi(r.FormValue("permissions"))
+	if err != nil {
+		log.Error().Str("createShare", "shares").Msgf("invalid type: %T", permKey)
+	}
+
+	role, ok := ocPermToRole[permKey]
+	if !ok {
+		log.Error().Str("permissionFromRequest", "shares").Msgf("invalid oC permission: %v", role)
+	}
+
+	perm, err := conversions.NewPermissions(permKey)
+	if err != nil {
+		return
+	}
+
+	p, err := h.map2CS3Permissions(role, perm)
+	if err != nil {
+		log.Error().Str("permissionFromRequest", "shares").Msgf("role to cs3permission %v", perm)
+	}
+
+	req := link.CreatePublicShareRequest{
+		ResourceInfo: statRes.GetInfo(),
+		Grant: &link.Grant{
+			Permissions: &link.PublicSharePermissions{
+				Permissions: p,
+			},
+			Password: r.FormValue("password"),
+		},
+	}
+
+	var expireTime time.Time
+	expireDate := r.FormValue("expireDate")
+	if expireDate != "" {
+		expireTime, err = time.Parse("2006-01-02T15:04:05Z0700", expireDate)
+		if err != nil {
+			response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "invalid date format", err)
+			return
+		}
+		req.Grant.Expiration = &types.Timestamp{
+			Nanos:   uint32(expireTime.UnixNano()),
+			Seconds: uint64(expireTime.Unix()),
+		}
+	}
+
+	// set displayname and password protected as arbitrary metadata
+	req.ResourceInfo.ArbitraryMetadata = &provider.ArbitraryMetadata{
+		Metadata: map[string]string{
+			"name": r.FormValue("name"),
+			// "password": r.FormValue("password"),
+		},
+	}
+
+	createRes, err := c.CreatePublicShare(ctx, &req)
+	if err != nil {
+		log.Debug().Err(err).Str("createShare", "shares").Msgf("error creating a public share to resource id: %v", statRes.Info.GetId())
+		response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "error creating public share", fmt.Errorf("error creating a public share to resource id: %v", statRes.Info.GetId()))
+		return
+	}
+
+	if createRes.Status.Code != rpc.Code_CODE_OK {
+		log.Debug().Err(errors.New("create public share failed")).Str("shares", "createShare").Msgf("create public share failed with status code: %v", createRes.Status.Code.String())
+		response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "grpc create public share request failed", err)
+		return
+	}
+
+	s := conversions.PublicShare2ShareData(createRes.Share, r)
+	err = h.addFileInfo(ctx, s, statRes.Info)
+
+	if err != nil {
+		response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "error enhancing response with share data", err)
+		return
+	}
+
+	response.WriteOCSSuccess(w, r, s)
+}
+
+func (h *Handler) createFederatedCloudShare(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	log := appctx.GetLogger(ctx)
+
+	c, err := pool.GetGatewayServiceClient(h.gatewayAddr)
+	if err != nil {
+		response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "error getting grpc gateway client", err)
+		return
+	}
+	// prefix the path with the owners home, because ocs share requests are relative to the home dir
+	// TODO the path actually depends on the configured webdav_namespace
+	hRes, err := c.GetHome(ctx, &provider.GetHomeRequest{})
+	if err != nil {
+		response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "error sending a grpc get home request", err)
+		return
+	}
+
+	prefix := hRes.GetPath()
+
+	shareWithUser, shareWithProvider := r.FormValue("shareWithUser"), r.FormValue("shareWithProvider")
+	if shareWithUser == "" || shareWithProvider == "" {
+		response.WriteOCSError(w, r, response.MetaBadRequest.StatusCode, "missing shareWith parameters", nil)
+		return
+	}
+
+	providerInfoResp, err := c.GetInfoByDomain(ctx, &ocmprovider.GetInfoByDomainRequest{
+		Domain: shareWithProvider,
+	})
+	if err != nil {
+		response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "error sending a grpc get invite by domain info request", err)
+		return
+	}
+
+	remoteUserRes, err := c.GetRemoteUser(ctx, &invitepb.GetRemoteUserRequest{
+		RemoteUserId: &userpb.UserId{OpaqueId: shareWithUser, Idp: shareWithProvider},
+	})
+	if err != nil {
+		response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "error searching recipient", err)
+		return
+	}
+	if remoteUserRes.Status.Code != rpc.Code_CODE_OK {
+		response.WriteOCSError(w, r, response.MetaNotFound.StatusCode, "user not found", err)
+		return
+	}
+
+	var permissions conversions.Permissions
+	var role string
+
+	pval := r.FormValue("permissions")
+	if pval == "" {
+		// by default only allow read permissions / assign viewer role
+		permissions = conversions.PermissionRead
+		role = conversions.RoleViewer
+	} else {
+		pint, err := strconv.Atoi(pval)
+		if err != nil {
+			response.WriteOCSError(w, r, response.MetaBadRequest.StatusCode, "permissions must be an integer", nil)
+			return
+		}
+		permissions, err = conversions.NewPermissions(pint)
+		if err != nil {
+			response.WriteOCSError(w, r, response.MetaBadRequest.StatusCode, err.Error(), nil)
+			return
+		}
+		role = conversions.Permissions2Role(permissions)
+	}
+
+	var resourcePermissions *provider.ResourcePermissions
+	resourcePermissions, err = h.map2CS3Permissions(role, permissions)
+	if err != nil {
+		log.Warn().Err(err).Msg("unknown role, mapping legacy permissions")
+		resourcePermissions = asCS3Permissions(permissions, nil)
+	}
+
+	permissionMap := map[string]string{"name": strconv.Itoa(int(permissions))}
+	val, err := json.Marshal(permissionMap)
+	if err != nil {
+		response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "could not encode role", err)
+		return
+	}
+
+	statReq := &provider.StatRequest{
+		Ref: &provider.Reference{
+			Spec: &provider.Reference_Path{
+				Path: path.Join(prefix, r.FormValue("path")),
+			},
+		},
+	}
+	statRes, err := c.Stat(ctx, statReq)
+	if err != nil {
+		response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "error sending a grpc stat request", err)
+		return
+	}
+	if statRes.Status.Code != rpc.Code_CODE_OK {
+		if statRes.Status.Code == rpc.Code_CODE_NOT_FOUND {
+			response.WriteOCSError(w, r, response.MetaNotFound.StatusCode, "not found", nil)
+			return
+		}
+		response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "grpc stat request failed", err)
+		return
+	}
+
+	createShareReq := &ocm.CreateOCMShareRequest{
+		Opaque: &types.Opaque{
+			Map: map[string]*types.OpaqueEntry{
+				"permissions": &types.OpaqueEntry{
+					Decoder: "json",
+					Value:   val,
+				},
+			},
+		},
+		ResourceId: statRes.Info.Id,
+		Grant: &ocm.ShareGrant{
+			Grantee: &provider.Grantee{
+				Type: provider.GranteeType_GRANTEE_TYPE_USER,
+				Id:   remoteUserRes.RemoteUser.GetId(),
+			},
+			Permissions: &ocm.SharePermissions{
+				Permissions: resourcePermissions,
+			},
+		},
+		RecipientMeshProvider: providerInfoResp.ProviderInfo,
+	}
+
+	createShareResponse, err := c.CreateOCMShare(ctx, createShareReq)
+	if err != nil {
+		response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "error sending a grpc create ocm share request", err)
+		return
+	}
+	if createShareResponse.Status.Code != rpc.Code_CODE_OK {
+		if createShareResponse.Status.Code == rpc.Code_CODE_NOT_FOUND {
+			response.WriteOCSError(w, r, response.MetaNotFound.StatusCode, "not found", nil)
+			return
+		}
+		response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "grpc create ocm share request failed", err)
+		return
+	}
+
+	response.WriteOCSSuccess(w, r, "OCM Share created")
+}
+
+func (h *Handler) stat(ctx context.Context, path string) (*provider.StatResponse, error) {
+	c, err := pool.GetGatewayServiceClient(h.gatewayAddr)
+	if err != nil {
+		return nil, fmt.Errorf("error getting grpc gateway client: %s", err.Error())
+	}
+	statReq := &provider.StatRequest{
+		Ref: &provider.Reference{
+			Spec: &provider.Reference_Path{
+				Path: path,
+			},
+		},
+	}
+
+	statRes, err := c.Stat(ctx, statReq)
+	if err != nil {
+		return nil, fmt.Errorf("error sending a grpc stat request: %s", err.Error())
+	}
+	return statRes, nil
 }
 
 // PublicShareContextName represent cross boundaries context for the name of the public share
@@ -727,110 +617,31 @@ func asCS3Permissions(p conversions.Permissions, rp *provider.ResourcePermission
 	return rp
 }
 
-func (h *Handler) role2CS3Permissions(r string) (*provider.ResourcePermissions, error) {
-	switch r {
-	case conversions.RoleViewer:
-		return &provider.ResourcePermissions{
-			ListContainer:        true,
-			ListGrants:           true,
-			ListFileVersions:     true,
-			ListRecycle:          true,
-			Stat:                 true,
-			GetPath:              true,
-			GetQuota:             true,
-			InitiateFileDownload: true,
-		}, nil
-	case conversions.RoleEditor:
-		return &provider.ResourcePermissions{
-			ListContainer:        true,
-			ListGrants:           true,
-			ListFileVersions:     true,
-			ListRecycle:          true,
-			Stat:                 true,
-			GetPath:              true,
-			GetQuota:             true,
-			InitiateFileDownload: true,
+func (h *Handler) map2CS3Permissions(role string, p conversions.Permissions) (*provider.ResourcePermissions, error) {
+	// TODO replace usage of this method with asCS3Permissions
+	rp := &provider.ResourcePermissions{
+		ListContainer:        p.Contain(conversions.PermissionRead),
+		ListGrants:           p.Contain(conversions.PermissionRead),
+		ListFileVersions:     p.Contain(conversions.PermissionRead),
+		ListRecycle:          p.Contain(conversions.PermissionRead),
+		Stat:                 p.Contain(conversions.PermissionRead),
+		GetPath:              p.Contain(conversions.PermissionRead),
+		GetQuota:             p.Contain(conversions.PermissionRead),
+		InitiateFileDownload: p.Contain(conversions.PermissionRead),
 
-			Move:               true,
-			InitiateFileUpload: true,
-			RestoreFileVersion: true,
-			RestoreRecycleItem: true,
-			CreateContainer:    true,
-			Delete:             true,
-			PurgeRecycle:       true,
-		}, nil
-	case conversions.RoleCoowner:
-		return &provider.ResourcePermissions{
-			ListContainer:        true,
-			ListGrants:           true,
-			ListFileVersions:     true,
-			ListRecycle:          true,
-			Stat:                 true,
-			GetPath:              true,
-			GetQuota:             true,
-			InitiateFileDownload: true,
+		Move:               p.Contain(conversions.PermissionWrite),
+		InitiateFileUpload: p.Contain(conversions.PermissionWrite),
+		CreateContainer:    p.Contain(conversions.PermissionCreate),
+		Delete:             p.Contain(conversions.PermissionDelete),
+		RestoreFileVersion: p.Contain(conversions.PermissionWrite),
+		RestoreRecycleItem: p.Contain(conversions.PermissionWrite),
+		PurgeRecycle:       p.Contain(conversions.PermissionDelete),
 
-			Move:               true,
-			InitiateFileUpload: true,
-			RestoreFileVersion: true,
-			RestoreRecycleItem: true,
-			CreateContainer:    true,
-			Delete:             true,
-			PurgeRecycle:       true,
-
-			AddGrant:    true,
-			RemoveGrant: true, // TODO when are you able to unshare / delete
-			UpdateGrant: true,
-		}, nil
-	default:
-		return nil, fmt.Errorf("unknown role: %s", r)
+		AddGrant:    p.Contain(conversions.PermissionShare),
+		RemoveGrant: p.Contain(conversions.PermissionShare), // TODO when are you able to unshare / delete
+		UpdateGrant: p.Contain(conversions.PermissionShare),
 	}
-}
-
-func (h *Handler) isPublicShare(r *http.Request, oid string) bool {
-	logger := appctx.GetLogger(r.Context())
-	client, err := pool.GetGatewayServiceClient(h.gatewayAddr)
-	if err != nil {
-		logger.Err(err)
-	}
-
-	psRes, err := client.GetPublicShare(r.Context(), &link.GetPublicShareRequest{
-		Ref: &link.PublicShareReference{
-			Spec: &link.PublicShareReference_Id{
-				Id: &link.PublicShareId{
-					OpaqueId: oid,
-				},
-			},
-		},
-	})
-	if err != nil {
-		logger.Err(err)
-	}
-
-	if psRes.GetShare() != nil {
-		return true
-	}
-
-	// check if we have a user share
-	uRes, err := client.GetShare(r.Context(), &collaboration.GetShareRequest{
-		Ref: &collaboration.ShareReference{
-			Spec: &collaboration.ShareReference_Id{
-				Id: &collaboration.ShareId{
-					OpaqueId: oid,
-				},
-			},
-		},
-	})
-	if err != nil {
-		logger.Err(err)
-	}
-
-	if uRes.GetShare() != nil {
-		return false
-	}
-
-	// TODO token is neither a public or a user share.
-	return false
+	return rp, nil
 }
 
 func (h *Handler) updateShare(w http.ResponseWriter, r *http.Request, shareID string) {
@@ -1287,16 +1098,22 @@ func (h *Handler) listUserShares(r *http.Request, filters []*collaboration.ListS
 }
 
 func (h *Handler) addFileInfo(ctx context.Context, s *conversions.ShareData, info *provider.ResourceInfo) error {
+	log := appctx.GetLogger(ctx)
 	if info != nil {
 		// TODO The owner is not set in the storage stat metadata ...
-		s.MimeType = info.MimeType
+		parsedMt, _, err := mime.ParseMediaType(info.MimeType)
+		if err != nil {
+			// Should never happen. We log anyways so that we know if it happens.
+			log.Warn().Err(err).Msg("failed to parse mimetype")
+		}
+		s.MimeType = parsedMt
 		// TODO STime:     &types.Timestamp{Seconds: info.Mtime.Seconds, Nanos: info.Mtime.Nanos},
 		s.StorageID = info.Id.StorageId
 		// TODO Storage: int
 		s.ItemSource = info.Id.OpaqueId
 		s.FileSource = info.Id.OpaqueId
 		s.FileTarget = path.Join("/", path.Base(info.Path))
-		s.Path = info.Path // TODO hm this might have to be relative to the users home ... depends on the webdav_namespace config
+		s.Path = path.Join("/", path.Base(info.Path)) // TODO hm this might have to be relative to the users home ... depends on the webdav_namespace config
 		// TODO FileParent:
 		// item type
 		s.ItemType = conversions.ResourceType(info.GetType()).String()
@@ -1469,4 +1286,228 @@ func (h *Handler) userShare2ShareData(ctx context.Context, share *collaboration.
 	// actually clients should be able to GET and cache the user info themselves ...
 	// TODO check grantee type for user vs group
 	return sd, nil
+}
+
+func (h *Handler) isPublicShare(r *http.Request, oid string) bool {
+	logger := appctx.GetLogger(r.Context())
+	client, err := pool.GetGatewayServiceClient(h.gatewayAddr)
+	if err != nil {
+		logger.Err(err)
+	}
+
+	psRes, err := client.GetPublicShare(r.Context(), &link.GetPublicShareRequest{
+		Ref: &link.PublicShareReference{
+			Spec: &link.PublicShareReference_Id{
+				Id: &link.PublicShareId{
+					OpaqueId: oid,
+				},
+			},
+		},
+	})
+	if err != nil {
+		logger.Err(err)
+	}
+
+	if psRes.GetShare() != nil {
+		return true
+	}
+
+	// check if we have a user share
+	uRes, err := client.GetShare(r.Context(), &collaboration.GetShareRequest{
+		Ref: &collaboration.ShareReference{
+			Spec: &collaboration.ShareReference_Id{
+				Id: &collaboration.ShareId{
+					OpaqueId: oid,
+				},
+			},
+		},
+	})
+	if err != nil {
+		logger.Err(err)
+	}
+
+	if uRes.GetShare() != nil {
+		return false
+	}
+
+	// TODO token is neither a public or a user share.
+	return false
+}
+
+func (h *Handler) updatePublicShare(w http.ResponseWriter, r *http.Request, token string) {
+	updates := []*link.UpdatePublicShareRequest_Update{}
+	shares := make([]*conversions.ShareData, 0)
+	logger := appctx.GetLogger(r.Context())
+
+	gwC, err := pool.GetGatewayServiceClient(h.gatewayAddr)
+	if err != nil {
+		log.Err(err).Str("updatePublicShare ref:", token).Msg("updating")
+		response.WriteOCSError(w, r, response.MetaBadRequest.StatusCode, "error getting a connection to the gateway service", nil)
+		return
+	}
+
+	before, err := gwC.GetPublicShare(r.Context(), &link.GetPublicShareRequest{
+		Ref: &link.PublicShareReference{
+			Spec: &link.PublicShareReference_Id{
+				Id: &link.PublicShareId{
+					OpaqueId: token,
+				},
+			},
+		},
+	})
+	if err != nil {
+		response.WriteOCSError(w, r, response.MetaBadRequest.StatusCode, "failed to get public share", nil)
+		return
+	}
+
+	if r.FormValue("name") != before.GetShare().DisplayName {
+		updates = append(updates, &link.UpdatePublicShareRequest_Update{
+			Type:        link.UpdatePublicShareRequest_Update_TYPE_DISPLAYNAME,
+			DisplayName: r.FormValue("name"),
+		})
+	}
+
+	// Permissions
+	publicSharePermissions := &link.PublicSharePermissions{
+		Permissions: permissionFromRequest(r, h),
+	}
+	beforePerm, _ := json.Marshal(before.GetShare().Permissions)
+	afterPerm, _ := json.Marshal(publicSharePermissions)
+	if string(beforePerm) != string(afterPerm) {
+		logger.Info().Str("shares", "update").Msgf("updating permissions from %v to: %v", string(beforePerm), string(afterPerm))
+		updates = append(updates, &link.UpdatePublicShareRequest_Update{
+			Type: link.UpdatePublicShareRequest_Update_TYPE_PERMISSIONS,
+			Grant: &link.Grant{
+				Permissions: publicSharePermissions,
+			},
+		})
+	}
+
+	// ExpireDate
+	newExpiration := expirationTimestampFromRequest(r, h)
+	beforeExpiration, _ := json.Marshal(before.Share.Expiration)
+	afterExpiration, _ := json.Marshal(newExpiration)
+	if newExpiration != nil || (string(afterExpiration) != string(beforeExpiration)) {
+		logger.Info().Str("shares", "update").Msgf("updating expire date from %v to: %v", string(beforeExpiration), string(afterExpiration))
+		updates = append(updates, &link.UpdatePublicShareRequest_Update{
+			Type: link.UpdatePublicShareRequest_Update_TYPE_EXPIRATION,
+			Grant: &link.Grant{
+				Expiration: newExpiration,
+			},
+		})
+	}
+
+	// Password
+	if len(r.FormValue("password")) > 0 {
+		logger.Info().Str("shares", "update").Msg("password updated")
+		updates = append(updates, &link.UpdatePublicShareRequest_Update{
+			Type: link.UpdatePublicShareRequest_Update_TYPE_PASSWORD,
+			Grant: &link.Grant{
+				Password: r.FormValue("password"),
+			},
+		})
+	}
+
+	// Updates are atomical. See: https://github.com/cs3org/cs3apis/pull/67#issuecomment-617651428 so in order to get the latest updated version
+	if len(updates) == 0 {
+		response.WriteOCSError(w, r, response.MetaBadRequest.StatusCode, "There is nothing to update.", nil) // TODO(refs) error? a simple noop might suffice
+		return
+	}
+
+	req := &link.UpdatePublicShareResponse{}
+	for k := range updates {
+		req, err = gwC.UpdatePublicShare(r.Context(), &link.UpdatePublicShareRequest{
+			Ref: &link.PublicShareReference{
+				Spec: &link.PublicShareReference_Id{
+					Id: &link.PublicShareId{
+						OpaqueId: token,
+					},
+				},
+			},
+			Update: updates[k],
+		})
+		if err != nil {
+			log.Err(err).Str("updatePublicShare ref:", token).Msg("sending update request to public link provider")
+		}
+	}
+
+	statReq := provider.StatRequest{
+		Ref: &provider.Reference{
+			Spec: &provider.Reference_Id{
+				Id: req.GetShare().GetResourceId(),
+			},
+		},
+	}
+
+	statRes, err := gwC.Stat(r.Context(), &statReq)
+	if err != nil {
+		log.Debug().Err(err).Str("shares", "update public share").Msg("error during stat")
+		response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "missing resource information", fmt.Errorf("error getting resource information"))
+		return
+	}
+
+	s := conversions.PublicShare2ShareData(req.Share, r)
+	err = h.addFileInfo(r.Context(), s, statRes.Info)
+
+	if err != nil {
+		response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "error enhancing response with share data", err)
+		return
+	}
+
+	shares = append(shares, s)
+	response.WriteOCSSuccess(w, r, shares)
+}
+
+func expirationTimestampFromRequest(r *http.Request, h *Handler) *types.Timestamp {
+	var expireTime time.Time
+	var err error
+
+	expireDate := r.FormValue("expireDate")
+	if expireDate != "" {
+		expireTime, err = time.Parse("2006-01-02T15:04:05Z0700", expireDate)
+		if err != nil {
+			log.Error().Str("expiration", "create public share").Msgf("date format invalid: %v", expireDate)
+		}
+		final := expireTime.UnixNano()
+
+		return &types.Timestamp{
+			Seconds: uint64(final / 1000000000),
+			Nanos:   uint32(final % 1000000000),
+		}
+	}
+
+	return nil
+}
+
+func permissionFromRequest(r *http.Request, h *Handler) *provider.ResourcePermissions {
+	// phoenix sends: {"permissions": 15}. See ocPermToRole struct for mapping
+	permKey, err := strconv.Atoi(r.FormValue("permissions"))
+	if err != nil {
+		log.Error().Str("permissionFromRequest", "shares").Msgf("invalid type: %T", permKey)
+	}
+
+	role, ok := ocPermToRole[permKey]
+	if !ok {
+		log.Error().Str("permissionFromRequest", "shares").Msgf("invalid oC permission: %v", role)
+	}
+
+	perm, err := conversions.NewPermissions(permKey)
+	if err != nil {
+		return nil
+	}
+
+	p, err := h.map2CS3Permissions(role, perm)
+	if err != nil {
+		log.Error().Str("permissionFromRequest", "shares").Msgf("role to cs3permission %v", perm)
+	}
+
+	return p
+}
+
+// Maps oc10 permissions to roles
+var ocPermToRole = map[int]string{
+	1:  "viewer",
+	15: "coowner",
+	31: "editor",
+	// 5: contributor (?)
 }

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/shares.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/shares.go
@@ -120,10 +120,8 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			if h.isPublicShare(r, strings.ReplaceAll(head, "/", "")) {
 				h.updatePublicShare(w, r, strings.ReplaceAll(head, "/", ""))
 				return
-			} else {
-				h.updateShare(w, r, head) // TODO PUT is used with incomplete data to update a share
-				return
 			}
+			h.updateShare(w, r, head) // TODO PUT is used with incomplete data to update a share
 		case "DELETE":
 			h.removeShare(w, r, head)
 		default:


### PR DESCRIPTION
Resend of https://github.com/cs3org/reva/pull/784 + extra fix

This is an expedited PR to fix an issue on roles and permissions on public shares caused by a refactor on shares.go.

It also enables password update on the public link json manager.

This makes the CI tests in owncloud/ocis-reva#232 pass, the ones which were failing due to regression.