### PR TITLE
Add option to disable TUS on OC layer

### DIFF
--- a/internal/http/services/owncloud/ocdav/ocdav.go
+++ b/internal/http/services/owncloud/ocdav/ocdav.go
@@ -65,6 +65,7 @@ type Config struct {
 	WebdavNamespace string `mapstructure:"webdav_namespace"`
 	ChunkFolder     string `mapstructure:"chunk_folder"`
 	GatewaySvc      string `mapstructure:"gatewaysvc"`
+	DisableTus      bool   `mapstructure:"disable_tus"`
 }
 
 type svc struct {

--- a/internal/http/services/owncloud/ocdav/options.go
+++ b/internal/http/services/owncloud/ocdav/options.go
@@ -27,15 +27,16 @@ func (s *svc) handleOptions(w http.ResponseWriter, r *http.Request, ns string) {
 	allow += " MOVE, UNLOCK, PROPFIND, MKCOL, REPORT, SEARCH,"
 	allow += " PUT" // TODO(jfd): only for files ... but we cannot create the full path without a user ... which we only have when credentials are sent
 
-	w.Header().Add("Access-Control-Allow-Headers", "Tus-Resumable")
-	w.Header().Add("Access-Control-Expose-Headers", "Tus-Resumable, Tus-Version, Tus-Extension")
-
 	w.Header().Set("Content-Type", "application/xml")
 	w.Header().Set("Allow", allow)
 	w.Header().Set("DAV", "1, 2")
 	w.Header().Set("MS-Author-Via", "DAV")
-	w.Header().Set("Tus-Resumable", "1.0.0") // TODO(jfd): only for dirs?
-	w.Header().Set("Tus-Version", "1.0.0")
-	w.Header().Set("Tus-Extension", "creation,creation-with-upload")
+	if !s.c.DisableTus {
+		w.Header().Add("Access-Control-Allow-Headers", "Tus-Resumable")
+		w.Header().Add("Access-Control-Expose-Headers", "Tus-Resumable, Tus-Version, Tus-Extension")
+		w.Header().Set("Tus-Resumable", "1.0.0") // TODO(jfd): only for dirs?
+		w.Header().Set("Tus-Version", "1.0.0")
+		w.Header().Set("Tus-Extension", "creation,creation-with-upload")
+	}
 	w.WriteHeader(http.StatusOK)
 }

--- a/internal/http/services/owncloud/ocdav/propfind.go
+++ b/internal/http/services/owncloud/ocdav/propfind.go
@@ -169,7 +169,7 @@ func (s *svc) handlePropfind(w http.ResponseWriter, r *http.Request, ns string) 
 	w.Header().Set("DAV", "1, 3, extended-mkcol")
 	w.Header().Set("Content-Type", "application/xml; charset=utf-8")
 	// let clients know this collection supports tus.io POST requests to start uploads
-	if info.Type == provider.ResourceType_RESOURCE_TYPE_CONTAINER {
+	if info.Type == provider.ResourceType_RESOURCE_TYPE_CONTAINER && !s.c.DisableTus {
 		w.Header().Add("Access-Control-Expose-Headers", "Tus-Resumable, Tus-Version, Tus-Extension")
 		w.Header().Set("Tus-Resumable", "1.0.0")
 		w.Header().Set("Tus-Version", "1.0.0")

--- a/internal/http/services/owncloud/ocdav/webdav.go
+++ b/internal/http/services/owncloud/ocdav/webdav.go
@@ -58,7 +58,11 @@ func (h *WebDavHandler) Handler(s *svc) http.Handler {
 		case http.MethodPut:
 			s.handlePut(w, r, h.namespace)
 		case http.MethodPost:
-			s.handleTusPost(w, r, h.namespace)
+			if !s.c.DisableTus {
+				s.handleTusPost(w, r, h.namespace)
+			} else {
+				w.WriteHeader(http.StatusNotFound)
+			}
 		case http.MethodOptions:
 			s.handleOptions(w, r, h.namespace)
 		case http.MethodHead:

--- a/internal/http/services/owncloud/ocs/config/config.go
+++ b/internal/http/services/owncloud/ocs/config/config.go
@@ -28,4 +28,5 @@ type Config struct {
 	Config       data.ConfigData       `mapstructure:"config"`
 	Capabilities data.CapabilitiesData `mapstructure:"capabilities"`
 	GatewaySvc   string                `mapstructure:"gatewaysvc"`
+	DisableTus   bool                  `mapstructure:"disable_tus"`
 }

--- a/internal/http/services/owncloud/ocs/handlers/cloud/capabilities/capabilities.go
+++ b/internal/http/services/owncloud/ocs/handlers/cloud/capabilities/capabilities.go
@@ -101,7 +101,7 @@ func (h *Handler) Init(c *config.Config) {
 	// h.c.Capabilities.Files.Undelete is boolean
 	// h.c.Capabilities.Files.Versioning is boolean
 
-	if h.c.Capabilities.Files.TusSupport == nil {
+	if h.c.Capabilities.Files.TusSupport == nil && !c.DisableTus {
 		// these are global capabilities
 		// TODO: infer from various TUS handlers from all known storages
 		h.c.Capabilities.Files.TusSupport = &data.CapabilitiesFilesTusSupport{


### PR DESCRIPTION
This way the TUS headers and capabilities are not returned when
disabled, to not advertise TUS support for clients.

Furthermore the TUS handlers are also disabled.

@butonic 

Context is in https://github.com/owncloud/ocis-reva/pull/228 and discussion in https://github.com/owncloud/ocis-reva/issues/177#issuecomment-635237630