### PR TITLE
OCS fixes for create public link

### DIFF
--- a/internal/http/services/owncloud/ocs/conversions/main.go
+++ b/internal/http/services/owncloud/ocs/conversions/main.go
@@ -130,7 +130,7 @@ type ShareData struct {
 	// Whether the recipient was notified, by mail, about the share being shared with them.
 	MailSend string `json:"mail_send" xml:"mail_send"`
 	// Name of the public share
-	Name string `json:"name,omitempty" xml:"name,omitempty"`
+	Name string `json:"name" xml:"name"`
 	// URL of the public share
 	URL string `json:"url,omitempty" xml:"url,omitempty"`
 	// Attributes associated

--- a/internal/http/services/owncloud/ocs/conversions/main.go
+++ b/internal/http/services/owncloud/ocs/conversions/main.go
@@ -290,14 +290,22 @@ func PublicShare2ShareData(share *link.PublicShare, r *http.Request) *ShareData 
 		Token:        share.Token,
 		Expiration:   expiration,
 		MimeType:     share.Mtime.String(),
-		Name:         r.FormValue("name"),
+		Name:         share.DisplayName,
 		URL:          r.Header.Get("Origin") + "/#/s/" + share.Token,
 		Permissions:  publicSharePermissions2OCSPermissions(share.GetPermissions()),
-		UIDOwner:     UserIDToString(share.Creator),
-		UIDFileOwner: UserIDToString(share.Owner),
+		UIDOwner:     LocalUserIDToString(share.Creator),
+		UIDFileOwner: LocalUserIDToString(share.Owner),
 	}
 	// actually clients should be able to GET and cache the user info themselves ...
 	// TODO check grantee type for user vs group
+}
+
+// LocalUserIDToString transforms a cs3api user id into an ocs data model without domain name
+func LocalUserIDToString(userID *userpb.UserId) string {
+	if userID == nil || userID.OpaqueId == "" {
+		return ""
+	}
+	return userID.OpaqueId
 }
 
 // UserIDToString transforms a cs3api user id into an ocs data model


### PR DESCRIPTION
- Return 404 if the target of createPublicLinkShare does not exist.
- Added default permission in case none was passed in the requested
- Fixed name field handling to get it from the share object and include it in the response even when empty (to be compliant with the old behavior)
- Fixed owner user id in response to not include IDP/domain (to be compliant with old behavior) https://github.com/owncloud/ocis-reva/issues/245

@refs FYI