### PR TITLE
OCDAV: fix returned timestamp format

### DIFF
--- a/internal/http/services/owncloud/ocdav/get.go
+++ b/internal/http/services/owncloud/ocdav/get.go
@@ -125,7 +125,7 @@ func (s *svc) handleGet(w http.ResponseWriter, r *http.Request, ns string) {
 	w.Header().Set("OC-FileId", wrapResourceID(info.Id))
 	w.Header().Set("OC-ETag", info.Etag)
 	t := utils.TSToTime(info.Mtime)
-	lastModifiedString := t.Format(time.RFC1123)
+	lastModifiedString := t.Format(time.RFC1123Z)
 	w.Header().Set("Last-Modified", lastModifiedString)
 	/*
 		if md.Checksum != "" {

--- a/internal/http/services/owncloud/ocdav/head.go
+++ b/internal/http/services/owncloud/ocdav/head.go
@@ -67,7 +67,7 @@ func (s *svc) handleHead(w http.ResponseWriter, r *http.Request, ns string) {
 	w.Header().Set("OC-FileId", wrapResourceID(info.Id))
 	w.Header().Set("OC-ETag", info.Etag)
 	t := utils.TSToTime(info.Mtime)
-	lastModifiedString := t.Format(time.RFC1123)
+	lastModifiedString := t.Format(time.RFC1123Z)
 	w.Header().Set("Last-Modified", lastModifiedString)
 	w.WriteHeader(http.StatusOK)
 }

--- a/internal/http/services/owncloud/ocdav/propfind.go
+++ b/internal/http/services/owncloud/ocdav/propfind.go
@@ -320,7 +320,7 @@ func (s *svc) mdToPropResponse(ctx context.Context, pf *propfindXML, md *provide
 		}
 		// Finder needs the the getLastModified property to work.
 		t := utils.TSToTime(md.Mtime).UTC()
-		lastModifiedString := t.Format(time.RFC1123)
+		lastModifiedString := t.Format(time.RFC1123Z)
 		response.Propstat[0].Prop = append(response.Propstat[0].Prop, s.newProp("d:getlastmodified", lastModifiedString))
 
 		if md.Checksum != nil {
@@ -475,7 +475,7 @@ func (s *svc) mdToPropResponse(ctx context.Context, pf *propfindXML, md *provide
 				case "getlastmodified": // both
 					// TODO we cannot find out if md.Mtime is set or not because ints in go default to 0
 					t := utils.TSToTime(md.Mtime).UTC()
-					lastModifiedString := t.Format(time.RFC1123)
+					lastModifiedString := t.Format(time.RFC1123Z)
 					propstatOK.Prop = append(propstatOK.Prop, s.newProp("d:getlastmodified", lastModifiedString))
 				default:
 					propstatNotFound.Prop = append(propstatNotFound.Prop, s.newProp("d:"+pf.Prop[i].Local, ""))

--- a/internal/http/services/owncloud/ocdav/put.go
+++ b/internal/http/services/owncloud/ocdav/put.go
@@ -300,7 +300,7 @@ func (s *svc) handlePut(w http.ResponseWriter, r *http.Request, ns string) {
 	w.Header().Set("OC-FileId", wrapResourceID(info2.Id))
 	w.Header().Set("OC-ETag", info2.Etag)
 	t := utils.TSToTime(info2.Mtime)
-	lastModifiedString := t.Format(time.RFC1123)
+	lastModifiedString := t.Format(time.RFC1123Z)
 	w.Header().Set("Last-Modified", lastModifiedString)
 	w.Header().Set("X-OC-MTime", "accepted")
 

--- a/internal/http/services/owncloud/ocdav/putchunked.go
+++ b/internal/http/services/owncloud/ocdav/putchunked.go
@@ -403,7 +403,7 @@ func (s *svc) handlePutChunked(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("OC-FileId", md2.Id)
 		w.Header().Set("OC-ETag", md2.Etag)
 		t := time.Unix(int64(md2.Mtime), 0)
-		lastModifiedString := t.Format(time.RFC1123)
+		lastModifiedString := t.Format(time.RFC1123Z)
 		w.Header().Set("Last-Modified", lastModifiedString)
 		w.Header().Set("X-OC-MTime", "accepted")
 

--- a/internal/http/services/owncloud/ocdav/trashbin.go
+++ b/internal/http/services/owncloud/ocdav/trashbin.go
@@ -286,7 +286,7 @@ func (h *TrashbinHandler) itemToPropResponse(ctx context.Context, s *svc, pf *pr
 	// TODO(jfd): if the path we list here is taken from the ListRecycle request we rely on the gateway to prefix it with the mount point
 
 	t := utils.TSToTime(item.DeletionTime).UTC()
-	dTime := t.Format(time.RFC1123)
+	dTime := t.Format(time.RFC1123Z)
 
 	// when allprops has been requested
 	if pf.Allprop != nil {


### PR DESCRIPTION
RFC1123 actually recommend the use of "UT" as zimezone instead of "UTC".
The way to do it with go is using the special "RFC1123Z" time.

Fixes issue with timestamp warnings on the client and makes the format
compliant with the old implementation.

See https://github.com/golang/go/issues/13781#issuecomment-168235353

Fixes https://github.com/owncloud/ocis-reva/issues/116