### PR TITLE
Fixed label naming

### DIFF
--- a/pkg/mentix/exporters/promfilesd.go
+++ b/pkg/mentix/exporters/promfilesd.go
@@ -115,7 +115,7 @@ func (exporter *PrometheusFileSDExporter) createScrapeConfig(site *meshdata.Site
 		Targets: []string{path.Join(host, endpoint.Path)},
 		Labels: map[string]string{
 			"site":         site.Name,
-			"service-type": endpoint.Type.Name,
+			"service_type": endpoint.Type.Name,
 		},
 	}
 }


### PR DESCRIPTION
Prometheus doesn't allow - in label names, so this fix replaces "service-type" by "service_type"