### PR TITLE
[TUS] Return metadata headers after direct upload

### DIFF
--- a/internal/http/services/owncloud/ocdav/tus.go
+++ b/internal/http/services/owncloud/ocdav/tus.go
@@ -21,10 +21,12 @@ package ocdav
 import (
 	"net/http"
 	"path"
+	"time"
 
 	rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	typespb "github.com/cs3org/go-cs3apis/cs3/types/v1beta1"
+	"github.com/cs3org/reva/internal/http/utils"
 	"github.com/cs3org/reva/pkg/appctx"
 	"github.com/cs3org/reva/pkg/rhttp"
 	tusd "github.com/tus/tusd/pkg/handler"
@@ -176,6 +178,39 @@ func (s *svc) handleTusPost(w http.ResponseWriter, r *http.Request, ns string) {
 		if httpRes.StatusCode != http.StatusNoContent {
 			w.WriteHeader(httpRes.StatusCode)
 			return
+		}
+
+		// check if upload was fully completed
+		if httpRes.Header.Get("Upload-Offset") == r.Header.Get("Upload-Length") {
+			// get uploaded file metadata
+			sRes, err := client.Stat(ctx, sReq)
+			if err != nil {
+				log.Error().Err(err).Msg("error sending grpc stat request")
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+
+			if sRes.Status.Code != rpc.Code_CODE_OK {
+				if sRes.Status.Code != rpc.Code_CODE_NOT_FOUND {
+					w.WriteHeader(http.StatusInternalServerError)
+					return
+				}
+			}
+
+			info := sRes.Info
+			if info == nil {
+				log.Error().Str("fn", fn).Msg("No info found for uploaded file")
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+
+			w.Header().Set("Content-Type", info.MimeType)
+			w.Header().Set("OC-FileId", wrapResourceID(info.Id))
+			w.Header().Set("OC-ETag", info.Etag)
+			w.Header().Set("ETag", info.Etag)
+			t := utils.TSToTime(info.Mtime)
+			lastModifiedString := t.Format(time.RFC1123Z)
+			w.Header().Set("Last-Modified", lastModifiedString)
 		}
 	}
 	w.WriteHeader(http.StatusCreated)


### PR DESCRIPTION
When uploading the full file using POST with the TUS extension
"creation-with-upload", the fileid, etag and mtime are now returned
through headers.

I've tested this using https://github.com/owncloud/phoenix/pull/3436

- [x] TEST: upload full file returns metadata
- [x] TEST: upload chunked file (where first chunk is sent with POST) does not return metadata

@butonic 