### PR TITLE
deployment: simplify config

### DIFF
--- a/docs/content/en/docs/config/grpc/services/storageprovider/_index.md
+++ b/docs/content/en/docs/config/grpc/services/storageprovider/_index.md
@@ -33,31 +33,15 @@ driver = "local"
 {{% /dir %}}
 
 {{% dir name="drivers" type="map[string]map[string]interface{}" default="docs/config/packages/storage/fs" %}}
-The configuration for the storage driver. [[Ref]](https://github.com/cs3org/reva/tree/master/internal/grpc/services/storageprovider/storageprovider.go#L55)
+ [[Ref]](https://github.com/cs3org/reva/tree/master/internal/grpc/services/storageprovider/storageprovider.go#L54)
 {{< highlight toml >}}
 [grpc.services.storageprovider.drivers]
 "[docs/config/packages/storage/fs]({{< ref "docs/config/packages/storage/fs" >}})"
 {{< /highlight >}}
 {{% /dir %}}
 
-{{% dir name="path_wrapper" type="string" default="/var/tmp/reva/" %}}
-Path wrapper. [[Ref]](https://github.com/cs3org/reva/tree/master/internal/grpc/services/storageprovider/storageprovider.go#L57)
-{{< highlight toml >}}
-[grpc.services.storageprovider]
-path_wrapper = "/var/tmp/reva/"
-{{< /highlight >}}
-{{% /dir %}}
-
-{{% dir name="path_wrappers" type="map[string]map[string]interface{}" default=nil %}}
-The configuration for the path wrapper. [[Ref]](https://github.com/cs3org/reva/tree/master/internal/grpc/services/storageprovider/storageprovider.go#L59)
-{{< highlight toml >}}
-[grpc.services.storageprovider]
-path_wrappers = nil
-{{< /highlight >}}
-{{% /dir %}}
-
 {{% dir name="tmp_folder" type="string" default="/var/tmp" %}}
-Path to temporary folder. [[Ref]](https://github.com/cs3org/reva/tree/master/internal/grpc/services/storageprovider/storageprovider.go#L60)
+Path to temporary folder. [[Ref]](https://github.com/cs3org/reva/tree/master/internal/grpc/services/storageprovider/storageprovider.go#L55)
 {{< highlight toml >}}
 [grpc.services.storageprovider]
 tmp_folder = "/var/tmp"
@@ -65,7 +49,7 @@ tmp_folder = "/var/tmp"
 {{% /dir %}}
 
 {{% dir name="data_server_url" type="string" default="http://localhost/data" %}}
-The URL for the data server. [[Ref]](https://github.com/cs3org/reva/tree/master/internal/grpc/services/storageprovider/storageprovider.go#L61)
+The URL for the data server. [[Ref]](https://github.com/cs3org/reva/tree/master/internal/grpc/services/storageprovider/storageprovider.go#L56)
 {{< highlight toml >}}
 [grpc.services.storageprovider]
 data_server_url = "http://localhost/data"
@@ -73,7 +57,7 @@ data_server_url = "http://localhost/data"
 {{% /dir %}}
 
 {{% dir name="expose_data_server" type="bool" default=false %}}
-Whether to expose data server. [[Ref]](https://github.com/cs3org/reva/tree/master/internal/grpc/services/storageprovider/storageprovider.go#L62)
+Whether to expose data server. [[Ref]](https://github.com/cs3org/reva/tree/master/internal/grpc/services/storageprovider/storageprovider.go#L57)
 {{< highlight toml >}}
 [grpc.services.storageprovider]
 expose_data_server = false
@@ -81,7 +65,7 @@ expose_data_server = false
 {{% /dir %}}
 
 {{% dir name="enable_home_creation" type="bool" default=false %}}
-Whether to enable home creation. [[Ref]](https://github.com/cs3org/reva/tree/master/internal/grpc/services/storageprovider/storageprovider.go#L64)
+ [[Ref]](https://github.com/cs3org/reva/tree/master/internal/grpc/services/storageprovider/storageprovider.go#L58)
 {{< highlight toml >}}
 [grpc.services.storageprovider]
 enable_home_creation = false
@@ -89,7 +73,7 @@ enable_home_creation = false
 {{% /dir %}}
 
 {{% dir name="disable_tus" type="bool" default=false %}}
-Whether to disable TUS uploads. [[Ref]](https://github.com/cs3org/reva/tree/master/internal/grpc/services/storageprovider/storageprovider.go#L65)
+Whether to disable TUS uploads. [[Ref]](https://github.com/cs3org/reva/tree/master/internal/grpc/services/storageprovider/storageprovider.go#L59)
 {{< highlight toml >}}
 [grpc.services.storageprovider]
 disable_tus = false
@@ -97,7 +81,7 @@ disable_tus = false
 {{% /dir %}}
 
 {{% dir name="available_checksums" type="map[string]uint32" default=nil %}}
-List of available checksums. [[Ref]](https://github.com/cs3org/reva/tree/master/internal/grpc/services/storageprovider/storageprovider.go#L66)
+List of available checksums. [[Ref]](https://github.com/cs3org/reva/tree/master/internal/grpc/services/storageprovider/storageprovider.go#L60)
 {{< highlight toml >}}
 [grpc.services.storageprovider]
 available_checksums = nil

--- a/docs/content/en/docs/config/grpc/services/storageprovider/_index.md
+++ b/docs/content/en/docs/config/grpc/services/storageprovider/_index.md
@@ -64,16 +64,8 @@ expose_data_server = false
 {{< /highlight >}}
 {{% /dir %}}
 
-{{% dir name="enable_home_creation" type="bool" default=false %}}
- [[Ref]](https://github.com/cs3org/reva/tree/master/internal/grpc/services/storageprovider/storageprovider.go#L58)
-{{< highlight toml >}}
-[grpc.services.storageprovider]
-enable_home_creation = false
-{{< /highlight >}}
-{{% /dir %}}
-
 {{% dir name="disable_tus" type="bool" default=false %}}
-Whether to disable TUS uploads. [[Ref]](https://github.com/cs3org/reva/tree/master/internal/grpc/services/storageprovider/storageprovider.go#L59)
+Whether to disable TUS uploads. [[Ref]](https://github.com/cs3org/reva/tree/master/internal/grpc/services/storageprovider/storageprovider.go#L58)
 {{< highlight toml >}}
 [grpc.services.storageprovider]
 disable_tus = false
@@ -81,7 +73,7 @@ disable_tus = false
 {{% /dir %}}
 
 {{% dir name="available_checksums" type="map[string]uint32" default=nil %}}
-List of available checksums. [[Ref]](https://github.com/cs3org/reva/tree/master/internal/grpc/services/storageprovider/storageprovider.go#L60)
+List of available checksums. [[Ref]](https://github.com/cs3org/reva/tree/master/internal/grpc/services/storageprovider/storageprovider.go#L59)
 {{< highlight toml >}}
 [grpc.services.storageprovider]
 available_checksums = nil

--- a/docs/content/en/docs/config/packages/storage/fs/local/_index.md
+++ b/docs/content/en/docs/config/packages/storage/fs/local/_index.md
@@ -16,11 +16,11 @@ root = "/var/tmp/reva/"
 {{< /highlight >}}
 {{% /dir %}}
 
-{{% dir name="enable_home" type="bool" default=false %}}
-Whether to have individual home directories for users. [[Ref]](https://github.com/cs3org/reva/tree/master/pkg/storage/fs/local/local.go#L53)
+{{% dir name="disable_home" type="bool" default=false %}}
+Whether to not have individual home directories for users. [[Ref]](https://github.com/cs3org/reva/tree/master/pkg/storage/fs/local/local.go#L53)
 {{< highlight toml >}}
 [storage.fs.local]
-enable_home = false
+disable_home = false
 {{< /highlight >}}
 {{% /dir %}}
 

--- a/examples/standalone/standalone.toml
+++ b/examples/standalone/standalone.toml
@@ -2,7 +2,6 @@
 [grpc.services.gateway]
 [grpc.services.storageregistry]
 [grpc.services.storageprovider]
-enable_home_creation = true
 [grpc.services.authprovider]
 [grpc.services.authregistry]
 [grpc.services.userprovider]

--- a/examples/standalone/standalone.toml
+++ b/examples/standalone/standalone.toml
@@ -1,77 +1,14 @@
-[shared]
-jwt_secret = "Pive-Fumkiu4"
-gatewaysvc = "localhost:19000"
-
-[grpc]
-address = "0.0.0.0:19000"
-
+# services to enable
 [grpc.services.gateway]
-authregistrysvc = "localhost:19000"
-storageregistrysvc = "localhost:19000"
-preferencessvc = "localhost:19000"
-userprovidersvc = "localhost:19000"
-usershareprovidersvc = "localhost:19000"
-publicshareprovidersvc = "localhost:19000"
-ocmshareprovidersvc = "localhost:19000"
-commit_share_to_storage_grant = false
-datagateway = "http://localhost:19001/data"
-transfer_shared_secret = "replace-me-with-a-transfer-secret" # for direct uploads
-transfer_expires = 6 # give it a moment
-
-[grpc.services.authregistry]
-driver = "static"
-[grpc.services.authregistry.drivers.static.rules]
-basic = "localhost:19000"
-
 [grpc.services.storageregistry]
-driver = "static"
-[grpc.services.storageregistry.drivers.static]
-home_provider = "/"
-[grpc.services.storageregistry.drivers.static.rules]
-"/" = "localhost:19000"
-"123e4567-e89b-12d3-a456-426655440000" = "localhost:19000"
-
-[grpc.services.usershareprovider]
-driver = "memory"
-
-[grpc.services.publicshareprovider]
-driver = "memory"
-
 [grpc.services.storageprovider]
-driver = "local"
-mount_path = "/"
-mount_id = "123e4567-e89b-12d3-a456-426655440000"
-expose_data_server = true
-data_server_url = "http://localhost:19001/data"
 enable_home_creation = true
-
-[grpc.services.storageprovider.drivers.local]
-namespace = "/var/tmp/reva/"
-user_layout = "{{.Username}}"
-enable_home = true
-
 [grpc.services.authprovider]
-auth_manager = "json"
-[grpc.services.authprovider.auth_managers.json]
-users = "users.demo.json"
-
+[grpc.services.authregistry]
 [grpc.services.userprovider]
-driver = "json"
-
-[grpc.services.userprovider.drivers.json]
-users = "users.demo.json"
-
-[http]
-address = "0.0.0.0:19001"
+[grpc.services.usershareprovider]
+[grpc.services.publicshareprovider]
 
 [http.services.dataprovider]
-driver = "local"
-temp_folder = "/var/tmp/"
+[http.services.prometheus]
 
-[http.services.dataprovider.drivers.local]
-namespace = "/var/tmp/reva/"
-user_layout = "{{.Username}}"
-enable_home = true
-
-#[http.services.datagateway]
-#transfer_shared_secret = "replace-me-with-a-transfer-secret" # for direct uploads

--- a/internal/grpc/services/authprovider/authprovider.go
+++ b/internal/grpc/services/authprovider/authprovider.go
@@ -42,6 +42,12 @@ type config struct {
 	AuthManagers map[string]map[string]interface{} `mapstructure:"auth_managers"`
 }
 
+func (c *config) init() {
+	if c.AuthManager == "" {
+		c.AuthManager = "json"
+	}
+}
+
 type service struct {
 	authmgr auth.Manager
 	conf    *config
@@ -53,6 +59,7 @@ func parseConfig(m map[string]interface{}) (*config, error) {
 		err = errors.Wrap(err, "error decoding conf")
 		return nil, err
 	}
+	c.init()
 	return c, nil
 }
 

--- a/internal/grpc/services/authregistry/authregistry.go
+++ b/internal/grpc/services/authregistry/authregistry.go
@@ -59,12 +59,20 @@ type config struct {
 	Drivers map[string]map[string]interface{} `mapstructure:"drivers"`
 }
 
+func (c *config) init() {
+	if c.Driver == "" {
+		c.Driver = "static"
+	}
+}
+
 // New creates a new AuthRegistry
 func New(m map[string]interface{}, ss *grpc.Server) (rgrpc.Service, error) {
 	c, err := parseConfig(m)
 	if err != nil {
 		return nil, err
 	}
+
+	c.init()
 
 	reg, err := getRegistry(c)
 	if err != nil {

--- a/internal/grpc/services/gateway/gateway.go
+++ b/internal/grpc/services/gateway/gateway.go
@@ -26,6 +26,7 @@ import (
 	gateway "github.com/cs3org/go-cs3apis/cs3/gateway/v1beta1"
 
 	"github.com/cs3org/reva/pkg/rgrpc"
+	"github.com/cs3org/reva/pkg/sharedconf"
 	"github.com/cs3org/reva/pkg/token"
 	"github.com/cs3org/reva/pkg/token/manager/registry"
 	"github.com/mitchellh/mapstructure"
@@ -49,16 +50,55 @@ type config struct {
 	OCMProviderAuthorizerEndpoint string `mapstructure:"ocmproviderauthorizersvc"`
 	OCMCoreEndpoint               string `mapstructure:"ocmcoresvc"`
 	UserProviderEndpoint          string `mapstructure:"userprovidersvc"`
+	DataGatewayEndpoint           string `mapstructure:"datagateway"`
 	CommitShareToStorageGrant     bool   `mapstructure:"commit_share_to_storage_grant"`
 	CommitShareToStorageRef       bool   `mapstructure:"commit_share_to_storage_ref"`
 	DisableHomeCreationOnLogin    bool   `mapstructure:"disable_home_creation_on_login"`
-	DataGatewayEndpoint           string `mapstructure:"datagateway"`
 	TransferSharedSecret          string `mapstructure:"transfer_shared_secret"`
-	TranserExpires                int64  `mapstructure:"transfer_expires"`
+	TransferExpires               int64  `mapstructure:"transfer_expires"`
 	TokenManager                  string `mapstructure:"token_manager"`
 	// ShareFolder is the location where to create shares in the recipient's storage provider.
 	ShareFolder   string                            `mapstructure:"share_folder"`
 	TokenManagers map[string]map[string]interface{} `mapstructure:"token_managers"`
+}
+
+// sets defaults
+func (c *config) init() {
+	if c.ShareFolder == "" {
+		c.ShareFolder = "MyShares"
+	}
+
+	c.ShareFolder = strings.Trim(c.ShareFolder, "/")
+
+	if c.TokenManager == "" {
+		c.TokenManager = "jwt"
+	}
+
+	// if services address are not specified we used the shared conf
+	// for the gatewaysvc to have dev setups very quickly.
+	c.AuthRegistryEndpoint = sharedconf.GetGatewaySVC(c.AuthRegistryEndpoint)
+	c.StorageRegistryEndpoint = sharedconf.GetGatewaySVC(c.AuthRegistryEndpoint)
+	c.AppRegistryEndpoint = sharedconf.GetGatewaySVC(c.StorageRegistryEndpoint)
+	c.PreferencesEndpoint = sharedconf.GetGatewaySVC(c.AppRegistryEndpoint)
+	c.UserShareProviderEndpoint = sharedconf.GetGatewaySVC(c.UserShareProviderEndpoint)
+	c.PublicShareProviderEndpoint = sharedconf.GetGatewaySVC(c.PublicShareProviderEndpoint)
+	c.OCMShareProviderEndpoint = sharedconf.GetGatewaySVC(c.OCMShareProviderEndpoint)
+	c.OCMInviteManagerEndpoint = sharedconf.GetGatewaySVC(c.OCMInviteManagerEndpoint)
+	c.OCMProviderAuthorizerEndpoint = sharedconf.GetGatewaySVC(c.OCMInviteManagerEndpoint)
+	c.OCMCoreEndpoint = sharedconf.GetGatewaySVC(c.OCMProviderAuthorizerEndpoint)
+	c.UserProviderEndpoint = sharedconf.GetGatewaySVC(c.OCMCoreEndpoint)
+
+	// we reuse the gateway configuration and add http as default data protocol.
+	c.DataGatewayEndpoint = sharedconf.GetGatewaySVC(c.DataGatewayEndpoint)
+	c.DataGatewayEndpoint = fmt.Sprintf("http://%s", c.DataGatewayEndpoint)
+
+	// use shared secret if not set
+	c.TransferSharedSecret = sharedconf.GetJWTSecret(c.TransferSharedSecret)
+
+	// if the transfer does not start in the next 10 seconds the session is expired.
+	if c.TransferExpires == 0 {
+		c.TransferExpires = 10
+	}
 }
 
 type svc struct {
@@ -76,22 +116,9 @@ func New(m map[string]interface{}, ss *grpc.Server) (rgrpc.Service, error) {
 		return nil, err
 	}
 
-	// set defaults
-	if c.ShareFolder == "" {
-		c.ShareFolder = "MyShares"
-	}
-
-	c.ShareFolder = strings.Trim(c.ShareFolder, "/")
-
-	if c.TokenManager == "" {
-		c.TokenManager = "jwt"
-	}
+	c.init()
 
 	// ensure DataGatewayEndpoint is a valid URI
-	if c.DataGatewayEndpoint == "" {
-		return nil, errors.New("datagateway is not defined")
-	}
-
 	u, err := url.Parse(c.DataGatewayEndpoint)
 	if err != nil {
 		return nil, err

--- a/internal/grpc/services/gateway/storageprovider.go
+++ b/internal/grpc/services/gateway/storageprovider.go
@@ -45,7 +45,7 @@ type transferClaims struct {
 }
 
 func (s *svc) sign(ctx context.Context, target string) (string, error) {
-	ttl := time.Duration(s.c.TranserExpires) * time.Second
+	ttl := time.Duration(s.c.TransferExpires) * time.Second
 	claims := transferClaims{
 		StandardClaims: jwt.StandardClaims{
 			ExpiresAt: time.Now().Add(ttl).Unix(),

--- a/internal/grpc/services/publicshareprovider/publicshareprovider.go
+++ b/internal/grpc/services/publicshareprovider/publicshareprovider.go
@@ -44,6 +44,12 @@ type config struct {
 	Drivers map[string]map[string]interface{} `mapstructure:"drivers"`
 }
 
+func (c *config) init() {
+	if c.Driver == "" {
+		c.Driver = "json"
+	}
+}
+
 type service struct {
 	conf *config
 	sm   publicshare.Manager
@@ -84,6 +90,8 @@ func New(m map[string]interface{}, ss *grpc.Server) (rgrpc.Service, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	c.init()
 
 	sm, err := getShareManager(c)
 	if err != nil {

--- a/internal/grpc/services/storageprovider/storageprovider.go
+++ b/internal/grpc/services/storageprovider/storageprovider.go
@@ -48,16 +48,15 @@ func init() {
 }
 
 type config struct {
-	MountPath          string                            `mapstructure:"mount_path" docs:"/;The path where the file system would be mounted."`
-	MountID            string                            `mapstructure:"mount_id" docs:"-;The ID of the mounted file system."`
-	Driver             string                            `mapstructure:"driver" docs:"local;The storage driver to be used."`
-	Drivers            map[string]map[string]interface{} `mapstructure:"drivers" docs:"url:docs/config/packages/storage/fs"`
-	TmpFolder          string                            `mapstructure:"tmp_folder" docs:"/var/tmp;Path to temporary folder."`
-	DataServerURL      string                            `mapstructure:"data_server_url" docs:"http://localhost/data;The URL for the data server."`
-	ExposeDataServer   bool                              `mapstructure:"expose_data_server" docs:"false;Whether to expose data server."` // if true the client will be able to upload/download directly to it
-	EnableHomeCreation bool                              `mapstructure:"enable_home_creation" docs:"false"`
-	DisableTus         bool                              `mapstructure:"disable_tus" docs:"false;Whether to disable TUS uploads."`
-	AvailableXS        map[string]uint32                 `mapstructure:"available_checksums" docs:"nil;List of available checksums."`
+	MountPath        string                            `mapstructure:"mount_path" docs:"/;The path where the file system would be mounted."`
+	MountID          string                            `mapstructure:"mount_id" docs:"-;The ID of the mounted file system."`
+	Driver           string                            `mapstructure:"driver" docs:"local;The storage driver to be used."`
+	Drivers          map[string]map[string]interface{} `mapstructure:"drivers" docs:"url:docs/config/packages/storage/fs"`
+	TmpFolder        string                            `mapstructure:"tmp_folder" docs:"/var/tmp;Path to temporary folder."`
+	DataServerURL    string                            `mapstructure:"data_server_url" docs:"http://localhost/data;The URL for the data server."`
+	ExposeDataServer bool                              `mapstructure:"expose_data_server" docs:"false;Whether to expose data server."` // if true the client will be able to upload/download directly to it
+	DisableTus       bool                              `mapstructure:"disable_tus" docs:"false;Whether to disable TUS uploads."`
+	AvailableXS      map[string]uint32                 `mapstructure:"available_checksums" docs:"nil;List of available checksums."`
 }
 
 func (c *config) init() {
@@ -322,17 +321,6 @@ func (s *service) GetPath(ctx context.Context, req *provider.GetPathRequest) (*p
 }
 
 func (s *service) GetHome(ctx context.Context, req *provider.GetHomeRequest) (*provider.GetHomeResponse, error) {
-	/*
-		relativeHome, err := s.storage.GetHome(ctx)
-		if err != nil {
-			st := status.NewInternal(ctx, err, "error getting home")
-			return &provider.GetHomeResponse{
-				Status: st,
-			}, nil
-		}
-	*/
-
-	//home := path.Join(s.mountPath, path.Clean(relativeHome))
 	home := path.Join(s.mountPath)
 
 	res := &provider.GetHomeResponse{
@@ -345,15 +333,6 @@ func (s *service) GetHome(ctx context.Context, req *provider.GetHomeRequest) (*p
 
 func (s *service) CreateHome(ctx context.Context, req *provider.CreateHomeRequest) (*provider.CreateHomeResponse, error) {
 	log := appctx.GetLogger(ctx)
-	if !s.conf.EnableHomeCreation {
-		err := errtypes.NotSupported("storageprovider: create home directories not enabled")
-		log.Err(err).Msg("storageprovider: home creation is disabled")
-		st := status.NewUnimplemented(ctx, err, "creating home directories is disabled by configuration")
-		return &provider.CreateHomeResponse{
-			Status: st,
-		}, nil
-
-	}
 	if err := s.storage.CreateHome(ctx); err != nil {
 		st := status.NewInternal(ctx, err, "error creating home")
 		log.Err(err).Msg("storageprovider: error calling CreateHome of storage driver")

--- a/internal/grpc/services/storageregistry/storageregistry.go
+++ b/internal/grpc/services/storageregistry/storageregistry.go
@@ -57,12 +57,20 @@ type config struct {
 	Drivers map[string]map[string]interface{} `mapstructure:"drivers"`
 }
 
+func (c *config) init() {
+	if c.Driver == "" {
+		c.Driver = "static"
+	}
+}
+
 // New creates a new StorageBrokerService
 func New(m map[string]interface{}, ss *grpc.Server) (rgrpc.Service, error) {
 	c, err := parseConfig(m)
 	if err != nil {
 		return nil, err
 	}
+
+	c.init()
 
 	reg, err := getRegistry(c)
 	if err != nil {

--- a/internal/grpc/services/userprovider/userprovider.go
+++ b/internal/grpc/services/userprovider/userprovider.go
@@ -41,12 +41,19 @@ type config struct {
 	Drivers map[string]map[string]interface{} `mapstructure:"drivers"`
 }
 
+func (c *config) init() {
+	if c.Driver == "" {
+		c.Driver = "json"
+	}
+}
+
 func parseConfig(m map[string]interface{}) (*config, error) {
 	c := &config{}
 	if err := mapstructure.Decode(m, c); err != nil {
 		err = errors.Wrap(err, "error decoding conf")
 		return nil, err
 	}
+	c.init()
 	return c, nil
 }
 

--- a/internal/grpc/services/usershareprovider/usershareprovider.go
+++ b/internal/grpc/services/usershareprovider/usershareprovider.go
@@ -43,6 +43,12 @@ type config struct {
 	Drivers map[string]map[string]interface{} `mapstructure:"drivers"`
 }
 
+func (c *config) init() {
+	if c.Driver == "" {
+		c.Driver = "json"
+	}
+}
+
 type service struct {
 	conf *config
 	sm   share.Manager
@@ -85,10 +91,7 @@ func New(m map[string]interface{}, ss *grpc.Server) (rgrpc.Service, error) {
 		return nil, err
 	}
 
-	// if driver is empty we default to json
-	if c.Driver == "" {
-		c.Driver = "json"
-	}
+	c.init()
 
 	sm, err := getShareManager(c)
 	if err != nil {

--- a/internal/http/services/datagateway/datagateway.go
+++ b/internal/http/services/datagateway/datagateway.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cs3org/reva/pkg/errtypes"
 	"github.com/cs3org/reva/pkg/rhttp"
 	"github.com/cs3org/reva/pkg/rhttp/global"
+	"github.com/cs3org/reva/pkg/sharedconf"
 	"github.com/dgrijalva/jwt-go"
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
@@ -52,6 +53,14 @@ type config struct {
 	TransferSharedSecret string `mapstructure:"transfer_shared_secret"`
 }
 
+func (c *config) init() {
+	if c.Prefix == "" {
+		c.Prefix = "data"
+	}
+
+	c.TransferSharedSecret = sharedconf.GetJWTSecret(c.TransferSharedSecret)
+}
+
 type svc struct {
 	conf    *config
 	handler http.Handler
@@ -64,9 +73,7 @@ func New(m map[string]interface{}, log *zerolog.Logger) (global.Service, error) 
 		return nil, err
 	}
 
-	if conf.Prefix == "" {
-		conf.Prefix = "data"
-	}
+	conf.init()
 
 	s := &svc{conf: conf}
 	s.setHandler()

--- a/internal/http/services/dataprovider/dataprovider.go
+++ b/internal/http/services/dataprovider/dataprovider.go
@@ -42,6 +42,17 @@ type config struct {
 	DisableTus bool                              `mapstructure:"disable_tus" docs:"false;Whether to disable TUS uploads."`
 }
 
+func (c *config) init() {
+	if c.Prefix == "" {
+		c.Prefix = "data"
+	}
+
+	if c.Driver == "" {
+		c.Driver = "local"
+	}
+
+}
+
 type svc struct {
 	conf    *config
 	handler http.Handler
@@ -55,9 +66,7 @@ func New(m map[string]interface{}, log *zerolog.Logger) (global.Service, error) 
 		return nil, err
 	}
 
-	if conf.Prefix == "" {
-		conf.Prefix = "data"
-	}
+	conf.init()
 
 	fs, err := getFS(conf)
 	if err != nil {

--- a/internal/http/services/dataprovider/dataprovider.go
+++ b/internal/http/services/dataprovider/dataprovider.go
@@ -77,6 +77,7 @@ func New(m map[string]interface{}, log *zerolog.Logger) (global.Service, error) 
 		storage: fs,
 		conf:    conf,
 	}
+
 	err = s.setHandler()
 	return s, err
 }

--- a/internal/http/services/helloworld/helloworld.go
+++ b/internal/http/services/helloworld/helloworld.go
@@ -37,9 +37,9 @@ func New(m map[string]interface{}, log *zerolog.Logger) (global.Service, error) 
 	if err := mapstructure.Decode(m, conf); err != nil {
 		return nil, err
 	}
-	if conf.HelloMessage == "" {
-		conf.HelloMessage = "Hello World!"
-	}
+
+	conf.init()
+
 	return &svc{conf: conf}, nil
 }
 
@@ -51,6 +51,16 @@ func (s *svc) Close() error {
 type config struct {
 	Prefix       string `mapstructure:"prefix"`
 	HelloMessage string `mapstructure:"message"`
+}
+
+func (c *config) init() {
+	if c.HelloMessage == "" {
+		c.HelloMessage = "Hello World!"
+	}
+
+	if c.Prefix == "" {
+		c.Prefix = "helloworld"
+	}
 }
 
 type svc struct {

--- a/internal/http/services/mentix/mentix.go
+++ b/internal/http/services/mentix/mentix.go
@@ -126,6 +126,8 @@ func New(m map[string]interface{}, log *zerolog.Logger) (global.Service, error) 
 		return nil, err
 	}
 
+	conf.Init()
+
 	// Create the Mentix instance
 	mntx, err := mentix.New(conf, log)
 	if err != nil {

--- a/internal/http/services/meshdirectory/meshdirectory.go
+++ b/internal/http/services/meshdirectory/meshdirectory.go
@@ -46,6 +46,20 @@ type config struct {
 	Static  string                            `mapstructure:"static"`
 }
 
+func (c *config) init() {
+	if c.Prefix == "" {
+		c.Prefix = "meshdir"
+	}
+
+	if c.Driver == "" {
+		c.Driver = "json"
+	}
+
+	if c.Static == "" {
+		c.Static = "static"
+	}
+}
+
 type svc struct {
 	mdm  meshdirectory.Manager
 	conf *config
@@ -74,17 +88,7 @@ func New(m map[string]interface{}, log *zerolog.Logger) (global.Service, error) 
 		return nil, err
 	}
 
-	if c.Prefix == "" {
-		c.Prefix = "meshdir"
-	}
-
-	if c.Driver == "" {
-		c.Driver = "json"
-	}
-
-	if c.Static == "" {
-		c.Static = "static"
-	}
+	c.init()
 
 	mdm, err := getMeshDirManager(c)
 	if err != nil {

--- a/internal/http/services/ocmd/ocmd.go
+++ b/internal/http/services/ocmd/ocmd.go
@@ -37,6 +37,14 @@ type Config struct {
 	Config     configData `mapstructure:"config"`
 }
 
+func (c *Config) init() {
+	c.GatewaySvc = sharedconf.GetGatewaySVC(c.GatewaySvc)
+
+	if c.Prefix == "" {
+		c.Prefix = "ocm"
+	}
+}
+
 type svc struct {
 	Conf                 *Config
 	SharesHandler        *sharesHandler
@@ -57,11 +65,8 @@ func New(m map[string]interface{}, log *zerolog.Logger) (global.Service, error) 
 	if err := mapstructure.Decode(m, conf); err != nil {
 		return nil, err
 	}
-	conf.GatewaySvc = sharedconf.GetGatewaySVC(conf.GatewaySvc)
 
-	if conf.Prefix == "" {
-		conf.Prefix = "ocm"
-	}
+	conf.init()
 
 	s := &svc{
 		Conf: conf,

--- a/internal/http/services/oidcprovider/oidcprovider.go
+++ b/internal/http/services/oidcprovider/oidcprovider.go
@@ -50,6 +50,15 @@ type config struct {
 	Issuer          string                            `mapstructure:"issuer"`
 }
 
+func (c *config) init() {
+
+	if c.Prefix == "" {
+		c.Prefix = "oauth2"
+	}
+
+	c.GatewayEndpoint = sharedconf.GetGatewaySVC(c.GatewayEndpoint)
+}
+
 type client struct {
 	ID            string   `mapstructure:"id"`
 	Secret        string   `mapstructure:"client_secret,"`
@@ -77,11 +86,7 @@ func New(m map[string]interface{}, log *zerolog.Logger) (global.Service, error) 
 		return nil, err
 	}
 
-	if c.Prefix == "" {
-		c.Prefix = "oauth2"
-	}
-
-	c.GatewayEndpoint = sharedconf.GetGatewaySVC(c.GatewayEndpoint)
+	c.init()
 
 	clients, err := getClients(c.Clients)
 	if err != nil {

--- a/internal/http/services/owncloud/ocdav/ocdav.go
+++ b/internal/http/services/owncloud/ocdav/ocdav.go
@@ -68,6 +68,19 @@ type Config struct {
 	DisableTus      bool   `mapstructure:"disable_tus"`
 }
 
+func (c *Config) init() {
+	if c.Prefix == "" {
+		c.Prefix = "webdav"
+	}
+
+	c.GatewaySvc = sharedconf.GetGatewaySVC(c.GatewaySvc)
+
+	if c.ChunkFolder == "" {
+		c.ChunkFolder = "/var/tmp/reva/tmp/davchunks"
+	}
+
+}
+
 type svc struct {
 	c             *Config
 	webDavHandler *WebDavHandler
@@ -81,11 +94,7 @@ func New(m map[string]interface{}, log *zerolog.Logger) (global.Service, error) 
 		return nil, err
 	}
 
-	conf.GatewaySvc = sharedconf.GetGatewaySVC(conf.GatewaySvc)
-
-	if conf.ChunkFolder == "" {
-		conf.ChunkFolder = os.TempDir()
-	}
+	conf.init()
 
 	if err := os.MkdirAll(conf.ChunkFolder, 0755); err != nil {
 		return nil, err

--- a/internal/http/services/owncloud/ocs/config/config.go
+++ b/internal/http/services/owncloud/ocs/config/config.go
@@ -20,6 +20,7 @@ package config
 
 import (
 	"github.com/cs3org/reva/internal/http/services/owncloud/ocs/data"
+	"github.com/cs3org/reva/pkg/sharedconf"
 )
 
 // Config holds the config options that need to be passed down to all ocs handlers
@@ -29,4 +30,12 @@ type Config struct {
 	Capabilities data.CapabilitiesData `mapstructure:"capabilities"`
 	GatewaySvc   string                `mapstructure:"gatewaysvc"`
 	DisableTus   bool                  `mapstructure:"disable_tus"`
+}
+
+func (c *Config) Init() {
+	if c.Prefix == "" {
+		c.Prefix = "ocs"
+	}
+
+	c.GatewaySvc = sharedconf.GetGatewaySVC(c.GatewaySvc)
 }

--- a/internal/http/services/owncloud/ocs/config/config.go
+++ b/internal/http/services/owncloud/ocs/config/config.go
@@ -32,6 +32,7 @@ type Config struct {
 	DisableTus   bool                  `mapstructure:"disable_tus"`
 }
 
+// Init sets sane defaults
 func (c *Config) Init() {
 	if c.Prefix == "" {
 		c.Prefix = "ocs"

--- a/internal/http/services/owncloud/ocs/ocs.go
+++ b/internal/http/services/owncloud/ocs/ocs.go
@@ -26,7 +26,6 @@ import (
 	"github.com/cs3org/reva/pkg/appctx"
 	"github.com/cs3org/reva/pkg/rhttp/global"
 	"github.com/cs3org/reva/pkg/rhttp/router"
-	"github.com/cs3org/reva/pkg/sharedconf"
 	"github.com/mitchellh/mapstructure"
 	"github.com/rs/zerolog"
 )
@@ -52,11 +51,7 @@ func New(m map[string]interface{}, log *zerolog.Logger) (global.Service, error) 
 		return nil, err
 	}
 
-	if conf.Prefix == "" {
-		conf.Prefix = "ocs"
-	}
-
-	conf.GatewaySvc = sharedconf.GetGatewaySVC(conf.GatewaySvc)
+	conf.Init()
 
 	s := &svc{
 		c:         conf,

--- a/internal/http/services/prometheus/prometheus.go
+++ b/internal/http/services/prometheus/prometheus.go
@@ -42,9 +42,7 @@ func New(m map[string]interface{}, log *zerolog.Logger) (global.Service, error) 
 		return nil, err
 	}
 
-	if conf.Prefix == "" {
-		conf.Prefix = "metrics"
-	}
+	conf.init()
 
 	pe, err := prometheus.NewExporter(prometheus.Options{
 		Namespace: "revad",
@@ -69,6 +67,12 @@ func New(m map[string]interface{}, log *zerolog.Logger) (global.Service, error) 
 
 type config struct {
 	Prefix string `mapstructure:"prefix"`
+}
+
+func (c *config) init() {
+	if c.Prefix == "" {
+		c.Prefix = "metrics"
+	}
 }
 
 type svc struct {

--- a/internal/http/services/wellknown/wellknown.go
+++ b/internal/http/services/wellknown/wellknown.go
@@ -44,6 +44,12 @@ type config struct {
 	EndSessionEndpoint    string `mapstructure:"end_session_endpoint"`
 }
 
+func (c *config) init() {
+	if c.Prefix == "" {
+		c.Prefix = ".well-known"
+	}
+}
+
 type svc struct {
 	conf    *config
 	handler http.Handler
@@ -56,9 +62,7 @@ func New(m map[string]interface{}, log *zerolog.Logger) (global.Service, error) 
 		return nil, err
 	}
 
-	if conf.Prefix == "" {
-		conf.Prefix = ".well-known"
-	}
+	conf.init()
 
 	s := &svc{
 		conf: conf,

--- a/pkg/auth/manager/json/json.go
+++ b/pkg/auth/manager/json/json.go
@@ -55,12 +55,19 @@ type config struct {
 	Users string `mapstructure:"users"`
 }
 
+func (c *config) init() {
+	if c.Users == "" {
+		c.Users = "/var/tmp/reva/users.json"
+	}
+}
+
 func parseConfig(m map[string]interface{}) (*config, error) {
 	c := &config{}
 	if err := mapstructure.Decode(m, c); err != nil {
 		err = errors.Wrap(err, "error decoding conf")
 		return nil, err
 	}
+	c.init()
 	return c, nil
 }
 

--- a/pkg/auth/registry/static/static.go
+++ b/pkg/auth/registry/static/static.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cs3org/reva/pkg/auth"
 	"github.com/cs3org/reva/pkg/auth/registry/registry"
 	"github.com/cs3org/reva/pkg/errtypes"
+	"github.com/cs3org/reva/pkg/sharedconf"
 	"github.com/mitchellh/mapstructure"
 )
 
@@ -34,6 +35,14 @@ func init() {
 
 type config struct {
 	Rules map[string]string `mapstructure:"rules"`
+}
+
+func (c *config) init() {
+	if len(c.Rules) == 0 {
+		c.Rules = map[string]string{
+			"basic": sharedconf.GetGatewaySVC(""),
+		}
+	}
 }
 
 type reg struct {
@@ -77,5 +86,6 @@ func New(m map[string]interface{}) (auth.Registry, error) {
 	if err != nil {
 		return nil, err
 	}
+	c.init()
 	return &reg{rules: c.Rules}, nil
 }

--- a/pkg/mentix/config/config.go
+++ b/pkg/mentix/config/config.go
@@ -40,6 +40,7 @@ type Configuration struct {
 	} `mapstructure:"prom_filesd"`
 }
 
+// Init sets sane defaults
 func (c *Configuration) Init() {
 	if c.Prefix == "" {
 		c.Prefix = "mentix"

--- a/pkg/mentix/config/config.go
+++ b/pkg/mentix/config/config.go
@@ -39,3 +39,10 @@ type Configuration struct {
 		OutputFile string `mapstructure:"output_file"`
 	} `mapstructure:"prom_filesd"`
 }
+
+func (c *Configuration) Init() {
+	if c.Prefix == "" {
+		c.Prefix = "mentix"
+	}
+	// TODO(daniel): add default that works out of the box
+}

--- a/pkg/publicshare/manager/json/json.go
+++ b/pkg/publicshare/manager/json/json.go
@@ -54,6 +54,8 @@ func New(c map[string]interface{}) (publicshare.Manager, error) {
 		return nil, err
 	}
 
+	conf.init()
+
 	m := manager{
 		mutex:       &sync.Mutex{},
 		marshaler:   jsonpb.Marshaler{},
@@ -88,6 +90,12 @@ func New(c map[string]interface{}) (publicshare.Manager, error) {
 
 type config struct {
 	File string `mapstructure:"file"`
+}
+
+func (c *config) init() {
+	if c.File == "" {
+		c.File = "/var/tmp/reva/publicshares"
+	}
 }
 
 type manager struct {

--- a/pkg/rgrpc/rgrpc.go
+++ b/pkg/rgrpc/rgrpc.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cs3org/reva/internal/grpc/interceptors/log"
 	"github.com/cs3org/reva/internal/grpc/interceptors/recovery"
 	"github.com/cs3org/reva/internal/grpc/interceptors/token"
+	"github.com/cs3org/reva/pkg/sharedconf"
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
@@ -100,6 +101,16 @@ type config struct {
 	EnableReflection bool                              `mapstructure:"enable_reflection"`
 }
 
+func (c *config) init() {
+	if c.Network == "" {
+		c.Network = "tcp"
+	}
+
+	if c.Address == "" {
+		c.Address = sharedconf.GetGatewaySVC("0.0.0.0:19000")
+	}
+}
+
 // Server is a gRPC server.
 type Server struct {
 	s        *grpc.Server
@@ -116,14 +127,7 @@ func NewServer(m interface{}, log zerolog.Logger) (*Server, error) {
 		return nil, err
 	}
 
-	// apply defaults
-	if conf.Network == "" {
-		conf.Network = "tcp"
-	}
-
-	if conf.Address == "" {
-		conf.Address = "localhost:9999"
-	}
+	conf.init()
 
 	server := &Server{conf: conf, log: log, services: map[string]Service{}}
 

--- a/pkg/rhttp/rhttp.go
+++ b/pkg/rhttp/rhttp.go
@@ -47,14 +47,7 @@ func New(m interface{}, l zerolog.Logger) (*Server, error) {
 		return nil, err
 	}
 
-	// apply defaults
-	if conf.Network == "" {
-		conf.Network = "tcp"
-	}
-
-	if conf.Address == "" {
-		conf.Address = "localhost:9998"
-	}
+	conf.init()
 
 	httpServer := &http.Server{}
 	s := &Server{
@@ -85,6 +78,17 @@ type config struct {
 	Address     string                            `mapstructure:"address"`
 	Services    map[string]map[string]interface{} `mapstructure:"services"`
 	Middlewares map[string]map[string]interface{} `mapstructure:"middlewares"`
+}
+
+func (c *config) init() {
+	// apply defaults
+	if c.Network == "" {
+		c.Network = "tcp"
+	}
+
+	if c.Address == "" {
+		c.Address = "0.0.0.0:19001"
+	}
 }
 
 // Start starts the server

--- a/pkg/share/manager/json/json.go
+++ b/pkg/share/manager/json/json.go
@@ -23,7 +23,6 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"os"
-	"path"
 	"reflect"
 	"sync"
 	"time"
@@ -53,15 +52,7 @@ func New(m map[string]interface{}) (share.Manager, error) {
 		return nil, err
 	}
 
-	// if file is not set we use temporary file
-	if c.File == "" {
-		dir, err := ioutil.TempDir("", "")
-		if err != nil {
-			err = errors.Wrap(err, "error creating temporary directory for storing shares")
-			return nil, err
-		}
-		c.File = path.Join(dir, "shares.json")
-	}
+	c.init()
 
 	// load or create file
 	model, err := loadOrCreate(c.File)
@@ -143,6 +134,12 @@ type mgr struct {
 
 type config struct {
 	File string `mapstructure:"file"`
+}
+
+func (c *config) init() {
+	if c.File == "" {
+		c.File = "/var/tmp/reva/shares.json"
+	}
 }
 
 func parseConfig(m map[string]interface{}) (*config, error) {

--- a/pkg/sharedconf/sharedconf.go
+++ b/pkg/sharedconf/sharedconf.go
@@ -35,6 +35,17 @@ func Decode(v interface{}) error {
 		return err
 	}
 
+	// add some defaults
+	if sharedConf.GatewaySVC == "" {
+		sharedConf.GatewaySVC = "0.0.0.0:19000"
+	}
+
+	// TODO(labkode): would be cool to autogenerate one secret and print
+	// it on init time.
+	if sharedConf.JWTSecret == "" {
+		sharedConf.JWTSecret = "changemeplease"
+	}
+
 	return nil
 }
 

--- a/pkg/sharedconf/sharedconf_test.go
+++ b/pkg/sharedconf/sharedconf_test.go
@@ -39,8 +39,8 @@ func Test(t *testing.T) {
 	}
 
 	got = GetJWTSecret("")
-	if got != "" {
-		t.Fatalf("expected %q got %q", "", got)
+	if got != "changemeplease" {
+		t.Fatalf("expected %q got %q", "changemeplease", got)
 	}
 
 	conf = map[string]interface{}{

--- a/pkg/storage/registry/static/static.go
+++ b/pkg/storage/registry/static/static.go
@@ -25,6 +25,7 @@ import (
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	registrypb "github.com/cs3org/go-cs3apis/cs3/storage/registry/v1beta1"
 	"github.com/cs3org/reva/pkg/errtypes"
+	"github.com/cs3org/reva/pkg/sharedconf"
 	"github.com/cs3org/reva/pkg/storage"
 	"github.com/cs3org/reva/pkg/storage/registry/registry"
 	"github.com/mitchellh/mapstructure"
@@ -38,6 +39,19 @@ func init() {
 type config struct {
 	Rules        map[string]string `mapstructure:"rules"`
 	HomeProvider string            `mapstructure:"home_provider"`
+}
+
+func (c *config) init() {
+	if c.HomeProvider == "" {
+		c.HomeProvider = "/"
+	}
+
+	if len(c.Rules) == 0 {
+		c.Rules = map[string]string{
+			"/":                                    sharedconf.GetGatewaySVC(""),
+			"00000000-0000-0000-0000-000000000000": sharedconf.GetGatewaySVC(""),
+		}
+	}
 }
 
 func parseConfig(m map[string]interface{}) (*config, error) {
@@ -55,6 +69,7 @@ func New(m map[string]interface{}) (storage.Registry, error) {
 	if err != nil {
 		return nil, err
 	}
+	c.init()
 	return &reg{c: c}, nil
 }
 

--- a/pkg/user/manager/json/json.go
+++ b/pkg/user/manager/json/json.go
@@ -46,12 +46,19 @@ type config struct {
 	Users string `mapstructure:"users"`
 }
 
+func (c *config) init() {
+	if c.Users == "" {
+		c.Users = "/var/tmp/reva/users.json"
+	}
+}
+
 func parseConfig(m map[string]interface{}) (*config, error) {
 	c := &config{}
 	if err := mapstructure.Decode(m, c); err != nil {
 		err = errors.Wrap(err, "error decoding conf")
 		return nil, err
 	}
+	c.init()
 	return c, nil
 }
 

--- a/pkg/user/manager/json/json_test.go
+++ b/pkg/user/manager/json/json_test.go
@@ -39,24 +39,6 @@ func TestUserManager(t *testing.T) {
 	}
 	defer os.RemoveAll(tempdir)
 
-	// parseConfig - negative test
-	input := map[string]interface{}{
-		"users": true,
-	}
-	_, err = New(input)
-	if err == nil {
-		t.Fatalf("no error (but we expected one) while get manager")
-	}
-
-	// read file - negative test
-	input = map[string]interface{}{
-		"thisFailsSoHard": "TestingTesting",
-	}
-	_, err = New(input)
-	if err == nil {
-		t.Fatalf("no error (but we expected one) while get manager")
-	}
-
 	// corrupt json object with user meta data
 	userJSON := `[{`
 
@@ -73,7 +55,7 @@ func TestUserManager(t *testing.T) {
 	}
 
 	// get manager
-	input = map[string]interface{}{
+	input := map[string]interface{}{
 		"users": file.Name(),
 	}
 	_, err = New(input)


### PR DESCRIPTION
This PR allows to run Reva with minimal configuration, easier for dev setups and IOP deployments:

```
$ cat examples/standalone/standalone.toml
# services to enable
[grpc.services.gateway]
[grpc.services.storageregistry]
[grpc.services.storageprovider]
[grpc.services.authprovider]
[grpc.services.authregistry]
[grpc.services.userprovider]
[grpc.services.usershareprovider]
[grpc.services.publicshareprovider]

[http.services.dataprovider]
[http.services.prometheus]

```

To test, will require to have pre-created the following file: `/var/tmp/reva/users.json`
