### PR TITLE
Default prefix for ocdav is empty string

### DIFF
--- a/internal/http/services/owncloud/ocdav/ocdav.go
+++ b/internal/http/services/owncloud/ocdav/ocdav.go
@@ -69,9 +69,7 @@ type Config struct {
 }
 
 func (c *Config) init() {
-	if c.Prefix == "" {
-		c.Prefix = "webdav"
-	}
+	// note: default c.Prefix is an empty string
 
 	c.GatewaySvc = sharedconf.GetGatewaySVC(c.GatewaySvc)
 


### PR DESCRIPTION
Fixes https://github.com/owncloud/ocis-reva/issues/270
