### PR TITLE
Propagate upload mtime to the storage

### DIFF
--- a/internal/http/services/owncloud/ocdav/put.go
+++ b/internal/http/services/owncloud/ocdav/put.go
@@ -210,7 +210,7 @@ func (s *svc) handlePut(w http.ResponseWriter, r *http.Request, ns string) {
 	opaqueMap := map[string]*typespb.OpaqueEntry{
 		"Upload-Length": {
 			Decoder: "plain",
-			Value:   []byte(r.Header.Get("Upload-Length")),
+			Value:   []byte(r.Header.Get("Content-Length")),
 		},
 	}
 

--- a/pkg/storage/fs/owncloud/owncloud.go
+++ b/pkg/storage/fs/owncloud/owncloud.go
@@ -957,6 +957,26 @@ func (fs *ocfs) CreateReference(ctx context.Context, path string, targetURI *url
 	return errtypes.NotSupported("ocfs: operation not supported")
 }
 
+func (fs *ocfs) setMtime(ctx context.Context, np string, mtimeString string) error {
+	log := appctx.GetLogger(ctx)
+	if mtime, err := parseMTime(mtimeString); err == nil {
+		// updating mtime also updates atime
+		if err := os.Chtimes(np, mtime, mtime); err != nil {
+			log.Error().Err(err).
+				Str("np", np).
+				Time("mtime", mtime).
+				Msg("could not set mtime")
+			return errors.Wrap(err, "could not set mtime")
+		}
+	} else {
+		log.Error().Err(err).
+			Str("np", np).
+			Str("mtimeString", mtimeString).
+			Msg("could not parse mtime")
+		return errors.Wrap(err, "could not parse mtime")
+	}
+	return nil
+}
 func (fs *ocfs) SetArbitraryMetadata(ctx context.Context, ref *provider.Reference, md *provider.ArbitraryMetadata) (err error) {
 	log := appctx.GetLogger(ctx)
 
@@ -978,21 +998,9 @@ func (fs *ocfs) SetArbitraryMetadata(ctx context.Context, ref *provider.Referenc
 
 	if md.Metadata != nil {
 		if val, ok := md.Metadata["mtime"]; ok {
-			if mtime, err := parseMTime(val); err == nil {
-				// updating mtime also updates atime
-				if err := os.Chtimes(np, mtime, mtime); err != nil {
-					log.Error().Err(err).
-						Str("np", np).
-						Time("mtime", mtime).
-						Msg("could not set mtime")
-					errs = append(errs, errors.Wrap(err, "could not set mtime"))
-				}
-			} else {
-				log.Error().Err(err).
-					Str("np", np).
-					Str("val", val).
-					Msg("could not parse mtime")
-				errs = append(errs, errors.Wrap(err, "could not parse mtime"))
+			err := fs.setMtime(ctx, np, val)
+			if err != nil {
+				errs = append(errs, errors.Wrap(err, "could not set mtime"))
 			}
 			// remove from metadata
 			delete(md.Metadata, "mtime")

--- a/pkg/storage/fs/s3/upload.go
+++ b/pkg/storage/fs/s3/upload.go
@@ -26,6 +26,6 @@ import (
 )
 
 // InitiateUpload returns an upload id that can be used for uploads with tus
-func (fs *s3FS) InitiateUpload(ctx context.Context, ref *provider.Reference, uploadLength int64) (uploadID string, err error) {
+func (fs *s3FS) InitiateUpload(ctx context.Context, ref *provider.Reference, uploadLength int64, metadata map[string]string) (uploadID string, err error) {
 	return "", errtypes.NotSupported("op not supported")
 }

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -36,7 +36,7 @@ type FS interface {
 	Move(ctx context.Context, oldRef, newRef *provider.Reference) error
 	GetMD(ctx context.Context, ref *provider.Reference) (*provider.ResourceInfo, error)
 	ListFolder(ctx context.Context, ref *provider.Reference) ([]*provider.ResourceInfo, error)
-	InitiateUpload(ctx context.Context, ref *provider.Reference, uploadLength int64) (string, error)
+	InitiateUpload(ctx context.Context, ref *provider.Reference, uploadLength int64, metadata map[string]string) (string, error)
 	Upload(ctx context.Context, ref *provider.Reference, r io.ReadCloser) error
 	Download(ctx context.Context, ref *provider.Reference) (io.ReadCloser, error)
 	ListRevisions(ctx context.Context, ref *provider.Reference) ([]*provider.FileVersion, error)

--- a/pkg/storage/utils/eosfs/upload.go
+++ b/pkg/storage/utils/eosfs/upload.go
@@ -60,7 +60,7 @@ func (fs *eosfs) Upload(ctx context.Context, ref *provider.Reference, r io.ReadC
 
 // InitiateUpload returns an upload id that can be used for uploads with tus
 // TODO read optional content for small files in this request
-func (fs *eosfs) InitiateUpload(ctx context.Context, ref *provider.Reference, uploadLength int64) (uploadID string, err error) {
+func (fs *eosfs) InitiateUpload(ctx context.Context, ref *provider.Reference, uploadLength int64, metadata map[string]string) (uploadID string, err error) {
 	u, err := getUser(ctx)
 	if err != nil {
 		return "", errors.Wrap(err, "eos: no user in ctx")
@@ -79,6 +79,10 @@ func (fs *eosfs) InitiateUpload(ctx context.Context, ref *provider.Reference, up
 			"dir":      filepath.Dir(p),
 		},
 		Size: uploadLength,
+	}
+
+	if metadata != nil && metadata["mtime"] != "" {
+		info.MetaData["mtime"] = metadata["mtime"]
 	}
 
 	upload, err := fs.NewUpload(ctx, info)
@@ -308,6 +312,9 @@ func (upload *fileUpload) FinishUpload(ctx context.Context) error {
 			}
 		}()
 	}
+
+	// TODO: set mtime if specified in metadata
+
 	// metadata propagation is left to the storage implementation
 	return err
 }


### PR DESCRIPTION
The value of X-OC-Mtime is now passed to InitiateFileUpload using an OpaqueEntry.

The storage FS interface's InitiateUpload was updated to include a new
metadata argument, and adjusted all known implementors.

This new metadata argument is used in the storage provider to pass in the
mtime to the storage implementations.

The ownCloud storage implementation was adjusted to read the mtime from the
metadata and set it using Chtimes. That logic was extracted in a new
private method to avoid gymnastics with path handling and also avoid the
implicit propagation that exists in SetArbitraryMetadata.

The other implementors like EOS and Local are currently ignoring the
mtime value and need to be adjusted later on.

@butonic FYI, I hope this approach makes sense. I had to extend the FS interface.