### PR TITLE
Properly read permissions when creating public link

### DIFF
--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/shares.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/shares.go
@@ -348,7 +348,7 @@ func (h *Handler) createPublicLinkShare(w http.ResponseWriter, r *http.Request) 
 	permKey := 1
 	if r.FormValue("permissions") != "" {
 		// phoenix sends: {"permissions": 15}. See ocPermToRole struct for mapping
-		permKey, err := strconv.Atoi(r.FormValue("permissions"))
+		permKey, err = strconv.Atoi(r.FormValue("permissions"))
 		if err != nil {
 			log.Error().Str("createShare", "shares").Str("permissions", r.FormValue("permissions")).Msgf("invalid type: %T", permKey)
 		}


### PR DESCRIPTION
There was a bug where the permKey variable is redefined inside a block
due to the extra colon, so the value did not get set to the outer
variable which got stuck on the value 1.

@refs FYI