### PR TITLE
meshdirectory: pass query params to selected provider

### DIFF
--- a/examples/meshdirectory/static/index.html
+++ b/examples/meshdirectory/static/index.html
@@ -76,7 +76,8 @@
         },
         methods: {
             providerLink(provider) {
-                return this.ocmService(provider).AdditionalEndpoints[0].Path
+                const query = this.queryParams.toString() ? `?${this.queryParams}` : ''
+                return `${this.ocmService(provider).AdditionalEndpoints[0].Path}${query}`
             },
             ocmService(provider) {
                 return provider.Services.find(s => {


### PR DESCRIPTION
Pass any query parameters from source URL to a provider
that user selects from the mesh directory list.

E.g. user opens the following link:
`https://sciencemesh.cesnet.cz/meshdir?token=xyz&providerDomain=https://cern.ch`

After selecting the University of Muenster, he should be redirected to its
OCM API endpoint (as configured in GOCDB), passing in both the `token` and `providerDomain` params