### PR TITLE
TUS upload support through datagateway

### DIFF
--- a/cmd/reva/download.go
+++ b/cmd/reva/download.go
@@ -24,6 +24,8 @@ import (
 	"net/http"
 	"os"
 
+	"github.com/cs3org/reva/internal/http/services/datagateway"
+
 	"github.com/cheggaaa/pb"
 	rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
@@ -89,7 +91,7 @@ func downloadCommand() *command {
 			return err
 		}
 
-		httpReq.Header.Set("X-Reva-Transfer", res.Token)
+		httpReq.Header.Set(datagateway.TokenTransportHeader, res.Token)
 		httpClient := rhttp.GetHTTPClient(ctx)
 
 		httpRes, err := httpClient.Do(httpReq)

--- a/cmd/reva/upload.go
+++ b/cmd/reva/upload.go
@@ -26,6 +26,8 @@ import (
 	"path/filepath"
 	"strconv"
 
+	"github.com/cs3org/reva/internal/http/services/datagateway"
+
 	"github.com/cheggaaa/pb"
 	rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
@@ -134,7 +136,7 @@ func uploadCommand() *command {
 		}
 		if res.Token != "" {
 			fmt.Printf("using X-Reva-Transfer header\n")
-			c.Header.Add("X-Reva-Transfer", res.Token)
+			c.Header.Add(datagateway.TokenTransportHeader, res.Token)
 		} else if token, ok := tokenpkg.ContextGetToken(ctx); ok {
 			fmt.Printf("using %s header\n", tokenpkg.TokenHeader)
 			c.Header.Add(tokenpkg.TokenHeader, token)

--- a/internal/grpc/services/storageprovider/storageprovider.go
+++ b/internal/grpc/services/storageprovider/storageprovider.go
@@ -79,9 +79,6 @@ func (c *config) init() {
 
 	c.DataServerURL = sharedconf.GetDataGateway(c.DataServerURL)
 
-	// TODO: Uploads currently don't work when ExposeDataServer is false
-	c.ExposeDataServer = true
-
 	// set sane defaults
 	if len(c.AvailableXS) == 0 {
 		c.AvailableXS = map[string]uint32{"md5": 100, "unset": 1000}

--- a/internal/http/services/datagateway/datagateway.go
+++ b/internal/http/services/datagateway/datagateway.go
@@ -36,7 +36,8 @@ import (
 )
 
 const (
-	tokenTransportHeader = "X-Reva-Transfer"
+	// TokenTransportHeader holds the header key for the reva transfer token
+	TokenTransportHeader = "X-Reva-Transfer"
 )
 
 func init() {
@@ -145,7 +146,7 @@ func (s *svc) doGet(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	log := appctx.GetLogger(ctx)
 
-	token := r.Header.Get(tokenTransportHeader)
+	token := r.Header.Get(TokenTransportHeader)
 	claims, err := s.verify(ctx, token)
 	if err != nil {
 		err = errors.Wrap(err, "datagateway: error validating transfer token")
@@ -188,7 +189,7 @@ func (s *svc) doPut(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	log := appctx.GetLogger(ctx)
 
-	token := r.Header.Get(tokenTransportHeader)
+	token := r.Header.Get(TokenTransportHeader)
 	claims, err := s.verify(ctx, token)
 	if err != nil {
 		err = errors.Wrap(err, "datagateway: error validating transfer token")

--- a/internal/http/services/owncloud/ocdav/get.go
+++ b/internal/http/services/owncloud/ocdav/get.go
@@ -19,6 +19,7 @@
 package ocdav
 
 import (
+	"github.com/cs3org/reva/internal/http/services/datagateway"
 	"io"
 	"net/http"
 	"path"
@@ -103,7 +104,7 @@ func (s *svc) handleGet(w http.ResponseWriter, r *http.Request, ns string) {
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
-	httpReq.Header.Set("X-Reva-Transfer", dRes.Token)
+	httpReq.Header.Set(datagateway.TokenTransportHeader, dRes.Token)
 	httpClient := rhttp.GetHTTPClient(ctx)
 
 	httpRes, err := httpClient.Do(httpReq)

--- a/internal/http/services/owncloud/ocdav/get.go
+++ b/internal/http/services/owncloud/ocdav/get.go
@@ -19,12 +19,13 @@
 package ocdav
 
 import (
-	"github.com/cs3org/reva/internal/http/services/datagateway"
 	"io"
 	"net/http"
 	"path"
 	"strconv"
 	"time"
+
+	"github.com/cs3org/reva/internal/http/services/datagateway"
 
 	rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"

--- a/internal/http/services/owncloud/ocdav/put.go
+++ b/internal/http/services/owncloud/ocdav/put.go
@@ -19,7 +19,6 @@
 package ocdav
 
 import (
-	"github.com/cs3org/reva/internal/http/services/datagateway"
 	"net/http"
 	"path"
 	"regexp"
@@ -29,6 +28,7 @@ import (
 	rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	typespb "github.com/cs3org/go-cs3apis/cs3/types/v1beta1"
+	"github.com/cs3org/reva/internal/http/services/datagateway"
 	"github.com/cs3org/reva/internal/http/utils"
 	"github.com/cs3org/reva/pkg/appctx"
 	"github.com/cs3org/reva/pkg/rhttp"

--- a/internal/http/services/owncloud/ocdav/put.go
+++ b/internal/http/services/owncloud/ocdav/put.go
@@ -19,6 +19,7 @@
 package ocdav
 
 import (
+	"github.com/cs3org/reva/internal/http/services/datagateway"
 	"net/http"
 	"path"
 	"regexp"
@@ -264,6 +265,7 @@ func (s *svc) handlePut(w http.ResponseWriter, r *http.Request, ns string) {
 		Str("token", tokenpkg.ContextMustGetToken(ctx)).
 		Msg("adding token to header")
 	c.Header.Set(tokenpkg.TokenHeader, tokenpkg.ContextMustGetToken(ctx))
+	c.Header.Set(datagateway.TokenTransportHeader, uRes.Token)
 
 	tusc, err := tus.NewClient(dataServerURL, c)
 	if err != nil {

--- a/internal/http/services/owncloud/ocdav/tus.go
+++ b/internal/http/services/owncloud/ocdav/tus.go
@@ -156,9 +156,9 @@ func (s *svc) handleTusPost(w http.ResponseWriter, r *http.Request, ns string) {
 	// The DataGateway has to take care of pulling it back into the request header upon request arrival.
 	if uRes.Token != "" {
 		if !strings.HasSuffix(uRes.UploadEndpoint, "/") {
-			uRes.UploadEndpoint = uRes.UploadEndpoint + "/"
+			uRes.UploadEndpoint += "/"
 		}
-		uRes.UploadEndpoint = uRes.UploadEndpoint + uRes.Token
+		uRes.UploadEndpoint += uRes.Token
 	}
 
 	w.Header().Set("Location", uRes.UploadEndpoint)

--- a/internal/http/services/owncloud/ocdav/tus.go
+++ b/internal/http/services/owncloud/ocdav/tus.go
@@ -21,6 +21,7 @@ package ocdav
 import (
 	"net/http"
 	"path"
+	"strings"
 	"time"
 
 	rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
@@ -149,6 +150,15 @@ func (s *svc) handleTusPost(w http.ResponseWriter, r *http.Request, ns string) {
 	if uRes.Status.Code != rpc.Code_CODE_OK {
 		w.WriteHeader(http.StatusInternalServerError)
 		return
+	}
+
+	// TUS clients don't understand the reva transfer token. We need to append it to the upload endpoint.
+	// The DataGateway has to take care of pulling it back into the request header upon request arrival.
+	if uRes.Token != "" {
+		if !strings.HasSuffix(uRes.UploadEndpoint, "/") {
+			uRes.UploadEndpoint = uRes.UploadEndpoint + "/"
+		}
+		uRes.UploadEndpoint = uRes.UploadEndpoint + uRes.Token
 	}
 
 	w.Header().Set("Location", uRes.UploadEndpoint)


### PR DESCRIPTION
In oCIS we want to be able to upload data through one single entrypoint and let the datagateway take care of dispatching the request to the respective ~~storage~~ data server. Reva already supports this by encoding the upload endpoint in an `X-Reva-Transfer` token.
This PR is about four things:
1. TUS clients don't understand the reva transfer token. Instead they expect to just work with a URL. In order to fill this gap, the tus code in ocdav now appends the token to the upload endpoint when the ~~storages~~ data servers are not exposed (i.e. as soon as a transfer token exists). Of course we want reva to still continue to work with the token. To achieve this, the datagateway now checks if a transfer token is present in the token verification step. If it's not present, we use the last segment of the request path as the transfer token.
2. Bring basic PATCH request support to the datagateway.
3. TUS code in ocdav didn't set the reva transfer token on the header in cases where it can actually be utilized. This is fixed in `put.go`.
4. Remove the hardcoded `ExposeDataServer = true`.

Also one small change: I've changed the datagateway to expose the `X-Reva-Transfer` constant and used it in all places where the string was hardcoded before. Makes it easier to find code fragments where the transfer token is used.

Happy to hear feedback on this.