### PR TITLE
Fix up download for public link shares

### DIFF
--- a/internal/grpc/services/publicstorageprovider/publicstorageprovider.go
+++ b/internal/grpc/services/publicstorageprovider/publicstorageprovider.go
@@ -188,11 +188,16 @@ func (s *service) initiateFileDownload(ctx context.Context, req *provider.Initia
 		}, nil
 	}
 
+	if !strings.HasSuffix(dRes.DownloadEndpoint, "/") {
+		dRes.DownloadEndpoint += "/"
+	}
+	dRes.DownloadEndpoint += dRes.Token
+
 	return &provider.InitiateFileDownloadResponse{
 		Opaque:           req.Opaque,
 		Status:           dRes.Status,
 		DownloadEndpoint: dRes.DownloadEndpoint,
-		Expose:           true, // TODO set to false, leave data provider lookup to the datagateway
+		Expose:           true, // the gateway already has encoded the upload endpoint
 	}, nil
 }
 
@@ -219,12 +224,17 @@ func (s *service) InitiateFileUpload(ctx context.Context, req *provider.Initiate
 		}, nil
 	}
 
+	if !strings.HasSuffix(uRes.UploadEndpoint, "/") {
+		uRes.UploadEndpoint += "/"
+	}
+	uRes.UploadEndpoint += uRes.Token
+
 	res := &provider.InitiateFileUploadResponse{
 		UploadEndpoint:     uRes.UploadEndpoint,
 		Status:             uRes.Status,
 		AvailableChecksums: uRes.AvailableChecksums,
 		Opaque:             uRes.Opaque,
-		Expose:             true, // TODO set to false, leave data provider lookup to the datagateway
+		Expose:             true, // the gateway already has encoded the upload endpoint
 	}
 
 	return res, nil

--- a/internal/http/services/owncloud/ocdav/put.go
+++ b/internal/http/services/owncloud/ocdav/put.go
@@ -261,9 +261,12 @@ func (s *svc) handlePut(w http.ResponseWriter, r *http.Request, ns string) {
 	}
 
 	log.Debug().
-		Str("header", tokenpkg.TokenHeader).
-		Str("token", tokenpkg.ContextMustGetToken(ctx)).
-		Msg("adding token to header")
+		Str("upload-endpoint", dataServerURL).
+		Str("auth-header", tokenpkg.TokenHeader).
+		Str("auth-token", tokenpkg.ContextMustGetToken(ctx)).
+		Str("transfer-header", datagateway.TokenTransportHeader).
+		Str("transfer-token", uRes.Token).
+		Msg("adding tokens to headers")
 	c.Header.Set(tokenpkg.TokenHeader, tokenpkg.ContextMustGetToken(ctx))
 	c.Header.Set(datagateway.TokenTransportHeader, uRes.Token)
 


### PR DESCRIPTION
the publicstorageprovider uses the gateway to initiate up and downloads. it needs to append the token to the url because it cannot return it as a token in the response