### PR TITLE
run litmus tests [basic http copymove props] in CI

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -215,3 +215,83 @@ steps:
       from_secret: dockerhub_username
     password:
       from_secret: dockerhub_password
+
+---
+kind: pipeline
+type: docker
+name: litmus-oc-old-webdav
+
+platform:
+  os: linux
+  arch: amd64
+
+trigger:
+  event:
+    include:
+      - pull_request
+      - tag
+
+steps:
+  - name: build
+    image: golang:1.13
+    commands:
+      - make build-ci
+
+  - name: revad-services
+    image: golang:1.13
+    detach: true
+    commands:
+      - cd /drone/src/drone/oc-litmus/
+      - /drone/src/cmd/revad/revad -c frontend.toml &
+      - /drone/src/cmd/revad/revad -c gateway.toml &
+      - /drone/src/cmd/revad/revad -c storage-home.toml &
+      - /drone/src/cmd/revad/revad -c storage-oc.toml &
+      - /drone/src/cmd/revad/revad -c users.toml
+
+  - name: litmus-oc-old-webdav
+    image: owncloud/litmus:latest
+    environment:
+      LITMUS_URL: http://revad-services:20080/remote.php/webdav
+      LITMUS_USERNAME: einstein
+      LITMUS_PASSWORD: relativity
+      TESTS: basic http copymove props
+
+---
+kind: pipeline
+type: docker
+name: litmus-oc-new-webdav
+
+platform:
+  os: linux
+  arch: amd64
+
+trigger:
+  event:
+    include:
+      - pull_request
+      - tag
+
+steps:
+  - name: build
+    image: golang:1.13
+    commands:
+      - make build-ci
+
+  - name: revad-services
+    image: golang:1.13
+    detach: true
+    commands:
+      - cd /drone/src/drone/oc-litmus/
+      - /drone/src/cmd/revad/revad -c frontend.toml &
+      - /drone/src/cmd/revad/revad -c gateway.toml &
+      - /drone/src/cmd/revad/revad -c storage-home.toml &
+      - /drone/src/cmd/revad/revad -c storage-oc.toml &
+      - /drone/src/cmd/revad/revad -c users.toml
+
+  - name: litmus-oc-new-webdav
+    image: owncloud/litmus:latest
+    environment:
+      LITMUS_URL: http://revad-services:20080/remote.php/dav/files/einstein
+      LITMUS_USERNAME: einstein
+      LITMUS_PASSWORD: relativity
+      TESTS: basic http copymove props

--- a/drone/oc-litmus/frontend.toml
+++ b/drone/oc-litmus/frontend.toml
@@ -1,0 +1,63 @@
+[shared]
+jwt_secret = "Pive-Fumkiu4"
+gatewaysvc = "localhost:19000"
+
+# This frontend.toml config file will start a reva service that:
+# - serves as the entrypoint for owncloud APIs.
+# - serves http endpoints on port 20080
+#   - / --------------- ocdav
+#   - /ocs ------------ ocs
+#   - /oauth2 --------- oidcprovider
+#   - /.well-known ---- wellknown service to announce openid-configuration
+#   - TODO(diocas): ocm
+# - authenticates requests using oidc bearer auth and basic auth as fallback
+# - serves the grpc services on port 20099
+[grpc]
+address = "0.0.0.0:20099"
+
+[grpc.services.authprovider]
+auth_manager = "oidc"
+
+# If you want to use your own openid provider change this config
+[grpc.services.authprovider.auth_managers.oidc]
+issuer = "http://localhost:20080"
+
+[http]
+address = "0.0.0.0:20080"
+
+[http.middlewares.cors]
+allow_credentials = true
+
+[http.services.ocdav]
+# serve ocdav on the root path
+prefix = ""
+chunk_folder = "/var/tmp/reva/chunks"
+# for user lookups
+# prefix the path of requests to /dav/files with this namespace
+# While owncloud has only listed usernames at this endpoint CERN has
+# been exposing more than just usernames. For owncloud deployments we
+# can prefix the path to jail the requests to the correct CS3 namespace.
+# In this deployment we mounted the owncloud storage provider at /oc. It
+# expects a username as the first path segment.
+# currently, only the desktop client will use this endpoint, but only if
+# the dav.chunking capability is available
+# TODO implement a path wrapper that rewrites `<username>` into the path
+# layout for the users home?
+# no, use GetHome?
+# for eos we need to rewrite the path
+# TODO strip the username from the path so the CS3 namespace can be mounted
+# at the files/<username> endpoint? what about migration? separate reva instance
+files_namespace = "/oc"
+
+# similar to the dav/files endpoint we can configure a prefix for the old webdav endpoint
+# we use the old webdav endpoint to present the cs3 namespace
+# note: this changes the tree that is rendered at remote.php/webdav from the users home to the cs3 namespace
+# use webdav_namespace = "/home" to use the old namespace that only exposes the users files
+# this endpoint should not affect the desktop client sync but will present different folders for the other clients:
+# - the desktop clients use a hardcoded remote.php/dav/files/<username> if the dav.chunkung capability is present
+# - the ios ios uses the core.webdav-root capability which points to remote.php/webdav in oc10
+# - the oc js sdk is hardcoded to the remote.php/webdav so it will see the new tree
+# - TODO android? no sync ... but will see different tree
+webdav_namespace = "/home"
+
+[http.services.ocs]

--- a/drone/oc-litmus/gateway.toml
+++ b/drone/oc-litmus/gateway.toml
@@ -1,0 +1,65 @@
+[shared]
+jwt_secret = "Pive-Fumkiu4"
+gatewaysvc = "localhost:19000"
+
+# This gateway.toml config file will start a reva service that:
+# - serves as a gateway for all requests
+# - looks up the storageprovider using a storageregistry
+# - looks up the authprovider using an authregistry
+# - serves the gateway on grpc port 19000
+# - serves http datagateway on port 19001
+#   - /data - datagateway: file up and download
+[grpc]
+address = "0.0.0.0:19000"
+
+[grpc.services.gateway]
+# registries
+authregistrysvc = "localhost:19000"
+storageregistrysvc = "localhost:19000"
+# user metadata
+preferencessvc = "localhost:18000"
+userprovidersvc = "localhost:18000"
+# an approvider lives on "localhost:18000" as well, see users.toml
+# sharing
+usershareprovidersvc = "localhost:17000"
+publicshareprovidersvc = "localhost:17000"
+# ocm
+ocmcoresvc = "localhost:13000"
+ocmshareprovidersvc = "localhost:13000"
+ocminvitemanagersvc = "localhost:13000"
+ocmproviderauthorizersvc = "localhost:13000"
+# other
+commit_share_to_storage_grant = true
+datagateway = "http://localhost:19001/data"
+transfer_shared_secret = "replace-me-with-a-transfer-secret" # for direct uploads
+transfer_expires = 6 # give it a moment
+#disable_home_creation_on_login = true
+
+[grpc.services.authregistry]
+driver = "static"
+
+[grpc.services.authregistry.drivers.static.rules]
+basic = "localhost:18000" # started with the users.toml
+bearer = "localhost:20099" # started with the frontend.toml
+
+[grpc.services.storageregistry]
+driver = "static"
+
+[grpc.services.storageregistry.drivers.static]
+home_provider = "/home"
+
+[grpc.services.storageregistry.drivers.static.rules]
+# mount a home storage provider that uses a context based path wrapper
+# to jail users into their home dir
+"/home" = "localhost:12000"
+
+# mount a storage provider without a path wrapper for direct access to users.
+"/oc" = "localhost:11000"
+"123e4567-e89b-12d3-a456-426655440000" = "localhost:11000"
+# another mount point might be "/projects/" 
+
+[http]
+address = "0.0.0.0:19001"
+
+[http.services.datagateway]
+transfer_shared_secret = "replace-me-with-a-transfer-secret"

--- a/drone/oc-litmus/storage-home.toml
+++ b/drone/oc-litmus/storage-home.toml
@@ -1,0 +1,46 @@
+# This storage-home.toml config file will start a reva service that:
+[shared]
+jwt_secret = "Pive-Fumkiu4"
+gatewaysvc = "localhost:19000"
+
+# - authenticates grpc storage provider requests using the internal jwt token
+# - authenticates http upload and download requests requests using basic auth
+# - serves the home storage provider on grpc port 12000
+# - serves http dataprovider for this storage on port 12001
+#   - /data - dataprovider: file up and download
+#
+# The home storage will inject the username into the path and jail users into
+# their home directory
+
+[grpc]
+address = "0.0.0.0:12000"
+
+# This is a storage provider that grants direct access to the wrapped storage
+# TODO same storage id as the /oc/ storage provider
+# if we have an id, we can directly go to that storage, no need to wrap paths
+# we have a locally running dataprovider
+# this is where clients can find it
+# the context path wrapper reads tho username from the context and prefixes the relative storage path with it
+[grpc.services.storageprovider]
+driver = "owncloud"
+mount_path = "/home"
+mount_id = "123e4567-e89b-12d3-a456-426655440000"
+expose_data_server = true
+data_server_url = "http://localhost:12001/data"
+enable_home_creation = true
+
+[grpc.services.storageprovider.drivers.owncloud]
+datadirectory = "/var/tmp/reva/data"
+enable_home = true
+
+
+[http]
+address = "0.0.0.0:12001"
+
+[http.services.dataprovider]
+driver = "owncloud"
+temp_folder = "/var/tmp/reva/tmp"
+
+[http.services.dataprovider.drivers.owncloud]
+datadirectory = "/var/tmp/reva/data"
+enable_home = true

--- a/drone/oc-litmus/storage-oc.toml
+++ b/drone/oc-litmus/storage-oc.toml
@@ -1,0 +1,35 @@
+# This storage.toml config file will start a reva service that:
+[shared]
+jwt_secret = "Pive-Fumkiu4"
+gatewaysvc = "localhost:19000"
+
+# - authenticates grpc storage provider requests using the internal jwt token
+# - authenticates http upload and download requests requests using basic auth
+# - serves the storage provider on grpc port 11000
+# - serves http dataprovider for this storage on port 11001
+#   - /data - dataprovider: file up and download
+[grpc]
+address = "0.0.0.0:11000"
+
+# This is a storage provider that grants direct access to the wrapped storage
+# we have a locally running dataprovider
+[grpc.services.storageprovider]
+driver = "owncloud"
+mount_path = "/oc"
+mount_id = "123e4567-e89b-12d3-a456-426655440000"
+expose_data_server = true
+data_server_url = "http://localhost:11001/data"
+
+[grpc.services.storageprovider.drivers.owncloud]
+datadirectory = "/var/tmp/reva/data"
+
+
+[http]
+address = "0.0.0.0:11001"
+
+[http.services.dataprovider]
+driver = "owncloud"
+temp_folder = "/var/tmp/reva/tmp"
+
+[http.services.dataprovider.drivers.owncloud]
+datadirectory = "/var/tmp/reva/data"

--- a/drone/oc-litmus/users.demo.json
+++ b/drone/oc-litmus/users.demo.json
@@ -1,0 +1,13 @@
+[
+	{
+		"id": {
+			"opaque_id": "4c510ada-c86b-4815-8820-42cdf82c3d51",
+			"idp": "http://localhost:20080"
+		},
+		"username": "einstein",
+		"secret": "relativity",
+		"mail": "einstein@example.org",
+		"display_name": "Albert Einstein",
+		"groups": []
+	}
+]

--- a/drone/oc-litmus/users.toml
+++ b/drone/oc-litmus/users.toml
@@ -1,0 +1,20 @@
+[shared]
+jwt_secret = "Pive-Fumkiu4"
+
+# This users.toml config file will start a reva service that:
+# - handles user metadata and user preferences
+# - serves the grpc services on port 18000
+[grpc]
+address = "0.0.0.0:18000"
+
+[grpc.services.authprovider]
+auth_manager = "json"
+
+[grpc.services.authprovider.auth_managers.json]
+users = "users.demo.json"
+
+[grpc.services.userprovider]
+driver = "json"
+
+[grpc.services.userprovider.drivers.json]
+users = "users.demo.json"


### PR DESCRIPTION
run those tests of the litmus suite that are passing on the ownCloud webdav endpoints

running them in separate pipelines because of: 
1. run tests in parallel
2. the tests seem not to clean up after itself in a way reva can cope with it. running the test the second time on the same instance fails

part of #884