### PR TITLE
Delete public share

### DIFF
--- a/internal/grpc/services/gateway/publicshareprovider.go
+++ b/internal/grpc/services/gateway/publicshareprovider.go
@@ -24,7 +24,6 @@ import (
 	rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
 	link "github.com/cs3org/go-cs3apis/cs3/sharing/link/v1beta1"
 	"github.com/cs3org/reva/pkg/appctx"
-	"github.com/cs3org/reva/pkg/rgrpc/status"
 	"github.com/cs3org/reva/pkg/rgrpc/todo/pool"
 	"github.com/pkg/errors"
 )
@@ -50,9 +49,15 @@ func (s *svc) RemovePublicShare(ctx context.Context, req *link.RemovePublicShare
 	log := appctx.GetLogger(ctx)
 	log.Info().Msg("remove public share")
 
-	return &link.RemovePublicShareResponse{
-		Status: status.NewOK(ctx),
-	}, nil
+	driver, err := pool.GetPublicShareProviderClient(s.c.PublicShareProviderEndpoint)
+	if err != nil {
+		return nil, err
+	}
+	res, err := driver.RemovePublicShare(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	return res, nil
 }
 
 func (s *svc) GetPublicShareByToken(ctx context.Context, req *link.GetPublicShareByTokenRequest) (*link.GetPublicShareByTokenResponse, error) {

--- a/internal/grpc/services/publicshareprovider/publicshareprovider.go
+++ b/internal/grpc/services/publicshareprovider/publicshareprovider.go
@@ -131,6 +131,13 @@ func (s *service) RemovePublicShare(ctx context.Context, req *link.RemovePublicS
 	log := appctx.GetLogger(ctx)
 	log.Info().Str("publicshareprovider", "remove").Msg("remove public share")
 
+	user := user.ContextMustGetUser(ctx)
+	err := s.sm.RevokePublicShare(ctx, user, req.Ref.GetId().OpaqueId)
+	if err != nil {
+		return &link.RemovePublicShareResponse{
+			Status: status.NewInternal(ctx, err, "error deleting public share"),
+		}, err
+	}
 	return &link.RemovePublicShareResponse{
 		Status: status.NewOK(ctx),
 	}, nil

--- a/pkg/publicshare/manager/json/json.go
+++ b/pkg/publicshare/manager/json/json.go
@@ -345,7 +345,17 @@ func (m *manager) ListPublicShares(ctx context.Context, u *user.User, filters []
 
 // RevokePublicShare undocumented.
 func (m *manager) RevokePublicShare(ctx context.Context, u *user.User, id string) error {
-	return fmt.Errorf("RevokePublicShare method unimplemented")
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	db, err := m.readDb()
+	if err != nil {
+		return err
+	}
+
+	delete(db, id)
+
+	return m.writeDb(db)
 }
 
 func (m *manager) getByToken(ctx context.Context, token string) (*link.PublicShare, error) {

--- a/pkg/publicshare/manager/json/json.go
+++ b/pkg/publicshare/manager/json/json.go
@@ -64,7 +64,9 @@ func New(c map[string]interface{}) (publicshare.Manager, error) {
 	}
 
 	// attempt to create the db file
-	if _, err := os.Stat(m.file); os.IsNotExist(err) {
+	var fi os.FileInfo
+	var err error
+	if fi, err = os.Stat(m.file); os.IsNotExist(err) {
 		folder := filepath.Dir(m.file)
 		if err := os.MkdirAll(folder, 0755); err != nil {
 			return nil, err
@@ -74,11 +76,7 @@ func New(c map[string]interface{}) (publicshare.Manager, error) {
 		}
 	}
 
-	fileContents, err := ioutil.ReadFile(m.file)
-	if err != nil {
-		return nil, err
-	}
-	if len(fileContents) == 0 {
+	if fi == nil || fi.Size() == 0 {
 		err := ioutil.WriteFile(m.file, []byte("{}"), 0644)
 		if err != nil {
 			return nil, err
@@ -164,13 +162,8 @@ func (m *manager) CreatePublicShare(ctx context.Context, u *user.User, rInfo *pr
 		return nil, err
 	}
 
-	db := map[string]interface{}{}
-	fileContents, err := ioutil.ReadFile(m.file)
+	db, err := m.readDb()
 	if err != nil {
-		return nil, err
-	}
-
-	if err := json.Unmarshal(fileContents, &db); err != nil {
 		return nil, err
 	}
 
@@ -183,14 +176,11 @@ func (m *manager) CreatePublicShare(ctx context.Context, u *user.User, rInfo *pr
 		return nil, errors.New("key already exists")
 	}
 
-	destJSON, err := json.Marshal(db)
+	err = m.writeDb(db)
 	if err != nil {
 		return nil, err
 	}
 
-	if err := ioutil.WriteFile(m.file, destJSON, 0644); err != nil {
-		return nil, err
-	}
 	return &s, nil
 }
 
@@ -234,13 +224,8 @@ func (m *manager) UpdatePublicShare(ctx context.Context, u *user.User, req *link
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 
-	db := map[string]interface{}{}
-	fileBytes, err := ioutil.ReadFile(m.file)
+	db, err := m.readDb()
 	if err != nil {
-		return nil, err
-	}
-
-	if err := json.Unmarshal(fileBytes, &db); err != nil {
 		return nil, err
 	}
 
@@ -256,12 +241,8 @@ func (m *manager) UpdatePublicShare(ctx context.Context, u *user.User, req *link
 		"password": p,
 	}
 
-	dbAsJSON, err := json.Marshal(db)
+	err = m.writeDb(db)
 	if err != nil {
-		return nil, err
-	}
-
-	if err := ioutil.WriteFile(m.file, dbAsJSON, 0644); err != nil {
 		return nil, err
 	}
 
@@ -281,13 +262,8 @@ func (m *manager) GetPublicShare(ctx context.Context, u *user.User, ref *link.Pu
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 
-	db := map[string]interface{}{}
-	fileBytes, err := ioutil.ReadFile(m.file)
+	db, err := m.readDb()
 	if err != nil {
-		return nil, err
-	}
-
-	if err := json.Unmarshal(fileBytes, &db); err != nil {
 		return nil, err
 	}
 
@@ -333,13 +309,8 @@ func (m *manager) ListPublicShares(ctx context.Context, u *user.User, filters []
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 
-	db := map[string]interface{}{}
-	readBytes, err := ioutil.ReadFile(m.file)
+	db, err := m.readDb()
 	if err != nil {
-		return nil, err
-	}
-
-	if err := json.Unmarshal(readBytes, &db); err != nil {
 		return nil, err
 	}
 
@@ -378,13 +349,8 @@ func (m *manager) RevokePublicShare(ctx context.Context, u *user.User, id string
 }
 
 func (m *manager) getByToken(ctx context.Context, token string) (*link.PublicShare, error) {
-	db := map[string]interface{}{}
-	readBytes, err := ioutil.ReadFile(m.file)
+	db, err := m.readDb()
 	if err != nil {
-		return nil, err
-	}
-
-	if err := json.Unmarshal(readBytes, &db); err != nil {
 		return nil, err
 	}
 
@@ -408,13 +374,8 @@ func (m *manager) getByToken(ctx context.Context, token string) (*link.PublicSha
 
 // GetPublicShareByToken gets a public share by its opaque token.
 func (m *manager) GetPublicShareByToken(ctx context.Context, token, password string) (*link.PublicShare, error) {
-	db := map[string]interface{}{}
-	readBytes, err := ioutil.ReadFile(m.file)
+	db, err := m.readDb()
 	if err != nil {
-		return nil, err
-	}
-
-	if err := json.Unmarshal(readBytes, &db); err != nil {
 		return nil, err
 	}
 
@@ -456,6 +417,31 @@ func randString(n int) string {
 		b[i] = l[rand.Intn(len(l))]
 	}
 	return string(b)
+}
+
+func (m *manager) readDb() (map[string]interface{}, error) {
+	db := map[string]interface{}{}
+	readBytes, err := ioutil.ReadFile(m.file)
+	if err != nil {
+		return nil, err
+	}
+	if err := json.Unmarshal(readBytes, &db); err != nil {
+		return nil, err
+	}
+	return db, nil
+}
+
+func (m *manager) writeDb(db map[string]interface{}) error {
+	dbAsJSON, err := json.Marshal(db)
+	if err != nil {
+		return err
+	}
+
+	if err := ioutil.WriteFile(m.file, dbAsJSON, 0644); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 type publicShare struct {


### PR DESCRIPTION
I extracted the read and write db methods into methods to reduce duplication and implemented the RevokePublicShareMethod.
@PVince81, can you have a look. Did I miss something for deleting?

Implements delete for owncloud/ocis-reva#293.

Related acceptance test changes: https://github.com/owncloud/core/pull/37608