### PR TITLE
Fix public stat and listcontainer response to contain the correct prefix

### DIFF
--- a/internal/grpc/services/publicstorageprovider/publicstorageprovider.go
+++ b/internal/grpc/services/publicstorageprovider/publicstorageprovider.go
@@ -390,7 +390,7 @@ func (s *service) Stat(ctx context.Context, req *provider.StatRequest) (*provide
 
 	// prevent leaking internal paths
 	if statResponse.Info != nil {
-		statResponse.Info.Path = path.Join("/", tkn, relativePath)
+		statResponse.Info.Path = path.Join(s.mountPath, "/", tkn, relativePath)
 	}
 
 	return statResponse, nil
@@ -428,7 +428,7 @@ func (s *service) ListContainer(ctx context.Context, req *provider.ListContainer
 	}
 
 	for i := range listContainerR.Infos {
-		listContainerR.Infos[i].Path = path.Join("/", tkn, relativePath, path.Base(listContainerR.Infos[i].Path))
+		listContainerR.Infos[i].Path = path.Join(s.mountPath, "/", tkn, relativePath, path.Base(listContainerR.Infos[i].Path))
 	}
 
 	return listContainerR, nil


### PR DESCRIPTION
Fixes COPY operations on public links

For https://github.com/owncloud/ocis-reva/issues/310

@butonic said that storage providers should not know about mount paths, but it seems this is currently technical debt / in discussion here: https://github.com/cs3org/reva/issues/578

so this PR is conforming to the current design.

- [x] TEST: COPY non-public file
```
% curl -u einstein:relativity -k -X COPY -H "Destination: https://localhost:9200/remote.php/dav/files/einstein/test-copyprivate.txt" -D - 'https://localhost:9200/remote.php/dav/files/einstein/md5.txt'

HTTP/1.1 201 Created
Access-Control-Allow-Origin: *
Content-Length: 0
Content-Security-Policy: default-src 'none';
Date: Mon, 29 Jun 2020 12:43:24 GMT
Vary: Origin
X-Access-Token: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJyZXZhIiwiZXhwIjoxNTkzNDM4MjA0LCJpYXQiOjE1OTM0MzQ2MDQsImlzcyI6Imh0dHBzOi8vbG9jYWxob3N0OjkyMDAiLCJ1c2VyIjp7ImlkIjp7ImlkcCI6Imh0dHBzOi8vbG9jYWxob3N0OjkyMDAiLCJvcGFxdWVfaWQiOiJlaW5zdGVpbiJ9LCJ1c2VybmFtZSI6ImVpbnN0ZWluIiwibWFpbCI6ImVpbnN0ZWluQGV4YW1wbGUub3JnIiwiZGlzcGxheV9uYW1lIjoiRWluc3RlaW4ifX0.kwNpTnr5-H-9POVHVkKe6DPKCC_72ewhSVea2EmfREA
X-Content-Type-Options: nosniff
X-Download-Options: noopen
X-Frame-Options: SAMEORIGIN
X-Permitted-Cross-Domain-Policies: none
X-Robots-Tag: none
X-Xss-Protection: 1; mode=block
```

- [x] TEST: COPY non-public folder

```
% curl -u einstein:relativity -k -X COPY -H "Depth: infinity" -H "Destination: https://localhost:9200/remote.php/dav/files/einstein/copyprivate-folder" -D - 'https://localhost:9200/remote.php/dav/files/einstein/test'

HTTP/1.1 201 Created
Access-Control-Allow-Origin: *
Content-Length: 0
Content-Security-Policy: default-src 'none';
Date: Mon, 29 Jun 2020 12:44:36 GMT
Vary: Origin
X-Access-Token: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJyZXZhIiwiZXhwIjoxNTkzNDM4Mjc2LCJpYXQiOjE1OTM0MzQ2NzYsImlzcyI6Imh0dHBzOi8vbG9jYWxob3N0OjkyMDAiLCJ1c2VyIjp7ImlkIjp7ImlkcCI6Imh0dHBzOi8vbG9jYWxob3N0OjkyMDAiLCJvcGFxdWVfaWQiOiJlaW5zdGVpbiJ9LCJ1c2VybmFtZSI6ImVpbnN0ZWluIiwibWFpbCI6ImVpbnN0ZWluQGV4YW1wbGUub3JnIiwiZGlzcGxheV9uYW1lIjoiRWluc3RlaW4ifX0.lOgrmRnoBNIyRmNyICKj2w9dL0xPhmcWHZ-FqbXZ1jk
X-Content-Type-Options: nosniff
X-Download-Options: noopen
X-Frame-Options: SAMEORIGIN
X-Permitted-Cross-Domain-Policies: none
X-Robots-Tag: none
X-Xss-Protection: 1; mode=block
```

- [x] TEST: COPY file within public folder

```
% curl -k -X COPY -H "Destination: https://localhost:9200/remote.php/dav/public-files/UbDkKrggmxpB/test-copy-file.txt" -D - 'https://localhost:9200/remote.php/dav/public-files/UbDkKrggmxpB/md5.txt'                                               
HTTP/1.1 201 Created
Access-Control-Allow-Origin: *
Content-Length: 0
Content-Security-Policy: default-src 'none';
Date: Mon, 29 Jun 2020 12:43:02 GMT
Vary: Origin
X-Content-Type-Options: nosniff
X-Download-Options: noopen
X-Frame-Options: SAMEORIGIN
X-Permitted-Cross-Domain-Policies: none
X-Robots-Tag: none
X-Xss-Protection: 1; mode=block
```

- [x] TEST: COPY folder within public folder

```
% curl -k -H "Depth: infinity" -X COPY -H "Destination: https://localhost:9200/remote.php/dav/public-files/UbDkKrggmxpB/test-folder-copy-test" -D - 'https://localhost:9200/remote.php/dav/public-files/UbDkKrggmxpB/test'
HTTP/1.1 201 Created
Access-Control-Allow-Origin: *
Content-Length: 0
Content-Security-Policy: default-src 'none';
Date: Mon, 29 Jun 2020 12:42:26 GMT
Vary: Origin
X-Content-Type-Options: nosniff
X-Download-Options: noopen
X-Frame-Options: SAMEORIGIN
X-Permitted-Cross-Domain-Policies: none
X-Robots-Tag: none
X-Xss-Protection: 1; mode=block
```

- [x] TEST: run related acceptance tests
   - PROPFIND as this might use listcontainer
   - existing COPY tests