### PR TITLE
Change percentagused to percentageused

### DIFF
--- a/pkg/eosclientgrpc/eos_grpc/eos_grpc.pb.go
+++ b/pkg/eosclientgrpc/eos_grpc/eos_grpc.pb.go
@@ -912,8 +912,8 @@ type QuotaProto struct {
 	Maxbytes             uint64    `protobuf:"varint,7,opt,name=maxbytes,proto3" json:"maxbytes,omitempty"`
 	Maxlogicalbytes      uint64    `protobuf:"varint,8,opt,name=maxlogicalbytes,proto3" json:"maxlogicalbytes,omitempty"`
 	Maxfiles             uint64    `protobuf:"varint,9,opt,name=maxfiles,proto3" json:"maxfiles,omitempty"`
-	Percentagusedbytes   float32   `protobuf:"fixed32,10,opt,name=percentagusedbytes,proto3" json:"percentagusedbytes,omitempty"`
-	Percentagusedfiles   float32   `protobuf:"fixed32,11,opt,name=percentagusedfiles,proto3" json:"percentagusedfiles,omitempty"`
+	Percentageusedbytes  float32   `protobuf:"fixed32,10,opt,name=percentageusedbytes,proto3" json:"percentageusedbytes,omitempty"`
+	Percentageusedfiles  float32   `protobuf:"fixed32,11,opt,name=percentageusedfiles,proto3" json:"percentageusedfiles,omitempty"`
 	Statusbytes          string    `protobuf:"bytes,12,opt,name=statusbytes,proto3" json:"statusbytes,omitempty"`
 	Statusfiles          string    `protobuf:"bytes,13,opt,name=statusfiles,proto3" json:"statusfiles,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}  `json:"-"`
@@ -1009,16 +1009,16 @@ func (m *QuotaProto) GetMaxfiles() uint64 {
 	return 0
 }
 
-func (m *QuotaProto) GetPercentagusedbytes() float32 {
+func (m *QuotaProto) GetPercentageusedbytes() float32 {
 	if m != nil {
-		return m.Percentagusedbytes
+		return m.Percentageusedbytes
 	}
 	return 0
 }
 
-func (m *QuotaProto) GetPercentagusedfiles() float32 {
+func (m *QuotaProto) GetPercentageusedfiles() float32 {
 	if m != nil {
-		return m.Percentagusedfiles
+		return m.Percentageusedfiles
 	}
 	return 0
 }

--- a/pkg/eosclientgrpc/eos_grpc/eos_grpc.proto
+++ b/pkg/eosclientgrpc/eos_grpc/eos_grpc.proto
@@ -138,19 +138,19 @@ enum TYPE { FILE = 0; CONTAINER = 1; LISTING = 2; STAT = 3;}
 enum QUOTATYPE { USER = 0; GROUP = 2; PROJECT = 3; ALL = 4;}
 
 message QuotaProto { 
-  bytes path = 1;                // quota node path
-  string name = 2;               // associated name for the given type
-  QUOTATYPE type = 3;            // user,group,project or all quota
-  uint64 usedbytes = 4;          // bytes used physical
-  uint64 usedlogicalbytes = 5;   // bytes used logical 
-  uint64 usedfiles = 6;          // number of files used
-  uint64 maxbytes = 7;           // maximum number of bytes (volume quota)
-  uint64 maxlogicalbytes = 8;    // maximum number of logical bytes (logical volume quota)
-  uint64 maxfiles = 9;           // maximum number of files (inode quota)
-  float percentagusedbytes = 10; // percentage of volume quota used from 0 to 100
-  float percentagusedfiles = 11; // percentage of inode quota used from 0 to 100
-  string statusbytes = 12;       // status string for volume quota ok,warning,exceeded
-  string statusfiles = 13;       // status string for inode quota ok,warning,exceeded
+  bytes path = 1;                 // quota node path
+  string name = 2;                // associated name for the given type
+  QUOTATYPE type = 3;             // user,group,project or all quota
+  uint64 usedbytes = 4;           // bytes used physical
+  uint64 usedlogicalbytes = 5;    // bytes used logical
+  uint64 usedfiles = 6;           // number of files used
+  uint64 maxbytes = 7;            // maximum number of bytes (volume quota)
+  uint64 maxlogicalbytes = 8;     // maximum number of logical bytes (logical volume quota)
+  uint64 maxfiles = 9;            // maximum number of files (inode quota)
+  float percentageusedbytes = 10; // percentage of volume quota used from 0 to 100
+  float percentageusedfiles = 11; // percentage of inode quota used from 0 to 100
+  string statusbytes = 12;        // status string for volume quota ok,warning,exceeded
+  string statusfiles = 13;        // status string for inode quota ok,warning,exceeded
 }
   
 message RoleId {


### PR DESCRIPTION
IMO these names can be fixed without created a BC-break problem. The "magic" numbers are still 10 and 11.

But happy to be told where the names are used elsewhere.