### PR TITLE
Return special value for public link password

### DIFF
--- a/internal/http/services/owncloud/ocs/conversions/main.go
+++ b/internal/http/services/owncloud/ocs/conversions/main.go
@@ -280,21 +280,28 @@ func PublicShare2ShareData(share *link.PublicShare, r *http.Request) *ShareData 
 		expiration = ""
 	}
 
+	shareWith := ""
+	if share.PasswordProtected {
+		shareWith = "***redacted***"
+	}
+
 	return &ShareData{
 		// share.permissions ar mapped below
 		// DisplaynameOwner:     creator.DisplayName,
 		// DisplaynameFileOwner: share.GetCreator().String(),
-		ID:           share.Id.OpaqueId,
-		ShareType:    ShareTypePublicLink,
-		STime:        share.Ctime.Seconds, // TODO CS3 api birth time = btime
-		Token:        share.Token,
-		Expiration:   expiration,
-		MimeType:     share.Mtime.String(),
-		Name:         share.DisplayName,
-		URL:          r.Header.Get("Origin") + "/#/s/" + share.Token,
-		Permissions:  publicSharePermissions2OCSPermissions(share.GetPermissions()),
-		UIDOwner:     LocalUserIDToString(share.Creator),
-		UIDFileOwner: LocalUserIDToString(share.Owner),
+		ID:                   share.Id.OpaqueId,
+		ShareType:            ShareTypePublicLink,
+		ShareWith:            shareWith,
+		ShareWithDisplayname: shareWith,
+		STime:                share.Ctime.Seconds, // TODO CS3 api birth time = btime
+		Token:                share.Token,
+		Expiration:           expiration,
+		MimeType:             share.Mtime.String(),
+		Name:                 share.DisplayName,
+		URL:                  r.Header.Get("Origin") + "/#/s/" + share.Token,
+		Permissions:          publicSharePermissions2OCSPermissions(share.GetPermissions()),
+		UIDOwner:             LocalUserIDToString(share.Creator),
+		UIDFileOwner:         LocalUserIDToString(share.Owner),
 	}
 	// actually clients should be able to GET and cache the user info themselves ...
 	// TODO check grantee type for user vs group


### PR DESCRIPTION
The old OCS public share API requires returning a non-empty
value for the share_with and share_with_displayname fields.

For https://github.com/owncloud/ocis-reva/issues/294

I ran the matching API tests locally and they pass now