### PR TITLE
Introduce Options for the httpclient

### DIFF
--- a/changelog/unreleased/make-httpclient-configurable.md
+++ b/changelog/unreleased/make-httpclient-configurable.md
@@ -1,0 +1,5 @@
+Enhancement: Make httpclient configurable
+
+- Introduce Options for the httpclient (#914)
+
+https://github.com/cs3org/reva/pull/914

--- a/cmd/reva/download.go
+++ b/cmd/reva/download.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/cs3org/reva/internal/http/services/datagateway"
 
@@ -92,7 +93,13 @@ func downloadCommand() *command {
 		}
 
 		httpReq.Header.Set(datagateway.TokenTransportHeader, res.Token)
-		httpClient := rhttp.GetHTTPClient(ctx)
+		httpClient := rhttp.GetHTTPClient(
+			rhttp.Context(ctx),
+			// TODO make insecure configurable
+			rhttp.Insecure(true),
+			// TODO make timeout configurable
+			rhttp.Timeout(time.Duration(24*int64(time.Hour))),
+		)
 
 		httpRes, err := httpClient.Do(httpReq)
 		if err != nil {

--- a/cmd/reva/upload.go
+++ b/cmd/reva/upload.go
@@ -26,6 +26,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"time"
 
 	"github.com/cs3org/reva/internal/http/services/datagateway"
 
@@ -144,7 +145,13 @@ func uploadCommand() *command {
 			q.Add("xs_type", storageprovider.GRPC2PKGXS(xsType).String())
 			httpReq.URL.RawQuery = q.Encode()
 
-			httpClient := rhttp.GetHTTPClient(ctx)
+			httpClient := rhttp.GetHTTPClient(
+				rhttp.Context(ctx),
+				// TODO make insecure configurable
+				rhttp.Insecure(true),
+				// TODO make timeout configurable
+				rhttp.Timeout(time.Duration(24*int64(time.Hour))),
+			)
 
 			httpRes, err := httpClient.Do(httpReq)
 			if err != nil {
@@ -158,7 +165,13 @@ func uploadCommand() *command {
 			// create the tus client.
 			c := tus.DefaultConfig()
 			c.Resume = true
-			c.HttpClient = rhttp.GetHTTPClient(ctx)
+			c.HttpClient = rhttp.GetHTTPClient(
+				rhttp.Context(ctx),
+				// TODO make insecure configurable
+				rhttp.Insecure(true),
+				// TODO make timeout configurable
+				rhttp.Timeout(time.Duration(24*int64(time.Hour))),
+			)
 			c.Store, err = memorystore.NewMemoryStore()
 			if err != nil {
 				return err

--- a/examples/meshdirectory/meshdirectory.toml
+++ b/examples/meshdirectory/meshdirectory.toml
@@ -13,3 +13,5 @@ driver = "mentix"
 #
 #[http.services.meshdirectory.drivers.mentix]
 #url = "http://localhost:9600/"
+#insecure = true
+#timeout = 10

--- a/internal/http/services/datagateway/datagateway.go
+++ b/internal/http/services/datagateway/datagateway.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 	"net/url"
 	"path"
+	"time"
 
 	"github.com/cs3org/reva/pkg/appctx"
 	"github.com/cs3org/reva/pkg/errtypes"
@@ -53,6 +54,8 @@ type transferClaims struct {
 type config struct {
 	Prefix               string `mapstructure:"prefix"`
 	TransferSharedSecret string `mapstructure:"transfer_shared_secret"`
+	Timeout              int64  `mapstructure:"timeout"`
+	Insecure             bool   `mapstructure:"insecure"`
 }
 
 func (c *config) init() {
@@ -167,7 +170,11 @@ func (s *svc) doHead(w http.ResponseWriter, r *http.Request) {
 
 	log.Debug().Str("target", claims.Target).Msg("sending request to internal data server")
 
-	httpClient := rhttp.GetHTTPClient(ctx)
+	httpClient := rhttp.GetHTTPClient(
+		rhttp.Context(ctx),
+		rhttp.Timeout(time.Duration(s.conf.Timeout*int64(time.Second))),
+		rhttp.Insecure(s.conf.Insecure),
+	)
 	httpReq, err := rhttp.NewRequest(ctx, "HEAD", claims.Target, nil)
 	if err != nil {
 		log.Err(err).Msg("wrong request")
@@ -206,7 +213,11 @@ func (s *svc) doGet(w http.ResponseWriter, r *http.Request) {
 
 	log.Debug().Str("target", claims.Target).Msg("sending request to internal data server")
 
-	httpClient := rhttp.GetHTTPClient(ctx)
+	httpClient := rhttp.GetHTTPClient(
+		rhttp.Context(ctx),
+		rhttp.Timeout(time.Duration(s.conf.Timeout*int64(time.Second))),
+		rhttp.Insecure(s.conf.Insecure),
+	)
 	httpReq, err := rhttp.NewRequest(ctx, "GET", claims.Target, nil)
 	if err != nil {
 		log.Err(err).Msg("wrong request")
@@ -261,7 +272,11 @@ func (s *svc) doPut(w http.ResponseWriter, r *http.Request) {
 
 	log.Debug().Str("target", claims.Target).Msg("sending request to internal data server")
 
-	httpClient := rhttp.GetHTTPClient(ctx)
+	httpClient := rhttp.GetHTTPClient(
+		rhttp.Context(ctx),
+		rhttp.Timeout(time.Duration(s.conf.Timeout*int64(time.Second))),
+		rhttp.Insecure(s.conf.Insecure),
+	)
 	httpReq, err := rhttp.NewRequest(ctx, "PUT", target, r.Body)
 	if err != nil {
 		log.Err(err).Msg("wrong request")
@@ -317,7 +332,11 @@ func (s *svc) doPatch(w http.ResponseWriter, r *http.Request) {
 
 	log.Debug().Str("target", claims.Target).Msg("sending request to internal data server")
 
-	httpClient := rhttp.GetHTTPClient(ctx)
+	httpClient := rhttp.GetHTTPClient(
+		rhttp.Context(ctx),
+		rhttp.Timeout(time.Duration(s.conf.Timeout*int64(time.Second))),
+		rhttp.Insecure(s.conf.Insecure),
+	)
 	httpReq, err := rhttp.NewRequest(ctx, "PATCH", target, r.Body)
 	if err != nil {
 		log.Err(err).Msg("wrong request")

--- a/internal/http/services/dataprovider/dataprovider.go
+++ b/internal/http/services/dataprovider/dataprovider.go
@@ -39,6 +39,8 @@ type config struct {
 	Prefix     string                            `mapstructure:"prefix" docs:"data;The prefix to be used for this HTTP service"`
 	Driver     string                            `mapstructure:"driver" docs:"localhome;The storage driver to be used."`
 	Drivers    map[string]map[string]interface{} `mapstructure:"drivers" docs:"url:docs/config/packages/storage/fs;The configuration for the storage driver"`
+	Timeout    int64                             `mapstructure:"timeout"`
+	Insecure   bool                              `mapstructure:"insecure"`
 	DisableTus bool                              `mapstructure:"disable_tus" docs:"false;Whether to disable TUS uploads."`
 }
 

--- a/internal/http/services/dataprovider/put.go
+++ b/internal/http/services/dataprovider/put.go
@@ -24,6 +24,7 @@ import (
 	"path"
 	"strconv"
 	"strings"
+	"time"
 
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	"github.com/cs3org/reva/pkg/appctx"
@@ -73,7 +74,11 @@ func (s *svc) doTusPut(w http.ResponseWriter, r *http.Request) {
 	// create the tus client.
 	c := tus.DefaultConfig()
 	c.Resume = true
-	c.HttpClient = rhttp.GetHTTPClient(ctx)
+	c.HttpClient = rhttp.GetHTTPClient(
+		rhttp.Context(ctx),
+		rhttp.Timeout(time.Duration(s.conf.Timeout*int64(time.Second))),
+		rhttp.Insecure(s.conf.Insecure),
+	)
 	c.Store, err = memorystore.NewMemoryStore()
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)

--- a/internal/http/services/owncloud/ocdav/get.go
+++ b/internal/http/services/owncloud/ocdav/get.go
@@ -106,7 +106,11 @@ func (s *svc) handleGet(w http.ResponseWriter, r *http.Request, ns string) {
 		return
 	}
 	httpReq.Header.Set(datagateway.TokenTransportHeader, dRes.Token)
-	httpClient := rhttp.GetHTTPClient(ctx)
+	httpClient := rhttp.GetHTTPClient(
+		rhttp.Context(ctx),
+		rhttp.Timeout(time.Duration(s.c.Timeout*int64(time.Second))),
+		rhttp.Insecure(s.c.Insecure),
+	)
 
 	httpRes, err := httpClient.Do(httpReq)
 	if err != nil {

--- a/internal/http/services/owncloud/ocdav/ocdav.go
+++ b/internal/http/services/owncloud/ocdav/ocdav.go
@@ -65,6 +65,8 @@ type Config struct {
 	WebdavNamespace string `mapstructure:"webdav_namespace"`
 	ChunkFolder     string `mapstructure:"chunk_folder"`
 	GatewaySvc      string `mapstructure:"gatewaysvc"`
+	Timeout         int64  `mapstructure:"timeout"`
+	Insecure        bool   `mapstructure:"insecure"`
 	DisableTus      bool   `mapstructure:"disable_tus"`
 }
 

--- a/internal/http/services/owncloud/ocdav/put.go
+++ b/internal/http/services/owncloud/ocdav/put.go
@@ -253,7 +253,11 @@ func (s *svc) handlePut(w http.ResponseWriter, r *http.Request, ns string) {
 	// create the tus client.
 	c := tus.DefaultConfig()
 	c.Resume = true
-	c.HttpClient = rhttp.GetHTTPClient(ctx)
+	c.HttpClient = rhttp.GetHTTPClient(
+		rhttp.Context(ctx),
+		rhttp.Timeout(time.Duration(s.c.Timeout*int64(time.Second))),
+		rhttp.Insecure(s.c.Insecure),
+	)
 	c.Store, err = memorystore.NewMemoryStore()
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)

--- a/internal/http/services/owncloud/ocdav/tus.go
+++ b/internal/http/services/owncloud/ocdav/tus.go
@@ -167,7 +167,11 @@ func (s *svc) handleTusPost(w http.ResponseWriter, r *http.Request, ns string) {
 	// TODO check this really streams
 	if r.Header.Get("Content-Type") == "application/offset+octet-stream" {
 
-		httpClient := rhttp.GetHTTPClient(ctx)
+		httpClient := rhttp.GetHTTPClient(
+			rhttp.Context(ctx),
+			rhttp.Timeout(time.Duration(s.c.Timeout*int64(time.Second))),
+			rhttp.Insecure(s.c.Insecure),
+		)
 		httpReq, err := rhttp.NewRequest(ctx, "PATCH", uRes.UploadEndpoint, r.Body)
 		if err != nil {
 			log.Err(err).Msg("wrong request")

--- a/pkg/meshdirectory/manager/mentix/mentix.go
+++ b/pkg/meshdirectory/manager/mentix/mentix.go
@@ -23,6 +23,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/cs3org/reva/pkg/meshdirectory"
 	"github.com/cs3org/reva/pkg/meshdirectory/manager/registry"
@@ -55,8 +56,12 @@ func New(m map[string]interface{}) (meshdirectory.Manager, error) {
 
 	client := &Client{
 		BaseURL: c.URL,
-		// TODO: pass/create context once it is required by GetHTTPClient
-		HTTPClient: rhttp.GetHTTPClient(context.TODO()),
+		HTTPClient: rhttp.GetHTTPClient(
+			// TODO: pass/create context once it is required by GetHTTPClient
+			rhttp.Context(context.TODO()),
+			rhttp.Insecure(c.Insecure),
+			rhttp.Timeout(time.Duration(c.Timeout*int64(time.Second))),
+		),
 	}
 
 	mgr := &mgr{
@@ -68,7 +73,9 @@ func New(m map[string]interface{}) (meshdirectory.Manager, error) {
 }
 
 type config struct {
-	URL string `mapstructure:"url"`
+	URL      string `mapstructure:"url"`
+	Timeout  int64  `mapstructure:"timeout"`
+	Insecure bool   `mapstructure:"insecure"`
 }
 
 type mgr struct {

--- a/pkg/rhttp/client.go
+++ b/pkg/rhttp/client.go
@@ -23,7 +23,6 @@ import (
 	"crypto/tls"
 	"io"
 	"net/http"
-	"time"
 
 	"github.com/cs3org/reva/pkg/token"
 	"github.com/pkg/errors"
@@ -33,15 +32,17 @@ import (
 // GetHTTPClient returns an http client with open census tracing support.
 // TODO(labkode): harden it.
 // https://medium.com/@nate510/don-t-use-go-s-default-http-client-4804cb19f779
-func GetHTTPClient(ctx context.Context) *http.Client {
+func GetHTTPClient(opts ...Option) *http.Client {
+	options := newOptions(opts...)
+
 	httpClient := &http.Client{
-		Timeout: time.Second * 10,
+		Timeout: options.Timeout,
 		Transport: &ochttp.Transport{
 			Base: &http.Transport{
-				// TODO: make TLS config configurable
 				TLSClientConfig: &tls.Config{
-					InsecureSkipVerify: true,
+					InsecureSkipVerify: options.Insecure,
 				},
+				DisableKeepAlives: options.DisableKeepAlive,
 			},
 		},
 	}

--- a/pkg/rhttp/option.go
+++ b/pkg/rhttp/option.go
@@ -1,0 +1,74 @@
+// Copyright 2018-2020 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package rhttp
+
+import (
+	"context"
+	"time"
+)
+
+// Option defines a single option function.
+type Option func(o *Options)
+
+// Options defines the available options for this package.
+type Options struct {
+	Context          context.Context
+	Timeout          time.Duration
+	Insecure         bool
+	DisableKeepAlive bool
+}
+
+// newOptions initializes the available default options.
+func newOptions(opts ...Option) Options {
+	opt := Options{}
+
+	for _, o := range opts {
+		o(&opt)
+	}
+
+	return opt
+}
+
+// Context provides a function to set the context option.
+func Context(val context.Context) Option {
+	return func(o *Options) {
+		o.Context = val
+	}
+}
+
+// Insecure provides a function to set the insecure option.
+func Insecure(insecure bool) Option {
+	return func(o *Options) {
+		o.Insecure = insecure
+	}
+}
+
+// Timeout provides a function to set the timeout option.
+func Timeout(t time.Duration) Option {
+	return func(o *Options) {
+		o.Timeout = t
+	}
+}
+
+// DisableKeepAlive provides a function to set the disablee keep alive option.
+func DisableKeepAlive(disable bool) Option {
+	return func(o *Options) {
+		o.DisableKeepAlive = disable
+	}
+}

--- a/pkg/user/manager/rest/rest.go
+++ b/pkg/user/manager/rest/rest.go
@@ -151,7 +151,7 @@ func (m *manager) getAPIToken(ctx context.Context) (string, time.Time, error) {
 		"audience":   {m.conf.TargetAPI},
 	}
 
-	httpClient := rhttp.GetHTTPClient(ctx)
+	httpClient := rhttp.GetHTTPClient(rhttp.Context(ctx), rhttp.Timeout(10*time.Second), rhttp.Insecure(true))
 	httpReq, err := rhttp.NewRequest(ctx, "POST", m.conf.OIDCTokenEndpoint, strings.NewReader(params.Encode()))
 	if err != nil {
 		return "", time.Time{}, err
@@ -186,7 +186,7 @@ func (m *manager) sendAPIRequest(ctx context.Context, url string) ([]interface{}
 		return nil, err
 	}
 
-	httpClient := rhttp.GetHTTPClient(ctx)
+	httpClient := rhttp.GetHTTPClient(rhttp.Context(ctx), rhttp.Timeout(10*time.Second), rhttp.Insecure(true))
 	httpReq, err := rhttp.NewRequest(ctx, "GET", url, nil)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Currently, slow up and downloads fail because the timeout is currently hardcoded to 10 sec.

This PR allows configuring the HTTPClient as needed. It also introduces `timeout` and `insecure` config options for the oc services. I tried not change the behavior or introduce config options when a config struct was not available, eg for the CLI up and download commands.

For mentix I updated the example config.

I also made the oidc client use the rhttp httpclient, so it should also send traces.

