### PR TITLE
WIP Add wopi open

### DIFF
--- a/cmd/reva/main.go
+++ b/cmd/reva/main.go
@@ -72,6 +72,7 @@ func main() {
 		shareUpdateCommand(),
 		shareListReceivedCommand(),
 		shareUpdateReceivedCommand(),
+		openFileInAppProviderCommand(),
 	}
 
 	mainUsage := createMainUsage(cmds)

--- a/cmd/reva/open-file-in-app-provider.go
+++ b/cmd/reva/open-file-in-app-provider.go
@@ -1,0 +1,103 @@
+// Copyright 2018-2020 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package main
+
+import (
+	"fmt"
+	"os"
+
+	providerpb "github.com/cs3org/go-cs3apis/cs3/app/provider/v1beta1"
+	rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
+	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+	tokenpkg "github.com/cs3org/reva/pkg/token"
+	"github.com/pkg/errors"
+)
+
+func openFileInAppProviderCommand() *command {
+	cmd := newCommand("open-file-in-app-provider")
+	cmd.Description = func() string { return "Open a file in an external app provider" }
+	cmd.Usage = func() string {
+		return "Usage: open-file-in-app-provider [-flags] <path> <viewMode (view, read, write)>"
+	}
+
+	cmd.Action = func() error {
+		ctx := getAuthContext()
+		if cmd.NArg() < 2 {
+			fmt.Println(cmd.Usage())
+			os.Exit(1)
+		}
+		path := cmd.Args()[0]
+
+		viewMode := getViewMode(cmd.Args()[1])
+
+		client, err := getClient()
+		if err != nil {
+			return err
+		}
+		ref := &provider.Reference{
+			Spec: &provider.Reference_Path{Path: path},
+		}
+		reqA := &provider.StatRequest{Ref: ref}
+		resA, err := client.Stat(ctx, reqA)
+		if err != nil {
+			return err
+		}
+		if resA.Status.Code != rpc.Code_CODE_OK {
+			return formatError(resA.Status)
+		}
+
+		ref1 := &provider.Reference{
+			Spec: &provider.Reference_Path{Path: path},
+		}
+		accessToken, ok := tokenpkg.ContextGetToken(ctx)
+		if !ok || accessToken == "" {
+			err := errors.New("Access token is invalid or empty")
+			return err
+		}
+
+		openRequest := &providerpb.OpenFileInAppProviderRequest{Ref: ref1, AccessToken: accessToken, ViewMode: viewMode}
+
+		openRes, err := client.OpenFileInAppProvider(ctx, openRequest)
+		if err != nil {
+			return err
+		}
+
+		if openRes.Status.Code != rpc.Code_CODE_OK {
+			return formatError(openRes.Status)
+		}
+
+		fmt.Println("App provider url: " + openRes.AppProviderUrl)
+
+		return nil
+	}
+	return cmd
+}
+
+func getViewMode(viewMode string) providerpb.OpenFileInAppProviderRequest_ViewMode {
+	switch viewMode {
+	case "view":
+		return providerpb.OpenFileInAppProviderRequest_VIEW_MODE_VIEW_ONLY
+	case "read":
+		return providerpb.OpenFileInAppProviderRequest_VIEW_MODE_READ_ONLY
+	case "write":
+		return providerpb.OpenFileInAppProviderRequest_VIEW_MODE_READ_WRITE
+	default:
+		return providerpb.OpenFileInAppProviderRequest_VIEW_MODE_INVALID
+	}
+}

--- a/docs/content/en/docs/config/grpc/services/appprovider/_index.md
+++ b/docs/content/en/docs/config/grpc/services/appprovider/_index.md
@@ -32,3 +32,11 @@ uirul = ""
 {{< /highlight >}}
 {{% /dir %}}
 
+{{% dir name="storageid" type="string" default="" %}}
+The storage id used by the wopiserver to look up the file or storage id defaults to default by the wopiserver if empty. [[Ref]](https://github.com/cs3org/reva/tree/master/internal/grpc/services/appprovider/appprovider.go#L62)
+{{< highlight toml >}}
+[grpc.services.appprovider]
+storageid = ""
+{{< /highlight >}}
+{{% /dir %}}
+

--- a/docs/content/en/docs/config/grpc/services/appprovider/_index.md
+++ b/docs/content/en/docs/config/grpc/services/appprovider/_index.md
@@ -1,0 +1,34 @@
+---
+title: "appprovider"
+linkTitle: "appprovider"
+weight: 10
+description: >
+  Configuration for the appprovider service
+---
+
+# _struct: config_
+
+{{% dir name="iopsecret" type="string" default="" %}}
+The iopsecret used to connect to the wopiserver. [[Ref]](https://github.com/cs3org/reva/tree/master/internal/grpc/services/appprovider/appprovider.go#L59)
+{{< highlight toml >}}
+[grpc.services.appprovider]
+iopsecret = ""
+{{< /highlight >}}
+{{% /dir %}}
+
+{{% dir name="wopiurl" type="string" default="" %}}
+The wopiserver's url. [[Ref]](https://github.com/cs3org/reva/tree/master/internal/grpc/services/appprovider/appprovider.go#L60)
+{{< highlight toml >}}
+[grpc.services.appprovider]
+wopiurl = ""
+{{< /highlight >}}
+{{% /dir %}}
+
+{{% dir name="uirul" type="string" default="" %}}
+URL to application (eg collabora) URL. [[Ref]](https://github.com/cs3org/reva/tree/master/internal/grpc/services/appprovider/appprovider.go#L61)
+{{< highlight toml >}}
+[grpc.services.appprovider]
+uirul = ""
+{{< /highlight >}}
+{{% /dir %}}
+

--- a/examples/ocmd/ocmd-server-1.toml
+++ b/examples/ocmd/ocmd-server-1.toml
@@ -69,6 +69,10 @@ driver = "memory"
 
 [grpc.services.appprovider]
 driver = "demo"
+iopsecret = "testsecret"
+wopiurl = "http://0.0.0.0:8880/"
+storageendpoint = ""
+uiurl = ""
 
 [grpc.services.appregistry]
 driver = "static"

--- a/examples/ocmd/ocmd-server-1.toml
+++ b/examples/ocmd/ocmd-server-1.toml
@@ -71,7 +71,7 @@ driver = "memory"
 driver = "demo"
 iopsecret = "testsecret"
 wopiurl = "http://0.0.0.0:8880/"
-storageendpoint = ""
+storageid = ""
 uiurl = ""
 
 [grpc.services.appregistry]

--- a/examples/ocmd/ocmd-server-1.toml
+++ b/examples/ocmd/ocmd-server-1.toml
@@ -7,6 +7,8 @@ address = "0.0.0.0:19000"
 
 [grpc.services.gateway]
 authregistrysvc = "localhost:19000"
+appprovidersvc = "localhost:19000"
+appregistry = "localhost:19000"
 storageregistrysvc = "localhost:19000"
 preferencessvc = "localhost:19000"
 userprovidersvc = "localhost:19000"
@@ -64,6 +66,15 @@ providers = "providers.demo.json"
 
 [grpc.services.publicshareprovider]
 driver = "memory"
+
+[grpc.services.appprovider]
+driver = "demo"
+
+[grpc.services.appregistry]
+driver = "static"
+
+[grpc.services.appregistry.drivers.static.rules]
+"text/plain" = "localhost:19000"
 
 [grpc.services.storageprovider]
 driver = "localhome"

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/cheggaaa/pb v1.0.28
 	github.com/coreos/go-oidc v2.2.1+incompatible
 	github.com/cs3org/cato v0.0.0-20200618163134-e83dd323b17e
-	github.com/cs3org/go-cs3apis v0.0.0-20200625121012-96e791152b14
+	github.com/cs3org/go-cs3apis v0.0.0-20200709064917-d96c5f2a42ad
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/eventials/go-tus v0.0.0-20190617130015-9db47421f6a0
 	github.com/go-openapi/strfmt v0.19.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -101,6 +101,8 @@ github.com/cs3org/go-cs3apis v0.0.0-20200622121618-dc54dffb5e44 h1:NhZ3gaHKs1tHu
 github.com/cs3org/go-cs3apis v0.0.0-20200622121618-dc54dffb5e44/go.mod h1:UXha4TguuB52H14EMoSsCqDj7k8a/t7g4gVP+bgY5LY=
 github.com/cs3org/go-cs3apis v0.0.0-20200625121012-96e791152b14 h1:ORPIrxw/T33ALlpaon9IMRzf54ArJQWCYlcECZiRmEc=
 github.com/cs3org/go-cs3apis v0.0.0-20200625121012-96e791152b14/go.mod h1:UXha4TguuB52H14EMoSsCqDj7k8a/t7g4gVP+bgY5LY=
+github.com/cs3org/go-cs3apis v0.0.0-20200709064917-d96c5f2a42ad h1:XxB0h+UKILRKdr+WgPJaOfW8duVPeVKq/18aip5D/Ws=
+github.com/cs3org/go-cs3apis v0.0.0-20200709064917-d96c5f2a42ad/go.mod h1:UXha4TguuB52H14EMoSsCqDj7k8a/t7g4gVP+bgY5LY=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/internal/grpc/services/appprovider/appprovider.go
+++ b/internal/grpc/services/appprovider/appprovider.go
@@ -105,7 +105,7 @@ func (s *service) OpenFileInAppProvider(ctx context.Context, req *providerpb.Ope
 	wopiurl := "http://0.0.0.0:8880/" //TODO!
 	iopsecret := "testsecret"         //TODO!
 	eos := ""                         //TODO!
-	folderUrl := "foo"                //TODO!
+	folderURL := "foo"                //TODO!
 
 	httpClient := rhttp.GetHTTPClient(ctx)
 
@@ -115,7 +115,7 @@ func (s *service) OpenFileInAppProvider(ctx context.Context, req *providerpb.Ope
 	q.Add("filename", req.Ref.GetPath())
 	q.Add("endpoint", eos)
 	q.Add("viewmode", req.ViewMode.String())
-	q.Add("folderurl", folderUrl)
+	q.Add("folderurl", folderURL)
 
 	httpReq.Header.Set("Authorization", "Bearer "+iopsecret)
 	httpReq.Header.Set("TokenHeader", req.AccessToken)

--- a/internal/grpc/services/appprovider/appprovider.go
+++ b/internal/grpc/services/appprovider/appprovider.go
@@ -56,10 +56,10 @@ type service struct {
 type config struct {
 	Driver    string                 `mapstructure:"driver"`
 	Demo      map[string]interface{} `mapstructure:"demo"`
-	IopSecret string                 `mapstructure:"iopsecret" docs:"The iopsecret used to connect to the wopiserver."`
-	WopiURL   string                 `mapstructure:"wopiurl" docs:"The wopiserver's url."`
-	UIURL     string                 `mapstructure:"uirul" docs:"URL to application (eg collabora) URL."`
-	StorageID string                 `mapstructure:"storageid" docs:"The storage id used by the wopiserver 
+	IopSecret string                 `mapstructure:"iopsecret" docs:";The iopsecret used to connect to the wopiserver."`
+	WopiURL   string                 `mapstructure:"wopiurl" docs:";The wopiserver's url."`
+	UIURL     string                 `mapstructure:"uirul" docs:";URL to application (eg collabora) URL."`
+	StorageID string                 `mapstructure:"storageid" docs:";The storage id used by the wopiserver 
 	to look up the file or storage id, defaults to "default" by the wopiserver if empty."`
 }
 

--- a/internal/grpc/services/appprovider/appprovider.go
+++ b/internal/grpc/services/appprovider/appprovider.go
@@ -21,14 +21,19 @@ package appprovider
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
 
 	providerpb "github.com/cs3org/go-cs3apis/cs3/app/provider/v1beta1"
 	"github.com/cs3org/reva/pkg/app"
 	"github.com/cs3org/reva/pkg/app/provider/demo"
 	"github.com/cs3org/reva/pkg/rgrpc"
 	"github.com/cs3org/reva/pkg/rgrpc/status"
+	"github.com/cs3org/reva/pkg/rhttp"
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
+	"github.com/rs/zerolog/log"
 	"google.golang.org/grpc"
 )
 
@@ -94,7 +99,96 @@ func getProvider(c *config) (app.Provider, error) {
 }
 
 func (s *service) Open(ctx context.Context, req *providerpb.OpenRequest) (*providerpb.OpenResponse, error) {
-	iframeLocation, err := s.provider.GetIFrame(ctx, req.ResourceInfo.Id, req.AccessToken)
+	// 1. Get the application URL for the file's mimetype.
+	//This is going to be the "Bring Your Own App registry" service in Reva,
+	//for now it's implemented by the wopiserver at /wopi/cbox/endpoints.
+	// 2. Call the wopiserver's /wopi/cbox/open and pass the requested arguments
+	// (documented at https://github.com/cs3org/wopiserver/blob/master/src/wopiserver.py#L238).
+	// 3. Output all as the iframe_url field of the OpenResponse.
+	//For reference, https://github.com/cs3org/wopiserver/blob/master/tools/wopiopen.py does a similar job
+
+	// 1. applicationURL = GET /wopi/cbox/endpoints
+	// # get the application server URLs
+	wopiurl := ""   //TODO!
+	iopsecret := "" //TODO!
+	filename := ""
+	eos := ""
+	//res, err := http.Get(wopiurl + "/wopi/cbox/endpoints")
+
+	var canedit bool
+
+	if req.GetViewMode == providerpb.OpenRequest.ViewMode.VIEW_MODE_READ_WRITE {
+		canedit = true
+	} else {
+		canedit = false
+	}
+
+	//2. tagert, accessToken = WOPI open(userId,canedit, username (optional), filename/fileid, folderUrl, endpoint(optional))
+	// def cboxOpen():
+	// '''Generates a WOPISrc target and an access token to be passed to a WOPI-compatible Office-like app
+	// for accessing a given file for a given user.
+	// Request arguments:
+	// - string userid: user identity, typically an x-access-token;
+	//   - OR int ruid, rgid: a real Unix user identity (id:group); this is for legacy compatibility
+	// - bool canedit: True if full access should be given to the user, otherwise read-only access is granted
+	// - string username (optional): user's full name, typically shown by the Office app
+	// - string filename OR fileid: the full path of the filename to be opened, or its fileid
+	// - string folderurl: the URL to come back to the containing folder for this file, typically shown by the Office app
+	// - string endpoint (optional): the storage endpoint to be used to look up the file or the storage id, in case of
+	//   multi-instance underlying storage; defaults to 'default'
+
+	// client := &http.Client{
+	// 	CheckRedirect: redirectPolicyFunc,
+	// }
+	httpClient := rhttp.GetHTTPClient(ctx)
+
+	// params := url.Values{
+	// 	"grant_type": {"client_credentials"},
+	// 	"audience":   {m.conf.TargetAPI},
+	// }
+	foourl := ""
+	params := url.Values{"x-access-token": {req.AccessToken}, "filename": {filename}, "endpoint": {eos},
+		"canedit": {"true"}, "username": {"Operator"}, "folderurl": {"foo"}}
+	httpReq, err := rhttp.NewRequest(ctx, "GET", foourl, strings.NewReader(params.Encode()))
+	if err != nil {
+		return nil, err
+	}
+
+	httpReq.Header.Set("Authorization", "Bearer "+iopsecret)
+
+	httpRes, err := httpClient.Do(httpReq)
+	// resp, err := client.Get("http://example.com")
+	// // ...
+
+	// req, err := http.NewRequest("GET", "http://example.com", nil)
+	// // ...
+
+	//wopisrc = http.Get(wopiurl + "/wopi/cbox/open",
+	//httpRes, err := httpClient.Do(httpReq)
+	if err != nil {
+		log.Error().Err(err).Msg("error performing http request")
+		// w.WriteHeader(http.StatusInternalServerError)
+		// return
+	}
+	defer httpRes.Body.Close()
+
+	if httpRes.StatusCode != http.StatusOK {
+		log.Error().Err(err).Msg("error performing http request")
+		// w.WriteHeader(http.StatusInternalServerError)
+		// return
+	}
+	// if httpRes.StatusCode != http.StatusOK {
+	// 	print("WOPI open request failed:\n%s" % httpRes.Body)
+	// 	//	sys.exit(-1)
+	// }
+
+	//# return the full URL to the user
+	// try:
+	// 	url = apps[os.path.splitext(filename)[1]]["edit"]
+	// 	url += '?'                              //if '?' not in url else '&'
+	// 	print("App URL:\n%sWOPISrc=%s\n" + url) // % (url, httpRes.content.decode()))
+
+	iframeLocation, err := s.provider.GetIFrame(ctx, req.Ref.GetId(), req.AccessToken)
 	if err != nil {
 		err := errors.Wrap(err, "appprovidersvc: error calling GetIFrame")
 		res := &providerpb.OpenResponse{
@@ -102,9 +196,9 @@ func (s *service) Open(ctx context.Context, req *providerpb.OpenRequest) (*provi
 		}
 		return res, nil
 	}
-	res := &providerpb.OpenResponse{
+	res1 := &providerpb.OpenResponse{
 		Status:    status.NewOK(ctx),
 		IframeUrl: iframeLocation,
 	}
-	return res, nil
+	return res1, nil
 }

--- a/internal/grpc/services/appprovider/appprovider.go
+++ b/internal/grpc/services/appprovider/appprovider.go
@@ -21,19 +21,19 @@ package appprovider
 import (
 	"context"
 	"fmt"
+	"io/ioutil"
 	"net/http"
-	"net/url"
-	"strings"
+	"strconv"
 
 	providerpb "github.com/cs3org/go-cs3apis/cs3/app/provider/v1beta1"
 	"github.com/cs3org/reva/pkg/app"
 	"github.com/cs3org/reva/pkg/app/provider/demo"
+	"github.com/cs3org/reva/pkg/appctx"
 	"github.com/cs3org/reva/pkg/rgrpc"
 	"github.com/cs3org/reva/pkg/rgrpc/status"
 	"github.com/cs3org/reva/pkg/rhttp"
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
-	"github.com/rs/zerolog/log"
 	"google.golang.org/grpc"
 )
 
@@ -98,107 +98,70 @@ func getProvider(c *config) (app.Provider, error) {
 	}
 }
 
-func (s *service) Open(ctx context.Context, req *providerpb.OpenRequest) (*providerpb.OpenResponse, error) {
-	// 1. Get the application URL for the file's mimetype.
-	//This is going to be the "Bring Your Own App registry" service in Reva,
-	//for now it's implemented by the wopiserver at /wopi/cbox/endpoints.
-	// 2. Call the wopiserver's /wopi/cbox/open and pass the requested arguments
-	// (documented at https://github.com/cs3org/wopiserver/blob/master/src/wopiserver.py#L238).
-	// 3. Output all as the iframe_url field of the OpenResponse.
-	//For reference, https://github.com/cs3org/wopiserver/blob/master/tools/wopiopen.py does a similar job
+func (s *service) OpenFileInAppProvider(ctx context.Context, req *providerpb.OpenFileInAppProviderRequest) (*providerpb.OpenFileInAppProviderResponse, error) {
 
-	// 1. applicationURL = GET /wopi/cbox/endpoints
-	// # get the application server URLs
-	wopiurl := ""   //TODO!
-	iopsecret := "" //TODO!
-	filename := ""
-	eos := ""
-	//res, err := http.Get(wopiurl + "/wopi/cbox/endpoints")
+	log := appctx.GetLogger(ctx)
 
-	var canedit bool
+	wopiurl := "http://0.0.0.0:8880/" //TODO!
+	iopsecret := "testsecret"         //TODO!
+	eos := ""                         //TODO!
+	folderUrl := "foo"                //TODO!
 
-	if req.GetViewMode == providerpb.OpenRequest.ViewMode.VIEW_MODE_READ_WRITE {
-		canedit = true
-	} else {
-		canedit = false
-	}
-
-	//2. tagert, accessToken = WOPI open(userId,canedit, username (optional), filename/fileid, folderUrl, endpoint(optional))
-	// def cboxOpen():
-	// '''Generates a WOPISrc target and an access token to be passed to a WOPI-compatible Office-like app
-	// for accessing a given file for a given user.
-	// Request arguments:
-	// - string userid: user identity, typically an x-access-token;
-	//   - OR int ruid, rgid: a real Unix user identity (id:group); this is for legacy compatibility
-	// - bool canedit: True if full access should be given to the user, otherwise read-only access is granted
-	// - string username (optional): user's full name, typically shown by the Office app
-	// - string filename OR fileid: the full path of the filename to be opened, or its fileid
-	// - string folderurl: the URL to come back to the containing folder for this file, typically shown by the Office app
-	// - string endpoint (optional): the storage endpoint to be used to look up the file or the storage id, in case of
-	//   multi-instance underlying storage; defaults to 'default'
-
-	// client := &http.Client{
-	// 	CheckRedirect: redirectPolicyFunc,
-	// }
 	httpClient := rhttp.GetHTTPClient(ctx)
 
-	// params := url.Values{
-	// 	"grant_type": {"client_credentials"},
-	// 	"audience":   {m.conf.TargetAPI},
-	// }
-	foourl := ""
-	params := url.Values{"x-access-token": {req.AccessToken}, "filename": {filename}, "endpoint": {eos},
-		"canedit": {"true"}, "username": {"Operator"}, "folderurl": {"foo"}}
-	httpReq, err := rhttp.NewRequest(ctx, "GET", foourl, strings.NewReader(params.Encode()))
+	httpReq, err := rhttp.NewRequest(ctx, "GET", wopiurl+"wopi/iop/open", nil)
+
+	q := httpReq.URL.Query()
+	q.Add("filename", req.Ref.GetPath())
+	q.Add("endpoint", eos)
+	q.Add("viewmode", req.ViewMode.String())
+	q.Add("folderurl", folderUrl)
+
+	httpReq.Header.Set("Authorization", "Bearer "+iopsecret)
+	httpReq.Header.Set("TokenHeader", req.AccessToken)
+
 	if err != nil {
 		return nil, err
 	}
-
-	httpReq.Header.Set("Authorization", "Bearer "+iopsecret)
-
+	httpReq.URL.RawQuery = q.Encode()
 	httpRes, err := httpClient.Do(httpReq)
-	// resp, err := client.Get("http://example.com")
-	// // ...
 
-	// req, err := http.NewRequest("GET", "http://example.com", nil)
-	// // ...
-
-	//wopisrc = http.Get(wopiurl + "/wopi/cbox/open",
-	//httpRes, err := httpClient.Do(httpReq)
 	if err != nil {
 		log.Error().Err(err).Msg("error performing http request")
-		// w.WriteHeader(http.StatusInternalServerError)
-		// return
+		res := &providerpb.OpenFileInAppProviderResponse{
+			Status: status.NewInternal(ctx, err, "error performing http request"),
+		}
+		return res, nil
 	}
 	defer httpRes.Body.Close()
 
 	if httpRes.StatusCode != http.StatusOK {
 		log.Error().Err(err).Msg("error performing http request")
-		// w.WriteHeader(http.StatusInternalServerError)
-		// return
+		res := &providerpb.OpenFileInAppProviderResponse{
+			Status: status.NewInternal(ctx, err, "error performing http request, status code: "+strconv.Itoa(httpRes.StatusCode)),
+		}
+		return res, nil
 	}
-	// if httpRes.StatusCode != http.StatusOK {
-	// 	print("WOPI open request failed:\n%s" % httpRes.Body)
-	// 	//	sys.exit(-1)
-	// }
 
-	//# return the full URL to the user
-	// try:
-	// 	url = apps[os.path.splitext(filename)[1]]["edit"]
-	// 	url += '?'                              //if '?' not in url else '&'
-	// 	print("App URL:\n%sWOPISrc=%s\n" + url) // % (url, httpRes.content.decode()))
-
-	iframeLocation, err := s.provider.GetIFrame(ctx, req.Ref.GetId(), req.AccessToken)
 	if err != nil {
 		err := errors.Wrap(err, "appprovidersvc: error calling GetIFrame")
-		res := &providerpb.OpenResponse{
+		res := &providerpb.OpenFileInAppProviderResponse{
 			Status: status.NewInternal(ctx, err, "error getting app's iframe"),
 		}
 		return res, nil
 	}
-	res1 := &providerpb.OpenResponse{
-		Status:    status.NewOK(ctx),
-		IframeUrl: iframeLocation,
+
+	resBody, err := ioutil.ReadAll(httpRes.Body)
+	if err != nil {
+		err := errors.Wrap(err, "appprovidersvc: error reading reponse body")
+		res := &providerpb.OpenFileInAppProviderResponse{
+			Status: status.NewInternal(ctx, err, "error reading reponse body"),
+		}
+		return res, nil
 	}
-	return res1, nil
+
+	return &providerpb.OpenFileInAppProviderResponse{
+		Status:         status.NewOK(ctx),
+		AppProviderUrl: string(resBody),
+	}, nil
 }

--- a/internal/grpc/services/gateway/appprovider.go
+++ b/internal/grpc/services/gateway/appprovider.go
@@ -37,7 +37,7 @@ func (s *svc) OpenFileInAppProvider(ctx context.Context, req *providerpb.OpenFil
 
 	log := appctx.GetLogger(ctx)
 
-	c, err := s.findByPath(ctx, req.Ref.GetPath())
+	c, err := s.find(ctx, req.Ref)
 	if err != nil {
 		if _, ok := err.(errtypes.IsNotFound); ok {
 			return &providerpb.OpenFileInAppProviderResponse{

--- a/internal/grpc/services/gateway/appprovider.go
+++ b/internal/grpc/services/gateway/appprovider.go
@@ -24,15 +24,61 @@ import (
 	providerpb "github.com/cs3org/go-cs3apis/cs3/app/provider/v1beta1"
 	registry "github.com/cs3org/go-cs3apis/cs3/app/registry/v1beta1"
 	rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
+	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	storageprovider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	"github.com/cs3org/reva/pkg/errtypes"
 	"github.com/cs3org/reva/pkg/rgrpc/status"
 	"github.com/cs3org/reva/pkg/rgrpc/todo/pool"
 	"github.com/pkg/errors"
+	"github.com/rs/zerolog/log"
 )
 
 func (s *svc) Open(ctx context.Context, req *providerpb.OpenRequest) (*providerpb.OpenResponse, error) {
-	provider, err := s.findAppProvider(ctx, req.ResourceInfo)
+	// get the metadata about the share
+	c, err := s.findByID(ctx, req.Ref.GetId())
+	if err != nil {
+		if _, ok := err.(errtypes.IsNotFound); ok {
+			return &providerpb.OpenResponse{
+				Status: status.NewInternal(ctx, err, "storage provider not found"),
+			}, nil
+			// return status.NewNotFound(ctx, "storage provider not found"), nil
+		}
+		return &providerpb.OpenResponse{
+			Status: status.NewInternal(ctx, err, "error finding storage provider"),
+		}, nil
+		// return status.NewInternal(ctx, err, "error finding storage provider"), nil
+	}
+	statReq := &provider.StatRequest{
+		Ref: &provider.Reference{
+			Spec: &provider.Reference_Id{
+				Id: req.Ref.GetId(),
+			},
+		},
+	}
+
+	statRes, err := c.Stat(ctx, statReq)
+	if err != nil {
+		log.Err(err).Msg("gateway: error calling Stat for the share resource id:" + req.Ref.GetId().String())
+		return &providerpb.OpenResponse{
+			Status: status.NewInternal(ctx, err, "gateway: error calling Stat for the share resource id"),
+		}, nil
+		// return &rpc.Status{
+		// 	Code: rpc.Code_CODE_INTERNAL,
+		// }, nil
+	}
+
+	if statRes.Status.Code != rpc.Code_CODE_OK {
+		err := status.NewErrorFromCode(statRes.Status.GetCode(), "gateway")
+		log.Err(err).Msg("gateway: error calling Stat for the share resource id:" + req.Ref.GetId().String())
+		return &providerpb.OpenResponse{
+			Status: status.NewInternal(ctx, err, "error updating received share"),
+		}, nil
+		//return status.NewInternal(ctx, err, "error updating received share"), nil
+	}
+
+	fileInfo := statRes.Info
+
+	provider, err := s.findAppProvider(ctx, fileInfo)
 	if err != nil {
 		err = errors.Wrap(err, "gateway: error calling findAppProvider")
 		var st *rpc.Status
@@ -47,15 +93,15 @@ func (s *svc) Open(ctx context.Context, req *providerpb.OpenRequest) (*providerp
 		}, nil
 	}
 
-	c, err := pool.GetAppProviderClient(provider.Address)
-	if err != nil {
-		err = errors.Wrap(err, "gateway: error calling GetAppProviderClient")
+	c1, err1 := pool.GetAppProviderClient(provider.Address)
+	if err1 != nil {
+		err = errors.Wrap(err1, "gateway: error calling GetAppProviderClient")
 		return &providerpb.OpenResponse{
 			Status: status.NewInternal(ctx, err, "error getting appprovider client"),
 		}, nil
 	}
 
-	res, err := c.Open(ctx, req)
+	res, err := c1.Open(ctx, req)
 	if err != nil {
 		return nil, errors.Wrap(err, "gateway: error calling c.Open")
 	}

--- a/pkg/app/registry/static/static.go
+++ b/pkg/app/registry/static/static.go
@@ -24,11 +24,20 @@ import (
 
 	"github.com/cs3org/reva/pkg/app"
 	"github.com/cs3org/reva/pkg/errtypes"
+	"github.com/cs3org/reva/pkg/sharedconf"
 	"github.com/mitchellh/mapstructure"
 )
 
 type registry struct {
 	rules map[string]string
+}
+
+func (c *config) init() {
+	if len(c.Rules) == 0 {
+		c.Rules = map[string]string{
+			"text/plain": sharedconf.GetGatewaySVC(""),
+		}
+	}
 }
 
 func (b *registry) ListProviders(ctx context.Context) ([]*app.ProviderInfo, error) {
@@ -80,5 +89,6 @@ func New(m map[string]interface{}) (app.Registry, error) {
 	if err != nil {
 		return nil, err
 	}
+	c.init()
 	return &registry{rules: c.Rules}, nil
 }

--- a/pkg/rgrpc/todo/pool/pool.go
+++ b/pkg/rgrpc/todo/pool/pool.go
@@ -373,8 +373,10 @@ func GetOCMCoreClient(endpoint string) (ocmcore.OcmCoreAPIClient, error) {
 
 // GetOpenFileInAppProviderClient returns a new OpenFileInAppProviderClient.
 func GetOpenFileInAppProviderClient(endpoint string) (appprovider.ProviderAPIClient, error) {
-	if val, ok := appProviders[endpoint]; ok {
-		return val, nil
+	appProviders.m.Lock()
+	defer appProviders.m.Unlock()
+	if c, ok := appProviders.conn[endpoint]; ok {
+		return c.(appprovider.ProviderAPIClient), nil
 	}
 
 	conn, err := NewConn(endpoint)
@@ -382,7 +384,8 @@ func GetOpenFileInAppProviderClient(endpoint string) (appprovider.ProviderAPICli
 		return nil, err
 	}
 
-	appProviders[endpoint] = appprovider.NewProviderAPIClient(conn)
+	v := appprovider.NewProviderAPIClient(conn)
+	appProviders.conn[endpoint] = v
 
-	return appProviders[endpoint], nil
+	return v, nil
 }

--- a/pkg/rgrpc/todo/pool/pool.go
+++ b/pkg/rgrpc/todo/pool/pool.go
@@ -370,22 +370,3 @@ func GetOCMCoreClient(endpoint string) (ocmcore.OcmCoreAPIClient, error) {
 	ocmCores.conn[endpoint] = v
 	return v, nil
 }
-
-// GetOpenFileInAppProviderClient returns a new OpenFileInAppProviderClient.
-func GetOpenFileInAppProviderClient(endpoint string) (appprovider.ProviderAPIClient, error) {
-	appProviders.m.Lock()
-	defer appProviders.m.Unlock()
-	if c, ok := appProviders.conn[endpoint]; ok {
-		return c.(appprovider.ProviderAPIClient), nil
-	}
-
-	conn, err := NewConn(endpoint)
-	if err != nil {
-		return nil, err
-	}
-
-	v := appprovider.NewProviderAPIClient(conn)
-	appProviders.conn[endpoint] = v
-
-	return v, nil
-}

--- a/pkg/rgrpc/todo/pool/pool.go
+++ b/pkg/rgrpc/todo/pool/pool.go
@@ -370,3 +370,19 @@ func GetOCMCoreClient(endpoint string) (ocmcore.OcmCoreAPIClient, error) {
 	ocmCores.conn[endpoint] = v
 	return v, nil
 }
+
+// GetOpenFileInAppProviderClient returns a new OpenFileInAppProviderClient.
+func GetOpenFileInAppProviderClient(endpoint string) (appprovider.ProviderAPIClient, error) {
+	if val, ok := appProviders[endpoint]; ok {
+		return val, nil
+	}
+
+	conn, err := NewConn(endpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	appProviders[endpoint] = appprovider.NewProviderAPIClient(conn)
+
+	return appProviders[endpoint], nil
+}


### PR DESCRIPTION
Adds a call to reva for opening a file in an app provider. The call returns the provider's url.
The cs3api needs to be updated, to override and use a local version, add `replace github.com/cs3org/go-cs3apis => ../cs3apis/build/go-cs3apis` in the bottom of `go.mod`.