### PR TITLE
Increase fossa test timeout from 10 to 15 minutes

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -62,7 +62,7 @@ steps:
       from_secret: fossa_api_key
   commands:
     - wget -qO- https://github.com/fossas/fossa-cli/releases/download/v1.0.11/fossa-cli_1.0.11_linux_amd64.tar.gz | tar xvz -C /go/bin/
-    - /go/bin/fossa test
+    - /go/bin/fossa test --timeout 900
 
 - name: publish-docker-reva-latest
   pull: always
@@ -131,7 +131,7 @@ steps:
       from_secret: fossa_api_key
   commands:
     - wget -qO- https://github.com/fossas/fossa-cli/releases/download/v1.0.11/fossa-cli_1.0.11_linux_amd64.tar.gz | tar xvz -C /go/bin/
-    - /go/bin/fossa test
+    - /go/bin/fossa test --timeout 900
 
 ---
 kind: pipeline
@@ -177,7 +177,7 @@ steps:
       from_secret: fossa_api_key
   commands:
     - wget -qO- https://github.com/fossas/fossa-cli/releases/download/v1.0.11/fossa-cli_1.0.11_linux_amd64.tar.gz | tar xvz -C /go/bin/
-    - /go/bin/fossa test
+    - /go/bin/fossa test --timeout 900
 
 - name: create-dist
   image: golang:1.13


### PR DESCRIPTION
The "fossa" test online service seems to take time to do its analysis. It defaults to a 10-minute timeout:
https://github.com/fossas/fossa-cli/blob/master/docs/user-guide.md/#fossa-test

Often it takes nearly 10 minutes to get a result, e.g. https://cloud.drone.io/cs3org/reva/1705/1/5

And often it times out, e.g. https://cloud.drone.io/cs3org/reva/1704/1/5

Failure is ignored in CI, so when this fails it does not fail the drone CI on GitHub - good. But it might be nice to have it pass most of the time, the red "x" on cloud.drone.io is distracting to see and have to understand it is not "really bad"

Increase the timeout to 15 minutes (900 seconds)