### PR TITLE
Refactor metrics package to implement reader interface

### DIFF
--- a/internal/http/services/prometheus/prometheus.go
+++ b/internal/http/services/prometheus/prometheus.go
@@ -21,14 +21,15 @@ package prometheus
 import (
 	"net/http"
 
-	"github.com/cs3org/reva/pkg/metrics"
-
 	"contrib.go.opencensus.io/exporter/prometheus"
 	"github.com/cs3org/reva/pkg/rhttp/global"
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 	"go.opencensus.io/stats/view"
+
+	// Initializes goroutines which periodically update stats
+	_ "github.com/cs3org/reva/pkg/metrics/reader/dummy"
 )
 
 func init() {
@@ -52,16 +53,6 @@ func New(m map[string]interface{}, log *zerolog.Logger) (global.Service, error) 
 	}
 
 	view.RegisterExporter(pe)
-
-	// register the desired measures' views
-	if err = view.Register(
-		metrics.GetNumUsersView(),
-		metrics.GetNumGroupsView(),
-		metrics.GetAmountStorageView(),
-	); err != nil {
-		return nil, errors.Wrap(err, "prometheus: error registering exporter")
-	}
-
 	return &svc{prefix: conf.Prefix, h: pe}, nil
 }
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -18,96 +18,22 @@
 
 package metrics
 
-// This package defines site metrics measures and views based on opencensus.io
-
 import (
-	"context"
-	"math/rand"
-	"time"
-
-	"go.opencensus.io/stats"
 	"go.opencensus.io/stats/view"
 )
 
-func init() {
-	// call the actual metric provider functions for the latest metrics every 4th second
-	go func() {
-		rand.Seed(time.Now().UnixNano())
-		for {
-			getNumUsers()
-			getNumGroups()
-			getAmountStorage()
-			time.Sleep(4 * time.Second)
-		}
-	}()
-}
+// Reader is the interface that defines how the metrics will be read.
+type Reader interface {
 
-// Create the measures
-var (
-	NumUsersMeasure      = stats.Int64("cs3_org_sciencemesh_site_total_num_users", "The total number of users within this site", stats.UnitDimensionless)
-	NumGroupsMeasure     = stats.Int64("cs3_org_sciencemesh_site_total_num_groups", "The total number of groups within this site", stats.UnitDimensionless)
-	AmountStorageMeasure = stats.Int64("cs3_org_sciencemesh_site_total_amount_storage", "The total amount of storage used within this site", stats.UnitBytes)
-)
+	// GetNumUsersView returns an OpenCensus stats view which records the
+	// number of users registered in the mesh provider.
+	GetNumUsersView() *view.View
 
-// initialize local dummy counters
-var (
-	numUsersCounter      = int64(0)
-	amountStorageCounter = int64(0)
-)
+	// GetNumGroupsView returns an OpenCensus stats view which records the
+	// number of user groups registered in the mesh provider.
+	GetNumGroupsView() *view.View
 
-// getNumberUsers links to the underlying number of site users provider
-func getNumUsers() {
-	ctx := context.Background()
-	// here we must request the actual number of site users
-	// for now this is a mockup: a number increasing over time
-	numUsersCounter += int64(rand.Intn(100))
-	stats.Record(ctx, NumUsersMeasure.M(numUsersCounter))
-}
-
-// GetNumUsersView returns the number of site users measure view
-func GetNumUsersView() *view.View {
-	return &view.View{
-		Name:        NumUsersMeasure.Name(),
-		Description: NumUsersMeasure.Description(),
-		Measure:     NumUsersMeasure,
-		Aggregation: view.LastValue(),
-	}
-}
-
-// getNumberGroups links to the underlying number of site groups provider
-func getNumGroups() {
-	ctx := context.Background()
-	// here we must request the actual number of site groups
-	// for now this is a mockup: a number changing over time
-	var numGroupsCounter = int64(rand.Intn(100))
-	stats.Record(ctx, NumGroupsMeasure.M(numGroupsCounter))
-}
-
-// GetNumGroupsView returns the number of site groups measure view
-func GetNumGroupsView() *view.View {
-	return &view.View{
-		Name:        NumGroupsMeasure.Name(),
-		Description: NumGroupsMeasure.Description(),
-		Measure:     NumGroupsMeasure,
-		Aggregation: view.LastValue(),
-	}
-}
-
-// getAmountStorage links to the underlying amount of storage provider
-func getAmountStorage() {
-	ctx := context.Background()
-	// here we must request the actual amount of storage used
-	// for now this is a mockup: a number increasing over time
-	amountStorageCounter += int64(rand.Intn(12865000))
-	stats.Record(ctx, AmountStorageMeasure.M(amountStorageCounter))
-}
-
-// GetAmountStorageView returns the amount of site storage measure view
-func GetAmountStorageView() *view.View {
-	return &view.View{
-		Name:        AmountStorageMeasure.Name(),
-		Description: AmountStorageMeasure.Description(),
-		Measure:     AmountStorageMeasure,
-		Aggregation: view.LastValue(),
-	}
+	// GetAmountStorageView returns an OpenCensus stats view which records the
+	// amount of storage in the system.
+	GetAmountStorageView() *view.View
 }

--- a/pkg/metrics/reader/dummy/dummy.go
+++ b/pkg/metrics/reader/dummy/dummy.go
@@ -1,0 +1,131 @@
+// Copyright 2018-2020 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package dummy
+
+import (
+	"context"
+	"math/rand"
+	"os"
+	"time"
+
+	"github.com/cs3org/reva/pkg/logger"
+	"github.com/cs3org/reva/pkg/metrics"
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
+)
+
+func init() {
+
+	log := logger.New().With().Int("pid", os.Getpid()).Logger()
+
+	m := &Metrics{
+		NumUsersMeasure:      stats.Int64("cs3_org_sciencemesh_site_total_num_users", "The total number of users within this site", stats.UnitDimensionless),
+		NumGroupsMeasure:     stats.Int64("cs3_org_sciencemesh_site_total_num_groups", "The total number of groups within this site", stats.UnitDimensionless),
+		AmountStorageMeasure: stats.Int64("cs3_org_sciencemesh_site_total_amount_storage", "The total amount of storage used within this site", stats.UnitBytes),
+	}
+
+	// Verify that the struct implements the metrics.Reader interface
+	_, ok := interface{}(m).(metrics.Reader)
+	if !ok {
+		log.Error().Msg("the driver does not implement the metrics.Reader interface")
+		return
+	}
+
+	// register the desired measures' views
+	if err := view.Register(
+		m.GetNumUsersView(),
+		m.GetNumGroupsView(),
+		m.GetAmountStorageView(),
+	); err != nil {
+		log.Error().Err(err).Msg("error registering views with opencensus exporter")
+		return
+	}
+
+	// call the actual metric provider functions for the latest metrics every 4th second
+	go func() {
+		rand.Seed(time.Now().UnixNano())
+		for {
+			m.getNumUsers()
+			m.getNumGroups()
+			m.getAmountStorage()
+			time.Sleep(4 * time.Second)
+		}
+	}()
+}
+
+// Metrics returns randomly generated values for the defined metrics.
+type Metrics struct {
+	numUsersCounter      int64
+	amountStorageCounter int64
+
+	NumUsersMeasure      *stats.Int64Measure
+	NumGroupsMeasure     *stats.Int64Measure
+	AmountStorageMeasure *stats.Int64Measure
+}
+
+// getNumberUsers links to the underlying number of site users provider
+func (m *Metrics) getNumUsers() {
+	ctx := context.Background()
+	m.numUsersCounter += int64(rand.Intn(100))
+	stats.Record(ctx, m.NumUsersMeasure.M(m.numUsersCounter))
+}
+
+// GetNumUsersView returns the number of site users measure view
+func (m *Metrics) GetNumUsersView() *view.View {
+	return &view.View{
+		Name:        m.NumUsersMeasure.Name(),
+		Description: m.NumUsersMeasure.Description(),
+		Measure:     m.NumUsersMeasure,
+		Aggregation: view.LastValue(),
+	}
+}
+
+// getNumberGroups links to the underlying number of site groups provider
+func (m *Metrics) getNumGroups() {
+	ctx := context.Background()
+	var numGroupsCounter = int64(rand.Intn(100))
+	stats.Record(ctx, m.NumGroupsMeasure.M(numGroupsCounter))
+}
+
+// GetNumGroupsView returns the number of site groups measure view
+func (m *Metrics) GetNumGroupsView() *view.View {
+	return &view.View{
+		Name:        m.NumGroupsMeasure.Name(),
+		Description: m.NumGroupsMeasure.Description(),
+		Measure:     m.NumGroupsMeasure,
+		Aggregation: view.LastValue(),
+	}
+}
+
+// getAmountStorage links to the underlying amount of storage provider
+func (m *Metrics) getAmountStorage() {
+	ctx := context.Background()
+	m.amountStorageCounter += int64(rand.Intn(12865000))
+	stats.Record(ctx, m.AmountStorageMeasure.M(m.amountStorageCounter))
+}
+
+// GetAmountStorageView returns the amount of site storage measure view
+func (m *Metrics) GetAmountStorageView() *view.View {
+	return &view.View{
+		Name:        m.AmountStorageMeasure.Name(),
+		Description: m.AmountStorageMeasure.Description(),
+		Measure:     m.AmountStorageMeasure,
+		Aggregation: view.LastValue(),
+	}
+}

--- a/pkg/metrics/reader/script/script.go
+++ b/pkg/metrics/reader/script/script.go
@@ -1,0 +1,78 @@
+// Copyright 2018-2020 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package script
+
+import (
+	"os"
+
+	"github.com/cs3org/reva/pkg/logger"
+	"github.com/cs3org/reva/pkg/metrics"
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
+)
+
+func init() {
+
+	log := logger.New().With().Int("pid", os.Getpid()).Logger()
+
+	m := &Metrics{
+		NumUsersMeasure:      stats.Int64("cs3_org_sciencemesh_site_total_num_users", "The total number of users within this site", stats.UnitDimensionless),
+		NumGroupsMeasure:     stats.Int64("cs3_org_sciencemesh_site_total_num_groups", "The total number of groups within this site", stats.UnitDimensionless),
+		AmountStorageMeasure: stats.Int64("cs3_org_sciencemesh_site_total_amount_storage", "The total amount of storage used within this site", stats.UnitBytes),
+	}
+
+	// Verify that the struct implements the metrics.Reader interface
+	_, ok := interface{}(m).(metrics.Reader)
+	if !ok {
+		log.Error().Msg("the driver does not implement the metrics.Reader interface")
+		return
+	}
+
+	// register the desired measures' views
+	if err := view.Register(
+		m.GetNumUsersView(),
+		m.GetNumGroupsView(),
+		m.GetAmountStorageView(),
+	); err != nil {
+		log.Error().Err(err).Msg("error registering views with opencensus exporter")
+		return
+	}
+}
+
+// Metrics returns randomly generated values for the defined metrics.
+type Metrics struct {
+	NumUsersMeasure      *stats.Int64Measure
+	NumGroupsMeasure     *stats.Int64Measure
+	AmountStorageMeasure *stats.Int64Measure
+}
+
+// GetNumUsersView returns the number of site users measure view
+func (m *Metrics) GetNumUsersView() *view.View {
+	return nil
+}
+
+// GetNumGroupsView returns the number of site groups measure view
+func (m *Metrics) GetNumGroupsView() *view.View {
+	return nil
+}
+
+// GetAmountStorageView returns the amount of site storage measure view
+func (m *Metrics) GetAmountStorageView() *view.View {
+	return nil
+}


### PR DESCRIPTION
This PR implements an interface in the metrics package which can be implemented by multiple drivers, each of which can register its views itself when its init method is called.

CC: @redblom 