### PR TITLE
fix initialization of shares json file

### DIFF
--- a/changelog/unreleased/fix-json-sharemanager-initialization.md
+++ b/changelog/unreleased/fix-json-sharemanager-initialization.md
@@ -1,0 +1,8 @@
+Bugfix: Fix initialization of json share manager
+
+When an empty shares.json file existed the json share manager would fail while
+trying to unmarshal the empty file.
+
+https://github.com/cs3org/reva/issues/941
+https://github.com/cs3org/reva/pull/940
+

--- a/pkg/share/manager/json/json.go
+++ b/pkg/share/manager/json/json.go
@@ -70,8 +70,8 @@ func New(m map[string]interface{}) (share.Manager, error) {
 }
 
 func loadOrCreate(file string) (*shareModel, error) {
-	_, err := os.Stat(file)
-	if os.IsNotExist(err) {
+	info, err := os.Stat(file)
+	if os.IsNotExist(err) || info.Size() == 0 {
 		if err := ioutil.WriteFile(file, []byte("{}"), 0700); err != nil {
 			err = errors.Wrap(err, "error opening/creating the file: "+file)
 			return nil, err


### PR DESCRIPTION
When the json file exists but is empty the manager would fail in line 95 when trying to unmarshal the empty file.

Fixes: https://github.com/cs3org/reva/issues/941