### PR TITLE
Fix returned public link URL

### DIFF
--- a/internal/http/services/owncloud/ocs/conversions/main.go
+++ b/internal/http/services/owncloud/ocs/conversions/main.go
@@ -22,6 +22,7 @@ package conversions
 import (
 	"fmt"
 	"net/http"
+	"path"
 	"time"
 
 	"github.com/cs3org/reva/pkg/publicshare"
@@ -272,7 +273,7 @@ func AsCS3Permissions(p int, rp *provider.ResourcePermissions) *provider.Resourc
 }
 
 // PublicShare2ShareData converts a cs3api public share into shareData data model
-func PublicShare2ShareData(share *link.PublicShare, r *http.Request) *ShareData {
+func PublicShare2ShareData(share *link.PublicShare, r *http.Request, publicURL string) *ShareData {
 	var expiration string
 	if share.Expiration != nil {
 		expiration = timestampToExpiration(share.Expiration)
@@ -299,7 +300,7 @@ func PublicShare2ShareData(share *link.PublicShare, r *http.Request) *ShareData 
 		MimeType:             share.Mtime.String(),
 		Name:                 share.DisplayName,
 		MailSend:             0,
-		URL:                  r.Header.Get("Origin") + "/#/s/" + share.Token,
+		URL:                  publicURL + path.Join("/", "#/s/"+share.Token),
 		Permissions:          publicSharePermissions2OCSPermissions(share.GetPermissions()),
 		UIDOwner:             LocalUserIDToString(share.Creator),
 		UIDFileOwner:         LocalUserIDToString(share.Owner),

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/shares.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/shares.go
@@ -52,11 +52,13 @@ import (
 // Handler implements the shares part of the ownCloud sharing API
 type Handler struct {
 	gatewayAddr string
+	publicURL   string
 }
 
 // Init initializes this and any contained handlers
 func (h *Handler) Init(c *config.Config) error {
 	h.gatewayAddr = c.GatewaySvc
+	h.publicURL = c.Config.Host
 	return nil
 }
 
@@ -418,7 +420,7 @@ func (h *Handler) createPublicLinkShare(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	s := conversions.PublicShare2ShareData(createRes.Share, r)
+	s := conversions.PublicShare2ShareData(createRes.Share, r, h.publicURL)
 	err = h.addFileInfo(ctx, s, statRes.Info)
 
 	if err != nil {
@@ -704,7 +706,7 @@ func (h *Handler) getShare(w http.ResponseWriter, r *http.Request, shareID strin
 	*/
 
 	if err == nil && psRes.GetShare() != nil {
-		share = conversions.PublicShare2ShareData(psRes.Share, r)
+		share = conversions.PublicShare2ShareData(psRes.Share, r, h.publicURL)
 		resourceID = psRes.Share.ResourceId
 	}
 
@@ -1128,7 +1130,7 @@ func (h *Handler) listPublicShares(r *http.Request, filters []*link.ListPublicSh
 				return nil, err
 			}
 
-			sData := conversions.PublicShare2ShareData(share, r)
+			sData := conversions.PublicShare2ShareData(share, r, h.publicURL)
 			if statResponse.Status.Code != rpc.Code_CODE_OK {
 				return nil, err
 			}
@@ -1668,7 +1670,7 @@ func (h *Handler) updatePublicShare(w http.ResponseWriter, r *http.Request, shar
 		return
 	}
 
-	s := conversions.PublicShare2ShareData(publicShare, r)
+	s := conversions.PublicShare2ShareData(publicShare, r, h.publicURL)
 	err = h.addFileInfo(r.Context(), s, statRes.Info)
 
 	if err != nil {


### PR DESCRIPTION
The public link URL is now based on the configured Reva Host URL as we
cannot expect the Origin header to be set when called from APIs instead
of the browser.

For https://github.com/owncloud/ocis-reva/issues/336