### PR TITLE
Bump core commit for API integration tests

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -336,7 +336,7 @@ steps:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
       - cd /drone/src/tmp/testrunner
-      - git checkout 9d27c9baab146c2787fc4274914c8231d1072e24
+      - git checkout 9687d7747ed42a64a77407d551fd0d8bfd320948
       - make test-acceptance-api
     environment:
       TEST_SERVER_URL: 'http://revad-services:20080'


### PR DESCRIPTION
I don't think there is anything much in core related to the test code.
PR https://github.com/owncloud/core/pull/37663 added some test code, but not used in the API tests anyway.
Other things are PHP dependency updates... so also not exciting for the test runner.

The same 423 scenarios are still passing.

This can be merged, or not, it does not really matter.