### PR TITLE
OCS Share wrap resource id correctly

### DIFF
--- a/internal/http/services/owncloud/ocdav/ocdav.go
+++ b/internal/http/services/owncloud/ocdav/ocdav.go
@@ -201,7 +201,7 @@ func wrapResourceID(r *provider.ResourceId) string {
 // The fileID must be encoded
 // - XML safe, because it is going to be used in the propfind result
 // - url safe, because the id might be used in a url, eg. the /dav/meta nodes
-// which is why we base62 encode it
+// which is why we base64 encode it
 func wrap(sid string, oid string) string {
 	return base64.URLEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", sid, oid)))
 }


### PR DESCRIPTION
Wrap the resource id and opaque id in OCS Share responses in the same
way like the resource id wrapping done on Webdav level.
This is important to be able to correlate the resources without
resorting to parsing the base64 bits.

Fixes https://github.com/owncloud/ocis-reva/issues/344