### PR TITLE
Recreate shares.json in case of deletion

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/cs3org/go-cs3apis v0.0.0-20200625121012-96e791152b14
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/eventials/go-tus v0.0.0-20190617130015-9db47421f6a0
+	github.com/fsnotify/fsnotify v1.4.7
 	github.com/go-openapi/strfmt v0.19.2 // indirect
 	github.com/gofrs/uuid v3.3.0+incompatible
 	github.com/golang/protobuf v1.4.2


### PR DESCRIPTION
To be able to clear shares when testing, we need to be able to reload
the json files after they have been deleted.

Later on, in a real-world scenario, we need to be able to rebuild the
json file based on information stored in the storage. (see inline TODO)

@butonic

### Test steps:

1. Create a folder "test"
1. Share "test" with "Marie"
1. Refresh the page, see that the share exists
1. Delete "shares.json"
1. Refresh the page, see that the shares are gone

Before this fix: the shares would still be there until the service is reloaded
After this fix: the shares are gone directly and the file is recreated empty.

### TODOs:

- [ ] get preliminary review for approach
- [ ] remove print statements
- [ ] apply the same approach for publicshares.json
