### PR TITLE
Remove Expired Link on Access

### DIFF
--- a/changelog/unreleased/remove-public-link-on-access.md
+++ b/changelog/unreleased/remove-public-link-on-access.md
@@ -1,0 +1,5 @@
+Enhancement: Remove expired Link on Access
+
+Since there is no background jobs scheduled to wipe out expired resources, for the time being public links are going to be removed on a "on demand" basis, meaning whenever there is an API call that access the list of shares for a given resource, we will check whether the share is expired and delete it if so. This code will not live in the managers (drivers), since we want the behavior to be consistent across implementations.
+
+https://github.com/cs3org/reva/pull/959

--- a/pkg/publicshare/manager/json/json.go
+++ b/pkg/publicshare/manager/json/json.go
@@ -316,7 +316,6 @@ func (m *manager) GetPublicShare(ctx context.Context, u *user.User, ref *link.Pu
 // ListPublicShares retrieves all the shares on the manager that are valid.
 func (m *manager) ListPublicShares(ctx context.Context, u *user.User, filters []*link.ListPublicSharesRequest_Filter, md *provider.ResourceInfo) ([]*link.PublicShare, error) {
 	shares := []*link.PublicShare{}
-	now := time.Now()
 
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
@@ -338,14 +337,11 @@ func (m *manager) ListPublicShares(ctx context.Context, u *user.User, filters []
 		} else {
 			for _, f := range filters {
 				if f.Type == link.ListPublicSharesRequest_Filter_TYPE_RESOURCE_ID {
-					t := time.Unix(int64(local.Expiration.GetSeconds()), int64(local.Expiration.GetNanos()))
 					if err != nil {
 						return nil, err
 					}
 					if local.ResourceId.StorageId == f.GetResourceId().StorageId && local.ResourceId.OpaqueId == f.GetResourceId().OpaqueId {
-						if (local.Expiration != nil && t.After(now)) || local.Expiration == nil {
-							shares = append(shares, &local.PublicShare)
-						}
+						shares = append(shares, &local.PublicShare)
 					}
 				}
 			}


### PR DESCRIPTION
Since there is no background jobs scheduled to wipe out expired resources, for the time being public links are going to be removed on a "on demand" basis, meaning whenever there is an API call that access the list of shares for a given resource, we will check whether the share is expired and delete it if so.

This code will not live in the managers (drivers), since we want the behavior to be consistent across implementations.

Closes https://github.com/owncloud/ocis/issues/372