### PR TITLE
Bump core commit for tests

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -336,7 +336,7 @@ steps:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
       - cd /drone/src/tmp/testrunner
-      - git checkout 9687d7747ed42a64a77407d551fd0d8bfd320948
+      - git checkout f0b7094665ac362059ed25b55b3b6e61576627bb
       - make test-acceptance-api
     environment:
       TEST_SERVER_URL: 'http://revad-services:20080'
@@ -345,6 +345,7 @@ steps:
       TEST_EXTERNAL_USER_BACKENDS: 'true'
       REVA_LDAP_HOSTNAME: 'ldap'
       TEST_OCIS: 'true'
+      TEST_REVA: 'true'
       BEHAT_FILTER_TAGS: '~@skipOnOcis&&~@skipOnOcis-OC-Storage'
 
 services:


### PR DESCRIPTION
Some test-related things that have happened in https://github.com/owncloud/core

- https://github.com/owncloud/core/pull/37656 test the API response of a share-update response
- https://github.com/owncloud/core/pull/37672 retag reva issue 249 with the correct issue tags
- https://github.com/owncloud/core/pull/37662 Remove test tags for 336
- https://github.com/owncloud/core/pull/37675 Add env var TEST_REVA

Set the env var TEST_REVA so that the test runner knows that we are testing against a `cs3org/reva` system (rather than `owncloud/ocis-reva` or `owncloud/ocis`. This allows the test runner to make slightly different expectations where behavior is different. See PR https://github.com/owncloud/core/pull/37675 for the difference in public link URL reports, the first example.