### PR TITLE
CI: enforce changelog

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -122,6 +122,11 @@ steps:
   commands:
     - golangci-lint run --timeout 2m0s
 
+- name: changelog
+  image: golang:1.13
+  commands:
+    - make check-changelog
+
 - name: license-check
   image: golang:1.13
   failure: ignore
@@ -131,11 +136,6 @@ steps:
   commands:
     - wget -qO- https://github.com/fossas/fossa-cli/releases/download/v1.0.11/fossa-cli_1.0.11_linux_amd64.tar.gz | tar xvz -C /go/bin/
     - /go/bin/fossa test --timeout 900
-
-- name: changelog
-  image: golang:1.13
-  commands:
-    - make checkchangelog
 
 ---
 kind: pipeline

--- a/.drone.yml
+++ b/.drone.yml
@@ -103,41 +103,10 @@ trigger:
     - pull_request
 
 steps:
-- name: license-scan
-  image: golang:1.13
-  environment:
-    FOSSA_API_KEY:
-      from_secret: fossa_api_key
-  detach: true
-  commands:
-    - wget -qO- https://github.com/fossas/fossa-cli/releases/download/v1.0.11/fossa-cli_1.0.11_linux_amd64.tar.gz | tar xvz -C /go/bin/
-    - /go/bin/fossa analyze
-
-- name: build
-  image: golang:1.13
-  commands:
-    - make ci
-
-- name: lint
-  image: golangci/golangci-lint:v1.26
-  commands:
-    - golangci-lint run --timeout 2m0s
-
 - name: changelog
   image: golang:1.13
   commands:
     - make checkchangelog
-
-
-- name: license-check
-  image: golang:1.13
-  failure: ignore
-  environment:
-    FOSSA_API_KEY:
-      from_secret: fossa_api_key
-  commands:
-    - wget -qO- https://github.com/fossas/fossa-cli/releases/download/v1.0.11/fossa-cli_1.0.11_linux_amd64.tar.gz | tar xvz -C /go/bin/
-    - /go/bin/fossa test --timeout 900
 
 ---
 kind: pipeline

--- a/.drone.yml
+++ b/.drone.yml
@@ -125,7 +125,7 @@ steps:
 - name: changelog
   image: golang:1.13
   commands:
-    - make check-changelog
+    - make check-changelog-drone
 
 - name: license-check
   image: golang:1.13

--- a/.drone.yml
+++ b/.drone.yml
@@ -43,7 +43,6 @@ steps:
     - wget -qO- https://github.com/fossas/fossa-cli/releases/download/v1.0.11/fossa-cli_1.0.11_linux_amd64.tar.gz | tar xvz -C /go/bin/
     - /go/bin/fossa analyze
 
-
 - name: build
   image: golang:1.13
   commands:
@@ -103,6 +102,36 @@ trigger:
     - pull_request
 
 steps:
+- name: license-scan
+  image: golang:1.13
+  environment:
+    FOSSA_API_KEY:
+      from_secret: fossa_api_key
+  detach: true
+  commands:
+    - wget -qO- https://github.com/fossas/fossa-cli/releases/download/v1.0.11/fossa-cli_1.0.11_linux_amd64.tar.gz | tar xvz -C /go/bin/
+    - /go/bin/fossa analyze
+
+- name: build
+  image: golang:1.13
+  commands:
+    - make ci
+
+- name: lint
+  image: golangci/golangci-lint:v1.26
+  commands:
+    - golangci-lint run --timeout 2m0s
+
+- name: license-check
+  image: golang:1.13
+  failure: ignore
+  environment:
+    FOSSA_API_KEY:
+      from_secret: fossa_api_key
+  commands:
+    - wget -qO- https://github.com/fossas/fossa-cli/releases/download/v1.0.11/fossa-cli_1.0.11_linux_amd64.tar.gz | tar xvz -C /go/bin/
+    - /go/bin/fossa test --timeout 900
+
 - name: changelog
   image: golang:1.13
   commands:

--- a/.drone.yml
+++ b/.drone.yml
@@ -126,7 +126,7 @@ steps:
 - name: changelog
   image: golang:1.13
   commands:
-    - git diff-index --quiet HEAD changelog/unreleased/; echo $?
+    - make checkchangelog
 
 
 - name: license-check

--- a/.drone.yml
+++ b/.drone.yml
@@ -123,6 +123,12 @@ steps:
   commands:
     - golangci-lint run --timeout 2m0s
 
+- name: changelog
+  image: golang:1.13
+  commands:
+    - git diff-index --quiet HEAD changelog/unreleased/; echo $?
+
+
 - name: license-check
   image: golang:1.13
   failure: ignore

--- a/.github/config.yml
+++ b/.github/config.yml
@@ -1,0 +1,13 @@
+# Configuration for update-docs - https://github.com/behaviorbot/update-docs
+
+# Comment to be posted to on PRs that don't update documentation
+updateDocsComment: >
+  Thanks for opening this pull request! The maintainers of this repository would appreciate it if you would create a [changelog](https://github.com/cs3org/reva/blob/master/changelog/README.md) item based on your changes.
+
+updateDocsWhiteList:
+  - Tests-only
+  - tests-only
+  - Tests-Only
+
+updateDocsTargetFiles:
+  - changelog/unreleased/

--- a/Makefile
+++ b/Makefile
@@ -80,4 +80,5 @@ release-deps:
 dist: default
 	go run tools/create-artifacts/main.go -version ${VERSION} -commit ${GIT_COMMIT} -goversion ${GO_VERSION}
 
-all: deps default
+checkchangelog:
+	go run tools/check-file-changed/main.go 

--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,8 @@ GIT_DIRTY=`git diff-index --quiet HEAD -- || echo "dirty-"`
 VERSION=`git describe --always`
 GO_VERSION=`go version | awk '{print $$3}'`
 
-default: build test lint gen-doc
-release: deps build test lint gen-doc
+default: build test lint gen-doc check-changelog
+release: deps build test lint gen-doc check-changelog
 
 off:
 	GOPROXY=off
@@ -60,6 +60,9 @@ lint-ci:
 gen-doc:
 	go run tools/generate-documentation/main.go
 
+check-changelog:
+	go run tools/check-changelog/main.go
+
 # to be run in CI platform
 ci: build-ci test  lint-ci
 
@@ -80,5 +83,4 @@ release-deps:
 dist: default
 	go run tools/create-artifacts/main.go -version ${VERSION} -commit ${GIT_COMMIT} -goversion ${GO_VERSION}
 
-checkchangelog:
-	go run tools/check-file-changed/main.go 
+all: deps default

--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,9 @@ gen-doc:
 check-changelog:
 	go run tools/check-changelog/main.go
 
+check-changelog-drone:
+	go run tools/check-changelog/main.go -repo origin
+
 # to be run in CI platform
 ci: build-ci test  lint-ci
 

--- a/changelog/unreleased/enforce-changelog.md
+++ b/changelog/unreleased/enforce-changelog.md
@@ -1,0 +1,6 @@
+Enhancement: Enforce adding changelog in make and CI
+
+When adding a feature or fixing a bug, a changelog needs to be specified,
+failing which the build wouldn't pass.
+
+https://github.com/cs3org/reva/pull/965

--- a/changelog/unreleased/enforce-changelog.md
+++ b/changelog/unreleased/enforce-changelog.md
@@ -1,0 +1,6 @@
+Enhancement: Enforce adding changelog in make and CI
+
+When adding a feature or fixing a bug, a changelog needs to be specified,
+failing which the build wouldn't pass
+
+https://github.com/cs3org/reva/pull/965

--- a/changelog/unreleased/enforce-changelog.md
+++ b/changelog/unreleased/enforce-changelog.md
@@ -1,6 +1,0 @@
-Enhancement: Enforce adding changelog in make and CI
-
-When adding a feature or fixing a bug, a changelog needs to be specified,
-failing which the build wouldn't pass.
-
-https://github.com/cs3org/reva/pull/965

--- a/changelog/unreleased/enforce-changelog.md
+++ b/changelog/unreleased/enforce-changelog.md
@@ -1,6 +1,6 @@
 Enhancement: Enforce adding changelog in make and CI
 
 When adding a feature or fixing a bug, a changelog needs to be specified,
-failing which the build wouldn't pass
+failing which the build wouldn't pass.
 
 https://github.com/cs3org/reva/pull/965

--- a/changelog/unreleased/fix-json-sharemanager-initialization.md
+++ b/changelog/unreleased/fix-json-sharemanager-initialization.md
@@ -1,8 +1,7 @@
-Bugfix: Fix initialization of json share manager
+aBugfix: Fix initialization of json share manager
 
 When an empty shares.json file existed the json share manager would fail while
 trying to unmarshal the empty file.
 
 https://github.com/cs3org/reva/issues/941
 https://github.com/cs3org/reva/pull/940
-

--- a/changelog/unreleased/fix-json-sharemanager-initialization.md
+++ b/changelog/unreleased/fix-json-sharemanager-initialization.md
@@ -1,4 +1,4 @@
-aBugfix: Fix initialization of json share manager
+Bugfix: Fix initialization of json share manager
 
 When an empty shares.json file existed the json share manager would fail while
 trying to unmarshal the empty file.

--- a/tools/check-changelog/main.go
+++ b/tools/check-changelog/main.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"log"
 	"os/exec"
+	"strings"
 )
 
 func main() {
@@ -30,7 +31,19 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	if string(out) == "" {
+
+	var changelog bool
+	mods := strings.Split(string(out), "\n")
+
+	for _, m := range mods {
+		params := strings.Split(m, " ")
+
+		// The fifth param in the output of diff-index is always the status followed by optional score number
+		if len(params) >= 5 && params[4][0] == 'A' {
+			changelog = true
+		}
+	}
+	if !changelog {
 		log.Fatal(errors.New("No changelog added. Please create a changelog item based on your changes"))
 	}
 }

--- a/tools/check-changelog/main.go
+++ b/tools/check-changelog/main.go
@@ -20,6 +20,7 @@ package main
 
 import (
 	"errors"
+	"flag"
 	"fmt"
 	"log"
 	"os/exec"
@@ -27,7 +28,13 @@ import (
 )
 
 func main() {
-	cmd := exec.Command("git", "diff-index", "master", "--", "changelog/unreleased")
+	repo := flag.String("repo", "", "the remote repo against which diff-index is to be derived")
+	branch := "master"
+	if *repo != "" {
+		branch += "/master"
+	}
+
+	cmd := exec.Command("git", "diff-index", branch, "--", "changelog/unreleased")
 	out, err := cmd.Output()
 	if err != nil {
 		log.Fatal(err)
@@ -39,7 +46,6 @@ func main() {
 
 	for _, m := range mods {
 		params := strings.Split(m, " ")
-
 		// The fifth param in the output of diff-index is always the status followed by optional score number
 		if len(params) >= 5 && params[4][0] == 'A' {
 			changelog = true

--- a/tools/check-changelog/main.go
+++ b/tools/check-changelog/main.go
@@ -19,42 +19,18 @@
 package main
 
 import (
-	"bytes"
-	"flag"
-	"fmt"
-	"io"
-	"os"
+	"errors"
+	"log"
 	"os/exec"
 )
 
-/*
-var (
-	version = flag.String("version", "", "version to release: 0.0.1")
-	commit  = flag.Bool("commit", false, "creates a commit")
-	tag     = flag.Bool("tag", false, "creates a tag")
-)
-*/
-
-func init() {
-	flag.Parse()
-
-}
-
 func main() {
 	cmd := exec.Command("git", "diff-index", "master", "--", "changelog/unreleased")
-	run(cmd)
-}
-
-func run(cmd *exec.Cmd) {
-	var b bytes.Buffer
-	mw := io.MultiWriter(os.Stdout, &b)
-	cmd.Stdout = mw
-	cmd.Stderr = mw
-	err := cmd.Run()
-	fmt.Println(cmd.Dir, cmd.Args)
-	fmt.Println(b.String())
+	out, err := cmd.Output()
 	if err != nil {
-		fmt.Println("ERROR: ", err.Error())
-		os.Exit(1)
+		log.Fatal(err)
+	}
+	if string(out) == "" {
+		log.Fatal(errors.New("No changelog added. Please create a changelog item based on your changes"))
 	}
 }

--- a/tools/check-changelog/main.go
+++ b/tools/check-changelog/main.go
@@ -21,7 +21,6 @@ package main
 import (
 	"errors"
 	"flag"
-	"fmt"
 	"log"
 	"os/exec"
 	"strings"
@@ -35,7 +34,6 @@ func main() {
 	if *repo != "" {
 		branch = *repo + "/master"
 	}
-	fmt.Println(branch)
 	cmd := exec.Command("git", "diff-index", branch, "--", "changelog/unreleased")
 	out, err := cmd.Output()
 	if err != nil {
@@ -44,7 +42,6 @@ func main() {
 
 	var changelog bool
 	mods := strings.Split(string(out), "\n")
-	fmt.Printf("%+q\n", mods)
 
 	for _, m := range mods {
 		params := strings.Split(m, " ")

--- a/tools/check-changelog/main.go
+++ b/tools/check-changelog/main.go
@@ -29,11 +29,13 @@ import (
 
 func main() {
 	repo := flag.String("repo", "", "the remote repo against which diff-index is to be derived")
+	flag.Parse()
+
 	branch := "master"
 	if *repo != "" {
-		branch += "/master"
+		branch = *repo + "/master"
 	}
-
+	fmt.Println(branch)
 	cmd := exec.Command("git", "diff-index", branch, "--", "changelog/unreleased")
 	out, err := cmd.Output()
 	if err != nil {

--- a/tools/check-changelog/main.go
+++ b/tools/check-changelog/main.go
@@ -43,6 +43,7 @@ func main() {
 			changelog = true
 		}
 	}
+
 	if !changelog {
 		log.Fatal(errors.New("No changelog added. Please create a changelog item based on your changes"))
 	}

--- a/tools/check-changelog/main.go
+++ b/tools/check-changelog/main.go
@@ -20,6 +20,7 @@ package main
 
 import (
 	"errors"
+	"fmt"
 	"log"
 	"os/exec"
 	"strings"
@@ -34,6 +35,7 @@ func main() {
 
 	var changelog bool
 	mods := strings.Split(string(out), "\n")
+	fmt.Printf("%+q\n", mods)
 
 	for _, m := range mods {
 		params := strings.Split(m, " ")

--- a/tools/check-file-changed/main.go
+++ b/tools/check-file-changed/main.go
@@ -41,7 +41,7 @@ func init() {
 }
 
 func main() {
-	cmd := exec.Command("git", "diff-index", "--quiet", "master", "--", "chanelog/unreleased")
+	cmd := exec.Command("git", "diff-index", "--quiet", "master", "--", "changelog/unreleased")
 	run(cmd)
 }
 

--- a/tools/check-file-changed/main.go
+++ b/tools/check-file-changed/main.go
@@ -41,7 +41,7 @@ func init() {
 }
 
 func main() {
-	cmd := exec.Command("git", "diff-index", "--quiet", "master", "--", "changelog/unreleased")
+	cmd := exec.Command("git", "diff-index", "master", "--", "changelog/unreleased")
 	run(cmd)
 }
 

--- a/tools/check-file-changed/main.go
+++ b/tools/check-file-changed/main.go
@@ -1,0 +1,60 @@
+// Copyright 2018-2020 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package main
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+)
+
+/*
+var (
+	version = flag.String("version", "", "version to release: 0.0.1")
+	commit  = flag.Bool("commit", false, "creates a commit")
+	tag     = flag.Bool("tag", false, "creates a tag")
+)
+*/
+
+func init() {
+	flag.Parse()
+
+}
+
+func main() {
+	cmd := exec.Command("git", "diff-index", "--quiet", "HEAD", "--", "chanelog/unreleased")
+	run(cmd)
+}
+
+func run(cmd *exec.Cmd) {
+	var b bytes.Buffer
+	mw := io.MultiWriter(os.Stdout, &b)
+	cmd.Stdout = mw
+	cmd.Stderr = mw
+	err := cmd.Run()
+	fmt.Println(cmd.Dir, cmd.Args)
+	fmt.Println(b.String())
+	if err != nil {
+		fmt.Println("ERROR: ", err.Error())
+		os.Exit(1)
+	}
+}

--- a/tools/check-file-changed/main.go
+++ b/tools/check-file-changed/main.go
@@ -41,7 +41,7 @@ func init() {
 }
 
 func main() {
-	cmd := exec.Command("git", "diff-index", "--quiet", "HEAD", "--", "chanelog/unreleased")
+	cmd := exec.Command("git", "diff-index", "--quiet", "master", "--", "chanelog/unreleased")
 	run(cmd)
 }
 


### PR DESCRIPTION
With this PR, when adding a feature or fixing a bug, a changelog needs to be specified, failing which the build wouldn't pass. Also configured the update-docs bot to comment if no changelog is created.

Without changelog: https://cloud.drone.io/cs3org/reva/1858/1/5
With changelog: https://cloud.drone.io/cs3org/reva/1859/1/5