### PR TITLE
[Tests-Only] Update owncloud/core commit id for oC10APIAcceptanceTests

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -340,7 +340,7 @@ steps:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
       - cd /drone/src/tmp/testrunner
-      - git checkout 73023ed1e0009dc25a68d4cfd3ddf11b9c33d115
+      - git checkout 9db442250583d3b71e633cf77fbcf643ed67e994
       - make test-acceptance-api
     environment:
       TEST_SERVER_URL: 'http://revad-services:20080'


### PR DESCRIPTION
Includes oC10APIAcceptanceTests changes from:

- https://github.com/owncloud/core/pull/37689 issue-49 tag removed for public link tests
- https://github.com/owncloud/core/pull/37660 Api test for copying file within a public link folder
- https://github.com/owncloud/core/pull/37691 Refactor webdav auth tests
- https://github.com/owncloud/core/pull/37701 Add acceptance tests to copy files over folder and vice versa
- https://github.com/owncloud/core/pull/37706 Fix replacement usernames
- https://github.com/owncloud/core/pull/37668 Reviewed scenarios with tag @issue-ocis-reva-21
- https://github.com/owncloud/core/pull/37714 Allow up to 9 seconds delay in setTimeout API tests
- https://github.com/owncloud/core/pull/37713 Api tests fix
- https://github.com/owncloud/core/pull/37707 Add acceptance tests to copy files/folders in received shares
- https://github.com/owncloud/core/pull/37722 Adjust test scenarios for ocis and reva so that they pass