### PR TITLE
Add UID and GID to the user object from EOS fs

### DIFF
--- a/changelog/unreleased/uid-gid-user-object.md
+++ b/changelog/unreleased/uid-gid-user-object.md
@@ -4,4 +4,4 @@ Currently, the UID and GID for users need to be read from the local system which
 requires local users to be present. This change retrieves that information from
 the user and auth packages and adds methods to retrieve it.
 
-https://github.com/cs3org/reva/pull/983
+https://github.com/cs3org/reva/pull/995

--- a/changelog/unreleased/uid-gid-user-object.md
+++ b/changelog/unreleased/uid-gid-user-object.md
@@ -4,4 +4,4 @@ Currently, the UID and GID for users need to be read from the local system which
 requires local users to be present. This change retrieves that information from
 the user and auth packages and adds methods to retrieve it.
 
-https://github.com/cs3org/reva/pull/982
+https://github.com/cs3org/reva/pull/983

--- a/changelog/unreleased/uid-gid-user-object.md
+++ b/changelog/unreleased/uid-gid-user-object.md
@@ -1,0 +1,7 @@
+Enhancement: Add UID and GID to the user object from user package
+
+Currently, the UID and GID for users need to be read from the local system which
+requires local users to be present. This change retrieves that information from
+the user and auth packages and adds methods to retrieve it.
+
+https://github.com/cs3org/reva/pull/982

--- a/docs/content/en/docs/config/packages/auth/_index.md
+++ b/docs/content/en/docs/config/packages/auth/_index.md
@@ -1,0 +1,7 @@
+---
+title: "auth"
+linkTitle: "auth"
+weight: 10
+description: >
+  Configuration for the auth service
+---

--- a/docs/content/en/docs/config/packages/auth/manager/_index.md
+++ b/docs/content/en/docs/config/packages/auth/manager/_index.md
@@ -1,0 +1,7 @@
+---
+title: "manager"
+linkTitle: "manager"
+weight: 10
+description: >
+  Configuration for the manager service
+---

--- a/docs/content/en/docs/config/packages/auth/manager/oidc/_index.md
+++ b/docs/content/en/docs/config/packages/auth/manager/oidc/_index.md
@@ -1,0 +1,50 @@
+---
+title: "oidc"
+linkTitle: "oidc"
+weight: 10
+description: >
+  Configuration for the oidc service
+---
+
+# _struct: config_
+
+{{% dir name="insecure" type="bool" default=false %}}
+Whether to skip certificate checks when sending requests. [[Ref]](https://github.com/cs3org/reva/tree/master/pkg/auth/manager/oidc/oidc.go#L50)
+{{< highlight toml >}}
+[auth.manager.oidc]
+insecure = false
+{{< /highlight >}}
+{{% /dir %}}
+
+{{% dir name="issuer" type="string" default="" %}}
+The issuer of the OIDC token. [[Ref]](https://github.com/cs3org/reva/tree/master/pkg/auth/manager/oidc/oidc.go#L51)
+{{< highlight toml >}}
+[auth.manager.oidc]
+issuer = ""
+{{< /highlight >}}
+{{% /dir %}}
+
+{{% dir name="id_claim" type="string" default="sub" %}}
+The claim containing the ID of the user. [[Ref]](https://github.com/cs3org/reva/tree/master/pkg/auth/manager/oidc/oidc.go#L52)
+{{< highlight toml >}}
+[auth.manager.oidc]
+id_claim = "sub"
+{{< /highlight >}}
+{{% /dir %}}
+
+{{% dir name="uid_claim" type="string" default="" %}}
+The claim containing the UID of the user. [[Ref]](https://github.com/cs3org/reva/tree/master/pkg/auth/manager/oidc/oidc.go#L53)
+{{< highlight toml >}}
+[auth.manager.oidc]
+uid_claim = ""
+{{< /highlight >}}
+{{% /dir %}}
+
+{{% dir name="gid_claim" type="string" default="" %}}
+The claim containing the GID of the user. [[Ref]](https://github.com/cs3org/reva/tree/master/pkg/auth/manager/oidc/oidc.go#L54)
+{{< highlight toml >}}
+[auth.manager.oidc]
+gid_claim = ""
+{{< /highlight >}}
+{{% /dir %}}
+

--- a/docs/content/en/docs/config/packages/storage/fs/eos/_index.md
+++ b/docs/content/en/docs/config/packages/storage/fs/eos/_index.md
@@ -136,3 +136,11 @@ use_keytab = false
 {{< /highlight >}}
 {{% /dir %}}
 
+{{% dir name="gatewaysvc" type="string" default="0.0.0.0:19000" %}}
+GatewaySvc stores the endpoint at which the GRPC gateway is exposed. [[Ref]](https://github.com/cs3org/reva/tree/master/pkg/storage/fs/eos/eos.go#L94)
+{{< highlight toml >}}
+[storage.fs.eos]
+gatewaysvc = "0.0.0.0:19000"
+{{< /highlight >}}
+{{% /dir %}}
+

--- a/docs/content/en/docs/config/packages/storage/fs/eoshome/_index.md
+++ b/docs/content/en/docs/config/packages/storage/fs/eoshome/_index.md
@@ -144,3 +144,11 @@ use_keytab = false
 {{< /highlight >}}
 {{% /dir %}}
 
+{{% dir name="gatewaysvc" type="string" default="0.0.0.0:19000" %}}
+GatewaySvc stores the endpoint at which the GRPC gateway is exposed. [[Ref]](https://github.com/cs3org/reva/tree/master/pkg/storage/fs/eoshome/eoshome.go#L100)
+{{< highlight toml >}}
+[storage.fs.eoshome]
+gatewaysvc = "0.0.0.0:19000"
+{{< /highlight >}}
+{{% /dir %}}
+

--- a/docs/content/en/docs/config/packages/user/manager/rest/_index.md
+++ b/docs/content/en/docs/config/packages/user/manager/rest/_index.md
@@ -8,16 +8,16 @@ description: >
 
 # _struct: config_
 
-{{% dir name="redis" type="string" default=":6379" %}}
-The port on which the redis server is running [[Ref]](https://github.com/cs3org/reva/tree/master/pkg/user/manager/rest/rest.go#L68)
+{{% dir name="redis_address" type="string" default="localhost:6379" %}}
+The address at which the redis server is running [[Ref]](https://github.com/cs3org/reva/tree/master/pkg/user/manager/rest/rest.go#L68)
 {{< highlight toml >}}
 [user.manager.rest]
-redis = ":6379"
+redis_address = "localhost:6379"
 {{< /highlight >}}
 {{% /dir %}}
 
 {{% dir name="user_groups_cache_expiration" type="int" default=5 %}}
-The time in minutes for which the groups to which a user belongs would be cached [[Ref]](https://github.com/cs3org/reva/tree/master/pkg/user/manager/rest/rest.go#L70)
+The time in minutes for which the groups to which a user belongs would be cached [[Ref]](https://github.com/cs3org/reva/tree/master/pkg/user/manager/rest/rest.go#L74)
 {{< highlight toml >}}
 [user.manager.rest]
 user_groups_cache_expiration = 5
@@ -25,7 +25,7 @@ user_groups_cache_expiration = 5
 {{% /dir %}}
 
 {{% dir name="id_provider" type="string" default="http://cernbox.cern.ch" %}}
-The OIDC Provider [[Ref]](https://github.com/cs3org/reva/tree/master/pkg/user/manager/rest/rest.go#L72)
+The OIDC Provider [[Ref]](https://github.com/cs3org/reva/tree/master/pkg/user/manager/rest/rest.go#L76)
 {{< highlight toml >}}
 [user.manager.rest]
 id_provider = "http://cernbox.cern.ch"
@@ -33,7 +33,7 @@ id_provider = "http://cernbox.cern.ch"
 {{% /dir %}}
 
 {{% dir name="api_base_url" type="string" default="https://authorization-service-api-dev.web.cern.ch/api/v1.0" %}}
-Base API Endpoint [[Ref]](https://github.com/cs3org/reva/tree/master/pkg/user/manager/rest/rest.go#L74)
+Base API Endpoint [[Ref]](https://github.com/cs3org/reva/tree/master/pkg/user/manager/rest/rest.go#L78)
 {{< highlight toml >}}
 [user.manager.rest]
 api_base_url = "https://authorization-service-api-dev.web.cern.ch/api/v1.0"
@@ -41,7 +41,7 @@ api_base_url = "https://authorization-service-api-dev.web.cern.ch/api/v1.0"
 {{% /dir %}}
 
 {{% dir name="client_id" type="string" default="-" %}}
-Client ID needed to authenticate [[Ref]](https://github.com/cs3org/reva/tree/master/pkg/user/manager/rest/rest.go#L76)
+Client ID needed to authenticate [[Ref]](https://github.com/cs3org/reva/tree/master/pkg/user/manager/rest/rest.go#L80)
 {{< highlight toml >}}
 [user.manager.rest]
 client_id = "-"
@@ -49,7 +49,7 @@ client_id = "-"
 {{% /dir %}}
 
 {{% dir name="client_secret" type="string" default="-" %}}
-Client Secret [[Ref]](https://github.com/cs3org/reva/tree/master/pkg/user/manager/rest/rest.go#L78)
+Client Secret [[Ref]](https://github.com/cs3org/reva/tree/master/pkg/user/manager/rest/rest.go#L82)
 {{< highlight toml >}}
 [user.manager.rest]
 client_secret = "-"
@@ -57,7 +57,7 @@ client_secret = "-"
 {{% /dir %}}
 
 {{% dir name="oidc_token_endpoint" type="string" default="https://keycloak-dev.cern.ch/auth/realms/cern/api-access/token" %}}
-Endpoint to generate token to access the API [[Ref]](https://github.com/cs3org/reva/tree/master/pkg/user/manager/rest/rest.go#L81)
+Endpoint to generate token to access the API [[Ref]](https://github.com/cs3org/reva/tree/master/pkg/user/manager/rest/rest.go#L85)
 {{< highlight toml >}}
 [user.manager.rest]
 oidc_token_endpoint = "https://keycloak-dev.cern.ch/auth/realms/cern/api-access/token"
@@ -65,7 +65,7 @@ oidc_token_endpoint = "https://keycloak-dev.cern.ch/auth/realms/cern/api-access/
 {{% /dir %}}
 
 {{% dir name="target_api" type="string" default="authorization-service-api" %}}
-The target application for which token needs to be generated [[Ref]](https://github.com/cs3org/reva/tree/master/pkg/user/manager/rest/rest.go#L83)
+The target application for which token needs to be generated [[Ref]](https://github.com/cs3org/reva/tree/master/pkg/user/manager/rest/rest.go#L87)
 {{< highlight toml >}}
 [user.manager.rest]
 target_api = "authorization-service-api"

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/cheggaaa/pb v1.0.28
 	github.com/coreos/go-oidc v2.2.1+incompatible
 	github.com/cs3org/cato v0.0.0-20200626150132-28a40e643719
-	github.com/cs3org/go-cs3apis v0.0.0-20200720081540-0d96aec81a2e
+	github.com/cs3org/go-cs3apis v0.0.0-20200728114537-4efa23660dbe
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/eventials/go-tus v0.0.0-20200718001131-45c7ec8f5d59
 	github.com/go-ldap/ldap/v3 v3.2.3

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/cheggaaa/pb v1.0.28
 	github.com/coreos/go-oidc v2.2.1+incompatible
 	github.com/cs3org/cato v0.0.0-20200626150132-28a40e643719
-	github.com/cs3org/go-cs3apis v0.0.0-20200709064917-d96c5f2a42ad
+	github.com/cs3org/go-cs3apis v0.0.0-20200720081540-0d96aec81a2e
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/eventials/go-tus v0.0.0-20200718001131-45c7ec8f5d59
 	github.com/go-ldap/ldap/v3 v3.2.3

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/go-openapi/strfmt v0.19.2 // indirect
 	github.com/gofrs/uuid v3.3.0+incompatible
 	github.com/golang/protobuf v1.4.2
-	github.com/gomodule/redigo v2.0.0+incompatible
+	github.com/gomodule/redigo v1.8.2
 	github.com/google/go-github v17.0.0+incompatible
 	github.com/google/go-querystring v1.0.0 // indirect
 	github.com/google/uuid v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -87,6 +87,8 @@ github.com/cs3org/cato v0.0.0-20200626150132-28a40e643719 h1:3vDKYhsyWSbrtX67i66
 github.com/cs3org/cato v0.0.0-20200626150132-28a40e643719/go.mod h1:XJEZ3/EQuI3BXTp/6DUzFr850vlxq11I6satRtz0YQ4=
 github.com/cs3org/go-cs3apis v0.0.0-20200709064917-d96c5f2a42ad h1:XxB0h+UKILRKdr+WgPJaOfW8duVPeVKq/18aip5D/Ws=
 github.com/cs3org/go-cs3apis v0.0.0-20200709064917-d96c5f2a42ad/go.mod h1:UXha4TguuB52H14EMoSsCqDj7k8a/t7g4gVP+bgY5LY=
+github.com/cs3org/go-cs3apis v0.0.0-20200720081540-0d96aec81a2e h1:Q1GsuqKBo74Z6WNkUTVmyCATf7WwaTk8Fyx3Xw4CrU4=
+github.com/cs3org/go-cs3apis v0.0.0-20200720081540-0d96aec81a2e/go.mod h1:UXha4TguuB52H14EMoSsCqDj7k8a/t7g4gVP+bgY5LY=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/go.sum
+++ b/go.sum
@@ -89,6 +89,8 @@ github.com/cs3org/go-cs3apis v0.0.0-20200709064917-d96c5f2a42ad h1:XxB0h+UKILRKd
 github.com/cs3org/go-cs3apis v0.0.0-20200709064917-d96c5f2a42ad/go.mod h1:UXha4TguuB52H14EMoSsCqDj7k8a/t7g4gVP+bgY5LY=
 github.com/cs3org/go-cs3apis v0.0.0-20200720081540-0d96aec81a2e h1:Q1GsuqKBo74Z6WNkUTVmyCATf7WwaTk8Fyx3Xw4CrU4=
 github.com/cs3org/go-cs3apis v0.0.0-20200720081540-0d96aec81a2e/go.mod h1:UXha4TguuB52H14EMoSsCqDj7k8a/t7g4gVP+bgY5LY=
+github.com/cs3org/go-cs3apis v0.0.0-20200728114537-4efa23660dbe h1:CQ/Grq7oVFqwiUg4VA/T+fl3JHZKEyo/RcTE7C23rW4=
+github.com/cs3org/go-cs3apis v0.0.0-20200728114537-4efa23660dbe/go.mod h1:UXha4TguuB52H14EMoSsCqDj7k8a/t7g4gVP+bgY5LY=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/go.sum
+++ b/go.sum
@@ -332,8 +332,8 @@ github.com/golang/protobuf v1.4.0/go.mod h1:jodUvKwWbYaEsadDk5Fwe5c77LiNKVO9IDvq
 github.com/golang/protobuf v1.4.2 h1:+Z5KGCizgyZCbGh1KZqA0fcLLkwbsjIzS4aV2v7wJX0=
 github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
-github.com/gomodule/redigo v2.0.0+incompatible h1:K/R+8tc58AaqLkqG2Ol3Qk+DR/TlNuhuh457pBFPtt0=
-github.com/gomodule/redigo v2.0.0+incompatible/go.mod h1:B4C85qUVwatsJoIUNIfCRsp7qO0iAmpGFZ4EELWSbC4=
+github.com/gomodule/redigo v1.8.2 h1:H5XSIre1MB5NbPYFp+i1NBbb5qN1W8Y8YAQoAYbkm8k=
+github.com/gomodule/redigo v1.8.2/go.mod h1:P9dn9mFrCBvWhGE1wpxx6fgq7BAeLBk+UUUzlpkBYO0=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=

--- a/internal/grpc/services/gateway/appprovider.go
+++ b/internal/grpc/services/gateway/appprovider.go
@@ -68,16 +68,6 @@ func (s *svc) OpenFileInAppProvider(ctx context.Context, req *providerpb.OpenFil
 		}, nil
 	}
 
-	if statRes != nil && statRes.Info != nil {
-		statRes.Info.Owner, err = s.resolveUIDToUser(ctx, statRes.Info.Owner)
-		if err != nil {
-			log.Err(err).Msg("gateway: error resolving UID to user ID:" + statRes.Info.Owner.OpaqueId)
-			return &providerpb.OpenFileInAppProviderResponse{
-				Status: status.NewInternal(ctx, err, "gateway: error resolving UID to user ID"),
-			}, nil
-		}
-	}
-
 	fileInfo := statRes.Info
 
 	provider, err := s.findAppProvider(ctx, fileInfo)

--- a/internal/grpc/services/gateway/appprovider.go
+++ b/internal/grpc/services/gateway/appprovider.go
@@ -68,12 +68,14 @@ func (s *svc) OpenFileInAppProvider(ctx context.Context, req *providerpb.OpenFil
 		}, nil
 	}
 
-	statRes.Info.Owner, err = s.resolveUIDToUser(ctx, statRes.Info.Owner)
-	if err != nil {
-		log.Err(err).Msg("gateway: error resolving UID to user ID:" + statRes.Info.Owner.OpaqueId)
-		return &providerpb.OpenFileInAppProviderResponse{
-			Status: status.NewInternal(ctx, err, "gateway: error resolving UID to user ID"),
-		}, nil
+	if statRes != nil && statRes.Info != nil {
+		statRes.Info.Owner, err = s.resolveUIDToUser(ctx, statRes.Info.Owner)
+		if err != nil {
+			log.Err(err).Msg("gateway: error resolving UID to user ID:" + statRes.Info.Owner.OpaqueId)
+			return &providerpb.OpenFileInAppProviderResponse{
+				Status: status.NewInternal(ctx, err, "gateway: error resolving UID to user ID"),
+			}, nil
+		}
 	}
 
 	fileInfo := statRes.Info

--- a/internal/grpc/services/gateway/storageprovider.go
+++ b/internal/grpc/services/gateway/storageprovider.go
@@ -847,11 +847,13 @@ func (s *svc) stat(ctx context.Context, req *provider.StatRequest) (*provider.St
 		}, nil
 	}
 
-	statRes.Info.Owner, err = s.resolveUIDToUser(ctx, statRes.Info.Owner)
-	if err != nil {
-		return &provider.StatResponse{
-			Status: status.NewInternal(ctx, err, "error resolving UID to user ID"),
-		}, nil
+	if statRes != nil && statRes.Info != nil {
+		statRes.Info.Owner, err = s.resolveUIDToUser(ctx, statRes.Info.Owner)
+		if err != nil {
+			return &provider.StatResponse{
+				Status: status.NewInternal(ctx, err, "error resolving UID to user ID"),
+			}, nil
+		}
 	}
 	return statRes, nil
 }
@@ -1072,11 +1074,13 @@ func (s *svc) listContainer(ctx context.Context, req *provider.ListContainerRequ
 	}
 
 	for i := range res.Infos {
-		res.Infos[i].Owner, err = s.resolveUIDToUser(ctx, res.Infos[i].Owner)
-		if err != nil {
-			return &provider.ListContainerResponse{
-				Status: status.NewInternal(ctx, err, "error resolving UID to user ID"),
-			}, nil
+		if res.Infos[i] != nil {
+			res.Infos[i].Owner, err = s.resolveUIDToUser(ctx, res.Infos[i].Owner)
+			if err != nil {
+				return &provider.ListContainerResponse{
+					Status: status.NewInternal(ctx, err, "error resolving UID to user ID"),
+				}, nil
+			}
 		}
 	}
 

--- a/internal/grpc/services/gateway/storageprovider.go
+++ b/internal/grpc/services/gateway/storageprovider.go
@@ -840,22 +840,7 @@ func (s *svc) stat(ctx context.Context, req *provider.StatRequest) (*provider.St
 		}, nil
 	}
 
-	statRes, err := c.Stat(ctx, req)
-	if err != nil {
-		return &provider.StatResponse{
-			Status: status.NewInternal(ctx, err, "error statting resource"),
-		}, nil
-	}
-
-	if statRes != nil && statRes.Info != nil {
-		statRes.Info.Owner, err = s.resolveUIDToUser(ctx, statRes.Info.Owner)
-		if err != nil {
-			return &provider.StatResponse{
-				Status: status.NewInternal(ctx, err, "error resolving UID to user ID"),
-			}, nil
-		}
-	}
-	return statRes, nil
+	return c.Stat(ctx, req)
 }
 
 func (s *svc) Stat(ctx context.Context, req *provider.StatRequest) (*provider.StatResponse, error) {
@@ -1071,17 +1056,6 @@ func (s *svc) listContainer(ctx context.Context, req *provider.ListContainerRequ
 	res, err := c.ListContainer(ctx, req)
 	if err != nil {
 		return nil, errors.Wrap(err, "gateway: error calling ListContainer")
-	}
-
-	for i := range res.Infos {
-		if res.Infos[i] != nil {
-			res.Infos[i].Owner, err = s.resolveUIDToUser(ctx, res.Infos[i].Owner)
-			if err != nil {
-				return &provider.ListContainerResponse{
-					Status: status.NewInternal(ctx, err, "error resolving UID to user ID"),
-				}, nil
-			}
-		}
 	}
 
 	return res, nil

--- a/internal/grpc/services/gateway/storageprovider.go
+++ b/internal/grpc/services/gateway/storageprovider.go
@@ -840,7 +840,20 @@ func (s *svc) stat(ctx context.Context, req *provider.StatRequest) (*provider.St
 		}, nil
 	}
 
-	return c.Stat(ctx, req)
+	statRes, err := c.Stat(ctx, req)
+	if err != nil {
+		return &provider.StatResponse{
+			Status: status.NewInternal(ctx, err, "error statting resource"),
+		}, nil
+	}
+
+	statRes.Info.Owner, err = s.resolveUIDToUser(ctx, statRes.Info.Owner)
+	if err != nil {
+		return &provider.StatResponse{
+			Status: status.NewInternal(ctx, err, "error resolving UID to user ID"),
+		}, nil
+	}
+	return statRes, nil
 }
 
 func (s *svc) Stat(ctx context.Context, req *provider.StatRequest) (*provider.StatResponse, error) {
@@ -1056,6 +1069,15 @@ func (s *svc) listContainer(ctx context.Context, req *provider.ListContainerRequ
 	res, err := c.ListContainer(ctx, req)
 	if err != nil {
 		return nil, errors.Wrap(err, "gateway: error calling ListContainer")
+	}
+
+	for i := range res.Infos {
+		res.Infos[i].Owner, err = s.resolveUIDToUser(ctx, res.Infos[i].Owner)
+		if err != nil {
+			return &provider.ListContainerResponse{
+				Status: status.NewInternal(ctx, err, "error resolving UID to user ID"),
+			}, nil
+		}
 	}
 
 	return res, nil

--- a/internal/grpc/services/gateway/userprovider.go
+++ b/internal/grpc/services/gateway/userprovider.go
@@ -20,11 +20,8 @@ package gateway
 
 import (
 	"context"
-	"strings"
 
 	user "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
-	rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
-	types "github.com/cs3org/go-cs3apis/cs3/types/v1beta1"
 	"github.com/cs3org/reva/pkg/rgrpc/status"
 	"github.com/cs3org/reva/pkg/rgrpc/todo/pool"
 	"github.com/pkg/errors"
@@ -92,30 +89,4 @@ func (s *svc) IsInGroup(ctx context.Context, req *user.IsInGroupRequest) (*user.
 	}
 
 	return res, nil
-}
-
-func (s *svc) resolveUIDToUser(ctx context.Context, uid *user.UserId) (*user.UserId, error) {
-	if !strings.HasPrefix(uid.OpaqueId, "uid:") {
-		return uid, nil
-	}
-	id := strings.TrimPrefix(uid.OpaqueId, "uid:")
-	getUserReq := &user.GetUserRequest{
-		Opaque: &types.Opaque{
-			Map: map[string]*types.OpaqueEntry{
-				"uid": &types.OpaqueEntry{
-					Decoder: "plain",
-					Value:   []byte(id),
-				},
-			},
-		},
-	}
-	getUserRes, err := s.GetUser(ctx, getUserReq)
-	if err != nil {
-		return nil, err
-	}
-	if getUserRes.Status.Code != rpc.Code_CODE_OK {
-		return nil, errors.New("error resolving UID to user ID")
-	}
-
-	return getUserRes.User.Id, nil
 }

--- a/internal/grpc/services/gateway/userprovider.go
+++ b/internal/grpc/services/gateway/userprovider.go
@@ -20,8 +20,11 @@ package gateway
 
 import (
 	"context"
+	"strings"
 
 	user "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
+	rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
+	types "github.com/cs3org/go-cs3apis/cs3/types/v1beta1"
 	"github.com/cs3org/reva/pkg/rgrpc/status"
 	"github.com/cs3org/reva/pkg/rgrpc/todo/pool"
 	"github.com/pkg/errors"
@@ -89,4 +92,30 @@ func (s *svc) IsInGroup(ctx context.Context, req *user.IsInGroupRequest) (*user.
 	}
 
 	return res, nil
+}
+
+func (s *svc) resolveUIDToUser(ctx context.Context, uid *user.UserId) (*user.UserId, error) {
+	if !strings.HasPrefix(uid.OpaqueId, "uid:") {
+		return uid, nil
+	}
+	id := strings.TrimPrefix(uid.OpaqueId, "uid:")
+	getUserReq := &user.GetUserRequest{
+		Opaque: &types.Opaque{
+			Map: map[string]*types.OpaqueEntry{
+				"uid": &types.OpaqueEntry{
+					Decoder: "plain",
+					Value:   []byte(id),
+				},
+			},
+		},
+	}
+	getUserRes, err := s.GetUser(ctx, getUserReq)
+	if err != nil {
+		return nil, err
+	}
+	if getUserRes.Status.Code != rpc.Code_CODE_OK {
+		return nil, errors.New("error resolving UID to user ID")
+	}
+
+	return getUserRes.User.Id, nil
 }

--- a/internal/grpc/services/gateway/userprovider.go
+++ b/internal/grpc/services/gateway/userprovider.go
@@ -43,6 +43,22 @@ func (s *svc) GetUser(ctx context.Context, req *user.GetUserRequest) (*user.GetU
 	return res, nil
 }
 
+func (s *svc) GetUserByClaim(ctx context.Context, req *user.GetUserByClaimRequest) (*user.GetUserByClaimResponse, error) {
+	c, err := pool.GetUserProviderServiceClient(s.c.UserProviderEndpoint)
+	if err != nil {
+		return &user.GetUserGetUserByClaimResponse{
+			Status: status.NewInternal(ctx, err, "error getting auth client"),
+		}, nil
+	}
+
+	res, err := c.GetUserByClaim(ctx, req)
+	if err != nil {
+		return nil, errors.Wrap(err, "gateway: error calling GetUserByClaim")
+	}
+
+	return res, nil
+}
+
 func (s *svc) FindUsers(ctx context.Context, req *user.FindUsersRequest) (*user.FindUsersResponse, error) {
 	c, err := pool.GetUserProviderServiceClient(s.c.UserProviderEndpoint)
 	if err != nil {

--- a/internal/grpc/services/gateway/userprovider.go
+++ b/internal/grpc/services/gateway/userprovider.go
@@ -46,7 +46,7 @@ func (s *svc) GetUser(ctx context.Context, req *user.GetUserRequest) (*user.GetU
 func (s *svc) GetUserByClaim(ctx context.Context, req *user.GetUserByClaimRequest) (*user.GetUserByClaimResponse, error) {
 	c, err := pool.GetUserProviderServiceClient(s.c.UserProviderEndpoint)
 	if err != nil {
-		return &user.GetUserGetUserByClaimResponse{
+		return &user.GetUserByClaimResponse{
 			Status: status.NewInternal(ctx, err, "error getting auth client"),
 		}, nil
 	}

--- a/internal/grpc/services/gateway/usershareprovider.go
+++ b/internal/grpc/services/gateway/usershareprovider.go
@@ -381,6 +381,11 @@ func (s *svc) createReference(ctx context.Context, resourceID *provider.Resource
 		return status.NewInternal(ctx, err, "error updating received share"), nil
 	}
 
+	statRes.Info.Owner, err = s.resolveUIDToUser(ctx, statRes.Info.Owner)
+	if err != nil {
+		return status.NewInternal(ctx, err, "error resolving UID to user ID"), nil
+	}
+
 	fileInfo := statRes.Info
 
 	homeReq := &provider.GetHomeRequest{}

--- a/internal/grpc/services/gateway/usershareprovider.go
+++ b/internal/grpc/services/gateway/usershareprovider.go
@@ -381,9 +381,11 @@ func (s *svc) createReference(ctx context.Context, resourceID *provider.Resource
 		return status.NewInternal(ctx, err, "error updating received share"), nil
 	}
 
-	statRes.Info.Owner, err = s.resolveUIDToUser(ctx, statRes.Info.Owner)
-	if err != nil {
-		return status.NewInternal(ctx, err, "error resolving UID to user ID"), nil
+	if statRes != nil && statRes.Info != nil {
+		statRes.Info.Owner, err = s.resolveUIDToUser(ctx, statRes.Info.Owner)
+		if err != nil {
+			return status.NewInternal(ctx, err, "error resolving UID to user ID"), nil
+		}
 	}
 
 	fileInfo := statRes.Info

--- a/internal/grpc/services/storageprovider/storageprovider.go
+++ b/internal/grpc/services/storageprovider/storageprovider.go
@@ -688,10 +688,6 @@ func (s *service) PurgeRecycle(ctx context.Context, req *provider.PurgeRecycleRe
 }
 
 func (s *service) ListGrants(ctx context.Context, req *provider.ListGrantsRequest) (*provider.ListGrantsResponse, error) {
-	// In the grants returned from the storage packages, depending on the driver
-	// used, the grantees might have UIDs with the prefix "uid:" instead of the
-	// user IDs. Those need to be resolved to their original user IDs in the gateway layer.
-
 	newRef, err := s.unwrap(ctx, req.Ref)
 	if err != nil {
 		return &provider.ListGrantsResponse{

--- a/internal/grpc/services/userprovider/userprovider.go
+++ b/internal/grpc/services/userprovider/userprovider.go
@@ -127,7 +127,7 @@ func (s *service) GetUserByClaim(ctx context.Context, req *userpb.GetUserByClaim
 		return res, nil
 	}
 
-	res := &userpb.GetUserByClaim{
+	res := &userpb.GetUserByClaimResponse{
 		Status: status.NewOK(ctx),
 		User:   user,
 	}

--- a/pkg/eosclient/eosclient.go
+++ b/pkg/eosclient/eosclient.go
@@ -318,9 +318,6 @@ func (c *Client) GetACL(ctx context.Context, uid, gid, path, aclType, target str
 	}
 	for _, a := range acls {
 		if a.Type == aclType && a.Qualifier == target {
-			if a.Type == acl.TypeUser {
-				a.Qualifier = "uid:" + a.Qualifier
-			}
 			return a, nil
 		}
 	}
@@ -338,16 +335,9 @@ func (c *Client) ListACLs(ctx context.Context, uid, gid, path string) ([]*acl.En
 		return nil, err
 	}
 
-	acls := []*acl.Entry{}
-	for _, a := range parsedACLs.Entries {
-		// since EOS Citrine ACLs are stored with uid, we need to append that info
-		// The UID will be resolved to the user opaque ID at the userprovider level.
-		if a.Type == acl.TypeUser {
-			a.Qualifier = "uid:" + a.Qualifier
-		}
-		acls = append(acls, a)
-	}
-	return acls, nil
+	// EOS Citrine ACLs are stored with uid. The UID will be resolved to the
+	// user opaque ID at the eosfs level.
+	return parsedACLs.Entries, nil
 }
 
 func (c *Client) getACLForPath(ctx context.Context, uid, gid, path string) (*acl.ACLs, error) {

--- a/pkg/eosclient/eosclient.go
+++ b/pkg/eosclient/eosclient.go
@@ -318,6 +318,9 @@ func (c *Client) GetACL(ctx context.Context, uid, gid, path, aclType, target str
 	}
 	for _, a := range acls {
 		if a.Type == aclType && a.Qualifier == target {
+			if a.Type == acl.TypeUser {
+				a.Qualifier = "uid:" + a.Qualifier
+			}
 			return a, nil
 		}
 	}

--- a/pkg/storage/fs/eos/eos.go
+++ b/pkg/storage/fs/eos/eos.go
@@ -91,7 +91,7 @@ type config struct {
 	UseKeytab bool `mapstructure:"use_keytab" docs:"false"`
 
 	// GatewaySvc stores the endpoint at which the GRPC gateway is exposed.
-	GatewaySvc string `mapstructure:"gatewaysvc"`
+	GatewaySvc string `mapstructure:"gatewaysvc" docs:"0.0.0.0:19000"`
 }
 
 func parseConfig(m map[string]interface{}) (*config, error) {

--- a/pkg/storage/fs/eos/eos.go
+++ b/pkg/storage/fs/eos/eos.go
@@ -89,6 +89,9 @@ type config struct {
 
 	// UseKeyTabAuth changes will authenticate requests by using an EOS keytab.
 	UseKeytab bool `mapstructure:"use_keytab" docs:"false"`
+
+	// GatewaySvc stores the endpoint at which the GRPC gateway is exposed.
+	GatewaySvc string `mapstructure:"gatewaysvc"`
 }
 
 func parseConfig(m map[string]interface{}) (*config, error) {

--- a/pkg/storage/fs/eoshome/eoshome.go
+++ b/pkg/storage/fs/eoshome/eoshome.go
@@ -95,6 +95,9 @@ type config struct {
 
 	// UseKeyTabAuth changes will authenticate requests by using an EOS keytab.
 	UseKeytab bool `mapstructure:"use_keytab" docs:"false"`
+
+	// GatewaySvc stores the endpoint at which the GRPC gateway is exposed.
+	GatewaySvc string `mapstructure:"gatewaysvc"`
 }
 
 func parseConfig(m map[string]interface{}) (*config, error) {

--- a/pkg/storage/fs/eoshome/eoshome.go
+++ b/pkg/storage/fs/eoshome/eoshome.go
@@ -97,7 +97,7 @@ type config struct {
 	UseKeytab bool `mapstructure:"use_keytab" docs:"false"`
 
 	// GatewaySvc stores the endpoint at which the GRPC gateway is exposed.
-	GatewaySvc string `mapstructure:"gatewaysvc"`
+	GatewaySvc string `mapstructure:"gatewaysvc" docs:"0.0.0.0:19000"`
 }
 
 func parseConfig(m map[string]interface{}) (*config, error) {

--- a/pkg/storage/utils/acl/acl.go
+++ b/pkg/storage/utils/acl/acl.go
@@ -20,6 +20,7 @@ package acl
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 )
 
@@ -77,6 +78,15 @@ func (m *ACLs) Serialize() string {
 	sysACL := []string{}
 	for _, e := range m.Entries {
 		sysACL = append(sysACL, e.serialize())
+	}
+	return strings.Join(sysACL, ShortTextForm)
+}
+
+// CitrineSerialize serializes ACLs for citrine EOS ACLs
+func (m *ACLs) CitrineSerialize() string {
+	sysACL := []string{}
+	for _, e := range m.Entries {
+		sysACL = append(sysACL, e.citrineSerialize())
 	}
 	return strings.Join(sysACL, ShortTextForm)
 }
@@ -144,4 +154,8 @@ func getShortType(aclType string) string {
 
 func (a *Entry) serialize() string {
 	return strings.Join([]string{a.Type, a.Qualifier, a.Permissions}, ":")
+}
+
+func (a *Entry) citrineSerialize() string {
+	return fmt.Sprintf("%s:%s=%s", a.Type, a.Qualifier, a.Permissions)
 }

--- a/pkg/storage/utils/acl/acl.go
+++ b/pkg/storage/utils/acl/acl.go
@@ -82,15 +82,6 @@ func (m *ACLs) Serialize() string {
 	return strings.Join(sysACL, ShortTextForm)
 }
 
-// CitrineSerialize serializes ACLs for citrine EOS ACLs
-func (m *ACLs) CitrineSerialize() string {
-	sysACL := []string{}
-	for _, e := range m.Entries {
-		sysACL = append(sysACL, e.citrineSerialize())
-	}
-	return strings.Join(sysACL, ShortTextForm)
-}
-
 // DeleteEntry removes an entry uniquely identified by acl type and qualifier
 func (m *ACLs) DeleteEntry(aclType string, qualifier string) {
 	aclType = getShortType(aclType)
@@ -141,6 +132,11 @@ func ParseEntry(singleSysACL string) (*Entry, error) {
 	}, nil
 }
 
+// CitrineSerialize serializes an ACL entry for citrine EOS ACLs
+func (a *Entry) CitrineSerialize() string {
+	return fmt.Sprintf("%s:%s=%s", a.Type, a.Qualifier, a.Permissions)
+}
+
 func getShortType(aclType string) string {
 	switch aclType[:1] {
 	case TypeUser:
@@ -154,8 +150,4 @@ func getShortType(aclType string) string {
 
 func (a *Entry) serialize() string {
 	return strings.Join([]string{a.Type, a.Qualifier, a.Permissions}, ":")
-}
-
-func (a *Entry) citrineSerialize() string {
-	return fmt.Sprintf("%s:%s=%s", a.Type, a.Qualifier, a.Permissions)
 }

--- a/pkg/storage/utils/eosfs/eosfs.go
+++ b/pkg/storage/utils/eosfs/eosfs.go
@@ -477,6 +477,11 @@ func (fs *eosfs) RemoveGrant(ctx context.Context, ref *provider.Reference, g *pr
 		}
 	}
 
+	eosACL := &acl.Entry{
+		Qualifier: recipient,
+		Type:      eosACLType,
+	}
+
 	p, err := fs.resolve(ctx, u, ref)
 	if err != nil {
 		return errors.Wrap(err, "eos: error resolving reference")
@@ -494,7 +499,7 @@ func (fs *eosfs) RemoveGrant(ctx context.Context, ref *provider.Reference, g *pr
 		return err
 	}
 
-	err = fs.c.RemoveACL(ctx, uid, gid, rootUID, rootGID, fn, eosACLType, recipient)
+	err = fs.c.RemoveACL(ctx, uid, gid, rootUID, rootGID, fn, eosACL)
 	if err != nil {
 		return errors.Wrap(err, "eos: error removing acl")
 	}

--- a/pkg/storage/utils/eosfs/eosfs.go
+++ b/pkg/storage/utils/eosfs/eosfs.go
@@ -1434,15 +1434,9 @@ func (fs *eosfs) getUserIDGateway(ctx context.Context, uid string) (*userpb.User
 	if err != nil {
 		return nil, errors.Wrap(err, "eos: error getting gateway grpc client")
 	}
-	getUserResp, err := client.GetUser(ctx, &userpb.GetUserRequest{
-		Opaque: &types.Opaque{
-			Map: map[string]*types.OpaqueEntry{
-				"uid": &types.OpaqueEntry{
-					Decoder: "plain",
-					Value:   []byte(uid),
-				},
-			},
-		},
+	getUserResp, err := client.GetUserByClaim(ctx, &userpb.GetUserByClaimRequest{
+		Claim: "uid",
+		Value: uid,
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "eos: error getting user")

--- a/pkg/storage/utils/eosfs/eosfs.go
+++ b/pkg/storage/utils/eosfs/eosfs.go
@@ -473,28 +473,7 @@ func (fs *eosfs) RemoveGrant(ctx context.Context, ref *provider.Reference, g *pr
 }
 
 func (fs *eosfs) UpdateGrant(ctx context.Context, ref *provider.Reference, g *provider.Grant) error {
-	u, err := getUser(ctx)
-	if err != nil {
-		return errors.Wrap(err, "eos: no user in ctx")
-	}
-
-	eosACL, err := fs.getEosACL(g)
-	if err != nil {
-		return errors.Wrap(err, "eos: error mapping acl")
-	}
-
-	p, err := fs.resolve(ctx, u, ref)
-	if err != nil {
-		return errors.Wrap(err, "eos: error resolving reference")
-	}
-	fn := fs.wrap(ctx, p)
-
-	uid, gid := extractUIDAndGID(u)
-	err = fs.c.AddACL(ctx, uid, gid, fn, eosACL)
-	if err != nil {
-		return errors.Wrap(err, "eos: error updating acl")
-	}
-	return nil
+	return fs.AddGrant(ctx, ref, g)
 }
 
 func (fs *eosfs) ListGrants(ctx context.Context, ref *provider.Reference) ([]*provider.Grant, error) {

--- a/pkg/storage/utils/eosfs/eosfs.go
+++ b/pkg/storage/utils/eosfs/eosfs.go
@@ -364,8 +364,7 @@ func (fs *eosfs) GetPathByID(ctx context.Context, id *provider.ResourceId) (stri
 		return "", errors.Wrap(err, "eos: error getting file info by inode")
 	}
 
-	fi := fs.convertToResourceInfo(ctx, eosFileInfo)
-	return fi.Path, nil
+	return fs.unwrap(ctx, eosFileInfo.File), nil
 }
 
 func (fs *eosfs) SetArbitraryMetadata(ctx context.Context, ref *provider.Reference, md *provider.ArbitraryMetadata) error {

--- a/pkg/storage/utils/eosfs/eosfs.go
+++ b/pkg/storage/utils/eosfs/eosfs.go
@@ -416,7 +416,12 @@ func (fs *eosfs) AddGrant(ctx context.Context, ref *provider.Reference, g *provi
 		return err
 	}
 
-	err = fs.c.AddACL(ctx, uid, gid, fn, eosACL)
+	rootUID, rootGID, err := fs.getRootUIDAndGID(ctx)
+	if err != nil {
+		return err
+	}
+
+	err = fs.c.AddACL(ctx, uid, gid, rootUID, rootGID, fn, eosACL)
 	if err != nil {
 		return errors.Wrap(err, "eos: error adding acl")
 	}
@@ -484,7 +489,12 @@ func (fs *eosfs) RemoveGrant(ctx context.Context, ref *provider.Reference, g *pr
 		return err
 	}
 
-	err = fs.c.RemoveACL(ctx, uid, gid, fn, eosACLType, recipient)
+	rootUID, rootGID, err := fs.getRootUIDAndGID(ctx)
+	if err != nil {
+		return err
+	}
+
+	err = fs.c.RemoveACL(ctx, uid, gid, rootUID, rootGID, fn, eosACLType, recipient)
 	if err != nil {
 		return errors.Wrap(err, "eos: error removing acl")
 	}
@@ -762,7 +772,12 @@ func (fs *eosfs) GetQuota(ctx context.Context) (int, int, error) {
 		return 0, 0, errors.Wrap(err, "eos: no user in ctx")
 	}
 
-	qi, err := fs.c.GetQuota(ctx, u.Username, fs.conf.Namespace)
+	rootUID, rootGID, err := fs.getRootUIDAndGID(ctx)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	qi, err := fs.c.GetQuota(ctx, u.Username, rootUID, rootGID, fs.conf.Namespace)
 	if err != nil {
 		err := errors.Wrap(err, "eosfs: error getting quota")
 		return 0, 0, err

--- a/pkg/storage/utils/eosfs/eosfs.go
+++ b/pkg/storage/utils/eosfs/eosfs.go
@@ -1209,7 +1209,7 @@ func (fs *eosfs) convert(ctx context.Context, eosFileInfo *eosclient.FileInfo) *
 	}
 
 	// The UID will be resolved to the user opaque ID at the userprovider level.
-	username := "uid:" + string(eosFileInfo.UID)
+	username := "uid:" + strconv.FormatUint(eosFileInfo.UID, 10)
 
 	info := &provider.ResourceInfo{
 		Id:            &provider.ResourceId{OpaqueId: fmt.Sprintf("%d", eosFileInfo.Inode)},

--- a/pkg/storage/utils/eosfs/upload.go
+++ b/pkg/storage/utils/eosfs/upload.go
@@ -43,7 +43,10 @@ func (fs *eosfs) Upload(ctx context.Context, ref *provider.Reference, r io.ReadC
 	if err != nil {
 		return errors.Wrap(err, "eos: no user in ctx")
 	}
-	uid, gid := extractUIDAndGID(u)
+	uid, gid, err := fs.getUserUIDAndGID(ctx, u)
+	if err != nil {
+		return err
+	}
 
 	p, err := fs.resolve(ctx, u, ref)
 	if err != nil {
@@ -134,7 +137,11 @@ func (fs *eosfs) NewUpload(ctx context.Context, info tusd.FileInfo) (upload tusd
 	if err != nil {
 		return nil, errors.Wrap(err, "eos: no user in ctx")
 	}
-	uid, gid := extractUIDAndGID(user)
+	uid, gid, err := fs.getUserUIDAndGID(ctx, user)
+	if err != nil {
+		return nil, err
+	}
+
 	info.Storage = map[string]string{
 		"Type":     "EOSStore",
 		"Username": user.Username,

--- a/pkg/user/manager/demo/demo.go
+++ b/pkg/user/manager/demo/demo.go
@@ -51,13 +51,31 @@ func (m *manager) GetUser(ctx context.Context, uid *userpb.UserId) (*userpb.User
 	return nil, errtypes.NotFound(uid.OpaqueId)
 }
 
-func (m *manager) GetUserByUID(ctx context.Context, uid string) (*userpb.User, error) {
+func (m *manager) GetUserByClaim(ctx context.Context, claim, value string) (*userpb.User, error) {
 	for _, u := range m.catalog {
-		if userUID, err := extractUID(u); err == nil && uid == userUID {
+		if userClaim, err := extractClaim(u, claim); err == nil && value == userClaim {
 			return u, nil
 		}
 	}
-	return nil, errtypes.NotFound(uid)
+	return nil, errtypes.NotFound(value)
+}
+
+func extractClaim(u *userpb.User, claim string) (string, error) {
+	switch claim {
+	case "mail":
+		return u.Mail, nil
+	case "username":
+		return u.Username, nil
+	case "uid":
+		if u.Opaque != nil && u.Opaque.Map != nil {
+			if uidObj, ok := u.Opaque.Map["uid"]; ok {
+				if uidObj.Decoder == "plain" {
+					return string(uidObj.Value), nil
+				}
+			}
+		}
+	}
+	return "", errors.New("demo: invalid field")
 }
 
 // TODO(jfd) search Opaque? compare sub?
@@ -95,17 +113,6 @@ func (m *manager) IsInGroup(ctx context.Context, uid *userpb.UserId, group strin
 		}
 	}
 	return false, nil
-}
-
-func extractUID(u *userpb.User) (string, error) {
-	if u.Opaque != nil && u.Opaque.Map != nil {
-		if uidObj, ok := u.Opaque.Map["uid"]; ok {
-			if uidObj.Decoder == "plain" {
-				return string(uidObj.Value), nil
-			}
-		}
-	}
-	return "", errors.New("demo: could not retrieve UID from user")
 }
 
 func getUsers() map[string]*userpb.User {

--- a/pkg/user/manager/demo/demo_test.go
+++ b/pkg/user/manager/demo/demo_test.go
@@ -65,17 +65,23 @@ func TestUserManager(t *testing.T) {
 		t.Fatalf("user not found error differs: expected='%v' got='%v'", expectedErr, err)
 	}
 
-	// positive test GetUserByUID
-	resUserByUID, _ := manager.GetUserByUID(ctx, "123")
+	// positive test GetUserByClaim by uid
+	resUserByUID, _ := manager.GetUserByClaim(ctx, "uid", "123")
 	if !reflect.DeepEqual(resUserByUID, userEinstein) {
 		t.Fatalf("user differs: expected=%v got=%v", userEinstein, resUserByUID)
 	}
 
-	// negative test GetUserByUID
+	// negative test GetUserByClaim by uid
 	expectedErr = errtypes.NotFound("789")
-	_, err = manager.GetUserByUID(ctx, "789")
+	_, err = manager.GetUserByClaim(ctx, "uid", "789")
 	if !reflect.DeepEqual(err, expectedErr) {
 		t.Fatalf("user not found error differs: expected='%v' got='%v'", expectedErr, err)
+	}
+
+	// positive test GetUserByClaim by mail
+	resUserByEmail, _ := manager.GetUserByClaim(ctx, "mail", "einstein@example.org")
+	if !reflect.DeepEqual(resUserByEmail, userEinstein) {
+		t.Fatalf("user differs: expected=%v got=%v", userEinstein, resUserByEmail)
 	}
 
 	// test FindUsers

--- a/pkg/user/manager/demo/demo_test.go
+++ b/pkg/user/manager/demo/demo_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
+	types "github.com/cs3org/go-cs3apis/cs3/types/v1beta1"
 	"github.com/cs3org/reva/pkg/errtypes"
 )
 
@@ -41,6 +42,12 @@ func TestUserManager(t *testing.T) {
 		Groups:      []string{"sailing-lovers", "violin-haters", "physics-lovers"},
 		Mail:        "einstein@example.org",
 		DisplayName: "Albert Einstein",
+		Opaque: &types.Opaque{
+			Map: map[string]*types.OpaqueEntry{
+				"uid": &types.OpaqueEntry{Decoder: "plain", Value: []byte("123")},
+				"gid": &types.OpaqueEntry{Decoder: "plain", Value: []byte("987")},
+			},
+		},
 	}
 	uidFake := &userpb.UserId{Idp: "nonesense", OpaqueId: "fakeUser"}
 	groupsEinstein := []string{"sailing-lovers", "violin-haters", "physics-lovers"}
@@ -48,20 +55,33 @@ func TestUserManager(t *testing.T) {
 	// positive test GetUserGroups
 	resGroups, _ := manager.GetUserGroups(ctx, uidEinstein)
 	if !reflect.DeepEqual(resGroups, groupsEinstein) {
-		t.Fatalf("groups differ: expected=%v got=%v", resGroups, groupsEinstein)
+		t.Fatalf("groups differ: expected=%v got=%v", groupsEinstein, resGroups)
 	}
 
 	// negative test GetUserGroups
 	expectedErr := errtypes.NotFound(uidFake.OpaqueId)
 	_, err := manager.GetUserGroups(ctx, uidFake)
 	if !reflect.DeepEqual(err, expectedErr) {
-		t.Fatalf("user not found error differ: expected='%v' got='%v'", expectedErr, err)
+		t.Fatalf("user not found error differs: expected='%v' got='%v'", expectedErr, err)
+	}
+
+	// positive test GetUserByUID
+	resUserByUID, _ := manager.GetUserByUID(ctx, "123")
+	if !reflect.DeepEqual(resUserByUID, userEinstein) {
+		t.Fatalf("user differs: expected=%v got=%v", userEinstein, resUserByUID)
+	}
+
+	// negative test GetUserByUID
+	expectedErr = errtypes.NotFound("789")
+	_, err = manager.GetUserByUID(ctx, "789")
+	if !reflect.DeepEqual(err, expectedErr) {
+		t.Fatalf("user not found error differs: expected='%v' got='%v'", expectedErr, err)
 	}
 
 	// test FindUsers
 	resUser, _ := manager.FindUsers(ctx, "einstein")
 	if !reflect.DeepEqual(resUser, []*userpb.User{userEinstein}) {
-		t.Fatalf("user differ: expected=%v got=%v", []*userpb.User{userEinstein}, resUser)
+		t.Fatalf("user differs: expected=%v got=%v", []*userpb.User{userEinstein}, resUser)
 	}
 
 	// negative test FindUsers
@@ -86,9 +106,9 @@ func TestUserManager(t *testing.T) {
 	expectedErr = errtypes.NotFound(uidFake.OpaqueId)
 	resInGroup, err = manager.IsInGroup(ctx, uidFake, "physics-lovers")
 	if !reflect.DeepEqual(err, expectedErr) {
-		t.Fatalf("user not in group error differ: expected='%v' got='%v'", expectedErr, err)
+		t.Fatalf("user not in group error differs: expected='%v' got='%v'", expectedErr, err)
 	}
 	if resInGroup {
-		t.Fatalf("user not in group bool differ: expected='%v' got='%v'", false, resInGroup)
+		t.Fatalf("user not in group bool differs: expected='%v' got='%v'", false, resInGroup)
 	}
 }

--- a/pkg/user/manager/json/json.go
+++ b/pkg/user/manager/json/json.go
@@ -95,8 +95,31 @@ func (m *manager) GetUser(ctx context.Context, uid *userpb.UserId) (*userpb.User
 	return nil, errtypes.NotFound(uid.OpaqueId)
 }
 
-func (m *manager) GetUserByUID(ctx context.Context, uid string) (*userpb.User, error) {
-	return nil, errtypes.NotSupported("json: looking up user by UID not supported")
+func (m *manager) GetUserByClaim(ctx context.Context, claim, value string) (*userpb.User, error) {
+	for _, u := range m.users {
+		if userClaim, err := extractClaim(u, claim); err == nil && value == userClaim {
+			return u, nil
+		}
+	}
+	return nil, errtypes.NotFound(value)
+}
+
+func extractClaim(u *userpb.User, claim string) (string, error) {
+	switch claim {
+	case "mail":
+		return u.Mail, nil
+	case "username":
+		return u.Username, nil
+	case "uid":
+		if u.Opaque != nil && u.Opaque.Map != nil {
+			if uidObj, ok := u.Opaque.Map["uid"]; ok {
+				if uidObj.Decoder == "plain" {
+					return string(uidObj.Value), nil
+				}
+			}
+		}
+	}
+	return "", errors.New("json: invalid field")
 }
 
 // TODO(jfd) search Opaque? compare sub?

--- a/pkg/user/manager/json/json.go
+++ b/pkg/user/manager/json/json.go
@@ -95,6 +95,10 @@ func (m *manager) GetUser(ctx context.Context, uid *userpb.UserId) (*userpb.User
 	return nil, errtypes.NotFound(uid.OpaqueId)
 }
 
+func (m *manager) GetUserByUID(ctx context.Context, uid string) (*userpb.User, error) {
+	return nil, errtypes.NotSupported("json: looking up user by UID not supported")
+}
+
 // TODO(jfd) search Opaque? compare sub?
 func userContains(u *userpb.User, query string) bool {
 	return strings.Contains(u.Username, query) || strings.Contains(u.DisplayName, query) || strings.Contains(u.Mail, query) || strings.Contains(u.Id.OpaqueId, query)

--- a/pkg/user/manager/json/json_test.go
+++ b/pkg/user/manager/json/json_test.go
@@ -89,12 +89,19 @@ func TestUserManager(t *testing.T) {
 	manager, _ := New(input)
 
 	// setup test data
-	userEinstein := &userpb.UserId{Idp: "localhost", OpaqueId: "einstein"}
+	uidEinstein := &userpb.UserId{Idp: "localhost", OpaqueId: "einstein"}
+	userEinstein := &userpb.User{
+		Id:          uidEinstein,
+		Username:    "einstein",
+		Groups:      []string{"sailing-lovers", "violin-haters", "physics-lovers"},
+		Mail:        "einstein@example.org",
+		DisplayName: "Albert Einstein",
+	}
 	userFake := &userpb.UserId{Idp: "localhost", OpaqueId: "fakeUser"}
 	groupsEinstein := []string{"sailing-lovers", "violin-haters", "physics-lovers"}
 
 	// positive test GetUserGroups
-	resGroups, _ := manager.GetUserGroups(ctx, userEinstein)
+	resGroups, _ := manager.GetUserGroups(ctx, uidEinstein)
 	if !reflect.DeepEqual(resGroups, groupsEinstein) {
 		t.Fatalf("groups differ: expected=%v got=%v", resGroups, groupsEinstein)
 	}
@@ -104,6 +111,19 @@ func TestUserManager(t *testing.T) {
 	_, err = manager.GetUserGroups(ctx, userFake)
 	if !reflect.DeepEqual(err, expectedErr) {
 		t.Fatalf("user not found error differ: expected='%v' got='%v'", expectedErr, err)
+	}
+
+	// positive test GetUserByClaim by mail
+	resUserByEmail, _ := manager.GetUserByClaim(ctx, "mail", "einstein@example.org")
+	if !reflect.DeepEqual(resUserByEmail, userEinstein) {
+		t.Fatalf("user differs: expected=%v got=%v", userEinstein, resUserByEmail)
+	}
+
+	// negative test GetUserByClaim by mail
+	expectedErr = errtypes.NotFound("abc@example.com")
+	_, err = manager.GetUserByClaim(ctx, "mail", "abc@example.com")
+	if !reflect.DeepEqual(err, expectedErr) {
+		t.Fatalf("user not found error differs: expected='%v' got='%v'", expectedErr, err)
 	}
 
 	// test FindUsers
@@ -116,13 +136,13 @@ func TestUserManager(t *testing.T) {
 	}
 
 	// positive test IsInGroup
-	resInGroup, _ := manager.IsInGroup(ctx, userEinstein, "physics-lovers")
+	resInGroup, _ := manager.IsInGroup(ctx, uidEinstein, "physics-lovers")
 	if !resInGroup {
 		t.Fatalf("user not in group: expected=%v got=%v", true, false)
 	}
 
 	// negative test IsInGroup with wrong group
-	resInGroup, _ = manager.IsInGroup(ctx, userEinstein, "notARealGroup")
+	resInGroup, _ = manager.IsInGroup(ctx, uidEinstein, "notARealGroup")
 	if resInGroup {
 		t.Fatalf("user not in group: expected=%v got=%v", true, false)
 	}

--- a/pkg/user/manager/ldap/ldap.go
+++ b/pkg/user/manager/ldap/ldap.go
@@ -179,6 +179,10 @@ func (m *manager) GetUser(ctx context.Context, uid *userpb.UserId) (*userpb.User
 	return u, nil
 }
 
+func (m *manager) GetUserByUID(ctx context.Context, uid string) (*userpb.User, error) {
+	return nil, errtypes.NotSupported("ldap: looking up user by UID not supported")
+}
+
 func (m *manager) FindUsers(ctx context.Context, query string) ([]*userpb.User, error) {
 	l, err := ldap.DialTLS("tcp", fmt.Sprintf("%s:%d", m.c.Hostname, m.c.Port), &tls.Config{InsecureSkipVerify: true})
 	if err != nil {

--- a/pkg/user/manager/ldap/ldap.go
+++ b/pkg/user/manager/ldap/ldap.go
@@ -179,8 +179,8 @@ func (m *manager) GetUser(ctx context.Context, uid *userpb.UserId) (*userpb.User
 	return u, nil
 }
 
-func (m *manager) GetUserByUID(ctx context.Context, uid string) (*userpb.User, error) {
-	return nil, errtypes.NotSupported("ldap: looking up user by UID not supported")
+func (m *manager) GetUserByClaim(ctx context.Context, field, claim string) (*userpb.User, error) {
+	return nil, errtypes.NotSupported("ldap: looking up user by specific field not supported")
 }
 
 func (m *manager) FindUsers(ctx context.Context, query string) ([]*userpb.User, error) {

--- a/pkg/user/manager/rest/cache.go
+++ b/pkg/user/manager/rest/cache.go
@@ -31,7 +31,6 @@ const (
 	userDetailsPrefix    = "user:"
 	userGroupsPrefix     = "groups:"
 	userInternalIDPrefix = "internal:"
-	userUIDPrefix        = "uid:"
 )
 
 func initRedisPool(address, username, password string) *redis.Pool {
@@ -136,14 +135,21 @@ func (m *manager) cacheUserDetails(u *userpb.User) error {
 	if err != nil {
 		return err
 	}
-	if err = m.setVal(userUIDPrefix+uid, u.Id.OpaqueId, -1); err != nil {
+
+	if err = m.setVal("uid:"+uid, u.Id.OpaqueId, -1); err != nil {
+		return err
+	}
+	if err = m.setVal("mail:"+u.Mail, u.Id.OpaqueId, -1); err != nil {
+		return err
+	}
+	if err = m.setVal("username:"+u.Username, u.Id.OpaqueId, -1); err != nil {
 		return err
 	}
 	return nil
 }
 
-func (m *manager) fetchCachedUID(uid string) (string, error) {
-	return m.getVal(userUIDPrefix + uid)
+func (m *manager) fetchCachedParam(field, claim string) (string, error) {
+	return m.getVal(field + ":" + claim)
 }
 
 func (m *manager) fetchCachedUserGroups(uid *userpb.UserId) ([]string, error) {

--- a/pkg/user/manager/rest/cache.go
+++ b/pkg/user/manager/rest/cache.go
@@ -34,7 +34,7 @@ const (
 	userUIDPrefix        = "uid:"
 )
 
-func initRedisPool(port string) *redis.Pool {
+func initRedisPool(address, username, password string) *redis.Pool {
 	return &redis.Pool{
 
 		MaxIdle:     50,
@@ -42,7 +42,22 @@ func initRedisPool(port string) *redis.Pool {
 		IdleTimeout: 240 * time.Second,
 
 		Dial: func() (redis.Conn, error) {
-			c, err := redis.Dial("tcp", port)
+			var c redis.Conn
+			var err error
+			switch {
+			case username != "":
+				c, err = redis.Dial("tcp", address,
+					redis.DialUsername(username),
+					redis.DialPassword(password),
+				)
+			case password != "":
+				c, err = redis.Dial("tcp", address,
+					redis.DialPassword(password),
+				)
+			default:
+				c, err = redis.Dial("tcp", address)
+			}
+
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/user/manager/rest/cache.go
+++ b/pkg/user/manager/rest/cache.go
@@ -28,8 +28,10 @@ import (
 )
 
 const (
-	userDetailsPrefix = "user:"
-	userGroupsPrefix  = "groups:"
+	userDetailsPrefix    = "user:"
+	userGroupsPrefix     = "groups:"
+	userInternalIDPrefix = "internal:"
+	userUIDPrefix        = "uid:"
 )
 
 func initRedisPool(port string) *redis.Pool {
@@ -54,68 +56,100 @@ func initRedisPool(port string) *redis.Pool {
 	}
 }
 
-func (m *manager) fetchCachedUserDetails(uid *userpb.UserId) (*userpb.User, error) {
+func (m *manager) setVal(key, val string, expiration int) error {
 	conn := m.redisPool.Get()
 	defer conn.Close()
 	if conn != nil {
-		user, err := redis.String(conn.Do("GET", userDetailsPrefix+uid.OpaqueId))
-		if err != nil {
-			return nil, err
+		if expiration != -1 {
+			if _, err := conn.Do("SET", key, val, "EX", expiration); err != nil {
+				return err
+			}
+		} else {
+			if _, err := conn.Do("SET", key, val); err != nil {
+				return err
+			}
 		}
-		u := userpb.User{}
-		if err = json.Unmarshal([]byte(user), &u); err != nil {
-			return nil, err
-		}
-		return &u, nil
+		return nil
 	}
-	return nil, errors.New("rest: unable to get connection from redis pool")
+	return errors.New("rest: unable to get connection from redis pool")
+}
+
+func (m *manager) getVal(key string) (string, error) {
+	conn := m.redisPool.Get()
+	defer conn.Close()
+	if conn != nil {
+		val, err := redis.String(conn.Do("GET", key))
+		if err != nil {
+			return "", err
+		}
+		return val, nil
+	}
+	return "", errors.New("rest: unable to get connection from redis pool")
+}
+
+func (m *manager) fetchCachedInternalID(uid *userpb.UserId) (string, error) {
+	return m.getVal(userInternalIDPrefix + uid.OpaqueId)
+}
+
+func (m *manager) cacheInternalID(uid *userpb.UserId, internalID string) error {
+	return m.setVal(userInternalIDPrefix+uid.OpaqueId, internalID, -1)
+}
+
+func (m *manager) fetchCachedUserDetails(uid *userpb.UserId) (*userpb.User, error) {
+	user, err := m.getVal(userDetailsPrefix + uid.OpaqueId)
+	if err != nil {
+		return nil, err
+	}
+
+	u := userpb.User{}
+	if err = json.Unmarshal([]byte(user), &u); err != nil {
+		return nil, err
+	}
+	return &u, nil
 }
 
 func (m *manager) cacheUserDetails(u *userpb.User) error {
-	conn := m.redisPool.Get()
-	defer conn.Close()
-	if conn != nil {
-		encodedUser, err := json.Marshal(&u)
-		if err != nil {
-			return err
-		}
-		if _, err = conn.Do("SET", userDetailsPrefix+u.Id.OpaqueId, string(encodedUser)); err != nil {
-			return err
-		}
-		return nil
+	encodedUser, err := json.Marshal(&u)
+	if err != nil {
+		return err
 	}
-	return errors.New("rest: unable to get connection from redis pool")
+	if err = m.setVal(userDetailsPrefix+u.Id.OpaqueId, string(encodedUser), -1); err != nil {
+		return err
+	}
+
+	uid, err := extractUID(u)
+	if err != nil {
+		return err
+	}
+	if err = m.setVal(userUIDPrefix+uid, u.Id.OpaqueId, -1); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *manager) fetchCachedUID(uid string) (string, error) {
+	return m.getVal(userUIDPrefix + uid)
 }
 
 func (m *manager) fetchCachedUserGroups(uid *userpb.UserId) ([]string, error) {
-	conn := m.redisPool.Get()
-	defer conn.Close()
-	if conn != nil {
-		groups, err := redis.String(conn.Do("GET", userGroupsPrefix+uid.OpaqueId))
-		if err != nil {
-			return nil, err
-		}
-		g := []string{}
-		if err = json.Unmarshal([]byte(groups), &g); err != nil {
-			return nil, err
-		}
-		return g, nil
+	groups, err := m.getVal(userGroupsPrefix + uid.OpaqueId)
+	if err != nil {
+		return nil, err
 	}
-	return nil, errors.New("rest: unable to get connection from redis pool")
+	g := []string{}
+	if err = json.Unmarshal([]byte(groups), &g); err != nil {
+		return nil, err
+	}
+	return g, nil
 }
 
 func (m *manager) cacheUserGroups(uid *userpb.UserId, groups []string) error {
-	conn := m.redisPool.Get()
-	defer conn.Close()
-	if conn != nil {
-		encodedGroups, err := json.Marshal(&groups)
-		if err != nil {
-			return err
-		}
-		if _, err = conn.Do("SET", userGroupsPrefix+uid.OpaqueId, string(encodedGroups), "EX", m.conf.UserGroupsCacheExpiration*60); err != nil {
-			return err
-		}
-		return nil
+	g, err := json.Marshal(&groups)
+	if err != nil {
+		return err
 	}
-	return errors.New("rest: unable to get connection from redis pool")
+	if err = m.setVal(userGroupsPrefix+uid.OpaqueId, string(g), m.conf.UserGroupsCacheExpiration*60); err != nil {
+		return err
+	}
+	return nil
 }

--- a/pkg/user/manager/rest/rest.go
+++ b/pkg/user/manager/rest/rest.go
@@ -320,13 +320,24 @@ func (m *manager) GetUser(ctx context.Context, uid *userpb.UserId) (*userpb.User
 	return u, nil
 }
 
-func (m *manager) GetUserByUID(ctx context.Context, uid string) (*userpb.User, error) {
-	opaqueID, err := m.fetchCachedUID(uid)
+func (m *manager) GetUserByClaim(ctx context.Context, claim, value string) (*userpb.User, error) {
+	opaqueID, err := m.fetchCachedParam(claim, value)
 	if err == nil {
 		return m.GetUser(ctx, &userpb.UserId{OpaqueId: opaqueID})
 	}
 
-	userData, err := m.getUserByParam(ctx, "uid", uid)
+	switch claim {
+	case "mail":
+		claim = "primaryAccountEmail"
+	case "uid":
+		claim = "uid"
+	case "username":
+		claim = "upn"
+	default:
+		return nil, errors.New("rest: invalid field")
+	}
+
+	userData, err := m.getUserByParam(ctx, claim, value)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/user/manager/rest/rest.go
+++ b/pkg/user/manager/rest/rest.go
@@ -354,28 +354,23 @@ func (m *manager) findUsersByFilter(ctx context.Context, url string) ([]*userpb.
 		}
 
 		uid := &userpb.UserId{
-			OpaqueId: usrInfo["id"].(string),
+			OpaqueId: usrInfo["upn"].(string),
 			Idp:      m.conf.IDProvider,
-		}
-		userGroups, err := m.GetUserGroups(ctx, uid)
-		if err != nil {
-			return nil, err
 		}
 		users = append(users, &userpb.User{
 			Id:          uid,
 			Username:    usrInfo["upn"].(string),
 			Mail:        usrInfo["primaryAccountEmail"].(string),
 			DisplayName: usrInfo["displayName"].(string),
-			Groups:      userGroups,
 			Opaque: &types.Opaque{
 				Map: map[string]*types.OpaqueEntry{
 					"uid": &types.OpaqueEntry{
 						Decoder: "plain",
-						Value:   usrInfo["uid"].([]byte),
+						Value:   []byte(fmt.Sprintf("%0.f", usrInfo["uid"])),
 					},
 					"gid": &types.OpaqueEntry{
 						Decoder: "plain",
-						Value:   usrInfo["gid"].([]byte),
+						Value:   []byte(fmt.Sprintf("%0.f", usrInfo["gid"])),
 					},
 				},
 			},

--- a/pkg/user/manager/rest/rest.go
+++ b/pkg/user/manager/rest/rest.go
@@ -64,8 +64,12 @@ type OIDCToken struct {
 }
 
 type config struct {
-	// The port on which the redis server is running
-	Redis string `mapstructure:"redis" docs:":6379"`
+	// The address at which the redis server is running
+	RedisAddress string `mapstructure:"redis_address" docs:"localhost:6379"`
+	// The username for connecting to the redis server
+	RedisUsername string `mapstructure:"redis_username" docs:""`
+	// The password for connecting to the redis server
+	RedisPassword string `mapstructure:"redis_password" docs:""`
 	// The time in minutes for which the groups to which a user belongs would be cached
 	UserGroupsCacheExpiration int `mapstructure:"user_groups_cache_expiration" docs:"5"`
 	// The OIDC Provider
@@ -87,8 +91,8 @@ func (c *config) init() {
 	if c.UserGroupsCacheExpiration == 0 {
 		c.UserGroupsCacheExpiration = 5
 	}
-	if c.Redis == "" {
-		c.Redis = ":6379"
+	if c.RedisAddress == "" {
+		c.RedisAddress = ":6379"
 	}
 	if c.APIBaseURL == "" {
 		c.APIBaseURL = "https://authorization-service-api-dev.web.cern.ch/api/v1.0"
@@ -120,7 +124,7 @@ func New(m map[string]interface{}) (user.Manager, error) {
 	}
 	c.init()
 
-	redisPool := initRedisPool(c.Redis)
+	redisPool := initRedisPool(c.RedisAddress, c.RedisUsername, c.RedisPassword)
 	return &manager{
 		conf:      c,
 		redisPool: redisPool,

--- a/pkg/user/manager/rest/rest.go
+++ b/pkg/user/manager/rest/rest.go
@@ -274,11 +274,11 @@ func (m *manager) parseAndCacheUser(ctx context.Context, userData map[string]int
 			Map: map[string]*types.OpaqueEntry{
 				"uid": &types.OpaqueEntry{
 					Decoder: "plain",
-					Value:   userData["uid"].([]byte),
+					Value:   []byte(fmt.Sprintf("%0.f", userData["uid"])),
 				},
 				"gid": &types.OpaqueEntry{
 					Decoder: "plain",
-					Value:   userData["gid"].([]byte),
+					Value:   []byte(fmt.Sprintf("%0.f", userData["gid"])),
 				},
 			},
 		},

--- a/pkg/user/user.go
+++ b/pkg/user/user.go
@@ -65,6 +65,7 @@ func ContextSetUserID(ctx context.Context, id *userpb.UserId) context.Context {
 // Manager is the interface to implement to manipulate users.
 type Manager interface {
 	GetUser(ctx context.Context, uid *userpb.UserId) (*userpb.User, error)
+	GetUserByUID(ctx context.Context, uid string) (*userpb.User, error)
 	GetUserGroups(ctx context.Context, uid *userpb.UserId) ([]string, error)
 	IsInGroup(ctx context.Context, uid *userpb.UserId, group string) (bool, error)
 	FindUsers(ctx context.Context, query string) ([]*userpb.User, error)

--- a/pkg/user/user.go
+++ b/pkg/user/user.go
@@ -65,7 +65,7 @@ func ContextSetUserID(ctx context.Context, id *userpb.UserId) context.Context {
 // Manager is the interface to implement to manipulate users.
 type Manager interface {
 	GetUser(ctx context.Context, uid *userpb.UserId) (*userpb.User, error)
-	GetUserByUID(ctx context.Context, uid string) (*userpb.User, error)
+	GetUserByClaim(ctx context.Context, claim, value string) (*userpb.User, error)
 	GetUserGroups(ctx context.Context, uid *userpb.UserId) ([]string, error)
 	IsInGroup(ctx context.Context, uid *userpb.UserId, group string) (bool, error)
 	FindUsers(ctx context.Context, query string) ([]*userpb.User, error)


### PR DESCRIPTION
This is an alternative approach to #983 where the gateway is available to EOS fs, from where it can resolve UIDs back to users, instead of passing it to the gateway layers.