### PR TITLE
Split LDAP user filters

### DIFF
--- a/changelog/unreleased/split-ldap-filters.md
+++ b/changelog/unreleased/split-ldap-filters.md
@@ -1,0 +1,11 @@
+Enhancement: Split LDAP user filters
+
+The current LDAP user filters only allow a single `%s` to be replaced with the relevant string. We moved to filter templates that can use the CS3 user id properties `{{.OpaqueId}}` and `{{.Idp}}`. Furthermore,
+we introduced a new find filter that is used when searching for users. An example config would be
+```
+userfilter = "(&(objectclass=posixAccount)(|(ownclouduuid={{.OpaqueId}})(cn={{.OpaqueId}})))"
+findfilter = "(&(objectclass=posixAccount)(|(cn={{query}}*)(displayname={{query}}*)(mail={{query}}*)))"
+```
+As you can see the userfilter is used to lookup a single user, whereas the findfilter is for a broader search, e.g. used when searching for share recipients.
+
+https://github.com/cs3org/reva/pull/996

--- a/changelog/unreleased/split-ldap-filters.md
+++ b/changelog/unreleased/split-ldap-filters.md
@@ -1,11 +1,25 @@
 Enhancement: Split LDAP user filters
 
-The current LDAP user filters only allow a single `%s` to be replaced with the relevant string. We moved to filter templates that can use the CS3 user id properties `{{.OpaqueId}}` and `{{.Idp}}`. Furthermore,
-we introduced a new find filter that is used when searching for users. An example config would be
+The current LDAP user and auth filters only allow a single `%s` to be replaced with the relevant string.
+The current `userfilter` is used to lookup a single user, search for share recipients and for login. To make each use case more flexible we split this in three and introduced templates.
+
+For the `userfilter` we moved to filter templates that can use the CS3 user id properties `{{.OpaqueId}}` and `{{.Idp}}`:
 ```
 userfilter = "(&(objectclass=posixAccount)(|(ownclouduuid={{.OpaqueId}})(cn={{.OpaqueId}})))"
+```
+
+We introduced a new `findfilter` that is used when searching for users. Use it like this:
+```
 findfilter = "(&(objectclass=posixAccount)(|(cn={{query}}*)(displayname={{query}}*)(mail={{query}}*)))"
 ```
-As you can see the userfilter is used to lookup a single user, whereas the findfilter is for a broader search, e.g. used when searching for share recipients.
+
+Furthermore, we also introduced a dedicated login filter for the LDAP auth manager:
+```
+loginfilter = "(&(objectclass=posixAccount)(|(cn={{login}})(mail={{login}})))"
+```
+
+These filter changes are backward compatible: `findfilter` and `loginfilter` will be derived from the `userfilter` by replacing `%s` with `{{query}}` and `{{login}}` respectively. The `userfilter` replaces `%s` with `{{.OpaqueId}}`
+
+Finally, we changed the default attribute for the immutable uid of a user to `ms-DS-ConsistencyGuid`. See https://docs.microsoft.com/en-us/azure/active-directory/hybrid/plan-connect-design-concepts for the background. You can fall back to `objectguid` or even `samaccountname` but you will run into trouble when user names change. You have been warned.
 
 https://github.com/cs3org/reva/pull/996


### PR DESCRIPTION
The current LDAP user filters only allow a single `%s` to be replaced with the relevant string. I moved to filter templates that can use the CS3 user id properties `{{.OpaqueId}}` and `{{.Idp}}`. Furthermore,
I introduced a new find filter that is used when searching for users. An example config would be
```
userfilter = "(&(objectclass=posixAccount)(|(ownclouduuid={{.OpaqueId}})(cn={{.OpaqueId}})))"
findfilter = "(&(objectclass=posixAccount)(|(cn={{query}}*)(displayname={{query}}*)(mail={{query}}*)))"
```
As you can see the userfilter is used to lookup a single user, whereas the findfilter is for a broader search, e.g. used when searching for share recipients.

Related: https://github.com/cs3org/reva/issues/326