### PR TITLE
add TODOs for userid lookup in storage drivers

### DIFF
--- a/pkg/eosclient/eosclient.go
+++ b/pkg/eosclient/eosclient.go
@@ -382,6 +382,7 @@ func (c *Client) ListACLs(ctx context.Context, username, path string) ([]*acl.En
 	for _, acl := range parsedACLs.Entries {
 		// since EOS Citrine ACLs are is stored with uid, we need to convert uid to username
 		// TODO map group names as well if acl.Type == "g" ...
+		// TODO look up the actual userid at the user provider, maybe even by uidnumber and gidnumber
 		acl.Qualifier, err = getUsername(acl.Qualifier)
 		if err != nil {
 			log.Warn().Err(err).Str("path", path).Str("username", username).Str("qualifier", acl.Qualifier).Msg("cannot map qualifier to name")

--- a/pkg/storage/fs/owncloud/owncloud.go
+++ b/pkg/storage/fs/owncloud/owncloud.go
@@ -141,9 +141,12 @@ const (
 	// SharePrefix is the prefix for sharing related extended attributes
 	sharePrefix       string = "user.oc.acl."
 	trashOriginPrefix string = "user.oc.o"
-	mdPrefix          string = "user.oc.md."   // arbitrary metadata
-	favPrefix         string = "user.oc.fav."  // favorite flag, per user
-	etagPrefix        string = "user.oc.etag." // allow overriding a calculated etag with one from the extended attributes
+	// TODO store the owners uuid on the root folder to store the uuid of the user, see getOwner
+	// but we also need to use the uuid in acls
+	userPrefix string = "user.oc.u"
+	mdPrefix   string = "user.oc.md."   // arbitrary metadata
+	favPrefix  string = "user.oc.fav."  // favorite flag, per user
+	etagPrefix string = "user.oc.etag." // allow overriding a calculated etag with one from the extended attributes
 	//checksumPrefix    string = "user.oc.cs."   // TODO add checksum support
 )
 
@@ -464,6 +467,7 @@ func (fs *ocfs) unwrapShadow(ctx context.Context, internal string) (external str
 }
 
 // TODO the owner needs to come from a different place
+// read from the extended attributes?
 func (fs *ocfs) getOwner(internal string) string {
 	internal = strings.TrimPrefix(internal, fs.c.DataDirectory)
 	parts := strings.SplitN(internal, "/", 3)

--- a/pkg/storage/utils/eosfs/eosfs.go
+++ b/pkg/storage/utils/eosfs/eosfs.go
@@ -488,6 +488,12 @@ func (fs *eosfs) ListGrants(ctx context.Context, ref *provider.Reference) ([]*pr
 	grantList := []*provider.Grant{}
 	for _, a := range acls {
 		grantee := &provider.Grantee{
+			// TODO a.Qualifier is a username, but OpaqueID should be the immutable userid
+			// so we need to look up the actual userid at the user provider
+			// options:
+			// - a new API call: getUserByUsername (proper solution)
+			// - configure ldap to search both: uid and cn, hoping there will never be collisions (short term option)
+			// - use FindUser, but this is not en exact search (not really an option)
 			Id:   &userpb.UserId{OpaqueId: a.Qualifier},
 			Type: grants.GetGranteeType(a.Type),
 		}
@@ -1184,8 +1190,14 @@ func (fs *eosfs) convert(ctx context.Context, eosFileInfo *eosclient.FileInfo) *
 	}
 
 	info := &provider.ResourceInfo{
-		Id:            &provider.ResourceId{OpaqueId: fmt.Sprintf("%d", eosFileInfo.Inode)},
-		Path:          path,
+		Id:   &provider.ResourceId{OpaqueId: fmt.Sprintf("%d", eosFileInfo.Inode)},
+		Path: path,
+		// TODO a.Qualifier is a username, but OpaqueID should be the immutable userid
+		// so we need to look up the actual userid at the user provider
+		// options:
+		// - a new API call: getUserByUsername (proper solution)
+		// - configure ldap to search both: uid and cn, hoping there will never be collisions (short term option)
+		// - use FindUser, but this is not en exact search (not really an option)
 		Owner:         &userpb.UserId{OpaqueId: username},
 		Etag:          fmt.Sprintf("\"%s\"", strings.Trim(eosFileInfo.ETag, "\"")),
 		MimeType:      mime.Detect(eosFileInfo.IsDir, path),


### PR DESCRIPTION
Currently, all storage drivers use the username to build a cs3 userid, which is incorrect. The UserId.OpaqueId is different from the username.

The solution is to look up the userid at the user provider, which would also address https://github.com/cs3org/reva/issues/964 needs a new CS3 call AFAICT

I tried marking relevant places in the code. The first step for really treating username and uid differently is in https://github.com/cs3org/reva/pull/996

I think this is also needed for OCM because we need to have a stable federated sharing id, which is differnt from the username because it actually should never change ...

Let me know what you think.