### PR TITLE
Update github.com/eventials/go-tus to v0.0.0-20200718001131-45c7ec8f5d59

### DIFF
--- a/changelog/unreleased/update-go-tus-client.md
+++ b/changelog/unreleased/update-go-tus-client.md
@@ -1,0 +1,5 @@
+Enhancement: Update github.com/eventials/go-tus to v0.0.0-20200718001131-45c7ec8f5d59
+
+The lib now uses go mod which should help golang to sort out dependencies when running `go mod tidy`.
+
+https://github.com/cs3org/reva/pull/1007

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/cs3org/cato v0.0.0-20200626150132-28a40e643719
 	github.com/cs3org/go-cs3apis v0.0.0-20200709064917-d96c5f2a42ad
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
-	github.com/eventials/go-tus v0.0.0-20190617130015-9db47421f6a0
+	github.com/eventials/go-tus v0.0.0-20200718001131-45c7ec8f5d59
 	github.com/go-ldap/ldap/v3 v3.2.3
 	github.com/go-openapi/strfmt v0.19.2 // indirect
 	github.com/gofrs/uuid v3.3.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -47,8 +47,6 @@ github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a h1:idn718Q4
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/aws/aws-sdk-go v1.20.1/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.23.19/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
-github.com/aws/aws-sdk-go v1.33.7 h1:vOozL5hmWHHriRviVTQnUwz8l05RS0rehmEFymI+/x8=
-github.com/aws/aws-sdk-go v1.33.7/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/aws/aws-sdk-go v1.33.11 h1:A7b3mNKbh/0zrhnNN/KxWD0YZJw2RImnjFXWOquYKB4=
 github.com/aws/aws-sdk-go v1.33.11/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/aws/aws-xray-sdk-go v0.9.4/go.mod h1:XtMKdBQfpVut+tJEwI7+dJFRxxRdxHDyVNp2tHXRq04=
@@ -470,8 +468,6 @@ github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQz
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.3.1 h1:cCBH2gTD2K0OtLlv/Y5H01VQCqmlDxz30kS5Y5bqfLA=
 github.com/mitchellh/mapstructure v1.3.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
-github.com/mitchellh/mapstructure v1.3.2 h1:mRS76wmkOn3KkKAyXDu42V+6ebnXWIztFSYGN7GeoRg=
-github.com/mitchellh/mapstructure v1.3.2/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/mapstructure v1.3.3 h1:SzB1nHZ2Xi+17FP0zVQBHIZqvwRN9408fJO8h+eeNA8=
 github.com/mitchellh/mapstructure v1.3.3/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/reflectwalk v1.0.0 h1:9D+8oIskB4VJBN5SFlmc27fSlIBZaov1Wpk/IfikLNY=


### PR DESCRIPTION
The lib now uses go mod which should help golang to sort out dependencies when running `go mod tidy`:
```
go: finding module for package github.com/tus/tusd/filestore
go: finding module for package github.com/tus/tusd
github.com/owncloud/ocis/pkg/command imports
        github.com/owncloud/ocis-reva/pkg/command imports
        github.com/cs3org/reva/cmd/revad/runtime imports
        github.com/cs3org/reva/internal/http/services/loader imports
        github.com/cs3org/reva/internal/http/services/dataprovider imports
        github.com/eventials/go-tus tested by
        github.com/eventials/go-tus.test imports
        github.com/tus/tusd: module github.com/tus/tusd@latest found (v1.3.0), but does not contain package github.com/tus/tusd
github.com/owncloud/ocis/pkg/command imports
        github.com/owncloud/ocis-reva/pkg/command imports
        github.com/cs3org/reva/cmd/revad/runtime imports
        github.com/cs3org/reva/internal/http/services/loader imports
        github.com/cs3org/reva/internal/http/services/dataprovider imports
        github.com/eventials/go-tus tested by
        github.com/eventials/go-tus.test imports
        github.com/tus/tusd/filestore: module github.com/tus/tusd@latest found (v1.3.0), but does not contain package github.com/tus/tusd/filestore
```