### PR TITLE
Use proper logging for ldap auth requests

### DIFF
--- a/changelog/unreleased/sane-ldap-auth-logging.md
+++ b/changelog/unreleased/sane-ldap-auth-logging.md
@@ -1,0 +1,5 @@
+Enhancement: Use proper logging for ldap auth requests
+
+Instead of logging to stdout we now log using debug level logging or error level logging in case the configured system user cannot bind to LDAP.
+
+https://github.com/cs3org/reva/pull/1008

--- a/pkg/auth/manager/ldap/ldap.go
+++ b/pkg/auth/manager/ldap/ldap.go
@@ -121,6 +121,7 @@ func (am *mgr) Authenticate(ctx context.Context, clientID, clientSecret string) 
 	// First bind with a read only user
 	err = l.Bind(am.c.BindUsername, am.c.BindPassword)
 	if err != nil {
+		log.Error().Err(err).Msg("bind with system user failed")
 		return nil, err
 	}
 
@@ -142,13 +143,12 @@ func (am *mgr) Authenticate(ctx context.Context, clientID, clientSecret string) 
 		return nil, errtypes.NotFound(clientID)
 	}
 
-	log.Debug().Interface("entries", sr.Entries).Msg("entries")
-
 	userdn := sr.Entries[0].DN
 
 	// Bind as the user to verify their password
 	err = l.Bind(userdn, clientSecret)
 	if err != nil {
+		log.Debug().Err(err).Interface("userdn", userdn).Msg("bind with user credentials failed")
 		return nil, err
 	}
 
@@ -164,7 +164,7 @@ func (am *mgr) Authenticate(ctx context.Context, clientID, clientSecret string) 
 		Mail:        sr.Entries[0].GetEqualFoldAttributeValue(am.c.Schema.Mail),
 		DisplayName: sr.Entries[0].GetEqualFoldAttributeValue(am.c.Schema.DisplayName),
 	}
-	fmt.Printf("\n\n\n%+v\n\n\n", u)
+	log.Debug().Interface("entry", sr.Entries[0]).Interface("user", u).Msg("authenticated user")
 
 	return u, nil
 


### PR DESCRIPTION
Instead of logging to stdout we now log using debug level logging or an error.