### PR TITLE
[Tests-Only] Bump commit id for oC10APIAcceptanceTests

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -343,7 +343,7 @@ steps:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
       - cd /drone/src/tmp/testrunner
-      - git checkout 9db442250583d3b71e633cf77fbcf643ed67e994
+      - git checkout e33cfcb2816abd07ec97a244ee41e92af2267ad9
       - make test-acceptance-api
     environment:
       TEST_SERVER_URL: 'http://revad-services:20080'

--- a/.drone.yml
+++ b/.drone.yml
@@ -343,7 +343,7 @@ steps:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
       - cd /drone/src/tmp/testrunner
-      - git checkout e33cfcb2816abd07ec97a244ee41e92af2267ad9
+      - git checkout 1b42efd260ba9ccffedd3bb580ad41fd16916a75
       - make test-acceptance-api
     environment:
       TEST_SERVER_URL: 'http://revad-services:20080'

--- a/.drone.yml
+++ b/.drone.yml
@@ -343,7 +343,7 @@ steps:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
       - cd /drone/src/tmp/testrunner
-      - git checkout 1b42efd260ba9ccffedd3bb580ad41fd16916a75
+      - git checkout 378d38ab844e048bc88ca7cc365592017f0c7227
       - make test-acceptance-api
     environment:
       TEST_SERVER_URL: 'http://revad-services:20080'


### PR DESCRIPTION
It gets us test scenarios that have been added/changed over the past week:
https://github.com/owncloud/core/pull/37717 Add EXPECTED_FAILURES_FILE capability to acceptance tests run.sh (I  will make a proposed PR to use that capability later this week)
https://github.com/owncloud/core/pull/37721 Modify functions to check the presence of files and folders - does more strict checking when a resource should be a file and not a folder or vice-versa
https://github.com/owncloud/core/pull/37740 Remove skipOnOcis tag for scenarios not to be skipped on ocis
https://github.com/owncloud/core/pull/37742 Fix tests for ocis with proxy