### PR TITLE
[Tests-Only] Bump commit for oC10APIAcceptanceTests

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -343,7 +343,7 @@ steps:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
       - cd /drone/src/tmp/testrunner
-      - git checkout 378d38ab844e048bc88ca7cc365592017f0c7227
+      - git checkout 24b305a38f259584b683256880eb9e42f99f19c5
       - make test-acceptance-api
     environment:
       TEST_SERVER_URL: 'http://revad-services:20080'


### PR DESCRIPTION
Includes these oC10APIAcceptanceTests changes from recent days:
https://github.com/owncloud/core/pull/37745 Include trailing slash when matching a suite name
https://github.com/owncloud/core/pull/37746 Refactor listFolder acceptance tests
https://github.com/owncloud/core/pull/37749 use usersHaveBeenCreated & delete UserHelper::createUser
https://github.com/owncloud/core/pull/37751 Add tests for new capabilities
https://github.com/owncloud/core/pull/37752 Skip new lock tests on old ownCloud