### PR TITLE
ocfs: lookup user to render template properly

### DIFF
--- a/changelog/unreleased/ocfs-user-lookup.md
+++ b/changelog/unreleased/ocfs-user-lookup.md
@@ -1,0 +1,5 @@
+Bugfix: ocfs: Lookup user to render template properly
+
+Currently, the username is used to construct paths, which breaks when mounting the `owncloud` storage driver at `/oc` and then expecting paths that use the username like `/oc/einstein/foo` to work, because they will mismatch the path that is used from propagation which uses `/oc/u-u-i-d` as the root, giving an `internal path outside root` error
+
+https://github.com/cs3org/reva/pull/1033

--- a/pkg/storage/fs/owncloud/owncloud.go
+++ b/pkg/storage/fs/owncloud/owncloud.go
@@ -155,14 +155,14 @@ func init() {
 }
 
 type config struct {
-	DataDirectory             string `mapstructure:"datadirectory"`
-	UploadInfoDir             string `mapstructure:"upload_info_dir"`
-	ShareDirectory            string `mapstructure:"sharedirectory"`
-	UserLayout                string `mapstructure:"user_layout"`
-	Redis                     string `mapstructure:"redis"`
-	EnableHome                bool   `mapstructure:"enable_home"`
-	Scan                      bool   `mapstructure:"scan"`
-	UserShareProviderEndpoint string `mapstructure:"usershareprovidersvc"`
+	DataDirectory        string `mapstructure:"datadirectory"`
+	UploadInfoDir        string `mapstructure:"upload_info_dir"`
+	ShareDirectory       string `mapstructure:"sharedirectory"`
+	UserLayout           string `mapstructure:"user_layout"`
+	Redis                string `mapstructure:"redis"`
+	EnableHome           bool   `mapstructure:"enable_home"`
+	Scan                 bool   `mapstructure:"scan"`
+	UserProviderEndpoint string `mapstructure:"userprovidersvc"`
 }
 
 func parseConfig(m map[string]interface{}) (*config, error) {
@@ -191,7 +191,7 @@ func (c *config) init(m map[string]interface{}) {
 	if _, ok := m["scan"]; !ok {
 		c.Scan = true
 	}
-	c.UserShareProviderEndpoint = sharedconf.GetGatewaySVC(c.UserShareProviderEndpoint)
+	c.UserProviderEndpoint = sharedconf.GetGatewaySVC(c.UserProviderEndpoint)
 }
 
 // New returns an implementation to of the storage.FS interface that talk to
@@ -522,7 +522,7 @@ func (fs *ocfs) getUser(ctx context.Context, usernameOrID string) (id *userpb.Us
 	// look up at the userprovider
 
 	// parts[0] contains the username or userid. use  user service to look up id
-	c, err := pool.GetUserProviderServiceClient(fs.c.UserShareProviderEndpoint)
+	c, err := pool.GetUserProviderServiceClient(fs.c.UserProviderEndpoint)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/storage/fs/owncloud/upload.go
+++ b/pkg/storage/fs/owncloud/upload.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cs3org/reva/pkg/appctx"
 	"github.com/cs3org/reva/pkg/errtypes"
 	"github.com/cs3org/reva/pkg/logger"
+	"github.com/cs3org/reva/pkg/storage/utils/templates"
 	"github.com/cs3org/reva/pkg/user"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
@@ -203,7 +204,8 @@ func (fs *ocfs) getUploadPath(ctx context.Context, uploadID string) (string, err
 		err := errors.Wrap(errtypes.UserRequired("userrequired"), "error getting user from ctx")
 		return "", err
 	}
-	return filepath.Join(fs.c.DataDirectory, u.Username, "uploads", uploadID), nil
+	layout := templates.WithUser(u, fs.c.UserLayout)
+	return filepath.Join(fs.c.DataDirectory, layout, "uploads", uploadID), nil
 }
 
 // GetUpload returns the Upload for the given upload id


### PR DESCRIPTION
Currently, the username is used to construct paths, which breaks when mounting the owncloud storage driver at /oc and then expecting paths that use the username like `/oc/einstein/foo` to work, because they will mismatch the path that is used from propagation which uses `/oc/u-u-i-d` as the root, giving a `internal path outside root` error like this:

```
11:25AM ERR home/jfd/go/pkg/mod/github.com/cs3org/reva@v0.1.1-0.20200728071211-c948977dd3a0/pkg/storage/fs/owncloud/owncloud.go:1885 > could not propagate change error="internal path outside root" leafPath=/var/tmp/reva/data/4c510ada-c86b-4815-8820-42cdf82c3d51/files/TUS-upload.png pid=32062 root=/var/tmp/reva/data/einstein/files
[tusd] 2020/07/30 11:25:42 event="ResponseOutgoing" status="500" method="PATCH" path="/5137f8b9-cbad-40a2-a20b-e06a8bfd5a5a" error="internal path outside root" requestId=""
2020-07-30T11:25:42+02:00 ERR http end="30/Jul/2020:11:25:42 +0200" host=::1 method=PATCH pkg=rhttp proto=HTTP/1.1 service=reva size=27 start="30/Jul/2020:11:25:42 +0200" status=500 time_ns=912434 traceid=3c125790948fbeb2499020acafb12108 uri=/data/5137f8b9-cbad-40a2-a20b-e06a8bfd5a5a url=/data/5137f8b9-cbad-40a2-a20b-e06a8bfd5a5a
2020-07-30T11:25:42+02:00 ERR http end="30/Jul/2020:11:25:42 +0200" host=::1 method=PATCH pkg=rhttp proto=HTTP/1.1 service=reva size=0 start="30/Jul/2020:11:25:42 +0200" status=500 time_ns=1823731 traceid=3c125790948fbeb2499020acafb12108 uri=/data/eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJyZXZhIiwiZXhwIjoxNTk2MTg3NTQyLCJpYXQiOjE1OTYxMDExNDIsInRhcmdldCI6Imh0dHA6Ly9sb2NhbGhvc3Q6OTE2NC9kYXRhLzUxMzdmOGI5LWNiYWQtNDBhMi1hMjBiLWUwNmE4YmZkNWE1YSJ9.cyLG5VtERyCrRdZcK6PF1sTNCF_GmHl5Ii1o8AV6jUc url=/data/eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJyZXZhIiwiZXhwIjoxNTk2MTg3NTQyLCJpYXQiOjE1OTYxMDExNDIsInRhcmdldCI6Imh0dHA6Ly9sb2NhbGhvc3Q6OTE2NC9kYXRhLzUxMzdmOGI5LWNiYWQtNDBhMi1hMjBiLWUwNmE4YmZkNWE1YSJ9.cyLG5VtERyCrRdZcK6PF1sTNCF_GmHl5Ii1o8AV6jUc
2020-07-30 11:25:42.675756 I | httputil: ReverseProxy read error during body copy: unexpected EOF
2020-07-30 11:25:42.675767 I | suppressing panic for copyResponse error in test; copy error: unexpected EOF
```

To fix this we need to lookup the user at the user provider. using the username as the opaqueid works when the ldap filter is configured to allow lookup by both eg: `(&(objectclass=posixAccount)(|(ownclouduuid={{.OpaqueId}})(cn={{.OpaqueId}})))`

An annoying thing is that this makes the storage driver depend on the user provider... I am using the `sharedconf` package to make this default to the gateway.

We can save the trip to the user provider if the currently logged in user happens to match the requested user.

@labkode the eos driver should do a similar thing eg when parsing back the acls into a user. I can look into that after fixing our update branch, because it requires a lot of attenrtion right now, because we need to fix the testsuite to deal with the userid / username split.