### PR TITLE
[Tests-Only] Bump core commit id for API acceptance tests

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -343,7 +343,7 @@ steps:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
       - cd /drone/src/tmp/testrunner
-      - git checkout 24b305a38f259584b683256880eb9e42f99f19c5
+      - git checkout 9416491281aa5315b630e02e3c7e8ca76689505a
       - make test-acceptance-api
     environment:
       TEST_SERVER_URL: 'http://revad-services:20080'


### PR DESCRIPTION
Gets us these core acceptance test changes:

https://github.com/owncloud/core/pull/37753 only send userid and password on user creation
https://github.com/owncloud/core/pull/37756 Delete users after test ocis ocs
https://github.com/owncloud/core/pull/37757 delete reva data folder after tests
https://github.com/owncloud/core/pull/37759 Respect the user creation method in usersHaveBeenCreated
https://github.com/owncloud/core/pull/37736 Tag tests to implement on ocis or not