### PR TITLE
List public shares only created by the current user

### DIFF
--- a/changelog/unreleased/publicshares-list-fix.md
+++ b/changelog/unreleased/publicshares-list-fix.md
@@ -1,0 +1,7 @@
+Bugfix: List public shares only created by the current user
+
+When running ocis, the public links created by a user are visible to all the
+users under the 'Shared with others' tab. This PR fixes that by returning only
+those links which are created by a user themselves.
+
+https://github.com/cs3org/reva/pull/1042

--- a/pkg/publicshare/manager/json/json.go
+++ b/pkg/publicshare/manager/json/json.go
@@ -333,6 +333,11 @@ func (m *manager) ListPublicShares(ctx context.Context, u *user.User, filters []
 			return nil, err
 		}
 
+		// Skip if the share isn't created by the current user
+		if local.Creator != u.Id {
+			continue
+		}
+
 		if len(filters) == 0 {
 			shares = append(shares, &local.PublicShare)
 		} else {

--- a/pkg/publicshare/manager/json/json.go
+++ b/pkg/publicshare/manager/json/json.go
@@ -334,7 +334,7 @@ func (m *manager) ListPublicShares(ctx context.Context, u *user.User, filters []
 		}
 
 		// Skip if the share isn't created by the current user
-		if local.Creator != u.Id {
+		if local.Creator.GetOpaqueId() != u.Id.OpaqueId || (local.Creator.GetIdp() != "" && u.Id.Idp != local.Creator.GetIdp()) {
 			continue
 		}
 

--- a/pkg/publicshare/manager/memory/memory.go
+++ b/pkg/publicshare/manager/memory/memory.go
@@ -170,13 +170,17 @@ func (m *manager) ListPublicShares(ctx context.Context, u *user.User, filters []
 	shares := []*link.PublicShare{}
 	m.shares.Range(func(k, v interface{}) bool {
 		s := v.(*link.PublicShare)
-		if len(filters) == 0 {
-			shares = append(shares, s)
-		} else {
-			for _, f := range filters {
-				if f.Type == link.ListPublicSharesRequest_Filter_TYPE_RESOURCE_ID {
-					if s.ResourceId.StorageId == f.GetResourceId().StorageId && s.ResourceId.OpaqueId == f.GetResourceId().OpaqueId {
-						shares = append(shares, s)
+
+		// Skip if the share isn't created by the current user
+		if s.Creator == u.Id {
+			if len(filters) == 0 {
+				shares = append(shares, s)
+			} else {
+				for _, f := range filters {
+					if f.Type == link.ListPublicSharesRequest_Filter_TYPE_RESOURCE_ID {
+						if s.ResourceId.StorageId == f.GetResourceId().StorageId && s.ResourceId.OpaqueId == f.GetResourceId().OpaqueId {
+							shares = append(shares, s)
+						}
 					}
 				}
 			}

--- a/pkg/publicshare/manager/memory/memory.go
+++ b/pkg/publicshare/manager/memory/memory.go
@@ -172,7 +172,7 @@ func (m *manager) ListPublicShares(ctx context.Context, u *user.User, filters []
 		s := v.(*link.PublicShare)
 
 		// Skip if the share isn't created by the current user
-		if s.Creator == u.Id {
+		if s.Creator.GetOpaqueId() == u.Id.OpaqueId && (s.Creator.GetIdp() == "" || u.Id.Idp == s.Creator.GetIdp()) {
 			if len(filters) == 0 {
 				shares = append(shares, s)
 			} else {


### PR DESCRIPTION
When running ocis, the public links created by a user are visible to all the users under the 'Shared with others' tab. This PR fixes that by returning only those links which are created by a user themselves.