### PR TITLE
Local storage provider: Fixed resolution of fileid

### DIFF
--- a/changelog/unreleased/localfs-fix.md
+++ b/changelog/unreleased/localfs-fix.md
@@ -1,0 +1,7 @@
+Bugfix: Fixed resolution of fileid in GetPathByID.
+
+Following refactoring of fileid generations in the
+local storage provider, this ensures fileid to path
+resolution works again.
+
+https://github.com/cs3org/reva/pull/1046

--- a/pkg/storage/utils/localfs/localfs.go
+++ b/pkg/storage/utils/localfs/localfs.go
@@ -340,7 +340,15 @@ func (fs *localfs) retrieveArbitraryMetadata(ctx context.Context, fn string, mdK
 // GetPathByID returns the path pointed by the file id
 // In this implementation the file id is in the form `fileid-url_encoded_path`
 func (fs *localfs) GetPathByID(ctx context.Context, id *provider.ResourceId) (string, error) {
-	return url.QueryUnescape(strings.TrimPrefix(id.OpaqueId, "fileid-"))
+	var layout string
+	if !fs.conf.DisableHome {
+		var err error
+		layout, err = fs.GetHome(ctx)
+		if err != nil {
+			return "", err
+		}
+	}
+	return url.QueryUnescape(strings.TrimPrefix(id.OpaqueId, "fileid-"+layout))
 }
 
 func (fs *localfs) AddGrant(ctx context.Context, ref *provider.Reference, g *provider.Grant) error {


### PR DESCRIPTION
Following refactoring of fileid generations in the local storage provider, this ensures fileid to path resolution works again.
