### PR TITLE
[Tests-Only] Bump core commit to latest

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -343,7 +343,7 @@ steps:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
       - cd /drone/src/tmp/testrunner
-      - git checkout 9416491281aa5315b630e02e3c7e8ca76689505a
+      - git checkout 1bee9ca8bc5ca37d3ceeb1f22f89ff8fb9690d83
       - make test-acceptance-api
     environment:
       TEST_SERVER_URL: 'http://revad-services:20080'

--- a/.drone.yml
+++ b/.drone.yml
@@ -343,7 +343,7 @@ steps:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
       - cd /drone/src/tmp/testrunner
-      - git checkout 1bee9ca8bc5ca37d3ceeb1f22f89ff8fb9690d83
+      - git checkout 9ebf886779b98fc3f78e11cf138246f80d5cab39
       - make test-acceptance-api
     environment:
       TEST_SERVER_URL: 'http://revad-services:20080'


### PR DESCRIPTION
Gets us:
https://github.com/owncloud/core/pull/37767 Report the total scenarios that passed and failed across all suites
https://github.com/owncloud/core/pull/37769 Remove old skipOnOcV10.* tags

in CI,

and any core changes that happened with the merge-back of core `release-10.5.0` branch. (There was nothing in that that looked interesting for tests)

This is also in #1036 which is ready for review.