### PR TITLE
Improve timestamp precision while logging

### DIFF
--- a/changelog/unreleased/log-time-precision.md
+++ b/changelog/unreleased/log-time-precision.md
@@ -1,0 +1,7 @@
+Enhancement: Improve timestamp precision while logging
+
+Previously, the timestamp associated with a log just had the hour and minute,
+which made debugging quite difficult. This PR increases the precision of the
+associated timestamp.
+
+https://github.com/cs3org/reva/pull/1059

--- a/go.sum
+++ b/go.sum
@@ -107,6 +107,8 @@ github.com/cs3org/cato v0.0.0-20200626150132-28a40e643719 h1:3vDKYhsyWSbrtX67i66
 github.com/cs3org/cato v0.0.0-20200626150132-28a40e643719/go.mod h1:XJEZ3/EQuI3BXTp/6DUzFr850vlxq11I6satRtz0YQ4=
 github.com/cs3org/go-cs3apis v0.0.0-20200728114537-4efa23660dbe h1:CQ/Grq7oVFqwiUg4VA/T+fl3JHZKEyo/RcTE7C23rW4=
 github.com/cs3org/go-cs3apis v0.0.0-20200728114537-4efa23660dbe/go.mod h1:UXha4TguuB52H14EMoSsCqDj7k8a/t7g4gVP+bgY5LY=
+github.com/cs3org/go-cs3apis v0.0.0-20200730121022-c4f3d4f7ddfd h1:uMaudkC7znaiIKT9rxIhoRYzrhTg1Nc78X7XEqhmjSk=
+github.com/cs3org/go-cs3apis v0.0.0-20200730121022-c4f3d4f7ddfd/go.mod h1:UXha4TguuB52H14EMoSsCqDj7k8a/t7g4gVP+bgY5LY=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -21,12 +21,14 @@ package logger
 import (
 	"io"
 	"os"
+	"time"
 
 	"github.com/rs/zerolog"
 )
 
 func init() {
 	zerolog.CallerSkipFrameCount = 2
+	zerolog.TimeFieldFormat = time.RFC3339Nano
 }
 
 // Mode changes the logging format.
@@ -64,7 +66,7 @@ func WithLevel(lvl string) Option {
 func WithWriter(w io.Writer, m Mode) Option {
 	return func(l *zerolog.Logger) {
 		if m == ConsoleMode {
-			*l = l.Output(zerolog.ConsoleWriter{Out: w})
+			*l = l.Output(zerolog.ConsoleWriter{Out: w, TimeFormat: "2006-01-02 15:04:05.999"})
 		} else {
 			*l = l.Output(w)
 		}


### PR DESCRIPTION
@labkode this probably won't break log-parsing in ocis as it overrides the format, but it'd good to confirm once.