### PR TITLE
[Tests-Only] Bump core commit for tests and avoid preview-extension-required scenarios

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -343,7 +343,7 @@ steps:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
       - cd /drone/src/tmp/testrunner
-      - git checkout 9ebf886779b98fc3f78e11cf138246f80d5cab39
+      - git checkout e3aba53ada536915cd0e1bdbf33527d9970a13d3
       - make test-acceptance-api
     environment:
       TEST_SERVER_URL: 'http://revad-services:20080'
@@ -353,7 +353,7 @@ steps:
       REVA_LDAP_HOSTNAME: 'ldap'
       TEST_OCIS: 'true'
       TEST_REVA: 'true'
-      BEHAT_FILTER_TAGS: '~@skipOnOcis&&~@skipOnOcis-OC-Storage'
+      BEHAT_FILTER_TAGS: '~@skipOnOcis&&~@skipOnOcis-OC-Storage&&~@preview-extension-required'
 
 services:
   - 'name': 'ldap'

--- a/.drone.yml
+++ b/.drone.yml
@@ -343,7 +343,7 @@ steps:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
       - cd /drone/src/tmp/testrunner
-      - git checkout e3aba53ada536915cd0e1bdbf33527d9970a13d3
+      - git checkout 03c68e17ebab61da2ebb0a9f541a6cffac0908ac
       - make test-acceptance-api
     environment:
       TEST_SERVER_URL: 'http://revad-services:20080'


### PR DESCRIPTION
core PR https://github.com/owncloud/core/pull/37777 was merged. It adds a tag `preview-extension-required` to tag test scenarios for previews.

1) Bump the core commit id to the latest commit.
2) Adjust the oC10APIAcceptanceTests step so that it does not run scenarios with the `preview-extension-required` tag


Previews are not implemented yet, and the implementation detail remains to be sorted out, so do not accidentally run any of those test scenarios.

Note: similar in ocis-reva is https://github.com/owncloud/ocis-reva/pull/426 https://github.com/owncloud/ocis-reva/pull/428