### PR TITLE
[Tests-Only] Run local integration tests in a separate pipeline

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -308,7 +308,7 @@ steps:
 ---
 kind: pipeline
 type: docker
-name: owncloud-integration-tests
+name: local-integration-tests
 
 platform:
   os: linux
@@ -361,6 +361,65 @@ steps:
       TEST_REVA: 'true'
       BEHAT_FILTER_TAGS: '~@skipOnOcis-OC-Storage'
       PATH_TO_CORE: '/drone/src/tmp/testrunner'
+
+services:
+  - 'name': 'ldap'
+    'image': 'osixia/openldap:1.3.0'
+    'pull': 'always'
+    'environment':
+      LDAP_DOMAIN: 'owncloud.com'
+      LDAP_ORGANISATION: 'ownCloud'
+      LDAP_ADMIN_PASSWORD: 'admin'
+      LDAP_TLS_VERIFY_CLIENT: 'never'
+      HOSTNAME: 'ldap'
+
+  - name: redis
+    image: webhippie/redis
+    'pull': 'always'
+    'environment':
+      REDIS_DATABASES: 1
+
+---
+kind: pipeline
+type: docker
+name: owncloud-integration-tests
+
+platform:
+  os: linux
+  arch: amd64
+
+trigger:
+  event:
+    include:
+      - pull_request
+      - tag
+
+steps:
+  - name: build
+    image: golang:1.13
+    commands:
+      - make build-ci
+
+  - name: revad-services
+    image: golang:1.13
+    detach: true
+    commands:
+      - cd /drone/src/drone/oc-integration-tests/
+      - /drone/src/cmd/revad/revad -c frontend.toml &
+      - /drone/src/cmd/revad/revad -c gateway.toml &
+      - /drone/src/cmd/revad/revad -c shares.toml &
+      - /drone/src/cmd/revad/revad -c storage-home.toml &
+      - /drone/src/cmd/revad/revad -c storage-oc.toml &
+      - /drone/src/cmd/revad/revad -c storage-publiclink.toml &
+      - /drone/src/cmd/revad/revad -c ldap-users.toml
+
+  - name: clone-oC10-test-repos
+    image: owncloudci/php:7.2
+    commands:
+      - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
+      - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
+      - cd /drone/src/tmp/testrunner
+      - git checkout 33c64ea3d56ec20e5d0cbc0f745ed2c04589b7f8
 
   - name: oC10APIAcceptanceTests
     image: owncloudci/php:7.2

--- a/tests/acceptance/expected-failures-on-EOS-storage.txt
+++ b/tests/acceptance/expected-failures-on-EOS-storage.txt
@@ -186,10 +186,6 @@ apiShareManagementBasic/deleteShare.feature:36
 apiShareManagementBasic/deleteShare.feature:37
 #
 # https://github.com/owncloud/ocis-reva/issues/260 Sharee retrieves the information about a share -but gets response containing all the shares
-apiShareOperations/accessToShare.feature:20
-apiShareOperations/accessToShare.feature:21
-apiShareOperations/accessToShare.feature:34
-apiShareOperations/accessToShare.feature:35
 apiShareOperations/accessToShare.feature:48
 apiShareOperations/accessToShare.feature:49
 #

--- a/tests/acceptance/expected-failures-on-OC-storage.txt
+++ b/tests/acceptance/expected-failures-on-OC-storage.txt
@@ -184,10 +184,6 @@ apiShareManagementBasic/deleteShare.feature:36
 apiShareManagementBasic/deleteShare.feature:37
 #
 # https://github.com/owncloud/ocis-reva/issues/260 Sharee retrieves the information about a share -but gets response containing all the shares
-apiShareOperations/accessToShare.feature:20
-apiShareOperations/accessToShare.feature:21
-apiShareOperations/accessToShare.feature:34
-apiShareOperations/accessToShare.feature:35
 apiShareOperations/accessToShare.feature:48
 apiShareOperations/accessToShare.feature:49
 #


### PR DESCRIPTION
Part of issue #1081 

This is the simple copy-paste edit of `.drone.yml` to run both a local and owncloud integration tests pipeline.

Benefits:
1) get a separate pass/fail result and log for each set of tests
2) a bit less elapsed time 

Note: when the oC10 core tests are run on their own (in a separate pipeline, so the local integration tests have not been run first) then these tests are passing:
```
apiShareOperations/accessToShare.feature:20
apiShareOperations/accessToShare.feature:21
apiShareOperations/accessToShare.feature:34
apiShareOperations/accessToShare.feature:35
```

So there is some side-effect left behind by the local integration tests that was causing those `accessToShare` tests to fail. That needs investigation - issue #1085 and https://github.com/owncloud/ocis-reva/issues/438

But that is an existing issue that happens the same in `owncloud/ocis-reva` so IMO this PR can still move forward.