### PR TITLE
[Tests-Only] Fix .drone.yml merge issue from PRs 1073 and 1084

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -404,7 +404,7 @@ steps:
     image: golang:1.13
     detach: true
     commands:
-      - cd /drone/src/drone/oc-integration-tests/
+      - cd /drone/src/tests/oc-integration-tests/drone/
       - /drone/src/cmd/revad/revad -c frontend.toml &
       - /drone/src/cmd/revad/revad -c gateway.toml &
       - /drone/src/cmd/revad/revad -c shares.toml &


### PR DESCRIPTION
PR #1073 changed a folder path in the CI steps
`cd /drone/src/tests/oc-integration-tests/drone/`

PR #1084 made an extra pipeline. GitHub merge was not able to notice that the folder path in the new pipeline also needed to be updated.

Both PRs had been in existence for a while. And CI passes on each one independently, but not together.

So CI is currently failing:
https://cloud.drone.io/cs3org/reva/2345/5/5
```
/bin/sh: 18: cd: can't cd to /drone/src/drone/oc-integration-tests/
```

This fixes it.