### PR TITLE
ocdav: handle redirection prefixes when extracting destination from URL

### DIFF
--- a/changelog/unreleased/eosfs-recycle-purge.md
+++ b/changelog/unreleased/eosfs-recycle-purge.md
@@ -1,6 +1,5 @@
 Bugfix: do not restore recycle entry on purge
 
-
 This PR fixes a bug in the EOSFS driver that was restoring a deleted entry
 when asking for its permanent purge.
 EOS does not have the functionality to purge individual files, but the whole recycle of the user.

--- a/changelog/unreleased/webdav-move-prefix.md
+++ b/changelog/unreleased/webdav-move-prefix.md
@@ -1,0 +1,8 @@
+Bugfix: Handle redirection prefixes when extracting destination from URL
+
+The move function handler in ocdav extracts the destination path from the URL by
+removing the base URL prefix from the URL path. This would fail in case there is
+a redirection prefix. This PR takes care of that and it also allows zero-size
+uploads for localfs.
+
+https://github.com/cs3org/reva/pull/1111

--- a/cmd/reva/ocm-share-create.go
+++ b/cmd/reva/ocm-share-create.go
@@ -117,8 +117,6 @@ func ocmShareCreateCommand() *command {
 			},
 		}
 
-		fmt.Println("res.Info.Path" + res.Info.Path)
-
 		opaqueObj := &types.Opaque{
 			Map: map[string]*types.OpaqueEntry{
 				"permissions": &types.OpaqueEntry{

--- a/internal/http/services/owncloud/ocdav/copy.go
+++ b/internal/http/services/owncloud/ocdav/copy.go
@@ -123,8 +123,14 @@ func (s *svc) handleCopy(w http.ResponseWriter, r *http.Request, ns string) {
 	}
 
 	// TODO check if path is on same storage, return 502 on problems, see https://tools.ietf.org/html/rfc4918#section-9.9.4
+	// The base URI might contain redirection prefixes which need to be handled
+	urlSplit := strings.Split(urlPath, baseURI)
+	if len(urlSplit) != 2 {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
 	// prefix to namespace
-	dst := path.Join(ns, urlPath[len(baseURI):])
+	dst := path.Join(ns, urlSplit[1])
 
 	// check dst exists
 	ref = &provider.Reference{

--- a/internal/http/services/owncloud/ocdav/move.go
+++ b/internal/http/services/owncloud/ocdav/move.go
@@ -103,8 +103,14 @@ func (s *svc) handleMove(w http.ResponseWriter, r *http.Request, ns string) {
 	}
 
 	// TODO check if path is on same storage, return 502 on problems, see https://tools.ietf.org/html/rfc4918#section-9.9.4
+	// The base URI might contain redirection prefixes which need to be handled
+	urlSplit := strings.Split(urlPath, baseURI)
+	if len(urlSplit) != 2 {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
 	// prefix to namespace
-	dst := path.Join(ns, urlPath[len(baseURI):])
+	dst := path.Join(ns, urlSplit[1])
 
 	// check dst exists
 	dstStatRef := &provider.Reference{

--- a/internal/http/services/owncloud/ocdav/trashbin.go
+++ b/internal/http/services/owncloud/ocdav/trashbin.go
@@ -96,44 +96,22 @@ func (h *TrashbinHandler) Handler(s *svc) http.Handler {
 			return
 		}
 		if key != "" && r.Method == "MOVE" {
-			dstHeader := r.Header.Get("Destination")
-
-			log.Debug().Str("key", key).Str("dst", dstHeader).Msg("restore")
-
-			if dstHeader == "" {
-				w.WriteHeader(http.StatusBadRequest)
-				return
-			}
-			// strip baseURL from destination
-			dstURL, err := url.ParseRequestURI(dstHeader)
-			if err != nil {
-				w.WriteHeader(http.StatusBadRequest)
-				return
-			}
-
-			urlPath := dstURL.Path
-
 			// find path in url relative to trash base
 			trashBase := ctx.Value(ctxKeyBaseURI).(string)
 			baseURI := path.Join(path.Dir(trashBase), "files", userid)
 			ctx = context.WithValue(ctx, ctxKeyBaseURI, baseURI)
 			r = r.WithContext(ctx)
 
-			log.Debug().Str("url_path", urlPath).Str("base_uri", baseURI).Msg("move urls")
 			// TODO make request.php optional in destination header
-			i := strings.Index(urlPath, baseURI)
-			if i == -1 {
+			dstHeader := r.Header.Get("Destination")
+			dst, err := extractDestination(dstHeader, baseURI)
+			if err != nil {
 				w.WriteHeader(http.StatusBadRequest)
 				return
 			}
+			dst = path.Clean(dst)
 
-			urlSplit := strings.Split(urlPath, baseURI)
-			if len(urlSplit) != 2 {
-				w.WriteHeader(http.StatusBadRequest)
-				return
-			}
-
-			dst := path.Clean(urlSplit[1])
+			log.Debug().Str("key", key).Str("dst", dst).Msg("restore")
 
 			h.restore(w, r, s, u, dst, key)
 			return

--- a/internal/http/services/owncloud/ocdav/trashbin.go
+++ b/internal/http/services/owncloud/ocdav/trashbin.go
@@ -126,7 +126,14 @@ func (h *TrashbinHandler) Handler(s *svc) http.Handler {
 				w.WriteHeader(http.StatusBadRequest)
 				return
 			}
-			dst := path.Clean(urlPath[len(baseURI):])
+
+			urlSplit := strings.Split(urlPath, baseURI)
+			if len(urlSplit) != 2 {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+
+			dst := path.Clean(urlSplit[1])
 
 			h.restore(w, r, s, u, dst, key)
 			return

--- a/pkg/user/manager/rest/rest.go
+++ b/pkg/user/manager/rest/rest.go
@@ -235,6 +235,10 @@ func (m *manager) getUserByParam(ctx context.Context, param, val string) (map[st
 	if err != nil {
 		return nil, err
 	}
+	if len(responseData) == 0 {
+		return nil, errors.New("rest: no user found")
+	}
+
 	userData, ok := responseData[0].(map[string]interface{})
 	if !ok {
 		return nil, errors.New("rest: error in type assertion")


### PR DESCRIPTION
The move, copy and trashbin function handler in ocdav extract the destination path from the URL by removing the base URL prefix from the URL path. This would fail in case there is a redirection prefix. This PR takes care of that.

It also allows zero-size uploads for localfs; closes #1104 
