### PR TITLE
[owncloud] propagate mtime on RemoveGrant

### DIFF
--- a/changelog/unreleased/propagate-mtime-on-remove-grant.md
+++ b/changelog/unreleased/propagate-mtime-on-remove-grant.md
@@ -1,0 +1,5 @@
+Bugfix: owncloud driver - propagate mtime on RemoveGrant
+
+When removing a grant the mtime change also needs to be propagated. Only affectsn the owncluod storage driver.
+
+https://github.com/cs3org/reva/pull/1115

--- a/pkg/storage/fs/owncloud/owncloud.go
+++ b/pkg/storage/fs/owncloud/owncloud.go
@@ -1081,7 +1081,11 @@ func (fs *ocfs) RemoveGrant(ctx context.Context, ref *provider.Reference, g *pro
 		attr = sharePrefix + "u:" + g.Grantee.Id.OpaqueId
 	}
 
-	return xattr.Remove(np, attr)
+	if err = xattr.Remove(np, attr); err != nil {
+		return
+	}
+
+	return fs.propagate(ctx, np)
 }
 
 func (fs *ocfs) UpdateGrant(ctx context.Context, ref *provider.Reference, g *provider.Grant) error {


### PR DESCRIPTION
When removing a grant the mtime change also needs to be propagated. Only affectsn the owncluod storage driver.