### PR TITLE
Rewire dav files endpoint to home

### DIFF
--- a/changelog/unreleased/ocdav-dav-files-to-home.md
+++ b/changelog/unreleased/ocdav-dav-files-to-home.md
@@ -1,0 +1,8 @@
+Enhancement: Rewire dav files to the home storage
+
+If the user specified in the dav files URL matches the current one,
+rewire it to use the webDavHandler which is wired to the home storage.
+
+This fixes path mapping issues.
+
+https://github.com/cs3org/reva/pull/1120

--- a/internal/http/services/owncloud/ocdav/ocdav.go
+++ b/internal/http/services/owncloud/ocdav/ocdav.go
@@ -181,13 +181,13 @@ func (s *svc) Handler() http.Handler {
 			parts := strings.SplitN(strings.Trim(r.URL.Path, "/"), "/", 3)
 			log.Debug().Interface("pathParts", parts).Msg("Checking user from path")
 			if len(parts) >= 2 && parts[0] == "files" && parts[1] != "" {
-				requestUrlUserID := parts[1]
+				requestURLUserID := parts[1]
 				contextUser := ctxuser.ContextMustGetUser(ctx)
 				log.Debug().Str("contextUserId", contextUser.Id.OpaqueId).
-					Str("requestUrlUserId", requestUrlUserID).
+					Str("requestUrlUserId", requestURLUserID).
 					Msg("Checking user from URL")
 
-				if contextUser.Id.OpaqueId == requestUrlUserID {
+				if contextUser.Id.OpaqueId == requestURLUserID {
 					if len(parts) > 2 {
 						r.URL.Path = parts[2]
 					} else {


### PR DESCRIPTION
If the user specified in the dav files URL matches the current one,
rewire it to use the webDavHandler which is wired to the home storage.

This fixes path mapping issues.

- [x] add changelog
- [ ] EOS
   - [ ] test regular file operations on dav files
   - [ ] test upload on dav files => :boom: 
   - [ ] test file ops on a received share
   - [ ] test upload on a received share
- [ ] OC storage
   - [ ] test regular file operations on dav files
   - [ ] test upload on dav files
   - [ ] test file ops on a received share
   - [ ] test upload on a received share
- [ ] BUG: litmus issue with OPTIONS on new dav:
```
 2. options............... FAIL (OPTIONS on base collection `/remote.php/dav/files/4c510ada-c86b-4815-8820-42cdf82c3d51/litmus/': Could not read status line: connection was closed by server)
```
- [ ] fix base path for PROPFIND response on new dav

@butonic FYI