### PR TITLE
[Tests-Only] Add api trashbin tests

### DIFF
--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -26,6 +26,7 @@ default:
         - FavoritesContext:
         - FilesVersionsContext:
         - PublicWebDavContext:
+        - TrashbinContext:
         - WebDavPropertiesContext:
 
   extensions:

--- a/tests/acceptance/expected-failures-on-OC-storage.txt
+++ b/tests/acceptance/expected-failures-on-OC-storage.txt
@@ -468,6 +468,8 @@ apiSharePublicLink2/uploadToPublicLinkShare.feature:255
 # https://github.com/owncloud/ocis-reva/issues/286 Upload-only shares must not overwrite but create a separate file
 apiSharePublicLink2/uploadToPublicLinkShare.feature:273
 #
+# https://github.com/owncloud/product/issues/179 Propfind to trashbin endpoint requires UUID
+# https://github.com/owncloud/product/issues/178 File deletion using dav gives unique string in filename in the trashbin
 apiTrashbin/trashbinDelete.feature:31
 apiTrashbin/trashbinDelete.feature:32
 apiTrashbin/trashbinDelete.feature:33
@@ -476,6 +478,8 @@ apiTrashbin/trashbinDelete.feature:37
 apiTrashbin/trashbinDelete.feature:50
 apiTrashbin/trashbinDelete.feature:67
 #
+# https://github.com/owncloud/product/issues/179 Propfind to trashbin endpoint requires UUID
+# https://github.com/owncloud/product/issues/178 File deletion using dav gives unique string in filename in the trashbin
 apiTrashbin/trashbinFilesFolders.feature:44
 apiTrashbin/trashbinFilesFolders.feature:45
 apiTrashbin/trashbinFilesFolders.feature:60
@@ -497,6 +501,8 @@ apiTrashbin/trashbinFilesFolders.feature:242
 apiTrashbin/trashbinFilesFolders.feature:255
 apiTrashbin/trashbinFilesFolders.feature:256
 #
+# https://github.com/owncloud/product/issues/179 Propfind to trashbin endpoint requires UUID
+# https://github.com/owncloud/product/issues/178 File deletion using dav gives unique string in filename in the trashbin
 apiTrashbin/trashbinRestore.feature:31
 apiTrashbin/trashbinRestore.feature:32
 apiTrashbin/trashbinRestore.feature:62

--- a/tests/acceptance/features/apiOcisSpecific/apiTrashbin-trashbinDelete.feature
+++ b/tests/acceptance/features/apiOcisSpecific/apiTrashbin-trashbinDelete.feature
@@ -1,0 +1,52 @@
+@api @files_trashbin-app-required
+Feature: files and folders can be deleted from the trashbin
+  As a user
+  I want to delete files and folders from the trashbin
+  So that I can control my trashbin space and which files are kept in that space
+
+  Background:
+    Given user "Alice" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file with content "to delete" to "/textfile0.txt"
+    And user "Alice" has uploaded file with content "to delete" to "/textfile1.txt"
+    And user "Alice" has created folder "PARENT"
+    And user "Alice" has created folder "PARENT/CHILD"
+    And user "Alice" has uploaded file with content "to delete" to "/PARENT/parent.txt"
+    And user "Alice" has uploaded file with content "to delete" to "/PARENT/CHILD/child.txt"
+
+  @smokeTest
+  @issue-product-139
+  @issue-product-178
+  @issue-product-179
+  Scenario Outline: Trashbin cannot be emptied
+  # after fixing all issues delete this Scenario and use the one from oC10 core
+  # because of @issue-product-178 we cannot perform this test using new dav, so only old dav is being used
+    Given user "Alice" has uploaded file with content "file with comma" to "sample,0.txt"
+    And user "Alice" has uploaded file with content "file with comma" to "sample,1.txt"
+    And using old DAV path
+    And user "Alice" has deleted file "<filename1>"
+    And user "Alice" has deleted file "<filename2>"
+    And as "Alice" file "<filename1>" should exist in the trashbin
+    And as "Alice" file "<filename2>" should exist in the trashbin
+    When user "Alice" empties the trashbin using the trashbin API
+    Then as "Alice" the file with original path "<filename1>" should exist in the trashbin
+    And as "Alice" the file with original path "<filename2>" should exist in the trashbin
+    Examples:
+      | filename1     | filename2     |
+      | textfile0.txt | textfile1.txt |
+      | sample,0.txt  | sample,1.txt  |
+
+  @smokeTest
+  @issue-ocis-reva-118
+  @issue-product-179
+  # after fixing all issues delete this Scenario and use the one from oC10 core
+  Scenario: delete a single file from the trashbin
+    Given user "Alice" has deleted file "/textfile0.txt"
+    And user "Alice" has deleted file "/textfile1.txt"
+    And user "Alice" has deleted file "/PARENT/parent.txt"
+    And user "Alice" has deleted file "/PARENT/CHILD/child.txt"
+    When user "Alice" deletes the file with original path "textfile1.txt" from the trashbin using the trashbin API
+    Then the HTTP status code should be "405"
+    And as "Alice" the file with original path "/textfile1.txt" should exist in the trashbin
+    But as "Alice" the file with original path "/textfile0.txt" should exist in the trashbin
+    And as "Alice" the file with original path "/PARENT/parent.txt" should exist in the trashbin
+    And as "Alice" the file with original path "/PARENT/CHILD/child.txt" should exist in the trashbin

--- a/tests/acceptance/features/apiOcisSpecific/apiTrashbin-trashbinDelete.feature
+++ b/tests/acceptance/features/apiOcisSpecific/apiTrashbin-trashbinDelete.feature
@@ -19,10 +19,9 @@ Feature: files and folders can be deleted from the trashbin
   @issue-product-179
   Scenario Outline: Trashbin cannot be emptied
   # after fixing all issues delete this Scenario and use the one from oC10 core
-  # because of @issue-product-178 we cannot perform this test using new dav, so only old dav is being used
     Given user "Alice" has uploaded file with content "file with comma" to "sample,0.txt"
     And user "Alice" has uploaded file with content "file with comma" to "sample,1.txt"
-    And using old DAV path
+    And using <dav-path> DAV path
     And user "Alice" has deleted file "<filename1>"
     And user "Alice" has deleted file "<filename2>"
     And as "Alice" file "<filename1>" should exist in the trashbin
@@ -31,9 +30,11 @@ Feature: files and folders can be deleted from the trashbin
     Then as "Alice" the file with original path "<filename1>" should exist in the trashbin
     And as "Alice" the file with original path "<filename2>" should exist in the trashbin
     Examples:
-      | filename1     | filename2     |
-      | textfile0.txt | textfile1.txt |
-      | sample,0.txt  | sample,1.txt  |
+      | dav-path | filename1     | filename2     |
+      | old      | textfile0.txt | textfile1.txt |
+      | old      | sample,0.txt  | sample,1.txt  |
+      | new      | textfile0.txt | textfile1.txt |
+      | new      | sample,0.txt  | sample,1.txt  |
 
   @smokeTest
   @issue-ocis-reva-118

--- a/tests/acceptance/features/apiOcisSpecific/apiTrashbin-trashbinFilesFolders.feature
+++ b/tests/acceptance/features/apiOcisSpecific/apiTrashbin-trashbinFilesFolders.feature
@@ -16,8 +16,7 @@ Feature: files and folders exist in the trashbin after being deleted
     And using new DAV path
     When user "Alice" deletes file "/textfile1.txt" using the WebDAV API
     Then as "Alice" the file with original path "/textfile0.txt" should exist in the trashbin
-    But as "Alice" the file with original path "/textfile1.txt" should not exist in the trashbin
-    And as "Alice" the file with original path "Alice/textfile1.txt" should exist in the trashbin
+    And as "Alice" the file with original path "/textfile1.txt" should exist in the trashbin
     And as "Alice" file "/textfile0.txt" should not exist
     And as "Alice" file "/textfile1.txt" should not exist
 
@@ -32,7 +31,6 @@ Feature: files and folders exist in the trashbin after being deleted
     And using new DAV path
     When user "Alice" deletes folder "/tmp2" using the WebDAV API
     Then as "Alice" the folder with original path "/tmp1" should exist in the trashbin
-    But as "Alice" the folder with original path "/tmp2" should not exist in the trashbin
-    And as "Alice" the folder with original path "Alice/tmp2" should exist in the trashbin
+    And as "Alice" the folder with original path "/tmp2" should exist in the trashbin
     And as "Alice" folder "/tmp1" should not exist
     And as "Alice" folder "/tmp2" should not exist

--- a/tests/acceptance/features/apiOcisSpecific/apiTrashbin-trashbinFilesFolders.feature
+++ b/tests/acceptance/features/apiOcisSpecific/apiTrashbin-trashbinFilesFolders.feature
@@ -1,0 +1,38 @@
+@api @files_trashbin-app-required
+Feature: files and folders exist in the trashbin after being deleted
+  As a user
+  I want deleted files and folders to be available in the trashbin
+  So that I can recover data easily
+
+  Background:
+    Given user "Alice" has been created with default attributes and skeleton files
+
+  @smokeTest
+  @issue-product-178
+  # after fixing all issues delete this Scenario and use the one from oC10 core
+  Scenario: deleting a file moves it to trashbin
+    Given using old DAV path
+    When user "Alice" deletes file "/textfile0.txt" using the WebDAV API
+    And using new DAV path
+    When user "Alice" deletes file "/textfile1.txt" using the WebDAV API
+    Then as "Alice" the file with original path "/textfile0.txt" should exist in the trashbin
+    But as "Alice" the file with original path "/textfile1.txt" should not exist in the trashbin
+    And as "Alice" the file with original path "Alice/textfile1.txt" should exist in the trashbin
+    And as "Alice" file "/textfile0.txt" should not exist
+    And as "Alice" file "/textfile1.txt" should not exist
+
+  @smokeTest
+  @issue-product-178
+  # after fixing all issues delete this Scenario and use the one from oC10 core
+  Scenario: deleting a folder moves it to trashbin
+    Given user "Alice" has created folder "/tmp1"
+    And user "Alice" has created folder "/tmp2"
+    And using old DAV path
+    When user "Alice" deletes folder "/tmp1" using the WebDAV API
+    And using new DAV path
+    When user "Alice" deletes folder "/tmp2" using the WebDAV API
+    Then as "Alice" the folder with original path "/tmp1" should exist in the trashbin
+    But as "Alice" the folder with original path "/tmp2" should not exist in the trashbin
+    And as "Alice" the folder with original path "Alice/tmp2" should exist in the trashbin
+    And as "Alice" folder "/tmp1" should not exist
+    And as "Alice" folder "/tmp2" should not exist


### PR DESCRIPTION
### Description
This PR adds `apiTrashbin` bug verification scenarios.

The same as PR https://github.com/owncloud/ocis/pull/489 and PR https://github.com/owncloud/ocis-reva/pull/453

This enables future developers to be able to see the behavior in tests while they are understanding and fixing.