### PR TITLE
[Tests-Only] Bump oC10 test commit id

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -345,7 +345,7 @@ steps:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
       - cd /drone/src/tmp/testrunner
-      - git checkout a992db8cfb9a4368b1e3368cd96bdc7513faac2e
+      - git checkout 7b6a4cf6dab990d1624042589d22e348e027b74b
 
   - name: localAPIAcceptanceTestsOcStorage
     image: owncloudci/php:7.2
@@ -419,7 +419,7 @@ steps:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
       - cd /drone/src/tmp/testrunner
-      - git checkout a992db8cfb9a4368b1e3368cd96bdc7513faac2e
+      - git checkout 7b6a4cf6dab990d1624042589d22e348e027b74b
 
   - name: oC10APIAcceptanceTests
     image: owncloudci/php:7.2


### PR DESCRIPTION
Includes core test changes:
https://github.com/owncloud/core/pull/37849 [Tests-Only] remove UI tests from expected failures if rerun is successful
https://github.com/owncloud/core/pull/37847 [Tests-Only] Improve header response checks in theHeaderChecksumShoudMatch
https://github.com/owncloud/core/pull/37851[Tests-Only] Fix theseUsersHaveBeenCreatedUsingTheOccCommand so it works with mixed-case usernames
https://github.com/owncloud/core/pull/37855 [Tests-Only] Process unexpected Behat exit status in acceptance tests
https://github.com/owncloud/core/pull/37852 [Tests-Only] Reporting expected failures when running a single feature