### PR TITLE
Use updated cato to display nested package config in parent docs

### DIFF
--- a/changelog/unreleased/cato-nested-packages.md
+++ b/changelog/unreleased/cato-nested-packages.md
@@ -1,0 +1,7 @@
+Enhancement: Use updated cato to display nested package config in parent docs
+
+Previously, in case of nested packages, we just had a link pointing to the child
+package. Now we copy the nested package's documentation to the parent itself to
+make it easier for devs.
+
+https://github.com/cs3org/reva/pull/1131

--- a/docs/content/en/docs/config/grpc/services/storageprovider/_index.md
+++ b/docs/content/en/docs/config/grpc/services/storageprovider/_index.md
@@ -32,11 +32,11 @@ driver = "localhome"
 {{< /highlight >}}
 {{% /dir %}}
 
-{{% dir name="drivers" type="map[string]map[string]interface{}" default="docs/config/packages/storage/fs" %}}
+{{% dir name="drivers" type="map[string]map[string]interface{}" default="pkg/storage/fs/localhome/localhome.go" %}}
  [[Ref]](https://github.com/cs3org/reva/tree/master/internal/grpc/services/storageprovider/storageprovider.go#L54)
 {{< highlight toml >}}
 [grpc.services.storageprovider.drivers]
-"[docs/config/packages/storage/fs]({{< ref "docs/config/packages/storage/fs" >}})"
+"[pkg/storage/fs/localhome/localhome.go]({{< ref "pkg/storage/fs/localhome/localhome.go" >}})"
 {{< /highlight >}}
 {{% /dir %}}
 

--- a/docs/content/en/docs/config/grpc/services/storageprovider/_index.md
+++ b/docs/content/en/docs/config/grpc/services/storageprovider/_index.md
@@ -32,11 +32,14 @@ driver = "localhome"
 {{< /highlight >}}
 {{% /dir %}}
 
-{{% dir name="drivers" type="map[string]map[string]interface{}" default="pkg/storage/fs/localhome/localhome.go" %}}
+{{% dir name="drivers" type="map[string]map[string]interface{}" default="localhome" %}}
  [[Ref]](https://github.com/cs3org/reva/tree/master/internal/grpc/services/storageprovider/storageprovider.go#L54)
 {{< highlight toml >}}
-[grpc.services.storageprovider.drivers]
-"[pkg/storage/fs/localhome/localhome.go]({{< ref "pkg/storage/fs/localhome/localhome.go" >}})"
+[grpc.services.storageprovider.drivers.localhome]
+root = "/var/tmp/reva/"
+share_folder = "/MyShares"
+user_layout = "{{.Username}}"
+
 {{< /highlight >}}
 {{% /dir %}}
 

--- a/docs/content/en/docs/config/http/services/dataprovider/_index.md
+++ b/docs/content/en/docs/config/http/services/dataprovider/_index.md
@@ -24,11 +24,11 @@ driver = "localhome"
 {{< /highlight >}}
 {{% /dir %}}
 
-{{% dir name="drivers" type="map[string]map[string]interface{}" default="docs/config/packages/storage/fs" %}}
+{{% dir name="drivers" type="map[string]map[string]interface{}" default="pkg/storage/fs/localhome/localhome.go" %}}
 The configuration for the storage driver [[Ref]](https://github.com/cs3org/reva/tree/master/internal/http/services/dataprovider/dataprovider.go#L41)
 {{< highlight toml >}}
 [http.services.dataprovider.drivers]
-"[docs/config/packages/storage/fs]({{< ref "docs/config/packages/storage/fs" >}})"
+"[pkg/storage/fs/localhome/localhome.go]({{< ref "pkg/storage/fs/localhome/localhome.go" >}})"
 {{< /highlight >}}
 {{% /dir %}}
 

--- a/docs/content/en/docs/config/http/services/dataprovider/_index.md
+++ b/docs/content/en/docs/config/http/services/dataprovider/_index.md
@@ -24,11 +24,14 @@ driver = "localhome"
 {{< /highlight >}}
 {{% /dir %}}
 
-{{% dir name="drivers" type="map[string]map[string]interface{}" default="pkg/storage/fs/localhome/localhome.go" %}}
+{{% dir name="drivers" type="map[string]map[string]interface{}" default="localhome" %}}
 The configuration for the storage driver [[Ref]](https://github.com/cs3org/reva/tree/master/internal/http/services/dataprovider/dataprovider.go#L41)
 {{< highlight toml >}}
-[http.services.dataprovider.drivers]
-"[pkg/storage/fs/localhome/localhome.go]({{< ref "pkg/storage/fs/localhome/localhome.go" >}})"
+[http.services.dataprovider.drivers.localhome]
+root = "/var/tmp/reva/"
+share_folder = "/MyShares"
+user_layout = "{{.Username}}"
+
 {{< /highlight >}}
 {{% /dir %}}
 

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/c-bata/go-prompt v0.2.3
 	github.com/cheggaaa/pb v1.0.29
 	github.com/coreos/go-oidc v2.2.1+incompatible
-	github.com/cs3org/cato v0.0.0-20200626150132-28a40e643719
+	github.com/cs3org/cato v0.0.0-20200828125504-e418fc54dd5e
 	github.com/cs3org/go-cs3apis v0.0.0-20200810113633-b00aca449666
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/eventials/go-tus v0.0.0-20200718001131-45c7ec8f5d59

--- a/go.sum
+++ b/go.sum
@@ -115,6 +115,8 @@ github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwc
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/cs3org/cato v0.0.0-20200626150132-28a40e643719 h1:3vDKYhsyWSbrtX67i669M7r8p9nQTE3iDl8U9vG11KM=
 github.com/cs3org/cato v0.0.0-20200626150132-28a40e643719/go.mod h1:XJEZ3/EQuI3BXTp/6DUzFr850vlxq11I6satRtz0YQ4=
+github.com/cs3org/cato v0.0.0-20200828125504-e418fc54dd5e h1:tqSPWQeueWTKnJVMJffz4pz0o1WuQxJ28+5x5JgaHD8=
+github.com/cs3org/cato v0.0.0-20200828125504-e418fc54dd5e/go.mod h1:XJEZ3/EQuI3BXTp/6DUzFr850vlxq11I6satRtz0YQ4=
 github.com/cs3org/go-cs3apis v0.0.0-20200728114537-4efa23660dbe h1:CQ/Grq7oVFqwiUg4VA/T+fl3JHZKEyo/RcTE7C23rW4=
 github.com/cs3org/go-cs3apis v0.0.0-20200728114537-4efa23660dbe/go.mod h1:UXha4TguuB52H14EMoSsCqDj7k8a/t7g4gVP+bgY5LY=
 github.com/cs3org/go-cs3apis v0.0.0-20200730121022-c4f3d4f7ddfd h1:uMaudkC7znaiIKT9rxIhoRYzrhTg1Nc78X7XEqhmjSk=

--- a/internal/grpc/services/storageprovider/storageprovider.go
+++ b/internal/grpc/services/storageprovider/storageprovider.go
@@ -51,7 +51,7 @@ type config struct {
 	MountPath        string                            `mapstructure:"mount_path" docs:"/;The path where the file system would be mounted."`
 	MountID          string                            `mapstructure:"mount_id" docs:"-;The ID of the mounted file system."`
 	Driver           string                            `mapstructure:"driver" docs:"localhome;The storage driver to be used."`
-	Drivers          map[string]map[string]interface{} `mapstructure:"drivers" docs:"url:docs/config/packages/storage/fs"`
+	Drivers          map[string]map[string]interface{} `mapstructure:"drivers" docs:"url:pkg/storage/fs/localhome/localhome.go"`
 	TmpFolder        string                            `mapstructure:"tmp_folder" docs:"/var/tmp;Path to temporary folder."`
 	DataServerURL    string                            `mapstructure:"data_server_url" docs:"http://localhost/data;The URL for the data server."`
 	ExposeDataServer bool                              `mapstructure:"expose_data_server" docs:"false;Whether to expose data server."` // if true the client will be able to upload/download directly to it

--- a/internal/http/services/dataprovider/dataprovider.go
+++ b/internal/http/services/dataprovider/dataprovider.go
@@ -38,7 +38,7 @@ func init() {
 type config struct {
 	Prefix     string                            `mapstructure:"prefix" docs:"data;The prefix to be used for this HTTP service"`
 	Driver     string                            `mapstructure:"driver" docs:"localhome;The storage driver to be used."`
-	Drivers    map[string]map[string]interface{} `mapstructure:"drivers" docs:"url:docs/config/packages/storage/fs;The configuration for the storage driver"`
+	Drivers    map[string]map[string]interface{} `mapstructure:"drivers" docs:"url:pkg/storage/fs/localhome/localhome.go;The configuration for the storage driver"`
 	Timeout    int64                             `mapstructure:"timeout"`
 	Insecure   bool                              `mapstructure:"insecure"`
 	DisableTus bool                              `mapstructure:"disable_tus" docs:"false;Whether to disable TUS uploads."`


### PR DESCRIPTION
Now nested configs look like this https://5f49071b89d86b0007317df7--cs3org-reva.netlify.app/docs/config/grpc/services/storageprovider/#drivers