### PR TITLE
[Tests-Only] Bump core commit 20200902

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -434,7 +434,7 @@ steps:
       REVA_LDAP_HOSTNAME: 'ldap'
       TEST_OCIS: 'true'
       TEST_REVA: 'true'
-      BEHAT_FILTER_TAGS: '~@notToImplementOnOCIS&&~@toImplementOnOCIS&&~@preview-extension-required&&~@local_storage'
+      BEHAT_FILTER_TAGS: '~@notToImplementOnOCIS&&~@toImplementOnOCIS&&~@provisioning_api-app-required&&~@preview-extension-required&&~@local_storage'
       EXPECTED_FAILURES_FILE: '/drone/src/tests/acceptance/expected-failures-on-OC-storage.txt'
 
 services:

--- a/.drone.yml
+++ b/.drone.yml
@@ -345,7 +345,7 @@ steps:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
       - cd /drone/src/tmp/testrunner
-      - git checkout 7b6a4cf6dab990d1624042589d22e348e027b74b
+      - git checkout ecd1e3f70d32f89c497ebaa20aaaf139bb4c6a89
 
   - name: localAPIAcceptanceTestsOcStorage
     image: owncloudci/php:7.2
@@ -419,7 +419,7 @@ steps:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
       - cd /drone/src/tmp/testrunner
-      - git checkout 7b6a4cf6dab990d1624042589d22e348e027b74b
+      - git checkout ecd1e3f70d32f89c497ebaa20aaaf139bb4c6a89
 
   - name: oC10APIAcceptanceTests
     image: owncloudci/php:7.2

--- a/tests/acceptance/expected-failures-on-OC-storage.txt
+++ b/tests/acceptance/expected-failures-on-OC-storage.txt
@@ -490,16 +490,16 @@ apiTrashbin/trashbinFilesFolders.feature:104
 apiTrashbin/trashbinFilesFolders.feature:105
 apiTrashbin/trashbinFilesFolders.feature:136
 apiTrashbin/trashbinFilesFolders.feature:137
-apiTrashbin/trashbinFilesFolders.feature:185
-apiTrashbin/trashbinFilesFolders.feature:186
-apiTrashbin/trashbinFilesFolders.feature:203
-apiTrashbin/trashbinFilesFolders.feature:204
-apiTrashbin/trashbinFilesFolders.feature:227
-apiTrashbin/trashbinFilesFolders.feature:228
-apiTrashbin/trashbinFilesFolders.feature:241
-apiTrashbin/trashbinFilesFolders.feature:242
-apiTrashbin/trashbinFilesFolders.feature:255
-apiTrashbin/trashbinFilesFolders.feature:256
+apiTrashbin/trashbinFilesFolders.feature:217
+apiTrashbin/trashbinFilesFolders.feature:218
+apiTrashbin/trashbinFilesFolders.feature:235
+apiTrashbin/trashbinFilesFolders.feature:236
+apiTrashbin/trashbinFilesFolders.feature:259
+apiTrashbin/trashbinFilesFolders.feature:260
+apiTrashbin/trashbinFilesFolders.feature:273
+apiTrashbin/trashbinFilesFolders.feature:274
+apiTrashbin/trashbinFilesFolders.feature:287
+apiTrashbin/trashbinFilesFolders.feature:288
 #
 # https://github.com/owncloud/product/issues/179 Propfind to trashbin endpoint requires UUID
 # https://github.com/owncloud/product/issues/178 File deletion using dav gives unique string in filename in the trashbin


### PR DESCRIPTION
Gets test changes in core API tests:
https://github.com/owncloud/core/pull/37865 [Tests-Only] Improve error reporting for various tests
https://github.com/owncloud/core/pull/37866 [Tests-Only] Enable Provisioning Api Tests for OCIS
https://github.com/owncloud/core/pull/37863 [Tests-Only] Run multiple tests for trashbinFilesFolders
https://github.com/owncloud/core/pull/37868 [Tests-Only] Improve acceptance test error handling
https://github.com/owncloud/core/pull/37871 [Tests-Only] Fix case of tag notToImplementOnOCIS

Note: the core OCS Provisioning API are now enabled by default so that they can run in `owncloud/ocis`. The OCS Provisioning API is not implemented in `cs3org/reva` so the scenarios tagged `@provisioning_api-app-required` are skipped. There is no point running them (and having to add them to expected-failures)