### PR TITLE
Functionality to map home directory to different storage providers

### DIFF
--- a/changelog/unreleased/home-sp-mapping.md
+++ b/changelog/unreleased/home-sp-mapping.md
@@ -1,0 +1,7 @@
+Enhancement: Functionality to map home directory to different storage providers
+
+We hardcode the home path for all users to /home. This forbids redirecting
+requests for different users to multiple storage providers. This PR provides the
+option to map the home directories of different users using user attributes.
+
+https://github.com/cs3org/reva/pull/1142

--- a/internal/grpc/services/gateway/authprovider.go
+++ b/internal/grpc/services/gateway/authprovider.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cs3org/reva/pkg/rgrpc/status"
 	"github.com/cs3org/reva/pkg/rgrpc/todo/pool"
 	tokenpkg "github.com/cs3org/reva/pkg/token"
+	userpkg "github.com/cs3org/reva/pkg/user"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc/metadata"
 )
@@ -108,11 +109,11 @@ func (s *svc) Authenticate(ctx context.Context, req *gateway.AuthenticateRequest
 	// we need to pass the token to authenticate the CreateHome request.
 	// TODO(labkode): appending to existing context will not pass the token.
 	ctx = tokenpkg.ContextSetToken(ctx, token)
+	ctx = userpkg.ContextSetUser(ctx, user)
 	ctx = metadata.AppendToOutgoingContext(ctx, tokenpkg.TokenHeader, token) // TODO(jfd): hardcoded metadata key. use  PerRPCCredentials?
 
 	// create home directory
-	createHomeReq := &storageprovider.CreateHomeRequest{}
-	createHomeRes, err := s.CreateHome(ctx, createHomeReq)
+	createHomeRes, err := s.CreateHome(ctx, &storageprovider.CreateHomeRequest{})
 	if err != nil {
 		log.Err(err).Msg("error calling CreateHome")
 		return &gateway.AuthenticateResponse{

--- a/internal/grpc/services/gateway/gateway.go
+++ b/internal/grpc/services/gateway/gateway.go
@@ -59,6 +59,7 @@ type config struct {
 	TokenManager                  string `mapstructure:"token_manager"`
 	// ShareFolder is the location where to create shares in the recipient's storage provider.
 	ShareFolder   string                            `mapstructure:"share_folder"`
+	HomeMapping   string                            `mapstructure:"home_mapping"`
 	TokenManagers map[string]map[string]interface{} `mapstructure:"token_managers"`
 }
 

--- a/internal/grpc/services/gateway/storageprovider.go
+++ b/internal/grpc/services/gateway/storageprovider.go
@@ -1797,13 +1797,13 @@ func (s *svc) getStorageProviderClient(_ context.Context, p *registry.ProviderIn
 }
 
 func (s *svc) findProvider(ctx context.Context, ref *provider.Reference) (*registry.ProviderInfo, error) {
-	if s.c.HomeMapping != "" {
+	home, err := s.GetHome(ctx, &provider.GetHomeRequest{})
+	if err != nil {
+		return nil, err
+	}
+	if strings.HasPrefix(ref.GetPath(), home.Path) && s.c.HomeMapping != "" {
 		if u, ok := user.ContextGetUser(ctx); ok {
 			layout := templates.WithUser(u, s.c.HomeMapping)
-			home, err := s.GetHome(ctx, &provider.GetHomeRequest{})
-			if err != nil {
-				return nil, err
-			}
 			newRef := &provider.Reference{
 				Spec: &provider.Reference_Path{
 					Path: path.Join(layout, strings.TrimPrefix(ref.GetPath(), home.Path)),

--- a/internal/grpc/services/gateway/usershareprovider.go
+++ b/internal/grpc/services/gateway/usershareprovider.go
@@ -381,10 +381,7 @@ func (s *svc) createReference(ctx context.Context, resourceID *provider.Resource
 		return status.NewInternal(ctx, err, "error updating received share"), nil
 	}
 
-	fileInfo := statRes.Info
-
-	homeReq := &provider.GetHomeRequest{}
-	homeRes, err := s.GetHome(ctx, homeReq)
+	homeRes, err := s.GetHome(ctx, &provider.GetHomeRequest{})
 	if err != nil {
 		err := errors.Wrap(err, "gateway: error calling GetHome")
 		return status.NewInternal(ctx, err, "error updating received share"), nil
@@ -400,7 +397,7 @@ func (s *svc) createReference(ctx context.Context, resourceID *provider.Resource
 	// It is the responsibility of the gateway to resolve these references and merge the response back
 	// from the main request.
 	// TODO(labkode): the name of the share should be the filename it points to by default.
-	refPath := path.Join(homeRes.Path, s.c.ShareFolder, path.Base(fileInfo.Path))
+	refPath := path.Join(homeRes.Path, s.c.ShareFolder, path.Base(statRes.Info.Path))
 	log.Info().Msg("mount path will be:" + refPath)
 
 	createRefReq := &provider.CreateReferenceRequest{

--- a/internal/http/interceptors/auth/auth.go
+++ b/internal/http/interceptors/auth/auth.go
@@ -169,8 +169,7 @@ func New(m map[string]interface{}, unprotected []string) (global.Middleware, err
 						log.Debug().Err(err).Msg("error retrieving credentials")
 					}
 					if creds != nil {
-						log.Debug().Msgf("credentials obtained from credential strategy: %+v", creds)
-
+						log.Debug().Msgf("credentials obtained from credential strategy: type: %s, client_id: %s", creds.Type, creds.ClientID)
 						break
 					}
 				}
@@ -191,7 +190,7 @@ func New(m map[string]interface{}, unprotected []string) (global.Middleware, err
 					ClientSecret: creds.ClientSecret,
 				}
 
-				log.Debug().Msgf("AuthenticateRequest: %+v against %s", req, conf.GatewaySvc)
+				log.Debug().Msgf("AuthenticateRequest: type: %s, client_id: %s against %s", req.Type, req.ClientId, conf.GatewaySvc)
 
 				client, err := pool.GetGatewayServiceClient(conf.GatewaySvc)
 				if err != nil {


### PR DESCRIPTION
We hardcode the home path for all users to /home. This forbids redirecting requests for different users to multiple storage providers. This PR provides the option to map the home directories of different users using user attributes.

For example, with home_mapping set to `/user/{{substr 0 1 .Username}}`, `/home/abc` for einstein could now be redirected to the storage provider corresponding to the rule `/user/e` and for marie, it could be redirected to that referred by the rule `/user/m`.

Also closes #1145 