### PR TITLE
App provider: fallback to env. variable if 'iopsecret' unset

### DIFF
--- a/internal/grpc/services/appprovider/appprovider.go
+++ b/internal/grpc/services/appprovider/appprovider.go
@@ -27,6 +27,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"os"
 	"path"
 	"strconv"
 	"strings"
@@ -184,6 +185,11 @@ func (s *service) OpenFileInAppProvider(ctx context.Context, req *providerpb.Ope
 		q.Add("username", u.Username)
 	}
 	// else defaults to "Anonymous Guest"
+
+	if s.conf.IopSecret == "" {
+		s.conf.IopSecret = os.Getenv("REVA_APPPROVIDER_IOPSECRET")
+	}
+
 	httpReq.Header.Set("Authorization", "Bearer "+s.conf.IopSecret)
 	httpReq.Header.Set("TokenHeader", req.AccessToken)
 


### PR DESCRIPTION
Forgot to open this PR a while back. Giving it a second though, we should review all the parameters in the config that refer to passwords/secrets and provide a fallback to environment variables in case they are not present. 

Thoughts? cc/ @labkode @ishank011 