### PR TITLE
[Tests-Only] sleep after revad start

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -256,6 +256,11 @@ steps:
       - /drone/src/cmd/revad/revad -c storage-oc.toml &
       - /drone/src/cmd/revad/revad -c users.toml
 
+  - name: sleep-for-revad-start
+    image: golang:1.13
+    commands:
+      - sleep 5
+
   - name: litmus-oc-old-webdav
     image: owncloud/litmus:latest
     environment:
@@ -295,6 +300,11 @@ steps:
       - /drone/src/cmd/revad/revad -c storage-home.toml &
       - /drone/src/cmd/revad/revad -c storage-oc.toml &
       - /drone/src/cmd/revad/revad -c users.toml
+
+  - name: sleep-for-revad-start
+    image: golang:1.13
+    commands:
+      - sleep 5
 
   - name: litmus-oc-new-webdav
     image: owncloud/litmus:latest


### PR DESCRIPTION
Sometimes this happens in CI:

https://cloud.drone.io/cs3org/reva/2476/2/4
```
latest: Pulling from owncloud/litmus
Digest: sha256:155d66b7c4324d45a2391702f7857f7e96d79e3d96a2460298b9a4c4867074b5
Status: Image is up to date for owncloud/litmus:latest
-> running `basic':

 0. init.................. 
 0. init.................. FAIL (connection refused by `revad-services' port 20080: Connection refused)
<- summary for `basic': of 1 tests run: 0 passed, 1 failed. 0.0%
See debug.log for network/debug traces.
```

This PR is a "simple hack" to insert a short wait after starting `revad` to give it a proper chance for all its components to be up-and-running. (We could also devise some more fancy logic to loop checking to see evidence that it is properly "up", but is it worth thinking about that?)