### PR TITLE
cache displaynames in ocs

### DIFF
--- a/changelog/unreleased/ocis-cache-displayname.md
+++ b/changelog/unreleased/ocis-cache-displayname.md
@@ -1,0 +1,5 @@
+Bugfix: Cache display names in ocs service
+
+The ocs list shares endpoint may need to fetch the displayname for multiple different users. We are now caching the lookup fo 60 seconds to save redundant RPCs to the users service.
+
+https://github.com/cs3org/reva/pull/1161

--- a/internal/http/services/owncloud/ocs/conversions/main.go
+++ b/internal/http/services/owncloud/ocs/conversions/main.go
@@ -305,30 +305,29 @@ func PublicShare2ShareData(share *link.PublicShare, r *http.Request, publicURL s
 		expiration = ""
 	}
 
-	shareWith := ""
-	if share.PasswordProtected {
-		shareWith = "***redacted***"
+	sd := &ShareData{
+		// share.permissions are mapped below
+		// Displaynames are added later
+		ID:           share.Id.OpaqueId,
+		ShareType:    ShareTypePublicLink,
+		STime:        share.Ctime.Seconds, // TODO CS3 api birth time = btime
+		Token:        share.Token,
+		Expiration:   expiration,
+		MimeType:     share.Mtime.String(),
+		Name:         share.DisplayName,
+		MailSend:     0,
+		URL:          publicURL + path.Join("/", "#/s/"+share.Token),
+		Permissions:  publicSharePermissions2OCSPermissions(share.GetPermissions()),
+		UIDOwner:     LocalUserIDToString(share.Creator),
+		UIDFileOwner: LocalUserIDToString(share.Owner),
 	}
 
-	return &ShareData{
-		// share.permissions ar mapped below
-		// DisplaynameOwner:     creator.DisplayName,
-		// DisplaynameFileOwner: share.GetCreator().String(),
-		ID:                   share.Id.OpaqueId,
-		ShareType:            ShareTypePublicLink,
-		ShareWith:            shareWith,
-		ShareWithDisplayname: shareWith,
-		STime:                share.Ctime.Seconds, // TODO CS3 api birth time = btime
-		Token:                share.Token,
-		Expiration:           expiration,
-		MimeType:             share.Mtime.String(),
-		Name:                 share.DisplayName,
-		MailSend:             0,
-		URL:                  publicURL + path.Join("/", "#/s/"+share.Token),
-		Permissions:          publicSharePermissions2OCSPermissions(share.GetPermissions()),
-		UIDOwner:             LocalUserIDToString(share.Creator),
-		UIDFileOwner:         LocalUserIDToString(share.Owner),
+	if share.PasswordProtected {
+		sd.ShareWith = "***redacted***"
+		sd.ShareWithDisplayname = "***redacted***"
 	}
+
+	return sd
 	// actually clients should be able to GET and cache the user info themselves ...
 	// TODO check grantee type for user vs group
 }

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/ttlmap.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/ttlmap.go
@@ -1,0 +1,77 @@
+// Copyright 2018-2020 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package shares
+
+import (
+	"sync"
+	"time"
+)
+
+// below code copied from https://stackoverflow.com/a/25487392
+type item struct {
+	value      string
+	lastAccess int64
+}
+
+type TTLMap struct {
+	m map[string]*item
+	l sync.Mutex
+}
+
+func New(ln int, maxTTL int) (m *TTLMap) {
+	m = &TTLMap{m: make(map[string]*item, ln)}
+	go func() {
+		for now := range time.Tick(time.Second) {
+			m.l.Lock()
+			for k, v := range m.m {
+				if now.Unix()-v.lastAccess > int64(maxTTL) {
+					delete(m.m, k)
+				}
+			}
+			m.l.Unlock()
+		}
+	}()
+	return
+}
+
+func (m *TTLMap) Len() int {
+	return len(m.m)
+}
+
+func (m *TTLMap) Put(k, v string) {
+	m.l.Lock()
+	it, ok := m.m[k]
+	if !ok {
+		it = &item{value: v}
+		m.m[k] = it
+	}
+	it.lastAccess = time.Now().Unix()
+	m.l.Unlock()
+}
+
+func (m *TTLMap) Get(k string) (v string) {
+	m.l.Lock()
+	if it, ok := m.m[k]; ok {
+		v = it.value
+		it.lastAccess = time.Now().Unix()
+	}
+	m.l.Unlock()
+	return
+
+}

--- a/internal/http/services/owncloud/ocs/response/response.go
+++ b/internal/http/services/owncloud/ocs/response/response.go
@@ -26,7 +26,6 @@ import (
 	"net/http"
 	"reflect"
 
-	user "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	"github.com/cs3org/reva/pkg/appctx"
 )
 
@@ -181,14 +180,6 @@ func WriteOCSResponse(w http.ResponseWriter, r *http.Request, res Response, err 
 		appctx.GetLogger(r.Context()).Error().Err(err).Msg("error writing ocs response")
 		w.WriteHeader(http.StatusInternalServerError)
 	}
-}
-
-// UserIDToString returns a userid string with an optional idp separated by @: "<opaque id>[@<idp>]"
-func UserIDToString(userID *user.UserId) string {
-	if userID == nil || userID.OpaqueId == "" {
-		return ""
-	}
-	return userID.OpaqueId
 }
 
 func encodeXML(res Response) ([]byte, error) {


### PR DESCRIPTION
The ocs list shares endpoint may need to fetch the displayname for multiple different users. We are now caching the lookup fo 60 seconds to save redundant RPCs to the users service.

- [ ] ~~get a better cache implementation?~~ moving to a pkg because caching a username for 60sec is good enough for now.
 
- [ ] ~~use a displayname cache or better a full blown user struct cache that could bu used in other handlers as well?~~ for now, the sharing code really only needs to look up displaynames

- [ ] ~~implement a recent users (and groups) cache whenever we get a new userid in the access token so we always have the most recent users cached?~~ left for a subsequent PR. It would need to make the cache part of the handler that is used in all ocs handlers.

