### PR TITLE
up and download of file shares

### DIFF
--- a/changelog/unreleased/file-share-up-download.md
+++ b/changelog/unreleased/file-share-up-download.md
@@ -1,0 +1,5 @@
+Bugfix: up and download of file shares
+
+The shared folder logic in the gateway storageprovider was not allowing file up and downloads for single file shares. We now check if the reference is actually a file to determine if up / download should be allowed.
+
+https://github.com/cs3org/reva/pull/1170

--- a/tests/acceptance/expected-failures-on-OC-storage.txt
+++ b/tests/acceptance/expected-failures-on-OC-storage.txt
@@ -179,10 +179,6 @@ apiShareManagement/acceptShares.feature:582
 apiShareManagement/acceptShares.feature:652
 apiShareManagement/acceptShares.feature:696
 #
-# https://github.com/owncloud/product/issues/208 After accepting a share data in the received file cannot be downloaded
-apiShareManagement/acceptSharesToSharesFolder.feature:15
-apiShareManagement/acceptSharesToSharesFolder.feature:22
-#
 # https://github.com/owncloud/product/issues/207 Response is empty when accepting a share
 apiShareManagement/acceptSharesToSharesFolder.feature:30
 apiShareManagement/acceptSharesToSharesFolder.feature:52
@@ -265,12 +261,6 @@ apiShareToSharesManagementBasic/excludeGroupFromReceivingSharesToSharesFolder.fe
 apiShareToSharesManagementBasic/excludeGroupFromReceivingSharesToSharesFolder.feature:98
 apiShareToSharesManagementBasic/excludeGroupFromReceivingSharesToSharesFolder.feature:135
 apiShareToSharesManagementBasic/excludeGroupFromReceivingSharesToSharesFolder.feature:136
-#
-# These currently pass in owncloud/ocis-reva and fail in cs3org/reva
-apiShareToSharesManagementBasic/excludeGroupFromReceivingSharesToSharesFolder.feature:115
-apiShareToSharesManagementBasic/excludeGroupFromReceivingSharesToSharesFolder.feature:116
-apiShareToSharesManagementBasic/excludeGroupFromReceivingSharesToSharesFolder.feature:153
-apiShareToSharesManagementBasic/excludeGroupFromReceivingSharesToSharesFolder.feature:154
 #
 # https://github.com/owncloud/ocis-reva/issues/260 Sharee retrieves the information about a share -but gets response containing all the shares
 apiShareOperations/accessToShare.feature:48
@@ -670,14 +660,8 @@ apiShareReshareToShares2/reShareWhenShareWithOnlyMembershipGroups.feature:41
 apiShareReshareToShares2/reShareWhenShareWithOnlyMembershipGroups.feature:42
 apiShareReshareToShares3/reShareUpdate.feature:25
 apiShareReshareToShares3/reShareUpdate.feature:26
-apiShareReshareToShares3/reShareUpdate.feature:42
-apiShareReshareToShares3/reShareUpdate.feature:43
 apiShareReshareToShares3/reShareUpdate.feature:59
 apiShareReshareToShares3/reShareUpdate.feature:60
-apiShareReshareToShares3/reShareUpdate.feature:76
-apiShareReshareToShares3/reShareUpdate.feature:77
-apiShareReshareToShares3/reShareUpdate.feature:93
-apiShareReshareToShares3/reShareUpdate.feature:94
 apiShareReshareToShares3/reShareUpdate.feature:112
 apiShareReshareToShares3/reShareUpdate.feature:113
 apiShareReshareToShares3/reShareUpdate.feature:131

--- a/tests/acceptance/features/apiOcisSpecific/apiWebdavPreviews-previews.feature
+++ b/tests/acceptance/features/apiOcisSpecific/apiWebdavPreviews-previews.feature
@@ -69,13 +69,13 @@ Feature: previews of files downloaded through the webdav API
     Then the HTTP status code should be "200"
     And the downloaded image should be "1240" pixels wide and "648" pixels high
 
-  @issue-ocis-thumbnails-191 @skipOnOcis-EOS-Storage @issue-ocis-reva-308 @skipOnOcis-OCIS-Storage
+  @issue-ocis-191 @skipOnOcis-EOS-Storage @issue-ocis-reva-308 @skipOnOcis-OCIS-Storage
   # after fixing all issues delete this Scenario and use the one from oC10 core
   Scenario: download previews of other users files
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file "filesForUpload/lorem.txt" to "/parent.txt"
     When user "Brian" downloads the preview of "/parent.txt" of "Alice" with width "32" and height "32" using the WebDAV API
-    Then the HTTP status code should be "500"
+    Then the HTTP status code should be "200"
 
   @issue-ocis-190
   # after fixing all issues delete this Scenario and use the one from oC10 core

--- a/tests/oc-integration-tests/drone/gateway.toml
+++ b/tests/oc-integration-tests/drone/gateway.toml
@@ -30,6 +30,7 @@ ocminvitemanagersvc = "localhost:13000"
 ocmproviderauthorizersvc = "localhost:13000"
 # other
 commit_share_to_storage_grant = true
+commit_share_to_storage_ref = true
 datagateway = "http://localhost:19001/data"
 transfer_shared_secret = "replace-me-with-a-transfer-secret" # for direct uploads
 transfer_expires = 6 # give it a moment

--- a/tests/oc-integration-tests/drone/gateway.toml
+++ b/tests/oc-integration-tests/drone/gateway.toml
@@ -31,6 +31,7 @@ ocmproviderauthorizersvc = "localhost:13000"
 # other
 commit_share_to_storage_grant = true
 commit_share_to_storage_ref = true
+share_folder = "Shares"
 datagateway = "http://localhost:19001/data"
 transfer_shared_secret = "replace-me-with-a-transfer-secret" # for direct uploads
 transfer_expires = 6 # give it a moment

--- a/tests/oc-integration-tests/drone/storage-home-owncloud.toml
+++ b/tests/oc-integration-tests/drone/storage-home-owncloud.toml
@@ -33,6 +33,7 @@ enable_home_creation = true
 datadirectory = "/drone/src/tmp/reva/data"
 enable_home = true
 redis = "redis:6379"
+userprovidersvc = "localhost:18000"
 
 
 [http]
@@ -46,3 +47,4 @@ temp_folder = "/drone/src/tmp/reva/tmp"
 datadirectory = "/drone/src/tmp/reva/data"
 enable_home = true
 redis = "redis:6379"
+userprovidersvc = "localhost:18000"

--- a/tests/oc-integration-tests/drone/storage-oc-owncloud.toml
+++ b/tests/oc-integration-tests/drone/storage-oc-owncloud.toml
@@ -35,3 +35,4 @@ temp_folder = "/drone/src/tmp/reva/tmp"
 [http.services.dataprovider.drivers.owncloud]
 datadirectory = "/drone/src/tmp/reva/data"
 redis = "redis:6379"
+userprovidersvc = "localhost:18000"

--- a/tests/oc-integration-tests/local/gateway.toml
+++ b/tests/oc-integration-tests/local/gateway.toml
@@ -30,6 +30,7 @@ ocminvitemanagersvc = "localhost:13000"
 ocmproviderauthorizersvc = "localhost:13000"
 # other
 commit_share_to_storage_grant = true
+commit_share_to_storage_ref = true
 datagateway = "http://localhost:19001/data"
 transfer_shared_secret = "replace-me-with-a-transfer-secret" # for direct uploads
 transfer_expires = 6 # give it a moment

--- a/tests/oc-integration-tests/local/gateway.toml
+++ b/tests/oc-integration-tests/local/gateway.toml
@@ -31,6 +31,7 @@ ocmproviderauthorizersvc = "localhost:13000"
 # other
 commit_share_to_storage_grant = true
 commit_share_to_storage_ref = true
+share_folder = "Shares"
 datagateway = "http://localhost:19001/data"
 transfer_shared_secret = "replace-me-with-a-transfer-secret" # for direct uploads
 transfer_expires = 6 # give it a moment

--- a/tests/oc-integration-tests/local/storage-home.toml
+++ b/tests/oc-integration-tests/local/storage-home.toml
@@ -33,6 +33,7 @@ enable_home_creation = true
 datadirectory = "/var/tmp/reva/data"
 enable_home = true
 redis = "localhost:6379"
+userprovidersvc = "localhost:18000"
 
 
 [http]
@@ -46,3 +47,4 @@ temp_folder = "/var/tmp/reva/tmp"
 datadirectory = "/var/tmp/reva/data"
 enable_home = true
 redis = "localhost:6379"
+userprovidersvc = "localhost:18000"

--- a/tests/oc-integration-tests/local/storage-oc.toml
+++ b/tests/oc-integration-tests/local/storage-oc.toml
@@ -35,3 +35,4 @@ temp_folder = "/var/tmp/reva/tmp"
 [http.services.dataprovider.drivers.owncloud]
 datadirectory = "/var/tmp/reva/data"
 redis = "localhost:6379"
+userprovidersvc = "localhost:18000"


### PR DESCRIPTION
The shared folder logic in the gateway storageprovider was not allowing file up and downloads for single file shares. We now check if the reference is actually a file to determine if up / download should be allowed.

fixes: https://github.com/owncloud/product/issues/205 and as a result likely https://github.com/owncloud/product/issues/229, https://github.com/owncloud/product/issues/208 and probably more.

cc @phil-davis 