### PR TITLE
[Tests-Only] Bump core commit for tests 20200915

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -355,7 +355,7 @@ steps:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
       - cd /drone/src/tmp/testrunner
-      - git checkout b3404863626519fc2aa758286385290abdf43d52
+      - git checkout 39bcf3874f2e388bbe7a7802e2f1e3c6a4b8216a
 
   - name: localAPIAcceptanceTestsOcStorage
     image: owncloudci/php:7.2
@@ -429,7 +429,7 @@ steps:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
       - cd /drone/src/tmp/testrunner
-      - git checkout b3404863626519fc2aa758286385290abdf43d52
+      - git checkout 39bcf3874f2e388bbe7a7802e2f1e3c6a4b8216a
 
   - name: oC10APIAcceptanceTests
     image: owncloudci/php:7.2

--- a/.drone.yml
+++ b/.drone.yml
@@ -355,7 +355,7 @@ steps:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
       - cd /drone/src/tmp/testrunner
-      - git checkout 39bcf3874f2e388bbe7a7802e2f1e3c6a4b8216a
+      - git checkout cb90a3b8bfcddb81f8cf6d84750feaa779105b94
 
   - name: localAPIAcceptanceTestsOcStorage
     image: owncloudci/php:7.2
@@ -429,7 +429,7 @@ steps:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
       - cd /drone/src/tmp/testrunner
-      - git checkout 39bcf3874f2e388bbe7a7802e2f1e3c6a4b8216a
+      - git checkout cb90a3b8bfcddb81f8cf6d84750feaa779105b94
 
   - name: oC10APIAcceptanceTests
     image: owncloudci/php:7.2

--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -33,3 +33,5 @@ default:
     jarnaiz\JUnitFormatter\JUnitFormatterExtension:
       filename: report.xml
       outputDir: '%paths.base%/../output/'
+
+    Cjm\Behat\StepThroughExtension: ~

--- a/vendor-bin/behat/composer.json
+++ b/vendor-bin/behat/composer.json
@@ -10,6 +10,7 @@
         "behat/mink-extension": "^2.3",
         "behat/mink-goutte-driver": "^1.2",
         "behat/mink-selenium2-driver": "^1.4",
+        "ciaranmcnulty/behat-stepthroughextension" : "dev-master",
         "jarnaiz/behat-junit-formatter": "^1.3",
         "rdx/behat-variables": "^1.2",
         "sensiolabs/behat-page-object-extension": "^2.3",


### PR DESCRIPTION
Gets us:
1) https://github.com/owncloud/core/pull/37913 [Tests-Only] Report HTTP status when file content is wrong

That helps to see the HTTP  status of a test when the downloaded file content is wrong.

2) https://github.com/owncloud/core/pull/37915 [Tests-Only] Add behat-stepthroughextension to acceptance test runner

That lets developers step through a test scenario 1 step at a time. See the linked core PR for details.