### PR TITLE
fix ocis move

### DIFF
--- a/changelog/unreleased/fix-oci-move.md
+++ b/changelog/unreleased/fix-oci-move.md
@@ -1,0 +1,5 @@
+Bugfix: Fix ocis move
+
+When renaming a file we updating the name attribute on the wrong node, causing the path construction to use the wrong name. This fixes the litmus move_coll test.
+
+https://github.com/cs3org/reva/pull/1177

--- a/pkg/storage/fs/ocis/tree.go
+++ b/pkg/storage/fs/ocis/tree.go
@@ -141,7 +141,8 @@ func (t *Tree) Move(ctx context.Context, oldNode *Node, newNode *Node) (err erro
 			return errors.Wrap(err, "ocisfs: could not rename child")
 		}
 
-		tgtPath := filepath.Join(t.pw.Root, "nodes", newNode.ID)
+		// the new node id might be different, so we need to use the old nodes id
+		tgtPath := filepath.Join(t.pw.Root, "nodes", oldNode.ID)
 
 		// update name attribute
 		if err := xattr.Set(tgtPath, "user.ocis.name", []byte(newNode.Name)); err != nil {


### PR DESCRIPTION
When renaming a file we updating the name attribute on the wrong node, causing the path construction to use the wrong name. This fixes the litmus move_coll test.