### PR TITLE
Fix litmus failing on ocis storage

### DIFF
--- a/changelog/unreleased/fix-oci-props.md
+++ b/changelog/unreleased/fix-oci-props.md
@@ -1,0 +1,6 @@
+Bugfix: Fix litmus failing on ocis storage
+
+We now ignore the `no data available` error when removing a non existing metadata attribute, which is ok because we are trying to delete it anyway.
+
+https://github.com/cs3org/reva/issues/1178
+https://github.com/cs3org/reva/pull/1179


### PR DESCRIPTION
We now ignore the `no data available` error when removing a non existing metadata attribute, which is ok because we are trying to delete it anyway.

fixes https://github.com/cs3org/reva/issues/1178