### PR TITLE
[Tests-Only] Bump core commit 20200918

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -446,7 +446,7 @@ steps:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
       - cd /drone/src/tmp/testrunner
-      - git checkout cb90a3b8bfcddb81f8cf6d84750feaa779105b94
+      - git checkout 2c5bb68fc689d7e9dd912125680c0fad99528fa9
 
   - name: localAPIAcceptanceTestsOcStorage
     image: owncloudci/php:7.2
@@ -520,7 +520,7 @@ steps:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
       - cd /drone/src/tmp/testrunner
-      - git checkout cb90a3b8bfcddb81f8cf6d84750feaa779105b94
+      - git checkout 2c5bb68fc689d7e9dd912125680c0fad99528fa9
 
   - name: oC10APIAcceptanceTests
     image: owncloudci/php:7.2


### PR DESCRIPTION
Gets:

https://github.com/owncloud/core/pull/37917 [Tests-Only] Do not overwrite user information when testing duplicate user creation

which reduces possible problems deleting users in `afterSccenario` of tests, particularly test scenarios that have atttempted to create users with different mixes of case - `alice` `Alice` and `ALICE`. Now exactly the first successfully created username is the one that is used for the "delete user" in the `afterScenario`
