### PR TITLE
Handle eos EPERM as permission denied

### DIFF
--- a/changelog/unreleased/handle-eos-eperm.md
+++ b/changelog/unreleased/handle-eos-eperm.md
@@ -1,0 +1,5 @@
+Bugfix: Handle eos EPERM as permission denied
+
+We now treat EPERM errors, which occur, eg. when acl checks fail and return a permission denied error.
+
+https://github.com/cs3org/reva/pull/1183

--- a/pkg/eosclient/eosclient.go
+++ b/pkg/eosclient/eosclient.go
@@ -247,7 +247,7 @@ func (c *Client) executeEOS(ctx context.Context, cmd *exec.Cmd) (string, string,
 				err = nil
 			case 2:
 				err = errtypes.NotFound(errBuf.String())
-			case 22:
+			case 1, 22:
 				// eos reports back error code 22 when the user is not allowed to enter the instance
 				err = errtypes.PermissionDenied(errBuf.String())
 			}


### PR DESCRIPTION
We now treat EPERM errors, which occur, eg. when acl checks fail and return a permission denied error.