### PR TITLE
[Tests-Only] Run local integration tests with OCIS storage

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -409,7 +409,7 @@ steps:
 ---
 kind: pipeline
 type: docker
-name: local-integration-tests
+name: local-integration-tests-owncloud
 
 platform:
   os: linux
@@ -448,7 +448,7 @@ steps:
       - cd /drone/src/tmp/testrunner
       - git checkout ceb1b471b639c0f5eb5af2c7e04ffd25395f4d57
 
-  - name: localAPIAcceptanceTestsOcStorage
+  - name: localAPIAcceptanceTestsOwncloudStorage
     image: owncloudci/php:7.2
     commands:
       - make test-acceptance-api
@@ -461,6 +461,80 @@ steps:
       TEST_OCIS: 'true'
       TEST_REVA: 'true'
       BEHAT_FILTER_TAGS: '~@skipOnOcis-OC-Storage'
+      PATH_TO_CORE: '/drone/src/tmp/testrunner'
+
+services:
+  - 'name': 'ldap'
+    'image': 'osixia/openldap:1.3.0'
+    'pull': 'always'
+    'environment':
+      LDAP_DOMAIN: 'owncloud.com'
+      LDAP_ORGANISATION: 'ownCloud'
+      LDAP_ADMIN_PASSWORD: 'admin'
+      LDAP_TLS_VERIFY_CLIENT: 'never'
+      HOSTNAME: 'ldap'
+
+  - name: redis
+    image: webhippie/redis
+    'pull': 'always'
+    'environment':
+      REDIS_DATABASES: 1
+
+---
+kind: pipeline
+type: docker
+name: local-integration-tests-ocis
+
+platform:
+  os: linux
+  arch: amd64
+
+trigger:
+  event:
+    include:
+      - pull_request
+      - tag
+
+steps:
+  - name: build
+    image: golang:1.13
+    commands:
+      - make build-ci
+
+  - name: revad-services
+    image: golang:1.13
+    detach: true
+    commands:
+      - cd /drone/src/tests/oc-integration-tests/drone/
+      - /drone/src/cmd/revad/revad -c frontend.toml &
+      - /drone/src/cmd/revad/revad -c gateway.toml &
+      - /drone/src/cmd/revad/revad -c shares.toml &
+      - /drone/src/cmd/revad/revad -c storage-home-ocis.toml &
+      - /drone/src/cmd/revad/revad -c storage-oc-ocis.toml &
+      - /drone/src/cmd/revad/revad -c storage-publiclink-ocis.toml &
+      - /drone/src/cmd/revad/revad -c ldap-users.toml
+
+  - name: clone-oC10-test-repos
+    image: owncloudci/php:7.2
+    commands:
+      - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
+      - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
+      - cd /drone/src/tmp/testrunner
+      - git checkout ceb1b471b639c0f5eb5af2c7e04ffd25395f4d57
+
+  - name: localAPIAcceptanceTestsOcisStorage
+    image: owncloudci/php:7.2
+    commands:
+      - make test-acceptance-api
+    environment:
+      TEST_SERVER_URL: 'http://revad-services:20080'
+      OCIS_REVA_DATA_ROOT: '/drone/src/tmp/reva/'
+      SKELETON_DIR: '/drone/src/tmp/testing/data/apiSkeleton'
+      TEST_EXTERNAL_USER_BACKENDS: 'true'
+      REVA_LDAP_HOSTNAME: 'ldap'
+      TEST_OCIS: 'true'
+      TEST_REVA: 'true'
+      BEHAT_FILTER_TAGS: '~@skipOnOcis-OCIS-Storage'
       PATH_TO_CORE: '/drone/src/tmp/testrunner'
 
 services:

--- a/tests/acceptance/features/apiOcisSpecific/apiAuthWebDav-webDavMOVEAuth.feature
+++ b/tests/acceptance/features/apiOcisSpecific/apiAuthWebDav-webDavMOVEAuth.feature
@@ -9,7 +9,7 @@ Feature: MOVE file/folder
     And user "Alice" has uploaded file with content "some data" to "/PARENT/parent.txt"
     And user "Brian" has been created with default attributes and without skeleton files
 
-  @issue-ocis-reva-14
+  @issue-ocis-reva-14 @skipOnOcis-OCIS-Storage
   # after fixing all issues delete this Scenario and use the one from oC10 core
   Scenario: send MOVE requests to another user's webDav endpoints as normal user
     When user "Brian" requests these endpoints with "MOVE" including body "doesnotmatter" about user "Alice"

--- a/tests/acceptance/features/apiOcisSpecific/apiAuthWebDav-webDavPROPFINDAuth.feature
+++ b/tests/acceptance/features/apiOcisSpecific/apiAuthWebDav-webDavPROPFINDAuth.feature
@@ -9,7 +9,7 @@ Feature: get file info using PROPFIND
     And user "Alice" has uploaded file with content "some data" to "/PARENT/parent.txt"
     And user "Brian" has been created with default attributes and without skeleton files
 
-  @issue-ocis-reva-9 @skipOnOcis-EOS-Storage @issue-ocis-reva-303
+  @issue-ocis-reva-9 @skipOnOcis-EOS-Storage @issue-ocis-reva-303 @skipOnOcis-OCIS-Storage
   # after fixing all issues delete this Scenario and use the one from oC10 core
   Scenario: send PROPFIND requests to another user's webDav endpoints as normal user
     When user "Brian" requests these endpoints with "PROPFIND" to get property "d:getetag" about user "Alice"

--- a/tests/acceptance/features/apiOcisSpecific/apiFavorites-favorites.feature
+++ b/tests/acceptance/features/apiOcisSpecific/apiFavorites-favorites.feature
@@ -13,7 +13,7 @@ Feature: favorite
     And user "Alice" has created folder "/PARENT"
     And user "Alice" has uploaded file with content "some data" to "/PARENT/parent.txt"
 
-  @skipOnOcis-OC-Storage @issue-ocis-reva-276
+  @skipOnOcis-OC-Storage @skipOnOcis-OCIS-Storage @issue-ocis-reva-276
   # after fixing all issues delete this Scenario and use the one from oC10 core
   Scenario Outline: Favorite a folder
     Given using <dav_version> DAV path

--- a/tests/acceptance/features/apiOcisSpecific/apiMain-checksums.feature
+++ b/tests/acceptance/features/apiOcisSpecific/apiMain-checksums.feature
@@ -31,16 +31,21 @@ Feature: checksums
 
   @issue-ocis-reva-99
   # after fixing all issues delete this Scenario and use the one from oC10 core
-  Scenario Outline: Upload a file where checksum does not match
-    Given using <dav_version> DAV path
+  Scenario: Upload a file where checksum does not match (old DAV path)
+    Given using old DAV path
     When user "Alice" uploads file with checksum "SHA1:f005ba11" and content "Some Text" to "/chksumtst.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And user "Alice" should see the following elements
       | /chksumtst.txt |
-    Examples:
-      | dav_version |
-      | old         |
-      | new         |
+
+  @issue-ocis-reva-99 @skipOnOcis-OCIS-Storage
+  # after fixing all issues delete this Scenario and use the one from oC10 core
+  Scenario: Upload a file where checksum does not match (new DAV path)
+    Given using new DAV path
+    When user "Alice" uploads file with checksum "SHA1:f005ba11" and content "Some Text" to "/chksumtst.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And user "Alice" should see the following elements
+      | /chksumtst.txt |
 
   @issue-ocis-reva-99
   # after fixing all issues delete this Scenario and use the one from oC10 core

--- a/tests/acceptance/features/apiOcisSpecific/apiShareCreateSpecial2-createShareWithInvalidPermissions.feature
+++ b/tests/acceptance/features/apiOcisSpecific/apiShareCreateSpecial2-createShareWithInvalidPermissions.feature
@@ -6,7 +6,7 @@ Feature: cannot share resources with invalid permissions
     And user "Alice" has uploaded file with content "some data" to "/textfile0.txt"
     And user "Alice" has created folder "/PARENT"
 
-  @issue-ocis-reva-45 @issue-ocis-reva-243
+  @issue-ocis-reva-45 @issue-ocis-reva-243 @skipOnOcis-OCIS-Storage
   # after fixing all issues delete this Scenario and use the one from oC10 core
   Scenario Outline: Cannot create a share of a file with a user with only create permission
     Given using OCS API version "<ocs_api_version>"
@@ -24,7 +24,7 @@ Feature: cannot share resources with invalid permissions
       | 1               | 100               | 996               | 200                | 500                |
       | 2               | 200               | 996               | 200                | 500                |
 
-  @issue-ocis-reva-45 @issue-ocis-reva-243
+  @issue-ocis-reva-45 @issue-ocis-reva-243 @skipOnOcis-OCIS-Storage
   # after fixing all issues delete this Scenario and use the one from oC10 core
   Scenario Outline: Cannot create a share of a file with a user with only (create,delete) permission
     Given using OCS API version "<ocs_api_version>"

--- a/tests/acceptance/features/apiOcisSpecific/apiShareManagementBasic-createShare.feature
+++ b/tests/acceptance/features/apiOcisSpecific/apiShareManagementBasic-createShare.feature
@@ -5,7 +5,7 @@ Feature: sharing
     Given user "Alice" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt"
 
-  @skipOnOcis-OC-Storage @issue-ocis-reva-301 @issue-ocis-reva-302
+  @skipOnOcis-OC-Storage @issue-ocis-reva-301 @issue-ocis-reva-302 @skipOnOcis-OCIS-Storage
   # after fixing all issues delete this Scenario and use the one from oC10 core
   Scenario Outline: Creating a share of a file with a user and asking for various permission combinations
     Given using OCS API version "<ocs_api_version>"
@@ -43,7 +43,7 @@ Feature: sharing
 
   @issue-ocis-reva-243
   # after fixing all issues delete this Scenario and use the one from oC10 core
-  Scenario Outline: more tests to demonstrate different ocis-reva issue 243 behaviours
+  Scenario Outline: more tests to demonstrate different ocis-reva issue 243 behaviours (OCS API v1)
     Given using OCS API version "<ocs_api_version>"
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/home"
@@ -54,9 +54,22 @@ Feature: sharing
     Examples:
       | ocs_api_version | http_status_code_ocs | http_status_code_eos |
       | 1               | 200                | 500                |
+
+  @issue-ocis-reva-243 @skipOnOcis-OCIS-Storage
+  # after fixing all issues delete this Scenario and use the one from oC10 core
+  Scenario Outline: more tests to demonstrate different ocis-reva issue 243 behaviours (OCS API v2)
+    Given using OCS API version "<ocs_api_version>"
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "/home"
+    And user "Alice" has uploaded file with content "Random data" to "/home/randomfile.txt"
+    When user "Alice" shares file "/home/randomfile.txt" with user "Brian" using the sharing API
+    And the HTTP status code should be "<http_status_code_ocs>" or "<http_status_code_eos>"
+    And as "Brian" file "randomfile.txt" should not exist
+    Examples:
+      | ocs_api_version | http_status_code_ocs | http_status_code_eos |
       | 2               | 200                | 500                |
 
-  @skipOnOcis-OC-Storage @issue-ocis-reva-301 @issue-ocis-reva-302
+  @skipOnOcis-OC-Storage @issue-ocis-reva-301 @issue-ocis-reva-302 @skipOnOcis-OCIS-Storage
   # after fixing all issues delete this Scenario and use the one from oC10 core
   Scenario Outline: Creating a share of a folder with a user, the default permissions are all permissions(31)
     Given using OCS API version "<ocs_api_version>"
@@ -83,7 +96,7 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
-  @issue-ocis-reva-372 @issue-ocis-reva-243
+  @issue-ocis-reva-372 @issue-ocis-reva-243 @skipOnOcis-OCIS-Storage
   # after fixing all issues delete this Scenario and use the one from oC10 core
   Scenario Outline: sharing subfolder of already shared folder, GET result is correct
     Given using OCS API version "<ocs_api_version>"

--- a/tests/acceptance/features/apiOcisSpecific/apiShareManagementBasic-deleteShare.feature
+++ b/tests/acceptance/features/apiOcisSpecific/apiShareManagementBasic-deleteShare.feature
@@ -1,7 +1,7 @@
 @api @files_sharing-app-required @issue-ocis-reva-243
 Feature: sharing
 
-  @issue-ocis-reva-356
+  @issue-ocis-reva-356 @skipOnOcis-OCIS-Storage
   # after fixing all issues delete this Scenario and use the one from oC10 core
   Scenario Outline: delete a share
     Given user "Alice" has been created with default attributes and skeleton files

--- a/tests/acceptance/features/apiOcisSpecific/apiShareOperations-accessToShare.feature
+++ b/tests/acceptance/features/apiOcisSpecific/apiShareOperations-accessToShare.feature
@@ -20,4 +20,17 @@ Feature: sharing
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
+
+  @issue-ocis-reva-260 @skipOnOcis-OCIS-Storage
+  # after fixing all issues delete this Scenario and use the one from oC10 core
+  Scenario Outline: Sharee can't see the share that is filtered out
+    Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has shared file "textfile0.txt" with user "Brian"
+    And user "Alice" has shared file "textfile1.txt" with user "Brian"
+    When user "Brian" gets all the shares shared with him that are received as file "textfile0 (2).txt" using the provisioning API
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And the last share_id should be included in the response
+    Examples:
+      | ocs_api_version | ocs_status_code |
       | 2               | 200             |

--- a/tests/acceptance/features/apiOcisSpecific/apiShareOperations-gettingShares.feature
+++ b/tests/acceptance/features/apiOcisSpecific/apiShareOperations-gettingShares.feature
@@ -7,7 +7,7 @@ Feature: sharing
       | Alice    |
       | Brian    |
 
-  @issue-ocis-reva-374
+  @issue-ocis-reva-374 @skipOnOcis-OCIS-Storage
   # after fixing all issues delete this Scenario and use the one from oC10 core
   Scenario Outline: Get a share with a user that didn't receive the share
     Given using OCS API version "<ocs_api_version>"

--- a/tests/acceptance/features/apiOcisSpecific/apiSharePublicLink1-createPublicLinkShare.feature
+++ b/tests/acceptance/features/apiOcisSpecific/apiSharePublicLink1-createPublicLinkShare.feature
@@ -5,7 +5,7 @@ Feature: create a public link share
   Background:
     Given user "Alice" has been created with default attributes and skeleton files
 
-  @issue-37605
+  @issue-37605 @skipOnOcis-OCIS-Storage
   # after fixing all issues make the oC10 scenario like this one, and delete this scenario
   Scenario: Get the mtime of a file inside a folder shared by public link using new webDAV version (run on OCIS)
     Given user "Alice" has created folder "testFolder"
@@ -17,7 +17,7 @@ Feature: create a public link share
     And as "Alice" the mtime of the file "testFolder/file.txt" should be "Thu, 08 Aug 2019 04:18:13 GMT"
     And the mtime of file "file.txt" in the last shared public link using the WebDAV API should be "Thu, 08 Aug 2019 04:18:13 GMT"
 
-  @issue-37605
+  @issue-37605 @skipOnOcis-OCIS-Storage
   # after fixing all issues make the oC10 scenario like this one, and delete this scenario
   Scenario: overwriting a file changes its mtime (new public webDAV API) (run on OCIS)
     Given user "Alice" has created folder "testFolder"

--- a/tests/acceptance/features/apiOcisSpecific/apiSharePublicLink2-copyFromPublicLink.feature
+++ b/tests/acceptance/features/apiOcisSpecific/apiSharePublicLink2-copyFromPublicLink.feature
@@ -6,7 +6,7 @@ Feature: copying from public link share
     And user "Alice" has created folder "/PARENT"
     And the administrator has enabled DAV tech_preview
 
-  @issue-ocis-reva-373 @issue-core-37683
+  @issue-ocis-reva-373 @issue-core-37683 @skipOnOcis-OCIS-Storage
   # after fixing all issues delete this Scenario and use the one from oC10 core
   Scenario: Copy folder within a public link folder to the same folder name as an already existing file
     Given user "Alice" has created folder "/PARENT/testFolder"
@@ -22,7 +22,7 @@ Feature: copying from public link share
     And the content of file "/PARENT/testFolder/testfile.txt" for user "Alice" should be "some data"
     And the content of file "/PARENT/copy1.txt" for user "Alice" should be "some data 1"
 
-  @issue-ocis-reva-373 @issue-core-37683
+  @issue-ocis-reva-373 @issue-core-37683 @skipOnOcis-OCIS-Storage
   # after fixing all issues delete this Scenario and use the one from oC10 core
   Scenario: Copy file within a public link folder to a file with name same as an existing folder
     Given user "Alice" has uploaded file with content "some data" to "/PARENT/testfile.txt"
@@ -37,7 +37,7 @@ Feature: copying from public link share
     And as "Alice" file "/PARENT/new-folder" should exist
     And the content of file "/PARENT/testfile.txt" for user "Alice" should be "some data"
 
-  @issue-ocis-reva-368
+  @issue-ocis-reva-368 @skipOnOcis-OCIS-Storage
   # after fixing all issues delete this Scenario and use the one from oC10 core
   Scenario Outline: Copy file within a public link folder to a file with unusual destination names
     Given user "Alice" has uploaded file with content "some data" to "/PARENT/testfile.txt"
@@ -53,7 +53,7 @@ Feature: copying from public link share
       | testfile.txt          |
       |                       |
 
-  @issue-ocis-reva-368
+  @issue-ocis-reva-368 @skipOnOcis-OCIS-Storage
   # after fixing all issues delete this Scenario and use the one from oC10 core
   Scenario: Copy folder within a public link folder to a folder with unusual destination names
     Given user "Alice" has created folder "/PARENT/testFolder"

--- a/tests/acceptance/features/apiOcisSpecific/apiShareUpdate-updateShare.feature
+++ b/tests/acceptance/features/apiOcisSpecific/apiShareUpdate-updateShare.feature
@@ -5,7 +5,7 @@ Feature: sharing
     Given using OCS API version "1"
     And user "Alice" has been created with default attributes and skeleton files
 
-  @skipOnOcis-EOS-Storage @toFixOnOCIS @issue-ocis-reva-243
+  @skipOnOcis-EOS-Storage @toFixOnOCIS @issue-ocis-reva-243 @skipOnOcis-OCIS-Storage
   # after fixing all issues delete this Scenario and use the one from oC10 core
   Scenario: Share ownership change after moving a shared file to another share
     Given these users have been created with default attributes and without skeleton files:
@@ -43,7 +43,7 @@ Feature: sharing
     And as "Alice" folder "/Alice-folder/folder2" should exist
     And as "Carol" folder "/Carol-folder/folder2" should not exist
 
-  @skipOnOcis-OC-Storage @toFixOnOCIS @issue-ocis-reva-243
+  @skipOnOcis-OC-Storage @toFixOnOCIS @issue-ocis-reva-243 @skipOnOcis-OCIS-Storage
   # same as oC10 core Scenario but without displayname_owner because EOS does not report it
   # after fixing all issues delete this Scenario and use the one from oC10 core
   Scenario: Share ownership change after moving a shared file to another share
@@ -74,7 +74,7 @@ Feature: sharing
     And as "Alice" folder "/Alice-folder/folder2" should exist
     And as "Carol" folder "/Carol-folder/folder2" should not exist
 
-  @toFixOnOCIS @toFixOnOcV10 @issue-ocis-reva-243 @issue-ocis-reva-349 @issue-ocis-reva-350 @issue-ocis-reva-352 @issue-37653
+  @toFixOnOCIS @toFixOnOcV10 @issue-ocis-reva-243 @issue-ocis-reva-349 @issue-ocis-reva-350 @issue-ocis-reva-352 @issue-37653 @skipOnOcis-OCIS-Storage
   # after fixing all issues delete this Scenario and use the one from oC10 core
   Scenario Outline: API responds with a full set of parameters when owner changes the permission of a share
     Given using OCS API version "<ocs_api_version>"

--- a/tests/acceptance/features/apiOcisSpecific/apiTrashbin-trashbinDelete.feature
+++ b/tests/acceptance/features/apiOcisSpecific/apiTrashbin-trashbinDelete.feature
@@ -16,7 +16,7 @@ Feature: files and folders can be deleted from the trashbin
   @smokeTest
   @issue-product-139
   @issue-product-178
-  @issue-product-179
+  @issue-product-179 @skipOnOcis-OCIS-Storage
   Scenario Outline: Trashbin cannot be emptied
   # after fixing all issues delete this Scenario and use the one from oC10 core
     Given user "Alice" has uploaded file with content "file with comma" to "sample,0.txt"
@@ -38,7 +38,7 @@ Feature: files and folders can be deleted from the trashbin
 
   @smokeTest
   @issue-ocis-reva-118
-  @issue-product-179
+  @issue-product-179 @skipOnOcis-OCIS-Storage
   # after fixing all issues delete this Scenario and use the one from oC10 core
   Scenario: delete a single file from the trashbin
     Given user "Alice" has deleted file "/textfile0.txt"

--- a/tests/acceptance/features/apiOcisSpecific/apiVersions-fileVersions.feature
+++ b/tests/acceptance/features/apiOcisSpecific/apiVersions-fileVersions.feature
@@ -16,7 +16,7 @@ Feature: dav-versions
     And as "Alice" file "/davtest.txt-olddav-oldchunking" should not exist
     And as "Alice" file "/davtest.txt-newdav-newchunking" should not exist
 
-  @issue-ocis-reva-17 @issue-ocis-reva-56
+  @issue-ocis-reva-17 @issue-ocis-reva-56 @skipOnOcis-OCIS-Storage
   # after fixing all issues delete this Scenario and use the one from oC10 core
   Scenario: Upload a file twice and versions are available using various chunking methods
     When user "Alice" uploads file "filesForUpload/davtest.txt" to filenames based on "/davtest.txt" with all mechanisms using the WebDAV API
@@ -39,7 +39,7 @@ Feature: dav-versions
 #    And the version folder of file "/sharefile.txt" for user "Alice" should contain "1" element
 
   @files_sharing-app-required
-  @issue-ocis-reva-243
+  @issue-ocis-reva-243 @skipOnOcis-OCIS-Storage
   # after fixing all issues delete this Scenario and use the one from oC10 core
   Scenario: sharer of a file can restore the original content of a shared file after the file has been modified by the sharee
     Given user "Brian" has been created with default attributes and without skeleton files
@@ -56,7 +56,7 @@ Feature: dav-versions
   @files_sharing-app-required
   @issue-ocis-reva-243 @issue-ocis-reva-386
   # after fixing all issues delete this Scenario and use the one from oC10 core
-  Scenario Outline: Moving a file (with versions) into a shared folder as the sharee and as the sharer
+  Scenario Outline: Moving a file (with versions) into a shared folder as the sharee and as the sharer (old DAV path)
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Brian" has created folder "/testshare"
@@ -81,10 +81,38 @@ Feature: dav-versions
     Examples:
       | dav_version |
       | old         |
+
+  @files_sharing-app-required
+  @issue-ocis-reva-243 @issue-ocis-reva-386 @skipOnOcis-OCIS-Storage
+  # after fixing all issues delete this Scenario and use the one from oC10 core
+  Scenario Outline: Moving a file (with versions) into a shared folder as the sharee and as the sharer (new DAV path)
+    Given using <dav_version> DAV path
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Brian" has created folder "/testshare"
+    And user "Brian" has created a share with settings
+      | path        | testshare |
+      | shareType   | user      |
+      | permissions | change    |
+      | shareWith   | Alice     |
+    And user "Brian" has uploaded file with content "test data 1" to "/testfile.txt"
+    And user "Brian" has uploaded file with content "test data 2" to "/testfile.txt"
+    And user "Brian" has uploaded file with content "test data 3" to "/testfile.txt"
+    And user "Brian" moves file "/testfile.txt" to "/testshare/testfile.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And the content of file "/testshare/testfile.txt" for user "Alice" should be ""
+#    And the content of file "/testshare/testfile.txt" for user "Alice" should be "test data 3"
+    And the content of file "/testshare/testfile.txt" for user "Brian" should be "test data 3"
+    And as "Brian" file "/testfile.txt" should not exist
+    And as "Alice" file "/testshare/testfile.txt" should not exist
+    And the content of file "/testshare/testfile.txt" for user "Brian" should be "test data 3"
+#    And the version folder of file "/testshare/testfile.txt" for user "Alice" should contain "2" elements
+#    And the version folder of file "/testshare/testfile.txt" for user "Brian" should contain "2" elements
+    Examples:
+      | dav_version |
       | new         |
 
   @files_sharing-app-required
-  @issue-ocis-reva-243 @issue-ocis-reva-386
+  @issue-ocis-reva-243 @issue-ocis-reva-386 @skipOnOcis-OCIS-Storage
   # after fixing all issues delete this Scenario and use the one from oC10 core
   Scenario Outline: Moving a file (with versions) out of a shared folder as the sharee and as the sharer
     Given using <dav_version> DAV path
@@ -110,7 +138,7 @@ Feature: dav-versions
       | new         |
 
   @skipOnStorage:ceph @files_primary_s3-issue-161 @files_sharing-app-required
-  @issue-ocis-reva-376
+  @issue-ocis-reva-376 @skipOnOcis-OCIS-Storage
   # after fixing all issues delete this Scenario and use the one from oC10 core
   Scenario: Receiver tries get file versions of shared file from the sharer
     Given user "Brian" has been created with default attributes and without skeleton files

--- a/tests/acceptance/features/apiOcisSpecific/apiWebdavMove1-moveFolder.feature
+++ b/tests/acceptance/features/apiOcisSpecific/apiWebdavMove1-moveFolder.feature
@@ -18,6 +18,16 @@ Feature: move (rename) folder
     Examples:
       | dav_version |
       | old         |
+
+  @issue-ocis-reva-211 @skipOnOcis-OCIS-Storage
+  # after fixing all issues delete this Scenario and use the one from oC10 core
+  Scenario Outline: Renaming a folder to a backslash is allowed
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/testshare"
+    When user "Alice" moves folder "/testshare" to "\" using the WebDAV API
+    Then the HTTP status code should be "201" or "500"
+    Examples:
+      | dav_version |
       | new         |
 
   @issue-ocis-reva-211
@@ -30,6 +40,16 @@ Feature: move (rename) folder
     Examples:
       | dav_version |
       | old         |
+
+  @issue-ocis-reva-211 @skipOnOcis-OCIS-Storage
+  # after fixing all issues delete this Scenario and use the one from oC10 core
+  Scenario Outline: Renaming a folder beginning with a backslash is allowed
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/testshare"
+    When user "Alice" moves folder "/testshare" to "\testshare" using the WebDAV API
+    Then the HTTP status code should be "201" or "500"
+    Examples:
+      | dav_version |
       | new         |
 
   @issue-ocis-reva-211
@@ -42,4 +62,14 @@ Feature: move (rename) folder
     Examples:
       | dav_version |
       | old         |
+
+  @issue-ocis-reva-211 @skipOnOcis-OCIS-Storage
+  # after fixing all issues delete this Scenario and use the one from oC10 core
+  Scenario Outline: Renaming a folder including a backslash encoded is allowed
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/testshare"
+    When user "Alice" moves folder "/testshare" to "/hola\hola" using the WebDAV API
+    Then the HTTP status code should be "201" or "500"
+    Examples:
+      | dav_version |
       | new         |

--- a/tests/acceptance/features/apiOcisSpecific/apiWebdavMove1-moveFolderToBlacklistedName.feature
+++ b/tests/acceptance/features/apiOcisSpecific/apiWebdavMove1-moveFolderToBlacklistedName.feature
@@ -8,7 +8,7 @@ Feature: users cannot move (rename) a folder to a blacklisted name
     Given using OCS API version "1"
     And user "Alice" has been created with default attributes and without skeleton files
 
-  @issue-ocis-reva-211 @skipOnOcis-EOS-Storage @issue-ocis-reva-269
+  @issue-ocis-reva-211 @skipOnOcis-EOS-Storage @issue-ocis-reva-269 @skipOnOcis-OCIS-Storage
   # after fixing all issues delete this Scenario and use the one from oC10 core
   Scenario Outline: Renaming a folder to a name that is banned by default is allowed
     Given using <dav_version> DAV path

--- a/tests/acceptance/features/apiOcisSpecific/apiWebdavMove2-moveFile.feature
+++ b/tests/acceptance/features/apiOcisSpecific/apiWebdavMove2-moveFile.feature
@@ -8,7 +8,7 @@ Feature: move (rename) file
     Given using OCS API version "1"
     And user "Alice" has been created with default attributes and skeleton files
 
-  @issue-ocis-reva-211
+  @issue-ocis-reva-211 @skipOnOcis-OCIS-Storage
   # after fixing all issues delete this Scenario and use the one from oC10 core
   Scenario Outline: rename a file into an invalid filename
     Given using <dav_version> DAV path
@@ -20,7 +20,7 @@ Feature: move (rename) file
       | old         |
       | new         |
 
-  @issue-ocis-reva-211
+  @issue-ocis-reva-211 @skipOnOcis-OCIS-Storage
   # after fixing all issues delete this Scenario and use the one from oC10 core
   Scenario Outline: Renaming a file to a path with extension .part is possible
     Given using <dav_version> DAV path
@@ -32,7 +32,7 @@ Feature: move (rename) file
       | old         |
       | new         |
 
-  @skipOnOcis-OC-Storage @issue-ocis-reva-211
+  @skipOnOcis-OC-Storage @issue-ocis-reva-211 @skipOnOcis-OCIS-Storage
   # after fixing all issues delete this Scenario and use the one from oC10 core
   Scenario Outline: renaming to a file with special characters
     When user "Alice" moves file "/textfile0.txt" to "/<renamed_file>" using the WebDAV API

--- a/tests/acceptance/features/apiOcisSpecific/apiWebdavMove2-moveFileToBlacklistedName.feature
+++ b/tests/acceptance/features/apiOcisSpecific/apiWebdavMove2-moveFileToBlacklistedName.feature
@@ -8,7 +8,7 @@ Feature: users cannot move (rename) a file to a blacklisted name
     Given using OCS API version "1"
     And user "Alice" has been created with default attributes and skeleton files
 
-  @issue-ocis-reva-211
+  @issue-ocis-reva-211 @skipOnOcis-OCIS-Storage
   # after fixing all issues delete this Scenario and use the one from oC10 core
   Scenario Outline: rename a file to a filename that is banned by default
     Given using <dav_version> DAV path

--- a/tests/acceptance/features/apiOcisSpecific/apiWebdavPreviews-previews.feature
+++ b/tests/acceptance/features/apiOcisSpecific/apiWebdavPreviews-previews.feature
@@ -69,7 +69,7 @@ Feature: previews of files downloaded through the webdav API
     Then the HTTP status code should be "200"
     And the downloaded image should be "1240" pixels wide and "648" pixels high
 
-  @issue-ocis-thumbnails-191 @skipOnOcis-EOS-Storage @issue-ocis-reva-308
+  @issue-ocis-thumbnails-191 @skipOnOcis-EOS-Storage @issue-ocis-reva-308 @skipOnOcis-OCIS-Storage
   # after fixing all issues delete this Scenario and use the one from oC10 core
   Scenario: download previews of other users files
     Given user "Brian" has been created with default attributes and without skeleton files
@@ -101,7 +101,7 @@ Feature: previews of files downloaded through the webdav API
     When user "Alice" downloads the preview of "/parent.txt" with width "32" and height "32" using the WebDAV API
     Then the HTTP status code should be "200"
 
-  @issue-ocis-193
+  @issue-ocis-193 @skipOnOcis-OCIS-Storage
   # after fixing all issues delete this Scenario and use the one from oC10 core
   Scenario: set maximum size of previews
     Given user "Alice" has uploaded file "filesForUpload/lorem.txt" to "/parent.txt"

--- a/tests/acceptance/features/apiOcisSpecific/apiWebdavProperties1-createFolder.feature
+++ b/tests/acceptance/features/apiOcisSpecific/apiWebdavProperties1-createFolder.feature
@@ -8,7 +8,7 @@ Feature: create folder
     Given using OCS API version "1"
     And user "Alice" has been created with default attributes and without skeleton files
 
-  @issue-ocis-reva-168 @skipOnOcis-EOS-Storage
+  @issue-ocis-reva-168 @skipOnOcis-EOS-Storage @skipOnOcis-OCIS-Storage
   # after fixing all issues delete this Scenario and use the one from oC10 core
   Scenario Outline: try to create a folder that already exists
     Given using <dav_version> DAV path

--- a/tests/acceptance/features/apiOcisSpecific/apiWebdavProperties1-setFileProperties.feature
+++ b/tests/acceptance/features/apiOcisSpecific/apiWebdavProperties1-setFileProperties.feature
@@ -8,7 +8,7 @@ Feature: set file properties
     Given using OCS API version "1"
     And user "Alice" has been created with default attributes and without skeleton files
 
-  @skipOnOcis-OC-Storage @issue-ocis-reva-276
+  @skipOnOcis-OC-Storage @issue-ocis-reva-276 @skipOnOcis-OCIS-Storage
   # after fixing all issues delete this Scenario and use the one from oC10 core
   Scenario Outline: Setting custom DAV property
     Given using <dav_version> DAV path

--- a/tests/acceptance/features/apiOcisSpecific/apiWebdavProperties2-getFileProperties.feature
+++ b/tests/acceptance/features/apiOcisSpecific/apiWebdavProperties2-getFileProperties.feature
@@ -8,7 +8,7 @@ Feature: get file properties
     Given using OCS API version "1"
     And user "Alice" has been created with default attributes and without skeleton files
 
-  @issue-ocis-reva-214
+  @issue-ocis-reva-214 @skipOnOcis-OCIS-Storage
   # after fixing all issues delete this Scenario and use the one from oC10 core
   Scenario Outline: Do a PROPFIND of various file names
     Given using <dav_version> DAV path
@@ -25,7 +25,7 @@ Feature: get file properties
       | new         | /file #2.txt  | dav\/files\/%username%\/file%20%232\.txt  |
       | new         | /file &2.txt  | dav\/files\/%username%\/file%20&2\.txt    |
 
-  @issue-ocis-reva-214 @issue-ocis-reva-265 @skipOnOcis-EOS-Storage
+  @issue-ocis-reva-214 @issue-ocis-reva-265 @skipOnOcis-EOS-Storage @skipOnOcis-OCIS-Storage
   # after fixing all issues delete this Scenario and use the one from oC10 core
   Scenario Outline: Do a PROPFIND of various file names
     Given using <dav_version> DAV path
@@ -38,7 +38,7 @@ Feature: get file properties
       | old         | /file ?2.txt | webdav\/file%20%3F2\.txt                 |
       | new         | /file ?2.txt | dav\/files\/%username%\/file%20%3F2\.txt |
 
-  @skipOnOcis-OC-Storage @issue-ocis-reva-265
+  @skipOnOcis-OC-Storage @issue-ocis-reva-265 @skipOnOcis-OCIS-Storage
   # after fixing all issues delete this Scenario and use the one from oC10 core
   Scenario Outline: upload a file to content
     Given using <dav_version> DAV path
@@ -49,7 +49,7 @@ Feature: get file properties
       | old         | /file ?2.txt  |
       | new         | /file ?2.txt  |
 
-  @issue-ocis-reva-214
+  @issue-ocis-reva-214 @skipOnOcis-OCIS-Storage
   # after fixing all issues delete this Scenario and use the one from oC10 core
   Scenario Outline: Do a PROPFIND of various folder names
     Given using <dav_version> DAV path
@@ -68,6 +68,20 @@ Feature: get file properties
       | old         | /नेपाली         | webdav\/%E0%A4%A8%E0%A5%87%E0%A4%AA%E0%A4%BE%E0%A4%B2%E0%A5%80            |
       | old         | /folder #2.txt  | webdav\/folder%20%232\.txt                                                |
       | old         | /folder &2.txt  | webdav\/folder%20&2\.txt                                                  |
+
+  @issue-ocis-reva-214 @skipOnOcis-OCIS-Storage
+  # after fixing all issues delete this Scenario and use the one from oC10 core
+  Scenario Outline: Do a PROPFIND of various folder names
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "<folder_name>"
+    And user "Alice" has uploaded file with content "uploaded content" to "<folder_name>/file1.txt"
+    And user "Alice" has uploaded file with content "uploaded content" to "<folder_name>/file2.txt"
+    When user "Alice" gets the properties of folder "<folder_name>" with depth 1 using the WebDAV API
+    Then the value of the item "//d:response[1]/d:href" in the response to user "Alice" should match "/remote\.php\/<expected_href>\//"
+    And the value of the item "//d:response[2]/d:href" in the response to user "Alice" should match "/remote\.php\/<expected_href>\/file1.txt/"
+    And the value of the item "//d:response[3]/d:href" in the response to user "Alice" should match "/remote\.php\/<expected_href>\/file2.txt/"
+    Examples:
+      | dav_version | folder_name     | expected_href                                                             |
       | new         | /upload         | dav\/files\/%username%\/upload                                                 |
       | new         | /strängé folder | dav\/files\/%username%\/str%C3%A4ng%C3%A9%20folder                             |
       | new         | /C++ folder     | dav\/files\/%username%\/C\+\+%20folder                                           |
@@ -75,7 +89,7 @@ Feature: get file properties
       | new         | /folder #2.txt  | dav\/files\/%username%\/folder%20%232\.txt                                     |
       | new         | /folder &2.txt  | dav\/files\/%username%\/folder%20&2\.txt                                       |
 
-  @issue-ocis-reva-214 @skipOnOcis-EOS-Storage @issue-ocis-reva-265
+  @issue-ocis-reva-214 @skipOnOcis-EOS-Storage @issue-ocis-reva-265 @skipOnOcis-OCIS-Storage
   # after fixing all issues delete this Scenario and use the one from oC10 core
   Scenario Outline: Do a PROPFIND of various folder names
     Given using <dav_version> DAV path
@@ -91,7 +105,7 @@ Feature: get file properties
       | old         | /folder ?2.txt  | webdav\/folder%20%3F2\.txt                                                |
       | new         | /folder ?2.txt  | dav\/files\/%username%\/folder%20%3F2\.txt                                     |
 
-  @skipOnOcis-OC-Storage @issue-ocis-reva-265
+  @skipOnOcis-OC-Storage @issue-ocis-reva-265 @skipOnOcis-OCIS-Storage
   # after fixing all issues delete this Scenario and use the one from oC10 core
   Scenario Outline: Do a PROPFIND of various folder names
     Given using <dav_version> DAV path

--- a/tests/acceptance/features/apiOcisSpecific/apiWebdavUpload1-uploadFile.feature
+++ b/tests/acceptance/features/apiOcisSpecific/apiWebdavUpload1-uploadFile.feature
@@ -8,7 +8,7 @@ Feature: upload file
     Given using OCS API version "1"
     And user "Alice" has been created with default attributes and without skeleton files
 
-  @skipOnOcis-OC-Storage @issue-ocis-reva-265
+  @skipOnOcis-OC-Storage @issue-ocis-reva-265 @skipOnOcis-OCIS-Storage
   # after fixing all issues delete this Scenario and use the one from oC10 core
   Scenario Outline: upload a file and check download content
     Given using <dav_version> DAV path
@@ -19,7 +19,7 @@ Feature: upload file
       | old         | "file ?2.txt"       |
       | new         | "file ?2.txt"       |
 
-  @skipOnOcis-OC-Storage @issue-product-127
+  @skipOnOcis-OC-Storage @issue-product-127 @skipOnOcis-OCIS-Storage
   # this scenario passes/fails intermittently on OC storage, so do not run it in CI
   # after fixing all issues delete this Scenario and use the one from oC10 core
   Scenario Outline: uploading a file inside a folder changes its etag


### PR DESCRIPTION
The local integration tests are actually bug-demonstration scenarios of bugs that are known in `owncloud` storage. Some of those "fail" on `ocis` storage - either because the bug is fixed on `ocis` storage, or because the failing behavior is different on `ocis` storage. Either way, we skip those scenarios when testing with `ocis` storage.

I am working on issue https://github.com/owncloud/product/issues/225 to sort out which bugs are fixed on `ocis` storage and which are failing in a different way.
