### PR TITLE
[Tests-Only] Sort out owncloud and ocis storage toml

### DIFF
--- a/tests/oc-integration-tests/drone/storage-publiclink-ocis.toml
+++ b/tests/oc-integration-tests/drone/storage-publiclink-ocis.toml
@@ -17,6 +17,6 @@ data_server_url = "http://localhost:13001/data"
 gateway_addr = "0.0.0.0:19000"
 enable_home_creation = true
 
-[grpc.services.publicstorageprovider.drivers.owncloud]
+[grpc.services.publicstorageprovider.drivers.ocis]
 datadirectory = "/drone/src/tmp/reva/data"
 enable_home = true


### PR DESCRIPTION
Fixup this mention in https://github.com/cs3org/reva/blob/master/tests/oc-integration-tests/drone/storage-publiclink-ocis.toml from "owncloud" to "ocis".

I guess we were testing something a bit different? Or did this not matter?