### PR TITLE
Allow using the username when accessing the users home

### DIFF
--- a/changelog/unreleased/allow-username-in-dav-files.md
+++ b/changelog/unreleased/allow-username-in-dav-files.md
@@ -1,0 +1,6 @@
+Enhancement: Allow using the username when accessing the users home
+
+We now allow using the userid and the username when accessing the
+users home on the `/dev/files` endpoint.
+
+https://github.com/cs3org/reva/pull/1205


### PR DESCRIPTION
We now allow using the userid and the username when accessing the
users home on the `/dev/files` endpoint.