### PR TITLE
do not swallow permission denied errors in storageprovider

### DIFF
--- a/changelog/unreleased/no-longer-swallow-permissions-errors.md
+++ b/changelog/unreleased/no-longer-swallow-permissions-errors.md
@@ -1,0 +1,6 @@
+Bugfix: No longer swallow permissions errors
+
+The storageprovider is no longer ignoring permissions errors.
+It will now report them properly using `status.NewPermissionDenied(...)` instead of `status.NewInternal(...)`
+
+https://github.com/cs3org/reva/pull/1206

--- a/pkg/rgrpc/status/status.go
+++ b/pkg/rgrpc/status/status.go
@@ -88,6 +88,18 @@ func NewUnauthenticated(ctx context.Context, err error, msg string) *rpc.Status 
 	}
 }
 
+// NewPermissionDenied returns a Status with PERMISSION_DENIED and logs the msg.
+func NewPermissionDenied(ctx context.Context, err error, msg string) *rpc.Status {
+	log := appctx.GetLogger(ctx).With().CallerWithSkipFrameCount(3).Logger()
+	log.Err(err).Msg(msg)
+
+	return &rpc.Status{
+		Code:    rpc.Code_CODE_PERMISSION_DENIED,
+		Message: msg,
+		Trace:   getTrace(ctx),
+	}
+}
+
 // NewUnimplemented returns a Status with CODE_UNIMPLEMENTED and logs the msg.
 func NewUnimplemented(ctx context.Context, err error, msg string) *rpc.Status {
 	log := appctx.GetLogger(ctx).With().CallerWithSkipFrameCount(3).Logger()


### PR DESCRIPTION
The storageprovider is no longer ignoring permissions errors.
It will now report them properly using `status.NewPermissionDenied(...)` instead of `status.NewInternal(...)`