### PR TITLE
do not swallow permissions errors in ocdav

### DIFF
--- a/changelog/unreleased/ocdav-permissions-errors.md
+++ b/changelog/unreleased/ocdav-permissions-errors.md
@@ -1,0 +1,6 @@
+Bugfix: No longer swallow permissions errors in ocdav
+
+The ocdav api is no longer ignoring permissions errors.
+It will now check the status for `rpc.Code_CODE_PERMISSION_DENIED` codes and report them properly using `http.StatusForbidden` instead of `http.StatusInternalServerError`
+
+https://github.com/cs3org/reva/pull/1207

--- a/internal/http/services/owncloud/ocdav/dav.go
+++ b/internal/http/services/owncloud/ocdav/dav.go
@@ -20,7 +20,6 @@ package ocdav
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"path"
 
@@ -161,14 +160,30 @@ func (h *DavHandler) Handler(s *svc) http.Handler {
 
 			r = r.WithContext(ctx)
 
-			statInfo, err := getTokenStatInfo(ctx, c, token)
+			sRes, err := getTokenStatInfo(ctx, c, token)
 			if err != nil {
+				log.Error().Err(err).Msg("error sending grpc stat request")
 				w.WriteHeader(http.StatusInternalServerError)
 				return
 			}
-			log.Debug().Interface("statInfo", statInfo).Msg("Stat info from public link token path")
-			if statInfo.Type != provider.ResourceType_RESOURCE_TYPE_CONTAINER {
-				ctx := context.WithValue(ctx, tokenStatInfoKey{}, statInfo)
+			if sRes.Status.Code != rpc.Code_CODE_OK {
+				switch sRes.Status.Code {
+				case rpc.Code_CODE_NOT_FOUND:
+					log.Debug().Str("token", token).Interface("status", res.Status).Msg("resource not found")
+					w.WriteHeader(http.StatusNotFound)
+				case rpc.Code_CODE_PERMISSION_DENIED:
+					log.Debug().Str("token", token).Interface("status", res.Status).Msg("permission denied")
+					w.WriteHeader(http.StatusForbidden)
+				default:
+					log.Error().Str("token", token).Interface("status", res.Status).Msg("grpc stat request failed")
+					w.WriteHeader(http.StatusInternalServerError)
+				}
+				return
+			}
+			log.Debug().Interface("statInfo", sRes.Info).Msg("Stat info from public link token path")
+
+			if sRes.Info.Type != provider.ResourceType_RESOURCE_TYPE_CONTAINER {
+				ctx := context.WithValue(ctx, tokenStatInfoKey{}, sRes.Info)
 				r = r.WithContext(ctx)
 				h.PublicFileHandler.Handler(s).ServeHTTP(w, r)
 			} else {
@@ -181,7 +196,7 @@ func (h *DavHandler) Handler(s *svc) http.Handler {
 	})
 }
 
-func getTokenStatInfo(ctx context.Context, client gatewayv1beta1.GatewayAPIClient, token string) (*provider.ResourceInfo, error) {
+func getTokenStatInfo(ctx context.Context, client gatewayv1beta1.GatewayAPIClient, token string) (*provider.StatResponse, error) {
 	ns := "/public"
 
 	fn := path.Join(ns, token)
@@ -189,18 +204,5 @@ func getTokenStatInfo(ctx context.Context, client gatewayv1beta1.GatewayAPIClien
 		Spec: &provider.Reference_Path{Path: fn},
 	}
 	req := &provider.StatRequest{Ref: ref}
-	res, err := client.Stat(ctx, req)
-	if err != nil {
-		return nil, err
-	}
-
-	if res.Status.Code != rpc.Code_CODE_OK {
-		return nil, fmt.Errorf("Failed to stat, status code %d: %s", res.Status.Code, res.Status.Message)
-	}
-
-	if res.Info == nil {
-		return nil, fmt.Errorf("Failed to stat, info is nil")
-	}
-
-	return res.Info, nil
+	return client.Stat(ctx, req)
 }

--- a/internal/http/services/owncloud/ocdav/delete.go
+++ b/internal/http/services/owncloud/ocdav/delete.go
@@ -53,16 +53,17 @@ func (s *svc) handleDelete(w http.ResponseWriter, r *http.Request, ns string) {
 		return
 	}
 
-	if res.Status.Code == rpc.Code_CODE_NOT_FOUND {
-		log.Warn().Str("code", string(res.Status.Code)).Msg("resource not found")
+	switch res.Status.Code {
+	case rpc.Code_CODE_OK:
+		w.WriteHeader(http.StatusNoContent)
+	case rpc.Code_CODE_NOT_FOUND:
+		log.Debug().Str("path", fn).Interface("status", res.Status).Msg("resource not found")
 		w.WriteHeader(http.StatusNotFound)
-		return
-	}
-
-	if res.Status.Code != rpc.Code_CODE_OK {
-		log.Warn().Str("code", string(res.Status.Code)).Msg("grpc request failed")
+	case rpc.Code_CODE_PERMISSION_DENIED:
+		log.Debug().Str("path", fn).Interface("status", res.Status).Msg("permission denied")
+		w.WriteHeader(http.StatusForbidden)
+	default:
+		log.Error().Str("path", fn).Interface("status", res.Status).Msg("grpc delete request failed")
 		w.WriteHeader(http.StatusInternalServerError)
-		return
 	}
-	w.WriteHeader(http.StatusNoContent)
 }

--- a/internal/http/services/owncloud/ocdav/head.go
+++ b/internal/http/services/owncloud/ocdav/head.go
@@ -57,8 +57,17 @@ func (s *svc) handleHead(w http.ResponseWriter, r *http.Request, ns string) {
 	}
 
 	if res.Status.Code != rpc.Code_CODE_OK {
-		log.Error().Msgf("error calling grpc: %s", res.Status.String())
-		w.WriteHeader(http.StatusInternalServerError)
+		switch res.Status.Code {
+		case rpc.Code_CODE_NOT_FOUND:
+			log.Debug().Str("path", fn).Interface("status", res.Status).Msg("resource not found")
+			w.WriteHeader(http.StatusNotFound)
+		case rpc.Code_CODE_PERMISSION_DENIED:
+			log.Debug().Str("path", fn).Interface("status", res.Status).Msg("permission denied")
+			w.WriteHeader(http.StatusForbidden)
+		default:
+			log.Error().Str("path", fn).Interface("status", res.Status).Msg("grpc stat request failed")
+			w.WriteHeader(http.StatusInternalServerError)
+		}
 		return
 	}
 

--- a/internal/http/services/owncloud/ocdav/propfind.go
+++ b/internal/http/services/owncloud/ocdav/propfind.go
@@ -88,12 +88,17 @@ func (s *svc) handlePropfind(w http.ResponseWriter, r *http.Request, ns string) 
 	}
 
 	if res.Status.Code != rpc.Code_CODE_OK {
-		if res.Status.Code == rpc.Code_CODE_NOT_FOUND {
-			log.Warn().Str("path", fn).Msg("resource not found")
+		switch res.Status.Code {
+		case rpc.Code_CODE_NOT_FOUND:
+			log.Debug().Str("path", fn).Interface("status", res.Status).Msg("resource not found")
 			w.WriteHeader(http.StatusNotFound)
-			return
+		case rpc.Code_CODE_PERMISSION_DENIED:
+			log.Debug().Str("path", fn).Interface("status", res.Status).Msg("permission denied")
+			w.WriteHeader(http.StatusForbidden)
+		default:
+			log.Error().Str("path", fn).Interface("status", res.Status).Msg("grpc stat request failed")
+			w.WriteHeader(http.StatusInternalServerError)
 		}
-		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 
@@ -111,8 +116,17 @@ func (s *svc) handlePropfind(w http.ResponseWriter, r *http.Request, ns string) 
 		}
 
 		if res.Status.Code != rpc.Code_CODE_OK {
-			log.Err(err).Msg("error calling grpc list container")
-			w.WriteHeader(http.StatusInternalServerError)
+			switch res.Status.Code {
+			case rpc.Code_CODE_NOT_FOUND:
+				log.Debug().Str("path", fn).Interface("status", res.Status).Msg("resource not found")
+				w.WriteHeader(http.StatusNotFound)
+			case rpc.Code_CODE_PERMISSION_DENIED:
+				log.Debug().Str("path", fn).Interface("status", res.Status).Msg("permission denied")
+				w.WriteHeader(http.StatusForbidden)
+			default:
+				log.Error().Str("path", fn).Interface("status", res.Status).Msg("grpc list container request failed")
+				w.WriteHeader(http.StatusInternalServerError)
+			}
 			return
 		}
 		infos = append(infos, res.Infos...)
@@ -136,8 +150,17 @@ func (s *svc) handlePropfind(w http.ResponseWriter, r *http.Request, ns string) 
 				return
 			}
 			if res.Status.Code != rpc.Code_CODE_OK {
-				log.Err(err).Str("path", path).Msg("error calling grpc list container")
-				w.WriteHeader(http.StatusInternalServerError)
+				switch res.Status.Code {
+				case rpc.Code_CODE_NOT_FOUND:
+					log.Debug().Str("path", fn).Interface("status", res.Status).Msg("resource not found")
+					w.WriteHeader(http.StatusNotFound)
+				case rpc.Code_CODE_PERMISSION_DENIED:
+					log.Debug().Str("path", fn).Interface("status", res.Status).Msg("permission denied")
+					w.WriteHeader(http.StatusForbidden)
+				default:
+					log.Error().Str("path", fn).Interface("status", res.Status).Msg("grpc list container request failed")
+					w.WriteHeader(http.StatusInternalServerError)
+				}
 				return
 			}
 

--- a/internal/http/services/owncloud/ocdav/proppatch.go
+++ b/internal/http/services/owncloud/ocdav/proppatch.go
@@ -77,12 +77,17 @@ func (s *svc) handleProppatch(w http.ResponseWriter, r *http.Request, ns string)
 	}
 
 	if statRes.Status.Code != rpc.Code_CODE_OK {
-		if statRes.Status.Code == rpc.Code_CODE_NOT_FOUND {
-			log.Warn().Str("path", fn).Msg("resource not found")
+		switch statRes.Status.Code {
+		case rpc.Code_CODE_NOT_FOUND:
+			log.Debug().Str("path", fn).Interface("status", statRes.Status).Msg("resource not found")
 			w.WriteHeader(http.StatusNotFound)
-			return
+		case rpc.Code_CODE_PERMISSION_DENIED:
+			log.Debug().Str("path", fn).Interface("status", statRes.Status).Msg("permission denied")
+			w.WriteHeader(http.StatusForbidden)
+		default:
+			log.Error().Str("path", fn).Interface("status", statRes.Status).Msg("grpc stat request failed")
+			w.WriteHeader(http.StatusInternalServerError)
 		}
-		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 
@@ -132,12 +137,17 @@ func (s *svc) handleProppatch(w http.ResponseWriter, r *http.Request, ns string)
 				}
 
 				if res.Status.Code != rpc.Code_CODE_OK {
-					if res.Status.Code == rpc.Code_CODE_NOT_FOUND {
-						log.Warn().Str("path", fn).Msg("resource not found")
+					switch res.Status.Code {
+					case rpc.Code_CODE_NOT_FOUND:
+						log.Debug().Str("path", fn).Interface("status", res.Status).Msg("resource not found")
 						w.WriteHeader(http.StatusNotFound)
-						return
+					case rpc.Code_CODE_PERMISSION_DENIED:
+						log.Debug().Str("path", fn).Interface("status", res.Status).Msg("permission denied")
+						w.WriteHeader(http.StatusForbidden)
+					default:
+						log.Error().Str("path", fn).Interface("status", res.Status).Msg("grpc unset arbitrary metadata request failed")
+						w.WriteHeader(http.StatusInternalServerError)
 					}
-					w.WriteHeader(http.StatusInternalServerError)
 					return
 				}
 				removedProps = append(removedProps, propNameXML)
@@ -151,14 +161,20 @@ func (s *svc) handleProppatch(w http.ResponseWriter, r *http.Request, ns string)
 				}
 
 				if res.Status.Code != rpc.Code_CODE_OK {
-					if res.Status.Code == rpc.Code_CODE_NOT_FOUND {
-						log.Warn().Str("path", fn).Msg("resource not found")
+					switch res.Status.Code {
+					case rpc.Code_CODE_NOT_FOUND:
+						log.Debug().Str("path", fn).Interface("status", res.Status).Msg("resource not found")
 						w.WriteHeader(http.StatusNotFound)
-						return
+					case rpc.Code_CODE_PERMISSION_DENIED:
+						log.Debug().Str("path", fn).Interface("status", res.Status).Msg("permission denied")
+						w.WriteHeader(http.StatusForbidden)
+					default:
+						log.Error().Str("path", fn).Interface("status", res.Status).Msg("grpc set arbitrary metadata request failed")
+						w.WriteHeader(http.StatusInternalServerError)
 					}
-					w.WriteHeader(http.StatusInternalServerError)
 					return
 				}
+
 				acceptedProps = append(acceptedProps, propNameXML)
 				delete(sreq.ArbitraryMetadata.Metadata, key)
 			}

--- a/internal/http/services/owncloud/ocdav/putchunked.go
+++ b/internal/http/services/owncloud/ocdav/putchunked.go
@@ -270,11 +270,16 @@ func (s *svc) handlePutChunked(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if res.Status.Code != rpc.Code_CODE_OK {
-		if res.Status.Code != rpc.Code_CODE_NOT_FOUND {
+	if res.Status.Code != rpc.Code_CODE_OK && res.Status.Code != rpc.Code_CODE_NOT_FOUND {
+		switch res.Status.Code {
+		case rpc.Code_CODE_PERMISSION_DENIED:
+			log.Debug().Str("path", fn).Interface("status", res.Status).Msg("permission denied")
+			w.WriteHeader(http.StatusForbidden)
+		default:
+			log.Error().Str("path", fn).Interface("status", res.Status).Msg("grpc stat request failed")
 			w.WriteHeader(http.StatusInternalServerError)
-			return
 		}
+		return
 	}
 
 	info := res.Info

--- a/internal/http/services/owncloud/ocdav/tus.go
+++ b/internal/http/services/owncloud/ocdav/tus.go
@@ -89,11 +89,16 @@ func (s *svc) handleTusPost(w http.ResponseWriter, r *http.Request, ns string) {
 		return
 	}
 
-	if sRes.Status.Code != rpc.Code_CODE_OK {
-		if sRes.Status.Code != rpc.Code_CODE_NOT_FOUND {
+	if sRes.Status.Code != rpc.Code_CODE_OK && sRes.Status.Code != rpc.Code_CODE_NOT_FOUND {
+		switch sRes.Status.Code {
+		case rpc.Code_CODE_PERMISSION_DENIED:
+			log.Debug().Str("path", fn).Interface("status", sRes.Status).Msg("permission denied")
+			w.WriteHeader(http.StatusForbidden)
+		default:
+			log.Error().Str("path", fn).Interface("status", sRes.Status).Msg("grpc stat request failed")
 			w.WriteHeader(http.StatusInternalServerError)
-			return
 		}
+		return
 	}
 
 	info := sRes.Info
@@ -148,7 +153,17 @@ func (s *svc) handleTusPost(w http.ResponseWriter, r *http.Request, ns string) {
 	}
 
 	if uRes.Status.Code != rpc.Code_CODE_OK {
-		w.WriteHeader(http.StatusInternalServerError)
+		switch uRes.Status.Code {
+		case rpc.Code_CODE_NOT_FOUND:
+			log.Debug().Str("path", fn).Interface("status", uRes.Status).Msg("resource not found")
+			w.WriteHeader(http.StatusNotFound)
+		case rpc.Code_CODE_PERMISSION_DENIED:
+			log.Debug().Str("path", fn).Interface("status", uRes.Status).Msg("permission denied")
+			w.WriteHeader(http.StatusForbidden)
+		default:
+			log.Error().Str("path", fn).Interface("status", uRes.Status).Msg("grpc initiate file upload request failed")
+			w.WriteHeader(http.StatusInternalServerError)
+		}
 		return
 	}
 
@@ -213,11 +228,16 @@ func (s *svc) handleTusPost(w http.ResponseWriter, r *http.Request, ns string) {
 				return
 			}
 
-			if sRes.Status.Code != rpc.Code_CODE_OK {
-				if sRes.Status.Code != rpc.Code_CODE_NOT_FOUND {
+			if sRes.Status.Code != rpc.Code_CODE_OK && sRes.Status.Code != rpc.Code_CODE_NOT_FOUND {
+				switch sRes.Status.Code {
+				case rpc.Code_CODE_PERMISSION_DENIED:
+					log.Debug().Str("path", fn).Interface("status", sRes.Status).Msg("permission denied")
+					w.WriteHeader(http.StatusForbidden)
+				default:
+					log.Error().Str("path", fn).Interface("status", sRes.Status).Msg("grpc stat request failed")
 					w.WriteHeader(http.StatusInternalServerError)
-					return
 				}
+				return
 			}
 
 			info := sRes.Info


### PR DESCRIPTION
The ocdav api is no longer ignoring permissions errors.
It will now check the status for `rpc.Code_CODE_PERMISSION_DENIED` codes and report them properly using `http.StatusForbidden` instead of `http.StatusInternalServerError`