### PR TITLE
[Tests-Only] Remove passing webDavPUTAuth scenario from expected-failures

### DIFF
--- a/tests/acceptance/expected-failures-on-EOS-storage.txt
+++ b/tests/acceptance/expected-failures-on-EOS-storage.txt
@@ -103,9 +103,6 @@ apiAuthWebDav/webDavPROPFINDAuth.feature:37
 # https://github.com/owncloud/ocis-reva/issues/9 users can access each-others data using the new webdav API
 apiAuthWebDav/webDavPROPPATCHAuth.feature:38
 #
-# https://github.com/owncloud/ocis-reva/issues/9 users can access each-others data using the new webdav API
-apiAuthWebDav/webDavPUTAuth.feature:38
-#
 # https://github.com/owncloud/ocis-reva/issues/175 Default capabilities for normal user not same as in oC-core
 # https://github.com/owncloud/ocis-reva/issues/176 Difference in response content of status.php and default capabilities
 apiCapabilities/capabilitiesWithNormalUser.feature:11

--- a/tests/acceptance/expected-failures-on-OC-storage.txt
+++ b/tests/acceptance/expected-failures-on-OC-storage.txt
@@ -96,9 +96,6 @@ apiAuthWebDav/webDavPROPFINDAuth.feature:37
 # https://github.com/owncloud/ocis-reva/issues/9 users can access each-others data using the new webdav API
 apiAuthWebDav/webDavPROPPATCHAuth.feature:38
 #
-# https://github.com/owncloud/ocis-reva/issues/9 users can access each-others data using the new webdav API
-apiAuthWebDav/webDavPUTAuth.feature:38
-#
 # https://github.com/owncloud/ocis-reva/issues/175 Default capabilities for normal user not same as in oC-core
 # https://github.com/owncloud/ocis-reva/issues/176 Difference in response content of status.php and default capabilities
 apiCapabilities/capabilitiesWithNormalUser.feature:11


### PR DESCRIPTION
PR #1216 changed code so that `apiAuthWebDav/webDavPUTAuth.feature:38` passes.
That PR was force-merged even though CI "failed".

Remove the scenario from the expected-failures list. That will get CI green again.