### PR TITLE
[WIP] enable group shares

### DIFF
--- a/internal/http/services/owncloud/ocs/conversions/main.go
+++ b/internal/http/services/owncloud/ocs/conversions/main.go
@@ -42,11 +42,11 @@ const (
 	// ShareTypeUser refers to user shares
 	ShareTypeUser ShareType = 0
 
+	// ShareTypeGroup represents a group share
+	ShareTypeGroup ShareType = 1
+
 	// ShareTypePublicLink refers to public link shares
 	ShareTypePublicLink ShareType = 3
-
-	// ShareTypeGroup represents a group share
-	// ShareTypeGroup ShareType = 1
 
 	// ShareTypeFederatedCloudShare represents a federated share
 	ShareTypeFederatedCloudShare ShareType = 6
@@ -278,10 +278,15 @@ func AsCS3Permissions(p int, rp *provider.ResourcePermissions) *provider.Resourc
 func UserShare2ShareData(ctx context.Context, share *collaboration.Share) (*ShareData, error) {
 	sd := &ShareData{
 		Permissions:  UserSharePermissions2OCSPermissions(share.GetPermissions()),
-		ShareType:    ShareTypeUser,
 		UIDOwner:     LocalUserIDToString(share.GetCreator()),
 		UIDFileOwner: LocalUserIDToString(share.GetOwner()),
 		ShareWith:    LocalUserIDToString(share.GetGrantee().GetId()),
+	}
+	switch share.GetGrantee().GetType() {
+	case provider.GranteeType_GRANTEE_TYPE_GROUP:
+		sd.ShareType = ShareTypeGroup
+	default:
+		sd.ShareType = ShareTypeUser
 	}
 
 	if share.Id != nil && share.Id.OpaqueId != "" {


### PR DESCRIPTION
We are tentatively allowing group shares. Currently, the shareWith is used as is and persisted in the storage as is ...
- the name of a group might change, then the share will break
- reva currently has neither an API to look up a group id nor a group display name 
- other than the above ... I could share with the users group and access a folder :-)

tested on top of https://github.com/cs3org/reva/pull/1219 and https://github.com/cs3org/reva/pull/1213 but can be merged standalone