### PR TITLE
ocis: allow setting owner of root

### DIFF
--- a/changelog/unreleased/ocis-set-owner.md
+++ b/changelog/unreleased/ocis-set-owner.md
@@ -1,0 +1,5 @@
+Enhancement: Allow setting the owner when using the ocis driver
+
+To support the metadata storage we allow setting the owner of the root node so that subsequent requests with that owner can be used to manage the storage.
+
+https://github.com/cs3org/reva/pull/1225

--- a/pkg/storage/fs/ocis/ocis.go
+++ b/pkg/storage/fs/ocis/ocis.go
@@ -26,6 +26,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	userv1beta1 "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	"github.com/cs3org/reva/pkg/appctx"
 	"github.com/cs3org/reva/pkg/errtypes"
@@ -122,6 +123,7 @@ func New(m map[string]interface{}) (storage.FS, error) {
 	}
 	o.init(m)
 
+	// create data paths for internal layout
 	dataPaths := []string{
 		filepath.Join(o.Root, "nodes"),
 		// notes contain symlinks from nodes/<u-u-i-d>/uploads/<uploadid> to ../../uploads/<uploadid>
@@ -141,9 +143,14 @@ func New(m map[string]interface{}) (storage.FS, error) {
 		Options: o,
 	}
 
-	// the root node has an empty name, or use `.` ?
-	// the root node has no parent, or use `root` ?
-	if err = createNode(&Node{lu: lu, ID: "root"}, nil); err != nil {
+	// the root node has an empty name
+	// the root node has no parent
+	if err = createNode(
+		&Node{lu: lu, ID: "root"},
+		&userv1beta1.UserId{
+			OpaqueId: o.Owner,
+		},
+	); err != nil {
 		return nil, err
 	}
 

--- a/pkg/storage/fs/ocis/option.go
+++ b/pkg/storage/fs/ocis/option.go
@@ -40,6 +40,9 @@ type Options struct {
 
 	// propagate size changes as treesize
 	TreeSizeAccounting bool `mapstructure:"treesize_accounting"`
+
+	// set an owner for the root node
+	Owner string `mapstructure:"owner"`
 }
 
 // newOptions initializes the available default options.


### PR DESCRIPTION
Enhancement: Allow setting the owner when using the ocis driver

To support the metadata storage we allow setting the owner of the root node so that subsequent requests with that owner can be used to manage the storage.