### PR TITLE
quote etags in OCIS-Storage

### DIFF
--- a/changelog/unreleased/fix-quote-etag-on-ocis-storage.md
+++ b/changelog/unreleased/fix-quote-etag-on-ocis-storage.md
@@ -1,0 +1,6 @@
+Bugfix: Fix missing quotes on OCIS-Storage
+
+Etags have to be enclosed in quotes ". Return correct etags on OCIS-Storage.
+
+https://github.com/owncloud/product/issues/237
+https://github.com/cs3org/reva/pull/1232

--- a/pkg/storage/fs/ocis/node.go
+++ b/pkg/storage/fs/ocis/node.go
@@ -355,9 +355,9 @@ func (n *Node) AsResourceInfo(ctx context.Context) (ri *provider.ResourceInfo, e
 
 	// use temporary etag if it is set
 	if b, err := xattr.Get(nodePath, tmpEtagAttr); err == nil {
-		ri.Etag = string(b)
+		ri.Etag = fmt.Sprintf(`"%x"`, string(b))
 	} else {
-		ri.Etag = fmt.Sprintf("%x", h.Sum(nil))
+		ri.Etag = fmt.Sprintf(`"%x"`, h.Sum(nil))
 	}
 
 	// mtime uses tmtime if present


### PR DESCRIPTION
With OCIS-Storage the etags haven't been quoted, but they have to be
see also https://github.com/cs3org/reva/issues/865

fixes https://github.com/owncloud/product/issues/237