### PR TITLE
Remove changelog files from unreleased directory from v1.3.0

### DIFF
--- a/changelog/unreleased/allow-username-in-dav-files.md
+++ b/changelog/unreleased/allow-username-in-dav-files.md
@@ -1,6 +1,0 @@
-Enhancement: Allow using the username when accessing the users home
-
-We now allow using the userid and the username when accessing the
-users home on the `/dev/files` endpoint.
-
-https://github.com/cs3org/reva/pull/1205

--- a/changelog/unreleased/appprovider-stat.md
+++ b/changelog/unreleased/appprovider-stat.md
@@ -1,7 +1,0 @@
-Bugfix: Call the gateway stat method from appprovider
-
-The appprovider service used to directly pass the stat request to the storage
-provider bypassing the gateway, which resulted in errors while handling share
-children as they are resolved in the gateway path.
-
-https://github.com/cs3org/reva/pull/1140

--- a/changelog/unreleased/cato-nested-packages.md
+++ b/changelog/unreleased/cato-nested-packages.md
@@ -1,7 +1,0 @@
-Enhancement: Use updated cato to display nested package config in parent docs
-
-Previously, in case of nested packages, we just had a link pointing to the child
-package. Now we copy the nested package's documentation to the parent itself to
-make it easier for devs.
-
-https://github.com/cs3org/reva/pull/1131

--- a/changelog/unreleased/check-permissions-in-ocis-driver.md
+++ b/changelog/unreleased/check-permissions-in-ocis-driver.md
@@ -1,5 +1,0 @@
-Enhancement: check permissions in ocis driver
-
-We are now checking grant permissions in the ocis storage driver.
-
-https://github.com/cs3org/reva/pull/1213

--- a/changelog/unreleased/chheck-permissions-in-owncloud-driver.md
+++ b/changelog/unreleased/chheck-permissions-in-owncloud-driver.md
@@ -1,5 +1,0 @@
-Enhancement: check permissions in owncloud driver
-
-We are now checking grant permissions in the owncloud storage driver.
-
-https://github.com/cs3org/reva/pull/1202

--- a/changelog/unreleased/create-symlink-stubs.md
+++ b/changelog/unreleased/create-symlink-stubs.md
@@ -1,3 +1,0 @@
-Enhancement: Add GRPC stubs for CreateSymlink method
-
-https://github.com/cs3org/reva/pull/1228

--- a/changelog/unreleased/eos-version-invariant.md
+++ b/changelog/unreleased/eos-version-invariant.md
@@ -1,8 +1,0 @@
-Enhancement: Add logic in EOS FS for maintaining same inode across file versions
-
-This PR adds the functionality to maintain the same inode across various
-versions of a file by returning the inode of the version folder which remains
-constant. It requires extra metadata operations so a flag is provided to disable
-it.
-
-https://github.com/cs3org/reva/pull/1174.

--- a/changelog/unreleased/file-share-up-download.md
+++ b/changelog/unreleased/file-share-up-download.md
@@ -1,5 +1,0 @@
-Bugfix: up and download of file shares
-
-The shared folder logic in the gateway storageprovider was not allowing file up and downloads for single file shares. We now check if the reference is actually a file to determine if up / download should be allowed.
-
-https://github.com/cs3org/reva/pull/1170

--- a/changelog/unreleased/fix-oci-move.md
+++ b/changelog/unreleased/fix-oci-move.md
@@ -1,5 +1,0 @@
-Bugfix: Fix ocis move
-
-When renaming a file we updating the name attribute on the wrong node, causing the path construction to use the wrong name. This fixes the litmus move_coll test.
-
-https://github.com/cs3org/reva/pull/1177

--- a/changelog/unreleased/fix-oci-props.md
+++ b/changelog/unreleased/fix-oci-props.md
@@ -1,6 +1,0 @@
-Bugfix: Fix litmus failing on ocis storage
-
-We now ignore the `no data available` error when removing a non existing metadata attribute, which is ok because we are trying to delete it anyway.
-
-https://github.com/cs3org/reva/issues/1178
-https://github.com/cs3org/reva/pull/1179

--- a/changelog/unreleased/fix-quote-etag-on-ocis-storage.md
+++ b/changelog/unreleased/fix-quote-etag-on-ocis-storage.md
@@ -1,6 +1,0 @@
-Bugfix: Fix missing quotes on OCIS-Storage
-
-Etags have to be enclosed in quotes ". Return correct etags on OCIS-Storage.
-
-https://github.com/owncloud/product/issues/237
-https://github.com/cs3org/reva/pull/1232

--- a/changelog/unreleased/gateway-permissions-errors.md
+++ b/changelog/unreleased/gateway-permissions-errors.md
@@ -1,7 +1,0 @@
-Bugfix: No longer swallow permissions errors in the gateway
-
-The gateway is no longer ignoring permissions errors.
-It will now check the status for `rpc.Code_CODE_PERMISSION_DENIED` codes
-and report them properly using `status.NewPermissionDenied` or `status.NewInternal` instead of reusing the original response status.
-
-https://github.com/cs3org/reva/pull/1210

--- a/changelog/unreleased/handle-eos-eperm.md
+++ b/changelog/unreleased/handle-eos-eperm.md
@@ -1,5 +1,0 @@
-Bugfix: Handle eos EPERM as permission denied
-
-We now treat EPERM errors, which occur, eg. when acl checks fail and return a permission denied error.
-
-https://github.com/cs3org/reva/pull/1183

--- a/changelog/unreleased/home-sp-mapping.md
+++ b/changelog/unreleased/home-sp-mapping.md
@@ -1,7 +1,0 @@
-Enhancement: Functionality to map home directory to different storage providers
-
-We hardcode the home path for all users to /home. This forbids redirecting
-requests for different users to multiple storage providers. This PR provides the
-option to map the home directories of different users using user attributes.
-
-https://github.com/cs3org/reva/pull/1142

--- a/changelog/unreleased/mentix-bbe-support.md
+++ b/changelog/unreleased/mentix-bbe-support.md
@@ -1,5 +1,0 @@
-Enhancement: Add Blackbox Exporter support to Mentix
-
-This update extends Mentix to export a Prometheus SD file specific to the Blackbox Exporter which will be used for initial health monitoring. Usually, Prometheus requires its targets to only consist of the target's hostname; the BBE though expects a full URL here. This makes exporting two distinct files necessary.
-
-https://github.com/cs3org/reva/pull/1190

--- a/changelog/unreleased/new-gateway-datatx-service.md
+++ b/changelog/unreleased/new-gateway-datatx-service.md
@@ -1,5 +1,0 @@
-Enhancement: New gateway datatx service
-
-Represents the CS3 datatx module in the gateway.
-
-https://github.com/cs3org/reva/pull/1229

--- a/changelog/unreleased/no-longer-swallow-permissions-errors.md
+++ b/changelog/unreleased/no-longer-swallow-permissions-errors.md
@@ -1,6 +1,0 @@
-Bugfix: No longer swallow permissions errors
-
-The storageprovider is no longer ignoring permissions errors.
-It will now report them properly using `status.NewPermissionDenied(...)` instead of `status.NewInternal(...)`
-
-https://github.com/cs3org/reva/pull/1206

--- a/changelog/unreleased/ocdav-permissions-errors.md
+++ b/changelog/unreleased/ocdav-permissions-errors.md
@@ -1,6 +1,0 @@
-Bugfix: No longer swallow permissions errors in ocdav
-
-The ocdav api is no longer ignoring permissions errors.
-It will now check the status for `rpc.Code_CODE_PERMISSION_DENIED` codes and report them properly using `http.StatusForbidden` instead of `http.StatusInternalServerError`
-
-https://github.com/cs3org/reva/pull/1207

--- a/changelog/unreleased/ocis-cache-displayname.md
+++ b/changelog/unreleased/ocis-cache-displayname.md
@@ -1,5 +1,0 @@
-Bugfix: Cache display names in ocs service
-
-The ocs list shares endpoint may need to fetch the displayname for multiple different users. We are now caching the lookup fo 60 seconds to save redundant RPCs to the users service.
-
-https://github.com/cs3org/reva/pull/1161

--- a/changelog/unreleased/ocis-set-owner.md
+++ b/changelog/unreleased/ocis-set-owner.md
@@ -1,5 +1,0 @@
-Enhancement: Allow setting the owner when using the ocis driver
-
-To support the metadata storage we allow setting the owner of the root node so that subsequent requests with that owner can be used to manage the storage.
-
-https://github.com/cs3org/reva/pull/1225

--- a/changelog/unreleased/ocis-synctime-accounting.md
+++ b/changelog/unreleased/ocis-synctime-accounting.md
@@ -1,7 +1,0 @@
-Enhancement: introduce ocis driver treetime accounting
-
-We added tree time accounting to the ocis storage driver which is modeled after [eos synctime accounting](http://eos-docs.web.cern.ch/eos-docs/configuration/namespace.html#enable-subtree-accounting).
-It can be enabled using the new `treetime_accounting` option, which defaults to `false`
-The `tmtime` is stored in an extended attribute `user.ocis.tmtime`. The treetime accounting is enabled for nodes which have the `user.ocis.propagation` extended attribute set to `"1"`. Currently, propagation is in sync.
-
-https://github.com/cs3org/reva/pull/1180

--- a/changelog/unreleased/ref-errors.md
+++ b/changelog/unreleased/ref-errors.md
@@ -1,4 +1,0 @@
-Bugfix: Add error handling for invalid references
-
-https://github.com/cs3org/reva/pull/1216
-https://github.com/cs3org/reva/pull/1218

--- a/changelog/unreleased/virtual-etag.md
+++ b/changelog/unreleased/virtual-etag.md
@@ -1,9 +1,0 @@
-Enhancement: Calculate etags on-the-fly for shares directory and home folder
-
-We create references for accepted shares in the shares directory, but these
-aren't updated when the original resource is modified. This PR adds the
-functionality to generate the etag for the shares directory and correspondingly,
-the home directory, based on the actual resources which the references point to,
-enabling the sync functionality.
-
-https://github.com/cs3org/reva/pull/1208

--- a/go.sum
+++ b/go.sum
@@ -134,6 +134,7 @@ github.com/cs3org/go-cs3apis v0.0.0-20200810113633-b00aca449666 h1:E7VsSSN/2YZLS
 github.com/cs3org/go-cs3apis v0.0.0-20200810113633-b00aca449666/go.mod h1:UXha4TguuB52H14EMoSsCqDj7k8a/t7g4gVP+bgY5LY=
 github.com/cs3org/go-cs3apis v0.0.0-20200903142434-7dfeb0059208 h1:EnNRlx2qlHh1l4rLIdlA2QVwvHyKT1KFZxRyDqm0NNQ=
 github.com/cs3org/go-cs3apis v0.0.0-20200903142434-7dfeb0059208/go.mod h1:UXha4TguuB52H14EMoSsCqDj7k8a/t7g4gVP+bgY5LY=
+github.com/cs3org/go-cs3apis v0.0.0-20200929101248-821df597ec8d/go.mod h1:UXha4TguuB52H14EMoSsCqDj7k8a/t7g4gVP+bgY5LY=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/tools/prepare-release/main.go
+++ b/tools/prepare-release/main.go
@@ -182,7 +182,7 @@ func isRepoDirty() bool {
 
 func add(msg string, files ...string) {
 	for _, f := range files {
-		cmd := exec.Command("git", "add", f)
+		cmd := exec.Command("git", "add", "--all", f)
 		cmd.Dir = "."
 		run(cmd)
 	}


### PR DESCRIPTION
Older git versions don't add deleted files for staging by default. So it missed removing the files from the unreleased directory in the commit. Also fixed this issue in prepare-release.