### PR TITLE
Add a test user to all sites

### DIFF
--- a/changelog/unreleased/add-test-user.md
+++ b/changelog/unreleased/add-test-user.md
@@ -1,0 +1,5 @@
+Enhancement: Add a test user to all sites
+
+For health monitoring of all mesh sites, we need a special user account that is present on every site. This PR adds such a user to each users-*.json file so that every site will have the same test user credentials.
+
+https://github.com/cs3org/reva/pull/1257

--- a/examples/ocm-partners/users-ailleron.json
+++ b/examples/ocm-partners/users-ailleron.json
@@ -31,5 +31,16 @@
 		"mail": "dawid@softwaremind.com",
 		"display_name": "Dawid",
 		"groups": ["quantum-lovers", "philosophy-haters", "physics-lovers"]
+	},
+	{
+		"id": {
+			"opaque_id": "test4242",
+			"idp": "softwaremind.com"
+		},
+		"username": "test",
+		"secret": "testpass",
+		"mail": "test42@softwaremind.com",
+		"display_name": "Testuser",
+		"groups": ["test-lovers", "bug-haters", "ai-lovers"]
 	}
 ]

--- a/examples/ocm-partners/users-cern.json
+++ b/examples/ocm-partners/users-cern.json
@@ -31,5 +31,16 @@
 		"mail": "samuel@cern.ch",
 		"display_name": "Samuel Alfageme Sainz",
 		"groups": ["quantum-lovers", "philosophy-haters", "physics-lovers"]
+	},
+	{
+		"id": {
+			"opaque_id": "test4242",
+			"idp": "cern.ch"
+		},
+		"username": "test",
+		"secret": "testpass",
+		"mail": "test42@cern.ch",
+		"display_name": "Testuser",
+		"groups": ["test-lovers", "bug-haters", "ai-lovers"]
 	}
 ]

--- a/examples/ocm-partners/users-cesnet.json
+++ b/examples/ocm-partners/users-cesnet.json
@@ -20,5 +20,16 @@
 		"mail": "milan@cesnet.cz",
 		"display_name": "Milan",
 		"groups": ["radium-lovers", "polonium-lovers", "physics-lovers"]
+	},
+	{
+		"id": {
+			"opaque_id": "test4242",
+			"idp": "cesnet.cz"
+		},
+		"username": "test",
+		"secret": "testpass",
+		"mail": "test42@cesnet.cz",
+		"display_name": "Testuser",
+		"groups": ["test-lovers", "bug-haters", "ai-lovers"]
 	}
 ]

--- a/examples/ocm-partners/users-cubbit.json
+++ b/examples/ocm-partners/users-cubbit.json
@@ -20,5 +20,16 @@
 		"mail": "lorenzo@cubbit.io",
 		"display_name": "Lorenzo",
 		"groups": ["radium-lovers", "polonium-lovers", "physics-lovers"]
+	},
+	{
+		"id": {
+			"opaque_id": "test4242",
+			"idp": "cubbit.io"
+		},
+		"username": "test",
+		"secret": "testpass",
+		"mail": "test42@cubbit.io",
+		"display_name": "Testuser",
+		"groups": ["test-lovers", "bug-haters", "ai-lovers"]
 	}
 ]

--- a/examples/ocm-partners/users-surfsara.json
+++ b/examples/ocm-partners/users-surfsara.json
@@ -20,5 +20,16 @@
 		"mail": "antoon@surfsara.nl",
 		"display_name": "Antoon",
 		"groups": ["radium-lovers", "polonium-lovers", "physics-lovers"]
+	},
+	{
+		"id": {
+			"opaque_id": "test4242",
+			"idp": "surfsara.nl"
+		},
+		"username": "test",
+		"secret": "testpass",
+		"mail": "test42@surfsara.nl",
+		"display_name": "Testuser",
+		"groups": ["test-lovers", "bug-haters", "ai-lovers"]
 	}
 ]

--- a/examples/ocm-partners/users-switch.json
+++ b/examples/ocm-partners/users-switch.json
@@ -31,5 +31,16 @@
 		"mail": "urs.schmid@switch.ch",
 		"display_name": "Urs Schmid",
 		"groups": ["quantum-lovers", "philosophy-haters", "physics-lovers"]
+	},
+	{
+		"id": {
+			"opaque_id": "test4242",
+			"idp": "switch.ch"
+		},
+		"username": "test",
+		"secret": "testpass",
+		"mail": "test42@switch.ch",
+		"display_name": "Testuser",
+		"groups": ["test-lovers", "bug-haters", "ai-lovers"]
 	}
 ]

--- a/examples/ocm-partners/users-wwu.json
+++ b/examples/ocm-partners/users-wwu.json
@@ -20,5 +20,16 @@
 		"mail": "daniel@uni-muenster.de",
 		"display_name": "Daniel",
 		"groups": ["radium-lovers", "polonium-lovers", "physics-lovers"]
+	},
+	{
+		"id": {
+			"opaque_id": "test4242",
+			"idp": "uni-muenster.de"
+		},
+		"username": "test",
+		"secret": "testpass",
+		"mail": "test42@uni-muenster.de",
+		"display_name": "Testuser",
+		"groups": ["test-lovers", "bug-haters", "ai-lovers"]
 	}
 ]


### PR DESCRIPTION
For health monitoring of all mesh sites, we need a special user account that is present on every site. This PR adds such a user to each `users-*.json` file so that every site will have the same test user credentials (which are, of course, **test/testpass**).

This omnipresent test user allows us to perform remote checks that require authentication using the same credentials for every site, making automated check configuration much easier.

_Note that this is just a temporary solution, but for this initial phase, this is the easiest solution._

(I recreated this PR as the previous one was a mess)