### PR TITLE
update grants in the storage provider on share update

### DIFF
--- a/changelog/unreleased/update-grants-on-share-update.md
+++ b/changelog/unreleased/update-grants-on-share-update.md
@@ -1,0 +1,5 @@
+Bugfix: update share grants on share update 
+
+When a share was updated the share information in the share manager was updated but the grants set by the storage provider were not.
+
+https://github.com/cs3org/reva/pull/1258

--- a/internal/grpc/services/gateway/usershareprovider.go
+++ b/internal/grpc/services/gateway/usershareprovider.go
@@ -205,10 +205,15 @@ func (s *svc) UpdateShare(ctx context.Context, req *collaboration.UpdateShareReq
 		updateGrantStatus, err := s.updateGrant(ctx, getShareRes.GetShare().GetResourceId(),
 			getShareRes.GetShare().GetGrantee(),
 			getShareRes.GetShare().GetPermissions().GetPermissions())
+
+		if err != nil {
+			return nil, errors.Wrap(err, "gateway: error calling updateGrant")
+		}
+
 		if updateGrantStatus.Code != rpc.Code_CODE_OK {
 			return &collaboration.UpdateShareResponse{
 				Status: updateGrantStatus,
-			}, err
+			}, nil
 		}
 	}
 

--- a/tests/acceptance/expected-failures-on-OWNCLOUD-storage.txt
+++ b/tests/acceptance/expected-failures-on-OWNCLOUD-storage.txt
@@ -609,19 +609,8 @@ apiShareReshareToShares2/reShareSubfolder.feature:84
 #
 # https://github.com/owncloud/product/issues/270 share permissions are not enforced
 #
-apiShareReshareToShares3/reShareUpdate.feature:25
-apiShareReshareToShares3/reShareUpdate.feature:26
 apiShareReshareToShares3/reShareUpdate.feature:59
 apiShareReshareToShares3/reShareUpdate.feature:60
-#
-# WebDav::listFolderAndReturnResponseXml Received empty response where XML was expected (Exception) (note: passes in owncloud/ocis)
-#
-apiShareReshareToShares3/reShareUpdate.feature:42
-apiShareReshareToShares3/reShareUpdate.feature:43
-apiShareReshareToShares3/reShareUpdate.feature:76
-apiShareReshareToShares3/reShareUpdate.feature:77
-apiShareReshareToShares3/reShareUpdate.feature:93
-apiShareReshareToShares3/reShareUpdate.feature:94
 #
 # https://github.com/owncloud/product/issues/207 Response is empty when accepting a share
 #


### PR DESCRIPTION
The grants set by the ocis storage were not updated when updating a share.
This PR reimplements the code, that was there before but commented out, in a way that is similar to the `addGrant` logic in `CreateShare`