### PR TITLE
change response status to maintain backwards compatibility to ownClou…

### DIFF
--- a/changelog/unreleased/propfind-backwards-compatibility.md
+++ b/changelog/unreleased/propfind-backwards-compatibility.md
@@ -1,0 +1,7 @@
+Bugfix: Fix propfind response code on forbidden files 
+
+When executing a propfind to a resource owned by another user the service would respond with a HTTP 403.
+In ownCloud 10 the response was HTTP 207. This change sets the response code to HTTP 207 to stay backwards compatible.
+
+https://github.com/cs3org/reva/pull/1259
+

--- a/internal/http/services/owncloud/ocdav/propfind.go
+++ b/internal/http/services/owncloud/ocdav/propfind.go
@@ -94,7 +94,7 @@ func (s *svc) handlePropfind(w http.ResponseWriter, r *http.Request, ns string) 
 			w.WriteHeader(http.StatusNotFound)
 		case rpc.Code_CODE_PERMISSION_DENIED:
 			log.Debug().Str("path", fn).Interface("status", res.Status).Msg("permission denied")
-			w.WriteHeader(http.StatusForbidden)
+			w.WriteHeader(http.StatusMultiStatus)
 		default:
 			log.Error().Str("path", fn).Interface("status", res.Status).Msg("grpc stat request failed")
 			w.WriteHeader(http.StatusInternalServerError)


### PR DESCRIPTION
…d 10

When executing a propfind to a resource owned by another user the service would respond with a HTTP 403.
In ownCloud 10 the response was HTTP 207. This change sets the response code to HTTP 207 to stay backwards compatible.