### PR TITLE
Reuse HTTP Clients

### DIFF
--- a/changelog/unreleased/ocdav-fix-file-descriptor-leak.md
+++ b/changelog/unreleased/ocdav-fix-file-descriptor-leak.md
@@ -2,4 +2,4 @@ Bugfix: Fix file descriptor leak on ocdav put handler
 
 File descriptors on the ocdav service, especially on the put handler was leaking http connections. This PR addresses this.
 
-https://github.com/cs3org/reva/pull/1259
+https://github.com/cs3org/reva/pull/1260

--- a/changelog/unreleased/ocdav-fix-file-descriptor-leak.md
+++ b/changelog/unreleased/ocdav-fix-file-descriptor-leak.md
@@ -1,0 +1,5 @@
+Bugfix: Fix file descriptor leak on ocdav put handler 
+
+File descriptors on the ocdav service, especially on the put handler was leaking http connections. This PR addresses this.
+
+https://github.com/cs3org/reva/pull/1259

--- a/internal/http/services/datagateway/datagateway.go
+++ b/internal/http/services/datagateway/datagateway.go
@@ -20,12 +20,6 @@ package datagateway
 
 import (
 	"context"
-	"io"
-	"net/http"
-	"net/url"
-	"path"
-	"time"
-
 	"github.com/cs3org/reva/pkg/appctx"
 	"github.com/cs3org/reva/pkg/errtypes"
 	"github.com/cs3org/reva/pkg/rhttp"
@@ -35,6 +29,11 @@ import (
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
+	"io"
+	"net/http"
+	"net/url"
+	"path"
+	"time"
 )
 
 const (

--- a/internal/http/services/datagateway/datagateway.go
+++ b/internal/http/services/datagateway/datagateway.go
@@ -20,6 +20,12 @@ package datagateway
 
 import (
 	"context"
+	"io"
+	"net/http"
+	"net/url"
+	"path"
+	"time"
+
 	"github.com/cs3org/reva/pkg/appctx"
 	"github.com/cs3org/reva/pkg/errtypes"
 	"github.com/cs3org/reva/pkg/rhttp"
@@ -29,11 +35,6 @@ import (
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
-	"io"
-	"net/http"
-	"net/url"
-	"path"
-	"time"
 )
 
 const (

--- a/internal/http/services/owncloud/ocdav/copy.go
+++ b/internal/http/services/owncloud/ocdav/copy.go
@@ -21,6 +21,11 @@ package ocdav
 import (
 	"context"
 	"fmt"
+	"io"
+	"net/http"
+	"path"
+	"strings"
+
 	gateway "github.com/cs3org/go-cs3apis/cs3/gateway/v1beta1"
 	rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
@@ -31,10 +36,6 @@ import (
 	tokenpkg "github.com/cs3org/reva/pkg/token"
 	"github.com/eventials/go-tus"
 	"github.com/eventials/go-tus/memorystore"
-	"io"
-	"net/http"
-	"path"
-	"strings"
 )
 
 func (s *svc) handleCopy(w http.ResponseWriter, r *http.Request, ns string) {

--- a/internal/http/services/owncloud/ocdav/copy.go
+++ b/internal/http/services/owncloud/ocdav/copy.go
@@ -21,12 +21,6 @@ package ocdav
 import (
 	"context"
 	"fmt"
-	"io"
-	"net/http"
-	"path"
-	"strings"
-	"time"
-
 	gateway "github.com/cs3org/go-cs3apis/cs3/gateway/v1beta1"
 	rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
@@ -37,6 +31,10 @@ import (
 	tokenpkg "github.com/cs3org/reva/pkg/token"
 	"github.com/eventials/go-tus"
 	"github.com/eventials/go-tus/memorystore"
+	"io"
+	"net/http"
+	"path"
+	"strings"
 )
 
 func (s *svc) handleCopy(w http.ResponseWriter, r *http.Request, ns string) {
@@ -282,11 +280,7 @@ func (s *svc) descend(ctx context.Context, client gateway.GatewayAPIClient, src 
 		}
 		httpDownloadReq.Header.Set(datagateway.TokenTransportHeader, dRes.Token)
 
-		httpDownloadClient := rhttp.GetHTTPClient(
-			rhttp.Context(ctx),
-			rhttp.Timeout(time.Duration(s.c.Timeout*int64(time.Second))),
-			rhttp.Insecure(s.c.Insecure),
-		)
+		httpDownloadClient := s.client
 
 		httpDownloadRes, err := httpDownloadClient.Do(httpDownloadReq)
 		if err != nil {
@@ -314,11 +308,7 @@ func (s *svc) tusUpload(ctx context.Context, dataServerURL string, transferToken
 	// create the tus client.
 	c := tus.DefaultConfig()
 	c.Resume = true
-	c.HttpClient = rhttp.GetHTTPClient(
-		rhttp.Context(ctx),
-		rhttp.Timeout(time.Duration(s.c.Timeout*int64(time.Second))),
-		rhttp.Insecure(s.c.Insecure),
-	)
+	c.HttpClient = s.client
 	c.Store, err = memorystore.NewMemoryStore()
 	if err != nil {
 		return err

--- a/internal/http/services/owncloud/ocdav/get.go
+++ b/internal/http/services/owncloud/ocdav/get.go
@@ -121,11 +121,7 @@ func (s *svc) handleGet(w http.ResponseWriter, r *http.Request, ns string) {
 		return
 	}
 	httpReq.Header.Set(datagateway.TokenTransportHeader, dRes.Token)
-	httpClient := rhttp.GetHTTPClient(
-		rhttp.Context(ctx),
-		rhttp.Timeout(time.Duration(s.c.Timeout*int64(time.Second))),
-		rhttp.Insecure(s.c.Insecure),
-	)
+	httpClient := s.client
 
 	httpRes, err := httpClient.Do(httpReq)
 	if err != nil {

--- a/internal/http/services/owncloud/ocdav/ocdav.go
+++ b/internal/http/services/owncloud/ocdav/ocdav.go
@@ -22,6 +22,13 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"path"
+	"strings"
+	"time"
+
 	gateway "github.com/cs3org/go-cs3apis/cs3/gateway/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	"github.com/cs3org/reva/pkg/appctx"
@@ -35,12 +42,6 @@ import (
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
-	"net/http"
-	"net/url"
-	"os"
-	"path"
-	"strings"
-	"time"
 )
 
 type ctxKey int
@@ -88,7 +89,7 @@ type svc struct {
 	c             *Config
 	webDavHandler *WebDavHandler
 	davHandler    *DavHandler
-	client *http.Client
+	client        *http.Client
 }
 
 // New returns a new ocdav

--- a/internal/http/services/owncloud/ocdav/put.go
+++ b/internal/http/services/owncloud/ocdav/put.go
@@ -31,7 +31,6 @@ import (
 	"github.com/cs3org/reva/internal/http/services/datagateway"
 	"github.com/cs3org/reva/internal/http/utils"
 	"github.com/cs3org/reva/pkg/appctx"
-	"github.com/cs3org/reva/pkg/rhttp"
 	tokenpkg "github.com/cs3org/reva/pkg/token"
 	"github.com/eventials/go-tus"
 	"github.com/eventials/go-tus/memorystore"
@@ -272,11 +271,8 @@ func (s *svc) handlePut(w http.ResponseWriter, r *http.Request, ns string) {
 	// create the tus client.
 	c := tus.DefaultConfig()
 	c.Resume = true
-	c.HttpClient = rhttp.GetHTTPClient(
-		rhttp.Context(ctx),
-		rhttp.Timeout(time.Duration(s.c.Timeout*int64(time.Second))),
-		rhttp.Insecure(s.c.Insecure),
-	)
+	c.HttpClient = s.client
+
 	c.Store, err = memorystore.NewMemoryStore()
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)

--- a/internal/http/services/owncloud/ocdav/tus.go
+++ b/internal/http/services/owncloud/ocdav/tus.go
@@ -193,11 +193,7 @@ func (s *svc) handleTusPost(w http.ResponseWriter, r *http.Request, ns string) {
 		var httpRes *http.Response
 
 		if length != 0 {
-			httpClient := rhttp.GetHTTPClient(
-				rhttp.Context(ctx),
-				rhttp.Timeout(time.Duration(s.c.Timeout*int64(time.Second))),
-				rhttp.Insecure(s.c.Insecure),
-			)
+			httpClient := s.client
 			httpReq, err := rhttp.NewRequest(ctx, "PATCH", uRes.UploadEndpoint, r.Body)
 			if err != nil {
 				log.Err(err).Msg("wrong request")


### PR DESCRIPTION
File descriptors on the ocdav service, especially on the put handler was leaking http connections. This PR addresses this.