### PR TITLE
fix etag propagation in ocis driver

### DIFF
--- a/changelog/unreleased/ocis-fix-etag-propagation.md
+++ b/changelog/unreleased/ocis-fix-etag-propagation.md
@@ -1,0 +1,6 @@
+Bugfix: Fix etag propagation in ocis driver
+
+We now use a new synctime timestamp instead of trying to read the mtime to avoid race conditions when the stat request happens too quickly.
+
+https://github.com/cs3org/reva/pull/1264
+https://github.com/owncloud/product/issues/249


### PR DESCRIPTION
We now use a new synctime timestamp instead of trying to read the mtime to avoid race conditions when the stat request happens too quickly.

fixes https://github.com/owncloud/product/issues/249