### PR TITLE
map more permission denied codes

### DIFF
--- a/changelog/unreleased/handle-more-eos-errors.md
+++ b/changelog/unreleased/handle-more-eos-errors.md
@@ -1,0 +1,5 @@
+Bugfix: Handle more eos errors
+
+We now treat E2BIG, EACCES as a permission error, which occur, eg. when acl checks fail and return a permission denied error.
+
+https://github.com/cs3org/reva/pull/1269


### PR DESCRIPTION
I replaced the magic numbers with syscall.E* error codes. I also encounter an E2BIG error (7) when trying to list a no longer shared folder ... why is eos retuning an E2BIG? or are the error codes different from syscall.E* ones? if so, can you point me to a list of the error codes? 

I only added the permission checks to `executeEOS()`. what about `execute`? AFAICT it should also wrap  permission errors properly, right?

@labkode @ishank011 what other error codes do we need to map?