### PR TITLE
[WIP] json share manager - delete state when deleting share

### DIFF
--- a/pkg/share/manager/json/json.go
+++ b/pkg/share/manager/json/json.go
@@ -272,6 +272,9 @@ func (m *mgr) Unshare(ctx context.Context, ref *collaboration.ShareReference) er
 	m.Lock()
 	defer m.Unlock()
 	user := user.ContextMustGetUser(ctx)
+	if v, ok := m.model.State[user.Id.String()]; ok {
+		delete(v, ref.GetId().String())
+	}
 	for i, s := range m.model.Shares {
 		if equal(ref, s) {
 			if (user.Id.Idp == s.Owner.Idp && user.Id.OpaqueId == s.Owner.OpaqueId) ||


### PR DESCRIPTION
the share state is currently left in the file when deleting a share ... but this quick hack did not work properly ... relying on the String() of structs seems to be a bad idea.

I'd like to introduce a more meaningful struct, or better yet use a single json file per user.