### PR TITLE
let the gateway filter invalid references

### DIFF
--- a/changelog/unreleased/gateway-filter-invalid-references.md
+++ b/changelog/unreleased/gateway-filter-invalid-references.md
@@ -1,0 +1,5 @@
+Bugfix: let the gateway filter invalid references
+
+We now filter deleted and unshared entries from the response when listing the shares folder of a user.
+
+https://github.com/cs3org/reva/pull/1274


### PR DESCRIPTION
We now filter deleted and unshared entries from the response when listing the shares folder of a user.

AFAICT the references which represent the mountpoint of a share are never deleted.

I created https://github.com/cs3org/reva/issues/1275 to track cleaning up references.