### PR TITLE
[tests-only] No need for a redis process for OCIS storage

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -551,12 +551,6 @@ services:
       LDAP_TLS_VERIFY_CLIENT: 'never'
       HOSTNAME: 'ldap'
 
-  - name: redis
-    image: webhippie/redis
-    'pull': 'always'
-    'environment':
-      REDIS_DATABASES: 1
-
 ---
 kind: pipeline
 type: docker
@@ -629,12 +623,6 @@ services:
       LDAP_ADMIN_PASSWORD: 'admin'
       LDAP_TLS_VERIFY_CLIENT: 'never'
       HOSTNAME: 'ldap'
-
-  - name: redis
-    image: webhippie/redis
-    'pull': 'always'
-    'environment':
-      REDIS_DATABASES: 1
 
 ---
 kind: pipeline
@@ -709,12 +697,6 @@ services:
       LDAP_TLS_VERIFY_CLIENT: 'never'
       HOSTNAME: 'ldap'
 
-  - name: redis
-    image: webhippie/redis
-    'pull': 'always'
-    'environment':
-      REDIS_DATABASES: 1
-
 ---
 kind: pipeline
 type: docker
@@ -787,12 +769,6 @@ services:
       LDAP_ADMIN_PASSWORD: 'admin'
       LDAP_TLS_VERIFY_CLIENT: 'never'
       HOSTNAME: 'ldap'
-
-  - name: redis
-    image: webhippie/redis
-    'pull': 'always'
-    'environment':
-      REDIS_DATABASES: 1
 
 ---
 kind: pipeline
@@ -867,12 +843,6 @@ services:
       LDAP_TLS_VERIFY_CLIENT: 'never'
       HOSTNAME: 'ldap'
 
-  - name: redis
-    image: webhippie/redis
-    'pull': 'always'
-    'environment':
-      REDIS_DATABASES: 1
-
 ---
 kind: pipeline
 type: docker
@@ -946,12 +916,6 @@ services:
       LDAP_TLS_VERIFY_CLIENT: 'never'
       HOSTNAME: 'ldap'
 
-  - name: redis
-    image: webhippie/redis
-    'pull': 'always'
-    'environment':
-      REDIS_DATABASES: 1
-
 ---
 kind: pipeline
 type: docker
@@ -1024,12 +988,6 @@ services:
       LDAP_ADMIN_PASSWORD: 'admin'
       LDAP_TLS_VERIFY_CLIENT: 'never'
       HOSTNAME: 'ldap'
-
-  - name: redis
-    image: webhippie/redis
-    'pull': 'always'
-    'environment':
-      REDIS_DATABASES: 1
 
 ---
 kind: pipeline

--- a/tests/oc-integration-tests/drone/storage-home-ocis.toml
+++ b/tests/oc-integration-tests/drone/storage-home-ocis.toml
@@ -34,7 +34,6 @@ root = "/drone/src/tmp/reva/data"
 enable_home = true
 treetime_accounting = true
 treesize_accounting = true
-redis = "redis:6379"
 
 
 [http]
@@ -49,4 +48,3 @@ root = "/drone/src/tmp/reva/data"
 enable_home = true
 treetime_accounting = true
 treesize_accounting = true
-redis = "redis:6379"

--- a/tests/oc-integration-tests/drone/storage-oc-ocis.toml
+++ b/tests/oc-integration-tests/drone/storage-oc-ocis.toml
@@ -24,7 +24,6 @@ data_server_url = "http://localhost:11001/data"
 root = "/drone/src/tmp/reva/data"
 treetime_accounting = true
 treesize_accounting = true
-redis = "redis:6379"
 userprovidersvc = "localhost:18000"
 
 [http]
@@ -38,4 +37,3 @@ temp_folder = "/drone/src/tmp/reva/tmp"
 root = "/drone/src/tmp/reva/data"
 treetime_accounting = true
 treesize_accounting = true
-redis = "redis:6379"


### PR DESCRIPTION
The OCIS storage implementation does not require `redis` to be running.
Remove it from the drone services. That will use a little bit less system resources, and more importantly, reduce future confusion.