### PR TITLE
[tests-only] Bump oc10 test commit

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -446,7 +446,7 @@ steps:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
       - cd /drone/src/tmp/testrunner
-      - git checkout 5711a600adc10b9cbdceae3ee316b22d302bee4f
+      - git checkout 21d80141035c2bc1becb7fe23ab04a24a62b6372
 
   - name: localAPIAcceptanceTestsOwncloudStorage
     image: owncloudci/php:7.2
@@ -521,7 +521,7 @@ steps:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
       - cd /drone/src/tmp/testrunner
-      - git checkout 5711a600adc10b9cbdceae3ee316b22d302bee4f
+      - git checkout 21d80141035c2bc1becb7fe23ab04a24a62b6372
 
   - name: localAPIAcceptanceTestsOcisStorage
     image: owncloudci/php:7.2
@@ -591,7 +591,7 @@ steps:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
       - cd /drone/src/tmp/testrunner
-      - git checkout 5711a600adc10b9cbdceae3ee316b22d302bee4f
+      - git checkout 21d80141035c2bc1becb7fe23ab04a24a62b6372
 
   - name: oC10APIAcceptanceTestsOcisStorage
     image: owncloudci/php:7.2
@@ -664,7 +664,7 @@ steps:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
       - cd /drone/src/tmp/testrunner
-      - git checkout 5711a600adc10b9cbdceae3ee316b22d302bee4f
+      - git checkout 21d80141035c2bc1becb7fe23ab04a24a62b6372
 
   - name: oC10APIAcceptanceTestsOcisStorage
     image: owncloudci/php:7.2
@@ -737,7 +737,7 @@ steps:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
       - cd /drone/src/tmp/testrunner
-      - git checkout 5711a600adc10b9cbdceae3ee316b22d302bee4f
+      - git checkout 21d80141035c2bc1becb7fe23ab04a24a62b6372
 
   - name: oC10APIAcceptanceTestsOcisStorage
     image: owncloudci/php:7.2
@@ -810,7 +810,7 @@ steps:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
       - cd /drone/src/tmp/testrunner
-      - git checkout 5711a600adc10b9cbdceae3ee316b22d302bee4f
+      - git checkout 21d80141035c2bc1becb7fe23ab04a24a62b6372
 
   - name: oC10APIAcceptanceTestsOcisStorage
     image: owncloudci/php:7.2
@@ -883,7 +883,7 @@ steps:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
       - cd /drone/src/tmp/testrunner
-      - git checkout 5711a600adc10b9cbdceae3ee316b22d302bee4f
+      - git checkout 21d80141035c2bc1becb7fe23ab04a24a62b6372
 
   - name: oC10APIAcceptanceTestsOcisStorage
     image: owncloudci/php:7.2
@@ -956,7 +956,7 @@ steps:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
       - cd /drone/src/tmp/testrunner
-      - git checkout 5711a600adc10b9cbdceae3ee316b22d302bee4f
+      - git checkout 21d80141035c2bc1becb7fe23ab04a24a62b6372
 
   - name: oC10APIAcceptanceTestsOcisStorage
     image: owncloudci/php:7.2
@@ -1029,7 +1029,7 @@ steps:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
       - cd /drone/src/tmp/testrunner
-      - git checkout 5711a600adc10b9cbdceae3ee316b22d302bee4f
+      - git checkout 21d80141035c2bc1becb7fe23ab04a24a62b6372
 
   - name: oC10APIAcceptanceTestsOwncloudStorage
     image: owncloudci/php:7.2
@@ -1107,7 +1107,7 @@ steps:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
       - cd /drone/src/tmp/testrunner
-      - git checkout 5711a600adc10b9cbdceae3ee316b22d302bee4f
+      - git checkout 21d80141035c2bc1becb7fe23ab04a24a62b6372
 
   - name: oC10APIAcceptanceTestsOwncloudStorage
     image: owncloudci/php:7.2
@@ -1185,7 +1185,7 @@ steps:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
       - cd /drone/src/tmp/testrunner
-      - git checkout 5711a600adc10b9cbdceae3ee316b22d302bee4f
+      - git checkout 21d80141035c2bc1becb7fe23ab04a24a62b6372
 
   - name: oC10APIAcceptanceTestsOwncloudStorage
     image: owncloudci/php:7.2
@@ -1263,7 +1263,7 @@ steps:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
       - cd /drone/src/tmp/testrunner
-      - git checkout 5711a600adc10b9cbdceae3ee316b22d302bee4f
+      - git checkout 21d80141035c2bc1becb7fe23ab04a24a62b6372
 
   - name: oC10APIAcceptanceTestsOwncloudStorage
     image: owncloudci/php:7.2
@@ -1341,7 +1341,7 @@ steps:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
       - cd /drone/src/tmp/testrunner
-      - git checkout 5711a600adc10b9cbdceae3ee316b22d302bee4f
+      - git checkout 21d80141035c2bc1becb7fe23ab04a24a62b6372
 
   - name: oC10APIAcceptanceTestsOwncloudStorage
     image: owncloudci/php:7.2
@@ -1419,7 +1419,7 @@ steps:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
       - cd /drone/src/tmp/testrunner
-      - git checkout 5711a600adc10b9cbdceae3ee316b22d302bee4f
+      - git checkout 21d80141035c2bc1becb7fe23ab04a24a62b6372
 
   - name: oC10APIAcceptanceTestsOwncloudStorage
     image: owncloudci/php:7.2

--- a/tests/acceptance/expected-failures-on-OCIS-storage.txt
+++ b/tests/acceptance/expected-failures-on-OCIS-storage.txt
@@ -1357,3 +1357,55 @@ apiWebdavEtagPropagation2/restoreFromTrash.feature:87
 # https://github.com/owncloud/product/issues/210 Implement Versions Feature for ocis storage
 #
 apiWebdavEtagPropagation2/restoreVersion.feature:10
+#
+# https://github.com/owncloud/ocis/issues/762 path and other information are not shown if a share does not have "read" permission
+#
+apiShareOperationsToShares/uploadToShare.feature:64
+apiShareOperationsToShares/uploadToShare.feature:65
+#
+# https://github.com/owncloud/ocis-reva/issues/34 groups endpoint does not exist
+# https://github.com/owncloud/ocis-ocs/issues/35 group support is not yet implemented
+#
+apiShareOperationsToShares/uploadToShare.feature:39
+apiShareOperationsToShares/uploadToShare.feature:40
+apiShareOperationsToShares/uploadToShare.feature:91
+apiShareOperationsToShares/uploadToShare.feature:92
+apiShareOperationsToShares/uploadToShare.feature:139
+apiShareOperationsToShares/uploadToShare.feature:140
+#
+# https://github.com/owncloud/ocis/issues/763 [OCIS-storage] reading a file that a collaborator uploaded is impossible
+#
+apiShareOperationsToShares/uploadToShare.feature:114
+apiShareOperationsToShares/uploadToShare.feature:115
+#
+# https://github.com/owncloud/product/issues/247 changing user quota gives ocs status 103 / Cannot set quota
+#
+apiShareOperationsToShares/uploadToShare.feature:162
+apiShareOperationsToShares/uploadToShare.feature:163
+apiShareOperationsToShares/uploadToShare.feature:181
+apiShareOperationsToShares/uploadToShare.feature:182
+apiShareOperationsToShares/uploadToShare.feature:202
+apiShareOperationsToShares/uploadToShare.feature:203
+apiShareOperationsToShares/uploadToShare.feature:221
+apiShareOperationsToShares/uploadToShare.feature:222
+apiShareOperationsToShares/uploadToShare.feature:242
+apiShareOperationsToShares/uploadToShare.feature:243
+#
+# https://github.com/owncloud/ocis-reva/issues/56  remote.php/dav/uploads endpoint does not exist
+#
+apiShareOperationsToShares/uploadToShare.feature:246
+#
+# not possible to move file into a received folder https://github.com/owncloud/ocis/issues/764
+#
+apiShareOperationsToShares/changingFilesShare.feature:23
+apiShareOperationsToShares/changingFilesShare.feature:24
+apiShareOperationsToShares/changingFilesShare.feature:63
+apiShareOperationsToShares/changingFilesShare.feature:79
+apiShareOperationsToShares/changingFilesShare.feature:95
+#
+# https://github.com/owncloud/ocis/issues/560 cannot move from Shares folder
+#
+apiShareOperationsToShares/changingFilesShare.feature:40
+apiShareOperationsToShares/changingFilesShare.feature:41
+apiShareOperationsToShares/changingFilesShare.feature:59
+apiShareOperationsToShares/changingFilesShare.feature:60

--- a/tests/acceptance/expected-failures-on-OWNCLOUD-storage.txt
+++ b/tests/acceptance/expected-failures-on-OWNCLOUD-storage.txt
@@ -1264,3 +1264,50 @@ apiWebdavUpload2/uploadFileUsingOldChunking.feature:97
 apiWebdavUpload2/uploadFileUsingOldChunking.feature:98
 apiWebdavUpload2/uploadFileUsingOldChunking.feature:99
 apiWebdavUpload2/uploadFileUsingOldChunking.feature:100
+#
+# https://github.com/owncloud/ocis/issues/762 path and other information are not shown if a share does not have "read" permission
+#
+apiShareOperationsToShares/uploadToShare.feature:64
+apiShareOperationsToShares/uploadToShare.feature:65
+#
+# https://github.com/owncloud/ocis-reva/issues/34 groups endpoint does not exist
+# https://github.com/owncloud/ocis-ocs/issues/35 group support is not yet implemented
+#
+apiShareOperationsToShares/uploadToShare.feature:39
+apiShareOperationsToShares/uploadToShare.feature:40
+apiShareOperationsToShares/uploadToShare.feature:91
+apiShareOperationsToShares/uploadToShare.feature:92
+apiShareOperationsToShares/uploadToShare.feature:139
+apiShareOperationsToShares/uploadToShare.feature:140
+#
+# https://github.com/owncloud/product/issues/247 changing user quota gives ocs status 103 / Cannot set quota
+#
+apiShareOperationsToShares/uploadToShare.feature:162
+apiShareOperationsToShares/uploadToShare.feature:163
+apiShareOperationsToShares/uploadToShare.feature:181
+apiShareOperationsToShares/uploadToShare.feature:182
+apiShareOperationsToShares/uploadToShare.feature:202
+apiShareOperationsToShares/uploadToShare.feature:203
+apiShareOperationsToShares/uploadToShare.feature:221
+apiShareOperationsToShares/uploadToShare.feature:222
+apiShareOperationsToShares/uploadToShare.feature:242
+apiShareOperationsToShares/uploadToShare.feature:243
+#
+# https://github.com/owncloud/ocis-reva/issues/56  remote.php/dav/uploads endpoint does not exist
+#
+apiShareOperationsToShares/uploadToShare.feature:246
+#
+# not possible to move file into a received folder https://github.com/owncloud/ocis/issues/764
+#
+apiShareOperationsToShares/changingFilesShare.feature:23
+apiShareOperationsToShares/changingFilesShare.feature:24
+apiShareOperationsToShares/changingFilesShare.feature:63
+apiShareOperationsToShares/changingFilesShare.feature:79
+apiShareOperationsToShares/changingFilesShare.feature:95
+#
+# https://github.com/owncloud/ocis/issues/560 cannot move from Shares folder
+#
+apiShareOperationsToShares/changingFilesShare.feature:40
+apiShareOperationsToShares/changingFilesShare.feature:41
+apiShareOperationsToShares/changingFilesShare.feature:59
+apiShareOperationsToShares/changingFilesShare.feature:60


### PR DESCRIPTION
get newly enabled and improved sharing tests (from https://github.com/owncloud/core/pull/38045) into the reva test-suite