### PR TITLE
Move mime types registration to storageprovider

### DIFF
--- a/changelog/unreleased/zmd-mimetype.md
+++ b/changelog/unreleased/zmd-mimetype.md
@@ -1,5 +1,7 @@
 Enhancement: add support for custom CodiMD mimetype
 
 The new mimetype is associated with the `.zmd` file extension.
+The corresponding configuration is associated with the storageprovider.
 
 https://github.com/cs3org/reva/pull/1233
+https://github.com/cs3org/reva/pull/1284

--- a/docs/content/en/docs/config/grpc/services/appprovider/_index.md
+++ b/docs/content/en/docs/config/grpc/services/appprovider/_index.md
@@ -9,7 +9,7 @@ description: >
 # _struct: config_
 
 {{% dir name="iopsecret" type="string" default="" %}}
-The iopsecret used to connect to the wopiserver. [[Ref]](https://github.com/cs3org/reva/tree/master/internal/grpc/services/appprovider/appprovider.go#L59)
+The iopsecret used to connect to the wopiserver. [[Ref]](https://github.com/cs3org/reva/tree/master/internal/grpc/services/appprovider/appprovider.go#L58)
 {{< highlight toml >}}
 [grpc.services.appprovider]
 iopsecret = ""
@@ -17,7 +17,7 @@ iopsecret = ""
 {{% /dir %}}
 
 {{% dir name="wopiurl" type="string" default="" %}}
-The wopiserver's URL. [[Ref]](https://github.com/cs3org/reva/tree/master/internal/grpc/services/appprovider/appprovider.go#L60)
+The wopiserver's URL. [[Ref]](https://github.com/cs3org/reva/tree/master/internal/grpc/services/appprovider/appprovider.go#L59)
 {{< highlight toml >}}
 [grpc.services.appprovider]
 wopiurl = ""
@@ -25,18 +25,10 @@ wopiurl = ""
 {{% /dir %}}
 
 {{% dir name="wopibridgeurl" type="string" default="" %}}
-The wopibridge's URL. [[Ref]](https://github.com/cs3org/reva/tree/master/internal/grpc/services/appprovider/appprovider.go#L61)
+The wopibridge's URL. [[Ref]](https://github.com/cs3org/reva/tree/master/internal/grpc/services/appprovider/appprovider.go#L60)
 {{< highlight toml >}}
 [grpc.services.appprovider]
 wopibridgeurl = ""
-{{< /highlight >}}
-{{% /dir %}}
-
-{{% dir name="mimetypes" type="map[string]string" default=nil %}}
-List of supported mime types and corresponding file extensions. [[Ref]](https://github.com/cs3org/reva/tree/master/internal/grpc/services/appprovider/appprovider.go#L62)
-{{< highlight toml >}}
-[grpc.services.appprovider]
-mimetypes = nil
 {{< /highlight >}}
 {{% /dir %}}
 

--- a/docs/content/en/docs/config/grpc/services/storageprovider/_index.md
+++ b/docs/content/en/docs/config/grpc/services/storageprovider/_index.md
@@ -9,7 +9,7 @@ description: >
 # _struct: config_
 
 {{% dir name="mount_path" type="string" default="/" %}}
-The path where the file system would be mounted. [[Ref]](https://github.com/cs3org/reva/tree/master/internal/grpc/services/storageprovider/storageprovider.go#L51)
+The path where the file system would be mounted. [[Ref]](https://github.com/cs3org/reva/tree/master/internal/grpc/services/storageprovider/storageprovider.go#L53)
 {{< highlight toml >}}
 [grpc.services.storageprovider]
 mount_path = "/"
@@ -17,7 +17,7 @@ mount_path = "/"
 {{% /dir %}}
 
 {{% dir name="mount_id" type="string" default="-" %}}
-The ID of the mounted file system. [[Ref]](https://github.com/cs3org/reva/tree/master/internal/grpc/services/storageprovider/storageprovider.go#L52)
+The ID of the mounted file system. [[Ref]](https://github.com/cs3org/reva/tree/master/internal/grpc/services/storageprovider/storageprovider.go#L54)
 {{< highlight toml >}}
 [grpc.services.storageprovider]
 mount_id = "-"
@@ -25,7 +25,7 @@ mount_id = "-"
 {{% /dir %}}
 
 {{% dir name="driver" type="string" default="localhome" %}}
-The storage driver to be used. [[Ref]](https://github.com/cs3org/reva/tree/master/internal/grpc/services/storageprovider/storageprovider.go#L53)
+The storage driver to be used. [[Ref]](https://github.com/cs3org/reva/tree/master/internal/grpc/services/storageprovider/storageprovider.go#L55)
 {{< highlight toml >}}
 [grpc.services.storageprovider]
 driver = "localhome"
@@ -33,7 +33,7 @@ driver = "localhome"
 {{% /dir %}}
 
 {{% dir name="drivers" type="map[string]map[string]interface{}" default="localhome" %}}
- [[Ref]](https://github.com/cs3org/reva/tree/master/internal/grpc/services/storageprovider/storageprovider.go#L54)
+ [[Ref]](https://github.com/cs3org/reva/tree/master/internal/grpc/services/storageprovider/storageprovider.go#L56)
 {{< highlight toml >}}
 [grpc.services.storageprovider.drivers.localhome]
 root = "/var/tmp/reva/"
@@ -44,7 +44,7 @@ user_layout = "{{.Username}}"
 {{% /dir %}}
 
 {{% dir name="tmp_folder" type="string" default="/var/tmp" %}}
-Path to temporary folder. [[Ref]](https://github.com/cs3org/reva/tree/master/internal/grpc/services/storageprovider/storageprovider.go#L55)
+Path to temporary folder. [[Ref]](https://github.com/cs3org/reva/tree/master/internal/grpc/services/storageprovider/storageprovider.go#L57)
 {{< highlight toml >}}
 [grpc.services.storageprovider]
 tmp_folder = "/var/tmp"
@@ -52,7 +52,7 @@ tmp_folder = "/var/tmp"
 {{% /dir %}}
 
 {{% dir name="data_server_url" type="string" default="http://localhost/data" %}}
-The URL for the data server. [[Ref]](https://github.com/cs3org/reva/tree/master/internal/grpc/services/storageprovider/storageprovider.go#L56)
+The URL for the data server. [[Ref]](https://github.com/cs3org/reva/tree/master/internal/grpc/services/storageprovider/storageprovider.go#L58)
 {{< highlight toml >}}
 [grpc.services.storageprovider]
 data_server_url = "http://localhost/data"
@@ -60,7 +60,7 @@ data_server_url = "http://localhost/data"
 {{% /dir %}}
 
 {{% dir name="expose_data_server" type="bool" default=false %}}
-Whether to expose data server. [[Ref]](https://github.com/cs3org/reva/tree/master/internal/grpc/services/storageprovider/storageprovider.go#L57)
+Whether to expose data server. [[Ref]](https://github.com/cs3org/reva/tree/master/internal/grpc/services/storageprovider/storageprovider.go#L59)
 {{< highlight toml >}}
 [grpc.services.storageprovider]
 expose_data_server = false
@@ -68,7 +68,7 @@ expose_data_server = false
 {{% /dir %}}
 
 {{% dir name="disable_tus" type="bool" default=false %}}
-Whether to disable TUS uploads. [[Ref]](https://github.com/cs3org/reva/tree/master/internal/grpc/services/storageprovider/storageprovider.go#L58)
+Whether to disable TUS uploads. [[Ref]](https://github.com/cs3org/reva/tree/master/internal/grpc/services/storageprovider/storageprovider.go#L60)
 {{< highlight toml >}}
 [grpc.services.storageprovider]
 disable_tus = false
@@ -76,10 +76,18 @@ disable_tus = false
 {{% /dir %}}
 
 {{% dir name="available_checksums" type="map[string]uint32" default=nil %}}
-List of available checksums. [[Ref]](https://github.com/cs3org/reva/tree/master/internal/grpc/services/storageprovider/storageprovider.go#L59)
+List of available checksums. [[Ref]](https://github.com/cs3org/reva/tree/master/internal/grpc/services/storageprovider/storageprovider.go#L61)
 {{< highlight toml >}}
 [grpc.services.storageprovider]
 available_checksums = nil
+{{< /highlight >}}
+{{% /dir %}}
+
+{{% dir name="mimetypes" type="map[string]string" default=nil %}}
+List of supported mime types and corresponding file extensions. [[Ref]](https://github.com/cs3org/reva/tree/master/internal/grpc/services/storageprovider/storageprovider.go#L62)
+{{< highlight toml >}}
+[grpc.services.storageprovider]
+mimetypes = nil
 {{< /highlight >}}
 {{% /dir %}}
 

--- a/examples/ocmd/ocmd-server-1.toml
+++ b/examples/ocmd/ocmd-server-1.toml
@@ -69,10 +69,7 @@ driver = "memory"
 driver = "demo"
 iopsecret = "testsecret"
 wopiurl = "http://0.0.0.0:8880/"
-wopibridgeurl = "http://localhost:8000/"
-
-[grpc.services.appprovider.mimetypes]
-".zmd" = "application/compressed-markdown"
+wopibridgeurl = "http://localhost:8000/wopib"
 
 [grpc.services.appregistry]
 driver = "static"
@@ -92,6 +89,9 @@ mount_id = "123e4567-e89b-12d3-a456-426655440000"
 expose_data_server = true
 data_server_url = "http://localhost:19001/data"
 enable_home_creation = true
+
+[grpc.services.storageprovider.mimetypes]
+".zmd" = "application/compressed-markdown"
 
 [grpc.services.storageprovider.drivers.localhome]
 user_layout = "{{.Username}}"

--- a/internal/grpc/services/appprovider/appprovider.go
+++ b/internal/grpc/services/appprovider/appprovider.go
@@ -253,7 +253,7 @@ func (s *service) OpenFileInAppProvider(ctx context.Context, req *providerpb.Ope
 
 	// In case of applications served by the WOPI bridge, resolve the URL and go to the app
 	// Note that URL matching is performed via string matching, not via IP resolution: may need to fix this
-	if strings.Contains(appProviderURL, s.conf.WopiBrURL) {
+	if len(s.conf.WopiBrURL) > 0 && strings.Contains(appProviderURL, s.conf.WopiBrURL) {
 		httpClient := rhttp.GetHTTPClient(
 			rhttp.Context(ctx),
 			rhttp.Timeout(time.Duration(5*int64(time.Second))),

--- a/internal/grpc/services/appprovider/appprovider.go
+++ b/internal/grpc/services/appprovider/appprovider.go
@@ -35,7 +35,6 @@ import (
 	"github.com/cs3org/reva/pkg/app"
 	"github.com/cs3org/reva/pkg/app/provider/demo"
 	"github.com/cs3org/reva/pkg/appctx"
-	"github.com/cs3org/reva/pkg/mime"
 	"github.com/cs3org/reva/pkg/rgrpc"
 	"github.com/cs3org/reva/pkg/rgrpc/status"
 	"github.com/cs3org/reva/pkg/rhttp"
@@ -60,7 +59,6 @@ type config struct {
 	IopSecret string                 `mapstructure:"iopsecret" docs:";The iopsecret used to connect to the wopiserver."`
 	WopiURL   string                 `mapstructure:"wopiurl" docs:";The wopiserver's URL."`
 	WopiBrURL string                 `mapstructure:"wopibridgeurl" docs:";The wopibridge's URL."`
-	MimeTypes map[string]string      `mapstructure:"mimetypes" docs:"nil;List of supported mime types and corresponding file extensions."`
 }
 
 // New creates a new AppProviderService
@@ -69,8 +67,6 @@ func New(m map[string]interface{}, ss *grpc.Server) (rgrpc.Service, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	registerMimeTypes(c.MimeTypes)
 
 	provider, err := getProvider(c)
 	if err != nil {
@@ -94,12 +90,6 @@ func parseConfig(m map[string]interface{}) (*config, error) {
 		return nil, err
 	}
 	return c, nil
-}
-
-func registerMimeTypes(mimes map[string]string) {
-	for k, v := range mimes {
-		mime.RegisterMime(k, v)
-	}
 }
 
 func (s *service) Close() error {


### PR DESCRIPTION
Tested with @SamuAlfageme: the yet unreleased custom mimetypes registration (#1233) to support `.zmd` needs to be moved to the storageprovider, in order to support the case of (remote) storageproviders running separately from appproviders.

On top, PR #1234 has a bug in case the WOPI bridge is not configured. This patch fixes that as well.