### PR TITLE
[tests-only] bump core commit id

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -441,7 +441,7 @@ steps:
       - /drone/src/cmd/revad/revad -c ldap-users.toml
 
   - name: clone-oC10-test-repos
-    image: owncloudci/php:7.2
+    image: owncloudci/php:7.4
     commands:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
@@ -449,7 +449,7 @@ steps:
       - git checkout 8fee3047cadfaae5a4cee330a102af8d1ada8160
 
   - name: localAPIAcceptanceTestsOwncloudStorage
-    image: owncloudci/php:7.2
+    image: owncloudci/php:7.4
     commands:
       - make test-acceptance-api
     environment:
@@ -516,7 +516,7 @@ steps:
       - /drone/src/cmd/revad/revad -c ldap-users.toml
 
   - name: clone-oC10-test-repos
-    image: owncloudci/php:7.2
+    image: owncloudci/php:7.4
     commands:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
@@ -524,7 +524,7 @@ steps:
       - git checkout 8fee3047cadfaae5a4cee330a102af8d1ada8160
 
   - name: localAPIAcceptanceTestsOcisStorage
-    image: owncloudci/php:7.2
+    image: owncloudci/php:7.4
     commands:
       - make test-acceptance-api
     environment:
@@ -586,7 +586,7 @@ steps:
       - /drone/src/cmd/revad/revad -c ldap-users.toml
 
   - name: clone-oC10-test-repos
-    image: owncloudci/php:7.2
+    image: owncloudci/php:7.4
     commands:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
@@ -594,7 +594,7 @@ steps:
       - git checkout 8fee3047cadfaae5a4cee330a102af8d1ada8160
 
   - name: oC10APIAcceptanceTestsOcisStorage
-    image: owncloudci/php:7.2
+    image: owncloudci/php:7.4
     commands:
       - cd /drone/src/tmp/testrunner
       - make test-acceptance-api
@@ -659,7 +659,7 @@ steps:
       - /drone/src/cmd/revad/revad -c ldap-users.toml
 
   - name: clone-oC10-test-repos
-    image: owncloudci/php:7.2
+    image: owncloudci/php:7.4
     commands:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
@@ -667,7 +667,7 @@ steps:
       - git checkout 8fee3047cadfaae5a4cee330a102af8d1ada8160
 
   - name: oC10APIAcceptanceTestsOcisStorage
-    image: owncloudci/php:7.2
+    image: owncloudci/php:7.4
     commands:
       - cd /drone/src/tmp/testrunner
       - make test-acceptance-api
@@ -732,7 +732,7 @@ steps:
       - /drone/src/cmd/revad/revad -c ldap-users.toml
 
   - name: clone-oC10-test-repos
-    image: owncloudci/php:7.2
+    image: owncloudci/php:7.4
     commands:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
@@ -740,7 +740,7 @@ steps:
       - git checkout 8fee3047cadfaae5a4cee330a102af8d1ada8160
 
   - name: oC10APIAcceptanceTestsOcisStorage
-    image: owncloudci/php:7.2
+    image: owncloudci/php:7.4
     commands:
       - cd /drone/src/tmp/testrunner
       - make test-acceptance-api
@@ -805,7 +805,7 @@ steps:
       - /drone/src/cmd/revad/revad -c ldap-users.toml
 
   - name: clone-oC10-test-repos
-    image: owncloudci/php:7.2
+    image: owncloudci/php:7.4
     commands:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
@@ -813,7 +813,7 @@ steps:
       - git checkout 8fee3047cadfaae5a4cee330a102af8d1ada8160
 
   - name: oC10APIAcceptanceTestsOcisStorage
-    image: owncloudci/php:7.2
+    image: owncloudci/php:7.4
     commands:
       - cd /drone/src/tmp/testrunner
       - make test-acceptance-api
@@ -878,7 +878,7 @@ steps:
       - /drone/src/cmd/revad/revad -c ldap-users.toml
 
   - name: clone-oC10-test-repos
-    image: owncloudci/php:7.2
+    image: owncloudci/php:7.4
     commands:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
@@ -886,7 +886,7 @@ steps:
       - git checkout 8fee3047cadfaae5a4cee330a102af8d1ada8160
 
   - name: oC10APIAcceptanceTestsOcisStorage
-    image: owncloudci/php:7.2
+    image: owncloudci/php:7.4
     commands:
       - cd /drone/src/tmp/testrunner
       - make test-acceptance-api
@@ -951,7 +951,7 @@ steps:
       - /drone/src/cmd/revad/revad -c ldap-users.toml
 
   - name: clone-oC10-test-repos
-    image: owncloudci/php:7.2
+    image: owncloudci/php:7.4
     commands:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
@@ -959,7 +959,7 @@ steps:
       - git checkout 8fee3047cadfaae5a4cee330a102af8d1ada8160
 
   - name: oC10APIAcceptanceTestsOcisStorage
-    image: owncloudci/php:7.2
+    image: owncloudci/php:7.4
     commands:
       - cd /drone/src/tmp/testrunner
       - make test-acceptance-api
@@ -1024,7 +1024,7 @@ steps:
       - /drone/src/cmd/revad/revad -c ldap-users.toml
 
   - name: clone-oC10-test-repos
-    image: owncloudci/php:7.2
+    image: owncloudci/php:7.4
     commands:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
@@ -1032,7 +1032,7 @@ steps:
       - git checkout 8fee3047cadfaae5a4cee330a102af8d1ada8160
 
   - name: oC10APIAcceptanceTestsOwncloudStorage
-    image: owncloudci/php:7.2
+    image: owncloudci/php:7.4
     commands:
       - cd /drone/src/tmp/testrunner
       - make test-acceptance-api
@@ -1102,7 +1102,7 @@ steps:
       - /drone/src/cmd/revad/revad -c ldap-users.toml
 
   - name: clone-oC10-test-repos
-    image: owncloudci/php:7.2
+    image: owncloudci/php:7.4
     commands:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
@@ -1110,7 +1110,7 @@ steps:
       - git checkout 8fee3047cadfaae5a4cee330a102af8d1ada8160
 
   - name: oC10APIAcceptanceTestsOwncloudStorage
-    image: owncloudci/php:7.2
+    image: owncloudci/php:7.4
     commands:
       - cd /drone/src/tmp/testrunner
       - make test-acceptance-api
@@ -1180,7 +1180,7 @@ steps:
       - /drone/src/cmd/revad/revad -c ldap-users.toml
 
   - name: clone-oC10-test-repos
-    image: owncloudci/php:7.2
+    image: owncloudci/php:7.4
     commands:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
@@ -1188,7 +1188,7 @@ steps:
       - git checkout 8fee3047cadfaae5a4cee330a102af8d1ada8160
 
   - name: oC10APIAcceptanceTestsOwncloudStorage
-    image: owncloudci/php:7.2
+    image: owncloudci/php:7.4
     commands:
       - cd /drone/src/tmp/testrunner
       - make test-acceptance-api
@@ -1258,7 +1258,7 @@ steps:
       - /drone/src/cmd/revad/revad -c ldap-users.toml
 
   - name: clone-oC10-test-repos
-    image: owncloudci/php:7.2
+    image: owncloudci/php:7.4
     commands:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
@@ -1266,7 +1266,7 @@ steps:
       - git checkout 8fee3047cadfaae5a4cee330a102af8d1ada8160
 
   - name: oC10APIAcceptanceTestsOwncloudStorage
-    image: owncloudci/php:7.2
+    image: owncloudci/php:7.4
     commands:
       - cd /drone/src/tmp/testrunner
       - make test-acceptance-api
@@ -1336,7 +1336,7 @@ steps:
       - /drone/src/cmd/revad/revad -c ldap-users.toml
 
   - name: clone-oC10-test-repos
-    image: owncloudci/php:7.2
+    image: owncloudci/php:7.4
     commands:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
@@ -1344,7 +1344,7 @@ steps:
       - git checkout 8fee3047cadfaae5a4cee330a102af8d1ada8160
 
   - name: oC10APIAcceptanceTestsOwncloudStorage
-    image: owncloudci/php:7.2
+    image: owncloudci/php:7.4
     commands:
       - cd /drone/src/tmp/testrunner
       - make test-acceptance-api
@@ -1414,7 +1414,7 @@ steps:
       - /drone/src/cmd/revad/revad -c ldap-users.toml
 
   - name: clone-oC10-test-repos
-    image: owncloudci/php:7.2
+    image: owncloudci/php:7.4
     commands:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
@@ -1422,7 +1422,7 @@ steps:
       - git checkout 8fee3047cadfaae5a4cee330a102af8d1ada8160
 
   - name: oC10APIAcceptanceTestsOwncloudStorage
-    image: owncloudci/php:7.2
+    image: owncloudci/php:7.4
     commands:
       - cd /drone/src/tmp/testrunner
       - make test-acceptance-api

--- a/.drone.yml
+++ b/.drone.yml
@@ -446,7 +446,7 @@ steps:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
       - cd /drone/src/tmp/testrunner
-      - git checkout 47365d22af95d90fcbd7705572f715a7b93d31b6
+      - git checkout 8fee3047cadfaae5a4cee330a102af8d1ada8160
 
   - name: localAPIAcceptanceTestsOwncloudStorage
     image: owncloudci/php:7.2
@@ -521,7 +521,7 @@ steps:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
       - cd /drone/src/tmp/testrunner
-      - git checkout 47365d22af95d90fcbd7705572f715a7b93d31b6
+      - git checkout 8fee3047cadfaae5a4cee330a102af8d1ada8160
 
   - name: localAPIAcceptanceTestsOcisStorage
     image: owncloudci/php:7.2
@@ -591,7 +591,7 @@ steps:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
       - cd /drone/src/tmp/testrunner
-      - git checkout 47365d22af95d90fcbd7705572f715a7b93d31b6
+      - git checkout 8fee3047cadfaae5a4cee330a102af8d1ada8160
 
   - name: oC10APIAcceptanceTestsOcisStorage
     image: owncloudci/php:7.2
@@ -664,7 +664,7 @@ steps:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
       - cd /drone/src/tmp/testrunner
-      - git checkout 47365d22af95d90fcbd7705572f715a7b93d31b6
+      - git checkout 8fee3047cadfaae5a4cee330a102af8d1ada8160
 
   - name: oC10APIAcceptanceTestsOcisStorage
     image: owncloudci/php:7.2
@@ -737,7 +737,7 @@ steps:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
       - cd /drone/src/tmp/testrunner
-      - git checkout 47365d22af95d90fcbd7705572f715a7b93d31b6
+      - git checkout 8fee3047cadfaae5a4cee330a102af8d1ada8160
 
   - name: oC10APIAcceptanceTestsOcisStorage
     image: owncloudci/php:7.2
@@ -810,7 +810,7 @@ steps:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
       - cd /drone/src/tmp/testrunner
-      - git checkout 47365d22af95d90fcbd7705572f715a7b93d31b6
+      - git checkout 8fee3047cadfaae5a4cee330a102af8d1ada8160
 
   - name: oC10APIAcceptanceTestsOcisStorage
     image: owncloudci/php:7.2
@@ -883,7 +883,7 @@ steps:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
       - cd /drone/src/tmp/testrunner
-      - git checkout 47365d22af95d90fcbd7705572f715a7b93d31b6
+      - git checkout 8fee3047cadfaae5a4cee330a102af8d1ada8160
 
   - name: oC10APIAcceptanceTestsOcisStorage
     image: owncloudci/php:7.2
@@ -956,7 +956,7 @@ steps:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
       - cd /drone/src/tmp/testrunner
-      - git checkout 47365d22af95d90fcbd7705572f715a7b93d31b6
+      - git checkout 8fee3047cadfaae5a4cee330a102af8d1ada8160
 
   - name: oC10APIAcceptanceTestsOcisStorage
     image: owncloudci/php:7.2
@@ -1029,7 +1029,7 @@ steps:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
       - cd /drone/src/tmp/testrunner
-      - git checkout 47365d22af95d90fcbd7705572f715a7b93d31b6
+      - git checkout 8fee3047cadfaae5a4cee330a102af8d1ada8160
 
   - name: oC10APIAcceptanceTestsOwncloudStorage
     image: owncloudci/php:7.2
@@ -1107,7 +1107,7 @@ steps:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
       - cd /drone/src/tmp/testrunner
-      - git checkout 47365d22af95d90fcbd7705572f715a7b93d31b6
+      - git checkout 8fee3047cadfaae5a4cee330a102af8d1ada8160
 
   - name: oC10APIAcceptanceTestsOwncloudStorage
     image: owncloudci/php:7.2
@@ -1185,7 +1185,7 @@ steps:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
       - cd /drone/src/tmp/testrunner
-      - git checkout 47365d22af95d90fcbd7705572f715a7b93d31b6
+      - git checkout 8fee3047cadfaae5a4cee330a102af8d1ada8160
 
   - name: oC10APIAcceptanceTestsOwncloudStorage
     image: owncloudci/php:7.2
@@ -1263,7 +1263,7 @@ steps:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
       - cd /drone/src/tmp/testrunner
-      - git checkout 47365d22af95d90fcbd7705572f715a7b93d31b6
+      - git checkout 8fee3047cadfaae5a4cee330a102af8d1ada8160
 
   - name: oC10APIAcceptanceTestsOwncloudStorage
     image: owncloudci/php:7.2
@@ -1341,7 +1341,7 @@ steps:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
       - cd /drone/src/tmp/testrunner
-      - git checkout 47365d22af95d90fcbd7705572f715a7b93d31b6
+      - git checkout 8fee3047cadfaae5a4cee330a102af8d1ada8160
 
   - name: oC10APIAcceptanceTestsOwncloudStorage
     image: owncloudci/php:7.2
@@ -1419,7 +1419,7 @@ steps:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
       - cd /drone/src/tmp/testrunner
-      - git checkout 47365d22af95d90fcbd7705572f715a7b93d31b6
+      - git checkout 8fee3047cadfaae5a4cee330a102af8d1ada8160
 
   - name: oC10APIAcceptanceTestsOwncloudStorage
     image: owncloudci/php:7.2

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "cs3org/reva",
   "config" : {
     "platform": {
-      "php": "7.2"
+      "php": "7.4"
     }
   },
   "require": {

--- a/tests/acceptance/expected-failures-on-OCIS-storage.txt
+++ b/tests/acceptance/expected-failures-on-OCIS-storage.txt
@@ -514,26 +514,38 @@ apiSharePublicLink2/updatePublicLinkShare.feature:94
 apiSharePublicLink2/updatePublicLinkShare.feature:284
 apiSharePublicLink2/updatePublicLinkShare.feature:285
 #
-# https://github.com/owncloud/ocis/issues/776 investigate ocis issues in apiSharePublicLink2/reShareAsPublicLinkToShares
+# https://github.com/owncloud/ocis/issues/270 [OCIS] share permissions not enforced
 #
-apiSharePublicLink2/reShareAsPublicLinkToShares.feature:25
-apiSharePublicLink2/reShareAsPublicLinkToShares.feature:26
-apiSharePublicLink2/reShareAsPublicLinkToShares.feature:47
-apiSharePublicLink2/reShareAsPublicLinkToShares.feature:48
-apiSharePublicLink2/reShareAsPublicLinkToShares.feature:63
-apiSharePublicLink2/reShareAsPublicLinkToShares.feature:64
-apiSharePublicLink2/reShareAsPublicLinkToShares.feature:78
-apiSharePublicLink2/reShareAsPublicLinkToShares.feature:79
-apiSharePublicLink2/reShareAsPublicLinkToShares.feature:100
-apiSharePublicLink2/reShareAsPublicLinkToShares.feature:101
-apiSharePublicLink2/reShareAsPublicLinkToShares.feature:123
-apiSharePublicLink2/reShareAsPublicLinkToShares.feature:124
-apiSharePublicLink2/reShareAsPublicLinkToShares.feature:140
-apiSharePublicLink2/reShareAsPublicLinkToShares.feature:141
-apiSharePublicLink2/reShareAsPublicLinkToShares.feature:161
-apiSharePublicLink2/reShareAsPublicLinkToShares.feature:162
-apiSharePublicLink2/reShareAsPublicLinkToShares.feature:184
-apiSharePublicLink2/reShareAsPublicLinkToShares.feature:185
+apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature:25
+apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature:26
+apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature:62
+apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature:63
+apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature:77
+apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature:78
+apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature:136
+apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature:137
+apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature:157
+apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature:158
+apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature:179
+apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature:180
+#
+# https://github.com/owncloud/ocis-reva/issues/292 Public link enforce permissions
+#
+apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature:97
+apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature:98
+#
+# https://github.com/owncloud/product/issues/272 [OCIS] old public webdav api doesnt works
+#
+apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature:30
+apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature:31
+apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature:50
+apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature:51
+apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature:71
+apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature:72
+apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature:92
+apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature:93
+apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature:114
+apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature:115
 #
 # https://github.com/owncloud/ocis-reva/issues/11 listing received shares does not work
 #
@@ -1202,10 +1214,6 @@ apiWebdavProperties2/getFileProperties.feature:327
 apiWebdavProperties2/getFileProperties.feature:328
 apiWebdavProperties2/getFileProperties.feature:376
 apiWebdavProperties2/getFileProperties.feature:377
-apiWebdavProperties2/getFileProperties.feature:389
-apiWebdavProperties2/getFileProperties.feature:390
-apiWebdavProperties2/getFileProperties.feature:402
-apiWebdavProperties2/getFileProperties.feature:403
 apiWebdavProperties2/getFileProperties.feature:415
 apiWebdavProperties2/getFileProperties.feature:416
 apiWebdavProperties2/getFileProperties.feature:428

--- a/tests/acceptance/expected-failures-on-OWNCLOUD-storage.txt
+++ b/tests/acceptance/expected-failures-on-OWNCLOUD-storage.txt
@@ -494,26 +494,38 @@ apiSharePublicLink2/updatePublicLinkShare.feature:94
 apiSharePublicLink2/updatePublicLinkShare.feature:284
 apiSharePublicLink2/updatePublicLinkShare.feature:285
 #
-# https://github.com/owncloud/ocis/issues/776 investigate ocis issues in apiSharePublicLink2/reShareAsPublicLinkToShares
+# https://github.com/owncloud/ocis/issues/270 [OCIS] share permissions not enforced
 #
-apiSharePublicLink2/reShareAsPublicLinkToShares.feature:25
-apiSharePublicLink2/reShareAsPublicLinkToShares.feature:26
-apiSharePublicLink2/reShareAsPublicLinkToShares.feature:47
-apiSharePublicLink2/reShareAsPublicLinkToShares.feature:48
-apiSharePublicLink2/reShareAsPublicLinkToShares.feature:63
-apiSharePublicLink2/reShareAsPublicLinkToShares.feature:64
-apiSharePublicLink2/reShareAsPublicLinkToShares.feature:78
-apiSharePublicLink2/reShareAsPublicLinkToShares.feature:79
-apiSharePublicLink2/reShareAsPublicLinkToShares.feature:100
-apiSharePublicLink2/reShareAsPublicLinkToShares.feature:101
-apiSharePublicLink2/reShareAsPublicLinkToShares.feature:123
-apiSharePublicLink2/reShareAsPublicLinkToShares.feature:124
-apiSharePublicLink2/reShareAsPublicLinkToShares.feature:140
-apiSharePublicLink2/reShareAsPublicLinkToShares.feature:141
-apiSharePublicLink2/reShareAsPublicLinkToShares.feature:161
-apiSharePublicLink2/reShareAsPublicLinkToShares.feature:162
-apiSharePublicLink2/reShareAsPublicLinkToShares.feature:184
-apiSharePublicLink2/reShareAsPublicLinkToShares.feature:185
+apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature:25
+apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature:26
+apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature:62
+apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature:63
+apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature:77
+apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature:78
+apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature:136
+apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature:137
+apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature:157
+apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature:158
+apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature:179
+apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature:180
+#
+# https://github.com/owncloud/ocis-reva/issues/292 Public link enforce permissions
+#
+apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature:97
+apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature:98
+#
+# https://github.com/owncloud/product/issues/272 [OCIS] old public webdav api doesnt works
+#
+apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature:30
+apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature:31
+apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature:50
+apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature:51
+apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature:71
+apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature:72
+apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature:92
+apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature:93
+apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature:114
+apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature:115
 #
 # https://github.com/owncloud/ocis-reva/issues/11 listing received shares does not work
 #
@@ -1182,10 +1194,6 @@ apiWebdavProperties2/getFileProperties.feature:327
 apiWebdavProperties2/getFileProperties.feature:328
 apiWebdavProperties2/getFileProperties.feature:376
 apiWebdavProperties2/getFileProperties.feature:377
-apiWebdavProperties2/getFileProperties.feature:389
-apiWebdavProperties2/getFileProperties.feature:390
-apiWebdavProperties2/getFileProperties.feature:402
-apiWebdavProperties2/getFileProperties.feature:403
 apiWebdavProperties2/getFileProperties.feature:415
 apiWebdavProperties2/getFileProperties.feature:416
 apiWebdavProperties2/getFileProperties.feature:428

--- a/vendor-bin/behat/composer.json
+++ b/vendor-bin/behat/composer.json
@@ -1,7 +1,7 @@
 {
     "config" : {
         "platform": {
-            "php": "7.2"
+            "php": "7.4"
         }
     },
     "require": {


### PR DESCRIPTION
1) similar to https://github.com/owncloud/ocis/pull/784

Includes test changes from:
https://github.com/owncloud/core/pull/38050 [tests-only] correct reshare test to use the correct path
https://github.com/owncloud/core/pull/38051 [tests-only] Improve skeleton upload error message
https://github.com/owncloud/core/pull/38052 [tests-only] test webdav locks when shares are received in a sub-folder
https://github.com/owncloud/core/pull/38056 [tests-only] split public link tests into separate files for new/old dav
https://github.com/owncloud/core/pull/38058 [tests-only] Adjust tests to better run on PGSQL

2) issue https://github.com/owncloud/core/issues/38067 - due to composer 2.0 there are issues with dependencies for the `behat` acceptance test runner dependencies when using PHP 7.2 or 7.3. Use PHP 7.4 for the `behat` test runner. (There is no need to look into what is happening with PHP  7.2 or 7.3 - we only use PHP here for the test runner anyway, so may as well use the latest)