### PR TITLE
fix error type in ReadNode when file was not found

### DIFF
--- a/changelog/unreleased/readnode-error-type.md
+++ b/changelog/unreleased/readnode-error-type.md
@@ -1,0 +1,6 @@
+Bugfix: Fix error type in read node when file was not found 
+
+The method ReadNode in the ocis storage didn't return the error type NotFound when a file was not found.
+
+https://github.com/cs3org/reva/pull/1294
+

--- a/pkg/storage/fs/ocis/node.go
+++ b/pkg/storage/fs/ocis/node.go
@@ -183,7 +183,7 @@ func ReadNode(ctx context.Context, lu *Lookup, id string) (n *Node, err error) {
 		} else {
 			log.Error().Err(err).Interface("node", n).Str("root.ID", root.ID).Msg("ReadNode()")
 			if isNotFound(err) {
-				return
+				return nil, errtypes.NotFound(err.Error())
 			}
 			return
 		}


### PR DESCRIPTION
The method ReadNode in the ocis storage didn't return the error type NotFound when a file was not found.