### PR TITLE
[OCS] filter share with me requests

### DIFF
--- a/changelog/unreleased/ocs-filter-path-and-status.md
+++ b/changelog/unreleased/ocs-filter-path-and-status.md
@@ -1,0 +1,5 @@
+Bugfix: filter share with me requests
+
+The OCS API now properly filters share with me requests by path and by share status (pending, accepted, rejected, all)
+
+https://github.com/cs3org/reva/pull/1301


### PR DESCRIPTION
The OCS API now properly filters share with me requests by path and by share status.