### PR TITLE
[tests-only] Bump core commit for tests 2020-11-09

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -446,7 +446,7 @@ steps:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
       - cd /drone/src/tmp/testrunner
-      - git checkout 5279179f6b70ace81d6a7758d2f46c3d284d7933
+      - git checkout a6cae1e241bfa259b176878e4e1e3596b6eda9b8
 
   - name: localAPIAcceptanceTestsOwncloudStorage
     image: owncloudci/php:7.4
@@ -520,7 +520,7 @@ steps:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
       - cd /drone/src/tmp/testrunner
-      - git checkout 5279179f6b70ace81d6a7758d2f46c3d284d7933
+      - git checkout a6cae1e241bfa259b176878e4e1e3596b6eda9b8
 
   - name: localAPIAcceptanceTestsOcisStorage
     image: owncloudci/php:7.4
@@ -589,7 +589,7 @@ steps:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
       - cd /drone/src/tmp/testrunner
-      - git checkout 5279179f6b70ace81d6a7758d2f46c3d284d7933
+      - git checkout a6cae1e241bfa259b176878e4e1e3596b6eda9b8
 
   - name: oC10APIAcceptanceTestsOcisStorage
     image: owncloudci/php:7.4
@@ -661,7 +661,7 @@ steps:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
       - cd /drone/src/tmp/testrunner
-      - git checkout 5279179f6b70ace81d6a7758d2f46c3d284d7933
+      - git checkout a6cae1e241bfa259b176878e4e1e3596b6eda9b8
 
   - name: oC10APIAcceptanceTestsOcisStorage
     image: owncloudci/php:7.4
@@ -733,7 +733,7 @@ steps:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
       - cd /drone/src/tmp/testrunner
-      - git checkout 5279179f6b70ace81d6a7758d2f46c3d284d7933
+      - git checkout a6cae1e241bfa259b176878e4e1e3596b6eda9b8
 
   - name: oC10APIAcceptanceTestsOcisStorage
     image: owncloudci/php:7.4
@@ -805,7 +805,7 @@ steps:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
       - cd /drone/src/tmp/testrunner
-      - git checkout 5279179f6b70ace81d6a7758d2f46c3d284d7933
+      - git checkout a6cae1e241bfa259b176878e4e1e3596b6eda9b8
 
   - name: oC10APIAcceptanceTestsOcisStorage
     image: owncloudci/php:7.4
@@ -877,7 +877,7 @@ steps:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
       - cd /drone/src/tmp/testrunner
-      - git checkout 5279179f6b70ace81d6a7758d2f46c3d284d7933
+      - git checkout a6cae1e241bfa259b176878e4e1e3596b6eda9b8
 
   - name: oC10APIAcceptanceTestsOcisStorage
     image: owncloudci/php:7.4
@@ -949,7 +949,7 @@ steps:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
       - cd /drone/src/tmp/testrunner
-      - git checkout 5279179f6b70ace81d6a7758d2f46c3d284d7933
+      - git checkout a6cae1e241bfa259b176878e4e1e3596b6eda9b8
 
   - name: oC10APIAcceptanceTestsOcisStorage
     image: owncloudci/php:7.4
@@ -1021,7 +1021,7 @@ steps:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
       - cd /drone/src/tmp/testrunner
-      - git checkout 5279179f6b70ace81d6a7758d2f46c3d284d7933
+      - git checkout a6cae1e241bfa259b176878e4e1e3596b6eda9b8
 
   - name: oC10APIAcceptanceTestsOwncloudStorage
     image: owncloudci/php:7.4
@@ -1098,7 +1098,7 @@ steps:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
       - cd /drone/src/tmp/testrunner
-      - git checkout 5279179f6b70ace81d6a7758d2f46c3d284d7933
+      - git checkout a6cae1e241bfa259b176878e4e1e3596b6eda9b8
 
   - name: oC10APIAcceptanceTestsOwncloudStorage
     image: owncloudci/php:7.4
@@ -1175,7 +1175,7 @@ steps:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
       - cd /drone/src/tmp/testrunner
-      - git checkout 5279179f6b70ace81d6a7758d2f46c3d284d7933
+      - git checkout a6cae1e241bfa259b176878e4e1e3596b6eda9b8
 
   - name: oC10APIAcceptanceTestsOwncloudStorage
     image: owncloudci/php:7.4
@@ -1252,7 +1252,7 @@ steps:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
       - cd /drone/src/tmp/testrunner
-      - git checkout 5279179f6b70ace81d6a7758d2f46c3d284d7933
+      - git checkout a6cae1e241bfa259b176878e4e1e3596b6eda9b8
 
   - name: oC10APIAcceptanceTestsOwncloudStorage
     image: owncloudci/php:7.4
@@ -1329,7 +1329,7 @@ steps:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
       - cd /drone/src/tmp/testrunner
-      - git checkout 5279179f6b70ace81d6a7758d2f46c3d284d7933
+      - git checkout a6cae1e241bfa259b176878e4e1e3596b6eda9b8
 
   - name: oC10APIAcceptanceTestsOwncloudStorage
     image: owncloudci/php:7.4
@@ -1406,7 +1406,7 @@ steps:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
       - cd /drone/src/tmp/testrunner
-      - git checkout 5279179f6b70ace81d6a7758d2f46c3d284d7933
+      - git checkout a6cae1e241bfa259b176878e4e1e3596b6eda9b8
 
   - name: oC10APIAcceptanceTestsOwncloudStorage
     image: owncloudci/php:7.4

--- a/tests/acceptance/expected-failures-on-OCIS-storage.txt
+++ b/tests/acceptance/expected-failures-on-OCIS-storage.txt
@@ -105,6 +105,10 @@ apiAuthWebDav/webDavPROPFINDAuth.feature:37
 #
 apiAuthWebDav/webDavPROPPATCHAuth.feature:38
 #
+# https://github.com/owncloud/ocis/issues/824 PUT request with missing parent must return status code 409
+#
+apiAuthWebDav/webDavPUTAuth.feature:38
+#
 # https://github.com/owncloud/ocis-reva/issues/175 Default capabilities for normal user not same as in oC-core
 # https://github.com/owncloud/ocis-reva/issues/176 Difference in response content of status.php and default capabilities
 #
@@ -497,10 +501,11 @@ apiSharePublicLink1/createPublicLinkShare.feature:742
 # https://github.com/owncloud/ocis-reva/issues/373 copying a folder within a public link folder to folder with same name as an already existing file overwrites the parent file
 #
 apiSharePublicLink2/copyFromPublicLink.feature:60
+apiSharePublicLink2/copyFromPublicLink.feature:85
+apiSharePublicLink2/copyFromPublicLink.feature:166
 apiSharePublicLink2/copyFromPublicLink.feature:167
-apiSharePublicLink2/copyFromPublicLink.feature:168
+apiSharePublicLink2/copyFromPublicLink.feature:182
 apiSharePublicLink2/copyFromPublicLink.feature:183
-apiSharePublicLink2/copyFromPublicLink.feature:184
 apiSharePublicLink2/updatePublicLinkShare.feature:44
 apiSharePublicLink2/updatePublicLinkShare.feature:45
 apiSharePublicLink2/updatePublicLinkShare.feature:93
@@ -1219,19 +1224,24 @@ apiWebdavProperties2/getFileProperties.feature:455
 #
 # https://github.com/owncloud/product/issues/237 etags are not quoted in PROPFIND
 #
-apiWebdavUpload1/uploadFile.feature:144
-apiWebdavUpload1/uploadFile.feature:145
-apiWebdavUpload1/uploadFile.feature:157
-apiWebdavUpload1/uploadFile.feature:158
-apiWebdavUpload1/uploadFile.feature:171
-apiWebdavUpload1/uploadFile.feature:172
-apiWebdavUpload1/uploadFile.feature:184
-apiWebdavUpload1/uploadFile.feature:185
+apiWebdavUpload1/uploadFile.feature:160
+apiWebdavUpload1/uploadFile.feature:161
+apiWebdavUpload1/uploadFile.feature:173
+apiWebdavUpload1/uploadFile.feature:174
+apiWebdavUpload1/uploadFile.feature:187
+apiWebdavUpload1/uploadFile.feature:188
+apiWebdavUpload1/uploadFile.feature:200
+apiWebdavUpload1/uploadFile.feature:201
 #
-# https://github.com/owncloud/ocis-reva/issues/15 blacklisted filenames like .htaccess & file.parts can be uploaded
+# https://github.com/owncloud/ocis/issues/824 PUT request with missing parent must return status code 409
 #
 apiWebdavUpload1/uploadFile.feature:112
 apiWebdavUpload1/uploadFile.feature:113
+#
+# https://github.com/owncloud/ocis-reva/issues/15 blacklisted filenames like .htaccess & file.parts can be uploaded
+#
+apiWebdavUpload1/uploadFile.feature:127
+apiWebdavUpload1/uploadFile.feature:128
 #
 # https://github.com/owncloud/ocis-reva/issues/56 remote.php/dav/uploads endpoint does not exist
 #
@@ -1322,20 +1332,20 @@ apiWebdavUpload2/uploadFileToExcludedDirectoryUsingOldChunking.feature:39
 #
 # https://github.com/owncloud/ocis-reva/issues/56 remote.php/dav/uploads endpoint does not exist
 #
-apiWebdavUpload2/uploadFileUsingNewChunking.feature:12
-apiWebdavUpload2/uploadFileUsingNewChunking.feature:29
-apiWebdavUpload2/uploadFileUsingNewChunking.feature:43
-apiWebdavUpload2/uploadFileUsingNewChunking.feature:57
-apiWebdavUpload2/uploadFileUsingNewChunking.feature:79
+apiWebdavUpload2/uploadFileUsingNewChunking.feature:13
+apiWebdavUpload2/uploadFileUsingNewChunking.feature:31
+apiWebdavUpload2/uploadFileUsingNewChunking.feature:46
+apiWebdavUpload2/uploadFileUsingNewChunking.feature:61
 apiWebdavUpload2/uploadFileUsingNewChunking.feature:85
-apiWebdavUpload2/uploadFileUsingNewChunking.feature:94
-apiWebdavUpload2/uploadFileUsingNewChunking.feature:98
-apiWebdavUpload2/uploadFileUsingNewChunking.feature:106
-apiWebdavUpload2/uploadFileUsingNewChunking.feature:135
-apiWebdavUpload2/uploadFileUsingNewChunking.feature:136
-apiWebdavUpload2/uploadFileUsingNewChunking.feature:137
-apiWebdavUpload2/uploadFileUsingNewChunking.feature:157
-apiWebdavUpload2/uploadFileUsingNewChunking.feature:158
+apiWebdavUpload2/uploadFileUsingNewChunking.feature:92
+apiWebdavUpload2/uploadFileUsingNewChunking.feature:102
+apiWebdavUpload2/uploadFileUsingNewChunking.feature:107
+apiWebdavUpload2/uploadFileUsingNewChunking.feature:116
+apiWebdavUpload2/uploadFileUsingNewChunking.feature:145
+apiWebdavUpload2/uploadFileUsingNewChunking.feature:146
+apiWebdavUpload2/uploadFileUsingNewChunking.feature:147
+apiWebdavUpload2/uploadFileUsingNewChunking.feature:168
+apiWebdavUpload2/uploadFileUsingNewChunking.feature:169
 #
 # https://github.com/owncloud/ocis-reva/issues/17  uploading with old-chunking does not work
 #

--- a/tests/acceptance/expected-failures-on-OWNCLOUD-storage.txt
+++ b/tests/acceptance/expected-failures-on-OWNCLOUD-storage.txt
@@ -472,10 +472,11 @@ apiSharePublicLink1/createPublicLinkShare.feature:742
 # https://github.com/owncloud/ocis-reva/issues/373 copying a folder within a public link folder to folder with same name as an already existing file overwrites the parent file
 #
 apiSharePublicLink2/copyFromPublicLink.feature:60
+apiSharePublicLink2/copyFromPublicLink.feature:85
+apiSharePublicLink2/copyFromPublicLink.feature:166
 apiSharePublicLink2/copyFromPublicLink.feature:167
-apiSharePublicLink2/copyFromPublicLink.feature:168
+apiSharePublicLink2/copyFromPublicLink.feature:182
 apiSharePublicLink2/copyFromPublicLink.feature:183
-apiSharePublicLink2/copyFromPublicLink.feature:184
 apiSharePublicLink2/updatePublicLinkShare.feature:44
 apiSharePublicLink2/updatePublicLinkShare.feature:45
 apiSharePublicLink2/updatePublicLinkShare.feature:93
@@ -1193,10 +1194,15 @@ apiWebdavProperties2/getFileProperties.feature:442
 apiWebdavProperties2/getFileProperties.feature:454
 apiWebdavProperties2/getFileProperties.feature:455
 #
-# https://github.com/owncloud/ocis-reva/issues/15 blacklisted filenames like .htaccess & file.parts can be uploaded
+# https://github.com/owncloud/ocis/issues/824 PUT request with missing parent must return status code 409
 #
 apiWebdavUpload1/uploadFile.feature:112
 apiWebdavUpload1/uploadFile.feature:113
+#
+# https://github.com/owncloud/ocis-reva/issues/15 blacklisted filenames like .htaccess & file.parts can be uploaded
+#
+apiWebdavUpload1/uploadFile.feature:127
+apiWebdavUpload1/uploadFile.feature:128
 #
 # https://github.com/owncloud/ocis-reva/issues/56 remote.php/dav/uploads endpoint does not exist
 # also requires test helper to read and clear the log file.
@@ -1257,20 +1263,20 @@ apiWebdavUpload2/uploadFileToExcludedDirectoryUsingNewChunking.feature:47
 apiWebdavUpload2/uploadFileToExcludedDirectoryUsingNewChunking.feature:48
 apiWebdavUpload2/uploadFileToExcludedDirectoryUsingNewChunking.feature:49
 apiWebdavUpload2/uploadFileToExcludedDirectoryUsingNewChunking.feature:52
-apiWebdavUpload2/uploadFileUsingNewChunking.feature:12
-apiWebdavUpload2/uploadFileUsingNewChunking.feature:29
-apiWebdavUpload2/uploadFileUsingNewChunking.feature:43
-apiWebdavUpload2/uploadFileUsingNewChunking.feature:57
-apiWebdavUpload2/uploadFileUsingNewChunking.feature:79
+apiWebdavUpload2/uploadFileUsingNewChunking.feature:13
+apiWebdavUpload2/uploadFileUsingNewChunking.feature:31
+apiWebdavUpload2/uploadFileUsingNewChunking.feature:46
+apiWebdavUpload2/uploadFileUsingNewChunking.feature:61
 apiWebdavUpload2/uploadFileUsingNewChunking.feature:85
-apiWebdavUpload2/uploadFileUsingNewChunking.feature:94
-apiWebdavUpload2/uploadFileUsingNewChunking.feature:98
-apiWebdavUpload2/uploadFileUsingNewChunking.feature:106
-apiWebdavUpload2/uploadFileUsingNewChunking.feature:135
-apiWebdavUpload2/uploadFileUsingNewChunking.feature:136
-apiWebdavUpload2/uploadFileUsingNewChunking.feature:137
-apiWebdavUpload2/uploadFileUsingNewChunking.feature:157
-apiWebdavUpload2/uploadFileUsingNewChunking.feature:158
+apiWebdavUpload2/uploadFileUsingNewChunking.feature:92
+apiWebdavUpload2/uploadFileUsingNewChunking.feature:102
+apiWebdavUpload2/uploadFileUsingNewChunking.feature:107
+apiWebdavUpload2/uploadFileUsingNewChunking.feature:116
+apiWebdavUpload2/uploadFileUsingNewChunking.feature:145
+apiWebdavUpload2/uploadFileUsingNewChunking.feature:146
+apiWebdavUpload2/uploadFileUsingNewChunking.feature:147
+apiWebdavUpload2/uploadFileUsingNewChunking.feature:168
+apiWebdavUpload2/uploadFileUsingNewChunking.feature:169
 #
 # https://github.com/owncloud/ocis-reva/issues/15 blacklisted filenames like .htaccess & file.parts can be uploaded
 #


### PR DESCRIPTION
Includes changes to core tests from

https://github.com/owncloud/core/pull/38092 Update sabre/dav (4.1.2 => 4.1.3) Webdav PUT of a file into a non-existent folder is expected to return 409.
https://github.com/owncloud/core/pull/38095 [Tests-Only] Refactored Oc10 bug demonstration scenarios that were tagged issue-core-nnnn
https://github.com/owncloud/core/pull/38093 [Tests-Only] fix user initialize and check on ocis
https://github.com/owncloud/core/pull/38096 [tests-only] skip on old oCV10 for scenarios that were added or changed by issue 38089
https://github.com/owncloud/core/pull/38097 [tests-only] Fix acceptance test exit status when running a single scenario
https://github.com/owncloud/core/pull/38098 [tests-only] Only use user 'moss' when isTestingOnOcis
