### PR TITLE
Lower level of "access token is already provided" message to debug

### DIFF
--- a/internal/http/interceptors/auth/auth.go
+++ b/internal/http/interceptors/auth/auth.go
@@ -218,7 +218,7 @@ func New(m map[string]interface{}, unprotected []string) (global.Middleware, err
 				tkn = res.Token
 				tokenWriter.WriteToken(tkn, w)
 			} else {
-				log.Info().Msg("access token is already provided")
+				log.Debug().Msg("access token is already provided")
 			}
 
 			// validate token


### PR DESCRIPTION
This is flooding the logs and seems not to be that important?