### PR TITLE
prevent nil pointer when listing shares

### DIFF
--- a/changelog/unreleased/ocs-prevent-nil-pointer.md
+++ b/changelog/unreleased/ocs-prevent-nil-pointer.md
@@ -1,0 +1,5 @@
+Bugfix: prevent nil pointer when listing shares
+
+We now handle cases where the grpc connection failed correctly by no longer trying to access the response status.
+
+https://github.com/cs3org/reva/pull/1317

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/user.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/user.go
@@ -80,13 +80,16 @@ func (h *Handler) listUserShares(r *http.Request, filters []*collaboration.ListS
 		// get a connection to the users share provider
 		c, err := pool.GetGatewayServiceClient(h.gatewayAddr)
 		if err != nil {
-			return nil, nil, err
+			return ocsDataPayload, nil, err
 		}
 
 		// do list shares request. filtered
 		lsUserSharesResponse, err := c.ListShares(ctx, &lsUserSharesRequest)
-		if err != nil || lsUserSharesResponse.Status.Code != rpc.Code_CODE_OK {
-			return nil, lsUserSharesResponse.Status, err
+		if err != nil {
+			return ocsDataPayload, nil, err
+		}
+		if lsUserSharesResponse.Status.Code != rpc.Code_CODE_OK {
+			return ocsDataPayload, lsUserSharesResponse.Status, nil
 		}
 
 		// build OCS response payload


### PR DESCRIPTION
We now handle cases where the grpc connection failed correctly by no longer trying to access the response status.