### PR TITLE
Log expected errors with debug level

### DIFF
--- a/changelog/unreleased/log-expected-errors-with-debug-level.md
+++ b/changelog/unreleased/log-expected-errors-with-debug-level.md
@@ -1,0 +1,5 @@
+Enhancement: Log expected errors with debug level
+
+While trying to download a non existing file and reading a non existing attribute are technically an error they are to be expected and nothing an admin can or even should act upon.
+
+https://github.com/cs3org/reva/pull/1324

--- a/internal/http/services/dataprovider/get.go
+++ b/internal/http/services/dataprovider/get.go
@@ -45,10 +45,10 @@ func (s *svc) doGet(w http.ResponseWriter, r *http.Request) {
 	rc, err := s.storage.Download(ctx, ref)
 	if err != nil {
 		if _, ok := err.(errtypes.IsNotFound); ok {
-			log.Err(err).Msg("datasvc: file not found")
+			log.Debug().Err(err).Msg("datasvc: file not found")
 			w.WriteHeader(http.StatusNotFound)
 		} else {
-			log.Err(err).Msg("datasvc: error downloading file")
+			log.Error().Err(err).Msg("datasvc: error downloading file")
 			w.WriteHeader(http.StatusInternalServerError)
 		}
 		return

--- a/pkg/storage/fs/ocis/grants.go
+++ b/pkg/storage/fs/ocis/grants.go
@@ -157,7 +157,7 @@ func extractACEsFromAttrs(ctx context.Context, fsfn string, attrs []string) (ent
 			var e *ace.ACE
 			principal := attrs[i][len(grantPrefix):]
 			if e, err = ace.Unmarshal(principal, value); err != nil {
-				log.Error().Err(err).Str("principal", principal).Str("attr", attrs[i]).Msg("could unmarshal ace")
+				log.Error().Err(err).Str("principal", principal).Str("attr", attrs[i]).Msg("could not unmarshal ace")
 				continue
 			}
 			entries = append(entries, e)

--- a/pkg/storage/fs/ocis/tree.go
+++ b/pkg/storage/fs/ocis/tree.go
@@ -349,7 +349,7 @@ func (t *Tree) Propagate(ctx context.Context, n *Node) (err error) {
 			switch {
 			case err != nil:
 				// missing attribute, or invalid format, overwrite
-				log.Error().Err(err).
+				log.Debug().Err(err).
 					Interface("node", n).
 					Msg("could not read tmtime attribute, overwriting")
 				updateSyncTime = true


### PR DESCRIPTION
While trying to download a non existing file and reading a non existing attribute are technically an error they are to be expected and nothing an admin can or even should act upon.