### PR TITLE
Set "Not Found" log-line to debug level

### DIFF
--- a/pkg/rhttp/datatx/manager/simple/simple.go
+++ b/pkg/rhttp/datatx/manager/simple/simple.go
@@ -81,7 +81,7 @@ func (m *manager) Handler(fs storage.FS) (http.Handler, error) {
 			rc, err := fs.Download(ctx, ref)
 			if err != nil {
 				if _, ok := err.(errtypes.IsNotFound); ok {
-					log.Err(err).Msg("datasvc: file not found")
+					log.Debug().Err(err).Msg("datasvc: file not found")
 					w.WriteHeader(http.StatusNotFound)
 				} else {
 					log.Err(err).Msg("datasvc: error downloading file")

--- a/pkg/rhttp/datatx/manager/tus/tus.go
+++ b/pkg/rhttp/datatx/manager/tus/tus.go
@@ -123,7 +123,7 @@ func (m *manager) Handler(fs storage.FS) (http.Handler, error) {
 			rc, err := fs.Download(ctx, ref)
 			if err != nil {
 				if _, ok := err.(errtypes.IsNotFound); ok {
-					log.Err(err).Msg("datasvc: file not found")
+					log.Debug().Err(err).Msg("datasvc: file not found")
 					w.WriteHeader(http.StatusNotFound)
 				} else {
 					log.Err(err).Msg("datasvc: error downloading file")


### PR DESCRIPTION
404 is an expected signal during normal operation thus should not be logged as application error. We see this error spamming our logs because we are using a GET request to check if a file already exists.