### PR TITLE
Fix home storage redirect for remote.php/dav/files

### DIFF
--- a/changelog/unreleased/fix-files-home-redirect.md
+++ b/changelog/unreleased/fix-files-home-redirect.md
@@ -1,0 +1,5 @@
+Bugfix: Dav endpoint routing to home storage when request is remote.php/dav/files
+
+There was a regression in which we were not routing correctly to the right storage depending on the url.
+
+https://github.com/cs3org/reva/pull/1342

--- a/internal/http/services/owncloud/ocdav/dav.go
+++ b/internal/http/services/owncloud/ocdav/dav.go
@@ -97,23 +97,30 @@ func (h *DavHandler) Handler(s *svc) http.Handler {
 		// https://github.com/owncloud/core/blob/18475dac812064b21dabcc50f25ef3ffe55691a5/tests/acceptance/features/apiWebdavOperations/propfind.feature
 		if r.URL.Path == "/files" {
 			log.Debug().Str("path", r.URL.Path).Msg("method not allowed")
-			w.WriteHeader(http.StatusMethodNotAllowed)
-			b, err := Marshal(exception{
-				code:    SabredavMethodNotAllowed,
-				message: "Listing members of this collection is disabled",
-			})
-			if err != nil {
-				log.Error().Msgf("error marshaling xml response: %s", b)
-				w.WriteHeader(http.StatusInternalServerError)
+			contextUser, ok := ctxuser.ContextGetUser(ctx)
+			if ok {
+				r.URL.Path = path.Join(r.URL.Path, contextUser.Username)
+			}
+
+			if r.Header.Get("Depth") == "" {
+				w.WriteHeader(http.StatusMethodNotAllowed)
+				b, err := Marshal(exception{
+					code:    SabredavMethodNotAllowed,
+					message: "Listing members of this collection is disabled",
+				})
+				if err != nil {
+					log.Error().Msgf("error marshaling xml response: %s", b)
+					w.WriteHeader(http.StatusInternalServerError)
+					return
+				}
+				_, err = w.Write(b)
+				if err != nil {
+					log.Error().Msgf("error writing xml response: %s", b)
+					w.WriteHeader(http.StatusInternalServerError)
+					return
+				}
 				return
 			}
-			_, err = w.Write(b)
-			if err != nil {
-				log.Error().Msgf("error writing xml response: %s", b)
-				w.WriteHeader(http.StatusInternalServerError)
-				return
-			}
-			return
 		}
 
 		var head string

--- a/internal/http/services/owncloud/ocdav/propfind.go
+++ b/internal/http/services/owncloud/ocdav/propfind.go
@@ -56,7 +56,7 @@ func (s *svc) handlePropfind(w http.ResponseWriter, r *http.Request, ns string) 
 		depth = "1"
 	}
 
-	// see https://tools.ietf.org/html/rfc4918#section-10.2
+	// see https://tools.ietf.org/html/rfc4918#section-9.1
 	if depth != "0" && depth != "1" && depth != "infinity" {
 		log.Error().Msgf("invalid Depth header value %s", depth)
 		w.WriteHeader(http.StatusBadRequest)


### PR DESCRIPTION
There was a regression in which we were not routing correctly to the right storage depending on the URL.

This is a pressing issue for oC mobile clients, the earlier we get it in the better :)

This sticks to webdav's RFC in the way that it's pretty ... unspecified what to do in this case:

> The following rules are the default behavior for any method that
   supports the Depth header.  A method may override these defaults by
   defining different behavior in its definition.

[sauce](https://tools.ietf.org/html/rfc4918#page-70)