### PR TITLE
fix ocis move

### DIFF
--- a/changelog/unreleased/fix-ocis-move.md
+++ b/changelog/unreleased/fix-ocis-move.md
@@ -1,0 +1,6 @@
+Bugfix: fix ocis move
+
+Use the old node id to build the target path for xattr updates.
+
+https://github.com/cs3org/reva/pull/1343
+https://github.com/owncloud/ocis/issues/975

--- a/tests/acceptance/expected-failures-on-OCIS-storage.txt
+++ b/tests/acceptance/expected-failures-on-OCIS-storage.txt
@@ -1491,8 +1491,6 @@ apiVersions/fileVersionsSharingToShares.feature:179
 #
 apiVersions/fileVersionsSharingToShares.feature:222
 apiVersions/fileVersionsSharingToShares.feature:223
-apiVersions/fileVersionsSharingToShares.feature:224
-apiVersions/fileVersionsSharingToShares.feature:225
 #
 # getting the metadata without permission results in a 403 error https://github.com/owncloud/ocis/issues/773
 #


### PR DESCRIPTION

Use the old node id to build the target path for xattr updates.

https://github.com/cs3org/reva/pull/1343
https://github.com/owncloud/ocis/issues/975
