### PR TITLE
Add a site property to explicitly enable health checks

### DIFF
--- a/changelog/unreleased/mentix-checks.md
+++ b/changelog/unreleased/mentix-checks.md
@@ -1,0 +1,5 @@
+Enhancement: Support property to enable health checking on a service
+
+This update introduces a new service property called `ENABLE_HEALTH_CHECKS` that must be explicitly set to `true` if a service should be checked for its health status. This allows us to only enable these checks for partner sites only, skipping vendor sites.
+
+https://github.com/cs3org/reva/pull/1347

--- a/pkg/mentix/exchangers/exporters/promsd.go
+++ b/pkg/mentix/exchangers/exporters/promsd.go
@@ -47,7 +47,7 @@ type PrometheusSDExporter struct {
 }
 
 func createMetricsSDScrapeConfig(site *meshdata.Site, host string, endpoint *meshdata.ServiceEndpoint) *prometheus.ScrapeConfig {
-	labels := getScrapeTargetLabels(site, endpoint)
+	labels := getScrapeTargetLabels(site, host, endpoint)
 
 	// If a metrics path was specified as a property, use that one by setting the corresponding label
 	if metricsPath := meshdata.GetPropertyValue(endpoint.Properties, meshdata.PropertyMetricsPath, ""); len(metricsPath) > 0 {
@@ -67,7 +67,7 @@ func createBlackboxSDScrapeConfig(site *meshdata.Site, host string, endpoint *me
 		return nil
 	}
 
-	labels := getScrapeTargetLabels(site, endpoint)
+	labels := getScrapeTargetLabels(site, host, endpoint)
 
 	// Check if health checks are enabled for the endpoint; if they aren't, skip this endpoint
 	if enableHealthChecks := meshdata.GetPropertyValue(endpoint.Properties, meshdata.PropertyEnableHealthChecks, "false"); !strings.EqualFold(enableHealthChecks, "true") {
@@ -80,14 +80,22 @@ func createBlackboxSDScrapeConfig(site *meshdata.Site, host string, endpoint *me
 	}
 }
 
-func getScrapeTargetLabels(site *meshdata.Site, endpoint *meshdata.ServiceEndpoint) map[string]string {
-	return map[string]string{
+func getScrapeTargetLabels(site *meshdata.Site, host string, endpoint *meshdata.ServiceEndpoint) map[string]string {
+	labels := map[string]string{
 		"__meta_mentix_site":         site.Name,
 		"__meta_mentix_site_type":    meshdata.GetSiteTypeName(site.Type),
 		"__meta_mentix_site_id":      site.GetID(),
+		"__meta_mentix_host":         host,
 		"__meta_mentix_country":      site.CountryCode,
 		"__meta_mentix_service_type": endpoint.Type.Name,
 	}
+
+	// Get the gRPC port if the corresponding property has been set
+	if port := meshdata.GetPropertyValue(endpoint.Properties, meshdata.PropertyGRPCPort, ""); len(port) > 0 {
+		labels["__meta_mentix_grpc_port"] = port
+	}
+
+	return labels
 }
 
 func (exporter *PrometheusSDExporter) registerScrapeCreators(conf *config.Configuration) error {

--- a/pkg/mentix/exchangers/exporters/promsd.go
+++ b/pkg/mentix/exchangers/exporters/promsd.go
@@ -24,6 +24,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/rs/zerolog"
 
@@ -67,6 +68,11 @@ func createBlackboxSDScrapeConfig(site *meshdata.Site, host string, endpoint *me
 	}
 
 	labels := getScrapeTargetLabels(site, endpoint)
+
+	// Check if health checks are enabled for the endpoint; if they aren't, skip this endpoint
+	if enableHealthChecks := meshdata.GetPropertyValue(endpoint.Properties, meshdata.PropertyEnableHealthChecks, "false"); !strings.EqualFold(enableHealthChecks, "true") {
+		return nil
+	}
 
 	return &prometheus.ScrapeConfig{
 		Targets: []string{target},

--- a/pkg/mentix/exchangers/exporters/promsd.go
+++ b/pkg/mentix/exchangers/exporters/promsd.go
@@ -67,10 +67,15 @@ func createBlackboxSDScrapeConfig(site *meshdata.Site, host string, endpoint *me
 		return nil
 	}
 
-	labels := getScrapeTargetLabels(site, host, endpoint)
-
 	// Check if health checks are enabled for the endpoint; if they aren't, skip this endpoint
 	if enableHealthChecks := meshdata.GetPropertyValue(endpoint.Properties, meshdata.PropertyEnableHealthChecks, "false"); !strings.EqualFold(enableHealthChecks, "true") {
+		return nil
+	}
+
+	labels := getScrapeTargetLabels(site, host, endpoint)
+
+	// For health checks, the gRPC port must be set
+	if _, ok := labels["__meta_mentix_grpc_port"]; !ok {
 		return nil
 	}
 

--- a/pkg/mentix/meshdata/properties.go
+++ b/pkg/mentix/meshdata/properties.go
@@ -25,6 +25,8 @@ const (
 	PropertyOrganization = "organization"
 	// PropertyMetricsPath identifies the metrics path property.
 	PropertyMetricsPath = "metrics_path"
+	// PropertyEnableHealthChecks identifies the enable health checks property.
+	PropertyEnableHealthChecks = "enable_health_checks"
 	// PropertyAPIVersion identifies the API version property.
 	PropertyAPIVersion = "api_version"
 )

--- a/pkg/mentix/meshdata/properties.go
+++ b/pkg/mentix/meshdata/properties.go
@@ -25,6 +25,8 @@ const (
 	PropertyOrganization = "organization"
 	// PropertyMetricsPath identifies the metrics path property.
 	PropertyMetricsPath = "metrics_path"
+	// PropertyGRPCPort identifies the gRPC port property.
+	PropertyGRPCPort = "grpc_port"
 	// PropertyEnableHealthChecks identifies the enable health checks property.
 	PropertyEnableHealthChecks = "enable_health_checks"
 	// PropertyAPIVersion identifies the API version property.


### PR DESCRIPTION
This update introduces a new service property called `ENABLE_HEALTH_CHECKS` that must be explicitly set to `true` if a service should be checked for its health status. This allows us to only enable these checks for partner sites only, skipping vendor sites.