### PR TITLE
Fix purging or restoring files with ocis storage

### DIFF
--- a/changelog/unreleased/fix-ocis-storage-purge.md
+++ b/changelog/unreleased/fix-ocis-storage-purge.md
@@ -1,0 +1,5 @@
+Bugfix: Fix purging deleted files with the ocis storage
+
+The ocis storage could load the owner information of a deleted file. This caused the storage to not be able to purge deleted files.
+
+https://github.com/owncloud/ocis/issues/551

--- a/pkg/storage/fs/ocis/node.go
+++ b/pkg/storage/fs/ocis/node.go
@@ -124,6 +124,18 @@ func ReadRecycleItem(ctx context.Context, lu *Lookup, key string) (n *Node, tras
 	} else {
 		return
 	}
+	// lookup ownerId in extended attributes
+	if attrBytes, err = xattr.Get(deletedNodePath, ownerIDAttr); err == nil {
+		n.ownerID = string(attrBytes)
+	} else {
+		return
+	}
+	// lookup ownerIdp in extended attributes
+	if attrBytes, err = xattr.Get(deletedNodePath, ownerIDPAttr); err == nil {
+		n.ownerIDP = string(attrBytes)
+	} else {
+		return
+	}
 
 	// get origin node
 	origin = "/"


### PR DESCRIPTION
we have to read the owner information in `ReadRecycleItem` because the lookup would return the origin node path instead of the deleted node path

Fixes owncloud/ocis#551