### PR TITLE
OCDAV: map bad request and unimplemented codes

### DIFF
--- a/changelog/unreleased/ocdav-handle-bad-request.md
+++ b/changelog/unreleased/ocdav-handle-bad-request.md
@@ -1,0 +1,5 @@
+Enhancement: Map bad request and unimplement to http status codes
+
+We now return a 400 bad request when a grpc call fails with an invalid argument status and a 501 not implemented when it fails with an unimplemented status. This prevents 500 errors when a user tries to add resources to the Share folder or a storage does not implement an action.
+
+https://github.com/cs3org/reva/pull/1354

--- a/internal/http/services/owncloud/ocdav/delete.go
+++ b/internal/http/services/owncloud/ocdav/delete.go
@@ -25,19 +25,23 @@ import (
 	rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	"github.com/cs3org/reva/pkg/appctx"
+	"go.opencensus.io/trace"
 )
 
 func (s *svc) handleDelete(w http.ResponseWriter, r *http.Request, ns string) {
 	ctx := r.Context()
-	log := appctx.GetLogger(ctx)
+	ctx, span := trace.StartSpan(ctx, "head")
+	defer span.End()
 
 	ns = applyLayout(ctx, ns)
 
 	fn := path.Join(ns, r.URL.Path)
 
+	sublog := appctx.GetLogger(ctx).With().Str("path", fn).Logger()
+
 	client, err := s.getClient()
 	if err != nil {
-		log.Error().Err(err).Msg("error getting grpc client")
+		sublog.Error().Err(err).Msg("error getting grpc client")
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
@@ -48,22 +52,14 @@ func (s *svc) handleDelete(w http.ResponseWriter, r *http.Request, ns string) {
 	req := &provider.DeleteRequest{Ref: ref}
 	res, err := client.Delete(ctx, req)
 	if err != nil {
-		log.Error().Err(err).Msg("error performing delete grpc request")
+		sublog.Error().Err(err).Msg("error performing delete grpc request")
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 
-	switch res.Status.Code {
-	case rpc.Code_CODE_OK:
-		w.WriteHeader(http.StatusNoContent)
-	case rpc.Code_CODE_NOT_FOUND:
-		log.Debug().Str("path", fn).Interface("status", res.Status).Msg("resource not found")
-		w.WriteHeader(http.StatusNotFound)
-	case rpc.Code_CODE_PERMISSION_DENIED:
-		log.Debug().Str("path", fn).Interface("status", res.Status).Msg("permission denied")
-		w.WriteHeader(http.StatusForbidden)
-	default:
-		log.Error().Str("path", fn).Interface("status", res.Status).Msg("grpc delete request failed")
-		w.WriteHeader(http.StatusInternalServerError)
+	if res.Status.Code != rpc.Code_CODE_OK {
+		handleErrorStatus(&sublog, w, res.Status)
+		return
 	}
+	w.WriteHeader(http.StatusNoContent)
 }


### PR DESCRIPTION
We now return a 400 bad request when a grpc call fails with an invalid argument status and a 501 not implemented when it fails with an unimplemented status. This prevents 500 errors when a user tries to add resources to the Share folder or a storage does not implement an action.

This is part of a series to get 500 errors returned as proper 400 errors: owncloud/product#7