### PR TITLE
[test-only] CI: fail when the daily builds cannot be uploaded via WebDAV

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -28,10 +28,10 @@ steps:
   detach: true
   commands:
     - TZ=Europe/Berlin go run tools/create-artifacts/main.go -dev -commit ${DRONE_COMMIT} -goversion `go version | awk '{print $$3}'`
-    - curl -X MKCOL "https://cernbox.cern.ch/cernbox/desktop/remote.php/webdav/eos/project/r/reva/www/daily/" -k -u $${USERNAME}:$${PASSWORD}
-    - curl -X MKCOL "https://cernbox.cern.ch/cernbox/desktop/remote.php/webdav/eos/project/r/reva/www/daily/`date '+%Y-%m-%d'`" -k -u $${USERNAME}:$${PASSWORD}
-    - curl -X MKCOL "https://cernbox.cern.ch/cernbox/desktop/remote.php/webdav/eos/project/r/reva/www/daily/`date '+%Y-%m-%d'`/${DRONE_COMMIT}" -k -u $${USERNAME}:$${PASSWORD}
-    - for i in $(ls /drone/src/dist);do curl -X PUT -u $${USERNAME}:$${PASSWORD} https://cernbox.cern.ch/cernbox/desktop/remote.php/webdav/eos/project/r/reva/www/daily/`date '+%Y-%m-%d'`/${DRONE_COMMIT}/$${i} --data-binary @./dist/$${i} ; done
+    - curl --fail -X MKCOL "https://cernbox.cern.ch/cernbox/desktop/remote.php/webdav/eos/project/r/reva/www/daily/" -k -u $${USERNAME}:$${PASSWORD}
+    - curl --fail -X MKCOL "https://cernbox.cern.ch/cernbox/desktop/remote.php/webdav/eos/project/r/reva/www/daily/`date '+%Y-%m-%d'`" -k -u $${USERNAME}:$${PASSWORD}
+    - curl --fail -X MKCOL "https://cernbox.cern.ch/cernbox/desktop/remote.php/webdav/eos/project/r/reva/www/daily/`date '+%Y-%m-%d'`/${DRONE_COMMIT}" -k -u $${USERNAME}:$${PASSWORD}
+    - for i in $(ls /drone/src/dist);do curl --fail -X PUT -u $${USERNAME}:$${PASSWORD} https://cernbox.cern.ch/cernbox/desktop/remote.php/webdav/eos/project/r/reva/www/daily/`date '+%Y-%m-%d'`/${DRONE_COMMIT}/$${i} --data-binary @./dist/$${i} ; done
 
 - name: license-scan
   image: golang:1.13

--- a/changelog/unreleased/ci-fail-on-daily-upload.md
+++ b/changelog/unreleased/ci-fail-on-daily-upload.md
@@ -1,0 +1,6 @@
+Enhancement: Mark 'store-dev-release' CI step as failed on 4XX/5XX errors
+
+Prevent the errors while storing new 'daily' releases from going unnoticed
+on the CI.
+
+https://github.com/cs3org/reva/pull/1362


### PR DESCRIPTION
e.g. on unauthorized:

```
curl --fail -X MKCOL \
	"https://cernbox.cern.ch/cernbox/desktop/remote.php/webdav/eos/project/r/reva/www/daily/" -k # no credentials
curl: (22) The requested URL returned error: 401
```