### PR TITLE
Delete public links on GET

### DIFF
--- a/changelog/unreleased/delete-public-link-on-get-operations.md
+++ b/changelog/unreleased/delete-public-link-on-get-operations.md
@@ -1,0 +1,5 @@
+Enhancement: Remove expired Link on Get
+
+There is the scenario in which a public link has expired but ListPublicLink has not run, accessing a technically expired public share is still possible.
+
+https://github.com/cs3org/reva/pull/1364

--- a/pkg/publicshare/manager/json/json.go
+++ b/pkg/publicshare/manager/json/json.go
@@ -62,7 +62,7 @@ func (j *janitor) run() {
 		select {
 		case <-work:
 			return
-		case _ = <-ticker.C:
+		case <-ticker.C:
 			j.m.cleanupExpiredShares()
 		}
 	}

--- a/pkg/publicshare/manager/json/json.go
+++ b/pkg/publicshare/manager/json/json.go
@@ -568,7 +568,3 @@ type publicShare struct {
 	link.PublicShare
 	Password string `json:"password"`
 }
-
-func cleanupExpired() {
-
-}


### PR DESCRIPTION
Following up on #1361 

Due to tunnel vision and solving one single problem, public links get deleted now on `ListPublicLinks` operations, but **as long as we don't have background jobs** they MUST also be deleted on `GetPublicLink` operations.

There is the scenario that a public link is expired but `ListPublicLink` has not run, accessing a technically expired public link is still possible.

A proposed solution is deleting the link on access.