### PR TITLE
map user id to username in share ocs share responses

### DIFF
--- a/changelog/unreleased/ocs-share-api-userid.md
+++ b/changelog/unreleased/ocs-share-api-userid.md
@@ -1,0 +1,6 @@
+Change: replace the user uuid with the username in ocs share responses
+
+The ocs api should not send the users uuid. Replaced the uuid with the username.
+
+https://github.com/owncloud/ocis/issues/990
+https://github.com/cs3org/reva/pull/1375

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/user.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/user.go
@@ -118,6 +118,7 @@ func (h *Handler) listUserShares(r *http.Request, filters []*collaboration.ListS
 				continue
 			}
 			h.addDisplaynames(ctx, c, data)
+			h.mapUserIds(ctx, c, data)
 
 			log.Debug().Interface("share", s).Interface("info", rInfo).Interface("shareData", data).Msg("mapped")
 			ocsDataPayload = append(ocsDataPayload, data)


### PR DESCRIPTION
The ocs api should not send the users uuid. Replaced the uuid with the username.

My PR got closed https://github.com/cs3org/reva/pull/1370 (probably because the unsafe branch was deleted)