### PR TITLE
[tests-only] Bump core commit id for tests

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -446,7 +446,7 @@ steps:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
       - cd /drone/src/tmp/testrunner
-      - git checkout 27eaa32d777052d1d210647cd38895e647c48fed
+      - git checkout c84aa4e95ac98f06dc2c17c570e65c36bfc17a78
 
   - name: localAPIAcceptanceTestsOwncloudStorage
     image: registry.cern.ch/docker.io/owncloudci/php:7.4
@@ -520,7 +520,7 @@ steps:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
       - cd /drone/src/tmp/testrunner
-      - git checkout 27eaa32d777052d1d210647cd38895e647c48fed
+      - git checkout c84aa4e95ac98f06dc2c17c570e65c36bfc17a78
 
   - name: localAPIAcceptanceTestsOcisStorage
     image: registry.cern.ch/docker.io/owncloudci/php:7.4
@@ -589,7 +589,7 @@ steps:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
       - cd /drone/src/tmp/testrunner
-      - git checkout 27eaa32d777052d1d210647cd38895e647c48fed
+      - git checkout c84aa4e95ac98f06dc2c17c570e65c36bfc17a78
 
   - name: oC10APIAcceptanceTestsOcisStorage
     image: registry.cern.ch/docker.io/owncloudci/php:7.4
@@ -661,7 +661,7 @@ steps:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
       - cd /drone/src/tmp/testrunner
-      - git checkout 27eaa32d777052d1d210647cd38895e647c48fed
+      - git checkout c84aa4e95ac98f06dc2c17c570e65c36bfc17a78
 
   - name: oC10APIAcceptanceTestsOcisStorage
     image: registry.cern.ch/docker.io/owncloudci/php:7.4
@@ -733,7 +733,7 @@ steps:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
       - cd /drone/src/tmp/testrunner
-      - git checkout 27eaa32d777052d1d210647cd38895e647c48fed
+      - git checkout c84aa4e95ac98f06dc2c17c570e65c36bfc17a78
 
   - name: oC10APIAcceptanceTestsOcisStorage
     image: registry.cern.ch/docker.io/owncloudci/php:7.4
@@ -805,7 +805,7 @@ steps:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
       - cd /drone/src/tmp/testrunner
-      - git checkout 27eaa32d777052d1d210647cd38895e647c48fed
+      - git checkout c84aa4e95ac98f06dc2c17c570e65c36bfc17a78
 
   - name: oC10APIAcceptanceTestsOcisStorage
     image: registry.cern.ch/docker.io/owncloudci/php:7.4
@@ -877,7 +877,7 @@ steps:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
       - cd /drone/src/tmp/testrunner
-      - git checkout 27eaa32d777052d1d210647cd38895e647c48fed
+      - git checkout c84aa4e95ac98f06dc2c17c570e65c36bfc17a78
 
   - name: oC10APIAcceptanceTestsOcisStorage
     image: registry.cern.ch/docker.io/owncloudci/php:7.4
@@ -949,7 +949,7 @@ steps:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
       - cd /drone/src/tmp/testrunner
-      - git checkout 27eaa32d777052d1d210647cd38895e647c48fed
+      - git checkout c84aa4e95ac98f06dc2c17c570e65c36bfc17a78
 
   - name: oC10APIAcceptanceTestsOcisStorage
     image: registry.cern.ch/docker.io/owncloudci/php:7.4
@@ -1021,7 +1021,7 @@ steps:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
       - cd /drone/src/tmp/testrunner
-      - git checkout 27eaa32d777052d1d210647cd38895e647c48fed
+      - git checkout c84aa4e95ac98f06dc2c17c570e65c36bfc17a78
 
   - name: oC10APIAcceptanceTestsOwncloudStorage
     image: registry.cern.ch/docker.io/owncloudci/php:7.4
@@ -1098,7 +1098,7 @@ steps:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
       - cd /drone/src/tmp/testrunner
-      - git checkout 27eaa32d777052d1d210647cd38895e647c48fed
+      - git checkout c84aa4e95ac98f06dc2c17c570e65c36bfc17a78
 
   - name: oC10APIAcceptanceTestsOwncloudStorage
     image: registry.cern.ch/docker.io/owncloudci/php:7.4
@@ -1175,7 +1175,7 @@ steps:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
       - cd /drone/src/tmp/testrunner
-      - git checkout 27eaa32d777052d1d210647cd38895e647c48fed
+      - git checkout c84aa4e95ac98f06dc2c17c570e65c36bfc17a78
 
   - name: oC10APIAcceptanceTestsOwncloudStorage
     image: registry.cern.ch/docker.io/owncloudci/php:7.4
@@ -1252,7 +1252,7 @@ steps:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
       - cd /drone/src/tmp/testrunner
-      - git checkout 27eaa32d777052d1d210647cd38895e647c48fed
+      - git checkout c84aa4e95ac98f06dc2c17c570e65c36bfc17a78
 
   - name: oC10APIAcceptanceTestsOwncloudStorage
     image: registry.cern.ch/docker.io/owncloudci/php:7.4
@@ -1329,7 +1329,7 @@ steps:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
       - cd /drone/src/tmp/testrunner
-      - git checkout 27eaa32d777052d1d210647cd38895e647c48fed
+      - git checkout c84aa4e95ac98f06dc2c17c570e65c36bfc17a78
 
   - name: oC10APIAcceptanceTestsOwncloudStorage
     image: registry.cern.ch/docker.io/owncloudci/php:7.4
@@ -1406,7 +1406,7 @@ steps:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
       - cd /drone/src/tmp/testrunner
-      - git checkout 27eaa32d777052d1d210647cd38895e647c48fed
+      - git checkout c84aa4e95ac98f06dc2c17c570e65c36bfc17a78
 
   - name: oC10APIAcceptanceTestsOwncloudStorage
     image: registry.cern.ch/docker.io/owncloudci/php:7.4

--- a/tests/acceptance/expected-failures-on-OCIS-storage.txt
+++ b/tests/acceptance/expected-failures-on-OCIS-storage.txt
@@ -841,15 +841,23 @@ apiShareReshareToShares3/reShareWithExpiryDate.feature:337
 apiShareReshareToShares3/reShareWithExpiryDate.feature:338
 #
 # https://github.com/owncloud/product/issues/254 empty trashbin does not work
-# https://github.com/owncloud/ocis/issues/551 delete from trashbin does not work
 #
 apiTrashbin/trashbinDelete.feature:31
 apiTrashbin/trashbinDelete.feature:32
 apiTrashbin/trashbinDelete.feature:33
 apiTrashbin/trashbinDelete.feature:34
 apiTrashbin/trashbinDelete.feature:37
+#
+# https://github.com/owncloud/ocis/issues/1120 href in trashbin PROPFIND response is wrong
+#
 apiTrashbin/trashbinDelete.feature:50
 apiTrashbin/trashbinDelete.feature:67
+#
+# https://github.com/owncloud/ocis/issues/1120 href in trashbin PROPFIND response is wrong
+# https://github.com/owncloud/ocis/issues/1077 [QA] trashcan cannot delete a deep tree
+#
+apiTrashbin/trashbinDelete.feature:107
+apiTrashbin/trashbinDelete.feature:123
 #
 # https://github.com/owncloud/product/issues/255 trashbin filename invalid for nested files/folders
 #
@@ -871,29 +879,21 @@ apiTrashbin/trashbinFilesFolders.feature:211
 apiTrashbin/trashbinFilesFolders.feature:224
 apiTrashbin/trashbinFilesFolders.feature:225
 #
-# https://github.com/owncloud/core/issues/38006 Review and fix the tests that have sharing step to work with ocis
+# https://github.com/owncloud/ocis/issues/1116 PROPFIND on trashbin with Depth: infinity only shows the first level
 #
-apiTrashbin/trashbinRestore.feature:40
-apiTrashbin/trashbinRestore.feature:41
+apiTrashbin/trashbinFilesFolders.feature:272
+apiTrashbin/trashbinFilesFolders.feature:273
 #
-# https://github.com/owncloud/ocis-reva/issues/117 cannot restore trashbin item
+# https://github.com/owncloud/ocis/issues/1120 href in trashbin PROPFIND response is wrong
 #
 apiTrashbin/trashbinRestore.feature:54
 apiTrashbin/trashbinRestore.feature:55
 apiTrashbin/trashbinRestore.feature:70
 apiTrashbin/trashbinRestore.feature:71
-apiTrashbin/trashbinRestore.feature:90
-apiTrashbin/trashbinRestore.feature:91
-apiTrashbin/trashbinRestore.feature:92
-apiTrashbin/trashbinRestore.feature:93
-apiTrashbin/trashbinRestore.feature:94
-apiTrashbin/trashbinRestore.feature:95
 apiTrashbin/trashbinRestore.feature:118
 apiTrashbin/trashbinRestore.feature:119
 apiTrashbin/trashbinRestore.feature:120
 apiTrashbin/trashbinRestore.feature:121
-apiTrashbin/trashbinRestore.feature:138
-apiTrashbin/trashbinRestore.feature:139
 apiTrashbin/trashbinRestore.feature:211
 apiTrashbin/trashbinRestore.feature:212
 apiTrashbin/trashbinRestore.feature:255
@@ -904,8 +904,43 @@ apiTrashbin/trashbinRestore.feature:259
 apiTrashbin/trashbinRestore.feature:260
 apiTrashbin/trashbinRestore.feature:275
 apiTrashbin/trashbinRestore.feature:276
+apiTrashbin/trashbinRestore.feature:292
+apiTrashbin/trashbinRestore.feature:293
+#
+# https://github.com/owncloud/ocis/issues/1120 href in trashbin PROPFIND response is wrong
+# https://github.com/owncloud/ocis/issues/1121 trash-bin restore move does not send back Etag and other headers
+#
+apiTrashbin/trashbinRestore.feature:40
+apiTrashbin/trashbinRestore.feature:41
+apiTrashbin/trashbinRestore.feature:138
+apiTrashbin/trashbinRestore.feature:139
+#
+# https://github.com/owncloud/ocis/issues/1120 href in trashbin PROPFIND response is wrong
+# https://github.com/owncloud/ocis/issues/1122 cannot restore to a different file-name
+# https://github.com/owncloud/ocis/issues/1121 trash-bin restore move does not send back Etag and other headers
+#
+apiTrashbin/trashbinRestore.feature:90
+apiTrashbin/trashbinRestore.feature:91
+apiTrashbin/trashbinRestore.feature:92
+apiTrashbin/trashbinRestore.feature:93
+apiTrashbin/trashbinRestore.feature:94
+apiTrashbin/trashbinRestore.feature:95
+#
+# https://github.com/owncloud/ocis/issues/1120 href in trashbin PROPFIND response is wrong
+# https://github.com/owncloud/ocis/issues/1122 cannot restore to a different file-name
+#
+apiTrashbin/trashbinRestore.feature:311
+apiTrashbin/trashbinRestore.feature:312
+apiTrashbin/trashbinRestore.feature:330
+apiTrashbin/trashbinRestore.feature:331
+#
+# https://github.com/owncloud/ocis/issues/1123 deleting a received share-folder moves it to trash-bin but does not unshare it
+#
 apiTrashbin/trashbinSharingToShares.feature:24
 apiTrashbin/trashbinSharingToShares.feature:25
+#
+# https://github.com/owncloud/ocis/issues/1124 deleting a file inside a received shared folder is moved to the trash-bin of the sharer not the receiver
+#
 apiTrashbin/trashbinSharingToShares.feature:40
 apiTrashbin/trashbinSharingToShares.feature:41
 apiTrashbin/trashbinSharingToShares.feature:63
@@ -2261,3 +2296,13 @@ apiWebdavUploadTUS/uploadToShare.feature:67
 # https://github.com/owncloud/product/issues/293 sharing with group not available
 apiWebdavUploadTUS/uploadToShare.feature:52
 apiWebdavUploadTUS/uploadToShare.feature:53
+
+# https://github.com/owncloud/ocis/issues/1001 invalid file-names should not be created using the TUS protocol
+apiWebdavUploadTUS/uploadFile.feature:135
+apiWebdavUploadTUS/uploadFile.feature:136
+apiWebdavUploadTUS/uploadFile.feature:137
+apiWebdavUploadTUS/uploadFile.feature:138
+apiWebdavUploadTUS/uploadFile.feature:139
+apiWebdavUploadTUS/uploadFile.feature:140
+apiWebdavUploadTUS/uploadFile.feature:141
+apiWebdavUploadTUS/uploadFile.feature:142

--- a/tests/acceptance/expected-failures-on-OWNCLOUD-storage.txt
+++ b/tests/acceptance/expected-failures-on-OWNCLOUD-storage.txt
@@ -821,6 +821,12 @@ apiTrashbin/trashbinDelete.feature:37
 apiTrashbin/trashbinDelete.feature:50
 apiTrashbin/trashbinDelete.feature:67
 #
+# https://github.com/owncloud/ocis/issues/1120 href in trashbin PROPFIND response is wrong
+# https://github.com/owncloud/ocis/issues/1077 [QA] trashcan cannot delete a deep tree
+#
+apiTrashbin/trashbinDelete.feature:107
+apiTrashbin/trashbinDelete.feature:123
+#
 # https://github.com/owncloud/product/issues/255 trashbin filename invalid for nested files/folders
 #
 apiTrashbin/trashbinFilesFolders.feature:44
@@ -838,34 +844,29 @@ apiTrashbin/trashbinFilesFolders.feature:172
 apiTrashbin/trashbinFilesFolders.feature:173
 apiTrashbin/trashbinFilesFolders.feature:196
 apiTrashbin/trashbinFilesFolders.feature:197
+#
+# https://github.com/owncloud/product/issues/273 invalid webdav responses for unauthorized requests.
+#
 apiTrashbin/trashbinFilesFolders.feature:210
 apiTrashbin/trashbinFilesFolders.feature:211
 apiTrashbin/trashbinFilesFolders.feature:224
 apiTrashbin/trashbinFilesFolders.feature:225
 #
-# https://github.com/owncloud/core/issues/38006 Review and fix the tests that have sharing step to work with ocis
+# https://github.com/owncloud/ocis/issues/1116 PROPFIND on trashbin with Depth: infinity only shows the first level
 #
-apiTrashbin/trashbinRestore.feature:40
-apiTrashbin/trashbinRestore.feature:41
+apiTrashbin/trashbinFilesFolders.feature:272
+apiTrashbin/trashbinFilesFolders.feature:273
 #
-# https://github.com/owncloud/ocis-reva/issues/117 cannot restore trashbin item
+# https://github.com/owncloud/ocis/issues/1120 href in trashbin PROPFIND response is wrong
 #
 apiTrashbin/trashbinRestore.feature:54
 apiTrashbin/trashbinRestore.feature:55
 apiTrashbin/trashbinRestore.feature:70
 apiTrashbin/trashbinRestore.feature:71
-apiTrashbin/trashbinRestore.feature:90
-apiTrashbin/trashbinRestore.feature:91
-apiTrashbin/trashbinRestore.feature:92
-apiTrashbin/trashbinRestore.feature:93
-apiTrashbin/trashbinRestore.feature:94
-apiTrashbin/trashbinRestore.feature:95
 apiTrashbin/trashbinRestore.feature:118
 apiTrashbin/trashbinRestore.feature:119
 apiTrashbin/trashbinRestore.feature:120
 apiTrashbin/trashbinRestore.feature:121
-apiTrashbin/trashbinRestore.feature:138
-apiTrashbin/trashbinRestore.feature:139
 apiTrashbin/trashbinRestore.feature:211
 apiTrashbin/trashbinRestore.feature:212
 apiTrashbin/trashbinRestore.feature:255
@@ -876,8 +877,43 @@ apiTrashbin/trashbinRestore.feature:259
 apiTrashbin/trashbinRestore.feature:260
 apiTrashbin/trashbinRestore.feature:275
 apiTrashbin/trashbinRestore.feature:276
+apiTrashbin/trashbinRestore.feature:292
+apiTrashbin/trashbinRestore.feature:293
+#
+# https://github.com/owncloud/ocis/issues/1120 href in trashbin PROPFIND response is wrong
+# https://github.com/owncloud/ocis/issues/1121 trash-bin restore move does not send back Etag and other headers
+#
+apiTrashbin/trashbinRestore.feature:40
+apiTrashbin/trashbinRestore.feature:41
+apiTrashbin/trashbinRestore.feature:138
+apiTrashbin/trashbinRestore.feature:139
+#
+# https://github.com/owncloud/ocis/issues/1120 href in trashbin PROPFIND response is wrong
+# https://github.com/owncloud/ocis/issues/1122 cannot restore to a different file-name
+# https://github.com/owncloud/ocis/issues/1121 trash-bin restore move does not send back Etag and other headers
+#
+apiTrashbin/trashbinRestore.feature:90
+apiTrashbin/trashbinRestore.feature:91
+apiTrashbin/trashbinRestore.feature:92
+apiTrashbin/trashbinRestore.feature:93
+apiTrashbin/trashbinRestore.feature:94
+apiTrashbin/trashbinRestore.feature:95
+#
+# https://github.com/owncloud/ocis/issues/1120 href in trashbin PROPFIND response is wrong
+# https://github.com/owncloud/ocis/issues/1122 cannot restore to a different file-name
+#
+apiTrashbin/trashbinRestore.feature:311
+apiTrashbin/trashbinRestore.feature:312
+apiTrashbin/trashbinRestore.feature:330
+apiTrashbin/trashbinRestore.feature:331
+#
+# https://github.com/owncloud/ocis/issues/1123 deleting a received share-folder moves it to trash-bin but does not unshare it
+#
 apiTrashbin/trashbinSharingToShares.feature:24
 apiTrashbin/trashbinSharingToShares.feature:25
+#
+# https://github.com/owncloud/ocis/issues/1124 deleting a file inside a received shared folder is moved to the trash-bin of the sharer not the receiver
+#
 apiTrashbin/trashbinSharingToShares.feature:40
 apiTrashbin/trashbinSharingToShares.feature:41
 apiTrashbin/trashbinSharingToShares.feature:63
@@ -2179,3 +2215,23 @@ apiWebdavUploadTUS/uploadToNonExistingFolder.feature:43
 apiWebdavUploadTUS/uploadToNonExistingFolder.feature:44
 apiWebdavUploadTUS/uploadToNonExistingFolder.feature:57
 apiWebdavUploadTUS/uploadToNonExistingFolder.feature:58
+
+# https://github.com/owncloud/ocis/issues/1039 The Patch Request Response doesnot contain a body
+apiWebdavUploadTUS/uploadToNonExistingFolder.feature:29
+apiWebdavUploadTUS/uploadToNonExistingFolder.feature:30
+
+# https://github.com/owncloud/ocis/issues/1047 500 Internal Server Error on Post request for TUS upload to a non-existing folder on the received share
+apiWebdavUploadTUS/uploadToNonExistingFolder.feature:43
+apiWebdavUploadTUS/uploadToNonExistingFolder.feature:44
+apiWebdavUploadTUS/uploadToNonExistingFolder.feature:57
+apiWebdavUploadTUS/uploadToNonExistingFolder.feature:58
+
+# https://github.com/owncloud/ocis/issues/1001 invalid file-names should not be created using the TUS protocol
+apiWebdavUploadTUS/uploadFile.feature:135
+apiWebdavUploadTUS/uploadFile.feature:136
+apiWebdavUploadTUS/uploadFile.feature:137
+apiWebdavUploadTUS/uploadFile.feature:138
+apiWebdavUploadTUS/uploadFile.feature:139
+apiWebdavUploadTUS/uploadFile.feature:140
+apiWebdavUploadTUS/uploadFile.feature:141
+apiWebdavUploadTUS/uploadFile.feature:142


### PR DESCRIPTION
Similar to https://github.com/owncloud/ocis/pull/1111

Gets latest test code and scenarios from `owncloud/core` for TUS and other tests.