### PR TITLE
make jaeger-agent usable

### DIFF
--- a/changelog/unreleased/make-jaeger-agent-usable.md
+++ b/changelog/unreleased/make-jaeger-agent-usable.md
@@ -1,0 +1,7 @@
+Bugfix: Make Jaeger agent usable
+
+Previously, you could not use tracing with jaeger agent because the tracing connector is always used instead of the tracing endpoint.
+
+This PR removes the defaults for collector and tracing endpoint. 
+
+https://github.com/cs3org/reva/pull/1379

--- a/cmd/revad/runtime/runtime.go
+++ b/cmd/revad/runtime/runtime.go
@@ -263,14 +263,6 @@ func setupOpenCensus(conf *coreConf) error {
 		return nil
 	}
 
-	if conf.TracingEndpoint == "" {
-		conf.TracingEndpoint = "localhost:6831"
-	}
-
-	if conf.TracingCollector == "" {
-		conf.TracingCollector = "http://localhost:14268/api/traces"
-	}
-
 	if conf.TracingServiceName == "" {
 		conf.TracingServiceName = "revad"
 	}


### PR DESCRIPTION
Currently you can not configure to send traces to jaeger agent.

This is because the tracing collector default is always used, even if a tracing endpoint is given.

https://github.com/cs3org/reva/blob/4a9be347ac29706e429d47525815e638f9770f29/cmd/revad/runtime/runtime.go#L270-L272

Jaeger first checks if a collector endpoint is given and then takes that. The tracing endpoint will never be used.
https://github.com/census-ecosystem/opencensus-go-exporter-jaeger/blob/30c8b0fe8ad9d0eac5785893f3941b2e72c5aaaa/jaeger.go#L88-L98

New behaviour: fail if tracing is enabled and none of collector / tracing endpoint is configured.