### PR TITLE
[tests-only] Bump core commit id to include PR 38268

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -446,7 +446,7 @@ steps:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
       - cd /drone/src/tmp/testrunner
-      - git checkout d07a7b297c5186de9994dacdbc7d9e19df10c9f5
+      - git checkout 7457f6394958cdb1aee3976edba3181173d64378
 
   - name: localAPIAcceptanceTestsOwncloudStorage
     image: registry.cern.ch/docker.io/owncloudci/php:7.4
@@ -520,7 +520,7 @@ steps:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
       - cd /drone/src/tmp/testrunner
-      - git checkout d07a7b297c5186de9994dacdbc7d9e19df10c9f5
+      - git checkout 7457f6394958cdb1aee3976edba3181173d64378
 
   - name: localAPIAcceptanceTestsOcisStorage
     image: registry.cern.ch/docker.io/owncloudci/php:7.4
@@ -589,7 +589,7 @@ steps:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
       - cd /drone/src/tmp/testrunner
-      - git checkout d07a7b297c5186de9994dacdbc7d9e19df10c9f5
+      - git checkout 7457f6394958cdb1aee3976edba3181173d64378
 
   - name: oC10APIAcceptanceTestsOcisStorage
     image: registry.cern.ch/docker.io/owncloudci/php:7.4
@@ -661,7 +661,7 @@ steps:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
       - cd /drone/src/tmp/testrunner
-      - git checkout d07a7b297c5186de9994dacdbc7d9e19df10c9f5
+      - git checkout 7457f6394958cdb1aee3976edba3181173d64378
 
   - name: oC10APIAcceptanceTestsOcisStorage
     image: registry.cern.ch/docker.io/owncloudci/php:7.4
@@ -733,7 +733,7 @@ steps:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
       - cd /drone/src/tmp/testrunner
-      - git checkout d07a7b297c5186de9994dacdbc7d9e19df10c9f5
+      - git checkout 7457f6394958cdb1aee3976edba3181173d64378
 
   - name: oC10APIAcceptanceTestsOcisStorage
     image: registry.cern.ch/docker.io/owncloudci/php:7.4
@@ -805,7 +805,7 @@ steps:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
       - cd /drone/src/tmp/testrunner
-      - git checkout d07a7b297c5186de9994dacdbc7d9e19df10c9f5
+      - git checkout 7457f6394958cdb1aee3976edba3181173d64378
 
   - name: oC10APIAcceptanceTestsOcisStorage
     image: registry.cern.ch/docker.io/owncloudci/php:7.4
@@ -877,7 +877,7 @@ steps:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
       - cd /drone/src/tmp/testrunner
-      - git checkout d07a7b297c5186de9994dacdbc7d9e19df10c9f5
+      - git checkout 7457f6394958cdb1aee3976edba3181173d64378
 
   - name: oC10APIAcceptanceTestsOcisStorage
     image: registry.cern.ch/docker.io/owncloudci/php:7.4
@@ -949,7 +949,7 @@ steps:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
       - cd /drone/src/tmp/testrunner
-      - git checkout d07a7b297c5186de9994dacdbc7d9e19df10c9f5
+      - git checkout 7457f6394958cdb1aee3976edba3181173d64378
 
   - name: oC10APIAcceptanceTestsOcisStorage
     image: registry.cern.ch/docker.io/owncloudci/php:7.4
@@ -1021,7 +1021,7 @@ steps:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
       - cd /drone/src/tmp/testrunner
-      - git checkout d07a7b297c5186de9994dacdbc7d9e19df10c9f5
+      - git checkout 7457f6394958cdb1aee3976edba3181173d64378
 
   - name: oC10APIAcceptanceTestsOwncloudStorage
     image: registry.cern.ch/docker.io/owncloudci/php:7.4
@@ -1098,7 +1098,7 @@ steps:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
       - cd /drone/src/tmp/testrunner
-      - git checkout d07a7b297c5186de9994dacdbc7d9e19df10c9f5
+      - git checkout 7457f6394958cdb1aee3976edba3181173d64378
 
   - name: oC10APIAcceptanceTestsOwncloudStorage
     image: registry.cern.ch/docker.io/owncloudci/php:7.4
@@ -1175,7 +1175,7 @@ steps:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
       - cd /drone/src/tmp/testrunner
-      - git checkout d07a7b297c5186de9994dacdbc7d9e19df10c9f5
+      - git checkout 7457f6394958cdb1aee3976edba3181173d64378
 
   - name: oC10APIAcceptanceTestsOwncloudStorage
     image: registry.cern.ch/docker.io/owncloudci/php:7.4
@@ -1252,7 +1252,7 @@ steps:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
       - cd /drone/src/tmp/testrunner
-      - git checkout d07a7b297c5186de9994dacdbc7d9e19df10c9f5
+      - git checkout 7457f6394958cdb1aee3976edba3181173d64378
 
   - name: oC10APIAcceptanceTestsOwncloudStorage
     image: registry.cern.ch/docker.io/owncloudci/php:7.4
@@ -1329,7 +1329,7 @@ steps:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
       - cd /drone/src/tmp/testrunner
-      - git checkout d07a7b297c5186de9994dacdbc7d9e19df10c9f5
+      - git checkout 7457f6394958cdb1aee3976edba3181173d64378
 
   - name: oC10APIAcceptanceTestsOwncloudStorage
     image: registry.cern.ch/docker.io/owncloudci/php:7.4
@@ -1406,7 +1406,7 @@ steps:
       - git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing
       - git clone -b master --single-branch --no-tags https://github.com/owncloud/core.git /drone/src/tmp/testrunner
       - cd /drone/src/tmp/testrunner
-      - git checkout d07a7b297c5186de9994dacdbc7d9e19df10c9f5
+      - git checkout 7457f6394958cdb1aee3976edba3181173d64378
 
   - name: oC10APIAcceptanceTestsOwncloudStorage
     image: registry.cern.ch/docker.io/owncloudci/php:7.4

--- a/tests/acceptance/expected-failures-on-OWNCLOUD-storage.txt
+++ b/tests/acceptance/expected-failures-on-OWNCLOUD-storage.txt
@@ -1465,8 +1465,6 @@ apiWebdavEtagPropagation1/moveFileFolder.feature:61
 apiWebdavEtagPropagation1/moveFileFolder.feature:62
 apiWebdavEtagPropagation1/moveFileFolder.feature:78
 apiWebdavEtagPropagation1/moveFileFolder.feature:79
-apiWebdavEtagPropagation1/moveFileFolder.feature:98
-apiWebdavEtagPropagation1/moveFileFolder.feature:99
 apiWebdavEtagPropagation1/moveFileFolder.feature:146
 apiWebdavEtagPropagation1/moveFileFolder.feature:147
 apiWebdavEtagPropagation1/moveFileFolder.feature:174


### PR DESCRIPTION
The same as https://github.com/owncloud/ocis/pull/1172 https://github.com/owncloud/ocis/pull/1172/commits/fb38637ed77678e87d3ecfe20fb36c15d2f0d77e

This avoids running a couple of Etag Propagation tests that intermittently pass/fail.