### PR TITLE
Use the user in request for deciding the layout for non-home DAV requests

### DIFF
--- a/changelog/unreleased/fix-dav-namespace.md
+++ b/changelog/unreleased/fix-dav-namespace.md
@@ -1,0 +1,16 @@
+Bugfix: Use the user in request for deciding the layout for non-home DAV requests
+
+For the incoming /dav/files/userID requests, we have different namespaces
+depending on whether the request is for the logged-in user's namespace or not.
+Since in the storage drivers, we specify the layout depending only on the user
+whose resources are to be accessed, this fails when a user wants to access
+another user's namespace when the storage provider depends on the logged in
+user's namespace. This PR fixes that.
+
+For example, consider the following case. The owncloud fs uses a layout
+{{substr 0 1 .Id.OpaqueId}}/{{.Id.OpaqueId}}. The user einstein sends a request
+to access a resource shared with him, say /dav/files/marie/abcd, which should be
+allowed. However, based on the way we applied the layout, there's no way in
+which this can be translated to /m/marie/.
+
+https://github.com/cs3org/reva/pull/1401

--- a/internal/http/services/owncloud/ocdav/copy.go
+++ b/internal/http/services/owncloud/ocdav/copy.go
@@ -40,8 +40,6 @@ func (s *svc) handleCopy(w http.ResponseWriter, r *http.Request, ns string) {
 	ctx, span := trace.StartSpan(ctx, "head")
 	defer span.End()
 
-	ns = applyLayout(ctx, ns)
-
 	src := path.Join(ns, r.URL.Path)
 	dstHeader := r.Header.Get("Destination")
 	overwrite := r.Header.Get("Overwrite")

--- a/internal/http/services/owncloud/ocdav/dav.go
+++ b/internal/http/services/owncloud/ocdav/dav.go
@@ -57,11 +57,11 @@ func (h *DavHandler) init(c *Config) error {
 		return err
 	}
 	h.FilesHandler = new(WebDavHandler)
-	if err := h.FilesHandler.init(c.FilesNamespace); err != nil {
+	if err := h.FilesHandler.init(c.FilesNamespace, false); err != nil {
 		return err
 	}
 	h.FilesHomeHandler = new(WebDavHandler)
-	if err := h.FilesHomeHandler.init(c.WebdavNamespace); err != nil {
+	if err := h.FilesHomeHandler.init(c.WebdavNamespace, true); err != nil {
 		return err
 	}
 	h.MetaHandler = new(MetaHandler)
@@ -71,7 +71,7 @@ func (h *DavHandler) init(c *Config) error {
 	h.TrashbinHandler = new(TrashbinHandler)
 
 	h.PublicFolderHandler = new(WebDavHandler)
-	if err := h.PublicFolderHandler.init("public"); err != nil { // jail public file requests to /public/ prefix
+	if err := h.PublicFolderHandler.init("public", true); err != nil { // jail public file requests to /public/ prefix
 		return err
 	}
 

--- a/internal/http/services/owncloud/ocdav/delete.go
+++ b/internal/http/services/owncloud/ocdav/delete.go
@@ -33,8 +33,6 @@ func (s *svc) handleDelete(w http.ResponseWriter, r *http.Request, ns string) {
 	ctx, span := trace.StartSpan(ctx, "head")
 	defer span.End()
 
-	ns = applyLayout(ctx, ns)
-
 	fn := path.Join(ns, r.URL.Path)
 
 	sublog := appctx.GetLogger(ctx).With().Str("path", fn).Logger()

--- a/internal/http/services/owncloud/ocdav/get.go
+++ b/internal/http/services/owncloud/ocdav/get.go
@@ -40,8 +40,6 @@ func (s *svc) handleGet(w http.ResponseWriter, r *http.Request, ns string) {
 	ctx, span := trace.StartSpan(ctx, "get")
 	defer span.End()
 
-	ns = applyLayout(ctx, ns)
-
 	fn := path.Join(ns, r.URL.Path)
 
 	sublog := appctx.GetLogger(ctx).With().Str("path", fn).Str("svc", "ocdav").Str("handler", "get").Logger()

--- a/internal/http/services/owncloud/ocdav/head.go
+++ b/internal/http/services/owncloud/ocdav/head.go
@@ -36,8 +36,6 @@ func (s *svc) handleHead(w http.ResponseWriter, r *http.Request, ns string) {
 	ctx, span := trace.StartSpan(ctx, "head")
 	defer span.End()
 
-	ns = applyLayout(ctx, ns)
-
 	fn := path.Join(ns, r.URL.Path)
 
 	sublog := appctx.GetLogger(ctx).With().Str("path", fn).Logger()

--- a/internal/http/services/owncloud/ocdav/mkcol.go
+++ b/internal/http/services/owncloud/ocdav/mkcol.go
@@ -34,8 +34,6 @@ func (s *svc) handleMkcol(w http.ResponseWriter, r *http.Request, ns string) {
 	ctx, span := trace.StartSpan(ctx, "mkcol")
 	defer span.End()
 
-	ns = applyLayout(ctx, ns)
-
 	fn := path.Join(ns, r.URL.Path)
 
 	sublog := appctx.GetLogger(ctx).With().Str("path", fn).Logger()

--- a/internal/http/services/owncloud/ocdav/move.go
+++ b/internal/http/services/owncloud/ocdav/move.go
@@ -34,8 +34,6 @@ func (s *svc) handleMove(w http.ResponseWriter, r *http.Request, ns string) {
 	ctx, span := trace.StartSpan(ctx, "move")
 	defer span.End()
 
-	ns = applyLayout(ctx, ns)
-
 	src := path.Join(ns, r.URL.Path)
 	dstHeader := r.Header.Get("Destination")
 	overwrite := r.Header.Get("Overwrite")

--- a/internal/http/services/owncloud/ocdav/ocdav.go
+++ b/internal/http/services/owncloud/ocdav/ocdav.go
@@ -193,8 +193,8 @@ func applyLayout(ctx context.Context, ns string, useLoggedInUserNS bool, request
 	// is not the same as the logged in user. In that case, we'll treat fileOwner
 	// as the username whose files are to be accessed and use that in the
 	// namespace template.
-	u := ctxuser.ContextMustGetUser(ctx)
-	if !useLoggedInUserNS {
+	u, ok := ctxuser.ContextGetUser(ctx)
+	if !ok || !useLoggedInUserNS {
 		requestUserID, _ := router.ShiftPath(requestPath)
 		u = &userpb.User{
 			Username: requestUserID,

--- a/internal/http/services/owncloud/ocdav/ocdav.go
+++ b/internal/http/services/owncloud/ocdav/ocdav.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	gateway "github.com/cs3org/go-cs3apis/cs3/gateway/v1beta1"
+	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	"github.com/cs3org/reva/pkg/appctx"
 	"github.com/cs3org/reva/pkg/rgrpc/todo/pool"
@@ -102,7 +103,7 @@ func New(m map[string]interface{}, log *zerolog.Logger) (global.Service, error) 
 		),
 	}
 	// initialize handlers and set default configs
-	if err := s.webDavHandler.init(conf.WebdavNamespace); err != nil {
+	if err := s.webDavHandler.init(conf.WebdavNamespace, true); err != nil {
 		return nil, err
 	}
 	if err := s.davHandler.init(conf); err != nil {
@@ -186,8 +187,20 @@ func (s *svc) getClient() (gateway.GatewayAPIClient, error) {
 	return pool.GetGatewayServiceClient(s.c.GatewaySvc)
 }
 
-func applyLayout(ctx context.Context, ns string) string {
-	return templates.WithUser(ctxuser.ContextMustGetUser(ctx), ns)
+func applyLayout(ctx context.Context, ns string, useLoggedInUserNS bool, requestPath string) string {
+	// If useLoggedInUserNS is false, that implies that the request is coming from
+	// the FilesHandler method invoked by a /dav/files/fileOwner where fileOwner
+	// is not the same as the logged in user. In that case, we'll treat fileOwner
+	// as the username whose files are to be accessed and use that in the
+	// namespace template.
+	u := ctxuser.ContextMustGetUser(ctx)
+	if !useLoggedInUserNS {
+		requestUserID, _ := router.ShiftPath(requestPath)
+		u = &userpb.User{
+			Username: requestUserID,
+		}
+	}
+	return templates.WithUser(u, ns)
 }
 
 func wrapResourceID(r *provider.ResourceId) string {

--- a/internal/http/services/owncloud/ocdav/propfind.go
+++ b/internal/http/services/owncloud/ocdav/propfind.go
@@ -59,8 +59,6 @@ func (s *svc) handlePropfind(w http.ResponseWriter, r *http.Request, ns string) 
 	ctx, span := trace.StartSpan(ctx, "propfind")
 	defer span.End()
 
-	ns = applyLayout(ctx, ns)
-
 	fn := path.Join(ns, r.URL.Path)
 	depth := r.Header.Get("Depth")
 	if depth == "" {

--- a/internal/http/services/owncloud/ocdav/proppatch.go
+++ b/internal/http/services/owncloud/ocdav/proppatch.go
@@ -44,8 +44,6 @@ func (s *svc) handleProppatch(w http.ResponseWriter, r *http.Request, ns string)
 	acceptedProps := []xml.Name{}
 	removedProps := []xml.Name{}
 
-	ns = applyLayout(ctx, ns)
-
 	fn := path.Join(ns, r.URL.Path)
 
 	sublog := appctx.GetLogger(ctx).With().Str("path", fn).Logger()

--- a/internal/http/services/owncloud/ocdav/put.go
+++ b/internal/http/services/owncloud/ocdav/put.go
@@ -103,8 +103,6 @@ func isContentRange(r *http.Request) bool {
 
 func (s *svc) handlePut(w http.ResponseWriter, r *http.Request, ns string) {
 	ctx := r.Context()
-
-	ns = applyLayout(ctx, ns)
 	fn := path.Join(ns, r.URL.Path)
 
 	sublog := appctx.GetLogger(ctx).With().Str("path", fn).Logger()

--- a/internal/http/services/owncloud/ocdav/tus.go
+++ b/internal/http/services/owncloud/ocdav/tus.go
@@ -65,8 +65,6 @@ func (s *svc) handleTusPost(w http.ResponseWriter, r *http.Request, ns string) {
 		return
 	}
 
-	ns = applyLayout(ctx, ns)
-
 	// append filename to current dir
 	fn := path.Join(ns, r.URL.Path, meta["filename"])
 

--- a/internal/http/services/owncloud/ocdav/webdav.go
+++ b/internal/http/services/owncloud/ocdav/webdav.go
@@ -25,46 +25,49 @@ import (
 
 // WebDavHandler implements a dav endpoint
 type WebDavHandler struct {
-	namespace string
+	namespace         string
+	useLoggedInUserNS bool
 }
 
-func (h *WebDavHandler) init(ns string) error {
+func (h *WebDavHandler) init(ns string, useLoggedInUserNS bool) error {
 	h.namespace = path.Join("/", ns)
+	h.useLoggedInUserNS = useLoggedInUserNS
 	return nil
 }
 
 // Handler handles requests
 func (h *WebDavHandler) Handler(s *svc) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ns := applyLayout(r.Context(), h.namespace, h.useLoggedInUserNS, r.URL.Path)
 		switch r.Method {
 		case "PROPFIND":
-			s.handlePropfind(w, r, h.namespace)
+			s.handlePropfind(w, r, ns)
 		case "LOCK":
-			s.handleLock(w, r, h.namespace)
+			s.handleLock(w, r, ns)
 		case "UNLOCK":
-			s.handleUnlock(w, r, h.namespace)
+			s.handleUnlock(w, r, ns)
 		case "PROPPATCH":
-			s.handleProppatch(w, r, h.namespace)
+			s.handleProppatch(w, r, ns)
 		case "MKCOL":
-			s.handleMkcol(w, r, h.namespace)
+			s.handleMkcol(w, r, ns)
 		case "MOVE":
-			s.handleMove(w, r, h.namespace)
+			s.handleMove(w, r, ns)
 		case "COPY":
-			s.handleCopy(w, r, h.namespace)
+			s.handleCopy(w, r, ns)
 		case "REPORT":
-			s.handleReport(w, r, h.namespace)
+			s.handleReport(w, r, ns)
 		case http.MethodGet:
-			s.handleGet(w, r, h.namespace)
+			s.handleGet(w, r, ns)
 		case http.MethodPut:
-			s.handlePut(w, r, h.namespace)
+			s.handlePut(w, r, ns)
 		case http.MethodPost:
-			s.handleTusPost(w, r, h.namespace)
+			s.handleTusPost(w, r, ns)
 		case http.MethodOptions:
-			s.handleOptions(w, r, h.namespace)
+			s.handleOptions(w, r, ns)
 		case http.MethodHead:
-			s.handleHead(w, r, h.namespace)
+			s.handleHead(w, r, ns)
 		case http.MethodDelete:
-			s.handleDelete(w, r, h.namespace)
+			s.handleDelete(w, r, ns)
 		default:
 			w.WriteHeader(http.StatusNotFound)
 		}


### PR DESCRIPTION
For the incoming `/dav/files/userID` requests, we have different namespaces depending on whether the request is for the logged-in user's namespace or not. Since in the storage drivers, we specify the layout depending only on the user whose resources are to be accessed, this fails when a user wants to access another user's namespace when the storage provider depends on the logged in user's namespace.

For example, consider the following case. The owncloud fs uses a layout `{{substr 0 1 .Username}}/{{.Username}}` and it's mounted at `/users`. The user einstein sends a request to access a resource shared with him, say `/dav/files/marie/abcd`, which should be allowed. However, based on the way we applied the layout, this can only be translated to `/users/e/marie/abcd`.

Fixes #1215 