### PR TITLE
quota querying and tree accounting

### DIFF
--- a/changelog/unreleased/ocis-quota.md
+++ b/changelog/unreleased/ocis-quota.md
@@ -1,5 +1,5 @@
-Enhancement: quota handling and tree accounting
+Enhancement: quota querying and tree accounting
 
-The ocs api now returns the user quota for the users home storage. Forthermore, the ocis driver we now expose the quota and propagate tree size changes.
+The ocs api now returns the user quota for the users home storage. Furthermore, the ocis storage driver now reads the quota from the extended attributes of the user home or root node and implements tree size accounting. Finally, ocdav PROPFINDS now handle the `DAV:quota-used-bytes` and `DAV:quote-available-bytes` properties.
 
 https://github.com/cs3org/reva/pull/1405

--- a/changelog/unreleased/ocis-quota.md
+++ b/changelog/unreleased/ocis-quota.md
@@ -1,0 +1,5 @@
+Enhancement: quota handling and tree accounting
+
+The ocs api now returns the user quota for the users home storage. Forthermore, the ocis driver we now expose the quota and propagate tree size changes.
+
+https://github.com/cs3org/reva/pull/1405

--- a/internal/grpc/services/gateway/storageprovider.go
+++ b/internal/grpc/services/gateway/storageprovider.go
@@ -1763,7 +1763,6 @@ func (s *svc) PurgeRecycle(ctx context.Context, req *gateway.PurgeRecycleRequest
 }
 
 func (s *svc) GetQuota(ctx context.Context, req *gateway.GetQuotaRequest) (*provider.GetQuotaResponse, error) {
-	// lookup storage by treating the key as a path. It has been prefixed with the storage path in ListRecycle
 	c, err := s.find(ctx, req.Ref)
 	if err != nil {
 		return &provider.GetQuotaResponse{

--- a/internal/grpc/services/storageprovider/storageprovider.go
+++ b/internal/grpc/services/storageprovider/storageprovider.go
@@ -1062,8 +1062,8 @@ func (s *service) GetQuota(ctx context.Context, req *provider.GetQuotaRequest) (
 
 	res := &provider.GetQuotaResponse{
 		Status:     status.NewOK(ctx),
-		TotalBytes: uint64(total),
-		UsedBytes:  uint64(used),
+		TotalBytes: total,
+		UsedBytes:  used,
 	}
 	return res, nil
 }

--- a/internal/http/services/owncloud/ocdav/propfind.go
+++ b/internal/http/services/owncloud/ocdav/propfind.go
@@ -53,9 +53,9 @@ const (
 	// RFC1123 time that mimics oc10. time.RFC1123 would end in "UTC", see https://github.com/golang/go/issues/13781
 	RFC1123 = "Mon, 02 Jan 2006 15:04:05 GMT"
 
-	_propQuotaUncalculated = "-1"
-	_propQuotaUnknown      = "-2"
-	_propQuotaUnlimited    = "-3"
+	//_propQuotaUncalculated = "-1"
+	_propQuotaUnknown = "-2"
+	//_propQuotaUnlimited    = "-3"
 )
 
 // ns is the namespace that is prefixed to the path in the cs3 namespace

--- a/internal/http/services/owncloud/ocs/handlers/cloud/cloud.go
+++ b/internal/http/services/owncloud/ocs/handlers/cloud/cloud.go
@@ -37,12 +37,12 @@ type Handler struct {
 }
 
 // Init initializes this and any contained handlers
-func (h *Handler) Init(c *config.Config) {
+func (h *Handler) Init(c *config.Config) error {
 	h.UserHandler = new(user.Handler)
-	h.UsersHandler = new(users.Handler)
-	h.UsersHandler.Init(c)
 	h.CapabilitiesHandler = new(capabilities.Handler)
 	h.CapabilitiesHandler.Init(c)
+	h.UsersHandler = new(users.Handler)
+	return h.UsersHandler.Init(c)
 }
 
 // Handler routes the cloud endpoints

--- a/internal/http/services/owncloud/ocs/handlers/cloud/cloud.go
+++ b/internal/http/services/owncloud/ocs/handlers/cloud/cloud.go
@@ -40,6 +40,7 @@ type Handler struct {
 func (h *Handler) Init(c *config.Config) {
 	h.UserHandler = new(user.Handler)
 	h.UsersHandler = new(users.Handler)
+	h.UsersHandler.Init(c)
 	h.CapabilitiesHandler = new(capabilities.Handler)
 	h.CapabilitiesHandler.Init(c)
 }

--- a/internal/http/services/owncloud/ocs/handlers/cloud/users/users.go
+++ b/internal/http/services/owncloud/ocs/handlers/cloud/users/users.go
@@ -22,13 +22,28 @@ import (
 	"fmt"
 	"net/http"
 
+	gateway "github.com/cs3org/go-cs3apis/cs3/gateway/v1beta1"
+	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
+	rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
+	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+	"github.com/cs3org/reva/internal/http/services/owncloud/ocdav"
+	"github.com/cs3org/reva/internal/http/services/owncloud/ocs/config"
 	"github.com/cs3org/reva/internal/http/services/owncloud/ocs/response"
+	"github.com/cs3org/reva/pkg/appctx"
+	"github.com/cs3org/reva/pkg/rgrpc/todo/pool"
 	"github.com/cs3org/reva/pkg/rhttp/router"
 	ctxuser "github.com/cs3org/reva/pkg/user"
 )
 
-// The UsersHandler renders user data for the user id given in the url path
+// Handler renders user data for the user id given in the url path
 type Handler struct {
+	gatewayAddr string
+}
+
+// Init initializes this and any contained handlers
+func (h *Handler) Init(c *config.Config) error {
+	h.gatewayAddr = c.GatewaySvc
+	return nil
 }
 
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -53,19 +68,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	head, r.URL.Path = router.ShiftPath(r.URL.Path)
 	switch head {
 	case "":
-		response.WriteOCSSuccess(w, r, &Users{
-			// FIXME query storages? cache a summary?
-			// TODO use list of storages to allow clients to resolve quota status
-			Quota: &Quota{
-				Free:       2840756224000,
-				Used:       5059416668,
-				Total:      2845815640668,
-				Relative:   0.18,
-				Definition: "default",
-			},
-			DisplayName: u.DisplayName,
-			Email:       u.Mail,
-		})
+		h.handleUsers(w, r, u)
 		return
 	case "groups":
 		response.WriteOCSSuccess(w, r, &Groups{})
@@ -99,4 +102,58 @@ type Users struct {
 // Groups holds group data
 type Groups struct {
 	Groups []string `json:"groups" xml:"groups>element"`
+}
+
+func (h *Handler) handleUsers(w http.ResponseWriter, r *http.Request, u *userpb.User) {
+	ctx := r.Context()
+	sublog := appctx.GetLogger(r.Context())
+
+	gc, err := pool.GetGatewayServiceClient(h.gatewayAddr)
+	if err != nil {
+		sublog.Error().Err(err).Msg("error getting gateway client")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	getHomeRes, err := gc.GetHome(ctx, &provider.GetHomeRequest{})
+	if err != nil {
+		sublog.Error().Err(err).Msg("error calling GetHome")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	if getHomeRes.Status.Code != rpc.Code_CODE_OK {
+		ocdav.HandleErrorStatus(sublog, w, getHomeRes.Status)
+		return
+	}
+
+	getQuotaRes, err := gc.GetQuota(ctx, &gateway.GetQuotaRequest{
+		Ref: &provider.Reference{
+			Spec: &provider.Reference_Path{
+				Path: getHomeRes.Path,
+			},
+		},
+	})
+	if err != nil {
+		sublog.Error().Err(err).Msg("error calling GetQuota")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	if getQuotaRes.Status.Code != rpc.Code_CODE_OK {
+		ocdav.HandleErrorStatus(sublog, w, getQuotaRes.Status)
+		return
+	}
+
+	response.WriteOCSSuccess(w, r, &Users{
+		// ocs can only return the home storage quota
+		Quota: &Quota{
+			Free:       int64(getQuotaRes.TotalBytes - getQuotaRes.UsedBytes),
+			Used:       int64(getQuotaRes.UsedBytes),
+			Total:      int64(getQuotaRes.TotalBytes), // -1, -2 have special meaning?
+			Relative:   float32(float64(getQuotaRes.UsedBytes) / float64(getQuotaRes.TotalBytes)),
+			Definition: "default",
+		},
+		DisplayName: u.DisplayName,
+		Email:       u.Mail,
+	})
 }

--- a/internal/http/services/owncloud/ocs/handlers/cloud/users/users.go
+++ b/internal/http/services/owncloud/ocs/handlers/cloud/users/users.go
@@ -59,7 +59,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if user != u.Username {
-		// FIXME allow fetching other users info?
+		// FIXME allow fetching other users info? only for admins
 		response.WriteOCSError(w, r, http.StatusForbidden, "user id mismatch", fmt.Errorf("%s tried to access %s user info endpoint", u.Id.OpaqueId, user))
 		return
 	}
@@ -147,9 +147,11 @@ func (h *Handler) handleUsers(w http.ResponseWriter, r *http.Request, u *userpb.
 	response.WriteOCSSuccess(w, r, &Users{
 		// ocs can only return the home storage quota
 		Quota: &Quota{
-			Free:       int64(getQuotaRes.TotalBytes - getQuotaRes.UsedBytes),
-			Used:       int64(getQuotaRes.UsedBytes),
-			Total:      int64(getQuotaRes.TotalBytes), // -1, -2 have special meaning?
+			Free: int64(getQuotaRes.TotalBytes - getQuotaRes.UsedBytes),
+			Used: int64(getQuotaRes.UsedBytes),
+			// TODO support negative values or flags for the quota to carry special meaning: -1 = uncalculated, -2 = unknown, -3 = unlimited
+			// for now we can only report total and used
+			Total:      int64(getQuotaRes.TotalBytes),
 			Relative:   float32(float64(getQuotaRes.UsedBytes) / float64(getQuotaRes.TotalBytes)),
 			Definition: "default",
 		},

--- a/internal/http/services/owncloud/ocs/v1.go
+++ b/internal/http/services/owncloud/ocs/v1.go
@@ -37,15 +37,14 @@ type V1Handler struct {
 }
 
 func (h *V1Handler) init(c *config.Config) error {
+	h.ConfigHandler = new(configHandler.Handler)
+	h.ConfigHandler.Init(c)
 	h.AppsHandler = new(apps.Handler)
 	if err := h.AppsHandler.Init(c); err != nil {
 		return err
 	}
 	h.CloudHandler = new(cloud.Handler)
-	h.CloudHandler.Init(c)
-	h.ConfigHandler = new(configHandler.Handler)
-	h.ConfigHandler.Init(c)
-	return nil
+	return h.CloudHandler.Init(c)
 }
 
 // Handler handles requests

--- a/pkg/eosclient/eosbinary/eosbinary.go
+++ b/pkg/eosclient/eosbinary/eosbinary.go
@@ -794,19 +794,19 @@ func (c *Client) parseQuota(path, raw string) (*eosclient.QuotaInfo, error) {
 		if strings.HasPrefix(path, space) {
 			maxBytesString := m["maxlogicalbytes"]
 			usedBytesString := m["usedlogicalbytes"]
-			maxBytes, _ := strconv.ParseInt(maxBytesString, 10, 64)
-			usedBytes, _ := strconv.ParseInt(usedBytesString, 10, 64)
+			maxBytes, _ := strconv.ParseUint(maxBytesString, 10, 64)
+			usedBytes, _ := strconv.ParseUint(usedBytesString, 10, 64)
 
 			maxInodesString := m["maxfiles"]
 			usedInodesString := m["usedfiles"]
-			maxInodes, _ := strconv.ParseInt(maxInodesString, 10, 64)
-			usedInodes, _ := strconv.ParseInt(usedInodesString, 10, 64)
+			maxInodes, _ := strconv.ParseUint(maxInodesString, 10, 64)
+			usedInodes, _ := strconv.ParseUint(usedInodesString, 10, 64)
 
 			qi := &eosclient.QuotaInfo{
-				AvailableBytes:  int(maxBytes),
-				UsedBytes:       int(usedBytes),
-				AvailableInodes: int(maxInodes),
-				UsedInodes:      int(usedInodes),
+				AvailableBytes:  maxBytes,
+				UsedBytes:       usedBytes,
+				AvailableInodes: maxInodes,
+				UsedInodes:      usedInodes,
 			}
 			return qi, nil
 		}

--- a/pkg/eosclient/eosclient.go
+++ b/pkg/eosclient/eosclient.go
@@ -96,9 +96,10 @@ type DeletedEntry struct {
 }
 
 // QuotaInfo reports the available bytes and inodes for a particular user.
+// eos reports all quota values are unsigned long, see https://github.com/cern-eos/eos/blob/93515df8c0d5a858982853d960bec98f983c1285/mgm/Quota.hh#L135
 type QuotaInfo struct {
-	AvailableBytes, UsedBytes   int
-	AvailableInodes, UsedInodes int
+	AvailableBytes, UsedBytes   uint64
+	AvailableInodes, UsedInodes uint64
 }
 
 // SetQuotaInfo encapsulates the information needed to

--- a/pkg/storage/fs/ocis/node.go
+++ b/pkg/storage/fs/ocis/node.go
@@ -27,6 +27,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -50,6 +51,12 @@ const (
 
 	_favoriteKey  = "http://owncloud.org/ns/favorite"
 	_checksumsKey = "http://owncloud.org/ns/checksums"
+	_treesizeKey  = "treesize"
+	_quotaKey     = "quota"
+
+	_quotaUncalculated = "-1"
+	_quotaUnknown      = "-2"
+	_quotaUnlimited    = "-3"
 )
 
 // Node represents a node in the tree and provides methods to get a Parent or Child instance
@@ -547,6 +554,31 @@ func (n *Node) AsResourceInfo(ctx context.Context, rp *provider.ResourcePermissi
 		readChecksumIntoOpaque(ctx, nodePath, storageprovider.XSAdler32, ri)
 	}
 
+	// treesize
+	if _, ok := mdKeysMap[_treesizeKey]; (nodeType == provider.ResourceType_RESOURCE_TYPE_CONTAINER) && returnAllKeys || ok {
+		readTreesizeIntoOpaque(ctx, nodePath, ri)
+	}
+
+	// quota
+	if _, ok := mdKeysMap[_quotaKey]; (nodeType == provider.ResourceType_RESOURCE_TYPE_CONTAINER) && returnAllKeys || ok {
+		var quotaPath string
+		if n.lu.Options.EnableHome {
+			if r, err := n.lu.HomeNode(ctx); err == nil {
+				quotaPath = n.lu.toInternalPath(r.ID)
+				readQuotaIntoOpaque(ctx, quotaPath, ri)
+			} else {
+				sublog.Error().Err(err).Msg("error determining home node for quota")
+			}
+		} else {
+			if r, err := n.lu.RootNode(ctx); err == nil {
+				quotaPath = n.lu.toInternalPath(r.ID)
+				readQuotaIntoOpaque(ctx, quotaPath, ri)
+			} else {
+				sublog.Error().Err(err).Msg("error determining root node for quota")
+			}
+		}
+	}
+
 	// only read the requested metadata attributes
 	attrs, err := xattr.List(nodePath)
 	if err != nil {
@@ -619,6 +651,112 @@ func readChecksumIntoOpaque(ctx context.Context, nodePath, algo string, ri *prov
 		appctx.GetLogger(ctx).Error().Err(err).Str("nodepath", nodePath).Str("algorithm", algo).Msg("could not read checksum")
 	}
 }
+func readTreesizeIntoOpaque(ctx context.Context, nodePath string, ri *provider.ResourceInfo) {
+	v, err := xattr.Get(nodePath, treesizeAttr)
+	switch {
+	case err == nil:
+		// make sure we have a proper unsigned int
+		if treesize, err := strconv.ParseUint(string(v), 10, 64); err == nil {
+			if ri.Opaque == nil {
+				ri.Opaque = &types.Opaque{
+					Map: map[string]*types.OpaqueEntry{},
+				}
+			}
+			ri.Opaque.Map[_treesizeKey] = &types.OpaqueEntry{
+				Decoder: "plain",
+				Value:   v,
+			}
+			// when it exists it also overrules the size
+			ri.Size = treesize
+		} else {
+			appctx.GetLogger(ctx).Error().Err(err).Str("nodepath", nodePath).Str("treesize", string(v)).Msg("malformed treesize")
+		}
+	case isNoData(err):
+		appctx.GetLogger(ctx).Debug().Err(err).Str("nodepath", nodePath).Msg("treesize not set")
+	case isNotFound(err):
+		appctx.GetLogger(ctx).Error().Err(err).Str("nodepath", nodePath).Msg("file not found when reading treesize")
+	default:
+		appctx.GetLogger(ctx).Error().Err(err).Str("nodepath", nodePath).Msg("could not read treesize")
+	}
+}
+
+// quota is always stored on the root node
+func readQuotaIntoOpaque(ctx context.Context, nodePath string, ri *provider.ResourceInfo) {
+	v, err := xattr.Get(nodePath, quotaAttr)
+	switch {
+	case err == nil:
+		// make sure we have a proper signed int
+		// we use the same magic numbers to indicate:
+		// -1 = uncalculated
+		// -2 = unknown
+		// -3 = unlimited
+		if _, err := strconv.ParseInt(string(v), 10, 64); err == nil {
+			if ri.Opaque == nil {
+				ri.Opaque = &types.Opaque{
+					Map: map[string]*types.OpaqueEntry{},
+				}
+			}
+			ri.Opaque.Map[_quotaKey] = &types.OpaqueEntry{
+				Decoder: "plain",
+				Value:   v,
+			}
+		} else {
+			appctx.GetLogger(ctx).Error().Err(err).Str("nodepath", nodePath).Str("treesize", string(v)).Msg("malformed quota")
+		}
+	case isNoData(err):
+		appctx.GetLogger(ctx).Debug().Err(err).Str("nodepath", nodePath).Msg("quota not set")
+	case isNotFound(err):
+		appctx.GetLogger(ctx).Error().Err(err).Str("nodepath", nodePath).Msg("file not found when reading quota")
+	default:
+		appctx.GetLogger(ctx).Error().Err(err).Str("nodepath", nodePath).Msg("could not read quota")
+	}
+}
+
+func (n *Node) CalculateTreeSize(ctx context.Context) (uint64, error) {
+	var size uint64
+	// TODO check if this is a dir?
+	nodePath := n.lu.toInternalPath(n.ID)
+
+	f, err := os.Open(nodePath)
+	if err != nil {
+		appctx.GetLogger(ctx).Error().Err(err).Str("nodepath", nodePath).Msg("could not open dir")
+		return 0, err
+	}
+	defer f.Close()
+
+	names, err := f.Readdirnames(0)
+	if err != nil {
+		appctx.GetLogger(ctx).Error().Err(err).Str("nodepath", nodePath).Msg("could not read dirnames")
+		return 0, err
+	}
+	for i := range names {
+		cPath := filepath.Join(nodePath, names[i])
+		info, err := os.Stat(cPath)
+		if err != nil {
+			appctx.GetLogger(ctx).Error().Err(err).Str("childpath", cPath).Msg("could not stat child entry")
+			continue // continue after an error
+		}
+		if !info.IsDir() {
+			size += uint64(info.Size())
+		} else {
+			// read from attr
+			var b []byte
+			// xattr.Get will follow the symlink
+			if b, err = xattr.Get(cPath, treesizeAttr); err != nil {
+				// TODO recursively descend and recalculate treesize
+				continue // continue after an error
+			}
+			csize, err := strconv.ParseUint(string(b), 10, 64)
+			if err != nil {
+				// TODO recursively descend and recalculate treesize
+				continue // continue after an error
+			}
+			size += csize
+		}
+	}
+	return size, err
+
+}
 
 // HasPropagation checks if the propagation attribute exists and is set to "1"
 func (n *Node) HasPropagation() (propagation bool) {
@@ -640,6 +778,20 @@ func (n *Node) GetTMTime() (tmTime time.Time, err error) {
 // SetTMTime writes the tmtime to the extended attributes
 func (n *Node) SetTMTime(t time.Time) (err error) {
 	return xattr.Set(n.lu.toInternalPath(n.ID), treeMTimeAttr, []byte(t.UTC().Format(time.RFC3339Nano)))
+}
+
+// GetTreeSize reads the treesize from the extended attributes
+func (n *Node) GetTreeSize() (treesize uint64, err error) {
+	var b []byte
+	if b, err = xattr.Get(n.lu.toInternalPath(n.ID), treesizeAttr); err != nil {
+		return
+	}
+	return strconv.ParseUint(string(b), 10, 64)
+}
+
+// SetTreeSize writes the treesize to the extended attributes
+func (n *Node) SetTreeSize(ts uint64) (err error) {
+	return xattr.Set(n.lu.toInternalPath(n.ID), treesizeAttr, []byte(strconv.FormatUint(ts, 10)))
 }
 
 // SetChecksum writes the checksum with the given checksum type to the extended attributes

--- a/pkg/storage/fs/ocis/ocis.go
+++ b/pkg/storage/fs/ocis/ocis.go
@@ -225,11 +225,12 @@ func (fs *ocisfs) GetQuota(ctx context.Context) (uint64, uint64, error) {
 		return 0, 0, err
 	}
 
-	total := stat.Blocks * uint64(stat.Bsize) // Total data blocks in filesystem
+	total := +ri.Size + (stat.Bavail * uint64(stat.Bsize)) // used treesize + available space
+
 	switch {
 	case quotaStr == _quotaUncalculated, quotaStr == _quotaUnknown, quotaStr == _quotaUnlimited:
 	// best we can do is return current total
-	// TODO indicate unlimited total?
+	// TODO indicate unlimited total? -> in opaque data?
 	default:
 		if quota, err := strconv.ParseUint(quotaStr, 10, 64); err == nil {
 			if total > quota {

--- a/pkg/storage/fs/ocis/ocis.go
+++ b/pkg/storage/fs/ocis/ocis.go
@@ -225,7 +225,7 @@ func (fs *ocisfs) GetQuota(ctx context.Context) (uint64, uint64, error) {
 		return 0, 0, err
 	}
 
-	total := +ri.Size + (stat.Bavail * uint64(stat.Bsize)) // used treesize + available space
+	total := ri.Size + (stat.Bavail * uint64(stat.Bsize)) // used treesize + available space
 
 	switch {
 	case quotaStr == _quotaUncalculated, quotaStr == _quotaUnknown, quotaStr == _quotaUnlimited:

--- a/pkg/storage/fs/ocis/tree.go
+++ b/pkg/storage/fs/ocis/tree.go
@@ -31,7 +31,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	"github.com/pkg/xattr"
-	"github.com/rs/zerolog/log"
 )
 
 // Tree manages a hierarchical tree
@@ -301,12 +300,12 @@ func (t *Tree) Delete(ctx context.Context, n *Node) (err error) {
 
 // Propagate propagates changes to the root of the tree
 func (t *Tree) Propagate(ctx context.Context, n *Node) (err error) {
+	sublog := appctx.GetLogger(ctx).With().Interface("node", n).Logger()
 	if !t.lu.Options.TreeTimeAccounting && !t.lu.Options.TreeSizeAccounting {
 		// no propagation enabled
-		log.Debug().Msg("propagation disabled")
+		sublog.Debug().Msg("propagation disabled")
 		return
 	}
-	log := appctx.GetLogger(ctx)
 
 	// is propagation enabled for the parent node?
 
@@ -320,16 +319,18 @@ func (t *Tree) Propagate(ctx context.Context, n *Node) (err error) {
 
 	// we loop until we reach the root
 	for err == nil && n.ID != root.ID {
-		log.Debug().Interface("node", n).Msg("propagating")
+		sublog.Debug().Msg("propagating")
 
 		// make n the parent or break the loop
 		if n, err = n.Parent(); err != nil {
 			break
 		}
 
+		sublog = sublog.With().Interface("node", n).Logger()
+
 		// TODO none, sync and async?
 		if !n.HasPropagation() {
-			log.Debug().Interface("node", n).Str("attr", propagationAttr).Msg("propagation attribute not set or unreadable, not propagating")
+			sublog.Debug().Str("attr", propagationAttr).Msg("propagation attribute not set or unreadable, not propagating")
 			// if the attribute is not set treat it as false / none / no propagation
 			return nil
 		}
@@ -343,20 +344,16 @@ func (t *Tree) Propagate(ctx context.Context, n *Node) (err error) {
 			switch {
 			case err != nil:
 				// missing attribute, or invalid format, overwrite
-				log.Debug().Err(err).
-					Interface("node", n).
-					Msg("could not read tmtime attribute, overwriting")
+				sublog.Debug().Err(err).Msg("could not read tmtime attribute, overwriting")
 				updateSyncTime = true
 			case tmTime.Before(sTime):
-				log.Debug().
-					Interface("node", n).
+				sublog.Debug().
 					Time("tmtime", tmTime).
 					Time("stime", sTime).
 					Msg("parent tmtime is older than node mtime, updating")
 				updateSyncTime = true
 			default:
-				log.Debug().
-					Interface("node", n).
+				sublog.Debug().
 					Time("tmtime", tmTime).
 					Time("stime", sTime).
 					Dur("delta", sTime.Sub(tmTime)).
@@ -366,14 +363,14 @@ func (t *Tree) Propagate(ctx context.Context, n *Node) (err error) {
 			if updateSyncTime {
 				// update the tree time of the parent node
 				if err = n.SetTMTime(sTime); err != nil {
-					log.Error().Err(err).Interface("node", n).Time("tmtime", sTime).Msg("could not update tmtime of parent node")
-					return
+					sublog.Error().Err(err).Time("tmtime", sTime).Msg("could not update tmtime of parent node")
+				} else {
+					sublog.Debug().Time("tmtime", sTime).Msg("updated tmtime of parent node")
 				}
-				log.Debug().Interface("node", n).Time("tmtime", sTime).Msg("updated tmtime of parent node")
 			}
 
 			if err := n.UnsetTempEtag(); err != nil {
-				log.Error().Err(err).Interface("node", n).Msg("could not remove temporary etag attribute")
+				sublog.Error().Err(err).Msg("could not remove temporary etag attribute")
 			}
 
 		}
@@ -386,27 +383,23 @@ func (t *Tree) Propagate(ctx context.Context, n *Node) (err error) {
 			var treeSize, calculatedTreeSize uint64
 			calculatedTreeSize, err = n.CalculateTreeSize(ctx)
 			if err != nil {
-				return
+				continue
 			}
 
 			treeSize, err = n.GetTreeSize()
 			switch {
 			case err != nil:
 				// missing attribute, or invalid format, overwrite
-				log.Debug().Err(err).
-					Interface("node", n).
-					Msg("could not read treesize attribute, overwriting")
+				sublog.Debug().Err(err).Msg("could not read treesize attribute, overwriting")
 				updateTreeSize = true
 			case treeSize != calculatedTreeSize:
-				log.Debug().
-					Interface("node", n).
+				sublog.Debug().
 					Uint64("treesize", treeSize).
 					Uint64("calculatedTreeSize", calculatedTreeSize).
 					Msg("parent treesize is different then calculated treesize, updating")
 				updateTreeSize = true
 			default:
-				log.Debug().
-					Interface("node", n).
+				sublog.Debug().
 					Uint64("treesize", treeSize).
 					Uint64("calculatedTreeSize", calculatedTreeSize).
 					Msg("parent size matches calculated size, not updating")
@@ -415,17 +408,15 @@ func (t *Tree) Propagate(ctx context.Context, n *Node) (err error) {
 			if updateTreeSize {
 				// update the tree time of the parent node
 				if err = n.SetTreeSize(calculatedTreeSize); err != nil {
-					log.Error().Err(err).Interface("node", n).Uint64("calculatedTreeSize", calculatedTreeSize).Msg("could not update treesize of parent node")
-					return
+					sublog.Error().Err(err).Uint64("calculatedTreeSize", calculatedTreeSize).Msg("could not update treesize of parent node")
+				} else {
+					sublog.Debug().Uint64("calculatedTreeSize", calculatedTreeSize).Msg("updated treesize of parent node")
 				}
-				log.Debug().Interface("node", n).Uint64("calculatedTreeSize", calculatedTreeSize).Msg("updated treesize of parent node")
 			}
 		}
-
 	}
 	if err != nil {
-		log.Error().Err(err).Interface("node", n).Msg("error propagating")
-		return
+		sublog.Error().Err(err).Msg("error propagating")
 	}
 	return
 }

--- a/pkg/storage/fs/owncloud/owncloud.go
+++ b/pkg/storage/fs/owncloud/owncloud.go
@@ -1102,7 +1102,7 @@ func (fs *ocfs) UpdateGrant(ctx context.Context, ref *provider.Reference, g *pro
 	return fs.propagate(ctx, ip)
 }
 
-func (fs *ocfs) GetQuota(ctx context.Context) (int, int, error) {
+func (fs *ocfs) GetQuota(ctx context.Context) (uint64, uint64, error) {
 	return 0, 0, nil
 }
 

--- a/pkg/storage/fs/s3/s3.go
+++ b/pkg/storage/fs/s3/s3.go
@@ -262,7 +262,7 @@ func (fs *s3FS) UpdateGrant(ctx context.Context, ref *provider.Reference, g *pro
 	return errtypes.NotSupported("s3: operation not supported")
 }
 
-func (fs *s3FS) GetQuota(ctx context.Context) (int, int, error) {
+func (fs *s3FS) GetQuota(ctx context.Context) (uint64, uint64, error) {
 	return 0, 0, nil
 }
 

--- a/pkg/storage/fs/s3ng/s3ng.go
+++ b/pkg/storage/fs/s3ng/s3ng.go
@@ -139,7 +139,7 @@ func (fs *s3ngfs) Shutdown(ctx context.Context) error {
 	return nil
 }
 
-func (fs *s3ngfs) GetQuota(ctx context.Context) (int, int, error) {
+func (fs *s3ngfs) GetQuota(ctx context.Context) (uint64, uint64, error) {
 	return 0, 0, nil
 }
 

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -51,7 +51,7 @@ type FS interface {
 	RemoveGrant(ctx context.Context, ref *provider.Reference, g *provider.Grant) error
 	UpdateGrant(ctx context.Context, ref *provider.Reference, g *provider.Grant) error
 	ListGrants(ctx context.Context, ref *provider.Reference) ([]*provider.Grant, error)
-	GetQuota(ctx context.Context) (int, int, error)
+	GetQuota(ctx context.Context) (uint64, uint64, error)
 	CreateReference(ctx context.Context, path string, targetURI *url.URL) error
 	Shutdown(ctx context.Context) error
 	SetArbitraryMetadata(ctx context.Context, ref *provider.Reference, md *provider.ArbitraryMetadata) error

--- a/pkg/storage/utils/eosfs/eosfs.go
+++ b/pkg/storage/utils/eosfs/eosfs.go
@@ -756,7 +756,7 @@ func (fs *eosfs) listShareFolderRoot(ctx context.Context, p string) (finfos []*p
 	return finfos, nil
 }
 
-func (fs *eosfs) GetQuota(ctx context.Context) (int, int, error) {
+func (fs *eosfs) GetQuota(ctx context.Context) (uint64, uint64, error) {
 	u, err := getUser(ctx)
 	if err != nil {
 		return 0, 0, errors.Wrap(err, "eos: no user in ctx")

--- a/pkg/storage/utils/localfs/localfs.go
+++ b/pkg/storage/utils/localfs/localfs.go
@@ -527,8 +527,8 @@ func (fs *localfs) GetQuota(ctx context.Context) (uint64, uint64, error) {
 	if err != nil {
 		return 0, 0, err
 	}
-	total := stat.Blocks * uint64(stat.Bsize) // Total data blocks in filesystem
-	used := stat.Bavail * uint64(stat.Bsize)  // Free blocks available to	unprivileged user
+	total := stat.Blocks * uint64(stat.Bsize)                // Total data blocks in filesystem
+	used := (stat.Blocks - stat.Bavail) * uint64(stat.Bsize) // Free blocks available to unprivileged user
 	return total, used, nil
 }
 

--- a/tests/acceptance/expected-failures-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-on-OCIS-storage.md
@@ -1,7 +1,7 @@
 ## Scenarios from ownCloud10 core API tests that are expected to fail with OCIS storage
 
 ### File
-Basic file management like up and download, move, copy, properties, trash, versions and chunking.
+Basic file management like up and download, move, copy, properties, quota, trash, versions and chunking.
 
 #### [Implement Trashbin Feature for ocis storage](https://github.com/owncloud/product/issues/209)
 
@@ -326,9 +326,6 @@ Scenario Outline: try to create a folder with a name of an existing file
 ### [Different webdav properties from core](https://github.com/owncloud/ocis/issues/1302)
 -   [apiWebdavProperties2/getFileProperties.feature:327](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties2/getFileProperties.feature#L327)
 -   [apiWebdavProperties2/getFileProperties.feature:328](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties2/getFileProperties.feature#L328)
-Scenario Outline: Propfind the size of a folder using webdav api `Property "oc:size" found with value "10", expected "#^0$#" or "#^0$#"`  
--   [apiWebdavProperties2/getFileProperties.feature:376](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties2/getFileProperties.feature#L376)
--   [apiWebdavProperties2/getFileProperties.feature:377](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties2/getFileProperties.feature#L377)
 Scenario Outline: Propfind the permissions on a file using webdav api `Property "oc:permissions" found with value "DNVWR", expected "/RM{0,1}DNVW/"`
 -   [apiWebdavProperties2/getFileProperties.feature:441](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties2/getFileProperties.feature#L441)
 -   [apiWebdavProperties2/getFileProperties.feature:442](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties2/getFileProperties.feature#L442)
@@ -1186,6 +1183,7 @@ File and sync features in a shared scenario
 -   [apiSharePublicLink2/uploadToPublicLinkShare.feature:66](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L66)
 
 #### [Set quota over settings](https://github.com/owncloud/ocis/issues/1290)
+_requires a [CS3 user provisioning api that can update the quota for a user](https://github.com/cs3org/cs3apis/pull/95#issuecomment-772780683)_
 -   [apiSharePublicLink2/uploadToPublicLinkShare.feature:148](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L148)
 -   [apiSharePublicLink2/uploadToPublicLinkShare.feature:158](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L158)
 -   [apiSharePublicLink2/uploadToPublicLinkShare.feature:167](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L167)
@@ -1393,6 +1391,7 @@ Scenario Outline: delete a folder when there is a default folder for received sh
 -   [apiWebdavProperties1/copyFile.feature:475](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/copyFile.feature#L475)
 
 #### [quota query](https://github.com/owncloud/ocis/issues/1313)
+_requires a [CS3 user provisioning api that can update the quota for a user](https://github.com/cs3org/cs3apis/pull/95#issuecomment-772780683)_
 -   [apiMain/quota.feature:41](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiMain/quota.feature#L41) Scenario: Uploading a file in received folder having enough quota
 -   [apiMain/quota.feature:54](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiMain/quota.feature#L54) Scenario: Uploading a file in received folder having insufficient quota
 -   [apiMain/quota.feature:68](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiMain/quota.feature#L68) Scenario: Overwriting a file in received folder having enough quota
@@ -1425,6 +1424,7 @@ Scenario Outline: Retrieving folder quota when quota is set and a file was recei
 -   [apiWebdavProperties2/getFileProperties.feature:233](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties2/getFileProperties.feature#L233)
 
 #### [changing user quota gives ocs status 103 / Cannot set quota](https://github.com/owncloud/product/issues/247)
+_requires a [CS3 user provisioning api that can update the quota for a user](https://github.com/cs3org/cs3apis/pull/95#issuecomment-772780683)_
 -   [apiShareOperationsToShares/uploadToShare.feature:162](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareOperationsToShares/uploadToShare.feature#L162)
 -   [apiShareOperationsToShares/uploadToShare.feature:163](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareOperationsToShares/uploadToShare.feature#L163)
 -   [apiShareOperationsToShares/uploadToShare.feature:181](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareOperationsToShares/uploadToShare.feature#L181)
@@ -1837,7 +1837,7 @@ User and group management features
 -   [apiProvisioning-v2/editUser.feature:47](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiProvisioning-v2/editUser.feature#L47)
 
 #### [quota query](https://github.com/owncloud/ocis/issues/1313)
-_getting and setting quota_
+_requires a [CS3 user provisioning api that can update the quota for a user](https://github.com/cs3org/cs3apis/pull/95#issuecomment-772780683)_
 -   [apiMain/quota.feature:9](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiMain/quota.feature#L9) Scenario: Uploading a file as owner having enough quota
 -   [apiMain/quota.feature:16](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiMain/quota.feature#L16) Scenario: Uploading a file as owner having insufficient quota
 -   [apiMain/quota.feature:23](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiMain/quota.feature#L23) Scenario: Overwriting a file as owner having enough quota
@@ -1850,6 +1850,7 @@ Scenario Outline: Retrieving folder quota when quota is set
 -   [apiWebdavProperties1/getQuota.feature:28](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/getQuota.feature#L28)
 
 #### [changing user quota gives ocs status 103 / Cannot set quota](https://github.com/owncloud/product/issues/247)
+_requires a [CS3 user provisioning api that can update the quota for a user](https://github.com/cs3org/cs3apis/pull/95#issuecomment-772780683)_
 -   [apiProvisioning-v1/editUser.feature:56](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiProvisioning-v1/editUser.feature#L56)
 -   [apiProvisioning-v1/editUser.feature:122](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiProvisioning-v1/editUser.feature#L122)
 -   [apiProvisioning-v2/editUser.feature:56](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiProvisioning-v2/editUser.feature#L56)

--- a/tests/acceptance/expected-failures-on-OWNCLOUD-storage.md
+++ b/tests/acceptance/expected-failures-on-OWNCLOUD-storage.md
@@ -1,7 +1,7 @@
 ## Scenarios from ownCloud10 core API tests that are expected to fail with owncloud storage
 
 ### File
-Basic file management like up and download, move, copy, properties, trash, versions and chunking.
+Basic file management like up and download, move, copy, properties, quota, trash, versions and chunking.
 
 #### [Implement Trashbin Feature for ocis storage](https://github.com/owncloud/product/issues/209)
 -   [apiWebdavEtagPropagation2/restoreFromTrash.feature:48](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavEtagPropagation2/restoreFromTrash.feature#L48)
@@ -1204,6 +1204,7 @@ The following scenarios fail on OWNCLOUD storage but not on OCIS storage:
 -   [apiSharePublicLink2/uploadToPublicLinkShare.feature:66](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L66)
 
 #### [Set quota over settings](https://github.com/owncloud/ocis/issues/1290)
+_requires a [CS3 user provisioning api that can update the quota for a user](https://github.com/cs3org/cs3apis/pull/95#issuecomment-772780683)_
 -   [apiSharePublicLink2/uploadToPublicLinkShare.feature:148](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L148)
 -   [apiSharePublicLink2/uploadToPublicLinkShare.feature:158](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L158)
 -   [apiSharePublicLink2/uploadToPublicLinkShare.feature:167](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L167)
@@ -1505,6 +1506,7 @@ Scenario Outline: delete a folder when there is a default folder for received sh
 -   [apiWebdavProperties1/copyFile.feature:475](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/copyFile.feature#L475)
 
 #### [quota query](https://github.com/owncloud/ocis/issues/1313)
+_requires a [CS3 user provisioning api that can update the quota for a user](https://github.com/cs3org/cs3apis/pull/95#issuecomment-772780683)_
 -   [apiMain/quota.feature:41](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiMain/quota.feature#L41) Scenario: Uploading a file in received folder having enough quota
 -   [apiMain/quota.feature:54](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiMain/quota.feature#L54) Scenario: Uploading a file in received folder having insufficient quota
 -   [apiMain/quota.feature:68](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiMain/quota.feature#L68) Scenario: Overwriting a file in received folder having enough quota
@@ -1542,6 +1544,7 @@ The following scenarios fail on OWNCLOUD storage but not on OCIS storage:
 -   [apiWebdavProperties2/getFileProperties.feature:233](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties2/getFileProperties.feature#L233)
 
 #### [changing user quota gives ocs status 103 / Cannot set quota](https://github.com/owncloud/product/issues/247)
+_requires a [CS3 user provisioning api that can update the quota for a user](https://github.com/cs3org/cs3apis/pull/95#issuecomment-772780683)_
 -   [apiShareOperationsToShares/uploadToShare.feature:162](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareOperationsToShares/uploadToShare.feature#L162)
 -   [apiShareOperationsToShares/uploadToShare.feature:163](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareOperationsToShares/uploadToShare.feature#L163)
 -   [apiShareOperationsToShares/uploadToShare.feature:181](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareOperationsToShares/uploadToShare.feature#L181)
@@ -1963,7 +1966,7 @@ special character username not valid
 -   [apiProvisioning-v2/editUser.feature:47](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiProvisioning-v2/editUser.feature#L47)
 
 #### [quota query](https://github.com/owncloud/ocis/issues/1313)
-_getting and setting quota_
+_requires a [CS3 user provisioning api that can update the quota for a user](https://github.com/cs3org/cs3apis/pull/95#issuecomment-772780683)_
 -   [apiMain/quota.feature:9](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiMain/quota.feature#L9) Scenario: Uploading a file as owner having enough quota
 -   [apiMain/quota.feature:16](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiMain/quota.feature#L16) Scenario: Uploading a file as owner having insufficient quota
 -   [apiMain/quota.feature:23](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiMain/quota.feature#L23) Scenario: Overwriting a file as owner having enough quota
@@ -1976,6 +1979,7 @@ _getting and setting quota_
 -   [apiWebdavProperties1/getQuota.feature:28](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/getQuota.feature#L28)
 
 #### [changing user quota gives ocs status 103 / Cannot set quota](https://github.com/owncloud/product/issues/247)
+_requires a [CS3 user provisioning api that can update the quota for a user](https://github.com/cs3org/cs3apis/pull/95#issuecomment-772780683)_
 -   [apiProvisioning-v1/editUser.feature:56](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiProvisioning-v1/editUser.feature#L56)
 -   [apiProvisioning-v1/editUser.feature:122](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiProvisioning-v1/editUser.feature#L122)
 -   [apiProvisioning-v2/editUser.feature:56](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiProvisioning-v2/editUser.feature#L56)


### PR DESCRIPTION
The ocs api now returns the user quota for the users home storage. Furthermore, the ocis storage driver now reads the quota from the extended attributes of the user home or root node and implements tree size accounting. Finally, ocdav PROPFINDS now handle the `DAV:quota-used-bytes` and `DAV:quote-available-bytes` properties.

- [ ] ~~check uploads against the quota~~ in a different PR, we need https://github.com/cs3org/cs3apis/pull/95 before continuing with anything quota related.

relvated: https://github.com/owncloud/ocis/issues/1313