### PR TITLE
Add the .git dir back into the revad image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,4 @@
 .github
-.git
 changelog
 docs
 examples

--- a/changelog/unreleased/fix-version-string.md
+++ b/changelog/unreleased/fix-version-string.md
@@ -1,0 +1,4 @@
+Bugfix: re-include the '.git' dir in the Docker images to pass the version tag
+and git SHA to the release tool.
+
+https://github.com/cs3org/reva/pull/1413

--- a/cmd/revad/main.go
+++ b/cmd/revad/main.go
@@ -86,7 +86,7 @@ func main() {
 func handleVersionFlag() {
 	if *versionFlag {
 		fmt.Fprintf(os.Stderr, "%s\n", getVersionString())
-		os.Exit(1)
+		os.Exit(0)
 	}
 }
 


### PR DESCRIPTION
So we can re-compute the version and sha on the build process

fixes https://github.com/cs3org/reva/issues/1406