### PR TITLE
[Tests-Only] Adjust the links in the expected-failures file

### DIFF
--- a/tests/acceptance/expected-failures-on-EOS-storage.md
+++ b/tests/acceptance/expected-failures-on-EOS-storage.md
@@ -1,4 +1,4 @@
-## Scenarios from ownCloud10 core api tests that are expected to fail with EOS storage
+## Scenarios from ownCloud10 core API tests that are expected to fail with EOS storage
 
 ### [Checksum feature](https://github.com/owncloud/ocis/issues/1291)
 -   [apiMain/checksums.feature:24](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiMain/checksums.feature#L24)
@@ -144,7 +144,10 @@
 -   [apiWebdavOperations/search.feature:213](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L213)
 -   [apiWebdavOperations/search.feature:229](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L229)
 
-OCS Provisioning API scenarios that fail - to be investigated and issues raised or comments added here
+### OCS Provisioning API scenarios that fail
+
+to be investigated and issues raised or comments added here
+
 -   [apiProvisioning-v1/addUser.feature:29](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiProvisioning-v1/addUser.feature#L29)
 -   [apiProvisioning-v1/addUser.feature:30](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiProvisioning-v1/addUser.feature#L30)
 -   [apiProvisioning-v1/addUser.feature:32](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiProvisioning-v1/addUser.feature#L32)
@@ -412,9 +415,6 @@ OCS Provisioning API scenarios that fail - to be investigated and issues raised 
 -   [apiShareToSharesManagementBasic/excludeGroupFromReceivingSharesToSharesFolder.feature:98](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareToSharesManagementBasic/excludeGroupFromReceivingSharesToSharesFolder.feature#L98)
 -   [apiShareToSharesManagementBasic/excludeGroupFromReceivingSharesToSharesFolder.feature:135](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareToSharesManagementBasic/excludeGroupFromReceivingSharesToSharesFolder.feature#L135)
 -   [apiShareToSharesManagementBasic/excludeGroupFromReceivingSharesToSharesFolder.feature:136](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareToSharesManagementBasic/excludeGroupFromReceivingSharesToSharesFolder.feature#L136)
-
-These currently pass in owncloud/ocis-reva and should start passing here in ocis soon
-
 -   [apiShareToSharesManagementBasic/excludeGroupFromReceivingSharesToSharesFolder.feature:115](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareToSharesManagementBasic/excludeGroupFromReceivingSharesToSharesFolder.feature#L115)
 -   [apiShareToSharesManagementBasic/excludeGroupFromReceivingSharesToSharesFolder.feature:116](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareToSharesManagementBasic/excludeGroupFromReceivingSharesToSharesFolder.feature#L116)
 -   [apiShareToSharesManagementBasic/excludeGroupFromReceivingSharesToSharesFolder.feature:153](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareToSharesManagementBasic/excludeGroupFromReceivingSharesToSharesFolder.feature#L153)

--- a/tests/acceptance/expected-failures-on-EOS-storage.md
+++ b/tests/acceptance/expected-failures-on-EOS-storage.md
@@ -1,6 +1,6 @@
-## Scenarios from ownCloud10 core API tests that are expected to fail with EOS storage
+## Scenarios from ownCloud10 core api tests that are expected to fail with EOS storage
 
-### [Checksum feature](https://github.com/owncloud/ocis-reva/issues/196)
+### [Checksum feature](https://github.com/owncloud/ocis/issues/1291)
 -   [apiMain/checksums.feature:24](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiMain/checksums.feature#L24)
 -   [apiMain/checksums.feature:25](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiMain/checksums.feature#L25)
 -   [apiMain/checksums.feature:35](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiMain/checksums.feature#L35)
@@ -35,14 +35,14 @@
 -   [apiMain/checksums.feature:312](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiMain/checksums.feature#L312)
 -   [apiMain/checksums.feature:324](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiMain/checksums.feature#L324)
 
-### [XML properties in webdav response not properly encoded](https://github.com/owncloud/ocis-reva/issues/214)
+### [XML properties in webdav response not properly encoded](https://github.com/owncloud/ocis/issues/1296)
 -   [apiMain/checksums.feature:346](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiMain/checksums.feature#L346)
 -   [apiMain/checksums.feature:347](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiMain/checksums.feature#L347)
 
-### [no robots.txt available](https://github.com/owncloud/ocis-reva/issues/100)
+### [no robots.txt available](https://github.com/owncloud/ocis/issues/1314)
 -   [apiMain/main.feature:5](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiMain/main.feature#L5)
 
-### [quota query](https://github.com/owncloud/ocis-reva/issues/101)
+### [quota query](https://github.com/owncloud/ocis/issues/1313)
 -   [apiMain/quota.feature:9](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiMain/quota.feature#L9)
 -   [apiMain/quota.feature:16](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiMain/quota.feature#L16)
 -   [apiMain/quota.feature:23](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiMain/quota.feature#L23)
@@ -64,12 +64,12 @@
 -   [apiWebdavProperties1/getQuota.feature:77](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/getQuota.feature#L77)
 -   [apiWebdavProperties1/getQuota.feature:78](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/getQuota.feature#L78)
 
-### [There is no such thing like a "super-user"](https://github.com/owncloud/ocis-reva/issues/65)
-### [no command equivalent to occ](https://github.com/owncloud/ocis-reva/issues/97)
+### [There is no such thing like a "super-user"](https://github.com/owncloud/ocis/issues/1319)
+### [no command equivalent to occ](https://github.com/owncloud/ocis/issues/1317)
 -   [apiMain/status.feature:5](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiMain/status.feature#L5)
 
-### [ocs config endpoint only accessible by authorized users](https://github.com/owncloud/ocis-reva/issues/29)
-### [HTTP 401 Unauthorized responses don't contain a body](https://github.com/owncloud/ocis-reva/issues/30)
+### [ocs config endpoint only accessible by authorized users](https://github.com/owncloud/ocis/issues/1338)
+### [HTTP 401 Unauthorized responses don't contain a body](https://github.com/owncloud/ocis/issues/1337)
 -   [apiAuthOcs/ocsDELETEAuth.feature:9](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiAuthOcs/ocsDELETEAuth.feature#L9)
 -   [apiAuthOcs/ocsGETAuth.feature:10](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiAuthOcs/ocsGETAuth.feature#L10)
 -   [apiAuthOcs/ocsGETAuth.feature:33](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiAuthOcs/ocsGETAuth.feature#L33)
@@ -80,24 +80,24 @@
 -   [apiAuthOcs/ocsPOSTAuth.feature:10](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiAuthOcs/ocsPOSTAuth.feature#L10)
 -   [apiAuthOcs/ocsPUTAuth.feature:10](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiAuthOcs/ocsPUTAuth.feature#L10)
 
-### [users can access each-others data using the new webdav API](https://github.com/owncloud/ocis-reva/issues/9)
+### [users can access each-others data using the new webdav API](https://github.com/owncloud/ocis/issues/1347)
 -   [apiAuthWebDav/webDavLOCKAuth.feature:38](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiAuthWebDav/webDavLOCKAuth.feature#L38)
 -   [apiAuthWebDav/webDavMKCOLAuth.feature:37](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiAuthWebDav/webDavMKCOLAuth.feature#L37)
 
 ### [renaming a resource does not work](https://github.com/owncloud/ocis-reva/issues/14)
 -   [apiAuthWebDav/webDavMOVEAuth.feature:37](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiAuthWebDav/webDavMOVEAuth.feature#L37)
 
-### [send POST requests to another user's webDav endpoints as normal user](https://github.com/owncloud/ocis-reva/issues/179)
+### [send POST requests to another user's webDav endpoints as normal user](https://github.com/owncloud/ocis/issues/1287)
 -   [apiAuthWebDav/webDavPOSTAuth.feature:38](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiAuthWebDav/webDavPOSTAuth.feature#L38)
 
-### [users can access each-others data using the new webdav API](https://github.com/owncloud/ocis-reva/issues/9)
+### [users can access each-others data using the new webdav API](https://github.com/owncloud/ocis/issues/1347)
 -   [apiAuthWebDav/webDavPUTAuth.feature:38](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiAuthWebDav/webDavPUTAuth.feature#L38)
 
-### [Default capabilities for normal user not same as in oC-core](https://github.com/owncloud/ocis-reva/issues/175)
-### [Difference in response content of status.php and default capabilities](https://github.com/owncloud/ocis-reva/issues/176)
+### [Default capabilities for normal user not same as in oC-core](https://github.com/owncloud/ocis/issues/1285)
+### [Difference in response content of status.php and default capabilities](https://github.com/owncloud/ocis/issues/1286)
 -   [apiCapabilities/capabilitiesWithNormalUser.feature:11](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiCapabilities/capabilitiesWithNormalUser.feature#L11)
 
-### [elements cannot be favorited](https://github.com/owncloud/ocis-reva/issues/276)
+### [elements cannot be favorited](https://github.com/owncloud/ocis/issues/1263)
 -   [apiFavorites/favorites.feature:28](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiFavorites/favorites.feature#L28)
 -   [apiFavorites/favorites.feature:29](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiFavorites/favorites.feature#L29)
 -   [apiFavorites/favorites.feature:44](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiFavorites/favorites.feature#L44)
@@ -114,15 +114,37 @@
 -   [apiWebdavProperties1/setFileProperties.feature:77](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/setFileProperties.feature#L77)
 -   [apiWebdavProperties1/setFileProperties.feature:80](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/setFileProperties.feature#L80)
 
-### [elements cannot be favorited](https://github.com/owncloud/ocis-reva/issues/265)
+### [elements cannot be favorited](https://github.com/owncloud/ocis/issues/1259)
 -   [apiWebdavProperties2/getFileProperties.feature:102](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties2/getFileProperties.feature#L102)
 -   [apiWebdavProperties2/getFileProperties.feature:103](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties2/getFileProperties.feature#L103)
 
-### [REPORT request not implemented](https://github.com/owncloud/ocis-reva/issues/39)
+### [REPORT request not implemented](https://github.com/owncloud/ocis/issues/1330)
 -   [apiFavorites/favorites.feature:228](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiFavorites/favorites.feature#L228)
 -   [apiFavorites/favorites.feature:229](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiFavorites/favorites.feature#L229)
+-   [apiWebdavOperations/search.feature:42](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L42)
+-   [apiWebdavOperations/search.feature:43](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L43)
+-   [apiWebdavOperations/search.feature:57](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L57)
+-   [apiWebdavOperations/search.feature:58](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L58)
+-   [apiWebdavOperations/search.feature:74](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L74)
+-   [apiWebdavOperations/search.feature:75](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L75)
+-   [apiWebdavOperations/search.feature:83](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L83)
+-   [apiWebdavOperations/search.feature:84](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L84)
+-   [apiWebdavOperations/search.feature:101](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L101)
+-   [apiWebdavOperations/search.feature:102](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L102)
+-   [apiWebdavOperations/search.feature:119](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L119)
+-   [apiWebdavOperations/search.feature:120](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L120)
+-   [apiWebdavOperations/search.feature:138](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L138)
+-   [apiWebdavOperations/search.feature:139](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L139)
+-   [apiWebdavOperations/search.feature:165](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L165)
+-   [apiWebdavOperations/search.feature:166](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L166)
+-   [apiWebdavOperations/search.feature:191](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L191)
+-   [apiWebdavOperations/search.feature:192](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L192)
+-   [apiWebdavOperations/search.feature:210](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L210)
+-   [apiWebdavOperations/search.feature:211](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L211)
+-   [apiWebdavOperations/search.feature:213](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L213)
+-   [apiWebdavOperations/search.feature:229](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L229)
 
-### OCS Provisioning API scenarios that fail - to be investigated and issues raised or comments added here
+OCS Provisioning API scenarios that fail - to be investigated and issues raised or comments added here
 -   [apiProvisioning-v1/addUser.feature:29](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiProvisioning-v1/addUser.feature#L29)
 -   [apiProvisioning-v1/addUser.feature:30](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiProvisioning-v1/addUser.feature#L30)
 -   [apiProvisioning-v1/addUser.feature:32](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiProvisioning-v1/addUser.feature#L32)
@@ -276,7 +298,7 @@
 -   [apiSharees/sharees.feature:537](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharees/sharees.feature#L537)
 -   [apiSharees/sharees.feature:538](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharees/sharees.feature#L538)
 
-### [various sharing settings cannot be set (shareapi_auto_accept_share)](https://github.com/owncloud/ocis-reva/issues/41)
+### [various sharing settings cannot be set (shareapi_auto_accept_share)](https://github.com/owncloud/ocis/issues/1328)
 -   [apiShareManagement/acceptShares.feature:155](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareManagement/acceptShares.feature#L155)
 -   [apiShareManagement/acceptShares.feature:313](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareManagement/acceptShares.feature#L313)
 -   [apiShareManagement/acceptShares.feature:333](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareManagement/acceptShares.feature#L333)
@@ -310,13 +332,13 @@
 -   [apiShareManagement/acceptSharesToSharesFolder.feature:52](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareManagement/acceptSharesToSharesFolder.feature#L52)
 
 ### [groups endpoint does not exist](https://github.com/owncloud/ocis-reva/issues/34)
-### [Sharing seems to work but does not work](https://github.com/owncloud/ocis-reva/issues/243)
-### [Listing shares via ocs API does not show path for parent folders](https://github.com/owncloud/ocis-reva/issues/372)
+### [Sharing seems to work but does not work](https://github.com/owncloud/ocis/issues/1303)
+### [Listing shares via ocs API does not show path for parent folders](https://github.com/owncloud/ocis/issues/1231)
 ### [Fields missing in delete share OCS response](https://github.com/owncloud/ocis-reva/issues/356)
 ### [file_target in share response](https://github.com/owncloud/product/issues/203)
-### [Shares not deleted when user is deleted](https://github.com/owncloud/ocis-reva/issues/357)
-### [[EOS] no displayname owner when creating share](https://github.com/owncloud/ocis-reva/issues/301)
-### [[EOS] mime-type is not set correctly when sharing](https://github.com/owncloud/ocis-reva/issues/302)
+### [Shares not deleted when user is deleted](hhttps://github.com/owncloud/ocis/issues/1226)
+### [EOS no displayname owner when creating share](https://github.com/owncloud/ocis/issues/1270)
+### [EOS mime-type is not set correctly when sharing](https://github.com/owncloud/ocis/issues/1271)
 -   [apiShareToSharesManagementBasic/createShareToSharesFolder.feature:36](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareToSharesManagementBasic/createShareToSharesFolder.feature#L36)
 -   [apiShareToSharesManagementBasic/createShareToSharesFolder.feature:37](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareToSharesManagementBasic/createShareToSharesFolder.feature#L37)
 -   [apiShareToSharesManagementBasic/createShareToSharesFolder.feature:66](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareToSharesManagementBasic/createShareToSharesFolder.feature#L66)
@@ -390,45 +412,48 @@
 -   [apiShareToSharesManagementBasic/excludeGroupFromReceivingSharesToSharesFolder.feature:98](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareToSharesManagementBasic/excludeGroupFromReceivingSharesToSharesFolder.feature#L98)
 -   [apiShareToSharesManagementBasic/excludeGroupFromReceivingSharesToSharesFolder.feature:135](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareToSharesManagementBasic/excludeGroupFromReceivingSharesToSharesFolder.feature#L135)
 -   [apiShareToSharesManagementBasic/excludeGroupFromReceivingSharesToSharesFolder.feature:136](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareToSharesManagementBasic/excludeGroupFromReceivingSharesToSharesFolder.feature#L136)
+
+These currently pass in owncloud/ocis-reva and should start passing here in ocis soon
+
 -   [apiShareToSharesManagementBasic/excludeGroupFromReceivingSharesToSharesFolder.feature:115](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareToSharesManagementBasic/excludeGroupFromReceivingSharesToSharesFolder.feature#L115)
 -   [apiShareToSharesManagementBasic/excludeGroupFromReceivingSharesToSharesFolder.feature:116](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareToSharesManagementBasic/excludeGroupFromReceivingSharesToSharesFolder.feature#L116)
 -   [apiShareToSharesManagementBasic/excludeGroupFromReceivingSharesToSharesFolder.feature:153](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareToSharesManagementBasic/excludeGroupFromReceivingSharesToSharesFolder.feature#L153)
 -   [apiShareToSharesManagementBasic/excludeGroupFromReceivingSharesToSharesFolder.feature:154](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareToSharesManagementBasic/excludeGroupFromReceivingSharesToSharesFolder.feature#L154)
 
-### [Sharee retrieves the information about a share -but gets response containing all the shares](https://github.com/owncloud/ocis-reva/issues/260)
+### [Sharee retrieves the information about a share -but gets response containing all the shares](https://github.com/owncloud/ocis/issues/1257)
 -   [apiShareOperations/accessToShare.feature:48](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareOperations/accessToShare.feature#L48)
 -   [apiShareOperations/accessToShare.feature:49](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareOperations/accessToShare.feature#L49)
 
-### [Shares are not deleted when user is deleted](https://github.com/owncloud/ocis-reva/issues/262)
+### [Shares are not deleted when user is deleted](https://github.com/owncloud/ocis/issues/1258)
 -   [apiShareOperations/gettingShares.feature:21](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareOperations/gettingShares.feature#L21)
 -   [apiShareOperations/gettingShares.feature:22](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareOperations/gettingShares.feature#L22)
 
-### [There is no such thing like a "super-user"](https://github.com/owncloud/ocis-reva/issues/65)
+### [There is no such thing like a "super-user"](https://github.com/owncloud/ocis/issues/1319)
 -   [apiShareOperations/gettingShares.feature:34](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareOperations/gettingShares.feature#L34)
 -   [apiShareOperations/gettingShares.feature:35](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareOperations/gettingShares.feature#L35)
 
-### [Delete shares from user when user is deleted](https://github.com/owncloud/ocis-reva/issues/357)
-### [no displayname_owner shown when creating a share](https://github.com/owncloud/ocis-reva/issues/301)
-### [when sharing a file mime-type field is set to application/octet-stream](https://github.com/owncloud/ocis-reva/issues/302)
+### [Delete shares from user when user is deleted](hhttps://github.com/owncloud/ocis/issues/1226)
+### [no displayname_owner shown when creating a share](https://github.com/owncloud/ocis/issues/1270)
+### [when sharing a file mime-type field is set to application/octet-stream](https://github.com/owncloud/ocis/issues/1271)
 -   [apiShareOperations/gettingShares.feature:124](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareOperations/gettingShares.feature#L124)
 -   [apiShareOperations/gettingShares.feature:125](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareOperations/gettingShares.feature#L125)
 
-### [OCS error message for attempting to access share via share id as an unauthorized user is not informative](https://github.com/owncloud/ocis-reva/issues/374)
+### [OCS error message for attempting to access share via share id as an unauthorized user is not informative](https://github.com/owncloud/ocis/issues/1233)
 -   [apiShareOperations/gettingShares.feature:168](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareOperations/gettingShares.feature#L168)
 -   [apiShareOperations/gettingShares.feature:169](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareOperations/gettingShares.feature#L169)
 
-### [Listing shares via ocs API does not show path for parent folders](https://github.com/owncloud/ocis-reva/issues/372)
+### [Listing shares via ocs API does not show path for parent folders](https://github.com/owncloud/ocis/issues/1231)
 -   [apiShareOperations/gettingShares.feature:204](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareOperations/gettingShares.feature#L204)
 -   [apiShareOperations/gettingShares.feature:205](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareOperations/gettingShares.feature#L205)
 
-### [cannot get ocs:share-permissions via WebDAV](https://github.com/owncloud/ocis-reva/issues/47)
+### [cannot get ocs:share-permissions via WebDAV](https://github.com/owncloud/ocis/issues/1326)
 -   [apiShareOperations/getWebDAVSharePermissions.feature:21](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareOperations/getWebDAVSharePermissions.feature#L21)
 -   [apiShareOperations/getWebDAVSharePermissions.feature:22](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareOperations/getWebDAVSharePermissions.feature#L22)
 -   [apiShareOperations/getWebDAVSharePermissions.feature:134](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareOperations/getWebDAVSharePermissions.feature#L134)
 -   [apiShareOperations/getWebDAVSharePermissions.feature:135](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareOperations/getWebDAVSharePermissions.feature#L135)
 
 ### [Split old public API webdav tests from new public webdav tests](https://github.com/owncloud/ocis-reva/issues/282)
-### [Public link enforce permissions](https://github.com/owncloud/ocis-reva/issues/292)
+### [Public link enforce permissions](https://github.com/owncloud/ocis/issues/1269)
 -   [apiSharePublicLink1/accessToPublicLinkShare.feature:10](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/accessToPublicLinkShare.feature#L10)
 -   [apiSharePublicLink1/accessToPublicLinkShare.feature:20](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/accessToPublicLinkShare.feature#L20)
 -   [apiSharePublicLink1/accessToPublicLinkShare.feature:30](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/accessToPublicLinkShare.feature#L30)
@@ -474,28 +499,28 @@
 -   [apiSharePublicLink2/uploadToPublicLinkShare.feature:121](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L121)
 -   [apiSharePublicLink2/uploadToPublicLinkShare.feature:139](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L139)
 
-### [Range Header is not obeyed when downloading a file](https://github.com/owncloud/ocis-reva/issues/12)
+### [Range Header is not obeyed when downloading a file](https://github.com/owncloud/ocis/issues/1346)
 -   [apiSharePublicLink1/createPublicLinkShare.feature:63](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature#L63)
 -   [apiSharePublicLink1/createPublicLinkShare.feature:64](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature#L64)
 
 -   [apiSharePublicLink1/createPublicLinkShare.feature:95](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature#L95)
 -   [apiSharePublicLink1/createPublicLinkShare.feature:96](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature#L96)
 
-### [Ability to return error messages in Webdav response bodies](https://github.com/owncloud/ocis-reva/issues/199)
+### [Ability to return error messages in Webdav response bodies](https://github.com/owncloud/ocis/issues/1293)
 -   [apiSharePublicLink1/createPublicLinkShare.feature:127](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature#L127)
 -   [apiSharePublicLink1/createPublicLinkShare.feature:128](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature#L128)
 
 -   [apiSharePublicLink1/createPublicLinkShare.feature:155](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature#L155)
 -   [apiSharePublicLink1/createPublicLinkShare.feature:156](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature#L156)
 
-### [Range Header is not obeyed when downloading a file](https://github.com/owncloud/ocis-reva/issues/12)
+### [Range Header is not obeyed when downloading a file](https://github.com/owncloud/ocis/issues/1346)
 -   [apiSharePublicLink1/createPublicLinkShare.feature:245](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature#L245)
 -   [apiSharePublicLink1/createPublicLinkShare.feature:246](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature#L246)
 
 -   [apiSharePublicLink1/createPublicLinkShare.feature:276](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature#L276)
 -   [apiSharePublicLink1/createPublicLinkShare.feature:277](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature#L277)
 
-### [various sharing settings cannot be set](https://github.com/owncloud/ocis-reva/issues/41)
+### [various sharing settings cannot be set](https://github.com/owncloud/ocis/issues/1328)
 -   [apiSharePublicLink1/createPublicLinkShare.feature:389](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature#L389)
 -   [apiSharePublicLink1/createPublicLinkShare.feature:390](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature#L390)
 -   [apiSharePublicLink1/createPublicLinkShare.feature:411](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature#L411)
@@ -527,7 +552,7 @@
 -   [apiSharePublicLink2/uploadToPublicLinkShare.feature:238](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L238)
 -   [apiSharePublicLink2/uploadToPublicLinkShare.feature:255](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L255)
 
-### [Prevent creating public share for the home root folder](https://github.com/owncloud/ocis-reva/issues/283)
+### [Prevent creating public share for the home root folder](https://github.com/owncloud/ocis/issues/1265)
 -   [apiSharePublicLink1/createPublicLinkShare.feature:620](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature#L620)
 -   [apiSharePublicLink1/createPublicLinkShare.feature:621](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature#L621)
 -   [apiSharePublicLink1/createPublicLinkShare.feature:634](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature#L634)
@@ -535,10 +560,10 @@
 -   [apiSharePublicLink1/createPublicLinkShare.feature:663](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature#L663)
 -   [apiSharePublicLink1/createPublicLinkShare.feature:664](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature#L664)
 
-### [Ability to return error messages in Webdav response bodies](https://github.com/owncloud/ocis-reva/issues/199)
+### [Ability to return error messages in Webdav response bodies](https://github.com/owncloud/ocis/issues/1293)
 -   [apiSharePublicLink1/createPublicLinkShare.feature:718](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature#L718)
 
-### [Cannot set Mtime on upload](https://github.com/owncloud/ocis-reva/issues/468)
+### [Cannot set Mtime on upload](https://github.com/owncloud/ocis/issues/1248)
 -   [apiSharePublicLink1/createPublicLinkShare.feature:760](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature#L760)
 -   [apiSharePublicLink1/createPublicLinkShare.feature:761](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature#L761)
 -   [apiSharePublicLink1/createPublicLinkShare.feature:774](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature#L774)
@@ -552,19 +577,19 @@
 -   [apiWebdavUpload1/uploadFile.feature:184](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUpload1/uploadFile.feature#L184)
 -   [apiWebdavUpload1/uploadFile.feature:185](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUpload1/uploadFile.feature#L185)
 
-### [copying a folder within a public link folder to folder with same name as an already existing file overwrites the parent file](https://github.com/owncloud/ocis-reva/issues/373)
+### [copying a folder within a public link folder to folder with same name as an already existing file overwrites the parent file](https://github.com/owncloud/ocis/issues/1232)
 -   [apiSharePublicLink2/copyFromPublicLink.feature:60](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/copyFromPublicLink.feature#L60)
 
-### https://github.com/owncloud/ocis-reva/issues/373
+### https://github.com/owncloud/ocis/issues/1232
 -   [apiSharePublicLink2/copyFromPublicLink.feature:86](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/copyFromPublicLink.feature#L86)
 
-### [copying a file from within a public link folder to "/" overwrites the parent folder](https://github.com/owncloud/ocis-reva/issues/368)
+### [copying a file from within a public link folder to "/" overwrites the parent folder](https://github.com/owncloud/ocis/issues/1230)
 -   [apiSharePublicLink2/copyFromPublicLink.feature:167](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/copyFromPublicLink.feature#L167)
 -   [apiSharePublicLink2/copyFromPublicLink.feature:168](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/copyFromPublicLink.feature#L168)
 -   [apiSharePublicLink2/copyFromPublicLink.feature:183](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/copyFromPublicLink.feature#L183)
 -   [apiSharePublicLink2/copyFromPublicLink.feature:184](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/copyFromPublicLink.feature#L184)
 
-### [overwriting a file removes it's public links](https://github.com/owncloud/ocis-reva/issues/476)
+### [overwriting a file removes it's public links](https://github.com/owncloud/ocis/issues/13266)
 -   [apiSharePublicLink2/multilinkSharing.feature:160](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/multilinkSharing.feature#L160)
 -   [apiSharePublicLink2/updatePublicLinkShare.feature:94](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L94)
 -   [apiSharePublicLink2/updatePublicLinkShare.feature:95](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L95)
@@ -589,21 +614,21 @@
 -   [apiSharePublicLink2/updatePublicLinkShare.feature:440](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L440)
 -   [apiSharePublicLink2/updatePublicLinkShare.feature:441](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L441)
 
-### [Upload-only shares must not overwrite but create a separate file](https://github.com/owncloud/ocis-reva/issues/286)
+### [Upload-only shares must not overwrite but create a separate file](https://github.com/owncloud/ocis/issues/1267)
 -   [apiSharePublicLink2/uploadToPublicLinkShare.feature:23](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L23)
 
-### [Accessing non-existing public link should return 404, not 500](https://github.com/owncloud/ocis-reva/issues/290)
+### [Accessing non-existing public link should return 404, not 500](https://github.com/owncloud/ocis/issues/1268)
 -   [apiSharePublicLink2/uploadToPublicLinkShare.feature:62](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L62)
 -   [apiSharePublicLink2/uploadToPublicLinkShare.feature:63](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L63)
 -   [apiSharePublicLink2/uploadToPublicLinkShare.feature:66](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L66)
 
-### [Set quota over settings](https://github.com/owncloud/ocis-reva/issues/195)
+### [Set quota over settings](https://github.com/owncloud/ocis/issues/1290)
 -   [apiSharePublicLink2/uploadToPublicLinkShare.feature:148](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L148)
 -   [apiSharePublicLink2/uploadToPublicLinkShare.feature:158](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L158)
 -   [apiSharePublicLink2/uploadToPublicLinkShare.feature:167](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L167)
 -   [apiSharePublicLink2/uploadToPublicLinkShare.feature:177](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L177)
 
-### [Upload-only shares must not overwrite but create a separate file](https://github.com/owncloud/ocis-reva/issues/286)
+### [Upload-only shares must not overwrite but create a separate file](https://github.com/owncloud/ocis/issues/1267)
 -   [apiSharePublicLink2/uploadToPublicLinkShare.feature:273](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L273)
 
 ### [Propfind to trashbin endpoint requires UUID](https://github.com/owncloud/product/issues/179)
@@ -674,8 +699,8 @@
 -   [apiTrashbin/trashbinRestore.feature:343](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiTrashbin/trashbinRestore.feature#L343)
 -   [apiTrashbin/trashbinRestore.feature:344](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiTrashbin/trashbinRestore.feature#L344)
 
-### [uploading with old-chunking does not work](https://github.com/owncloud/ocis-reva/issues/17)
-### [remote.php/dav/uploads endpoint does not exist](https://github.com/owncloud/ocis-reva/issues/56)
+### [uploading with old-chunking does not work](https://github.com/owncloud/ocis/issues/1343)
+### [remote.php/dav/uploads endpoint does not exist](https://github.com/owncloud/ocis/issues/1321)
 -   [apiWebdavUpload2/uploadFileUsingNewChunking.feature:12](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUpload2/uploadFileUsingNewChunking.feature#L12)
 -   [apiWebdavUpload2/uploadFileUsingNewChunking.feature:29](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUpload2/uploadFileUsingNewChunking.feature#L29)
 -   [apiWebdavUpload2/uploadFileUsingNewChunking.feature:43](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUpload2/uploadFileUsingNewChunking.feature#L43)
@@ -744,7 +769,7 @@
 -   [apiWebdavUpload2/uploadFileToExcludedDirectoryUsingNewChunking.feature:49](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUpload2/uploadFileToExcludedDirectoryUsingNewChunking.feature#L49)
 -   [apiWebdavUpload2/uploadFileToExcludedDirectoryUsingNewChunking.feature:52](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUpload2/uploadFileToExcludedDirectoryUsingNewChunking.feature#L52)
 
-### [file id changes on every uploaded](https://github.com/owncloud/ocis-reva/issues/275)
+### [file id changes on every uploaded](https://github.com/owncloud/ocis/issues/1262)
 -   [apiVersions/fileVersions.feature:29](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiVersions/fileVersions.feature#L29)
 -   [apiVersions/fileVersions.feature:52](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiVersions/fileVersions.feature#L52)
 -   [apiVersions/fileVersions.feature:61](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiVersions/fileVersions.feature#L61)
@@ -838,7 +863,7 @@
 -   [apiWebdavMove2/moveFileToExcludedDirectory.feature:63](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavMove2/moveFileToExcludedDirectory.feature#L63)
 -   [apiWebdavMove2/moveFileToExcludedDirectory.feature:64](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavMove2/moveFileToExcludedDirectory.feature#L64)
 
-### [file cannot contain ? character](https://github.com/owncloud/ocis-reva/issues/265)
+### [file cannot contain ? character](https://github.com/owncloud/ocis/issues/1259)
 -   [apiWebdavMove2/moveFile.feature:292](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavMove2/moveFile.feature#L292)
 
 ### [listing received shares does not work](https://github.com/owncloud/ocis-reva/issues/11)
@@ -849,7 +874,7 @@
 -   [apiWebdavOperations/deleteFolder.feature:91](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/deleteFolder.feature#L91)
 -   [apiWebdavOperations/deleteFolder.feature:92](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/deleteFolder.feature#L92)
 
-### [Range Header is not obeyed when downloading a file](https://github.com/owncloud/ocis-reva/issues/12)
+### [Range Header is not obeyed when downloading a file](https://github.com/owncloud/ocis/issues/1346)
 -   [apiWebdavOperations/downloadFile.feature:29](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/downloadFile.feature#L29)
 -   [apiWebdavOperations/downloadFile.feature:30](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/downloadFile.feature#L30)
 
@@ -865,41 +890,17 @@
 -   [apiWebdavOperations/refuseAccess.feature:33](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/refuseAccess.feature#L33)
 -   [apiWebdavOperations/refuseAccess.feature:34](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/refuseAccess.feature#L34)
 
-### [REPORT request not implemented](https://github.com/owncloud/ocis-reva/issues/39)
--   [apiWebdavOperations/search.feature:42](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L42)
--   [apiWebdavOperations/search.feature:43](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L43)
--   [apiWebdavOperations/search.feature:57](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L57)
--   [apiWebdavOperations/search.feature:58](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L58)
--   [apiWebdavOperations/search.feature:74](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L74)
--   [apiWebdavOperations/search.feature:75](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L75)
--   [apiWebdavOperations/search.feature:83](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L83)
--   [apiWebdavOperations/search.feature:84](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L84)
--   [apiWebdavOperations/search.feature:101](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L101)
--   [apiWebdavOperations/search.feature:102](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L102)
--   [apiWebdavOperations/search.feature:119](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L119)
--   [apiWebdavOperations/search.feature:120](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L120)
--   [apiWebdavOperations/search.feature:138](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L138)
--   [apiWebdavOperations/search.feature:139](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L139)
--   [apiWebdavOperations/search.feature:165](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L165)
--   [apiWebdavOperations/search.feature:166](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L166)
--   [apiWebdavOperations/search.feature:191](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L191)
--   [apiWebdavOperations/search.feature:192](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L192)
--   [apiWebdavOperations/search.feature:210](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L210)
--   [apiWebdavOperations/search.feature:211](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L211)
--   [apiWebdavOperations/search.feature:213](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L213)
--   [apiWebdavOperations/search.feature:229](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L229)
-
 ### [listing received shares does not work](https://github.com/owncloud/ocis-reva/issues/11)
 -   [apiWebdavProperties1/copyFile.feature:65](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/copyFile.feature#L65)
 -   [apiWebdavProperties1/copyFile.feature:66](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/copyFile.feature#L66)
 -   [apiWebdavProperties1/copyFile.feature:85](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/copyFile.feature#L85)
 -   [apiWebdavProperties1/copyFile.feature:86](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/copyFile.feature#L86)
 
-### [blacklisted filenames like .htaccess & file.parts can be uploaded](https://github.com/owncloud/ocis-reva/issues/15)
+### [blacklisted filenames like .htaccess & file.parts can be uploaded](https://github.com/owncloud/ocis/issues/1345)
 -   [apiWebdavProperties1/copyFile.feature:102](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/copyFile.feature#L102)
 -   [apiWebdavProperties1/copyFile.feature:103](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/copyFile.feature#L103)
 
-### [Getting information about a folder overwritten by a file gives 500 error instead of 404](https://github.com/owncloud/ocis-reva/issues/387)
+### [Getting information about a folder overwritten by a file gives 500 error instead of 404](https://github.com/owncloud/ocis/issues/1239)
 -   [apiWebdavProperties1/copyFile.feature:116](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/copyFile.feature#L116)
 -   [apiWebdavProperties1/copyFile.feature:117](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/copyFile.feature#L117)
 -   [apiWebdavProperties1/copyFile.feature:129](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/copyFile.feature#L129)
@@ -921,23 +922,23 @@
 -   [apiWebdavProperties1/copyFile.feature:474](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/copyFile.feature#L474)
 -   [apiWebdavProperties1/copyFile.feature:475](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/copyFile.feature#L475)
 
-### [blacklisted filenames like .htaccess & file.parts can be uploaded](https://github.com/owncloud/ocis-reva/issues/15)
+### [blacklisted filenames like .htaccess & file.parts can be uploaded](https://github.com/owncloud/ocis/issues/1345)
 -   [apiWebdavProperties1/createFolder.feature:71](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/createFolder.feature#L71)
 -   [apiWebdavProperties1/createFolder.feature:72](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/createFolder.feature#L72)
 
-### [creating a folder that already exists returns an empty body](https://github.com/owncloud/ocis-reva/issues/168)
+### [creating a folder that already exists returns an empty body](https://github.com/owncloud/ocis/issues/1283)
 -   [apiWebdavProperties1/createFolder.feature:85](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/createFolder.feature#L85)
 -   [apiWebdavProperties1/createFolder.feature:86](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/createFolder.feature#L86)
 -   [apiWebdavProperties1/createFolder.feature:99](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/createFolder.feature#L99)
 -   [apiWebdavProperties1/createFolder.feature:100](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/createFolder.feature#L100)
 
-### [Some failing tests with Webdav custom properties](https://github.com/owncloud/ocis-reva/issues/217)
+### [Some failing tests with Webdav custom properties](https://github.com/owncloud/ocis/issues/1297)
 -   [apiWebdavProperties1/setFileProperties.feature:32](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/setFileProperties.feature#L32)
 -   [apiWebdavProperties1/setFileProperties.feature:33](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/setFileProperties.feature#L33)
 -   [apiWebdavProperties1/setFileProperties.feature:63](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/setFileProperties.feature#L63)
 -   [apiWebdavProperties1/setFileProperties.feature:64](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/setFileProperties.feature#L64)
 
-### [XML properties in webdav response not properly encoded](https://github.com/owncloud/ocis-reva/issues/214)
+### [XML properties in webdav response not properly encoded](https://github.com/owncloud/ocis/issues/1296)
 -   [apiWebdavProperties2/getFileProperties.feature:37](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties2/getFileProperties.feature#L37)
 -   [apiWebdavProperties2/getFileProperties.feature:39](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties2/getFileProperties.feature#L39)
 -   [apiWebdavProperties2/getFileProperties.feature:40](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties2/getFileProperties.feature#L40)
@@ -967,18 +968,18 @@
 -   [apiWebdavProperties2/getFileProperties.feature:218](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties2/getFileProperties.feature#L218)
 -   [apiWebdavProperties2/getFileProperties.feature:219](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties2/getFileProperties.feature#L219)
 
-### [Private link support](https://github.com/owncloud/ocis-reva/issues/216)
+### [Private link support](https://github.com/owncloud/product/issues/201)
 -   [apiWebdavProperties2/getFileProperties.feature:232](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties2/getFileProperties.feature#L232)
 -   [apiWebdavProperties2/getFileProperties.feature:233](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties2/getFileProperties.feature#L233)
 
-### [trying to access a non-existing resource returns an empty body](https://github.com/owncloud/ocis-reva/issues/163)
+### [trying to access a non-existing resource returns an empty body](https://github.com/owncloud/ocis/issues/1282)
 -   [apiWebdavProperties2/getFileProperties.feature:242](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties2/getFileProperties.feature#L242)
 -   [apiWebdavProperties2/getFileProperties.feature:243](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties2/getFileProperties.feature#L243)
 
-### [Some failing tests with Webdav custom properties](https://github.com/owncloud/ocis-reva/issues/217)
+### [Some failing tests with Webdav custom properties](https://github.com/owncloud/ocis/issues/1297)
 -   [apiWebdavProperties2/getFileProperties.feature:246](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties2/getFileProperties.feature#L246)
 
-### [Some failing tests with Webdav custom properties](https://github.com/owncloud/ocis-reva/issues/217)
+### [Some failing tests with Webdav custom properties](https://github.com/owncloud/ocis/issues/1297)
 -   [apiWebdavProperties2/getFileProperties.feature:266](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties2/getFileProperties.feature#L266)
 -   [apiWebdavProperties2/getFileProperties.feature:301](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties2/getFileProperties.feature#L301)
 -   [apiWebdavProperties2/getFileProperties.feature:302](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties2/getFileProperties.feature#L302)
@@ -999,7 +1000,7 @@
 -   [apiWebdavProperties2/getFileProperties.feature:454](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties2/getFileProperties.feature#L454)
 -   [apiWebdavProperties2/getFileProperties.feature:455](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties2/getFileProperties.feature#L455)
 
-### [filename cannot contain ?](https://github.com/owncloud/ocis-reva/issues/265)
+### [filename cannot contain ?](https://github.com/owncloud/ocis/issues/1259)
 -   [apiWebdavUpload1/uploadFile.feature:48](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUpload1/uploadFile.feature#L48)
 -   [apiWebdavUpload1/uploadFile.feature:49](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUpload1/uploadFile.feature#L49)
 -   [apiWebdavUpload1/uploadFile.feature:50](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUpload1/uploadFile.feature#L50)
@@ -1011,19 +1012,19 @@
 -   [apiWebdavUpload1/uploadFile.feature:97](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUpload1/uploadFile.feature#L97)
 -   [apiWebdavUpload1/uploadFile.feature:98](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUpload1/uploadFile.feature#L98)
 
-### [blacklisted filenames like .htaccess & file.parts can be uploaded](https://github.com/owncloud/ocis-reva/issues/15)
+### [blacklisted filenames like .htaccess & file.parts can be uploaded](https://github.com/owncloud/ocis/issues/1345)
 -   [apiWebdavUpload1/uploadFile.feature:112](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUpload1/uploadFile.feature#L112)
 -   [apiWebdavUpload1/uploadFile.feature:113](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUpload1/uploadFile.feature#L113)
 -   [apiWebdavUpload1/uploadFileToBlacklistedName.feature:19](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUpload1/uploadFileToBlacklistedName.feature#L19)
 -   [apiWebdavUpload1/uploadFileToBlacklistedName.feature:20](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUpload1/uploadFileToBlacklistedName.feature#L20)
 
-### [system configuration options missing](https://github.com/owncloud/ocis-reva/issues/54)
+### [system configuration options missing](https://github.com/owncloud/ocis/issues/1323)
 -   [apiWebdavUpload1/uploadFileToBlacklistedName.feature:31](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUpload1/uploadFileToBlacklistedName.feature#L31)
 -   [apiWebdavUpload1/uploadFileToBlacklistedName.feature:32](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUpload1/uploadFileToBlacklistedName.feature#L32)
 -   [apiWebdavUpload1/uploadFileToBlacklistedName.feature:65](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUpload1/uploadFileToBlacklistedName.feature#L65)
 -   [apiWebdavUpload1/uploadFileToBlacklistedName.feature:66](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUpload1/uploadFileToBlacklistedName.feature#L66)
 
-### [blacklisted filenames like .htaccess & file.parts can be uploaded](https://github.com/owncloud/ocis-reva/issues/15)
+### [blacklisted filenames like .htaccess & file.parts can be uploaded](https://github.com/owncloud/ocis/issues/1345)
 -   [apiWebdavUpload2/uploadFileToBlacklistedNameUsingOldChunking.feature:13](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUpload2/uploadFileToBlacklistedNameUsingOldChunking.feature#L13)
 -   [apiWebdavUpload2/uploadFileToBlacklistedNameUsingOldChunking.feature:20](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUpload2/uploadFileToBlacklistedNameUsingOldChunking.feature#L20)
 -   [apiWebdavUpload2/uploadFileToBlacklistedNameUsingOldChunking.feature:37](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUpload2/uploadFileToBlacklistedNameUsingOldChunking.feature#L37)
@@ -1031,7 +1032,7 @@
 -   [apiWebdavUpload2/uploadFileToBlacklistedNameUsingOldChunking.feature:39](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUpload2/uploadFileToBlacklistedNameUsingOldChunking.feature#L39)
 -   [apiWebdavUpload2/uploadFileToBlacklistedNameUsingOldChunking.feature:42](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUpload2/uploadFileToBlacklistedNameUsingOldChunking.feature#L42)
 
-### [blacklisted filenames like .htaccess & file.parts can be uploaded](https://github.com/owncloud/ocis-reva/issues/15)
+### [blacklisted filenames like .htaccess & file.parts can be uploaded](https://github.com/owncloud/ocis/issues/1345)
 -   [apiWebdavUpload2/uploadFileToExcludedDirectoryUsingOldChunking.feature:13](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUpload2/uploadFileToExcludedDirectoryUsingOldChunking.feature#L13)
 -   [apiWebdavUpload2/uploadFileToExcludedDirectoryUsingOldChunking.feature:21](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUpload2/uploadFileToExcludedDirectoryUsingOldChunking.feature#L21)
 -   [apiWebdavUpload2/uploadFileToExcludedDirectoryUsingOldChunking.feature:39](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUpload2/uploadFileToExcludedDirectoryUsingOldChunking.feature#L39)
@@ -1039,7 +1040,7 @@
 -   [apiWebdavUpload2/uploadFileToExcludedDirectoryUsingOldChunking.feature:41](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUpload2/uploadFileToExcludedDirectoryUsingOldChunking.feature#L41)
 -   [apiWebdavUpload2/uploadFileToExcludedDirectoryUsingOldChunking.feature:44](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUpload2/uploadFileToExcludedDirectoryUsingOldChunking.feature#L44)
 
-### [uploading with old-chunking does not work](https://github.com/owncloud/ocis-reva/issues/17)
+### [uploading with old-chunking does not work](https://github.com/owncloud/ocis/issues/1343)
 -   [apiWebdavUpload2/uploadFileUsingOldChunking.feature:13](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUpload2/uploadFileUsingOldChunking.feature#L13)
 -   [apiWebdavUpload2/uploadFileUsingOldChunking.feature:26](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUpload2/uploadFileUsingOldChunking.feature#L26)
 -   [apiWebdavUpload2/uploadFileUsingOldChunking.feature:35](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUpload2/uploadFileUsingOldChunking.feature#L35)

--- a/tests/acceptance/expected-failures-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-on-OCIS-storage.md
@@ -1,4 +1,4 @@
-## Scenarios from ownCloud10 core api tests that are expected to fail with OCIS storage
+## Scenarios from ownCloud10 core API tests that are expected to fail with OCIS storage
 
 ### Test scenarios that specifically fail with OCIS storage
 

--- a/tests/acceptance/expected-failures-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-on-OCIS-storage.md
@@ -1,9 +1,11 @@
-## Scenarios from ownCloud10 core API tests that are expected to fail with OCIS storage
+## Scenarios from ownCloud10 core api tests that are expected to fail with OCIS storage
+
+### Test scenarios that specifically fail with OCIS storage
 
 -   [apiWebdavProperties1/setFileProperties.feature:32](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/setFileProperties.feature#L32)
 -   [apiWebdavProperties1/setFileProperties.feature:33](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/setFileProperties.feature#L33)
 
-### [Checksum feature](https://github.com/owncloud/ocis-reva/issues/196)
+### [Checksum feature](https://github.com/owncloud/ocis/issues/1291)
 -   [apiMain/checksums.feature:58](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiMain/checksums.feature#L58)
 -   [apiMain/checksums.feature:67](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiMain/checksums.feature#L67)
 -   [apiMain/checksums.feature:119](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiMain/checksums.feature#L119)
@@ -17,11 +19,11 @@
 -   [apiMain/checksums.feature:312](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiMain/checksums.feature#L312)
 -   [apiMain/checksums.feature:324](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiMain/checksums.feature#L324)
 
-### [no robots.txt available](https://github.com/owncloud/ocis-reva/issues/100)
+### [no robots.txt available](https://github.com/owncloud/ocis/issues/1314)
 
 -   [apiMain/main.feature:5](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiMain/main.feature#L5)
 
-### [quota query](https://github.com/owncloud/ocis-reva/issues/101)
+### [quota query](https://github.com/owncloud/ocis/issues/1313)
 
 -   [apiMain/quota.feature:9](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiMain/quota.feature#L9)
 -   [apiMain/quota.feature:16](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiMain/quota.feature#L16)
@@ -34,13 +36,13 @@
 -   [apiMain/quota.feature:99](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiMain/quota.feature#L99)
 -   [apiMain/quota.feature:112](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiMain/quota.feature#L112)
 
-### [There is no such thing like a "super-user"](https://github.com/owncloud/ocis-reva/issues/65)
-### [no command equivalent to occ](https://github.com/owncloud/ocis-reva/issues/97)
+### [There is no such thing like a "super-user"](https://github.com/owncloud/ocis/issues/1319)
+### [no command equivalent to occ](https://github.com/owncloud/ocis/issues/1317)
 
 -   [apiMain/status.feature:5](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiMain/status.feature#L5)
 
-### [ocs config endpoint only accessible by authorized users](https://github.com/owncloud/ocis-reva/issues/29)
-### [HTTP 401 Unauthorized responses don't contain a body](https://github.com/owncloud/ocis-reva/issues/30)
+### [ocs config endpoint only accessible by authorized users](https://github.com/owncloud/ocis/issues/1338)
+### [HTTP 401 Unauthorized responses don't contain a body](https://github.com/owncloud/ocis/issues/1337)
 -   [apiAuthOcs/ocsDELETEAuth.feature:10](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiAuthOcs/ocsDELETEAuth.feature#L10)
 -   [apiAuthOcs/ocsGETAuth.feature:10](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiAuthOcs/ocsGETAuth.feature#L10)
 -   [apiAuthOcs/ocsGETAuth.feature:33](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiAuthOcs/ocsGETAuth.feature#L33)
@@ -54,7 +56,7 @@
 ### [server returns 500 when trying to access a not existing file](https://github.com/owncloud/ocis-reva/issues/13)
 -   [apiAuthWebDav/webDavDELETEAuth.feature:36](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiAuthWebDav/webDavDELETEAuth.feature#L36)
 
-### [users can access each-others data using the new webdav API](https://github.com/owncloud/ocis-reva/issues/9)
+### [users can access each-others data using the new webdav API](https://github.com/owncloud/ocis/issues/1347)
 -   [apiAuthWebDav/webDavLOCKAuth.feature:38](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiAuthWebDav/webDavLOCKAuth.feature#L38)
 -   [apiAuthWebDav/webDavMKCOLAuth.feature:37](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiAuthWebDav/webDavMKCOLAuth.feature#L37)
 -   [apiAuthWebDav/webDavPROPFINDAuth.feature:37](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiAuthWebDav/webDavPROPFINDAuth.feature#L37)
@@ -63,18 +65,42 @@
 ### [renaming a resource does not work](https://github.com/owncloud/ocis-reva/issues/14)
 -   [apiAuthWebDav/webDavMOVEAuth.feature:37](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiAuthWebDav/webDavMOVEAuth.feature#L37)
 
-### [send POST requests to another user's webDav endpoints as normal user](https://github.com/owncloud/ocis-reva/issues/179)
+### [send POST requests to another user's webDav endpoints as normal user](https://github.com/owncloud/ocis/issues/1287)
 -   [apiAuthWebDav/webDavPOSTAuth.feature:38](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiAuthWebDav/webDavPOSTAuth.feature#L38)
 
 ### [PUT request with missing parent must return status code 409](https://github.com/owncloud/ocis/issues/824)
 -   [apiAuthWebDav/webDavPUTAuth.feature:38](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiAuthWebDav/webDavPUTAuth.feature#L38)
 
-### [Default capabilities for normal user not same as in oC-core](https://github.com/owncloud/ocis-reva/issues/175)
-### [Difference in response content of status.php and default capabilities](https://github.com/owncloud/ocis-reva/issues/176)
+### [Default capabilities for normal user not same as in oC-core](https://github.com/owncloud/ocis/issues/1285)
+### [Difference in response content of status.php and default capabilities](https://github.com/owncloud/ocis/issues/1286)
 -   [apiCapabilities/capabilitiesWithNormalUser.feature:11](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiCapabilities/capabilitiesWithNormalUser.feature#L11)
 
-### [REPORT request not implemented](https://github.com/owncloud/ocis-reva/issues/39)
-And other missing implementation of favorites
+### [REPORT request not implemented](https://github.com/owncloud/ocis/issues/1330)
+-   [apiWebdavOperations/search.feature:42](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L42)
+-   [apiWebdavOperations/search.feature:43](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L43)
+-   [apiWebdavOperations/search.feature:57](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L57)
+-   [apiWebdavOperations/search.feature:58](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L58)
+-   [apiWebdavOperations/search.feature:74](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L74)
+-   [apiWebdavOperations/search.feature:75](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L75)
+-   [apiWebdavOperations/search.feature:83](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L83)
+-   [apiWebdavOperations/search.feature:84](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L84)
+-   [apiWebdavOperations/search.feature:101](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L101)
+-   [apiWebdavOperations/search.feature:102](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L102)
+-   [apiWebdavOperations/search.feature:119](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L119)
+-   [apiWebdavOperations/search.feature:120](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L120)
+-   [apiWebdavOperations/search.feature:138](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L138)
+-   [apiWebdavOperations/search.feature:139](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L139)
+-   [apiWebdavOperations/search.feature:165](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L165)
+-   [apiWebdavOperations/search.feature:166](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L166)
+-   [apiWebdavOperations/search.feature:191](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L191)
+-   [apiWebdavOperations/search.feature:192](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L192)
+-   [apiWebdavOperations/search.feature:210](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L210)
+-   [apiWebdavOperations/search.feature:211](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L211)
+-   [apiWebdavOperations/search.feature:213](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L213)
+-   [apiWebdavOperations/search.feature:229](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L229)
+-   [apiWebdavOperations/search.feature:254](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L254)
+
+ And other missing implementation of favorites
 -   [apiFavorites/favorites.feature:91](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiFavorites/favorites.feature#L91)
 -   [apiFavorites/favorites.feature:92](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiFavorites/favorites.feature#L92)
 -   [apiFavorites/favorites.feature:112](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiFavorites/favorites.feature#L112)
@@ -97,7 +123,7 @@ And other missing implementation of favorites
 -   [apiFavorites/favoritesSharingToShares.feature:64](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiFavorites/favoritesSharingToShares.feature#L64)
 
 ### [Cannot create user with different username and emails](https://github.com/owncloud/product/issues/187)
-special character username not valid
+ special character username not valid
 
 -   [apiProvisioning-v1/addUser.feature:29](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiProvisioning-v1/addUser.feature#L29)
 -   [apiProvisioning-v1/addUser.feature:30](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiProvisioning-v1/addUser.feature#L30)
@@ -152,7 +178,7 @@ special character username not valid
 -   [apiProvisioning-v2/apiProvisioningUsingAppPassword.feature:39](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiProvisioning-v2/apiProvisioningUsingAppPassword.feature#L39)
 -   [apiProvisioning-v2/apiProvisioningUsingAppPassword.feature:67](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiProvisioning-v2/apiProvisioningUsingAppPassword.feature#L67)
 
-### [disable users /cloud/users/disable|enable not available](https://github.com/owncloud/ocis-ocs/issues/28)
+### [disable users /cloud/users/disable|enable not available](https://github.com/owncloud/ocis/issues/1420)
 -   [apiProvisioning-v1/disableUser.feature:99](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiProvisioning-v1/disableUser.feature#L99)
 -   [apiProvisioning-v1/disableUser.feature:129](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiProvisioning-v1/disableUser.feature#L129)
 -   [apiProvisioning-v1/disableUser.feature:165](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiProvisioning-v1/disableUser.feature#L165)
@@ -300,7 +326,7 @@ special character username not valid
 -   [apiShareManagementToShares/mergeShare.feature:42](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareManagementToShares/mergeShare.feature#L42)
 -   [apiShareManagementToShares/mergeShare.feature:89](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareManagementToShares/mergeShare.feature#L89)
 
-### [Shares are not deleted when user is deleted](https://github.com/owncloud/ocis-reva/issues/262)
+### [Shares are not deleted when user is deleted](https://github.com/owncloud/ocis/issues/1258)
 -   [apiShareManagementBasicToShares/createShareToSharesFolder.feature:100](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareManagementBasicToShares/createShareToSharesFolder.feature#L100)
 -   [apiShareManagementBasicToShares/createShareToSharesFolder.feature:101](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareManagementBasicToShares/createShareToSharesFolder.feature#L101)
 
@@ -348,7 +374,8 @@ special character username not valid
 -   [apiShareManagementBasicToShares/deleteShareFromShares.feature:58](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareManagementBasicToShares/deleteShareFromShares.feature#L58)
 -   [apiShareManagementBasicToShares/deleteShareFromShares.feature:72](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareManagementBasicToShares/deleteShareFromShares.feature#L72)
 
-### [Listing shares via ocs API does not show path for parent folders](https://github.com/owncloud/ocis-reva/issues/372)
+ cannot share a folder with create permission
+### [Listing shares via ocs API does not show path for parent folders](https://github.com/owncloud/ocis/issues/1231)
 
 -   [apiShareManagementBasicToShares/deleteShareFromShares.feature:118](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareManagementBasicToShares/deleteShareFromShares.feature#L118)
 -   [apiShareManagementBasicToShares/deleteShareFromShares.feature:130](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareManagementBasicToShares/deleteShareFromShares.feature#L130)
@@ -357,11 +384,11 @@ special character username not valid
 -   [apiShareManagementBasicToShares/deleteShareFromShares.feature:183](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareManagementBasicToShares/deleteShareFromShares.feature#L183)
 -   [apiShareManagementBasicToShares/deleteShareFromShares.feature:184](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareManagementBasicToShares/deleteShareFromShares.feature#L184)
 
-### [Shares are not deleted when user is deleted](https://github.com/owncloud/ocis-reva/issues/262)
+### [Shares are not deleted when user is deleted](https://github.com/owncloud/ocis/issues/1258)
 -   [apiShareOperationsToShares/gettingShares.feature:24](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareOperationsToShares/gettingShares.feature#L24)
 -   [apiShareOperationsToShares/gettingShares.feature:25](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareOperationsToShares/gettingShares.feature#L25)
 
-### [There is no such thing like a super-user](https://github.com/owncloud/ocis-reva/issues/65)
+### [There is no such thing like a super-user](https://github.com/owncloud/ocis/issues/1319)
 
 -   [apiShareOperationsToShares/gettingShares.feature:38](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareOperationsToShares/gettingShares.feature#L38)
 -   [apiShareOperationsToShares/gettingShares.feature:39](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareOperationsToShares/gettingShares.feature#L39)
@@ -373,12 +400,12 @@ special character username not valid
 -   [apiShareOperationsToShares/gettingShares.feature:135](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareOperationsToShares/gettingShares.feature#L135)
 -   [apiShareOperationsToShares/gettingShares.feature:136](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareOperationsToShares/gettingShares.feature#L136)
 
-### [OCS error message for attempting to access share via share id as an unauthorized user is not informative](https://github.com/owncloud/ocis-reva/issues/374)
+### [OCS error message for attempting to access share via share id as an unauthorized user is not informative](https://github.com/owncloud/ocis/issues/1233)
 
 -   [apiShareOperationsToShares/gettingShares.feature:180](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareOperationsToShares/gettingShares.feature#L180)
 -   [apiShareOperationsToShares/gettingShares.feature:181](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareOperationsToShares/gettingShares.feature#L181)
 
-### [Listing shares via ocs API does not show path for parent folders](https://github.com/owncloud/ocis-reva/issues/372)
+### [Listing shares via ocs API does not show path for parent folders](https://github.com/owncloud/ocis/issues/1231)
 
 -   [apiShareOperationsToShares/gettingShares.feature:219](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareOperationsToShares/gettingShares.feature#L219)
 -   [apiShareOperationsToShares/gettingShares.feature:220](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareOperationsToShares/gettingShares.feature#L220)
@@ -430,7 +457,7 @@ special character username not valid
 -   [apiSharePublicLink1/createPublicLinkShare.feature:790](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature#L790)
 
 ### [Split old public API webdav tests from new public webdav tests](https://github.com/owncloud/ocis-reva/issues/282)
-### [Public link enforce permissions](https://github.com/owncloud/ocis-reva/issues/292)
+### [Public link enforce permissions](https://github.com/owncloud/ocis/issues/1269)
 ### [Previews via webDAV API tests fail on OCIS](https://github.com/owncloud/ocis/issues/187)
 
 -   [apiSharePublicLink1/accessToPublicLinkShare.feature:10](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/accessToPublicLinkShare.feature#L10)
@@ -456,7 +483,7 @@ special character username not valid
 -   [apiSharePublicLink1/changingPublicLinkShare.feature:197](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/changingPublicLinkShare.feature#L197)
 -   [apiSharePublicLink1/changingPublicLinkShare.feature:244](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/changingPublicLinkShare.feature#L244)
 
-### [Public link enforce permissions](https://github.com/owncloud/ocis-reva/issues/292)
+### [Public link enforce permissions](https://github.com/owncloud/ocis/issues/1269)
 
 -   [apiSharePublicLink1/changingPublicLinkShare.feature:267](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/changingPublicLinkShare.feature#L267)
 -   [apiSharePublicLink1/changingPublicLinkShare.feature:289](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/changingPublicLinkShare.feature#L289)
@@ -471,21 +498,21 @@ special character username not valid
 -   [apiSharePublicLink1/createPublicLinkShare.feature:370](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature#L370)
 -   [apiSharePublicLink1/createPublicLinkShare.feature:371](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature#L371)
 
-### [Range Header is not obeyed when downloading a file](https://github.com/owncloud/ocis-reva/issues/12)
+### [Range Header is not obeyed when downloading a file](https://github.com/owncloud/ocis/issues/1346)
 
 -   [apiSharePublicLink1/createPublicLinkShare.feature:95](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature#L95)
 -   [apiSharePublicLink1/createPublicLinkShare.feature:96](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature#L96)
 -   [apiSharePublicLink1/createPublicLinkShare.feature:276](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature#L276)
 -   [apiSharePublicLink1/createPublicLinkShare.feature:277](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature#L277)
 
-### [Ability to return error messages in Webdav response bodies](https://github.com/owncloud/ocis-reva/issues/199)
+### [Ability to return error messages in Webdav response bodies](https://github.com/owncloud/ocis/issues/1293)
 
 -   [apiSharePublicLink1/createPublicLinkShare.feature:127](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature#L127)
 -   [apiSharePublicLink1/createPublicLinkShare.feature:128](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature#L128)
 -   [apiSharePublicLink1/createPublicLinkShare.feature:155](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature#L155)
 -   [apiSharePublicLink1/createPublicLinkShare.feature:156](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature#L156)
 
-### [various sharing settings cannot be set](https://github.com/owncloud/ocis-reva/issues/41)
+### [various sharing settings cannot be set](https://github.com/owncloud/ocis/issues/1328)
 
 -   [apiSharePublicLink1/createPublicLinkShare.feature:410](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature#L410)
 -   [apiSharePublicLink1/createPublicLinkShare.feature:411](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature#L411)
@@ -533,7 +560,7 @@ special character username not valid
 -   [apiSharePublicLink1/createPublicLinkShare.feature:733](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature#L733)
 -   [apiSharePublicLink1/createPublicLinkShare.feature:742](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature#L742)
 
-### [copying a folder within a public link folder to folder with same name as an already existing file overwrites the parent file](https://github.com/owncloud/ocis-reva/issues/373)
+### [copying a folder within a public link folder to folder with same name as an already existing file overwrites the parent file](https://github.com/owncloud/ocis/issues/1232)
 
 -   [apiSharePublicLink2/copyFromPublicLink.feature:60](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/copyFromPublicLink.feature#L60)
 -   [apiSharePublicLink2/copyFromPublicLink.feature:85](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/copyFromPublicLink.feature#L85)
@@ -557,7 +584,7 @@ special character username not valid
 -   [apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature:179](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature#L179)
 -   [apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature:180](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature#L180)
 
-### [OCIS old public webdav api does not work](https://github.com/owncloud/product/issues/272)
+### [OCIS old public webdav api doesnt works](https://github.com/owncloud/product/issues/272)
 
 -   [apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature:30](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature#L30)
 -   [apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature:31](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature#L31)
@@ -589,7 +616,7 @@ special character username not valid
 -   [apiSharePublicLink2/updatePublicLinkShare.feature:476](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L476)
 -   [apiSharePublicLink2/updatePublicLinkShare.feature:477](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L477)
 
-### [Public link enforce permissions](https://github.com/owncloud/ocis-reva/issues/292)
+### [Public link enforce permissions](https://github.com/owncloud/ocis/issues/1269)
 
 -   [apiSharePublicLink2/updatePublicLinkShare.feature:523](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L523)
 -   [apiSharePublicLink2/updatePublicLinkShare.feature:524](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L524)
@@ -599,7 +626,7 @@ special character username not valid
 -   [apiSharePublicLink2/uploadToPublicLinkShare.feature:121](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L121)
 -   [apiSharePublicLink2/uploadToPublicLinkShare.feature:139](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L139)
 
-### Upload to deleted public link share returns 401 instead of 404
+### [Upload-only shares must not overwrite but create a separate file](https://github.com/owncloud/ocis/issues/1267)
 
 -   [apiSharePublicLink2/uploadToPublicLinkShare.feature:48](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L48)
 -   [apiSharePublicLink2/uploadToPublicLinkShare.feature:49](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L49)
@@ -609,17 +636,17 @@ special character username not valid
 -   [apiSharePublicLink2/uploadToPublicLinkShare.feature:23](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L23)
 -   [apiSharePublicLink2/uploadToPublicLinkShare.feature:273](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L273)
 
-### [Accessing non-existing public link should return 404, not 500](https://github.com/owncloud/ocis-reva/issues/290)
+### [Accessing non-existing public link should return 404, not 500](https://github.com/owncloud/ocis/issues/1268)
 
 -   [apiSharePublicLink2/uploadToPublicLinkShare.feature:66](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L66)
 
-### [Set quota over settings](https://github.com/owncloud/ocis-reva/issues/195)
+### [Set quota over settings](https://github.com/owncloud/ocis/issues/1290)
 -   [apiSharePublicLink2/uploadToPublicLinkShare.feature:148](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L148)
 -   [apiSharePublicLink2/uploadToPublicLinkShare.feature:158](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L158)
 -   [apiSharePublicLink2/uploadToPublicLinkShare.feature:167](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L167)
 -   [apiSharePublicLink2/uploadToPublicLinkShare.feature:177](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L177)
 
-### [various sharing settings cannot be set](https://github.com/owncloud/ocis-reva/issues/41)
+### [various sharing settings cannot be set](https://github.com/owncloud/ocis/issues/1328)
 
 -   [apiSharePublicLink2/uploadToPublicLinkShare.feature:186](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L186)
 -   [apiSharePublicLink2/uploadToPublicLinkShare.feature:196](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L196)
@@ -693,7 +720,7 @@ special character username not valid
 
 -   [apiShareReshareToShares2/reShareChain.feature:10](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareReshareToShares2/reShareChain.feature#L10)
 
-### [various sharing settings cannot be set](https://github.com/owncloud/ocis-reva/issues/41)
+### [various sharing settings cannot be set](https://github.com/owncloud/ocis/issues/1328)
 
 -   [apiShareReshareToShares2/reShareDisabled.feature:24](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareReshareToShares2/reShareDisabled.feature#L24)
 -   [apiShareReshareToShares2/reShareDisabled.feature:25](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareReshareToShares2/reShareDisabled.feature#L25)
@@ -771,7 +798,7 @@ special character username not valid
 -   [apiTrashbin/trashbinDelete.feature:67](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiTrashbin/trashbinDelete.feature#L67)
 
 ### [href in trashbin PROPFIND response is wrong](https://github.com/owncloud/ocis/issues/1120)
-### [trashcan cannot delete a deep tree](https://github.com/owncloud/ocis/issues/1077)
+### [QA trashcan cannot delete a deep tree](https://github.com/owncloud/ocis/issues/1077)
 
 -   [apiTrashbin/trashbinDelete.feature:107](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiTrashbin/trashbinDelete.feature#L107)
 -   [apiTrashbin/trashbinDelete.feature:123](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiTrashbin/trashbinDelete.feature#L123)
@@ -869,8 +896,8 @@ special character username not valid
 -   [apiTrashbin/trashbinSharingToShares.feature:102](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiTrashbin/trashbinSharingToShares.feature#L102)
 -   [apiTrashbin/trashbinSharingToShares.feature:103](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiTrashbin/trashbinSharingToShares.feature#L103)
 
-### [uploading with old-chunking does not work](https://github.com/owncloud/ocis-reva/issues/17)
-### [remote.php/dav/uploads endpoint does not exist](https://github.com/owncloud/ocis-reva/issues/56)
+### [uploading with old-chunking does not work](https://github.com/owncloud/ocis/issues/1343)
+### [remote.php/dav/uploads endpoint does not exist](https://github.com/owncloud/ocis/issues/1321)
 
 -   [apiVersions/fileVersions.feature:15](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiVersions/fileVersions.feature#L15)
 -   [apiVersions/fileVersions.feature:23](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiVersions/fileVersions.feature#L23)
@@ -976,7 +1003,7 @@ special character username not valid
 -   [apiWebdavMove1/moveFileToExcludedDirectoryAsync.feature:19](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavMove1/moveFileToExcludedDirectoryAsync.feature#L19)
 -   [apiWebdavMove1/moveFileToExcludedDirectoryAsync.feature:27](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavMove1/moveFileToExcludedDirectoryAsync.feature#L27)
 
-### [renaming to banned name works](https://github.com/owncloud/ocis-reva/issues/211)
+### [renaming to banned name works](https://github.com/owncloud/ocis/issues/1295)
 
 -   [apiWebdavMove1/moveFolder.feature:21](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavMove1/moveFolder.feature#L21)
 -   [apiWebdavMove1/moveFolder.feature:22](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavMove1/moveFolder.feature#L22)
@@ -1055,7 +1082,7 @@ special character username not valid
 -   [apiWebdavOperations/deleteFolder.feature:91](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/deleteFolder.feature#L91)
 -   [apiWebdavOperations/deleteFolder.feature:92](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/deleteFolder.feature#L92)
 
-### [Range Header is not obeyed when downloading a file](https://github.com/owncloud/ocis-reva/issues/12)
+### [Range Header is not obeyed when downloading a file](https://github.com/owncloud/ocis/issues/1346)
 ### [Review and fix the tests that have sharing step to work with ocis](https://github.com/owncloud/core/issues/38006)
 
 -   [apiWebdavOperations/downloadFile.feature:60](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/downloadFile.feature#L60)
@@ -1069,32 +1096,6 @@ special character username not valid
 -   [apiWebdavOperations/refuseAccess.feature:33](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/refuseAccess.feature#L33)
 -   [apiWebdavOperations/refuseAccess.feature:34](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/refuseAccess.feature#L34)
 
-### [REPORT request not implemented](https://github.com/owncloud/ocis-reva/issues/39)
-
--   [apiWebdavOperations/search.feature:42](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L42)
--   [apiWebdavOperations/search.feature:43](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L43)
--   [apiWebdavOperations/search.feature:57](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L57)
--   [apiWebdavOperations/search.feature:58](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L58)
--   [apiWebdavOperations/search.feature:74](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L74)
--   [apiWebdavOperations/search.feature:75](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L75)
--   [apiWebdavOperations/search.feature:83](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L83)
--   [apiWebdavOperations/search.feature:84](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L84)
--   [apiWebdavOperations/search.feature:101](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L101)
--   [apiWebdavOperations/search.feature:102](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L102)
--   [apiWebdavOperations/search.feature:119](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L119)
--   [apiWebdavOperations/search.feature:120](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L120)
--   [apiWebdavOperations/search.feature:138](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L138)
--   [apiWebdavOperations/search.feature:139](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L139)
--   [apiWebdavOperations/search.feature:165](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L165)
--   [apiWebdavOperations/search.feature:166](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L166)
--   [apiWebdavOperations/search.feature:191](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L191)
--   [apiWebdavOperations/search.feature:192](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L192)
--   [apiWebdavOperations/search.feature:210](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L210)
--   [apiWebdavOperations/search.feature:211](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L211)
--   [apiWebdavOperations/search.feature:213](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L213)
--   [apiWebdavOperations/search.feature:229](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L229)
--   [apiWebdavOperations/search.feature:254](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L254)
-
 ### [Review and fix the tests that have sharing step to work with ocis](https://github.com/owncloud/core/issues/38006)
 
 -   [apiWebdavProperties1/copyFile.feature:65](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/copyFile.feature#L65)
@@ -1102,7 +1103,7 @@ special character username not valid
 -   [apiWebdavProperties1/copyFile.feature:85](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/copyFile.feature#L85)
 -   [apiWebdavProperties1/copyFile.feature:86](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/copyFile.feature#L86)
 
-### [blacklisted filenames like .htaccess & file.parts can be uploaded](https://github.com/owncloud/ocis-reva/issues/15)
+### [blacklisted filenames like .htaccess & file.parts can be uploaded](https://github.com/owncloud/ocis/issues/1345)
 
 -   [apiWebdavProperties1/copyFile.feature:102](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/copyFile.feature#L102)
 -   [apiWebdavProperties1/copyFile.feature:103](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/copyFile.feature#L103)
@@ -1123,7 +1124,7 @@ special character username not valid
 -   [apiWebdavUpload2/uploadFileToExcludedDirectoryUsingOldChunking.feature:38](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUpload2/uploadFileToExcludedDirectoryUsingOldChunking.feature#L38)
 -   [apiWebdavUpload2/uploadFileToExcludedDirectoryUsingOldChunking.feature:39](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUpload2/uploadFileToExcludedDirectoryUsingOldChunking.feature#L39)
 
-### [Getting information about a folder overwritten by a file gives 500 error instead of 404](https://github.com/owncloud/ocis-reva/issues/387)
+### [Getting information about a folder overwritten by a file gives 500 error instead of 404](https://github.com/owncloud/ocis/issues/1239)
 
 -   [apiWebdavProperties1/copyFile.feature:116](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/copyFile.feature#L116)
 -   [apiWebdavProperties1/copyFile.feature:117](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/copyFile.feature#L117)
@@ -1151,14 +1152,14 @@ special character username not valid
 -   [apiWebdavProperties1/copyFile.feature:474](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/copyFile.feature#L474)
 -   [apiWebdavProperties1/copyFile.feature:475](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/copyFile.feature#L475)
 
-### [creating a folder that already exists returns an empty body](https://github.com/owncloud/ocis-reva/issues/168)
+### [creating a folder that already exists returns an empty body](https://github.com/owncloud/ocis/issues/1283)
 
 -   [apiWebdavProperties1/createFolder.feature:85](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/createFolder.feature#L85)
 -   [apiWebdavProperties1/createFolder.feature:86](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/createFolder.feature#L86)
 -   [apiWebdavProperties1/createFolder.feature:99](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/createFolder.feature#L99)
 -   [apiWebdavProperties1/createFolder.feature:100](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/createFolder.feature#L100)
 
-### [quota query](https://github.com/owncloud/ocis-reva/issues/101)
+### [quota query](https://github.com/owncloud/ocis/issues/1313)
 
 -   [apiWebdavProperties1/getQuota.feature:17](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/getQuota.feature#L17)
 -   [apiWebdavProperties1/getQuota.feature:18](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/getQuota.feature#L18)
@@ -1171,12 +1172,12 @@ special character username not valid
 -   [apiWebdavProperties1/getQuota.feature:77](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/getQuota.feature#L77)
 -   [apiWebdavProperties1/getQuota.feature:78](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/getQuota.feature#L78)
 
-### [Some failing tests with Webdav custom properties](https://github.com/owncloud/ocis-reva/issues/217)
+### [Some failing tests with Webdav custom properties](https://github.com/owncloud/ocis/issues/1297)
 
 -   [apiWebdavProperties1/setFileProperties.feature:63](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/setFileProperties.feature#L63)
 -   [apiWebdavProperties1/setFileProperties.feature:64](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/setFileProperties.feature#L64)
 
-### [XML properties in webdav response not properly encoded](https://github.com/owncloud/ocis-reva/issues/214)
+### [XML properties in webdav response not properly encoded](https://github.com/owncloud/ocis/issues/1296)
 
 -   [apiWebdavProperties2/getFileProperties.feature:37](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties2/getFileProperties.feature#L37)
 -   [apiWebdavProperties2/getFileProperties.feature:39](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties2/getFileProperties.feature#L39)
@@ -1207,13 +1208,13 @@ special character username not valid
 -   [apiWebdavProperties2/getFileProperties.feature:206](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties2/getFileProperties.feature#L206)
 -   [apiWebdavProperties2/getFileProperties.feature:207](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties2/getFileProperties.feature#L207)
 
-### [Private link support](https://github.com/owncloud/ocis-reva/issues/216)
+### [Private link support](https://github.com/owncloud/product/issues/201)
 ### [oc:privatelink property not returned in webdav responses](https://github.com/owncloud/product/issues/262)
 
 -   [apiWebdavProperties2/getFileProperties.feature:232](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties2/getFileProperties.feature#L232)
 -   [apiWebdavProperties2/getFileProperties.feature:233](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties2/getFileProperties.feature#L233)
 
-### [trying to access a non-existing resource returns an empty body](https://github.com/owncloud/ocis-reva/issues/163)
+### [trying to access a non-existing resource returns an empty body](https://github.com/owncloud/ocis/issues/1282)
 
 -   [apiWebdavProperties2/getFileProperties.feature:242](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties2/getFileProperties.feature#L242)
 -   [apiWebdavProperties2/getFileProperties.feature:243](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties2/getFileProperties.feature#L243)
@@ -1223,7 +1224,7 @@ special character username not valid
 -   [apiWebdavProperties2/getFileProperties.feature:246](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties2/getFileProperties.feature#L246)
 -   [apiWebdavProperties2/getFileProperties.feature:266](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties2/getFileProperties.feature#L266)
 
-### [Different webdav properties from core](https://github.com/owncloud/ocis-reva/issues/236)
+### [Different webdav properties from core](https://github.com/owncloud/ocis/issues/1302)
 
 -   [apiWebdavProperties2/getFileProperties.feature:301](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties2/getFileProperties.feature#L301)
 -   [apiWebdavProperties2/getFileProperties.feature:302](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties2/getFileProperties.feature#L302)
@@ -1254,14 +1255,14 @@ special character username not valid
 -   [apiWebdavUpload1/uploadFile.feature:112](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUpload1/uploadFile.feature#L112)
 -   [apiWebdavUpload1/uploadFile.feature:113](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUpload1/uploadFile.feature#L113)
 
-### [system configuration options missing](https://github.com/owncloud/ocis-reva/issues/54)
+### [system configuration options missing](https://github.com/owncloud/ocis/issues/1323)
 
 -   [apiWebdavUpload1/uploadFileToBlacklistedName.feature:31](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUpload1/uploadFileToBlacklistedName.feature#L31)
 -   [apiWebdavUpload1/uploadFileToBlacklistedName.feature:32](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUpload1/uploadFileToBlacklistedName.feature#L32)
 -   [apiWebdavUpload1/uploadFileToBlacklistedName.feature:65](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUpload1/uploadFileToBlacklistedName.feature#L65)
 -   [apiWebdavUpload1/uploadFileToBlacklistedName.feature:66](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUpload1/uploadFileToBlacklistedName.feature#L66)
 
-### [ uploading with old-chunking does not work](https://github.com/owncloud/ocis-reva/issues/17)
+### [uploading with old-chunking does not work](https://github.com/owncloud/ocis/issues/1343)
 
 -   [apiWebdavUpload2/uploadFileUsingOldChunking.feature:43](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUpload2/uploadFileUsingOldChunking.feature#L43)
 -   [apiWebdavUpload2/uploadFileUsingOldChunking.feature:96](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUpload2/uploadFileUsingOldChunking.feature#L96)
@@ -1353,7 +1354,7 @@ special character username not valid
 -   [apiShareOperationsToShares/changingFilesShare.feature:59](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareOperationsToShares/changingFilesShare.feature#L59)
 -   [apiShareOperationsToShares/changingFilesShare.feature:60](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareOperationsToShares/changingFilesShare.feature#L60)
 
-### [OCIS-storage - overwriting a file as share receiver, does not create a new file version for the sharer](https://github.com/owncloud/ocis/issues/766)
+### [OCIS-storage overwriting a file as share receiver, does not create a new file version for the sharer](https://github.com/owncloud/ocis/issues/766)
 
 -   [apiVersions/fileVersionsSharingToShares.feature:33](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiVersions/fileVersionsSharingToShares.feature#L33)
 
@@ -1383,11 +1384,11 @@ special character username not valid
 
 -   [apiVersions/fileVersionsSharingToShares.feature:256](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiVersions/fileVersionsSharingToShares.feature#L256)
 
-### [The version number of a file is incorrect because of the incorrect number of `<d:getetag>` and `<d:getlastmodified>` element](https://github.com/owncloud/ocis-reva/issues/376)
+### [The version number of a file is incorrect because of the incorrect number of `<d:getetag>` and `<d:getlastmodified>` element](https://github.com/owncloud/ocis/issues/1234)
 
 -   [apiVersions/fileVersionsSharingToShares.feature:267](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiVersions/fileVersionsSharingToShares.feature#L267)
 
-### [wildcard Access-Control-Allow-Origin](https://github.com/owncloud/ocis-reva/issues/27)
+### [wildcard Access-Control-Allow-Origin](https://github.com/owncloud/ocis/issues/1340)
 
 -   [apiAuth/cors.feature:24](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiAuth/cors.feature#L24)
 -   [apiAuth/cors.feature:25](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiAuth/cors.feature#L25)
@@ -1460,17 +1461,17 @@ special character username not valid
 -   [apiAuth/cors.feature:182](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiAuth/cors.feature#L182)
 -   [apiAuth/cors.feature:183](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiAuth/cors.feature#L183)
 
-### [HTTP 401 Unauthorized responses don't contain a body](https://github.com/owncloud/ocis-reva/issues/30)
-### [app passwords are not possible](https://github.com/owncloud/ocis-reva/issues/60)
+### [HTTP 401 Unauthorized responses don't contain a body](https://github.com/owncloud/ocis/issues/1337)
+### [app passwords are not possible](https://github.com/owncloud/ocis/issues/1320)
 
 -   [apiAuthOcs/ocsGETAuth.feature:243](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiAuthOcs/ocsGETAuth.feature#L243)
 
-### [app passwords are not possible](https://github.com/owncloud/ocis-reva/issues/60)
+### [app passwords are not possible](https://github.com/owncloud/ocis/issues/1320)
 
 -   [apiAuthWebDav/webDavDELETEAuth.feature:78](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiAuthWebDav/webDavDELETEAuth.feature#L78)
 -   [apiAuthWebDav/webDavDELETEAuth.feature:92](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiAuthWebDav/webDavDELETEAuth.feature#L92)
 
-### [various sharing settings cannot be set](https://github.com/owncloud/ocis-reva/issues/41)
+### [various sharing settings cannot be set](https://github.com/owncloud/ocis/issues/1328)
 
 -   [apiCapabilities/capabilities.feature:8](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiCapabilities/capabilities.feature#L8)
 -   [apiCapabilities/capabilities.feature:15](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiCapabilities/capabilities.feature#L15)
@@ -1551,7 +1552,7 @@ special character username not valid
 -   [apiMain/carddav.feature:23](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiMain/carddav.feature#L23)
 -   [apiMain/carddav.feature:31](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiMain/carddav.feature#L31)
 
-### [user-sync endpoint does not exist](https://github.com/owncloud/ocis-reva/issues/401)
+### [user-sync endpoint does not exist](https://github.com/owncloud/ocis/issues/1241)
 
 -   [apiMain/userSync.feature:18](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiMain/userSync.feature#L18)
 -   [apiMain/userSync.feature:19](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiMain/userSync.feature#L19)
@@ -1581,8 +1582,8 @@ special character username not valid
 -   [apiTranslation/translation.feature:29](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiTranslation/translation.feature#L29)
 -   [apiTranslation/translation.feature:30](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiTranslation/translation.feature#L30)
 
-### [Sharing seems to work but does not work](https://github.com/owncloud/ocis-reva/issues/243)
-### [Expiration date for user shares is not implemented](https://github.com/owncloud/ocis-reva/issues/333)
+### [Sharing seems to work but does not work](https://github.com/owncloud/ocis/issues/1303)
+### [Expiration date for user shares is not implemented](https://github.com/owncloud/ocis/issues/1250)
 
 -   [apiShareCreateSpecialToShares1/createShareExpirationDate.feature:26](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareCreateSpecialToShares1/createShareExpirationDate.feature#L26)
 -   [apiShareCreateSpecialToShares1/createShareExpirationDate.feature:27](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareCreateSpecialToShares1/createShareExpirationDate.feature#L27)
@@ -1703,7 +1704,7 @@ special character username not valid
 -   [apiShareOperationsToShares/accessToShare.feature:71](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareOperationsToShares/accessToShare.feature#L71)
 -   [apiShareOperationsToShares/accessToShare.feature:72](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareOperationsToShares/accessToShare.feature#L72)
 
-### [Sharing seems to work but does not work](https://github.com/owncloud/ocis-reva/issues/243)
+### [Sharing seems to work but does not work](https://github.com/owncloud/ocis/issues/1303)
 
 -   [apiShareCreateSpecialToShares1/createShareUniqueReceivedNames.feature:15](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareCreateSpecialToShares1/createShareUniqueReceivedNames.feature#L15)
 -   [apiShareCreateSpecialToShares2/createShareWithDisabledUser.feature:18](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareCreateSpecialToShares2/createShareWithDisabledUser.feature#L18)
@@ -1756,19 +1757,19 @@ special character username not valid
 -   [apiShareUpdateToShares/updateShare.feature:123](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareUpdateToShares/updateShare.feature#L123)
 -   [apiShareUpdateToShares/updateShare.feature:155](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareUpdateToShares/updateShare.feature#L155)
 
-### [No way to set default folder for received shares](https://github.com/owncloud/ocis-reva/issues/42)
+### [No way to set default folder for received shares](https://github.com/owncloud/ocis/issues/1327)
 
 -   [apiShareCreateSpecialToShares2/createShareDefaultFolderForReceivedShares.feature:21](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareCreateSpecialToShares2/createShareDefaultFolderForReceivedShares.feature#L21)
 -   [apiShareCreateSpecialToShares2/createShareDefaultFolderForReceivedShares.feature:22](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareCreateSpecialToShares2/createShareDefaultFolderForReceivedShares.feature#L22)
 
-### [Group shares support ](https://github.com/owncloud/ocis-reva/issues/194)
+### [Group shares support ](https://github.com/owncloud/ocis/issues/1289)
 
 -   [apiShareOperationsToShares/gettingShares.feature:103](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareOperationsToShares/gettingShares.feature#L103)
 -   [apiShareOperationsToShares/gettingShares.feature:104](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareOperationsToShares/gettingShares.feature#L104)
 -   [apiShareOperationsToShares/gettingShares.feature:184](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareOperationsToShares/gettingShares.feature#L184)
 
-### [various sharing settings cannot be set](https://github.com/owncloud/ocis-reva/issues/41)
-### [Group shares support](https://github.com/owncloud/ocis-reva/issues/194)
+### [various sharing settings cannot be set](https://github.com/owncloud/ocis/issues/1328)
+### [Group shares support](https://github.com/owncloud/ocis/issues/1289)
 
 -   [apiShareUpdateToShares/updateShare.feature:290](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareUpdateToShares/updateShare.feature#L290)
 -   [apiShareUpdateToShares/updateShare.feature:291](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareUpdateToShares/updateShare.feature#L291)
@@ -1779,8 +1780,8 @@ special character username not valid
 -   [apiShareUpdateToShares/updateShare.feature:364](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareUpdateToShares/updateShare.feature#L364)
 -   [apiShareUpdateToShares/updateShare.feature:365](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareUpdateToShares/updateShare.feature#L365)
 
-### [Group shares support](https://github.com/owncloud/ocis-reva/issues/194)
-### [Sharing seems to work but does not work](https://github.com/owncloud/ocis-reva/issues/243)
+### [Group shares support](https://github.com/owncloud/ocis/issues/1289)
+### [Sharing seems to work but does not work](https://github.com/owncloud/ocis/issues/1303)
 
 -   [apiShareUpdateToShares/updateShare.feature:61](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareUpdateToShares/updateShare.feature#L61)
 -   [apiShareUpdateToShares/updateShare.feature:62](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareUpdateToShares/updateShare.feature#L62)
@@ -1801,14 +1802,14 @@ special character username not valid
 -   [apiShareUpdateToShares/updateShareGroupAndUserWithSameName.feature:54](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareUpdateToShares/updateShareGroupAndUserWithSameName.feature#L54)
 -   [apiShareUpdateToShares/updateShareGroupAndUserWithSameName.feature:55](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareUpdateToShares/updateShareGroupAndUserWithSameName.feature#L55)
 
-### [Share additional info](https://github.com/owncloud/ocis-reva/issues/349)
-### [Share extra attributes](https://github.com/owncloud/ocis-reva/issues/350)
-### [Edit user share response has an "name" field](https://github.com/owncloud/ocis-reva/issues/352)
+### [Share additional info](https://github.com/owncloud/ocis/issues/1253)
+### [Share extra attributes](https://github.com/owncloud/ocis/issues/1224)
+### [Edit user share response has an "name" field](https://github.com/owncloud/ocis/issues/1225)
 
 -   [apiShareUpdateToShares/updateShare.feature:230](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareUpdateToShares/updateShare.feature#L230)
 -   [apiShareUpdateToShares/updateShare.feature:231](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareUpdateToShares/updateShare.feature#L231)
 
-### [Webdav LOCK operations](https://github.com/owncloud/ocis-reva/issues/172)
+### [Webdav LOCK operations](https://github.com/owncloud/ocis/issues/1284)
 
 -   [apiWebdavLocks/exclusiveLocks.feature:17](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/exclusiveLocks.feature#L17)
 -   [apiWebdavLocks/exclusiveLocks.feature:18](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/exclusiveLocks.feature#L18)
@@ -2139,7 +2140,7 @@ special character username not valid
 -   [apiWebdavLocksUnlock/unlockSharingToShares.feature:167](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocksUnlock/unlockSharingToShares.feature#L167)
 -   [apiWebdavLocksUnlock/unlockSharingToShares.feature:168](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocksUnlock/unlockSharingToShares.feature#L168)
 
-### [Getting information about a folder overwritten by a file gives 500 error instead of 404](https://github.com/owncloud/ocis-reva/issues/387)
+### [Getting information about a folder overwritten by a file gives 500 error instead of 404](https://github.com/owncloud/ocis/issues/1239)
 
 -   [apiWebdavProperties1/copyFile.feature:220](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/copyFile.feature#L220)
 -   [apiWebdavProperties1/copyFile.feature:221](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/copyFile.feature#L221)
@@ -2219,6 +2220,7 @@ special character username not valid
 -   [apiProvisioningGroups-v2/removeFromGroup.feature:123](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiProvisioningGroups-v2/removeFromGroup.feature#L123)
 
 ### [Cannot create user with different username and emails](https://github.com/owncloud/product/issues/187)
+ special character username not valid
 -   [apiProvisioningGroups-v1/getGroup.feature:11](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiProvisioningGroups-v1/getGroup.feature#L11)
 -   [apiProvisioningGroups-v2/getGroup.feature:11](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiProvisioningGroups-v2/getGroup.feature#L11)
 
@@ -2266,7 +2268,7 @@ special character username not valid
 -   [apiWebdavUploadTUS/uploadFileMtimeShares.feature:40](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUploadTUS/uploadFileMtimeShares.feature#L40)
 -   [apiWebdavUploadTUS/uploadFileMtimeShares.feature:41](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUploadTUS/uploadFileMtimeShares.feature#L41)
 
-### [ocis-storage - PROPFIND on a file uploaded by share receiver is not possible](https://github.com/owncloud/ocis/issues/968)
+### [ocis-storage PROPFIND on a file uploaded by share receiver is not possible](https://github.com/owncloud/ocis/issues/968)
 -   [apiWebdavUploadTUS/uploadFileMtimeShares.feature:26](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUploadTUS/uploadFileMtimeShares.feature#L26)
 -   [apiWebdavUploadTUS/uploadFileMtimeShares.feature:27](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUploadTUS/uploadFileMtimeShares.feature#L27)
 -   [apiWebdavUploadTUS/uploadFileMtimeShares.feature:55](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUploadTUS/uploadFileMtimeShares.feature#L55)
@@ -2302,5 +2304,5 @@ special character username not valid
 -   [apiTrashbin/trashbinFilesFolders.feature:284](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature#L284)
 -   [apiTrashbin/trashbinFilesFolders.feature:285](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature#L285)
 
-### [OCIS-storage - overwriting a file as share receiver, does not create a new file version for the sharer](https://github.com/owncloud/ocis/issues/766)
+### [OCIS-storage overwriting a file as share receiver, does not create a new file version for the sharer](https://github.com/owncloud/ocis/issues/766)
 -   [apiVersions/fileVersionsSharingToShares.feature:291](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiVersions/fileVersionsSharingToShares.feature#L291)

--- a/tests/acceptance/expected-failures-on-OWNCLOUD-storage.md
+++ b/tests/acceptance/expected-failures-on-OWNCLOUD-storage.md
@@ -1,4 +1,4 @@
-## Scenarios from api tests that are expected to fail on OCIS with owncloud storage
+## Scenarios from ownCloud10 core API tests that are expected to fail with owncloud storage
 
 -   [apiWebdavProperties1/setFileProperties.feature:32](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/setFileProperties.feature#L32)
 -   [apiWebdavProperties1/setFileProperties.feature:33](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/setFileProperties.feature#L33)

--- a/tests/acceptance/expected-failures-on-OWNCLOUD-storage.md
+++ b/tests/acceptance/expected-failures-on-OWNCLOUD-storage.md
@@ -1,9 +1,9 @@
-## Scenarios from ownCloud10 core API tests that are expected to fail with owncloud storage
+## Scenarios from api tests that are expected to fail on OCIS with owncloud storage
 
 -   [apiWebdavProperties1/setFileProperties.feature:32](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/setFileProperties.feature#L32)
 -   [apiWebdavProperties1/setFileProperties.feature:33](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/setFileProperties.feature#L33)
 
-### [Checksum feature](https://github.com/owncloud/ocis-reva/issues/196)
+### [Checksum feature](https://github.com/owncloud/ocis/issues/1291)
 
 -   [apiMain/checksums.feature:24](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiMain/checksums.feature#L24)
 -   [apiMain/checksums.feature:25](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiMain/checksums.feature#L25)
@@ -39,11 +39,11 @@
 -   [apiMain/checksums.feature:312](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiMain/checksums.feature#L312)
 -   [apiMain/checksums.feature:324](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiMain/checksums.feature#L324)
 
-### [no robots.txt available](https://github.com/owncloud/ocis-reva/issues/100)
+### [no robots.txt available](https://github.com/owncloud/ocis/issues/1314)
 
 -   [apiMain/main.feature:5](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiMain/main.feature#L5)
 
-### [quota query](https://github.com/owncloud/ocis-reva/issues/101)
+### [quota query](https://github.com/owncloud/ocis/issues/1313)
 
 -   [apiMain/quota.feature:9](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiMain/quota.feature#L9)
 -   [apiMain/quota.feature:16](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiMain/quota.feature#L16)
@@ -56,14 +56,14 @@
 -   [apiMain/quota.feature:99](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiMain/quota.feature#L99)
 -   [apiMain/quota.feature:112](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiMain/quota.feature#L112)
 
-### [There is no such thing like a "super-user"](https://github.com/owncloud/ocis-reva/issues/65)
+### [There is no such thing like a "super-user"](https://github.com/owncloud/ocis/issues/1319)
 
-### [no command equivalent to occ](https://github.com/owncloud/ocis-reva/issues/97)
+### [no command equivalent to occ](https://github.com/owncloud/ocis/issues/1317)
 
 -   [apiMain/status.feature:5](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiMain/status.feature#L5)
 
-### [ocs config endpoint only accessible by authorized users](https://github.com/owncloud/ocis-reva/issues/29)
-### [HTTP 401 Unauthorized responses don't contain a body](https://github.com/owncloud/ocis-reva/issues/30)
+### [ocs config endpoint only accessible by authorized users](https://github.com/owncloud/ocis/issues/1338)
+### [HTTP 401 Unauthorized responses don't contain a body](https://github.com/owncloud/ocis/issues/1337)
 
 -   [apiAuthOcs/ocsDELETEAuth.feature:10](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiAuthOcs/ocsDELETEAuth.feature#L10)
 -   [apiAuthOcs/ocsGETAuth.feature:10](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiAuthOcs/ocsGETAuth.feature#L10)
@@ -79,11 +79,11 @@
 
 -   [apiAuthWebDav/webDavDELETEAuth.feature:36](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiAuthWebDav/webDavDELETEAuth.feature#L36)
 
-### [users can access each-others data using the new webdav API](https://github.com/owncloud/ocis-reva/issues/9)
+### [users can access each-others data using the new webdav API](https://github.com/owncloud/ocis/issues/1347)
 
 -   [apiAuthWebDav/webDavLOCKAuth.feature:38](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiAuthWebDav/webDavLOCKAuth.feature#L38)
 
-### [users can access each-others data using the new webdav API](https://github.com/owncloud/ocis-reva/issues/9)
+### [users can access each-others data using the new webdav API](https://github.com/owncloud/ocis/issues/1347)
 
 -   [apiAuthWebDav/webDavMKCOLAuth.feature:37](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiAuthWebDav/webDavMKCOLAuth.feature#L37)
 
@@ -91,29 +91,29 @@
 
 -   [apiAuthWebDav/webDavMOVEAuth.feature:37](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiAuthWebDav/webDavMOVEAuth.feature#L37)
 
-### [send POST requests to another user's webDav endpoints as normal user](https://github.com/owncloud/ocis-reva/issues/179)
+### [send POST requests to another user's webDav endpoints as normal user](https://github.com/owncloud/ocis/issues/1287)
 
 -   [apiAuthWebDav/webDavPOSTAuth.feature:38](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiAuthWebDav/webDavPOSTAuth.feature#L38)
 
-### [users can access each-others data using the new webdav API](https://github.com/owncloud/ocis-reva/issues/9)
+### [users can access each-others data using the new webdav API](https://github.com/owncloud/ocis/issues/1347)
 
 -   [apiAuthWebDav/webDavPROPFINDAuth.feature:37](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiAuthWebDav/webDavPROPFINDAuth.feature#L37)
 
-### [users can access each-others data using the new webdav API](https://github.com/owncloud/ocis-reva/issues/9)
+### [users can access each-others data using the new webdav API](https://github.com/owncloud/ocis/issues/1347)
 
 -   [apiAuthWebDav/webDavPROPPATCHAuth.feature:38](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiAuthWebDav/webDavPROPPATCHAuth.feature#L38)
 
-### [users can access each-others data using the new webdav API](https://github.com/owncloud/ocis-reva/issues/9)
+### [users can access each-others data using the new webdav API](https://github.com/owncloud/ocis/issues/1347)
 
 -   [apiAuthWebDav/webDavPUTAuth.feature:38](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiAuthWebDav/webDavPUTAuth.feature#L38)
 
-### [Default capabilities for normal user not same as in oC-core](https://github.com/owncloud/ocis-reva/issues/175)
-### [Difference in response content of status.php and default capabilities](https://github.com/owncloud/ocis-reva/issues/176)
+### [Default capabilities for normal user not same as in oC-core](https://github.com/owncloud/ocis/issues/1285)
+### [Difference in response content of status.php and default capabilities](https://github.com/owncloud/ocis/issues/1286)
 
 -   [apiCapabilities/capabilitiesWithNormalUser.feature:11](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiCapabilities/capabilitiesWithNormalUser.feature#L11)
 
-### [REPORT request not implemented](https://github.com/owncloud/ocis-reva/issues/39)
-And other missing implementation of favorites
+### [REPORT request not implemented](https://github.com/owncloud/ocis/issues/1330)
+### And other missing implementation of favorites
 
 -   [apiFavorites/favorites.feature:91](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiFavorites/favorites.feature#L91)
 -   [apiFavorites/favorites.feature:92](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiFavorites/favorites.feature#L92)
@@ -138,7 +138,32 @@ And other missing implementation of favorites
 -   [apiFavorites/favoritesSharingToShares.feature:77](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiFavorites/favoritesSharingToShares.feature#L77)
 -   [apiFavorites/favoritesSharingToShares.feature:78](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiFavorites/favoritesSharingToShares.feature#L78)
 
+-   [apiWebdavOperations/search.feature:42](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L42)
+-   [apiWebdavOperations/search.feature:43](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L43)
+-   [apiWebdavOperations/search.feature:57](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L57)
+-   [apiWebdavOperations/search.feature:58](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L58)
+-   [apiWebdavOperations/search.feature:74](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L74)
+-   [apiWebdavOperations/search.feature:75](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L75)
+-   [apiWebdavOperations/search.feature:83](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L83)
+-   [apiWebdavOperations/search.feature:84](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L84)
+-   [apiWebdavOperations/search.feature:101](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L101)
+-   [apiWebdavOperations/search.feature:102](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L102)
+-   [apiWebdavOperations/search.feature:119](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L119)
+-   [apiWebdavOperations/search.feature:120](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L120)
+-   [apiWebdavOperations/search.feature:138](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L138)
+-   [apiWebdavOperations/search.feature:139](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L139)
+-   [apiWebdavOperations/search.feature:165](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L165)
+-   [apiWebdavOperations/search.feature:166](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L166)
+-   [apiWebdavOperations/search.feature:191](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L191)
+-   [apiWebdavOperations/search.feature:192](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L192)
+-   [apiWebdavOperations/search.feature:210](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L210)
+-   [apiWebdavOperations/search.feature:211](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L211)
+-   [apiWebdavOperations/search.feature:213](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L213)
+-   [apiWebdavOperations/search.feature:229](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L229)
+-   [apiWebdavOperations/search.feature:254](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L254)
+
 ### [Cannot create user with different username and emails](https://github.com/owncloud/product/issues/187)
+### special character username not valid
 
 -   [apiProvisioning-v1/addUser.feature:29](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiProvisioning-v1/addUser.feature#L29)
 -   [apiProvisioning-v1/addUser.feature:30](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiProvisioning-v1/addUser.feature#L30)
@@ -180,7 +205,7 @@ And other missing implementation of favorites
 -   [apiProvisioning-v2/apiProvisioningUsingAppPassword.feature:39](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiProvisioning-v2/apiProvisioningUsingAppPassword.feature#L39)
 -   [apiProvisioning-v2/apiProvisioningUsingAppPassword.feature:67](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiProvisioning-v2/apiProvisioningUsingAppPassword.feature#L67)
 
-### [disable users /cloud/users/disable|enable not available](https://github.com/owncloud/ocis-ocs/issues/28)
+### [disable users /cloud/users/disable|enable not available](https://github.com/owncloud/ocis/issues/1420)
 
 -   [apiProvisioning-v1/disableUser.feature:99](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiProvisioning-v1/disableUser.feature#L99)
 -   [apiProvisioning-v1/disableUser.feature:129](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiProvisioning-v1/disableUser.feature#L129)
@@ -297,7 +322,7 @@ And other missing implementation of favorites
 
 ### [Response is empty when accepting a share](https://github.com/owncloud/product/issues/207)
 
-### User cannot create a folder named Share
+User cannot create a folder named Share
 -   [apiShareManagementToShares/acceptShares.feature:279](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareManagementToShares/acceptShares.feature#L279)
 -   [apiShareManagementToShares/acceptShares.feature:298](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareManagementToShares/acceptShares.feature#L298)
 
@@ -336,7 +361,7 @@ And other missing implementation of favorites
 -   [apiShareManagementToShares/mergeShare.feature:42](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareManagementToShares/mergeShare.feature#L42)
 -   [apiShareManagementToShares/mergeShare.feature:89](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareManagementToShares/mergeShare.feature#L89)
 
-### [Shares are not deleted when user is deleted](https://github.com/owncloud/ocis-reva/issues/262)
+### [Shares are not deleted when user is deleted](https://github.com/owncloud/ocis/issues/1258)
 
 -   [apiShareManagementBasicToShares/createShareToSharesFolder.feature:100](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareManagementBasicToShares/createShareToSharesFolder.feature#L100)
 -   [apiShareManagementBasicToShares/createShareToSharesFolder.feature:101](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareManagementBasicToShares/createShareToSharesFolder.feature#L101)
@@ -381,7 +406,8 @@ And other missing implementation of favorites
 -   [apiShareManagementBasicToShares/deleteShareFromShares.feature:58](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareManagementBasicToShares/deleteShareFromShares.feature#L58)
 -   [apiShareManagementBasicToShares/deleteShareFromShares.feature:72](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareManagementBasicToShares/deleteShareFromShares.feature#L72)
 
-### [Listing shares via ocs API does not show path for parent folders](https://github.com/owncloud/ocis-reva/issues/372)
+ cannot share a folder with create permission
+### [Listing shares via ocs API does not show path for parent folders](https://github.com/owncloud/ocis/issues/1231)
 
 -   [apiShareManagementBasicToShares/deleteShareFromShares.feature:118](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareManagementBasicToShares/deleteShareFromShares.feature#L118)
 -   [apiShareManagementBasicToShares/deleteShareFromShares.feature:130](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareManagementBasicToShares/deleteShareFromShares.feature#L130)
@@ -390,12 +416,12 @@ And other missing implementation of favorites
 -   [apiShareManagementBasicToShares/deleteShareFromShares.feature:183](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareManagementBasicToShares/deleteShareFromShares.feature#L183)
 -   [apiShareManagementBasicToShares/deleteShareFromShares.feature:184](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareManagementBasicToShares/deleteShareFromShares.feature#L184)
 
-### [Shares are not deleted when user is deleted](https://github.com/owncloud/ocis-reva/issues/262)
+### [Shares are not deleted when user is deleted](https://github.com/owncloud/ocis/issues/1258)
 
 -   [apiShareOperationsToShares/gettingShares.feature:24](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareOperationsToShares/gettingShares.feature#L24)
 -   [apiShareOperationsToShares/gettingShares.feature:25](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareOperationsToShares/gettingShares.feature#L25)
 
-### [There is no such thing like a super-user](https://github.com/owncloud/ocis-reva/issues/65)
+### [There is no such thing like a super-user](https://github.com/owncloud/ocis/issues/1319)
 
 -   [apiShareOperationsToShares/gettingShares.feature:38](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareOperationsToShares/gettingShares.feature#L38)
 -   [apiShareOperationsToShares/gettingShares.feature:39](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareOperationsToShares/gettingShares.feature#L39)
@@ -407,12 +433,12 @@ And other missing implementation of favorites
 -   [apiShareOperationsToShares/gettingShares.feature:135](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareOperationsToShares/gettingShares.feature#L135)
 -   [apiShareOperationsToShares/gettingShares.feature:136](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareOperationsToShares/gettingShares.feature#L136)
 
-### [OCS error message for attempting to access share via share id as an unauthorized user is not informative](https://github.com/owncloud/ocis-reva/issues/374)
+### [OCS error message for attempting to access share via share id as an unauthorized user is not informative](https://github.com/owncloud/ocis/issues/1233)
 
 -   [apiShareOperationsToShares/gettingShares.feature:180](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareOperationsToShares/gettingShares.feature#L180)
 -   [apiShareOperationsToShares/gettingShares.feature:181](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareOperationsToShares/gettingShares.feature#L181)
 
-### [Listing shares via ocs API does not show path for parent folders](https://github.com/owncloud/ocis-reva/issues/372)
+### [Listing shares via ocs API does not show path for parent folders](https://github.com/owncloud/ocis/issues/1231)
 
 -   [apiShareOperationsToShares/gettingShares.feature:219](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareOperationsToShares/gettingShares.feature#L219)
 -   [apiShareOperationsToShares/gettingShares.feature:220](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareOperationsToShares/gettingShares.feature#L220)
@@ -449,7 +475,7 @@ And other missing implementation of favorites
 -   [apiShareOperationsToShares/gettingSharesSharedFilteredEmpty.feature:80](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareOperationsToShares/gettingSharesSharedFilteredEmpty.feature#L80)
 
 ### [Split old public API webdav tests from new public webdav tests](https://github.com/owncloud/ocis-reva/issues/282)
-### [Public link enforce permissions](https://github.com/owncloud/ocis-reva/issues/292)
+### [Public link enforce permissions](https://github.com/owncloud/ocis/issues/1269)
 ### [Previews via webDAV API tests fail on OCIS](https://github.com/owncloud/ocis/issues/187)
 
 -   [apiSharePublicLink1/accessToPublicLinkShare.feature:10](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/accessToPublicLinkShare.feature#L10)
@@ -475,7 +501,7 @@ And other missing implementation of favorites
 -   [apiSharePublicLink1/changingPublicLinkShare.feature:197](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/changingPublicLinkShare.feature#L197)
 -   [apiSharePublicLink1/changingPublicLinkShare.feature:244](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/changingPublicLinkShare.feature#L244)
 
-### [Public link enforce permissions](https://github.com/owncloud/ocis-reva/issues/292)
+### [Public link enforce permissions](https://github.com/owncloud/ocis/issues/1269)
 ### [upload-only public link does not refer to files-drop page, nor are the permissions enforced](https://github.com/owncloud/ocis/issues/723)
 
 -   [apiSharePublicLink1/changingPublicLinkShare.feature:267](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/changingPublicLinkShare.feature#L267)
@@ -491,21 +517,21 @@ And other missing implementation of favorites
 -   [apiSharePublicLink1/createPublicLinkShare.feature:370](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature#L370)
 -   [apiSharePublicLink1/createPublicLinkShare.feature:371](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature#L371)
 
-### [Range Header is not obeyed when downloading a file](https://github.com/owncloud/ocis-reva/issues/12)
+### [Range Header is not obeyed when downloading a file](https://github.com/owncloud/ocis/issues/1346)
 
 -   [apiSharePublicLink1/createPublicLinkShare.feature:95](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature#L95)
 -   [apiSharePublicLink1/createPublicLinkShare.feature:96](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature#L96)
 -   [apiSharePublicLink1/createPublicLinkShare.feature:276](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature#L276)
 -   [apiSharePublicLink1/createPublicLinkShare.feature:277](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature#L277)
 
-### [Ability to return error messages in Webdav response bodies](https://github.com/owncloud/ocis-reva/issues/199)
+### [Ability to return error messages in Webdav response bodies](https://github.com/owncloud/ocis/issues/1293)
 
 -   [apiSharePublicLink1/createPublicLinkShare.feature:127](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature#L127)
 -   [apiSharePublicLink1/createPublicLinkShare.feature:128](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature#L128)
 -   [apiSharePublicLink1/createPublicLinkShare.feature:155](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature#L155)
 -   [apiSharePublicLink1/createPublicLinkShare.feature:156](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature#L156)
 
-### [various sharing settings cannot be set](https://github.com/owncloud/ocis-reva/issues/41)
+### [various sharing settings cannot be set](https://github.com/owncloud/ocis/issues/1328)
 
 -   [apiSharePublicLink1/createPublicLinkShare.feature:410](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature#L410)
 -   [apiSharePublicLink1/createPublicLinkShare.feature:411](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature#L411)
@@ -553,7 +579,7 @@ And other missing implementation of favorites
 -   [apiSharePublicLink1/createPublicLinkShare.feature:733](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature#L733)
 -   [apiSharePublicLink1/createPublicLinkShare.feature:742](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature#L742)
 
-### [copying a folder within a public link folder to folder with same name as an already existing file overwrites the parent file](https://github.com/owncloud/ocis-reva/issues/373)
+### [copying a folder within a public link folder to folder with same name as an already existing file overwrites the parent file](https://github.com/owncloud/ocis/issues/1232)
 
 -   [apiSharePublicLink2/copyFromPublicLink.feature:60](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/copyFromPublicLink.feature#L60)
 -   [apiSharePublicLink2/copyFromPublicLink.feature:85](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/copyFromPublicLink.feature#L85)
@@ -570,7 +596,7 @@ And other missing implementation of favorites
 -   [apiSharePublicLink2/updatePublicLinkShare.feature:321](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L321)
 -   [apiSharePublicLink2/updatePublicLinkShare.feature:322](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L322)
 
-### [share permissions not enforced](https://github.com/owncloud/product/issues/270)
+### [OCIS share permissions not enforced](https://github.com/owncloud/product/issues/270)
 
 -   [apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature:25](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature#L25)
 -   [apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature:26](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature#L26)
@@ -585,7 +611,7 @@ And other missing implementation of favorites
 -   [apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature:179](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature#L179)
 -   [apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature:180](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature#L180)
 
-### [old public webdav api doesnt works](https://github.com/owncloud/product/issues/272)
+### [OCIS old public webdav api doesnt works](https://github.com/owncloud/product/issues/272)
 
 -   [apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature:30](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature#L30)
 -   [apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature:31](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature#L31)
@@ -618,7 +644,7 @@ And other missing implementation of favorites
 -   [apiSharePublicLink2/updatePublicLinkShare.feature:476](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L476)
 -   [apiSharePublicLink2/updatePublicLinkShare.feature:477](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L477)
 
-### [Public link enforce permissions](https://github.com/owncloud/ocis-reva/issues/292)
+### [Public link enforce permissions](https://github.com/owncloud/ocis/issues/1269)
 
 -   [apiSharePublicLink2/updatePublicLinkShare.feature:523](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L523)
 -   [apiSharePublicLink2/updatePublicLinkShare.feature:524](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L524)
@@ -628,7 +654,7 @@ And other missing implementation of favorites
 -   [apiSharePublicLink2/uploadToPublicLinkShare.feature:121](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L121)
 -   [apiSharePublicLink2/uploadToPublicLinkShare.feature:139](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L139)
 
-### Upload to deleted public link share returns 401 instead of 404
+### [Upload-only shares must not overwrite but create a separate file](https://github.com/owncloud/ocis/issues/1267)
 
 -   [apiSharePublicLink2/uploadToPublicLinkShare.feature:48](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L48)
 -   [apiSharePublicLink2/uploadToPublicLinkShare.feature:49](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L49)
@@ -638,18 +664,18 @@ And other missing implementation of favorites
 -   [apiSharePublicLink2/uploadToPublicLinkShare.feature:23](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L23)
 -   [apiSharePublicLink2/uploadToPublicLinkShare.feature:273](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L273)
 
-### [Accessing non-existing public link should return 404, not 500](https://github.com/owncloud/ocis-reva/issues/290)
+### [Accessing non-existing public link should return 404, not 500](https://github.com/owncloud/ocis/issues/1268)
 
 -   [apiSharePublicLink2/uploadToPublicLinkShare.feature:66](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L66)
 
-### [Set quota over settings](https://github.com/owncloud/ocis-reva/issues/195)
+### [Set quota over settings](https://github.com/owncloud/ocis/issues/1290)
 
 -   [apiSharePublicLink2/uploadToPublicLinkShare.feature:148](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L148)
 -   [apiSharePublicLink2/uploadToPublicLinkShare.feature:158](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L158)
 -   [apiSharePublicLink2/uploadToPublicLinkShare.feature:167](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L167)
 -   [apiSharePublicLink2/uploadToPublicLinkShare.feature:177](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L177)
 
-### [various sharing settings cannot be set](https://github.com/owncloud/ocis-reva/issues/41)
+### [various sharing settings cannot be set](https://github.com/owncloud/ocis/issues/1328)
 
 -   [apiSharePublicLink2/uploadToPublicLinkShare.feature:186](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L186)
 -   [apiSharePublicLink2/uploadToPublicLinkShare.feature:196](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L196)
@@ -822,7 +848,7 @@ And other missing implementation of favorites
 
 -   [apiShareReshareToShares2/reShareChain.feature:10](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareReshareToShares2/reShareChain.feature#L10)
 
-### [various sharing settings cannot be set](https://github.com/owncloud/ocis-reva/issues/41)
+### [various sharing settings cannot be set](https://github.com/owncloud/ocis/issues/1328)
 
 -   [apiShareReshareToShares2/reShareDisabled.feature:24](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareReshareToShares2/reShareDisabled.feature#L24)
 -   [apiShareReshareToShares2/reShareDisabled.feature:25](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareReshareToShares2/reShareDisabled.feature#L25)
@@ -889,7 +915,7 @@ And other missing implementation of favorites
 -   [apiTrashbin/trashbinDelete.feature:67](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiTrashbin/trashbinDelete.feature#L67)
 
 ### [href in trashbin PROPFIND response is wrong](https://github.com/owncloud/ocis/issues/1120)
-### [trashcan cannot delete a deep tree](https://github.com/owncloud/ocis/issues/1077)
+### [QA trashcan cannot delete a deep tree](https://github.com/owncloud/ocis/issues/1077)
 
 -   [apiTrashbin/trashbinDelete.feature:107](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiTrashbin/trashbinDelete.feature#L107)
 -   [apiTrashbin/trashbinDelete.feature:123](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiTrashbin/trashbinDelete.feature#L123)
@@ -996,8 +1022,8 @@ And other missing implementation of favorites
 -   [apiTrashbin/trashbinSharingToShares.feature:102](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiTrashbin/trashbinSharingToShares.feature#L102)
 -   [apiTrashbin/trashbinSharingToShares.feature:103](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiTrashbin/trashbinSharingToShares.feature#L103)
 
-### [uploading with old-chunking does not work](https://github.com/owncloud/ocis-reva/issues/17)
-### [remote.php/dav/uploads endpoint does not exist](https://github.com/owncloud/ocis-reva/issues/56)
+### [uploading with old-chunking does not work](https://github.com/owncloud/ocis/issues/1343)
+### [remote.php/dav/uploads endpoint does not exist](https://github.com/owncloud/ocis/issues/1321)
 
 -   [apiVersions/fileVersions.feature:15](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiVersions/fileVersions.feature#L15)
 -   [apiVersions/fileVersions.feature:23](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiVersions/fileVersions.feature#L23)
@@ -1048,7 +1074,7 @@ And other missing implementation of favorites
 -   [apiWebdavMove1/moveFileToExcludedDirectoryAsync.feature:19](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavMove1/moveFileToExcludedDirectoryAsync.feature#L19)
 -   [apiWebdavMove1/moveFileToExcludedDirectoryAsync.feature:27](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavMove1/moveFileToExcludedDirectoryAsync.feature#L27)
 
-### [renaming to banned name works](https://github.com/owncloud/ocis-reva/issues/211)
+### [renaming to banned name works](https://github.com/owncloud/ocis/issues/1295)
 
 -   [apiWebdavMove1/moveFolder.feature:21](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavMove1/moveFolder.feature#L21)
 -   [apiWebdavMove1/moveFolder.feature:22](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavMove1/moveFolder.feature#L22)
@@ -1127,7 +1153,7 @@ And other missing implementation of favorites
 -   [apiWebdavOperations/deleteFolder.feature:91](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/deleteFolder.feature#L91)
 -   [apiWebdavOperations/deleteFolder.feature:92](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/deleteFolder.feature#L92)
 
-### [Range Header is not obeyed when downloading a file](https://github.com/owncloud/ocis-reva/issues/12)
+### [Range Header is not obeyed when downloading a file](https://github.com/owncloud/ocis/issues/1346)
 ### [Review and fix the tests that### have sharing step to work with ocis](https://github.com/owncloud/core/issues/38006)
 
 -   [apiWebdavOperations/downloadFile.feature:60](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/downloadFile.feature#L60)
@@ -1141,32 +1167,6 @@ And other missing implementation of favorites
 -   [apiWebdavOperations/refuseAccess.feature:33](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/refuseAccess.feature#L33)
 -   [apiWebdavOperations/refuseAccess.feature:34](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/refuseAccess.feature#L34)
 
-### [REPORT request not implemented](https://github.com/owncloud/ocis-reva/issues/39)
-
--   [apiWebdavOperations/search.feature:42](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L42)
--   [apiWebdavOperations/search.feature:43](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L43)
--   [apiWebdavOperations/search.feature:57](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L57)
--   [apiWebdavOperations/search.feature:58](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L58)
--   [apiWebdavOperations/search.feature:74](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L74)
--   [apiWebdavOperations/search.feature:75](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L75)
--   [apiWebdavOperations/search.feature:83](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L83)
--   [apiWebdavOperations/search.feature:84](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L84)
--   [apiWebdavOperations/search.feature:101](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L101)
--   [apiWebdavOperations/search.feature:102](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L102)
--   [apiWebdavOperations/search.feature:119](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L119)
--   [apiWebdavOperations/search.feature:120](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L120)
--   [apiWebdavOperations/search.feature:138](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L138)
--   [apiWebdavOperations/search.feature:139](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L139)
--   [apiWebdavOperations/search.feature:165](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L165)
--   [apiWebdavOperations/search.feature:166](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L166)
--   [apiWebdavOperations/search.feature:191](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L191)
--   [apiWebdavOperations/search.feature:192](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L192)
--   [apiWebdavOperations/search.feature:210](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L210)
--   [apiWebdavOperations/search.feature:211](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L211)
--   [apiWebdavOperations/search.feature:213](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L213)
--   [apiWebdavOperations/search.feature:229](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L229)
--   [apiWebdavOperations/search.feature:254](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L254)
-
 ### [Review and fix the tests that### have sharing step to work with ocis](https://github.com/owncloud/core/issues/38006)
 
 -   [apiWebdavProperties1/copyFile.feature:65](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/copyFile.feature#L65)
@@ -1174,14 +1174,14 @@ And other missing implementation of favorites
 -   [apiWebdavProperties1/copyFile.feature:85](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/copyFile.feature#L85)
 -   [apiWebdavProperties1/copyFile.feature:86](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/copyFile.feature#L86)
 
-### [blacklisted filenames like .htaccess & file.parts can be uploaded](https://github.com/owncloud/ocis-reva/issues/15)
+### [blacklisted filenames like .htaccess & file.parts can be uploaded](https://github.com/owncloud/ocis/issues/1345)
 
 -   [apiWebdavProperties1/copyFile.feature:102](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/copyFile.feature#L102)
 -   [apiWebdavProperties1/copyFile.feature:103](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/copyFile.feature#L103)
 -   [apiWebdavProperties1/createFolder.feature:71](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/createFolder.feature#L71)
 -   [apiWebdavProperties1/createFolder.feature:72](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/createFolder.feature#L72)
 
-### [Getting information about a folder overwritten by a file gives 500 error instead of 404](https://github.com/owncloud/ocis-reva/issues/387)
+### [Getting information about a folder overwritten by a file gives 500 error instead of 404](https://github.com/owncloud/ocis/issues/1239)
 
 -   [apiWebdavProperties1/copyFile.feature:116](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/copyFile.feature#L116)
 -   [apiWebdavProperties1/copyFile.feature:117](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/copyFile.feature#L117)
@@ -1209,14 +1209,14 @@ And other missing implementation of favorites
 -   [apiWebdavProperties1/copyFile.feature:474](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/copyFile.feature#L474)
 -   [apiWebdavProperties1/copyFile.feature:475](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/copyFile.feature#L475)
 
-### [creating a folder that already exists returns an empty body](https://github.com/owncloud/ocis-reva/issues/168)
+### [creating a folder that already exists returns an empty body](https://github.com/owncloud/ocis/issues/1283)
 
 -   [apiWebdavProperties1/createFolder.feature:85](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/createFolder.feature#L85)
 -   [apiWebdavProperties1/createFolder.feature:86](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/createFolder.feature#L86)
 -   [apiWebdavProperties1/createFolder.feature:99](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/createFolder.feature#L99)
 -   [apiWebdavProperties1/createFolder.feature:100](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/createFolder.feature#L100)
 
-### [quota query](https://github.com/owncloud/ocis-reva/issues/101)
+### [quota query](https://github.com/owncloud/ocis/issues/1313)
 
 -   [apiWebdavProperties1/getQuota.feature:17](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/getQuota.feature#L17)
 -   [apiWebdavProperties1/getQuota.feature:18](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/getQuota.feature#L18)
@@ -1229,12 +1229,12 @@ And other missing implementation of favorites
 -   [apiWebdavProperties1/getQuota.feature:77](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/getQuota.feature#L77)
 -   [apiWebdavProperties1/getQuota.feature:78](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/getQuota.feature#L78)
 
-### [Some failing tests with Webdav custom properties](https://github.com/owncloud/ocis-reva/issues/217)
+### [Some failing tests with Webdav custom properties](https://github.com/owncloud/ocis/issues/1297)
 
 -   [apiWebdavProperties1/setFileProperties.feature:63](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/setFileProperties.feature#L63)
 -   [apiWebdavProperties1/setFileProperties.feature:64](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/setFileProperties.feature#L64)
 
-### [XML properties in webdav response not properly encoded](https://github.com/owncloud/ocis-reva/issues/214)
+### [XML properties in webdav response not properly encoded](https://github.com/owncloud/ocis/issues/1296)
 
 -   [apiWebdavProperties2/getFileProperties.feature:37](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties2/getFileProperties.feature#L37)
 -   [apiWebdavProperties2/getFileProperties.feature:39](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties2/getFileProperties.feature#L39)
@@ -1267,13 +1267,13 @@ And other missing implementation of favorites
 -   [apiWebdavProperties2/getFileProperties.feature:206](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties2/getFileProperties.feature#L206)
 -   [apiWebdavProperties2/getFileProperties.feature:207](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties2/getFileProperties.feature#L207)
 
-### [Private link support](https://github.com/owncloud/ocis-reva/issues/216)
+### [Private link support](https://github.com/owncloud/product/issues/201)
 ### [oc:privatelink property not returned in webdav responses](https://github.com/owncloud/product/issues/262)
 
 -   [apiWebdavProperties2/getFileProperties.feature:232](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties2/getFileProperties.feature#L232)
 -   [apiWebdavProperties2/getFileProperties.feature:233](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties2/getFileProperties.feature#L233)
 
-### [trying to access a non-existing resource returns an empty body](https://github.com/owncloud/ocis-reva/issues/163)
+### [trying to access a non-existing resource returns an empty body](https://github.com/owncloud/ocis/issues/1282)
 
 -   [apiWebdavProperties2/getFileProperties.feature:242](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties2/getFileProperties.feature#L242)
 -   [apiWebdavProperties2/getFileProperties.feature:243](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties2/getFileProperties.feature#L243)
@@ -1283,7 +1283,7 @@ And other missing implementation of favorites
 -   [apiWebdavProperties2/getFileProperties.feature:246](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties2/getFileProperties.feature#L246)
 -   [apiWebdavProperties2/getFileProperties.feature:266](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties2/getFileProperties.feature#L266)
 
-### [Different webdav properties from core](https://github.com/owncloud/ocis-reva/issues/236)
+### [Different webdav properties from core](https://github.com/owncloud/ocis/issues/1302)
 
 -   [apiWebdavProperties2/getFileProperties.feature:301](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties2/getFileProperties.feature#L301)
 -   [apiWebdavProperties2/getFileProperties.feature:302](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties2/getFileProperties.feature#L302)
@@ -1303,13 +1303,13 @@ And other missing implementation of favorites
 -   [apiWebdavUpload1/uploadFile.feature:112](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUpload1/uploadFile.feature#L112)
 -   [apiWebdavUpload1/uploadFile.feature:113](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUpload1/uploadFile.feature#L113)
 
-### [blacklisted filenames like .htaccess & file.parts can be uploaded](https://github.com/owncloud/ocis-reva/issues/15)
+### [blacklisted filenames like .htaccess & file.parts can be uploaded](https://github.com/owncloud/ocis/issues/1345)
 
 -   [apiWebdavUpload1/uploadFile.feature:127](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUpload1/uploadFile.feature#L127)
 -   [apiWebdavUpload1/uploadFile.feature:128](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUpload1/uploadFile.feature#L128)
 
-### [remote.php/dav/uploads endpoint does not exist](https://github.com/owncloud/ocis-reva/issues/56)
-also requires test helper to read and clear the log file.
+### [remote.php/dav/uploads endpoint does not exist](https://github.com/owncloud/ocis/issues/1321)
+ also requires test helper to read and clear the log file.
 
 -   [apiWebdavUpload1/uploadFileAsyncUsingNewChunking.feature:14](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUpload1/uploadFileAsyncUsingNewChunking.feature#L14)
 -   [apiWebdavUpload1/uploadFileAsyncUsingNewChunking.feature:31](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUpload1/uploadFileAsyncUsingNewChunking.feature#L31)
@@ -1341,19 +1341,19 @@ also requires test helper to read and clear the log file.
 -   [apiWebdavUpload1/uploadFileToExcludedDirectory.feature:69](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUpload1/uploadFileToExcludedDirectory.feature#L69)
 -   [apiWebdavUpload1/uploadFileToExcludedDirectory.feature:70](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUpload1/uploadFileToExcludedDirectory.feature#L70)
 
-### [blacklisted filenames like .htaccess & file.parts can be uploaded](https://github.com/owncloud/ocis-reva/issues/15)
+### [blacklisted filenames like .htaccess & file.parts can be uploaded](https://github.com/owncloud/ocis/issues/1345)
 
 -   [apiWebdavUpload1/uploadFileToBlacklistedName.feature:19](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUpload1/uploadFileToBlacklistedName.feature#L19)
 -   [apiWebdavUpload1/uploadFileToBlacklistedName.feature:20](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUpload1/uploadFileToBlacklistedName.feature#L20)
 
-### [system configuration options missing](https://github.com/owncloud/ocis-reva/issues/54)
+### [system configuration options missing](https://github.com/owncloud/ocis/issues/1323)
 
 -   [apiWebdavUpload1/uploadFileToBlacklistedName.feature:31](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUpload1/uploadFileToBlacklistedName.feature#L31)
 -   [apiWebdavUpload1/uploadFileToBlacklistedName.feature:32](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUpload1/uploadFileToBlacklistedName.feature#L32)
 -   [apiWebdavUpload1/uploadFileToBlacklistedName.feature:65](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUpload1/uploadFileToBlacklistedName.feature#L65)
 -   [apiWebdavUpload1/uploadFileToBlacklistedName.feature:66](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUpload1/uploadFileToBlacklistedName.feature#L66)
 
-### [remote.php/dav/uploads endpoint does not exist](https://github.com/owncloud/ocis-reva/issues/56)
+### [remote.php/dav/uploads endpoint does not exist](https://github.com/owncloud/ocis/issues/1321)
 
 -   [apiWebdavUpload2/uploadFileToBlacklistedNameUsingNewChunking.feature:12](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUpload2/uploadFileToBlacklistedNameUsingNewChunking.feature#L12)
 -   [apiWebdavUpload2/uploadFileToBlacklistedNameUsingNewChunking.feature:21](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUpload2/uploadFileToBlacklistedNameUsingNewChunking.feature#L21)
@@ -1382,7 +1382,7 @@ also requires test helper to read and clear the log file.
 -   [apiWebdavUpload2/uploadFileUsingNewChunking.feature:168](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUpload2/uploadFileUsingNewChunking.feature#L168)
 -   [apiWebdavUpload2/uploadFileUsingNewChunking.feature:169](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUpload2/uploadFileUsingNewChunking.feature#L169)
 
-### [blacklisted filenames like .htaccess & file.parts can be uploaded](https://github.com/owncloud/ocis-reva/issues/15)
+### [blacklisted filenames like .htaccess & file.parts can be uploaded](https://github.com/owncloud/ocis/issues/1345)
 
 -   [apiWebdavUpload2/uploadFileToBlacklistedNameUsingOldChunking.feature:13](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUpload2/uploadFileToBlacklistedNameUsingOldChunking.feature#L13)
 -   [apiWebdavUpload2/uploadFileToBlacklistedNameUsingOldChunking.feature:19](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUpload2/uploadFileToBlacklistedNameUsingOldChunking.feature#L19)
@@ -1395,7 +1395,7 @@ also requires test helper to read and clear the log file.
 -   [apiWebdavUpload2/uploadFileToExcludedDirectoryUsingOldChunking.feature:38](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUpload2/uploadFileToExcludedDirectoryUsingOldChunking.feature#L38)
 -   [apiWebdavUpload2/uploadFileToExcludedDirectoryUsingOldChunking.feature:39](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUpload2/uploadFileToExcludedDirectoryUsingOldChunking.feature#L39)
 
-### [uploading with old-chunking does not work](https://github.com/owncloud/ocis-reva/issues/17)
+### [uploading with old-chunking does not work](https://github.com/owncloud/ocis/issues/1343)
 
 -   [apiWebdavUpload2/uploadFileUsingOldChunking.feature:43](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUpload2/uploadFileUsingOldChunking.feature#L43)
 -   [apiWebdavUpload2/uploadFileUsingOldChunking.feature:96](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUpload2/uploadFileUsingOldChunking.feature#L96)
@@ -1409,20 +1409,20 @@ also requires test helper to read and clear the log file.
 -   [apiWebdavUploadTUS/uploadToShare.feature:52](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUploadTUS/uploadToShare.feature#L52)
 -   [apiWebdavUploadTUS/uploadToShare.feature:53](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUploadTUS/uploadToShare.feature#L53)
 
-### [Sharing does not work](https://github.com/owncloud/ocis-reva/issues/243)
+### [Sharing does not work](https://github.com/owncloud/ocis/issues/1303)
 
 -   [apiShareManagementBasicToShares/createShareToSharesFolder.feature:529](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareManagementBasicToShares/createShareToSharesFolder.feature#L529)
 -   [apiShareManagementBasicToShares/createShareToSharesFolder.feature:547](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareManagementBasicToShares/createShareToSharesFolder.feature#L547)
 -   [apiShareManagementBasicToShares/createShareToSharesFolder.feature:565](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareManagementBasicToShares/createShareToSharesFolder.feature#L565)
 
-### [Delete shares from user when user is deleted](https://github.com/owncloud/ocis-reva/issues/357)
-### [when sharing a file mime-type field is set to `application/octet-stream](https://github.com/owncloud/ocis-reva/issues/302)
-### [no displayname_owner shown when creating a share](https://github.com/owncloud/ocis-reva/issues/301)
+### [Delete shares from user when user is deleted](hhttps://github.com/owncloud/ocis/issues/1226)
+### [when sharing a file mime-type field is set to `application/octet-stream](https://github.com/owncloud/ocis/issues/1271)
+### [no displayname_owner shown when creating a share](https://github.com/owncloud/ocis/issues/1270)
 
 -   [apiShareOperationsToShares/gettingShares.feature:167](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareOperationsToShares/gettingShares.feature#L167)
 -   [apiShareOperationsToShares/gettingShares.feature:168](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareOperationsToShares/gettingShares.feature#L168)
 
-### [Moving resource loses associated shares](https://github.com/owncloud/ocis-reva/issues/335)
+### [Moving resource loses associated shares](https://github.com/owncloud/ocis/issues/1251)
 
 -   [apiSharePublicLink2/multilinkSharing.feature:181](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/multilinkSharing.feature#L181)
 
@@ -1448,7 +1448,7 @@ also requires test helper to read and clear the log file.
 -   [apiShareOperationsToShares/uploadToShare.feature:242](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareOperationsToShares/uploadToShare.feature#L242)
 -   [apiShareOperationsToShares/uploadToShare.feature:243](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareOperationsToShares/uploadToShare.feature#L243)
 
-### [remote.php/dav/uploads endpoint does not exist](https://github.com/owncloud/ocis-reva/issues/56)
+### [remote.php/dav/uploads endpoint does not exist](https://github.com/owncloud/ocis/issues/1321)
 
 -   [apiShareOperationsToShares/uploadToShare.feature:246](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareOperationsToShares/uploadToShare.feature#L246)
 
@@ -1495,11 +1495,11 @@ also requires test helper to read and clear the log file.
 
 -   [apiVersions/fileVersionsSharingToShares.feature:256](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiVersions/fileVersionsSharingToShares.feature#L256)
 
-### [The version number of a file is incorrect because of the incorrect number of `<d:getetag>` and `<d:getlastmodified>` element](https://github.com/owncloud/ocis-reva/issues/376)
+### [The version number of a file is incorrect because of the incorrect number of `<d:getetag>` and `<d:getlastmodified>` element](https://github.com/owncloud/ocis/issues/1234)
 
 -   [apiVersions/fileVersionsSharingToShares.feature:267](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiVersions/fileVersionsSharingToShares.feature#L267)
 
-### [OC-Storage -moving a file out of folder removes the versions](https://github.com/owncloud/ocis/issues/777)
+### [OC-Storage moving a file out of folder removes the versions](https://github.com/owncloud/ocis/issues/777)
 
 -   [apiVersions/fileVersionsSharingToShares.feature:252](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiVersions/fileVersionsSharingToShares.feature#L252)
 -   [apiVersions/fileVersionsSharingToShares.feature:253](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiVersions/fileVersionsSharingToShares.feature#L253)
@@ -1534,7 +1534,7 @@ restoring a file doesn't changes the etags of the parents
 -   [apiWebdavEtagPropagation2/restoreFromTrash.feature:90](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavEtagPropagation2/restoreFromTrash.feature#L90)
 -   [apiWebdavEtagPropagation2/restoreFromTrash.feature:91](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavEtagPropagation2/restoreFromTrash.feature#L91)
 
-### [wildcard Access-Control-Allow-Origin](https://github.com/owncloud/ocis-reva/issues/27)
+### [wildcard Access-Control-Allow-Origin](https://github.com/owncloud/ocis/issues/1340)
 
 -   [apiAuth/cors.feature:24](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiAuth/cors.feature#L24)
 -   [apiAuth/cors.feature:25](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiAuth/cors.feature#L25)
@@ -1607,17 +1607,17 @@ restoring a file doesn't changes the etags of the parents
 -   [apiAuth/cors.feature:182](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiAuth/cors.feature#L182)
 -   [apiAuth/cors.feature:183](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiAuth/cors.feature#L183)
 
-### [HTTP 401 Unauthorized responses don't contain a body ](https://github.com/owncloud/ocis-reva/issues/30)
-### [app passwords are not possible](https://github.com/owncloud/ocis-reva/issues/60)
+### [HTTP 401 Unauthorized responses don't contain a body ](https://github.com/owncloud/ocis/issues/1337)
+### [app passwords are not possible](https://github.com/owncloud/ocis/issues/1320)
 
 -   [apiAuthOcs/ocsGETAuth.feature:243](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiAuthOcs/ocsGETAuth.feature#L243)
 
-### [app passwords are not possible](https://github.com/owncloud/ocis-reva/issues/60)
+### [app passwords are not possible](https://github.com/owncloud/ocis/issues/1320)
 
 -   [apiAuthWebDav/webDavDELETEAuth.feature:78](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiAuthWebDav/webDavDELETEAuth.feature#L78)
 -   [apiAuthWebDav/webDavDELETEAuth.feature:92](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiAuthWebDav/webDavDELETEAuth.feature#L92)
 
-### [various sharing settings cannot be set](https://github.com/owncloud/ocis-reva/issues/41)
+### [various sharing settings cannot be set](https://github.com/owncloud/ocis/issues/1328)
 
 -   [apiCapabilities/capabilities.feature:8](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiCapabilities/capabilities.feature#L8)
 -   [apiCapabilities/capabilities.feature:15](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiCapabilities/capabilities.feature#L15)
@@ -1698,7 +1698,7 @@ restoring a file doesn't changes the etags of the parents
 -   [apiMain/carddav.feature:23](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiMain/carddav.feature#L23)
 -   [apiMain/carddav.feature:31](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiMain/carddav.feature#L31)
 
-### [user-sync endpoint does not exist](https://github.com/owncloud/ocis-reva/issues/401)
+### [user-sync endpoint does not exist](https://github.com/owncloud/ocis/issues/1241)
 
 -   [apiMain/userSync.feature:18](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiMain/userSync.feature#L18)
 -   [apiMain/userSync.feature:19](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiMain/userSync.feature#L19)
@@ -1728,8 +1728,8 @@ restoring a file doesn't changes the etags of the parents
 -   [apiTranslation/translation.feature:29](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiTranslation/translation.feature#L29)
 -   [apiTranslation/translation.feature:30](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiTranslation/translation.feature#L30)
 
-### [Sharing seems to work but does not work](https://github.com/owncloud/ocis-reva/issues/243)
-### [Expiration date for user shares is not implemented](https://github.com/owncloud/ocis-reva/issues/333)
+### [Sharing seems to work but does not work](https://github.com/owncloud/ocis/issues/1303)
+### [Expiration date for user shares is not implemented](https://github.com/owncloud/ocis/issues/1250)
 
 -   [apiShareCreateSpecialToShares1/createShareExpirationDate.feature:26](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareCreateSpecialToShares1/createShareExpirationDate.feature#L26)
 -   [apiShareCreateSpecialToShares1/createShareExpirationDate.feature:27](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareCreateSpecialToShares1/createShareExpirationDate.feature#L27)
@@ -1850,7 +1850,7 @@ restoring a file doesn't changes the etags of the parents
 -   [apiShareOperationsToShares/accessToShare.feature:71](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareOperationsToShares/accessToShare.feature#L71)
 -   [apiShareOperationsToShares/accessToShare.feature:72](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareOperationsToShares/accessToShare.feature#L72)
 
-### [Sharing seems to work but does not work](https://github.com/owncloud/ocis-reva/issues/243)
+### [Sharing seems to work but does not work](https://github.com/owncloud/ocis/issues/1303)
 
 -   [apiShareCreateSpecialToShares1/createShareUniqueReceivedNames.feature:15](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareCreateSpecialToShares1/createShareUniqueReceivedNames.feature#L15)
 -   [apiShareCreateSpecialToShares2/createShareWithDisabledUser.feature:18](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareCreateSpecialToShares2/createShareWithDisabledUser.feature#L18)
@@ -1882,7 +1882,7 @@ restoring a file doesn't changes the etags of the parents
 -   [apiShareManagementToShares/moveReceivedShare.feature:222](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareManagementToShares/moveReceivedShare.feature#L222)
 
 ### [file_target in share response](https://github.com/owncloud/product/issues/203)
-### [cannot get ocs:share-permissions via WebDAV](https://github.com/owncloud/ocis-reva/issues/47)
+### [cannot get ocs:share-permissions via WebDAV](https://github.com/owncloud/ocis/issues/1326)
 -   [apiShareOperationsToShares/getWebDAVSharePermissions.feature:59](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareOperationsToShares/getWebDAVSharePermissions.feature#L59)
 -   [apiShareOperationsToShares/getWebDAVSharePermissions.feature:60](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareOperationsToShares/getWebDAVSharePermissions.feature#L60)
 -   [apiShareOperationsToShares/getWebDAVSharePermissions.feature:73](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareOperationsToShares/getWebDAVSharePermissions.feature#L73)
@@ -1920,19 +1920,19 @@ restoring a file doesn't changes the etags of the parents
 -   [apiShareUpdateToShares/updateShare.feature:123](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareUpdateToShares/updateShare.feature#L123)
 -   [apiShareUpdateToShares/updateShare.feature:155](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareUpdateToShares/updateShare.feature#L155)
 
-### [No way to set default folder for received shares](https://github.com/owncloud/ocis-reva/issues/42)
+### [No way to set default folder for received shares](https://github.com/owncloud/ocis/issues/1327)
 
 -   [apiShareCreateSpecialToShares2/createShareDefaultFolderForReceivedShares.feature:21](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareCreateSpecialToShares2/createShareDefaultFolderForReceivedShares.feature#L21)
 -   [apiShareCreateSpecialToShares2/createShareDefaultFolderForReceivedShares.feature:22](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareCreateSpecialToShares2/createShareDefaultFolderForReceivedShares.feature#L22)
 
-### [Group shares support](https://github.com/owncloud/ocis-reva/issues/194)
+### [Group shares support](https://github.com/owncloud/ocis/issues/1289)
 
 -   [apiShareOperationsToShares/gettingShares.feature:103](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareOperationsToShares/gettingShares.feature#L103)
 -   [apiShareOperationsToShares/gettingShares.feature:104](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareOperationsToShares/gettingShares.feature#L104)
 -   [apiShareOperationsToShares/gettingShares.feature:184](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareOperationsToShares/gettingShares.feature#L184)
 
-### [various sharing settings cannot be set](https://github.com/owncloud/ocis-reva/issues/41)
-### [Group shares support](https://github.com/owncloud/ocis-reva/issues/194)
+### [various sharing settings cannot be set](https://github.com/owncloud/ocis/issues/1328)
+### [Group shares support](https://github.com/owncloud/ocis/issues/1289)
 
 -   [apiShareUpdateToShares/updateShare.feature:290](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareUpdateToShares/updateShare.feature#L290)
 -   [apiShareUpdateToShares/updateShare.feature:291](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareUpdateToShares/updateShare.feature#L291)
@@ -1943,8 +1943,8 @@ restoring a file doesn't changes the etags of the parents
 -   [apiShareUpdateToShares/updateShare.feature:364](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareUpdateToShares/updateShare.feature#L364)
 -   [apiShareUpdateToShares/updateShare.feature:365](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareUpdateToShares/updateShare.feature#L365)
 
-### [Group shares support](https://github.com/owncloud/ocis-reva/issues/194)
-### [Sharing seems to work but does not work](https://github.com/owncloud/ocis-reva/issues/243)
+### [Group shares support](https://github.com/owncloud/ocis/issues/1289)
+### [Sharing seems to work but does not work](https://github.com/owncloud/ocis/issues/1303)
 
 -   [apiShareUpdateToShares/updateShare.feature:61](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareUpdateToShares/updateShare.feature#L61)
 -   [apiShareUpdateToShares/updateShare.feature:62](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareUpdateToShares/updateShare.feature#L62)
@@ -1965,14 +1965,14 @@ restoring a file doesn't changes the etags of the parents
 -   [apiShareUpdateToShares/updateShareGroupAndUserWithSameName.feature:54](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareUpdateToShares/updateShareGroupAndUserWithSameName.feature#L54)
 -   [apiShareUpdateToShares/updateShareGroupAndUserWithSameName.feature:55](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareUpdateToShares/updateShareGroupAndUserWithSameName.feature#L55)
 
-### [Share additional info](https://github.com/owncloud/ocis-reva/issues/349)
-### [Share extra attributes](https://github.com/owncloud/ocis-reva/issues/350)
-### [Edit user share response has an "name" field](https://github.com/owncloud/ocis-reva/issues/352)
+### [Share additional info](https://github.com/owncloud/ocis/issues/1253)
+### [Share extra attributes](https://github.com/owncloud/ocis/issues/1224)
+### [Edit user share response has an "name" field](https://github.com/owncloud/ocis/issues/1225)
 
 -   [apiShareUpdateToShares/updateShare.feature:230](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareUpdateToShares/updateShare.feature#L230)
 -   [apiShareUpdateToShares/updateShare.feature:231](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareUpdateToShares/updateShare.feature#L231)
 
-### [Webdav LOCK operations](https://github.com/owncloud/ocis-reva/issues/172)
+### [Webdav LOCK operations](https://github.com/owncloud/ocis/issues/1284)
 
 -   [apiWebdavLocks/exclusiveLocks.feature:17](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/exclusiveLocks.feature#L17)
 -   [apiWebdavLocks/exclusiveLocks.feature:18](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/exclusiveLocks.feature#L18)
@@ -2303,7 +2303,7 @@ restoring a file doesn't changes the etags of the parents
 -   [apiWebdavLocksUnlock/unlockSharingToShares.feature:167](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocksUnlock/unlockSharingToShares.feature#L167)
 -   [apiWebdavLocksUnlock/unlockSharingToShares.feature:168](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocksUnlock/unlockSharingToShares.feature#L168)
 
-### [Getting information about a folder overwritten by a file gives 500 error instead of 404](https://github.com/owncloud/ocis-reva/issues/387)
+### [Getting information about a folder overwritten by a file gives 500 error instead of 404](https://github.com/owncloud/ocis/issues/1239)
 
 -   [apiWebdavProperties1/copyFile.feature:220](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/copyFile.feature#L220)
 -   [apiWebdavProperties1/copyFile.feature:221](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/copyFile.feature#L221)
@@ -2383,6 +2383,7 @@ restoring a file doesn't changes the etags of the parents
 -   [apiProvisioningGroups-v2/removeFromGroup.feature:123](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiProvisioningGroups-v2/removeFromGroup.feature#L123)
 
 ### [Cannot create user with different username and emails](https://github.com/owncloud/product/issues/187)
+special character username not valid
 -   [apiProvisioningGroups-v1/getGroup.feature:11](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiProvisioningGroups-v1/getGroup.feature#L11)
 -   [apiProvisioningGroups-v2/getGroup.feature:11](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiProvisioningGroups-v2/getGroup.feature#L11)
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
"OCIS extension" repos were archived. So, the issues in these archived repos have been moved to ocis. This PR adjust the link to issues in expected-failure file.
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://github.com/owncloud/ocis/issues/1215