### PR TITLE
[tests-only] Bump behat/gherkin to 4.7.1

### DIFF
--- a/vendor-bin/behat/composer.json
+++ b/vendor-bin/behat/composer.json
@@ -6,7 +6,7 @@
     },
     "require": {
         "behat/behat": "^3.8",
-        "behat/gherkin": "4.6.2",
+        "behat/gherkin": "4.7.1",
         "behat/mink": "1.7.1",
         "behat/mink-extension": "^2.3",
         "behat/mink-selenium2-driver": "^1.4",


### PR DESCRIPTION
Part of issue https://github.com/owncloud/core/issues/38338

A new `Behat/Gherkin 4.7.1 patch release is now available and works.