### PR TITLE
hash share passwords

### DIFF
--- a/changelog/unreleased/hash-public-share-password.md
+++ b/changelog/unreleased/hash-public-share-password.md
@@ -1,0 +1,5 @@
+Enhancement: Hash public share passwords
+
+The share passwords were only base64 encoded. Added hashing using bcrypt with configurable hash cost.
+
+https://github.com/cs3org/reva/pull/1462


### PR DESCRIPTION
Passwords should never be stored in plaintext. The manager stored them base64 encoded which is very easily decoded to plaintext. Now the passwords are hashed using the bcrypt algorithm with a default cost of 11. The cost can be configured.