### PR TITLE
remove xml encoding from resourcetype

### DIFF
--- a/changelog/unreleased/align-href-url-encoding-with-oc10.md
+++ b/changelog/unreleased/align-href-url-encoding-with-oc10.md
@@ -3,6 +3,7 @@ Bugfix: Align href URL encoding with oc10
 We now use the same percent encoding for URLs in WebDAV href properties as ownCloud 10.
 
 https://github.com/cs3org/reva/pull/1425
+https://github.com/cs3org/reva/pull/1472
 https://github.com/owncloud/ocis/issues/1120
 https://github.com/owncloud/ocis/issues/1296
 https://github.com/owncloud/ocis/issues/1307

--- a/internal/http/services/owncloud/ocdav/trashbin.go
+++ b/internal/http/services/owncloud/ocdav/trashbin.go
@@ -274,7 +274,7 @@ func (h *TrashbinHandler) itemToPropResponse(ctx context.Context, s *svc, u *use
 		response.Propstat[0].Prop = append(response.Propstat[0].Prop, s.newProp("oc:trashbin-original-location", strings.TrimPrefix(item.Path, "/")))
 		response.Propstat[0].Prop = append(response.Propstat[0].Prop, s.newProp("oc:trashbin-delete-datetime", dTime))
 		if item.Type == provider.ResourceType_RESOURCE_TYPE_CONTAINER {
-			response.Propstat[0].Prop = append(response.Propstat[0].Prop, s.newProp("d:resourcetype", "<d:collection/>"))
+			response.Propstat[0].Prop = append(response.Propstat[0].Prop, s.newPropRaw("d:resourcetype", "<d:collection/>"))
 			// TODO(jfd): decide if we can and want to list oc:size for folders
 		} else {
 			response.Propstat[0].Prop = append(response.Propstat[0].Prop,
@@ -325,7 +325,7 @@ func (h *TrashbinHandler) itemToPropResponse(ctx context.Context, s *svc, u *use
 					}
 				case "resourcetype":
 					if item.Type == provider.ResourceType_RESOURCE_TYPE_CONTAINER {
-						propstatOK.Prop = append(propstatOK.Prop, s.newProp("d:resourcetype", "<d:collection/>"))
+						propstatOK.Prop = append(propstatOK.Prop, s.newPropRaw("d:resourcetype", "<d:collection/>"))
 					} else {
 						propstatOK.Prop = append(propstatOK.Prop, s.newProp("d:resourcetype", ""))
 						// redirectref is another option


### PR DESCRIPTION
@butonic PR https://github.com/cs3org/reva/commit/e3510caf40bb53fbc659345c8fc99c38f91e0fed#diff-9ea37ac2a75eab146ef45d95f9f0efc802922c0df47e108ce88de038e34509bfR304 added xml encoding to the `newProp` method.
But we want to append another xml element so we don't want to xml encode them.

We really need better XML handling... :see_no_evil: 