### PR TITLE
Introduce Named Services

### DIFF
--- a/changelog/unreleased/named-services.md
+++ b/changelog/unreleased/named-services.md
@@ -1,0 +1,5 @@
+Enhancement: Named Service Registration
+
+move away from hardcoding service IP addresses and rely upon name resolution instead. It delegates the address lookup to a static in-memory service registry, which can be re-implemented in multiple forms.
+
+https://github.com/cs3org/reva/pull/1509

--- a/examples/ocmd/ocmd-server-1.toml
+++ b/examples/ocmd/ocmd-server-1.toml
@@ -1,6 +1,17 @@
 [shared]
 gatewaysvc = "localhost:19000"
 
+[registry]
+driver = "static"
+
+[registry.static]
+services = ["authprovider","userprovider"]
+
+[registry.static.authprovider]
+bearer = ["localhost:0123"]
+basic = ["localhost:1234"]
+publiclink = ["localhost:9876"]
+
 [grpc]
 address = "0.0.0.0:19000"
 

--- a/go.mod
+++ b/go.mod
@@ -53,6 +53,7 @@ require (
 	golang.org/x/term v0.0.0-20201117132131-f5c789dd3221
 	google.golang.org/grpc v1.37.0
 	google.golang.org/protobuf v1.26.0
+	gotest.tools v2.2.0+incompatible
 )
 
 go 1.16

--- a/go.sum
+++ b/go.sum
@@ -1529,6 +1529,7 @@ gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20200605160147-a5ece683394c h1:grhR+C34yXImVGp7EzNk+DTIk+323eIUWOmEevy6bDo=
 gopkg.in/yaml.v3 v3.0.0-20200605160147-a5ece683394c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/internal/grpc/services/gateway/gateway.go
+++ b/internal/grpc/services/gateway/gateway.go
@@ -82,7 +82,10 @@ func (c *config) init() {
 
 	// if services address are not specified we used the shared conf
 	// for the gatewaysvc to have dev setups very quickly.
-	c.AuthRegistryEndpoint = sharedconf.GetGatewaySVC(c.AuthRegistryEndpoint)
+
+	// we're commenting this line to showcase the fact that now we don't want to point to an ip address but rather
+	// resolve an ip address from a name.
+	// c.AuthRegistryEndpoint = sharedconf.GetGatewaySVC(c.AuthRegistryEndpoint)
 	c.StorageRegistryEndpoint = sharedconf.GetGatewaySVC(c.StorageRegistryEndpoint)
 	c.AppRegistryEndpoint = sharedconf.GetGatewaySVC(c.AppRegistryEndpoint)
 	c.PreferencesEndpoint = sharedconf.GetGatewaySVC(c.PreferencesEndpoint)

--- a/internal/grpc/services/gateway/gateway.go
+++ b/internal/grpc/services/gateway/gateway.go
@@ -85,7 +85,7 @@ func (c *config) init() {
 
 	// we're commenting this line to showcase the fact that now we don't want to point to an ip address but rather
 	// resolve an ip address from a name.
-	// c.AuthRegistryEndpoint = sharedconf.GetGatewaySVC(c.AuthRegistryEndpoint)
+	c.AuthRegistryEndpoint = sharedconf.GetGatewaySVC(c.AuthRegistryEndpoint)
 	c.StorageRegistryEndpoint = sharedconf.GetGatewaySVC(c.StorageRegistryEndpoint)
 	c.AppRegistryEndpoint = sharedconf.GetGatewaySVC(c.AppRegistryEndpoint)
 	c.PreferencesEndpoint = sharedconf.GetGatewaySVC(c.PreferencesEndpoint)

--- a/pkg/registry/config.go
+++ b/pkg/registry/config.go
@@ -24,7 +24,7 @@ import (
 
 // Config configures a registry
 type Config struct {
-	Services map[string]map[string]*Service `mapstructure:"services"`
+	Services map[string]map[string]*service `mapstructure:"services"`
 }
 
 // service implements the Service interface. Attributes are exported so that mapstructure can unmarshal values onto them.
@@ -46,7 +46,7 @@ func ParseConfig(m map[string]interface{}) (*Config, error) {
 	}
 
 	if len(c.Services) == 0 {
-		c.Services = make(map[string]map[string]*Service)
+		c.Services = make(map[string]map[string]*service)
 	}
 
 	return c, nil

--- a/pkg/registry/config.go
+++ b/pkg/registry/config.go
@@ -24,10 +24,10 @@ import (
 
 // Config configures a registry
 type Config struct {
-	Services map[string][]*service `mapstructure:"services"`
+	Services map[string]map[string]*Service `mapstructure:"services"`
 }
 
-// service implements the Service interface
+// service implements the Service interface. Attributes are exported so that mapstructure can unmarshal values onto them.
 type service struct {
 	Name  string `mapstructure:"name"`
 	Nodes []node `mapstructure:"nodes"`
@@ -46,7 +46,7 @@ func ParseConfig(m map[string]interface{}) (*Config, error) {
 	}
 
 	if len(c.Services) == 0 {
-		c.Services = make(map[string][]*service)
+		c.Services = make(map[string]map[string]*Service)
 	}
 
 	return c, nil

--- a/pkg/registry/config.go
+++ b/pkg/registry/config.go
@@ -16,43 +16,38 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-package runtime
+package registry
 
 import (
-	"github.com/cs3org/reva/pkg/registry"
-	"github.com/rs/zerolog"
+	"github.com/mitchellh/mapstructure"
 )
 
-// Option defines a single option function.
-type Option func(o *Options)
-
-// Options defines the available options for this package.
-type Options struct {
-	Logger   *zerolog.Logger
-	Registry registry.Registry
+// Config configures a registry
+type Config struct {
+	Services map[string][]*service `mapstructure:"services"`
 }
 
-// newOptions initializes the available default options.
-func newOptions(opts ...Option) Options {
-	opt := Options{}
-
-	for _, o := range opts {
-		o(&opt)
-	}
-
-	return opt
+// service implements the Service interface
+type service struct {
+	Name  string `mapstructure:"name"`
+	Nodes []node `mapstructure:"nodes"`
 }
 
-// WithLogger provides a function to set the logger option.
-func WithLogger(logger *zerolog.Logger) Option {
-	return func(o *Options) {
-		o.Logger = logger
-	}
+type node struct {
+	Address  string            `mapstructure:"address"`
+	Metadata map[string]string `mapstructure:"metadata"`
 }
 
-// WithRegistry provides a function to set the registry.
-func WithRegistry(r registry.Registry) Option {
-	return func(o *Options) {
-		o.Registry = r
+// ParseConfig translates Config file values into a Config struct for consumers.
+func ParseConfig(m map[string]interface{}) (*Config, error) {
+	c := &Config{}
+	if err := mapstructure.Decode(m, c); err != nil {
+		return nil, err
 	}
+
+	if len(c.Services) == 0 {
+		c.Services = make(map[string][]*service)
+	}
+
+	return c, nil
 }

--- a/pkg/registry/config_test.go
+++ b/pkg/registry/config_test.go
@@ -1,3 +1,21 @@
+// Copyright 2018-2021 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
 package registry
 
 import (

--- a/pkg/registry/config_test.go
+++ b/pkg/registry/config_test.go
@@ -23,6 +23,26 @@ import (
 	"testing"
 )
 
+/*
+config example:
+
+---
+services:
+  authprovider:
+    basic:
+      name: auth-basic
+      nodes:
+      - address: 0.0.0.0:1234
+        metadata:
+          version: v0.1.0
+    bearer:
+      name: auth-bearer
+      nodes:
+      - address: 0.0.0.0:5678
+        metadata:
+          version: v0.1.0
+
+*/
 func TestParseConfig(t *testing.T) {
 	type args struct {
 		m map[string]interface{}

--- a/pkg/registry/config_test.go
+++ b/pkg/registry/config_test.go
@@ -1,0 +1,74 @@
+package registry
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseConfig(t *testing.T) {
+	type args struct {
+		m map[string]interface{}
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *Config
+		wantErr bool
+	}{
+		{name: "parse config", args: args{map[string]interface{}{
+			"services": map[string]map[string]interface{}{
+				"authprovider": map[string]interface{}{
+					"basic": map[string]interface{}{
+						"name": "auth-basic",
+						"nodes": []map[string]interface{}{
+							{
+								"address":  "0.0.0.0:1234",
+								"metadata": map[string]string{"version": "v0.1.0"},
+							},
+						},
+					},
+					"bearer": map[string]interface{}{
+						"name": "auth-bearer",
+						"nodes": []map[string]interface{}{
+							{
+								"address":  "0.0.0.0:5678",
+								"metadata": map[string]string{"version": "v0.1.0"},
+							},
+						},
+					},
+				},
+			},
+		}}, want: &Config{
+			Services: map[string]map[string]*service{
+				"authprovider": map[string]*service{
+					"basic": &service{
+						Name: "auth-basic",
+						Nodes: []node{{
+							Address:  "0.0.0.0:1234",
+							Metadata: map[string]string{"version": "v0.1.0"},
+						}},
+					},
+					"bearer": &service{
+						Name: "auth-bearer",
+						Nodes: []node{{
+							Address:  "0.0.0.0:5678",
+							Metadata: map[string]string{"version": "v0.1.0"},
+						}},
+					},
+				},
+			},
+		}, wantErr: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseConfig(tt.args.m)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseConfig() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ParseConfig() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/registry/memory/memory.go
+++ b/pkg/registry/memory/memory.go
@@ -70,10 +70,10 @@ func (r *Registry) GetService(name string) (registry.Service, error) {
 
 // New returns an implementation of the Registry interface.
 func New(m map[string]interface{}) registry.Registry {
-	//c, err := registry.ParseConfig(m)
-	//if err != nil {
+	// c, err := registry.ParseConfig(m)
+	// if err != nil {
 	//	return nil
-	//}
+	// }
 
 	return &Registry{
 		services: map[string]registry.Service{},

--- a/pkg/registry/memory/memory.go
+++ b/pkg/registry/memory/memory.go
@@ -1,0 +1,116 @@
+// Copyright 2018-2021 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package memory
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/cs3org/reva/pkg/registry"
+)
+
+// Registry implements the Registry interface.
+type Registry struct {
+	// m protects async access to the services map.
+	sync.Mutex
+	// services map a service name with a set of nodes.
+	services map[string][]registry.Service
+}
+
+// Add implements the Registry interface. If the service is already known in this registry it will only update the nodes.
+func (r *Registry) Add(svc registry.Service) error {
+	r.Lock()
+	defer r.Unlock()
+
+	// init the new service in the registry storage if we have not seen it before
+	if _, ok := r.services[svc.Name()]; !ok {
+		s := []registry.Service{svc}
+		r.services[svc.Name()] = s
+		return nil
+	}
+
+	// append the requested nodes to the existing service
+	for i := range r.services[svc.Name()] {
+		ns := make([]node, 0)
+		nodes := append(r.services[svc.Name()][i].Nodes(), svc.Nodes()...)
+		for n := range nodes {
+			ns = append(ns, node{
+				id:       nodes[n].ID(),
+				address:  nodes[n].Address(),
+				metadata: nodes[n].Metadata(),
+			})
+		}
+		r.services[svc.Name()] = []registry.Service{
+			service{
+				svc.Name(),
+				ns,
+			},
+		}
+		fmt.Printf("%+v\n", r.services[svc.Name()])
+	}
+
+	return nil
+}
+
+// GetService implements the Registry interface. There is currently no load balance being done, but it should not be
+// hard to add.
+func (r *Registry) GetService(name string) ([]registry.Service, error) {
+	r.Lock()
+	defer r.Unlock()
+
+	if services, ok := r.services[name]; ok {
+		return services, nil
+	}
+
+	return nil, fmt.Errorf("service %v not found", name)
+}
+
+// New returns an implementation of the Registry interface.
+func New(m map[string]interface{}) registry.Registry {
+	c, err := registry.ParseConfig(m)
+	if err != nil {
+		return nil
+	}
+
+	r := make(map[string][]registry.Service)
+	for sKey, services := range c.Services {
+		// allocate as much memory as total services were parsed from config
+		r[sKey] = make([]registry.Service, len(services))
+
+		for i := range services {
+			s := service{
+				name: services[i].Name,
+			}
+
+			// copy nodes
+			for j := range services[i].Nodes {
+				s.nodes = append(s.nodes, node{
+					address:  services[i].Nodes[j].Address,
+					metadata: services[i].Nodes[j].Metadata,
+				})
+			}
+
+			r[sKey][i] = &s
+		}
+	}
+
+	return &Registry{
+		services: r,
+	}
+}

--- a/pkg/registry/memory/memory_test.go
+++ b/pkg/registry/memory/memory_test.go
@@ -23,8 +23,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/cs3org/reva/pkg/registry"
-
 	"github.com/google/uuid"
 	"gotest.tools/assert"
 )
@@ -98,14 +96,7 @@ func TestAdd(t *testing.T) {
 	expectedNumberOfNodes := len(s1.nodes) + len(s2.nodes)
 	if s, err := reg.GetService(s1.name); err != nil {
 		t.Error(err)
-		collectedNumberOfNodes := 0
-		if len(s) != 0 {
-			for _, service := range s {
-				collectedNumberOfNodes += len(service.Nodes())
-			}
-		} else {
-			t.Error(fmt.Errorf("invalid number of registered services: 0"))
-		}
+		collectedNumberOfNodes := len(s.Nodes())
 
 		if expectedNumberOfNodes == collectedNumberOfNodes {
 			t.Error(fmt.Errorf("expected %v nodes, got: %v", expectedNumberOfNodes, collectedNumberOfNodes))
@@ -121,56 +112,25 @@ func TestGetService(t *testing.T) {
 				os.Exit(1)
 			}
 		}
+
 		t.Run(scenario.name, func(t *testing.T) {
 			svc, err := reg.GetService(scenario.in)
 			if err != nil {
 				t.Error(err)
 			}
 
-			totalNodes := 0
-			for i := range svc {
-				totalNodes += len(svc[i].Nodes())
-				for _, node := range svc[i].Nodes() {
-					if !contains(svc[i].Nodes(), node) {
-						t.Errorf("unexpected return value: Registry does not contain node %s", node)
-					}
-				}
-			}
+			totalNodes := len(svc.Nodes())
 			assert.Equal(t, len(scenario.expectedNodes), totalNodes)
 		})
 	}
 }
 
-func TestGetServiceInDepth(t *testing.T) {
-	for _, scenario := range scenarios {
-		// restart Registry
-		reg = New(in)
-		// register all services
-		for i := range scenario.services {
-			if err := reg.Add(&scenario.services[i]); err != nil {
-				os.Exit(1)
-			}
-		}
-		t.Run(scenario.name, func(t *testing.T) {
-			services, err := reg.GetService(scenario.in)
-			if err != nil {
-				t.Error(err)
-			}
-
-			for _, service := range services {
-				for _, nodes := range service.Nodes() {
-					fmt.Println(nodes.Address())
-				}
-			}
-		})
-	}
-}
-
-func contains(a []registry.Node, b registry.Node) bool {
-	for i := range a {
-		if a[i].Address() == b.Address() {
-			return true
-		}
-	}
-	return false
-}
+//
+//func contains(a []registry.Node, b registry.Node) bool {
+//	for i := range a {
+//		if a[i].Address() == b.Address() {
+//			return true
+//		}
+//	}
+//	return false
+//}

--- a/pkg/registry/memory/memory_test.go
+++ b/pkg/registry/memory/memory_test.go
@@ -1,0 +1,176 @@
+// Copyright 2018-2021 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package memory
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/cs3org/reva/pkg/registry"
+
+	"github.com/google/uuid"
+	"gotest.tools/assert"
+)
+
+var (
+	in    = make(map[string]interface{})
+	reg   = New(in)
+	node1 = node{
+		id:      uuid.New().String(),
+		address: "0.0.0.0:42069",
+		metadata: map[string]string{
+			"type": "auth-bearer",
+		},
+	}
+
+	node2 = node{
+		id:      uuid.New().String(),
+		address: "0.0.0.0:7777",
+		metadata: map[string]string{
+			"type": "auth-basic",
+		},
+	}
+
+	node3 = node{id: uuid.NewString(), address: "0.0.0.0:8888"}
+	node4 = node{id: uuid.NewString(), address: "0.0.0.0:9999"}
+)
+
+var scenarios = []struct {
+	name          string // scenario name
+	in            string // used to query the Registry by service name
+	services      []service
+	expectedNodes []node // expected set of nodes
+}{
+	{
+		name: "single service with 2 nodes",
+		in:   "auth-provider",
+		services: []service{
+			{name: "auth-provider", nodes: []node{node1, node2}},
+		},
+		expectedNodes: []node{node1, node2},
+	},
+	{
+		name: "single service with 2 nodes scaled x2",
+		in:   "auth-provider",
+		services: []service{
+			{name: "auth-provider", nodes: []node{node1, node2}},
+			{name: "auth-provider", nodes: []node{node3, node4}},
+		},
+		expectedNodes: []node{node1, node2, node3, node4},
+	},
+}
+
+func TestAdd(t *testing.T) {
+	reg = New(in)
+	s1 := scenarios[1].services[0]
+	s2 := scenarios[1].services[1]
+	_ = reg.Add(s1)
+	_ = reg.Add(s2)
+
+	_ = reg.Add(service{
+		name: "test",
+		nodes: []node{
+			{
+				id:       "1234",
+				address:  "localhost:8899",
+				metadata: nil,
+			},
+		},
+	})
+
+	expectedNumberOfNodes := len(s1.nodes) + len(s2.nodes)
+	if s, err := reg.GetService(s1.name); err != nil {
+		t.Error(err)
+		collectedNumberOfNodes := 0
+		if len(s) != 0 {
+			for _, service := range s {
+				collectedNumberOfNodes += len(service.Nodes())
+			}
+		} else {
+			t.Error(fmt.Errorf("invalid number of registered services: 0"))
+		}
+
+		if expectedNumberOfNodes == collectedNumberOfNodes {
+			t.Error(fmt.Errorf("expected %v nodes, got: %v", expectedNumberOfNodes, collectedNumberOfNodes))
+		}
+	}
+}
+
+func TestGetService(t *testing.T) {
+	for _, scenario := range scenarios {
+		reg = New(in)
+		for _, service := range scenario.services {
+			if err := reg.Add(&service); err != nil {
+				os.Exit(1)
+			}
+		}
+		t.Run(scenario.name, func(t *testing.T) {
+			svc, err := reg.GetService(scenario.in)
+			if err != nil {
+				t.Error(err)
+			}
+
+			totalNodes := 0
+			for i := range svc {
+				totalNodes += len(svc[i].Nodes())
+				for _, node := range svc[i].Nodes() {
+					if !contains(svc[i].Nodes(), node) {
+						t.Errorf("unexpected return value: Registry does not contain node %s", node)
+					}
+				}
+			}
+			assert.Equal(t, len(scenario.expectedNodes), totalNodes)
+		})
+	}
+}
+
+func TestGetServiceInDepth(t *testing.T) {
+	for _, scenario := range scenarios {
+		// restart Registry
+		reg = New(in)
+		// register all services
+		for i := range scenario.services {
+			if err := reg.Add(&scenario.services[i]); err != nil {
+				os.Exit(1)
+			}
+		}
+		t.Run(scenario.name, func(t *testing.T) {
+			services, err := reg.GetService(scenario.in)
+			if err != nil {
+				t.Error(err)
+			}
+
+			for _, service := range services {
+				for _, nodes := range service.Nodes() {
+					fmt.Println(nodes.Address())
+				}
+			}
+		})
+	}
+}
+
+func contains(a []registry.Node, b registry.Node) bool {
+	for i := range a {
+		if a[i].Address() == b.Address() {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/registry/memory/memory_test.go
+++ b/pkg/registry/memory/memory_test.go
@@ -125,12 +125,11 @@ func TestGetService(t *testing.T) {
 	}
 }
 
-//
-//func contains(a []registry.Node, b registry.Node) bool {
-//	for i := range a {
-//		if a[i].Address() == b.Address() {
-//			return true
+//	func contains(a []registry.Node, b registry.Node) bool {
+//		for i := range a {
+//			if a[i].Address() == b.Address() {
+//				return true
+//			}
 //		}
+//		return false
 //	}
-//	return false
-//}

--- a/pkg/registry/memory/node.go
+++ b/pkg/registry/memory/node.go
@@ -16,43 +16,29 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-package runtime
+package memory
 
-import (
-	"github.com/cs3org/reva/pkg/registry"
-	"github.com/rs/zerolog"
-)
+import "fmt"
 
-// Option defines a single option function.
-type Option func(o *Options)
-
-// Options defines the available options for this package.
-type Options struct {
-	Logger   *zerolog.Logger
-	Registry registry.Registry
+// node implements the registry.Node interface.
+type node struct {
+	id       string
+	address  string
+	metadata map[string]string
 }
 
-// newOptions initializes the available default options.
-func newOptions(opts ...Option) Options {
-	opt := Options{}
-
-	for _, o := range opts {
-		o(&opt)
-	}
-
-	return opt
+func (n node) Address() string {
+	return n.address
 }
 
-// WithLogger provides a function to set the logger option.
-func WithLogger(logger *zerolog.Logger) Option {
-	return func(o *Options) {
-		o.Logger = logger
-	}
+func (n node) Metadata() map[string]string {
+	return n.metadata
 }
 
-// WithRegistry provides a function to set the registry.
-func WithRegistry(r registry.Registry) Option {
-	return func(o *Options) {
-		o.Registry = r
-	}
+func (n node) String() string {
+	return fmt.Sprintf("%v-%v", n.id, n.address)
+}
+
+func (n node) ID() string {
+	return n.id
 }

--- a/pkg/registry/memory/service.go
+++ b/pkg/registry/memory/service.go
@@ -20,6 +20,7 @@ package memory
 
 import "github.com/cs3org/reva/pkg/registry"
 
+// NewService creates a new memory registry.Service.
 func NewService(name string, nodes []interface{}) registry.Service {
 	n := make([]node, 0)
 	for i := 0; i < len(nodes); i++ {
@@ -43,10 +44,12 @@ type service struct {
 	nodes []node
 }
 
+// Name implements the service interface.
 func (s service) Name() string {
 	return s.name
 }
 
+// Nodes implements the service interface.
 func (s service) Nodes() []registry.Node {
 	ret := make([]registry.Node, 0)
 	for i := range s.nodes {

--- a/pkg/registry/memory/service.go
+++ b/pkg/registry/memory/service.go
@@ -57,3 +57,14 @@ func (s service) Nodes() []registry.Node {
 	}
 	return ret
 }
+
+func (s *service) mergeNodes(n1, n2 []registry.Node) {
+	n1 = append(n1, n2...)
+	for _, n := range n1 {
+		s.nodes = append(s.nodes, node{
+			id:       n.ID(),
+			address:  n.Address(),
+			metadata: n.Metadata(),
+		})
+	}
+}

--- a/pkg/registry/memory/service.go
+++ b/pkg/registry/memory/service.go
@@ -1,0 +1,56 @@
+// Copyright 2018-2021 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package memory
+
+import "github.com/cs3org/reva/pkg/registry"
+
+func NewService(name string, nodes []interface{}) registry.Service {
+	n := make([]node, 0)
+	for i := 0; i < len(nodes); i++ {
+		n = append(n, node{
+			// explicit type conversions because types are not exported to prevent from circular dependencies until released.
+			id:      nodes[i].(map[string]interface{})["id"].(string),
+			address: nodes[i].(map[string]interface{})["address"].(string),
+			//metadata: nodes[i].(map[string]interface{})["metadata"].(map[string]string),
+		})
+	}
+
+	return service{
+		name:  name,
+		nodes: n,
+	}
+}
+
+// service implements the Service interface
+type service struct {
+	name  string
+	nodes []node
+}
+
+func (s service) Name() string {
+	return s.name
+}
+
+func (s service) Nodes() []registry.Node {
+	ret := make([]registry.Node, 0)
+	for i := range s.nodes {
+		ret = append(ret, s.nodes[i])
+	}
+	return ret
+}

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -25,7 +25,7 @@ type Registry interface {
 
 	// GetService retrieves a Service and all of its nodes by Service name. It returns []*Service because we can have
 	// multiple versions of the same Service running alongside each others.
-	GetService(string) ([]Service, error)
+	GetService(string) (Service, error)
 }
 
 // Service defines a service.

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -1,0 +1,49 @@
+// Copyright 2018-2021 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package registry
+
+// Registry provides with means for dynamically registering services.
+type Registry interface {
+	// Add registers a Service on the memoryRegistry. Repeated names is allowed, services are distinguished by their metadata.
+	Add(Service) error
+
+	// GetService retrieves a Service and all of its nodes by Service name. It returns []*Service because we can have
+	// multiple versions of the same Service running alongside each others.
+	GetService(string) ([]Service, error)
+}
+
+// Service defines a service.
+type Service interface {
+	Name() string
+	Nodes() []Node
+}
+
+// Node defines nodes on a service.
+type Node interface {
+	// Address where the given node is running.
+	Address() string
+
+	// metadata is used in order to differentiate services implementations. For instance an AuthProvider Service could
+	// have multiple implementations, basic, bearer ..., metadata would be used to select the Service type depending on
+	// its implementation.
+	Metadata() map[string]string
+
+	// ID returns the node ID.
+	ID() string
+}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -32,6 +32,8 @@ import (
 	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	types "github.com/cs3org/go-cs3apis/cs3/types/v1beta1"
+	"github.com/cs3org/reva/pkg/registry"
+	"github.com/cs3org/reva/pkg/registry/memory"
 	"github.com/golang/protobuf/proto"
 	"google.golang.org/protobuf/encoding/protojson"
 )
@@ -40,6 +42,9 @@ var (
 	matchFirstCap = regexp.MustCompile("(.)([A-Z][a-z]+)")
 	matchAllCap   = regexp.MustCompile("([a-z0-9])([A-Z])")
 	matchEmail    = regexp.MustCompile("^[a-zA-Z0-9.!#$%&'*+\\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$")
+	// GlobalRegistry configures a service registry globally accessible. It defaults to a memory registry. The usage of
+	// globals is not encouraged, and this is a workaround until the PR is out of a draft state.
+	GlobalRegistry registry.Registry = memory.New(map[string]interface{}{})
 )
 
 // Skip  evaluates whether a source endpoint contains any of the prefixes.

--- a/tests/oc-integration-tests/drone/gateway.toml
+++ b/tests/oc-integration-tests/drone/gateway.toml
@@ -2,6 +2,13 @@
 jwt_secret = "Pive-Fumkiu4"
 gatewaysvc = "localhost:19000"
 
+#[[registry.services.storagehome]]
+#name = 'authregistry'
+#
+#[[registry.services.storagehome.nodes]]
+#id = '65ad3270-9e87-11eb-a1aa-0fcc1edaa55e'
+#address = '0.0.0.0:9142'
+
 # This gateway.toml config file will start a reva service that:
 # - serves as a gateway for all requests
 # - looks up the storageprovider using a storageregistry

--- a/tests/oc-integration-tests/drone/storage-home-ocis.toml
+++ b/tests/oc-integration-tests/drone/storage-home-ocis.toml
@@ -3,6 +3,13 @@
 jwt_secret = "Pive-Fumkiu4"
 gatewaysvc = "localhost:19000"
 
+#[[registry.services.storagehome]]
+#name = 'storage-home'
+#
+#[[registry.services.storagehome.nodes]]
+#id = '130e0018-9e86-11eb-8634-336624ad2203'
+#address = '0.0.0.0:9154'
+
 # - authenticates grpc storage provider requests using the internal jwt token
 # - authenticates http upload and download requests requests using basic auth
 # - serves the home storage provider on grpc port 12000


### PR DESCRIPTION
## What?

Currently, the way that services are configured is very binary: if a key is present in the config file, use its value, or else default to the gateway address. This is inflexible in terms of scaling (in the cloud?) and we would rather use names instead of IP addresses.

When communicating with another service the caller needs to know beforehand the address of the target, the existing implementation defaults such address to the gateway. Every service needs to explicitly know the endpoints it needs to communicate with. This is a proposal to move away from hardcoding service IP addresses and rely upon name resolution instead. It delegates the address lookup to, for the sake of this PR, a static in-memory service registry, which can be re-implemented in multiple forms, since there is only an interface to satisfy.

### Technical Details

Reva configuration has been extended to support a top-level registry key / value pair. Its value looks like this:

```toml
## global registry initialization
[registry.services]
"com.owncloud.authregistry" = [{nodes = [{ address = "localhost:19000" }]}]
```

### Note

A decision was made not to support backward compatibility with the current IP addresses mapping in order to isolate the changes to a single service and fail if misconfigured; backward compatibility can be easily added to provide support for existing functionality by simply failing at querying the registry and defaulting to the current defaults.

### Implementation

The glue comes in the form of a new interface introduced in Reva, the Registry interface, that looks like:

```go
type Registry interface {
	Add(Service) error
	GetService(string) ([]*Service, error)
}
```

a Service type (that will be moved to be an interface)

```go
type Service struct {
	Name  string 	`mapstructure:"name"`
	Nodes []Node 	`mapstructure:"nodes"`
}
```

and Nodes:

```go
type Node struct {
	ID string 					`mapstructure:"id"`
	Address string 				`mapstructure:"address"`
	Metadata map[string]string 	`mapstructure:"metadata"`
}
```

This set of interfaces and types would theoretically allow any consumer of Reva that wants to start its own service to inject its own registry. Registry injection happens now as a functional option on `runtime.go`:

```go
func WithRegistry(r registry.Registry) Option {
	return func(o *Options) {
		o.Registry = r
	}
}
```

### Current Registry Implementation breakdown

The current registry relies on an in-memory implementation of the `registry.Registry` interface. It will parse the static config from the toml file. This has a set of drawbacks in the way that services outside the process boundary will not know of any registered service, but since the current changes are contained to the gateway, these effects are not yet seen. A good approach would be to have a dedicated service registry service running so it can be queried upon (for more on this, see https://www.nginx.com/blog/service-discovery-in-a-microservices-architecture/).

One drawback of this approach, as previously mentioned, is that we're using a global registry as default, to prove this hypothesis and showcase how it would work on Reva and with library consumers! We do not encourage the use of globals :)

### Ideas and further improvements

- With this in mind we could sanitize the set of defaults on the gateway config.
- Config would be much simpler as we don't have to carry IP addresses around every time a node is restarted, or we can provide support for dynamic IP addresses; configuration would just be a matter of writing the service name.
- Client-side load balancing; by adding client awareness of service registries and a selection strategy.