### PR TITLE
Fix recycle to different location

### DIFF
--- a/changelog/unreleased/fix-restore-to-different-location.md
+++ b/changelog/unreleased/fix-restore-to-different-location.md
@@ -1,0 +1,8 @@
+Bugfix: Allow for restoring recycle items to different locations
+
+The CS3 APIs specify a way to restore a recycle item to a different location
+than the original by setting the `restore_path` field in the
+`RestoreRecycleItemRequest`. This field had not been considered until now.
+
+https://github.com/cs3org/reva/pull/1541
+https://cs3org.github.io/cs3apis/

--- a/internal/grpc/services/storageprovider/storageprovider.go
+++ b/internal/grpc/services/storageprovider/storageprovider.go
@@ -814,7 +814,7 @@ func (s *service) ListRecycle(ctx context.Context, req *provider.ListRecycleRequ
 
 func (s *service) RestoreRecycleItem(ctx context.Context, req *provider.RestoreRecycleItemRequest) (*provider.RestoreRecycleItemResponse, error) {
 	// TODO(labkode): CRITICAL: fill recycle info with storage provider.
-	if err := s.storage.RestoreRecycleItem(ctx, req.Key); err != nil {
+	if err := s.storage.RestoreRecycleItem(ctx, req.Key, req.RestorePath); err != nil {
 		var st *rpc.Status
 		switch err.(type) {
 		case errtypes.IsNotFound:

--- a/pkg/storage/fs/owncloud/owncloud.go
+++ b/pkg/storage/fs/owncloud/owncloud.go
@@ -2140,7 +2140,7 @@ func (fs *ocfs) ListRecycle(ctx context.Context) ([]*provider.RecycleItem, error
 	return items, nil
 }
 
-func (fs *ocfs) RestoreRecycleItem(ctx context.Context, key string) error {
+func (fs *ocfs) RestoreRecycleItem(ctx context.Context, key, restorePath string) error {
 	// TODO check permission? on what? user must be the owner?
 	log := appctx.GetLogger(ctx)
 	rp, err := fs.getRecyclePath(ctx)
@@ -2155,16 +2155,17 @@ func (fs *ocfs) RestoreRecycleItem(ctx context.Context, key string) error {
 		return nil
 	}
 
-	origin := "/"
-	if v, err := xattr.Get(src, trashOriginPrefix); err != nil {
-		log.Error().Err(err).Str("key", key).Str("path", src).Msg("could not read origin")
-	} else {
-		origin = filepath.Clean(string(v))
+	if restorePath == "" {
+		v, err := xattr.Get(src, trashOriginPrefix)
+		if err != nil {
+			log.Error().Err(err).Str("key", key).Str("path", src).Msg("could not read origin")
+		}
+		restorePath = filepath.Join("/", filepath.Clean(string(v)), strings.TrimSuffix(filepath.Base(src), suffix))
 	}
-	tgt := fs.toInternalPath(ctx, filepath.Join("/", origin, strings.TrimSuffix(filepath.Base(src), suffix)))
+	tgt := fs.toInternalPath(ctx, restorePath)
 	// move back to original location
 	if err := os.Rename(src, tgt); err != nil {
-		log.Error().Err(err).Str("key", key).Str("origin", origin).Str("src", src).Str("tgt", tgt).Msg("could not restore item")
+		log.Error().Err(err).Str("key", key).Str("restorePath", restorePath).Str("src", src).Str("tgt", tgt).Msg("could not restore item")
 		return errors.Wrap(err, "ocfs: could not restore item")
 	}
 	// unset trash origin location in metadata

--- a/pkg/storage/fs/s3/s3.go
+++ b/pkg/storage/fs/s3/s3.go
@@ -656,6 +656,6 @@ func (fs *s3FS) ListRecycle(ctx context.Context) ([]*provider.RecycleItem, error
 	return nil, errtypes.NotSupported("list recycle")
 }
 
-func (fs *s3FS) RestoreRecycleItem(ctx context.Context, restoreKey string) error {
+func (fs *s3FS) RestoreRecycleItem(ctx context.Context, restoreKey, restorePath string) error {
 	return errtypes.NotSupported("restore recycle")
 }

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -43,7 +43,7 @@ type FS interface {
 	DownloadRevision(ctx context.Context, ref *provider.Reference, key string) (io.ReadCloser, error)
 	RestoreRevision(ctx context.Context, ref *provider.Reference, key string) error
 	ListRecycle(ctx context.Context) ([]*provider.RecycleItem, error)
-	RestoreRecycleItem(ctx context.Context, key string) error
+	RestoreRecycleItem(ctx context.Context, key, restorePath string) error
 	PurgeRecycleItem(ctx context.Context, key string) error
 	EmptyRecycle(ctx context.Context) error
 	GetPathByID(ctx context.Context, id *provider.ResourceId) (string, error)

--- a/pkg/storage/utils/decomposedfs/decomposedfs.go
+++ b/pkg/storage/utils/decomposedfs/decomposedfs.go
@@ -63,7 +63,7 @@ type Tree interface {
 	// CreateReference(ctx context.Context, node *node.Node, targetURI *url.URL) error
 	Move(ctx context.Context, oldNode *node.Node, newNode *node.Node) (err error)
 	Delete(ctx context.Context, node *node.Node) (err error)
-	RestoreRecycleItemFunc(ctx context.Context, key string) (*node.Node, func() error, error)
+	RestoreRecycleItemFunc(ctx context.Context, key, targetPath string) (*node.Node, func() error, error)
 	PurgeRecycleItemFunc(ctx context.Context, key string) (*node.Node, func() error, error)
 
 	WriteBlob(key string, reader io.Reader) error

--- a/pkg/storage/utils/decomposedfs/decomposedfs.go
+++ b/pkg/storage/utils/decomposedfs/decomposedfs.go
@@ -63,7 +63,7 @@ type Tree interface {
 	// CreateReference(ctx context.Context, node *node.Node, targetURI *url.URL) error
 	Move(ctx context.Context, oldNode *node.Node, newNode *node.Node) (err error)
 	Delete(ctx context.Context, node *node.Node) (err error)
-	RestoreRecycleItemFunc(ctx context.Context, key, targetPath string) (*node.Node, func() error, error)
+	RestoreRecycleItemFunc(ctx context.Context, key, restorePath string) (*node.Node, func() error, error)
 	PurgeRecycleItemFunc(ctx context.Context, key string) (*node.Node, func() error, error)
 
 	WriteBlob(key string, reader io.Reader) error

--- a/pkg/storage/utils/decomposedfs/recycle.go
+++ b/pkg/storage/utils/decomposedfs/recycle.go
@@ -146,8 +146,8 @@ func (fs *Decomposedfs) ListRecycle(ctx context.Context) (items []*provider.Recy
 }
 
 // RestoreRecycleItem restores the specified item
-func (fs *Decomposedfs) RestoreRecycleItem(ctx context.Context, key string) error {
-	rn, restoreFunc, err := fs.tp.RestoreRecycleItemFunc(ctx, key, "")
+func (fs *Decomposedfs) RestoreRecycleItem(ctx context.Context, key, restorePath string) error {
+	rn, restoreFunc, err := fs.tp.RestoreRecycleItemFunc(ctx, key, restorePath)
 	if err != nil {
 		return err
 	}

--- a/pkg/storage/utils/decomposedfs/recycle.go
+++ b/pkg/storage/utils/decomposedfs/recycle.go
@@ -147,7 +147,7 @@ func (fs *Decomposedfs) ListRecycle(ctx context.Context) (items []*provider.Recy
 
 // RestoreRecycleItem restores the specified item
 func (fs *Decomposedfs) RestoreRecycleItem(ctx context.Context, key string) error {
-	rn, restoreFunc, err := fs.tp.RestoreRecycleItemFunc(ctx, key)
+	rn, restoreFunc, err := fs.tp.RestoreRecycleItemFunc(ctx, key, "")
 	if err != nil {
 		return err
 	}

--- a/pkg/storage/utils/decomposedfs/tree/tree.go
+++ b/pkg/storage/utils/decomposedfs/tree/tree.go
@@ -345,16 +345,20 @@ func (t *Tree) Delete(ctx context.Context, n *node.Node) (err error) {
 }
 
 // RestoreRecycleItemFunc returns a node and a function to restore it from the trash
-func (t *Tree) RestoreRecycleItemFunc(ctx context.Context, key string) (*node.Node, func() error, error) {
+func (t *Tree) RestoreRecycleItemFunc(ctx context.Context, key, restorePath string) (*node.Node, func() error, error) {
 	rn, trashItem, deletedNodePath, origin, err := t.readRecycleItem(ctx, key)
 	if err != nil {
 		return nil, nil, err
 	}
 
+	if restorePath == "" {
+		restorePath = origin
+	}
+
 	fn := func() error {
 		// link to origin
 		var n *node.Node
-		n, err = t.lookup.NodeFromPath(ctx, origin)
+		n, err = t.lookup.NodeFromPath(ctx, restorePath)
 		if err != nil {
 			return err
 		}

--- a/pkg/storage/utils/decomposedfs/tree/tree_test.go
+++ b/pkg/storage/utils/decomposedfs/tree/tree_test.go
@@ -145,6 +145,7 @@ var _ = Describe("Tree", func() {
 					Expect(restoreFunc()).To(Succeed())
 
 					originalNode, err := env.Lookup.NodeFromPath(env.Ctx, originalPath)
+					Expect(err).ToNot(HaveOccurred())
 					Expect(originalNode.Exists).To(BeTrue())
 				})
 
@@ -155,9 +156,11 @@ var _ = Describe("Tree", func() {
 					Expect(restoreFunc()).To(Succeed())
 
 					newNode, err := env.Lookup.NodeFromPath(env.Ctx, "dir1/newLocation")
+					Expect(err).ToNot(HaveOccurred())
 					Expect(newNode.Exists).To(BeTrue())
 
 					originalNode, err := env.Lookup.NodeFromPath(env.Ctx, originalPath)
+					Expect(err).ToNot(HaveOccurred())
 					Expect(originalNode.Exists).To(BeFalse())
 				})
 

--- a/pkg/storage/utils/eosfs/eosfs.go
+++ b/pkg/storage/utils/eosfs/eosfs.go
@@ -1284,7 +1284,7 @@ func (fs *eosfs) ListRecycle(ctx context.Context) ([]*provider.RecycleItem, erro
 	return recycleEntries, nil
 }
 
-func (fs *eosfs) RestoreRecycleItem(ctx context.Context, key string) error {
+func (fs *eosfs) RestoreRecycleItem(ctx context.Context, key, restorePath string) error {
 	u, err := getUser(ctx)
 	if err != nil {
 		return errors.Wrap(err, "eos: no user in ctx")

--- a/pkg/storage/utils/localfs/localfs.go
+++ b/pkg/storage/utils/localfs/localfs.go
@@ -1192,11 +1192,12 @@ func (fs *localfs) RestoreRecycleItem(ctx context.Context, restoreKey, restorePa
 	}
 
 	var localRestorePath string
-	if restorePath != "" {
+	switch {
+	case restorePath != "":
 		localRestorePath = fs.wrap(ctx, restorePath)
-	} else if fs.isShareFolder(ctx, filePath) {
+	case fs.isShareFolder(ctx, filePath):
 		localRestorePath = fs.wrapReferences(ctx, filePath)
-	} else {
+	default:
 		localRestorePath = fs.wrap(ctx, filePath)
 	}
 

--- a/pkg/storage/utils/localfs/localfs.go
+++ b/pkg/storage/utils/localfs/localfs.go
@@ -1179,7 +1179,7 @@ func (fs *localfs) ListRecycle(ctx context.Context) ([]*provider.RecycleItem, er
 	return items, nil
 }
 
-func (fs *localfs) RestoreRecycleItem(ctx context.Context, restoreKey string) error {
+func (fs *localfs) RestoreRecycleItem(ctx context.Context, restoreKey, restorePath string) error {
 
 	suffix := path.Ext(restoreKey)
 	if len(suffix) == 0 || !strings.HasPrefix(suffix, ".d") {
@@ -1191,14 +1191,16 @@ func (fs *localfs) RestoreRecycleItem(ctx context.Context, restoreKey string) er
 		return errors.Wrap(err, "localfs: invalid key")
 	}
 
-	var originalPath string
-	if fs.isShareFolder(ctx, filePath) {
-		originalPath = fs.wrapReferences(ctx, filePath)
+	var localRestorePath string
+	if restorePath != "" {
+		localRestorePath = fs.wrap(ctx, restorePath)
+	} else if fs.isShareFolder(ctx, filePath) {
+		localRestorePath = fs.wrapReferences(ctx, filePath)
 	} else {
-		originalPath = fs.wrap(ctx, filePath)
+		localRestorePath = fs.wrap(ctx, filePath)
 	}
 
-	if _, err = os.Stat(originalPath); err == nil {
+	if _, err = os.Stat(localRestorePath); err == nil {
 		return errors.New("localfs: can't restore - file already exists at original path")
 	}
 
@@ -1210,7 +1212,7 @@ func (fs *localfs) RestoreRecycleItem(ctx context.Context, restoreKey string) er
 		return errors.Wrap(err, "localfs: error stating "+rp)
 	}
 
-	if err := os.Rename(rp, originalPath); err != nil {
+	if err := os.Rename(rp, localRestorePath); err != nil {
 		return errors.Wrap(err, "ocfs: could not restore item")
 	}
 
@@ -1219,7 +1221,7 @@ func (fs *localfs) RestoreRecycleItem(ctx context.Context, restoreKey string) er
 		return errors.Wrap(err, "localfs: error adding entry to DB")
 	}
 
-	return fs.propagate(ctx, originalPath)
+	return fs.propagate(ctx, localRestorePath)
 }
 
 func (fs *localfs) propagate(ctx context.Context, leafPath string) error {

--- a/tests/acceptance/expected-failures-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-on-OCIS-storage.md
@@ -3,13 +3,6 @@
 ### File
 Basic file management like up and download, move, copy, properties, quota, trash, versions and chunking.
 
-#### [Implement Trashbin Feature for ocis storage](https://github.com/owncloud/product/issues/209)
-
--   [apiWebdavEtagPropagation2/restoreFromTrash.feature:48](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavEtagPropagation2/restoreFromTrash.feature#L48)
--   [apiWebdavEtagPropagation2/restoreFromTrash.feature:49](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavEtagPropagation2/restoreFromTrash.feature#L49)
--   [apiWebdavEtagPropagation2/restoreFromTrash.feature:90](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavEtagPropagation2/restoreFromTrash.feature#L90)
--   [apiWebdavEtagPropagation2/restoreFromTrash.feature:91](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavEtagPropagation2/restoreFromTrash.feature#L91)
-
 #### [QA trashcan cannot delete a deep tree](https://github.com/owncloud/ocis/issues/1077)
 -   [apiTrashbin/trashbinDelete.feature:107](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiTrashbin/trashbinDelete.feature#L107)
 -   [apiTrashbin/trashbinDelete.feature:123](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiTrashbin/trashbinDelete.feature#L123)

--- a/tests/acceptance/expected-failures-on-OWNCLOUD-storage.md
+++ b/tests/acceptance/expected-failures-on-OWNCLOUD-storage.md
@@ -3,12 +3,6 @@
 ### File
 Basic file management like up and download, move, copy, properties, quota, trash, versions and chunking.
 
-#### [Implement Trashbin Feature for ocis storage](https://github.com/owncloud/product/issues/209)
--   [apiWebdavEtagPropagation2/restoreFromTrash.feature:48](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavEtagPropagation2/restoreFromTrash.feature#L48)
--   [apiWebdavEtagPropagation2/restoreFromTrash.feature:49](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavEtagPropagation2/restoreFromTrash.feature#L49)
--   [apiWebdavEtagPropagation2/restoreFromTrash.feature:90](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavEtagPropagation2/restoreFromTrash.feature#L90)
--   [apiWebdavEtagPropagation2/restoreFromTrash.feature:91](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavEtagPropagation2/restoreFromTrash.feature#L91)
-
 #### [QA trashcan cannot delete a deep tree](https://github.com/owncloud/ocis/issues/1077)
 -   [apiTrashbin/trashbinDelete.feature:107](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiTrashbin/trashbinDelete.feature#L107)
 -   [apiTrashbin/trashbinDelete.feature:123](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiTrashbin/trashbinDelete.feature#L123)

--- a/tests/acceptance/expected-failures-on-S3NG-storage.md
+++ b/tests/acceptance/expected-failures-on-S3NG-storage.md
@@ -3,13 +3,6 @@
 ### File
 Basic file management like up and download, move, copy, properties, quota, trash, versions and chunking.
 
-#### [Implement Trashbin Feature for ocis storage](https://github.com/owncloud/product/issues/209)
-
--   [apiWebdavEtagPropagation2/restoreFromTrash.feature:48](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavEtagPropagation2/restoreFromTrash.feature#L48)
--   [apiWebdavEtagPropagation2/restoreFromTrash.feature:49](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavEtagPropagation2/restoreFromTrash.feature#L49)
--   [apiWebdavEtagPropagation2/restoreFromTrash.feature:90](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavEtagPropagation2/restoreFromTrash.feature#L90)
--   [apiWebdavEtagPropagation2/restoreFromTrash.feature:91](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavEtagPropagation2/restoreFromTrash.feature#L91)
-
 #### [QA trashcan cannot delete a deep tree](https://github.com/owncloud/ocis/issues/1077)
 -   [apiTrashbin/trashbinDelete.feature:107](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiTrashbin/trashbinDelete.feature#L107)
 -   [apiTrashbin/trashbinDelete.feature:123](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiTrashbin/trashbinDelete.feature#L123)


### PR DESCRIPTION
Restoring to a different location than the original one is specified in the CS3 APIs as the `restore_path` field of the `RestoreRecycleItemRequest` resource but wasn't implemented in the storage provider until now.