### PR TITLE
readme: changed `storage-oc.toml` reference to `storage-users.toml`

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ You can also read the [build from sources guide](https://reva.link/docs/getting-
    ../../../cmd/revad/revad -c frontend.toml &
    ../../../cmd/revad/revad -c gateway.toml &
    ../../../cmd/revad/revad -c storage-home.toml &
-   ../../../cmd/revad/revad -c storage-oc.toml &
+   ../../../cmd/revad/revad -c storage-users.toml &
    ../../../cmd/revad/revad -c users.toml
    ```
 


### PR DESCRIPTION
`README.md` had reference to the old `storage-oc.toml` file in the [litmus tests](https://github.com/cs3org/reva/blob/master/README.md#litmus-tests) section. This PR updates the reference to `storage-users.toml`

Signed-off-by: Jimil Desai <jimildesai42@gmail.com>