### PR TITLE
Makefile: added make command to run litmus-tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,11 @@ GIT_DIRTY=`git diff-index --quiet HEAD -- || echo "dirty-"`
 VERSION=`git describe --always`
 GO_VERSION=`go version | awk '{print $$3}'`
 BUILD_FLAGS="-X main.gitCommit=${GIT_COMMIT} -X main.version=${VERSION} -X main.goVersion=${GO_VERSION} -X main.buildDate=${BUILD_DATE}"
-LITMUS_URL="http://localhost:20080/remote.php/webdav"
+LITMUS_URL_OLD="http://localhost:20080/remote.php/webdav"
+LITMUS_URL_NEW="http://localhost:20080/remote.php/dav/files/4c510ada-c86b-4815-8820-42cdf82c3d51"
 LITMUS_USERNAME="einstein"
 LITMUS_PASSWORD="relativity"
+TESTS="basic http copymove props"
 
 default: build test lint gen-doc check-changelog
 release: deps build test lint gen-doc
@@ -42,13 +44,21 @@ build-reva: imports
 test: off
 	go test -race ./...
 
-litmus-test: build
+litmus-test-old: build
 	cd tests/oc-integration-tests/local && ../../../cmd/revad/revad -c frontend.toml &
 	cd tests/oc-integration-tests/local && ../../../cmd/revad/revad -c gateway.toml &
 	cd tests/oc-integration-tests/local && ../../../cmd/revad/revad -c storage-home.toml &
 	cd tests/oc-integration-tests/local && ../../../cmd/revad/revad -c storage-users.toml &
 	cd tests/oc-integration-tests/local && ../../../cmd/revad/revad -c users.toml &
-	sudo docker run --rm --network=host -e LITMUS_URL=$(LITMUS_URL) -e LITMUS_USERNAME=$(LITMUS_USERNAME) -e LITMUS_PASSWORD=$(LITMUS_PASSWORD) owncloud/litmus:latest
+	docker run --rm --network=host -e LITMUS_URL=$(LITMUS_URL_OLD) -e LITMUS_USERNAME=$(LITMUS_USERNAME) -e LITMUS_PASSWORD=$(LITMUS_PASSWORD) -e TESTS=$(TESTS) owncloud/litmus:latest
+	pkill revad
+litmus-test-new: build
+	cd tests/oc-integration-tests/local && ../../../cmd/revad/revad -c frontend.toml &
+	cd tests/oc-integration-tests/local && ../../../cmd/revad/revad -c gateway.toml &
+	cd tests/oc-integration-tests/local && ../../../cmd/revad/revad -c storage-home.toml &
+	cd tests/oc-integration-tests/local && ../../../cmd/revad/revad -c storage-users.toml &
+	cd tests/oc-integration-tests/local && ../../../cmd/revad/revad -c users.toml &
+	docker run --rm --network=host -e LITMUS_URL=$(LITMUS_URL_NEW) -e LITMUS_USERNAME=$(LITMUS_USERNAME) -e LITMUS_PASSWORD=$(LITMUS_PASSWORD) -e TESTS=$(TESTS) owncloud/litmus:latest
 	pkill revad
 lint:
 	go run tools/check-license/check-license.go

--- a/Makefile
+++ b/Makefile
@@ -42,13 +42,14 @@ build-reva: imports
 test: off
 	go test -race ./...
 
-litmus-test:
+litmus-test: build
 	cd tests/oc-integration-tests/local && ../../../cmd/revad/revad -c frontend.toml &
 	cd tests/oc-integration-tests/local && ../../../cmd/revad/revad -c gateway.toml &
 	cd tests/oc-integration-tests/local && ../../../cmd/revad/revad -c storage-home.toml &
 	cd tests/oc-integration-tests/local && ../../../cmd/revad/revad -c storage-users.toml &
 	cd tests/oc-integration-tests/local && ../../../cmd/revad/revad -c users.toml &
-	docker run --rm --network=host -e LITMUS_URL=$(LITMUS_URL) -e LITMUS_USERNAME=$(LITMUS_USERNAME) -e LITMUS_PASSWORD=$(LITMUS_PASSWORD) owncloud/litmus:latest
+	sudo docker run --rm --network=host -e LITMUS_URL=$(LITMUS_URL) -e LITMUS_USERNAME=$(LITMUS_USERNAME) -e LITMUS_PASSWORD=$(LITMUS_PASSWORD) owncloud/litmus:latest
+	pkill revad
 lint:
 	go run tools/check-license/check-license.go
 	`go env GOPATH`/bin/golangci-lint run --timeout 2m0s

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,9 @@ GIT_DIRTY=`git diff-index --quiet HEAD -- || echo "dirty-"`
 VERSION=`git describe --always`
 GO_VERSION=`go version | awk '{print $$3}'`
 BUILD_FLAGS="-X main.gitCommit=${GIT_COMMIT} -X main.version=${VERSION} -X main.goVersion=${GO_VERSION} -X main.buildDate=${BUILD_DATE}"
+LITMUS_URL="http://localhost:20080/remote.php/webdav"
+LITMUS_USERNAME="einstein"
+LITMUS_PASSWORD="relativity"
 
 default: build test lint gen-doc check-changelog
 release: deps build test lint gen-doc
@@ -39,6 +42,13 @@ build-reva: imports
 test: off
 	go test -race ./...
 
+litmus-test:
+	cd tests/oc-integration-tests/local && ../../../cmd/revad/revad -c frontend.toml &
+	cd tests/oc-integration-tests/local && ../../../cmd/revad/revad -c gateway.toml &
+	cd tests/oc-integration-tests/local && ../../../cmd/revad/revad -c storage-home.toml &
+	cd tests/oc-integration-tests/local && ../../../cmd/revad/revad -c storage-users.toml &
+	cd tests/oc-integration-tests/local && ../../../cmd/revad/revad -c users.toml &
+	docker run --rm --network=host -e LITMUS_URL=$(LITMUS_URL) -e LITMUS_USERNAME=$(LITMUS_USERNAME) -e LITMUS_PASSWORD=$(LITMUS_PASSWORD) owncloud/litmus:latest
 lint:
 	go run tools/check-license/check-license.go
 	`go env GOPATH`/bin/golangci-lint run --timeout 2m0s

--- a/changelog/unreleased/makefile-litmus-test-command.md
+++ b/changelog/unreleased/makefile-litmus-test-command.md
@@ -1,0 +1,6 @@
+Enhancement: Make command to run litmus tests
+
+This updates adds an extra make command to run litmus tests via make. `make litmus-test` executes the tests.
+
+https://github.com/cs3org/reva/issues/1106
+https://github.com/cs3org/reva/pull/1543


### PR DESCRIPTION
Fixes #1106 

This PR adds an extra make command to run litmus tests via make. 
- `make litmus-test` executes the tests.

Signed-off-by: Jimil Desai <jimildesai42@gmail.com>