### PR TITLE
[Build-deps] Upgrade go version in revad-eos dockerfile

### DIFF
--- a/Dockerfile.revad-eos
+++ b/Dockerfile.revad-eos
@@ -15,7 +15,8 @@
 # In applying this license, CERN does not waive the privileges and immunities
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
-FROM golang:1.15 as builder
+
+FROM golang:1.16 as builder
 
 WORKDIR /go/src/github/cs3org/reva
 COPY . .


### PR DESCRIPTION
Publishing the revad-eos image to docker fails: https://drone.cernbox.cern.ch/cs3org/reva/878