### PR TITLE
cli: added ocm invitation workflow commands

### DIFF
--- a/changelog/unreleased/ocm-invitation-workflow.md
+++ b/changelog/unreleased/ocm-invitation-workflow.md
@@ -1,0 +1,5 @@
+Enhancement: Add CLI Commands for OCM invitation workflow
+
+This adds a couple of CLI commands, `ocm-invite-generate` and `ocm-invite-forward` to generate and forward ocm invitation tokens respectively.
+
+https://github.com/cs3org/reva/issues/1149

--- a/cmd/reva/main.go
+++ b/cmd/reva/main.go
@@ -56,6 +56,8 @@ var (
 		moveCommand(),
 		mkdirCommand(),
 		ocmFindAcceptedUsersCommand(),
+		ocmInviteGenerateCommand(),
+		ocmInviteForwardCommand(),
 		ocmShareCreateCommand(),
 		ocmShareListCommand(),
 		ocmShareRemoveCommand(),

--- a/cmd/reva/ocm-invite-forward.go
+++ b/cmd/reva/ocm-invite-forward.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io"
+
+	invitepb "github.com/cs3org/go-cs3apis/cs3/ocm/invite/v1beta1"
+	ocmprovider "github.com/cs3org/go-cs3apis/cs3/ocm/provider/v1beta1"
+	rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
+)
+
+func ocmInviteForwardCommand() *command {
+	cmd := newCommand("ocm-invite-forward")
+	cmd.Description = func() string { return "forward ocm invite token" }
+	cmd.Usage = func() string { return "Usage: ocm-invite-forward [-flags] <path>" }
+	token := cmd.String("token", "", "invite token")
+	idp := cmd.String("idp", "", "the idp of the user who generated the token")
+
+	cmd.ResetFlags = func() {
+		*token, *idp = "", ""
+	}
+
+	cmd.Action = func(w ...io.Writer) error {
+		// validate flags
+		if *token == "" {
+			return errors.New("token cannot be empty: use -token flag\n" + cmd.Usage())
+		}
+		if *idp == "" {
+			return errors.New("Provider domain cannot be empty: use -provider flag\n" + cmd.Usage())
+		}
+
+		ctx := getAuthContext()
+		client, err := getClient()
+		if err != nil {
+			return err
+		}
+
+		inviteToken := &invitepb.InviteToken{
+			Token: *token,
+		}
+
+		providerInfo, err := client.GetInfoByDomain(ctx, &ocmprovider.GetInfoByDomainRequest{
+			Domain: *idp,
+		})
+		if err != nil {
+			return err
+		}
+
+		forwardToken, err := client.ForwardInvite(ctx, &invitepb.ForwardInviteRequest{
+			InviteToken:          inviteToken,
+			OriginSystemProvider: providerInfo.ProviderInfo,
+		})
+		if err != nil {
+			return err
+		}
+
+		if forwardToken.Status.Code != rpc.Code_CODE_OK {
+			return formatError(forwardToken.Status)
+		}
+		fmt.Println(forwardToken.Status.Code)
+		return nil
+	}
+	return cmd
+}

--- a/cmd/reva/ocm-invite-forward.go
+++ b/cmd/reva/ocm-invite-forward.go
@@ -1,3 +1,21 @@
+// Copyright 2018-2021 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
 package main
 
 import (

--- a/cmd/reva/ocm-invite-forward.go
+++ b/cmd/reva/ocm-invite-forward.go
@@ -65,6 +65,10 @@ func ocmInviteForwardCommand() *command {
 			return err
 		}
 
+		if providerInfo.Status.Code != rpc.Code_CODE_OK {
+			return formatError(providerInfo.Status)
+		}
+
 		forwardToken, err := client.ForwardInvite(ctx, &invitepb.ForwardInviteRequest{
 			InviteToken:          inviteToken,
 			OriginSystemProvider: providerInfo.ProviderInfo,

--- a/cmd/reva/ocm-invite-generate.go
+++ b/cmd/reva/ocm-invite-generate.go
@@ -1,3 +1,21 @@
+// Copyright 2018-2021 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
 package main
 
 import (

--- a/cmd/reva/ocm-invite-generate.go
+++ b/cmd/reva/ocm-invite-generate.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"fmt"
+	"io"
+
+	invitepb "github.com/cs3org/go-cs3apis/cs3/ocm/invite/v1beta1"
+	rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
+)
+
+func ocmInviteGenerateCommand() *command {
+	cmd := newCommand("ocm-invite-generate")
+	cmd.Description = func() string { return "generate ocm invitation token" }
+	cmd.Usage = func() string { return "Usage: ocm-invite-generate" }
+
+	cmd.Action = func(w ...io.Writer) error {
+		ctx := getAuthContext()
+		client, err := getClient()
+		if err != nil {
+			return err
+		}
+
+		inviteToken, err := client.GenerateInviteToken(ctx, &invitepb.GenerateInviteTokenRequest{})
+		if err != nil {
+			return err
+		}
+		if inviteToken.Status.Code != rpc.Code_CODE_OK {
+			return formatError(inviteToken.Status)
+		}
+		fmt.Println(inviteToken)
+		return nil
+	}
+	return cmd
+}


### PR DESCRIPTION
Fixes #1149 

This PR adds 2 cli commands:
- `ocm-invite-generate`: to generate an invitation token (to be executed by originator)
- `ocm-invite-forward`: to forward the invitation token to the mesh provider (to be executed by recipient)

Signed-off-by: Jimil Desai <jimildesai42@gmail.com>