### PR TITLE
Modularized api token management in GRAPPA drivers

### DIFF
--- a/changelog/unreleased/modularize-api-token-management.md
+++ b/changelog/unreleased/modularize-api-token-management.md
@@ -1,0 +1,5 @@
+Change: Modularize api token management in GRAPPA drivers
+
+This PR moves the duplicated api token management methods into a seperate utils package
+
+https://github.com/cs3org/reva/issues/1562

--- a/pkg/cbox/group/rest/rest.go
+++ b/pkg/cbox/group/rest/rest.go
@@ -20,20 +20,18 @@ package rest
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"regexp"
 	"strings"
-	"sync"
 	"time"
 
 	grouppb "github.com/cs3org/go-cs3apis/cs3/identity/group/v1beta1"
 	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	"github.com/cs3org/reva/pkg/appctx"
+	utils "github.com/cs3org/reva/pkg/cbox/utils"
 	"github.com/cs3org/reva/pkg/group"
 	"github.com/cs3org/reva/pkg/group/manager/registry"
 	"github.com/cs3org/reva/pkg/rhttp"
@@ -52,15 +50,7 @@ var (
 type manager struct {
 	conf      *config
 	redisPool *redis.Pool
-	oidcToken OIDCToken
 	client    *http.Client
-}
-
-// OIDCToken stores the OIDC token used to authenticate requests to the REST API service
-type OIDCToken struct {
-	sync.Mutex          // concurrent access to apiToken and tokenExpirationTime
-	apiToken            string
-	tokenExpirationTime time.Time
 }
 
 type config struct {
@@ -135,116 +125,10 @@ func New(m map[string]interface{}) (group.Manager, error) {
 	}, nil
 }
 
-func (m *manager) renewAPIToken(ctx context.Context, forceRenewal bool) error {
-	// Received tokens have an expiration time of 20 minutes.
-	// Take a couple of seconds as buffer time for the API call to complete
-	if forceRenewal || m.oidcToken.tokenExpirationTime.Before(time.Now().Add(time.Second*time.Duration(2))) {
-		token, expiration, err := m.getAPIToken(ctx)
-		if err != nil {
-			return err
-		}
-
-		m.oidcToken.Lock()
-		defer m.oidcToken.Unlock()
-
-		m.oidcToken.apiToken = token
-		m.oidcToken.tokenExpirationTime = expiration
-	}
-	return nil
-}
-
-func (m *manager) getAPIToken(ctx context.Context) (string, time.Time, error) {
-
-	params := url.Values{
-		"grant_type": {"client_credentials"},
-		"audience":   {m.conf.TargetAPI},
-	}
-
-	httpReq, err := http.NewRequest("POST", m.conf.OIDCTokenEndpoint, strings.NewReader(params.Encode()))
-	if err != nil {
-		return "", time.Time{}, err
-	}
-	httpReq.SetBasicAuth(m.conf.ClientID, m.conf.ClientSecret)
-	httpReq.Header.Set("Content-Type", "application/x-www-form-urlencoded; param=value")
-
-	httpRes, err := m.client.Do(httpReq)
-	if err != nil {
-		return "", time.Time{}, err
-	}
-	defer httpRes.Body.Close()
-
-	body, err := ioutil.ReadAll(httpRes.Body)
-	if err != nil {
-		return "", time.Time{}, err
-	}
-	if httpRes.StatusCode < 200 || httpRes.StatusCode > 299 {
-		return "", time.Time{}, errors.New("rest: get token endpoint returned " + httpRes.Status)
-	}
-
-	var result map[string]interface{}
-	err = json.Unmarshal(body, &result)
-	if err != nil {
-		return "", time.Time{}, err
-	}
-
-	expirationSecs := result["expires_in"].(float64)
-	expirationTime := time.Now().Add(time.Second * time.Duration(expirationSecs))
-	return result["access_token"].(string), expirationTime, nil
-}
-
-func (m *manager) sendAPIRequest(ctx context.Context, url string, forceRenewal bool) ([]interface{}, error) {
-	err := m.renewAPIToken(ctx, forceRenewal)
-	if err != nil {
-		return nil, err
-	}
-
-	httpReq, err := http.NewRequest("GET", url, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	// We don't need to take the lock when reading apiToken, because if we reach here,
-	// the token is valid at least for a couple of seconds. Even if another request modifies
-	// the token and expiration time while this request is in progress, the current token will still be valid.
-	httpReq.Header.Set("Authorization", "Bearer "+m.oidcToken.apiToken)
-
-	httpRes, err := m.client.Do(httpReq)
-	if err != nil {
-		return nil, err
-	}
-	defer httpRes.Body.Close()
-
-	if httpRes.StatusCode == http.StatusUnauthorized {
-		// The token is no longer valid, try renewing it
-		return m.sendAPIRequest(ctx, url, true)
-	}
-	if httpRes.StatusCode < 200 || httpRes.StatusCode > 299 {
-		return nil, errors.New("rest: API request returned " + httpRes.Status)
-	}
-
-	body, err := ioutil.ReadAll(httpRes.Body)
-	if err != nil {
-		return nil, err
-	}
-
-	var result map[string]interface{}
-	err = json.Unmarshal(body, &result)
-	if err != nil {
-		return nil, err
-	}
-
-	responseData, ok := result["data"].([]interface{})
-	if !ok {
-		return nil, errors.New("rest: error in type assertion")
-	}
-
-	return responseData, nil
-}
-
 func (m *manager) getGroupByParam(ctx context.Context, param, val string) (map[string]interface{}, error) {
 	url := fmt.Sprintf("%s/Group?filter=%s:%s&field=groupIdentifier&field=displayName&field=gid",
 		m.conf.APIBaseURL, param, val)
-	responseData, err := m.sendAPIRequest(ctx, url, false)
+	responseData, err := utils.SendAPIRequest(ctx, url, false, m.client, m.conf.TargetAPI, m.conf.OIDCTokenEndpoint, m.conf.ClientID, m.conf.ClientSecret)
 	if err != nil {
 		return nil, err
 	}
@@ -369,7 +253,7 @@ func (m *manager) GetGroupByClaim(ctx context.Context, claim, value string) (*gr
 
 func (m *manager) findGroupsByFilter(ctx context.Context, url string, groups map[string]*grouppb.Group) error {
 
-	groupData, err := m.sendAPIRequest(ctx, url, false)
+	groupData, err := utils.SendAPIRequest(ctx, url, false, m.client, m.conf.TargetAPI, m.conf.OIDCTokenEndpoint, m.conf.ClientID, m.conf.ClientSecret)
 	if err != nil {
 		return err
 	}
@@ -440,7 +324,7 @@ func (m *manager) GetMembers(ctx context.Context, gid *grouppb.GroupId) ([]*user
 		return nil, err
 	}
 	url := fmt.Sprintf("%s/Group/%s/memberidentities/precomputed", m.conf.APIBaseURL, internalID)
-	userData, err := m.sendAPIRequest(ctx, url, false)
+	userData, err := utils.SendAPIRequest(ctx, url, false, m.client, m.conf.TargetAPI, m.conf.OIDCTokenEndpoint, m.conf.ClientID, m.conf.ClientSecret)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cbox/utils/tokenmanagement.go
+++ b/pkg/cbox/utils/tokenmanagement.go
@@ -1,3 +1,21 @@
+// Copyright 2018-2021 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
 package utils
 
 import (
@@ -12,6 +30,7 @@ import (
 	"time"
 )
 
+// APITokenManager stores config related to api management
 type APITokenManager struct {
 	oidcApiToken            string
 	oidcTokenExpirationTime time.Time
@@ -80,6 +99,7 @@ func (a *APITokenManager) getAPIToken(ctx context.Context) (string, time.Time, e
 	return result["access_token"].(string), expirationTime, nil
 }
 
+// SendAPIGetRequest makes an API GET Request to the passed URL
 func (a *APITokenManager) SendAPIGetRequest(ctx context.Context, url string, forceRenewal bool) ([]interface{}, error) {
 	err := a.renewAPIToken(ctx, forceRenewal)
 	if err != nil {

--- a/pkg/cbox/utils/tokenmanagement.go
+++ b/pkg/cbox/utils/tokenmanagement.go
@@ -32,7 +32,7 @@ import (
 
 // APITokenManager stores config related to api management
 type APITokenManager struct {
-	oidcApiToken            string
+	oidcAPIToken            string
 	oidcTokenExpirationTime time.Time
 	TargetAPI               string
 	OIDCTokenEndpoint       string
@@ -54,7 +54,7 @@ func (a *APITokenManager) renewAPIToken(ctx context.Context, forceRenewal bool) 
 		a.mu.Lock()
 		defer a.mu.Unlock()
 
-		a.oidcApiToken = token
+		a.oidcAPIToken = token
 		a.oidcTokenExpirationTime = expiration
 	}
 	return nil
@@ -114,7 +114,7 @@ func (a *APITokenManager) SendAPIGetRequest(ctx context.Context, url string, for
 	// We don't need to take the lock when reading apiToken, because if we reach here,
 	// the token is valid at least for a couple of seconds. Even if another request modifies
 	// the token and expiration time while this request is in progress, the current token will still be valid.
-	httpReq.Header.Set("Authorization", "Bearer "+a.oidcApiToken)
+	httpReq.Header.Set("Authorization", "Bearer "+a.oidcAPIToken)
 
 	httpRes, err := a.Client.Do(httpReq)
 	if err != nil {

--- a/pkg/cbox/utils/tokenmanagement.go
+++ b/pkg/cbox/utils/tokenmanagement.go
@@ -43,7 +43,7 @@ type APITokenManager struct {
 }
 
 func (a *APITokenManager) renewAPIToken(ctx context.Context, forceRenewal bool) error {
-	// Recieved tokens have an expiration time of 20 minutes.
+	// Received tokens have an expiration time of 20 minutes.
 	// Take a couple of seconds as buffer time for the API call to complete
 	if forceRenewal || a.oidcTokenExpirationTime.Before(time.Now().Add(time.Second*time.Duration(2))) {
 		token, expiration, err := a.getAPIToken(ctx)

--- a/pkg/cbox/utils/tokenmanagement.go
+++ b/pkg/cbox/utils/tokenmanagement.go
@@ -41,7 +41,7 @@ type APITokenManager struct {
 
 // OIDCToken stores the OIDC token used to authenticate requests to the REST API service
 type OIDCToken struct {
-	sync.Mutex          //concurrent access to apiToken and tokenExpirationTime
+	sync.Mutex          // concurrent access to apiToken and tokenExpirationTime
 	apiToken            string
 	tokenExpirationTime time.Time
 }
@@ -53,6 +53,7 @@ type config struct {
 	ClientSecret      string
 }
 
+// InitAPITokenManager initializes a new APITokenManager
 func InitAPITokenManager(targetAPI, oidcTokenEndpoint, clientID, clientSecret string) *APITokenManager {
 	return &APITokenManager{
 		conf: &config{

--- a/pkg/cbox/utils/tokenmanagement.go
+++ b/pkg/cbox/utils/tokenmanagement.go
@@ -1,0 +1,123 @@
+package utils
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+)
+
+var expirationTime time.Time
+
+func renewAPIToken(ctx context.Context, forceRenewal bool, targetAPI string, OIDCTokenEndpoint string, clientID string, clientSecret string, client *http.Client) (string, error) {
+	// Recieved tokens have an expiration time of 20 minutes.
+	// Take a couple of seconds as buffer time for the API call to complete
+	var apiToken string
+	var mutex = &sync.Mutex{}
+	if forceRenewal || expirationTime.Before(time.Now().Add(time.Second*time.Duration(2))) {
+		token, expiration, err := getAPIToken(ctx, targetAPI, OIDCTokenEndpoint, clientID, clientSecret, client)
+		if err != nil {
+			return "", err
+		}
+
+		mutex.Lock()
+		defer mutex.Unlock()
+
+		apiToken = token
+		expirationTime = expiration
+	}
+	return apiToken, nil
+}
+
+func getAPIToken(ctx context.Context, targetAPI string, OIDCTokenEndpoint string, clientID string, clientSecret string, client *http.Client) (string, time.Time, error) {
+	params := url.Values{
+		"grant_type": {"client_credentials"},
+		"audience":   {targetAPI},
+	}
+
+	httpReq, err := http.NewRequest("POST", OIDCTokenEndpoint, strings.NewReader(params.Encode()))
+	if err != nil {
+		return "", time.Time{}, err
+	}
+	httpReq.SetBasicAuth(clientID, clientSecret)
+	httpReq.Header.Set("Content-Type", "application/x-www-form-urlencoded; param=value")
+
+	httpRes, err := client.Do(httpReq)
+	if err != nil {
+		return "", time.Time{}, err
+	}
+	defer httpRes.Body.Close()
+
+	body, err := ioutil.ReadAll(httpRes.Body)
+	if err != nil {
+		return "", time.Time{}, err
+	}
+	if httpRes.StatusCode < 200 || httpRes.StatusCode > 299 {
+		return "", time.Time{}, errors.New("rest: get token endpoint returned " + httpRes.Status)
+	}
+
+	var result map[string]interface{}
+	err = json.Unmarshal(body, &result)
+	if err != nil {
+		return "", time.Time{}, err
+	}
+
+	expirationSecs := result["expires_in"].(float64)
+	expirationTime := time.Now().Add(time.Second * time.Duration(expirationSecs))
+
+	return result["access_token"].(string), expirationTime, nil
+}
+
+func SendAPIRequest(ctx context.Context, url string, forceRenewal bool, client *http.Client, targetAPI string, OIDCTokenEndpoint string, clientID string, clientSecret string) ([]interface{}, error) {
+	token, err := renewAPIToken(ctx, forceRenewal, targetAPI, OIDCTokenEndpoint, clientID, clientSecret, client)
+	if err != nil {
+		return nil, err
+	}
+
+	httpReq, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// We don't need to take the lock when reading apiToken, because if we reach here,
+	// the token is valid at least for a couple of seconds. Even if another request modifies
+	// the token and expiration time while this request is in progress, the current token will still be valid.
+	httpReq.Header.Set("Authorization", "Bearer "+token)
+
+	httpRes, err := client.Do(httpReq)
+	if err != nil {
+		return nil, err
+	}
+	defer httpRes.Body.Close()
+
+	if httpRes.StatusCode == http.StatusUnauthorized {
+		// The token is no longer valid, try renewing it
+		return SendAPIRequest(ctx, url, true, client, targetAPI, OIDCTokenEndpoint, clientID, clientSecret)
+	}
+	if httpRes.StatusCode < 200 || httpRes.StatusCode > 299 {
+		return nil, errors.New("rest: API request returned " + httpRes.Status)
+	}
+
+	body, err := ioutil.ReadAll(httpRes.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var result map[string]interface{}
+	err = json.Unmarshal(body, &result)
+	if err != nil {
+		return nil, err
+	}
+
+	responseData, ok := result["data"].([]interface{})
+	if !ok {
+		return nil, errors.New("rest: error in type assertion")
+	}
+
+	return responseData, nil
+}


### PR DESCRIPTION
Fixes #1562 

This PR moves duplicated api token management methods:
- `renewAPIToken`
- `getAPIToken`
- `SendAPIRequest`

into a seperate `utils` package to prevent duplication. The above methods are used by `user/rest` and `group/rest` packages. 

PS: I am not 100% sure of the approach used here, so it'd be great if someone could suggest a better way to implement this. I'd be happy to work on the changes.

Signed-off-by: Jimil Desai <jimildesai42@gmail.com>