### PR TITLE
Fix etag changing only once a second

### DIFF
--- a/changelog/unreleased/fix-etag-changing-only-every-second.md
+++ b/changelog/unreleased/fix-etag-changing-only-every-second.md
@@ -1,0 +1,6 @@
+Bugfix: Fix etag changing only once a second
+
+We fixed a problem with the owncloud storage driver only considering
+the mtime with a second resolution for the etag calculation.
+
+https://github.com/cs3org/reva/pull/1576

--- a/pkg/storage/fs/owncloud/owncloud_unix.go
+++ b/pkg/storage/fs/owncloud/owncloud_unix.go
@@ -43,7 +43,7 @@ import (
 func calcEtag(ctx context.Context, fi os.FileInfo) string {
 	log := appctx.GetLogger(ctx)
 	h := md5.New()
-	err := binary.Write(h, binary.BigEndian, fi.ModTime().Unix())
+	err := binary.Write(h, binary.BigEndian, fi.ModTime().UnixNano())
 	if err != nil {
 		log.Error().Err(err).Msg("error writing mtime")
 	}

--- a/pkg/storage/fs/owncloud/owncloud_windows.go
+++ b/pkg/storage/fs/owncloud/owncloud_windows.go
@@ -40,7 +40,7 @@ import (
 func calcEtag(ctx context.Context, fi os.FileInfo) string {
 	log := appctx.GetLogger(ctx)
 	h := md5.New()
-	err := binary.Write(h, binary.BigEndian, fi.ModTime().Unix())
+	err := binary.Write(h, binary.BigEndian, fi.ModTime().UnixNano())
 	if err != nil {
 		log.Error().Err(err).Msg("error writing mtime")
 	}

--- a/pkg/storage/utils/decomposedfs/tree/tree_test.go
+++ b/pkg/storage/utils/decomposedfs/tree/tree_test.go
@@ -208,6 +208,23 @@ var _ = Describe("Tree", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
+		Describe("with TreeTimeAccounting enabled", func() {
+			It("sets the tmtime of the parent", func() {
+				file, err := env.CreateTestFile("file1", "", 1, dir.ID)
+				Expect(err).ToNot(HaveOccurred())
+
+				riBefore, err := dir.AsResourceInfo(env.Ctx, node.OwnerPermissions, []string{})
+				Expect(err).ToNot(HaveOccurred())
+
+				err = env.Tree.Propagate(env.Ctx, file)
+				Expect(err).ToNot(HaveOccurred())
+
+				riAfter, err := dir.AsResourceInfo(env.Ctx, node.OwnerPermissions, []string{})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(riAfter.Etag).ToNot(Equal(riBefore.Etag))
+			})
+		})
+
 		Describe("with TreeSizeAccounting enabled", func() {
 			It("calculates the size", func() {
 				file, err := env.CreateTestFile("file1", "", 1, dir.ID)


### PR DESCRIPTION
The owncloud driver only used the mtime with a second resolution for calculating the etag, even if the underlying filesystem provided higher accuracy.

This PR also adds some etag related unit tests for the decomposedfs driver which are unrelated to the fix.