### PR TITLE
Privatelink support

### DIFF
--- a/internal/http/services/owncloud/ocdav/meta.go
+++ b/internal/http/services/owncloud/ocdav/meta.go
@@ -21,7 +21,11 @@ package ocdav
 import (
 	"net/http"
 
+	rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
+	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+	"github.com/cs3org/reva/pkg/appctx"
 	"github.com/cs3org/reva/pkg/rhttp/router"
+	"go.opencensus.io/trace"
 )
 
 // MetaHandler handles meta requests
@@ -49,12 +53,86 @@ func (h *MetaHandler) Handler(s *svc) http.Handler {
 
 		var head string
 		head, r.URL.Path = router.ShiftPath(r.URL.Path)
-		switch head {
-		case "v":
+		switch {
+		case head == "" && r.Method == "PROPFIND":
+			h.handlePropfind(w, r, s, did)
+		case head == "v":
 			h.VersionsHandler.Handler(s, did).ServeHTTP(w, r)
 		default:
 			w.WriteHeader(http.StatusNotFound)
 		}
-
 	})
+}
+
+func (h *MetaHandler) handlePropfind(w http.ResponseWriter, r *http.Request, s *svc, rid *provider.ResourceId) {
+	ctx := r.Context()
+	ctx, span := trace.StartSpan(ctx, "handlePropfind")
+	defer span.End()
+
+	sublog := appctx.GetLogger(ctx).With().Logger()
+
+	pf, status, err := readPropfind(r.Body)
+	if err != nil {
+		sublog.Debug().Err(err).Msg("error reading propfind request")
+		w.WriteHeader(status)
+		return
+	}
+
+	client, err := s.getClient()
+	if err != nil {
+		sublog.Error().Err(err).Msg("error getting grpc client")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	// TODO parse additional metdadata?
+
+	ref := &provider.Reference{
+		Spec: &provider.Reference_Id{Id: rid},
+	}
+	req := &provider.StatRequest{
+		Ref: ref,
+	}
+	res, err := client.Stat(ctx, req)
+	if err != nil {
+		sublog.Error().Err(err).Interface("req", req).Msg("error sending a grpc stat request")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	if res.Status.Code != rpc.Code_CODE_OK {
+		HandleErrorStatus(&sublog, w, res.Status)
+		return
+	}
+
+	info := res.Info
+	// TODO add /v entry
+	infos := []*provider.ResourceInfo{info}
+
+	propRes, err := s.formatPropfind(ctx, &pf, infos, "meta")
+	if err != nil {
+		sublog.Error().Err(err).Msg("error formatting propfind")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("DAV", "1, 3, extended-mkcol")
+	w.Header().Set("Content-Type", "application/xml; charset=utf-8")
+
+	var disableTus bool
+	// let clients know this collection supports tus.io POST requests to start uploads
+	if info.Type == provider.ResourceType_RESOURCE_TYPE_CONTAINER {
+		if info.Opaque != nil {
+			_, disableTus = info.Opaque.Map["disable_tus"]
+		}
+		if !disableTus {
+			w.Header().Add("Access-Control-Expose-Headers", "Tus-Resumable, Tus-Version, Tus-Extension")
+			w.Header().Set("Tus-Resumable", "1.0.0")
+			w.Header().Set("Tus-Version", "1.0.0")
+			w.Header().Set("Tus-Extension", "creation,creation-with-upload")
+		}
+	}
+	w.WriteHeader(http.StatusMultiStatus)
+	if _, err := w.Write([]byte(propRes)); err != nil {
+		sublog.Err(err).Msg("error writing response")
+	}
 }

--- a/internal/http/services/owncloud/ocdav/ocdav.go
+++ b/internal/http/services/owncloud/ocdav/ocdav.go
@@ -124,7 +124,7 @@ func (s *svc) Close() error {
 }
 
 func (s *svc) Unprotected() []string {
-	return []string{"/status.php", "/remote.php/dav/public-files/"}
+	return []string{"/status.php", "/remote.php/dav/public-files/", "/f/"}
 }
 
 func (s *svc) Handler() http.Handler {
@@ -158,7 +158,9 @@ func (s *svc) Handler() http.Handler {
 
 			// yet, add it to baseURI
 			base = path.Join(base, "remote.php")
-
+		case "f":
+			s.doPrivatelink(w, r)
+			return
 		}
 		switch head {
 		// the old `/webdav` endpoint uses remote.php/webdav/$path

--- a/internal/http/services/owncloud/ocdav/ocdav.go
+++ b/internal/http/services/owncloud/ocdav/ocdav.go
@@ -124,7 +124,7 @@ func (s *svc) Close() error {
 }
 
 func (s *svc) Unprotected() []string {
-	return []string{"/status.php", "/remote.php/dav/public-files/", "/f/"}
+	return []string{"/status.php", "/remote.php/dav/public-files/"}
 }
 
 func (s *svc) Handler() http.Handler {

--- a/internal/http/services/owncloud/ocdav/propfind.go
+++ b/internal/http/services/owncloud/ocdav/propfind.go
@@ -684,6 +684,8 @@ func (s *svc) mdToPropResponse(ctx context.Context, pf *propfindXML, md *provide
 						propstatNotFound.Prop = append(propstatNotFound.Prop, s.newProp("oc:"+pf.Prop[i].Local, ""))
 					}
 				case "privatelink": // phoenix only
+					path := fmt.Sprintf("/f/%s", wrapResourceID(md.Id))
+					propstatOK.Prop = append(propstatOK.Prop, s.newProp("oc:privatelink", s.c.PublicURL+path))
 					// <oc:privatelink>https://phoenix.owncloud.com/f/9</oc:privatelink>
 					fallthrough
 				case "dDC": // desktop


### PR DESCRIPTION
This pr adds initial support for private links, however due to the backwards compatible nature of the webdav api the `dav/meta` endpoint needs to return a path that is relative to the currently logged in users home. Currently shares are jailed into a subfolder inside the users home ... and we would need to reconstruct the path in the shares folder.

Maybe the full implementation should wait until we have a globally accessible endpoint.