### PR TITLE
Allow full paths targets

### DIFF
--- a/changelog/unreleased/fix-sharing-paths.md
+++ b/changelog/unreleased/fix-sharing-paths.md
@@ -1,0 +1,6 @@
+Bugfix: Allow to expose full paths in OCS API
+
+Before this fix a share file_target was always harcoded to use a base path.
+This fix provides the possiblity to expose full paths in the OCIS API and asymptotically in OCIS web.
+
+https://github.com/cs3org/reva/pull/1605

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/shares.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/shares.go
@@ -701,7 +701,7 @@ func (h *Handler) listSharesWithMe(w http.ResponseWriter, r *http.Request) {
 
 		if data.State == ocsStateAccepted {
 			// Needed because received shares can be jailed in a folder in the users home
-			data.FileTarget = path.Join(h.sharePrefix, path.Base(info.Path))
+			data.FileTarget = path.Join(h.sharePrefix, info.Path)
 			data.Path = path.Join(h.sharePrefix, info.Path)
 		}
 
@@ -844,8 +844,8 @@ func (h *Handler) addFileInfo(ctx context.Context, s *conversions.ShareData, inf
 		// TODO Storage: int
 		s.ItemSource = wrapResourceID(info.Id)
 		s.FileSource = s.ItemSource
-		s.FileTarget = path.Join("/", path.Base(info.Path))
-		s.Path = path.Join("/", info.Path) // TODO hm this might have to be relative to the users home ... depends on the webdav_namespace config
+		s.FileTarget = path.Join("/", info.Path)
+		s.Path = path.Join("/", info.Path)
 		// TODO FileParent:
 		// item type
 		s.ItemType = conversions.ResourceType(info.GetType()).String()

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/shares.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/shares.go
@@ -702,11 +702,12 @@ func (h *Handler) listSharesWithMe(w http.ResponseWriter, r *http.Request) {
 
 		if data.State == ocsStateAccepted {
 			// Needed because received shares can be jailed in a folder in the users home
-			data.FileTarget = path.Join(h.sharePrefix, path.Base(info.Path))
-			data.Path = path.Join(h.sharePrefix, path.Base(info.Path))
+			data.FileTarget = path.Join(h.sharePrefix, info.Path)
+			data.Path = path.Join(h.sharePrefix, info.Path)
 		}
 
 		shares = append(shares, data)
+		log.Info().Msgf("listSharesWithMe: %+v", *data)
 	}
 
 	response.WriteOCSSuccess(w, r, shares)
@@ -844,7 +845,7 @@ func (h *Handler) addFileInfo(ctx context.Context, s *conversions.ShareData, inf
 		// TODO Storage: int
 		s.ItemSource = wrapResourceID(info.Id)
 		s.FileSource = s.ItemSource
-		s.FileTarget = path.Join("/", path.Base(info.Path))
+		s.FileTarget = path.Join("/", info.Path)
 		s.Path = path.Join("/", path.Base(info.Path)) // TODO hm this might have to be relative to the users home ... depends on the webdav_namespace config
 		// TODO FileParent:
 		// item type

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/shares.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/shares.go
@@ -707,7 +707,7 @@ func (h *Handler) listSharesWithMe(w http.ResponseWriter, r *http.Request) {
 		}
 
 		shares = append(shares, data)
-		log.Info().Msgf("listSharesWithMe: %+v", *data)
+		log.Debug().Msgf("listSharesWithMe: %+v", *data)
 	}
 
 	response.WriteOCSSuccess(w, r, shares)

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/shares.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/shares.go
@@ -638,17 +638,16 @@ func (h *Handler) listSharesWithMe(w http.ResponseWriter, r *http.Request) {
 		response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "grpc ListReceivedShares request failed", err)
 		return
 	}
-	lrsRes.GetShares()
 
 	shares := make([]*conversions.ShareData, 0)
 
 	var info *provider.ResourceInfo
 	// TODO(refs) filter out "invalid" shares
 	for _, rs := range lrsRes.GetShares() {
-
 		if stateFilter != ocsStateUnknown && rs.GetState() != stateFilter {
 			continue
 		}
+
 		if pinfo != nil {
 			// check if the shared resource matches the path resource
 			if rs.Share.ResourceId.StorageId != pinfo.GetId().StorageId ||
@@ -845,8 +844,8 @@ func (h *Handler) addFileInfo(ctx context.Context, s *conversions.ShareData, inf
 		// TODO Storage: int
 		s.ItemSource = wrapResourceID(info.Id)
 		s.FileSource = s.ItemSource
-		s.FileTarget = path.Join("/", info.Path)
-		s.Path = path.Join("/", path.Base(info.Path)) // TODO hm this might have to be relative to the users home ... depends on the webdav_namespace config
+		s.FileTarget = path.Join("/", path.Base(info.Path))
+		s.Path = path.Join("/", info.Path) // TODO hm this might have to be relative to the users home ... depends on the webdav_namespace config
 		// TODO FileParent:
 		// item type
 		s.ItemType = conversions.ResourceType(info.GetType()).String()

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/shares.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/shares.go
@@ -701,12 +701,12 @@ func (h *Handler) listSharesWithMe(w http.ResponseWriter, r *http.Request) {
 
 		if data.State == ocsStateAccepted {
 			// Needed because received shares can be jailed in a folder in the users home
-			data.FileTarget = path.Join(h.sharePrefix, info.Path)
+			data.FileTarget = path.Join(h.sharePrefix, path.Base(info.Path))
 			data.Path = path.Join(h.sharePrefix, info.Path)
 		}
 
 		shares = append(shares, data)
-		log.Debug().Msgf("listSharesWithMe: %+v", *data)
+		log.Debug().Msgf("share: %+v", *data)
 	}
 
 	response.WriteOCSSuccess(w, r, shares)


### PR DESCRIPTION
Visually it allows to click on a share item in the "Shared with me" tab (accepted or not) and access it in the owner's path.

![Screenshot 2021-03-31 at 16 58 38](https://user-images.githubusercontent.com/5175912/113165797-801fda00-9242-11eb-97fe-0dc5e16a1287.png)
![Screenshot 2021-03-31 at 16 58 49](https://user-images.githubusercontent.com/5175912/113165819-831aca80-9242-11eb-8e1b-eb3b7e1cc37f.png)
![Screenshot 2021-03-31 at 16 58 55](https://user-images.githubusercontent.com/5175912/113165835-8615bb00-9242-11eb-95d7-1a292c497c23.png)

