### PR TITLE
Improve json marshalling of share protobuf messages

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -9,6 +9,9 @@ updateDocsWhiteList:
   - tests-only
   - Tests-Only
   - Build-deps
+  - docs-only
+  - Docs-only
+  - Docs-Only
 
 updateDocsTargetFiles:
   - changelog/unreleased/

--- a/changelog/unreleased/improve-share-json-marshal.md
+++ b/changelog/unreleased/improve-share-json-marshal.md
@@ -1,0 +1,9 @@
+Enhancement: Improve json marshalling of share protobuf messages
+
+Protobuf oneof fields cannot be properly handled by the native json marshaller,
+and the protojson package can only handle proto messages. Previously, we were
+using a workaround of storing these oneof fields separately, which made the code
+inelegant. Now we marshal these messages as strings before marshalling them via
+the native json package.
+
+https://github.com/cs3org/reva/pull/1655

--- a/examples/ocmd/ocmd-server-1.toml
+++ b/examples/ocmd/ocmd-server-1.toml
@@ -1,16 +1,16 @@
 [shared]
 gatewaysvc = "localhost:19000"
 
-[registry]
-driver = "static"
-
-[registry.static]
-services = ["authprovider","userprovider"]
-
-[registry.static.authprovider]
-bearer = ["localhost:0123"]
-basic = ["localhost:1234"]
-publiclink = ["localhost:9876"]
+# [registry]
+# driver = "static"
+#
+# [registry.static]
+# services = ["authprovider","userprovider"]
+#
+# [registry.static.authprovider]
+# bearer = ["localhost:0123"]
+# basic = ["localhost:1234"]
+# publiclink = ["localhost:9876"]
 
 [grpc]
 address = "0.0.0.0:19000"

--- a/internal/grpc/services/gateway/gateway.go
+++ b/internal/grpc/services/gateway/gateway.go
@@ -82,9 +82,6 @@ func (c *config) init() {
 
 	// if services address are not specified we used the shared conf
 	// for the gatewaysvc to have dev setups very quickly.
-
-	// we're commenting this line to showcase the fact that now we don't want to point to an ip address but rather
-	// resolve an ip address from a name.
 	c.AuthRegistryEndpoint = sharedconf.GetGatewaySVC(c.AuthRegistryEndpoint)
 	c.StorageRegistryEndpoint = sharedconf.GetGatewaySVC(c.StorageRegistryEndpoint)
 	c.AppRegistryEndpoint = sharedconf.GetGatewaySVC(c.AppRegistryEndpoint)

--- a/pkg/cbox/user/rest/rest.go
+++ b/pkg/cbox/user/rest/rest.go
@@ -123,7 +123,7 @@ func New(m map[string]interface{}) (user.Manager, error) {
 
 func (m *manager) getUserByParam(ctx context.Context, param, val string) (map[string]interface{}, error) {
 	url := fmt.Sprintf("%s/Identity?filter=%s:%s&field=upn&field=primaryAccountEmail&field=displayName&field=uid&field=gid&field=type",
-		m.conf.APIBaseURL, param, val)
+		m.conf.APIBaseURL, param, url.QueryEscape(val))
 	responseData, err := m.apiTokenManager.SendAPIGetRequest(ctx, url, false)
 	if err != nil {
 		return nil, err
@@ -225,7 +225,6 @@ func (m *manager) GetUser(ctx context.Context, uid *userpb.UserId) (*userpb.User
 }
 
 func (m *manager) GetUserByClaim(ctx context.Context, claim, value string) (*userpb.User, error) {
-	value = url.QueryEscape(value)
 	opaqueID, err := m.fetchCachedParam(claim, value)
 	if err == nil {
 		return m.GetUser(ctx, &userpb.UserId{OpaqueId: opaqueID})

--- a/tools/check-changelog/main.go
+++ b/tools/check-changelog/main.go
@@ -32,7 +32,7 @@ import (
 )
 
 // Case-insensitive list of PRs for which changelog enforcement needs to be skipped
-var skipTags = []string{"[tests-only]", "[build-deps]"}
+var skipTags = []string{"[tests-only]", "[build-deps]", "[docs-only]"}
 
 func skipPR(prID int) bool {
 	ctx := context.Background()


### PR DESCRIPTION
Protobuf `oneof` fields cannot be properly handled by the native json marshaller, and the protojson package can only handle proto messages. Previously, we were using a workaround of storing these `oneof` fields separately, which made the code
inelegant. Now we marshal these messages as strings before marshalling them via the native json package.

The existing json files storing the shares would need to be removed. Please add this to the changelog when you update the reva version in ocis @butonic @C0rby 