### PR TITLE
make build instead of make

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ You need to have [Go](https://golang.org/doc/install), [git](https://git-scm.com
 $ git clone https://github.com/cs3org/reva
 $ cd reva
 $ make deps
-$ make
+$ make build
 $ cd examples/storage-references
 $ ../../cmd/revad/revad -dev-dir .
 ```


### PR DESCRIPTION
The current 'Build and run it yourself' instructions from the readme will fail if there are unreleased changes, as described in #1654.
As per https://github.com/cs3org/reva/issues/1654#issuecomment-824061617, it should however be enough to run `make build` instead of the `make` step.