### PR TITLE
[docs-only] Run `make build` instead of `make`

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,14 @@ $ git clone https://github.com/cs3org/reva
 $ cd reva
 $ make deps
 $ make build
-$ cd examples/storage-references
-$ ../../cmd/revad/revad -dev-dir .
+$ sudo mkdir -p /etc/revad
+$ sudo cp examples/storage-references/users.demo.json /etc/revad/users.json
+$ sudo cp examples/storage-references/groups.demo.json /etc/revad/groups.json
+$ sudo cp examples/storage-references/providers.demo.json /etc/revad/ocm-providers.json
+$ cmd/revad/revad -dev-dir examples/storage-references
 ```
 
-You can also read the [build from sources guide](https://reva.link/docs/getting-started/build-reva/).
+You can also read the [build from sources guide](https://reva.link/docs/getting-started/build-reva/) and the [setup tutorial](https://github.com/cs3org/reva/blob/master/docs/content/en/docs/tutorials/setup-tutorial.md).
 
 ## Run tests
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ You need to have [Go](https://golang.org/doc/install), [git](https://git-scm.com
 $ git clone https://github.com/cs3org/reva
 $ cd reva
 $ make deps
-$ make
+$ make build
 $ cd examples/storage-references
 $ ../../cmd/revad/revad -dev-dir .
 ```

--- a/README.md
+++ b/README.md
@@ -18,17 +18,17 @@ Read the [getting started guide](https://reva.link/docs/getting-started/) and th
 
 
 ## Build and run it yourself
-You need to have [Go](https://golang.org/doc/install), [git](https://git-scm.com/) and [make](https://en.wikipedia.org/wiki/Make_(software)) installed.
+You need to have [Go](https://golang.org/doc/install), [git](https://git-scm.com/) and [make](https://en.wikipedia.org/wiki/Make_(software)) installed. Some of these commands may require `sudo`, depending on your system setup.
 
 ```
 $ git clone https://github.com/cs3org/reva
 $ cd reva
 $ make deps
 $ make build
-$ sudo mkdir -p /etc/revad
-$ sudo cp examples/storage-references/users.demo.json /etc/revad/users.json
-$ sudo cp examples/storage-references/groups.demo.json /etc/revad/groups.json
-$ sudo cp examples/storage-references/providers.demo.json /etc/revad/ocm-providers.json
+$ mkdir -p /etc/revad
+$ cp examples/storage-references/users.demo.json /etc/revad/users.json
+$ cp examples/storage-references/groups.demo.json /etc/revad/groups.json
+$ cp examples/storage-references/providers.demo.json /etc/revad/ocm-providers.json
 $ cmd/revad/revad -dev-dir examples/storage-references
 ```
 

--- a/docs/content/en/docs/getting-started/build-reva.md
+++ b/docs/content/en/docs/getting-started/build-reva.md
@@ -13,5 +13,5 @@ the Go programming language that installs the Go compiler.
 git clone https://github.com/cs3org/reva
 cd reva
 make deps
-make
+make build
 ```

--- a/docs/content/en/docs/tutorials/setup-tutorial.md
+++ b/docs/content/en/docs/tutorials/setup-tutorial.md
@@ -61,9 +61,10 @@ You can start these three daemons using the `-dev-dir` flag which fires up a dae
 
 ```
 > mkdir -p /var/tmp/reva
-> cp examples/storage-references/users.demo.json /etc/revad/users.json
-> cp examples/storage-references/groups.demo.json /etc/revad/groups.json
-> cp examples/storage-references/providers.demo.json /etc/revad/ocm-providers.json
+> sudo mkdir -p /etc/revad
+> sudo cp examples/storage-references/users.demo.json /etc/revad/users.json
+> sudo cp examples/storage-references/groups.demo.json /etc/revad/groups.json
+> sudo cp examples/storage-references/providers.demo.json /etc/revad/ocm-providers.json
 > cmd/revad/revad -dev-dir examples/storage-references
 ```
 

--- a/docs/content/en/docs/tutorials/setup-tutorial.md
+++ b/docs/content/en/docs/tutorials/setup-tutorial.md
@@ -57,14 +57,14 @@ Reva daemons are spawned using configuration specified in `toml` format. Multipl
                               G: gRPC exposed service
 ```
 
-You can start these three daemons using the `-dev-dir` flag which fires up a daemon for each toml file in a directory. The user, group and mesh provider services use JSON files by default as their data store, and expects these to be located at `/etc/revad`.
+You can start these three daemons using the `-dev-dir` flag which fires up a daemon for each toml file in a directory. The user, group and mesh provider services use JSON files by default as their data store, and expects these to be located at `/etc/revad`. Some of these commands may require `sudo`, depending on your system setup.
 
 ```
 > mkdir -p /var/tmp/reva
-> sudo mkdir -p /etc/revad
-> sudo cp examples/storage-references/users.demo.json /etc/revad/users.json
-> sudo cp examples/storage-references/groups.demo.json /etc/revad/groups.json
-> sudo cp examples/storage-references/providers.demo.json /etc/revad/ocm-providers.json
+> mkdir -p /etc/revad
+> cp examples/storage-references/users.demo.json /etc/revad/users.json
+> cp examples/storage-references/groups.demo.json /etc/revad/groups.json
+> cp examples/storage-references/providers.demo.json /etc/revad/ocm-providers.json
 > cmd/revad/revad -dev-dir examples/storage-references
 ```
 


### PR DESCRIPTION
The current 'Build and run it yourself' instructions from the readme will fail if there are unreleased changes, as described in #1654.
As per #1654 (comment), it should however be enough to run `make build` instead of the `make` step.

Continued from #1657.