### PR TITLE
Fix public file shares

### DIFF
--- a/changelog/unreleased/fix-public-file-shares.md
+++ b/changelog/unreleased/fix-public-file-shares.md
@@ -1,0 +1,6 @@
+Bugfix: Fix public file shares
+
+Fixed stat requests and propfind responses for publicly shared files.
+
+https://github.com/cs3org/reva/pull/1666
+

--- a/internal/http/services/owncloud/ocdav/publicfile.go
+++ b/internal/http/services/owncloud/ocdav/publicfile.go
@@ -231,9 +231,6 @@ func (s *svc) getPublicFileInfos(onContainer, onlyRoot bool, i *provider.Resourc
 		}
 	}
 
-	// link share only appears on root collection
-	delete(i.Opaque.Map, "link-share")
-
 	// add the file info
 	infos = append(infos, i)
 


### PR DESCRIPTION
Fixed stat requests and propfind responses for publicly shared files.

* To be able to create the `downloadURL` in the propfind response we need to access the link share. Before this change only the root collection was able to access the link share
* When doing a stat request in the public storage we need to differentiate between folder and file shares. If we want to stat a file in folder shares we need to concatenate the originalPath and the relative path because the originalPath is only the path to the share root. That means only up to the shared folder and the relative path contains the file path from the share root.
The originalPath in file share is already pointing to the shared file so
we don't need to append the relative path there.