### PR TITLE
[tests-only] Test against adjustUserDataCleanup core branch

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The test runner source for API tests
-CORE_COMMITID=182ac89d0ba4feecea786cf33b2192bd58daa67e
-CORE_BRANCH=master
+CORE_COMMITID=bd5a024d79d545108317f5ce6b66150cd37ab8ce
+CORE_BRANCH=adjustUserDataCleanup


### PR DESCRIPTION
core branch `adjustUserDataCleanup` removes `deleteAllSharesForUser` from the `afterScenario` of tests.

This PR demonstrates if it is OK to stop doing that now.

When users are deleted, the shares of the user should be getting cleaned up by reva already.