### PR TITLE
docker-build: reduce all the reva* image sizes

### DIFF
--- a/Dockerfile.reva
+++ b/Dockerfile.reva
@@ -16,9 +16,26 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
-FROM golang:1.16
+FROM golang:alpine as builder
+
+RUN apk --no-cache add \
+  ca-certificates \
+  bash \
+  git \
+  gcc \
+  libc-dev \
+  make
+
+ENV PATH /go/bin:/usr/local/go/bin:$PATH
+ENV GOPATH /go
 
 WORKDIR /go/src/github/cs3org/reva
 COPY . .
 RUN make build-reva-docker && cp /go/src/github/cs3org/reva/cmd/reva/reva /go/bin/reva
-ENTRYPOINT ["/go/bin/reva"]
+
+FROM scratch
+
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=builder /go/bin/reva /usr/bin/reva
+
+ENTRYPOINT [ "/usr/bin/reva" ]

--- a/Dockerfile.revad
+++ b/Dockerfile.revad
@@ -16,11 +16,33 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
-FROM golang:1.16
+FROM golang:alpine as builder
+
+RUN apk --no-cache add \
+  ca-certificates \
+  bash \
+  git \
+  gcc \
+  libc-dev \
+  make
+
+ENV PATH /go/bin:/usr/local/go/bin:$PATH
+ENV GOPATH /go
 
 WORKDIR /go/src/github/cs3org/reva
 COPY . .
-RUN make build-revad-docker && cp /go/src/github/cs3org/reva/cmd/revad/revad /go/bin/revad && mkdir -p /etc/revad/ && echo "" > /etc/revad/revad.toml
-EXPOSE 9999
-EXPOSE 10000
-CMD ["/go/bin/revad", "-c", "/etc/revad/revad.toml", "-p", "/var/run/revad.pid"]
+RUN make build-revad-docker && \
+    cp /go/src/github/cs3org/reva/cmd/revad/revad /go/bin/revad
+
+RUN mkdir -p /etc/revad/ && echo "" > /etc/revad/revad.toml
+
+FROM scratch
+
+EXPOSE 9999 10000
+
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=builder /go/bin/revad /usr/bin/revad
+COPY --from=builder /etc/revad /etc/revad
+
+ENTRYPOINT [ "/usr/bin/revad" ]
+CMD [ "-c", "/etc/revad/revad.toml", "-p", "/var/run/revad.pid" ]

--- a/Dockerfile.revad-eos
+++ b/Dockerfile.revad-eos
@@ -16,14 +16,34 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
-FROM golang:1.16 as builder
+FROM golang:alpine as builder
+
+RUN apk --no-cache add \
+  ca-certificates \
+  bash \
+  git \
+  gcc \
+  libc-dev \
+  make
+
+ENV PATH /go/bin:/usr/local/go/bin:$PATH
+ENV GOPATH /go
 
 WORKDIR /go/src/github/cs3org/reva
 COPY . .
 RUN make build-revad-docker && \
     cp /go/src/github/cs3org/reva/cmd/revad/revad /go/bin/revad
 
-FROM gitlab-registry.cern.ch/dss/eos:c8_4.8.15
+RUN mkdir -p /etc/revad/ && echo "" > /etc/revad/revad.toml
+
+FROM gitlab-registry.cern.ch/dss/eos/slim:4.8.43
+
 RUN mkdir -p /usr/local/bin
-COPY --from=builder /go/bin/revad /go/bin/
-RUN chmod +x /go/bin/revad
+
+COPY --from=builder /go/bin/revad /usr/bin/revad
+COPY --from=builder /etc/revad /etc/revad
+
+RUN chmod +x /usr/bin/revad
+
+ENTRYPOINT [ "/usr/bin/revad" ]
+CMD [ "-c", "/etc/revad/revad.toml", "-p", "/var/run/revad.pid" ]

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ GIT_BRANCH=`git rev-parse --symbolic-full-name --abbrev-ref HEAD`
 GIT_DIRTY=`git diff-index --quiet HEAD -- || echo "dirty-"`
 VERSION=`git describe --always`
 GO_VERSION=`go version | awk '{print $$3}'`
-BUILD_FLAGS="-X main.gitCommit=${GIT_COMMIT} -X main.version=${VERSION} -X main.goVersion=${GO_VERSION} -X main.buildDate=${BUILD_DATE}"
+BUILD_FLAGS="-w -extldflags "-static" -X main.gitCommit=${GIT_COMMIT} -X main.version=${VERSION} -X main.goVersion=${GO_VERSION} -X main.buildDate=${BUILD_DATE}"
 LITMUS_URL_OLD="http://localhost:20080/remote.php/webdav"
 LITMUS_URL_NEW="http://localhost:20080/remote.php/dav/files/4c510ada-c86b-4815-8820-42cdf82c3d51"
 LITMUS_USERNAME="einstein"

--- a/changelog/unreleased/reduce-docker-image-size.md
+++ b/changelog/unreleased/reduce-docker-image-size.md
@@ -1,0 +1,10 @@
+Enhancement: Reduce the size of all the container images built on CI
+
+Previously, all images were based on golang:1.16 which is built from Debian.
+Using 'scratch' as base, reduces the size of the artifacts well as the attack
+surface for all the images, plus copying the binary from the build step ensures
+that only the strictly required software is present on the final image.
+For the revad images tagged '-eos', eos-slim is used instead. It is still large
+but it updates the environment as well as the EOS version.
+
+https://github.com/cs3org/reva/pull/1705


### PR DESCRIPTION
- From 1.94GB to 40MB, using `golang:alpine` for the build and `scratch` as base for the binary
- '`latest-eos`' is still bloated due to `eos/slim`

```
REPOSITORY                                          TAG                IMAGE ID       CREATED         SIZE
alfageme/revad                                      latest             fee1a27ac5f0   4 minutes ago   40MB
alfageme/revad                                      latest-eos         02fd02258069   5 hours ago     2.43GB
alfageme/reva                                       latest             b830b5559200   5 hours ago     16MB
```

- Removes several [potential targets](https://artifacthub.io/packages/helm/cs3org/revad?modal=security-report) from the  image
- Enable static linking for the C libraries in the `BUILD_FLAGS`