### PR TITLE
[tests-only] Add feature to be able to run only specific part(s) of test suites in CI

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -92,6 +92,9 @@ def cephService():
 
 # Pipeline definitions
 def main(ctx):
+  # In order to run specific parts only, specify the parts as
+  # ocisIntegrationTests(6, [1, 4])     - this will only run 1st and 4th parts
+  # implemented for: ocisIntegrationTests, owncloudIntegrationTests and s3ngIntegrationTests
   return [
     buildAndPublishDocker(),
     buildOnly(),
@@ -636,9 +639,13 @@ def localIntegrationTestsOcis():
     ],
   }
 
-def ocisIntegrationTests(parallelRuns):
+def ocisIntegrationTests(parallelRuns, skipExceptParts = []):
   pipelines = []
+  debugPartsEnabled = (len(skipExceptParts) != 0)
   for runPart in range(1, parallelRuns + 1):
+    if debugPartsEnabled and runPart not in skipExceptParts:
+      continue
+
     pipelines.append(
       {
         "kind": "pipeline",
@@ -705,9 +712,13 @@ def ocisIntegrationTests(parallelRuns):
 
   return pipelines
 
-def owncloudIntegrationTests(parallelRuns):
+def owncloudIntegrationTests(parallelRuns, skipExceptParts = []):
   pipelines = []
+  debugPartsEnabled = (len(skipExceptParts) != 0)
   for runPart in range(1, parallelRuns + 1):
+    if debugPartsEnabled and runPart not in skipExceptParts:
+      continue
+
     pipelines.append(
       {
         "kind": "pipeline",
@@ -774,9 +785,13 @@ def owncloudIntegrationTests(parallelRuns):
 
   return pipelines
 
-def s3ngIntegrationTests(parallelRuns):
+def s3ngIntegrationTests(parallelRuns, skipExceptParts = []):
   pipelines = []
+  debugPartsEnabled = (len(skipExceptParts) != 0)
   for runPart in range(1, parallelRuns + 1):
+    if debugPartsEnabled and runPart not in skipExceptParts:
+      continue
+
     pipelines.append(
       {
         "kind": "pipeline",


### PR DESCRIPTION
This PR adds the feature to be able to run only the certain part(s) of the test suites.

E.g;
`ocisIntegrationTests(6, [1, 4])` will run only `1` and `4` parts out of 6

Part of https://github.com/owncloud/QA/issues/670