### PR TITLE
fix response format

### DIFF
--- a/changelog/unreleased/update-share-response.md
+++ b/changelog/unreleased/update-share-response.md
@@ -3,3 +3,4 @@ Enhancement: Add share to update response
 After accepting or rejecting a share the API includes the updated share in the response.
 
 https://github.com/cs3org/reva/pull/1685
+https://github.com/cs3org/reva/pull/1724

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/pending.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/pending.go
@@ -105,5 +105,5 @@ func (h *Handler) updateReceivedShare(w http.ResponseWriter, r *http.Request, sh
 		data.Path = path.Join(h.sharePrefix, path.Base(info.Path))
 	}
 
-	response.WriteOCSSuccess(w, r, data)
+	response.WriteOCSSuccess(w, r, []*conversions.ShareData{data})
 }


### PR DESCRIPTION
After accepting or declining a share the response needs to enclose the updated share in an array.
This is to make the API oc10 compatible.