### PR TITLE
set Content-Type correctly

### DIFF
--- a/changelog/unreleased/fix-content-type.md
+++ b/changelog/unreleased/fix-content-type.md
@@ -1,0 +1,5 @@
+Bugfix: set Content-Type header correctly for ocs requests
+
+Before this fix the `Content-Type` header was guessed by `w.Write` because `WriteHeader` was called to early. Now the `Content-Type` is set correctly and to the same values as in ownCloud 10
+
+https://github.com/owncloud/ocis/issues/1779

--- a/internal/http/services/owncloud/ocs/response/response.go
+++ b/internal/http/services/owncloud/ocs/response/response.go
@@ -155,19 +155,19 @@ func WriteOCSResponse(w http.ResponseWriter, r *http.Request, res Response, err 
 	version := APIVersion(r.Context())
 	m := statusCodeMapper(version)
 	statusCode := m(res.OCS.Meta)
-	w.WriteHeader(statusCode)
 	if version == "v2.php" && statusCode == http.StatusOK {
 		res.OCS.Meta.StatusCode = statusCode
 	}
 
 	var encoder func(Response) ([]byte, error)
 	if r.URL.Query().Get("format") == "json" {
-		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		encoder = encodeJSON
 	} else {
-		w.Header().Set("Content-Type", "application/xml")
+		w.Header().Set("Content-Type", "text/xml; charset=utf-8")
 		encoder = encodeXML
 	}
+	w.WriteHeader(statusCode)
 	encoded, err := encoder(res)
 	if err != nil {
 		appctx.GetLogger(r.Context()).Error().Err(err).Msg("error encoding ocs response")


### PR DESCRIPTION
all headers need to be set before `w.WriteHeader(status code)` is called

fixes https://github.com/owncloud/ocis/issues/1779