### PR TITLE
Build static binaries for Docker, so that we can use 'scratch' image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,9 +98,9 @@ ci: build-ci test  lint-ci
 
 # to be run in Docker build
 build-revad-docker: off
-	go build -ldflags ${BUILD_FLAGS} -o ./cmd/revad/revad ./cmd/revad
+	env CGO_ENABLED=0 go build -ldflags ${BUILD_FLAGS} -o ./cmd/revad/revad ./cmd/revad
 build-reva-docker: off
-	go build -ldflags ${BUILD_FLAGS} -o ./cmd/reva/reva ./cmd/reva
+	env CGO_ENABLED=0 go build -ldflags ${BUILD_FLAGS} -o ./cmd/reva/reva ./cmd/reva
 clean:
 	rm -rf dist
 

--- a/changelog/unreleased/set-cgo-enabled-0-flag.md
+++ b/changelog/unreleased/set-cgo-enabled-0-flag.md
@@ -1,0 +1,8 @@
+Bugfix: Set CGO_ENABLED flag for 'scratch' based docker builds
+
+The CGO_ENABLED=0 flag was added to the docker build flags so that it will
+produce a static build. This allows usage of the 'scratch' image for
+reduction of the docker image size.
+
+https://github.com/cs3org/reva/issues/1765
+https://github.com/cs3org/reva/pull/1766


### PR DESCRIPTION
This should fix issue #1765