### PR TITLE
[Tests-Only]Adjust expected Failures

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The test runner source for API tests
-CORE_COMMITID=b587826832245d9c5f72ab2a9d831b1be6b66210
+CORE_COMMITID=036d33e4bc91bdeb7671e1ca0d247acea629d762
 CORE_BRANCH=master

--- a/tests/acceptance/expected-failures-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-on-OCIS-storage.md
@@ -261,20 +261,18 @@ Scenario Outline: overwriting a file changes its mtime `expected -'1565237893', 
 -   [apiWebdavLocks/folder.feature:120](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/folder.feature#L120)
 -   [apiWebdavLocks/folder.feature:121](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/folder.feature#L121)
 -   [apiWebdavLocks/folder.feature:122](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/folder.feature#L122)
--   [apiWebdavLocks/publicLink.feature:23](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/publicLink.feature#L23)
--   [apiWebdavLocks/publicLink.feature:24](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/publicLink.feature#L24)
--   [apiWebdavLocks/publicLink.feature:25](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/publicLink.feature#L25)
--   [apiWebdavLocks/publicLink.feature:26](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/publicLink.feature#L26)
--   [apiWebdavLocks/publicLink.feature:40](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/publicLink.feature#L40)
--   [apiWebdavLocks/publicLink.feature:41](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/publicLink.feature#L41)
--   [apiWebdavLocks/publicLink.feature:53](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/publicLink.feature#L53)
--   [apiWebdavLocks/publicLink.feature:54](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/publicLink.feature#L54)
--   [apiWebdavLocks/publicLink.feature:68](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/publicLink.feature#L68)
--   [apiWebdavLocks/publicLink.feature:69](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/publicLink.feature#L69)
--   [apiWebdavLocks/publicLink.feature:80](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/publicLink.feature#L80)
--   [apiWebdavLocks/publicLink.feature:81](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/publicLink.feature#L81)
--   [apiWebdavLocks/publicLink.feature:82](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/publicLink.feature#L82)
--   [apiWebdavLocks/publicLink.feature:83](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/publicLink.feature#L83)
+-   [apiWebdavLocks/publicLink.feature:32](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/publicLink.feature#L32)
+-   [apiWebdavLocks/publicLink.feature:33](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/publicLink.feature#L33)
+-   [apiWebdavLocks/publicLink.feature:34](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/publicLink.feature#L34)
+-   [apiWebdavLocks/publicLink.feature:35](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/publicLink.feature#L35)
+-   [apiWebdavLocks/publicLink.feature:49](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/publicLink.feature#L49)
+-   [apiWebdavLocks/publicLink.feature:50](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/publicLink.feature#L50)
+-   [apiWebdavLocks/publicLink.feature:62](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/publicLink.feature#L62)
+-   [apiWebdavLocks/publicLink.feature:63](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/publicLink.feature#L63)
+-   [apiWebdavLocks/publicLink.feature:77](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/publicLink.feature#L77)
+-   [apiWebdavLocks/publicLink.feature:78](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/publicLink.feature#L78)
+-   [apiWebdavLocks/publicLink.feature:97](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/publicLink.feature#L97)
+-   [apiWebdavLocks/publicLink.feature:98](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/publicLink.feature#L98)
 -   [apiWebdavLocks/publicLinkLockdiscovery.feature:22](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/publicLinkLockdiscovery.feature#L22)
 -   [apiWebdavLocks/publicLinkLockdiscovery.feature:23](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/publicLinkLockdiscovery.feature#L23)
 -   [apiWebdavLocks/publicLinkLockdiscovery.feature:37](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/publicLinkLockdiscovery.feature#L37)
@@ -297,10 +295,10 @@ Scenario Outline: overwriting a file changes its mtime `expected -'1565237893', 
 -   [apiWebdavLocks/requestsWithToken.feature:82](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/requestsWithToken.feature#L82)
 -   [apiWebdavLocks/requestsWithToken.feature:83](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/requestsWithToken.feature#L83)
 -   [apiWebdavLocks/requestsWithToken.feature:84](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/requestsWithToken.feature#L84)
--   [apiWebdavLocks/requestsWithToken.feature:100](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/requestsWithToken.feature#L100)
--   [apiWebdavLocks/requestsWithToken.feature:101](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/requestsWithToken.feature#L101)
--   [apiWebdavLocks/requestsWithToken.feature:124](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/requestsWithToken.feature#L124)
--   [apiWebdavLocks/requestsWithToken.feature:125](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/requestsWithToken.feature#L125)
+-   [apiWebdavLocks/requestsWithToken.feature:106](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/requestsWithToken.feature#L106)
+-   [apiWebdavLocks/requestsWithToken.feature:107](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/requestsWithToken.feature#L107)
+-   [apiWebdavLocks/requestsWithToken.feature:130](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/requestsWithToken.feature#L130)
+-   [apiWebdavLocks/requestsWithToken.feature:131](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/requestsWithToken.feature#L131)
 -   [apiWebdavLocks2/resharedSharesToRoot.feature:29](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks2/resharedSharesToRoot.feature#L29)
 -   [apiWebdavLocks2/resharedSharesToRoot.feature:30](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks2/resharedSharesToRoot.feature#L30)
 -   [apiWebdavLocks2/resharedSharesToRoot.feature:31](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks2/resharedSharesToRoot.feature#L31)
@@ -784,17 +782,16 @@ File and sync features in a shared scenario
 -   [apiShareOperationsToShares/gettingShares.feature:170](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareOperationsToShares/gettingShares.feature#L170)
 -   [apiShareOperationsToShares/gettingShares.feature:171](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareOperationsToShares/gettingShares.feature#L171)
 
--   [apiSharePublicLink1/createPublicLinkShare.feature:737](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature#L737)
--   [apiSharePublicLink1/createPublicLinkShare.feature:748](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature#L748)
+-   [apiSharePublicLink1/createPublicLinkShare.feature:736](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature#L736)
+-   [apiSharePublicLink1/createPublicLinkShare.feature:747](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature#L747)
 
 #### [Cannot set mtime on upload](https://github.com/owncloud/product/issues/271)
 
+-   [apiSharePublicLink1/createPublicLinkShare.feature:717](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature#L717)
 -   [apiSharePublicLink1/createPublicLinkShare.feature:718](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature#L718)
--   [apiSharePublicLink1/createPublicLinkShare.feature:719](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature#L719)
+-   [apiSharePublicLink1/createPublicLinkShare.feature:732](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature#L732)
 -   [apiSharePublicLink1/createPublicLinkShare.feature:733](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature#L733)
--   [apiSharePublicLink1/createPublicLinkShare.feature:734](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature#L734)
 
-#### [Split old public API webdav tests from new public webdav tests](https://github.com/owncloud/ocis-reva/issues/282)
 #### [Public link enforce permissions](https://github.com/owncloud/ocis/issues/1269)
 #### [Previews via webDAV API tests fail on OCIS](https://github.com/owncloud/ocis/issues/187)
 
@@ -805,26 +802,12 @@ File and sync features in a shared scenario
 
 #### [creating public links with permissions fails](https://github.com/owncloud/product/issues/252)
 
--   [apiSharePublicLink1/changingPublicLinkShare.feature:22](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/changingPublicLinkShare.feature#L22)
--   [apiSharePublicLink1/changingPublicLinkShare.feature:23](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/changingPublicLinkShare.feature#L23)
--   [apiSharePublicLink1/changingPublicLinkShare.feature:35](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/changingPublicLinkShare.feature#L35)
--   [apiSharePublicLink1/changingPublicLinkShare.feature:39](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/changingPublicLinkShare.feature#L39)
--   [apiSharePublicLink1/changingPublicLinkShare.feature:49](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/changingPublicLinkShare.feature#L49)
--   [apiSharePublicLink1/changingPublicLinkShare.feature:79](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/changingPublicLinkShare.feature#L79)
--   [apiSharePublicLink1/changingPublicLinkShare.feature:88](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/changingPublicLinkShare.feature#L88)
-
-#### [Old webdav api does not work with public link](https://github.com/owncloud/product/issues/272)
-
--   [apiSharePublicLink1/changingPublicLinkShare.feature:59](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/changingPublicLinkShare.feature#L59)
--   [apiSharePublicLink1/changingPublicLinkShare.feature:97](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/changingPublicLinkShare.feature#L97)
--   [apiSharePublicLink1/changingPublicLinkShare.feature:133](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/changingPublicLinkShare.feature#L133)
--   [apiSharePublicLink1/changingPublicLinkShare.feature:173](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/changingPublicLinkShare.feature#L173)
--   [apiSharePublicLink1/changingPublicLinkShare.feature:214](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/changingPublicLinkShare.feature#L214)
+-   [apiSharePublicLink1/changingPublicLinkShare.feature:30](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/changingPublicLinkShare.feature#L30)
+-   [apiSharePublicLink1/changingPublicLinkShare.feature:51](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/changingPublicLinkShare.feature#L51)
+-   [apiSharePublicLink1/changingPublicLinkShare.feature:90](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/changingPublicLinkShare.feature#L90)
 
 #### [Public link enforce permissions](https://github.com/owncloud/ocis/issues/1269)
 
--   [apiSharePublicLink1/changingPublicLinkShare.feature:233](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/changingPublicLinkShare.feature#L233)
--   [apiSharePublicLink1/changingPublicLinkShare.feature:253](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/changingPublicLinkShare.feature#L253)
 -   [apiSharePublicLink1/createPublicLinkShare.feature:141](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature#L141)
 -   [apiSharePublicLink1/createPublicLinkShare.feature:142](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature#L142)
 -   [apiSharePublicLink1/createPublicLinkShare.feature:220](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature#L220)
@@ -872,8 +855,8 @@ File and sync features in a shared scenario
 
 #### [Public cannot upload file with mtime set on a public link share with new version of WebDAV API](https://github.com/owncloud/core/issues/37605)
 
--   [apiSharePublicLink1/createPublicLinkShare.feature:656](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature#L656)
--   [apiSharePublicLink1/createPublicLinkShare.feature:676](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature#L676)
+-   [apiSharePublicLink1/createPublicLinkShare.feature:673](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature#L673)
+-   [apiSharePublicLink1/createPublicLinkShare.feature:694](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature#L694)
 
 #### [copying a folder within a public link folder to folder with same name as an already existing file overwrites the parent file](https://github.com/owncloud/ocis/issues/1232)
 
@@ -887,10 +870,6 @@ File and sync features in a shared scenario
 -   [apiSharePublicLink2/updatePublicLinkShare.feature:46](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L46)
 -   [apiSharePublicLink2/updatePublicLinkShare.feature:117](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L117)
 -   [apiSharePublicLink2/updatePublicLinkShare.feature:118](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L118)
--   [apiSharePublicLink2/updatePublicLinkShare.feature:133](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L133)
--   [apiSharePublicLink2/updatePublicLinkShare.feature:134](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L134)
--   [apiSharePublicLink2/updatePublicLinkShare.feature:329](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L329)
--   [apiSharePublicLink2/updatePublicLinkShare.feature:330](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L330)
 
 #### [OCIS share permissions not enforced](https://github.com/owncloud/product/issues/270)
 
@@ -899,77 +878,28 @@ File and sync features in a shared scenario
 -   [apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature:181](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature#L181)
 -   [apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature:182](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature#L182)
 
-#### [OCIS old public webdav api doesnt works](https://github.com/owncloud/product/issues/272)
+#### [Adding public upload to a read only shared folder as a receipient is allowed ](https://github.com/owncloud/ocis/issues/2164)
 
--   [apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature:32](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature#L32)
--   [apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature:33](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature#L33)
--   [apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature:52](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature#L52)
--   [apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature:53](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature#L53)
--   [apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature:73](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature#L73)
--   [apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature:74](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature#L74)
--   [apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature:94](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature#L94)
--   [apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature:95](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature#L95)
--   [apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature:116](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature#L116)
--   [apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature:117](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature#L117)
-
-#### [listing received shares does not work](https://github.com/owncloud/ocis-reva/issues/11)
-
--   [apiSharePublicLink2/updatePublicLinkShare.feature:348](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L348)
--   [apiSharePublicLink2/updatePublicLinkShare.feature:349](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L349)
--   [apiSharePublicLink2/updatePublicLinkShare.feature:367](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L367)
--   [apiSharePublicLink2/updatePublicLinkShare.feature:368](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L368)
--   [apiSharePublicLink2/updatePublicLinkShare.feature:386](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L386)
--   [apiSharePublicLink2/updatePublicLinkShare.feature:387](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L387)
--   [apiSharePublicLink2/updatePublicLinkShare.feature:486](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L486)
--   [apiSharePublicLink2/updatePublicLinkShare.feature:487](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L487)
--   [apiSharePublicLink2/updatePublicLinkShare.feature:405](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L405)
--   [apiSharePublicLink2/updatePublicLinkShare.feature:406](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L406)
--   [apiSharePublicLink2/updatePublicLinkShare.feature:424](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L424)
--   [apiSharePublicLink2/updatePublicLinkShare.feature:425](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L425)
--   [apiSharePublicLink2/updatePublicLinkShare.feature:443](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L443)
--   [apiSharePublicLink2/updatePublicLinkShare.feature:444](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L444)
--   [apiSharePublicLink2/updatePublicLinkShare.feature:462](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L462)
--   [apiSharePublicLink2/updatePublicLinkShare.feature:463](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L463)
-
-#### [Public link enforce permissions](https://github.com/owncloud/ocis/issues/1269)
-
--   [apiSharePublicLink2/updatePublicLinkShare.feature:538](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L538)
--   [apiSharePublicLink2/updatePublicLinkShare.feature:539](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L539)
--   [apiSharePublicLink2/uploadToPublicLinkShare.feature:10](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L10)
--   [apiSharePublicLink2/uploadToPublicLinkShare.feature:82](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L82)
--   [apiSharePublicLink2/uploadToPublicLinkShare.feature:101](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L101)
--   [apiSharePublicLink2/uploadToPublicLinkShare.feature:118](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L118)
--   [apiSharePublicLink2/uploadToPublicLinkShare.feature:135](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L135)
-
-#### [Upload-only shares must not overwrite but create a separate file](https://github.com/owncloud/ocis/issues/1267)
-
--   [apiSharePublicLink2/uploadToPublicLinkShare.feature:48](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L48)
--   [apiSharePublicLink2/uploadToPublicLinkShare.feature:49](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L49)
+-   [apiSharePublicLink2/updatePublicLinkShare.feature:332](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L332)
+-   [apiSharePublicLink2/updatePublicLinkShare.feature:333](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L333)
+-   [apiSharePublicLink2/updatePublicLinkShare.feature:392](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L392)
+-   [apiSharePublicLink2/updatePublicLinkShare.feature:393](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L393)
 
 #### [Upload-only shares must not overwrite but create a separate file](https://github.com/owncloud/ocis-reva/issues/286)
 
 -   [apiSharePublicLink2/uploadToPublicLinkShare.feature:24](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L24)
--   [apiSharePublicLink2/uploadToPublicLinkShare.feature:262](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L262)
-
-#### [Accessing non-existing public link should return 404, not 500](https://github.com/owncloud/ocis/issues/1268)
-
--   [apiSharePublicLink2/uploadToPublicLinkShare.feature:66](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L66)
+-   [apiSharePublicLink2/uploadToPublicLinkShare.feature:268](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L268)
 
 #### [Set quota over settings](https://github.com/owncloud/ocis/issues/1290)
 _requires a [CS3 user provisioning api that can update the quota for a user](https://github.com/cs3org/cs3apis/pull/95#issuecomment-772780683)_
--   [apiSharePublicLink2/uploadToPublicLinkShare.feature:144](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L144)
--   [apiSharePublicLink2/uploadToPublicLinkShare.feature:153](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L153)
--   [apiSharePublicLink2/uploadToPublicLinkShare.feature:162](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L162)
+
+-   [apiSharePublicLink2/uploadToPublicLinkShare.feature:152](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L152)
 -   [apiSharePublicLink2/uploadToPublicLinkShare.feature:171](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L171)
 
 #### [various sharing settings cannot be set](https://github.com/owncloud/ocis/issues/1328)
 
--   [apiSharePublicLink2/uploadToPublicLinkShare.feature:180](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L180)
--   [apiSharePublicLink2/uploadToPublicLinkShare.feature:189](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L189)
--   [apiSharePublicLink2/uploadToPublicLinkShare.feature:199](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L199)
--   [apiSharePublicLink2/uploadToPublicLinkShare.feature:209](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L209)
--   [apiSharePublicLink2/uploadToPublicLinkShare.feature:229](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L229)
--   [apiSharePublicLink2/uploadToPublicLinkShare.feature:245](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L245)
+-   [apiSharePublicLink2/uploadToPublicLinkShare.feature:190](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L190)
+-   [apiSharePublicLink2/uploadToPublicLinkShare.feature:210](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L210)
 
 #### [Resharing does not work with ocis storage](https://github.com/owncloud/product/issues/265)
 
@@ -1549,18 +1479,6 @@ Scenario Outline: Retrieving folder quota when no quota is set
 Scenario Outline: Retrieving folder quota when quota is set
 -   [apiWebdavProperties1/getQuota.feature:27](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/getQuota.feature#L27)
 -   [apiWebdavProperties1/getQuota.feature:28](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/getQuota.feature#L28)
-
-#### [user-sync endpoint does not exist](https://github.com/owncloud/ocis/issues/1241)
--   [apiMain/userSync.feature:18](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiMain/userSync.feature#L18)
--   [apiMain/userSync.feature:19](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiMain/userSync.feature#L19)
--   [apiMain/userSync.feature:29](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiMain/userSync.feature#L29)
--   [apiMain/userSync.feature:30](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiMain/userSync.feature#L30)
--   [apiMain/userSync.feature:40](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiMain/userSync.feature#L40)
--   [apiMain/userSync.feature:41](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiMain/userSync.feature#L41)
--   [apiMain/userSync.feature:52](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiMain/userSync.feature#L52)
--   [apiMain/userSync.feature:53](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiMain/userSync.feature#L53)
--   [apiMain/userSync.feature:63](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiMain/userSync.feature#L63)
--   [apiMain/userSync.feature:64](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiMain/userSync.feature#L64)
 
 ### Other
 API, search, favorites, config, capabilities, not existing endpoints, CORS and others

--- a/tests/acceptance/expected-failures-on-OWNCLOUD-storage.md
+++ b/tests/acceptance/expected-failures-on-OWNCLOUD-storage.md
@@ -272,20 +272,18 @@ _ocdav: return checksum in upload response for chunked upload_
 -   [apiWebdavLocks/folder.feature:120](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/folder.feature#L120)
 -   [apiWebdavLocks/folder.feature:121](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/folder.feature#L121)
 -   [apiWebdavLocks/folder.feature:122](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/folder.feature#L122)
--   [apiWebdavLocks/publicLink.feature:23](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/publicLink.feature#L23)
--   [apiWebdavLocks/publicLink.feature:24](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/publicLink.feature#L24)
--   [apiWebdavLocks/publicLink.feature:25](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/publicLink.feature#L25)
--   [apiWebdavLocks/publicLink.feature:26](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/publicLink.feature#L26)
--   [apiWebdavLocks/publicLink.feature:40](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/publicLink.feature#L40)
--   [apiWebdavLocks/publicLink.feature:41](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/publicLink.feature#L41)
--   [apiWebdavLocks/publicLink.feature:53](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/publicLink.feature#L53)
--   [apiWebdavLocks/publicLink.feature:54](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/publicLink.feature#L54)
--   [apiWebdavLocks/publicLink.feature:68](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/publicLink.feature#L68)
--   [apiWebdavLocks/publicLink.feature:69](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/publicLink.feature#L69)
--   [apiWebdavLocks/publicLink.feature:80](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/publicLink.feature#L80)
--   [apiWebdavLocks/publicLink.feature:81](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/publicLink.feature#L81)
--   [apiWebdavLocks/publicLink.feature:82](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/publicLink.feature#L82)
--   [apiWebdavLocks/publicLink.feature:83](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/publicLink.feature#L83)
+-   [apiWebdavLocks/publicLink.feature:32](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/publicLink.feature#L32)
+-   [apiWebdavLocks/publicLink.feature:33](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/publicLink.feature#L33)
+-   [apiWebdavLocks/publicLink.feature:34](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/publicLink.feature#L34)
+-   [apiWebdavLocks/publicLink.feature:35](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/publicLink.feature#L35)
+-   [apiWebdavLocks/publicLink.feature:49](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/publicLink.feature#L49)
+-   [apiWebdavLocks/publicLink.feature:50](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/publicLink.feature#L50)
+-   [apiWebdavLocks/publicLink.feature:62](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/publicLink.feature#L62)
+-   [apiWebdavLocks/publicLink.feature:63](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/publicLink.feature#L63)
+-   [apiWebdavLocks/publicLink.feature:77](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/publicLink.feature#L77)
+-   [apiWebdavLocks/publicLink.feature:78](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/publicLink.feature#L78)
+-   [apiWebdavLocks/publicLink.feature:97](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/publicLink.feature#L97)
+-   [apiWebdavLocks/publicLink.feature:98](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/publicLink.feature#L98)
 -   [apiWebdavLocks/publicLinkLockdiscovery.feature:22](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/publicLinkLockdiscovery.feature#L22)
 -   [apiWebdavLocks/publicLinkLockdiscovery.feature:23](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/publicLinkLockdiscovery.feature#L23)
 -   [apiWebdavLocks/publicLinkLockdiscovery.feature:37](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/publicLinkLockdiscovery.feature#L37)
@@ -308,10 +306,10 @@ _ocdav: return checksum in upload response for chunked upload_
 -   [apiWebdavLocks/requestsWithToken.feature:82](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/requestsWithToken.feature#L82)
 -   [apiWebdavLocks/requestsWithToken.feature:83](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/requestsWithToken.feature#L83)
 -   [apiWebdavLocks/requestsWithToken.feature:84](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/requestsWithToken.feature#L84)
--   [apiWebdavLocks/requestsWithToken.feature:100](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/requestsWithToken.feature#L100)
--   [apiWebdavLocks/requestsWithToken.feature:101](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/requestsWithToken.feature#L101)
--   [apiWebdavLocks/requestsWithToken.feature:124](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/requestsWithToken.feature#L124)
--   [apiWebdavLocks/requestsWithToken.feature:125](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/requestsWithToken.feature#L125)
+-   [apiWebdavLocks/requestsWithToken.feature:106](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/requestsWithToken.feature#L106)
+-   [apiWebdavLocks/requestsWithToken.feature:107](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/requestsWithToken.feature#L107)
+-   [apiWebdavLocks/requestsWithToken.feature:130](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/requestsWithToken.feature#L130)
+-   [apiWebdavLocks/requestsWithToken.feature:131](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/requestsWithToken.feature#L131)
 -   [apiWebdavLocks2/resharedSharesToRoot.feature:29](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks2/resharedSharesToRoot.feature#L29)
 -   [apiWebdavLocks2/resharedSharesToRoot.feature:30](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks2/resharedSharesToRoot.feature#L30)
 -   [apiWebdavLocks2/resharedSharesToRoot.feature:31](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks2/resharedSharesToRoot.feature#L31)
@@ -803,7 +801,6 @@ cannot share a folder with create permission
 -   [apiShareOperationsToShares/gettingShares.feature:170](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareOperationsToShares/gettingShares.feature#L170)
 -   [apiShareOperationsToShares/gettingShares.feature:171](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareOperationsToShares/gettingShares.feature#L171)
 
-#### [Split old public API webdav tests from new public webdav tests](https://github.com/owncloud/ocis-reva/issues/282)
 #### [Public link enforce permissions](https://github.com/owncloud/ocis/issues/1269)
 #### [Previews via webDAV API tests fail on OCIS](https://github.com/owncloud/ocis/issues/187)
 
@@ -814,21 +811,9 @@ cannot share a folder with create permission
 
 #### [creating public links with permissions fails](https://github.com/owncloud/product/issues/252)
 
--   [apiSharePublicLink1/changingPublicLinkShare.feature:22](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/changingPublicLinkShare.feature#L22)
--   [apiSharePublicLink1/changingPublicLinkShare.feature:23](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/changingPublicLinkShare.feature#L23)
--   [apiSharePublicLink1/changingPublicLinkShare.feature:35](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/changingPublicLinkShare.feature#L35)
--   [apiSharePublicLink1/changingPublicLinkShare.feature:39](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/changingPublicLinkShare.feature#L39)
--   [apiSharePublicLink1/changingPublicLinkShare.feature:49](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/changingPublicLinkShare.feature#L49)
--   [apiSharePublicLink1/changingPublicLinkShare.feature:79](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/changingPublicLinkShare.feature#L79)
--   [apiSharePublicLink1/changingPublicLinkShare.feature:88](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/changingPublicLinkShare.feature#L88)
-
-#### [Old webdav api does not work with public link](https://github.com/owncloud/product/issues/272)
-
--   [apiSharePublicLink1/changingPublicLinkShare.feature:59](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/changingPublicLinkShare.feature#L59)
--   [apiSharePublicLink1/changingPublicLinkShare.feature:97](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/changingPublicLinkShare.feature#L97)
--   [apiSharePublicLink1/changingPublicLinkShare.feature:133](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/changingPublicLinkShare.feature#L133)
--   [apiSharePublicLink1/changingPublicLinkShare.feature:173](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/changingPublicLinkShare.feature#L173)
--   [apiSharePublicLink1/changingPublicLinkShare.feature:214](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/changingPublicLinkShare.feature#L214)
+-   [apiSharePublicLink1/changingPublicLinkShare.feature:30](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/changingPublicLinkShare.feature#L30)
+-   [apiSharePublicLink1/changingPublicLinkShare.feature:51](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/changingPublicLinkShare.feature#L51)
+-   [apiSharePublicLink1/changingPublicLinkShare.feature:90](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/changingPublicLinkShare.feature#L90)
 
 #### [Public link enforce permissions](https://github.com/owncloud/ocis/issues/1269)
 
@@ -879,8 +864,8 @@ cannot share a folder with create permission
 
 #### [Public cannot upload file with mtime set on a public link share with new version of WebDAV API](https://github.com/owncloud/core/issues/37605)
 
--   [apiSharePublicLink1/createPublicLinkShare.feature:656](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature#L656)
--   [apiSharePublicLink1/createPublicLinkShare.feature:676](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature#L676)
+-   [apiSharePublicLink1/createPublicLinkShare.feature:673](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature#L673)
+-   [apiSharePublicLink1/createPublicLinkShare.feature:694](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature#L694)
 
 #### [copying a folder within a public link folder to folder with same name as an already existing file overwrites the parent file](https://github.com/owncloud/ocis/issues/1232)
 
@@ -894,10 +879,6 @@ cannot share a folder with create permission
 -   [apiSharePublicLink2/updatePublicLinkShare.feature:46](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L46)
 -   [apiSharePublicLink2/updatePublicLinkShare.feature:117](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L117)
 -   [apiSharePublicLink2/updatePublicLinkShare.feature:118](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L118)
--   [apiSharePublicLink2/updatePublicLinkShare.feature:133](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L133)
--   [apiSharePublicLink2/updatePublicLinkShare.feature:134](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L134)
--   [apiSharePublicLink2/updatePublicLinkShare.feature:329](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L329)
--   [apiSharePublicLink2/updatePublicLinkShare.feature:330](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L330)
 
 #### [OCIS share permissions not enforced](https://github.com/owncloud/product/issues/270)
 
@@ -917,79 +898,27 @@ The following scenarios fail on OWNCLOUD storage but not on OCIS storage:
 -   [apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature:138](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature#L138)
 -   [apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature:139](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature#L139)
 
-#### [OCIS old public webdav api doesnt works](https://github.com/owncloud/product/issues/272)
+#### [Adding public upload to a read only shared folder as a receipient is allowed ](https://github.com/owncloud/ocis/issues/2164)
 
--   [apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature:32](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature#L32)
--   [apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature:33](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature#L33)
--   [apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature:52](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature#L52)
--   [apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature:53](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature#L53)
--   [apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature:73](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature#L73)
--   [apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature:74](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature#L74)
--   [apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature:94](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature#L94)
--   [apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature:95](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature#L95)
--   [apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature:116](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature#L116)
--   [apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature:117](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature#L117)
-
-#### [listing received shares does not work](https://github.com/owncloud/ocis-reva/issues/11)
-
--   [apiSharePublicLink2/updatePublicLinkShare.feature:348](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L348)
--   [apiSharePublicLink2/updatePublicLinkShare.feature:349](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L349)
--   [apiSharePublicLink2/updatePublicLinkShare.feature:367](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L367)
--   [apiSharePublicLink2/updatePublicLinkShare.feature:368](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L368)
--   [apiSharePublicLink2/updatePublicLinkShare.feature:386](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L386)
--   [apiSharePublicLink2/updatePublicLinkShare.feature:387](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L387)
--   [apiSharePublicLink2/updatePublicLinkShare.feature:486](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L486)
--   [apiSharePublicLink2/updatePublicLinkShare.feature:487](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L487)
--   [apiSharePublicLink2/updatePublicLinkShare.feature:405](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L405)
--   [apiSharePublicLink2/updatePublicLinkShare.feature:406](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L406)
--   [apiSharePublicLink2/updatePublicLinkShare.feature:424](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L424)
--   [apiSharePublicLink2/updatePublicLinkShare.feature:425](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L425)
--   [apiSharePublicLink2/updatePublicLinkShare.feature:443](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L443)
--   [apiSharePublicLink2/updatePublicLinkShare.feature:444](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L444)
--   [apiSharePublicLink2/updatePublicLinkShare.feature:462](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L462)
--   [apiSharePublicLink2/updatePublicLinkShare.feature:463](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L463)
-
-#### [Public link enforce permissions](https://github.com/owncloud/ocis/issues/1269)
-
--   [apiSharePublicLink1/changingPublicLinkShare.feature:233](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/changingPublicLinkShare.feature#L233)
--   [apiSharePublicLink1/changingPublicLinkShare.feature:253](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/changingPublicLinkShare.feature#L253)
--   [apiSharePublicLink2/updatePublicLinkShare.feature:538](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L538)
--   [apiSharePublicLink2/updatePublicLinkShare.feature:539](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L539)
--   [apiSharePublicLink2/uploadToPublicLinkShare.feature:10](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L10)
--   [apiSharePublicLink2/uploadToPublicLinkShare.feature:82](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L82)
--   [apiSharePublicLink2/uploadToPublicLinkShare.feature:101](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L101)
--   [apiSharePublicLink2/uploadToPublicLinkShare.feature:118](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L118)
--   [apiSharePublicLink2/uploadToPublicLinkShare.feature:135](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L135)
-
-#### [Upload-only shares must not overwrite but create a separate file](https://github.com/owncloud/ocis/issues/1267)
-
--   [apiSharePublicLink2/uploadToPublicLinkShare.feature:48](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L48)
--   [apiSharePublicLink2/uploadToPublicLinkShare.feature:49](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L49)
+-   [apiSharePublicLink2/updatePublicLinkShare.feature:332](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L332)
+-   [apiSharePublicLink2/updatePublicLinkShare.feature:333](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L333)
+-   [apiSharePublicLink2/updatePublicLinkShare.feature:392](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L392)
+-   [apiSharePublicLink2/updatePublicLinkShare.feature:393](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L393)
 
 #### [Upload-only shares must not overwrite but create a separate file](https://github.com/owncloud/ocis-reva/issues/286)
 
 -   [apiSharePublicLink2/uploadToPublicLinkShare.feature:24](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L24)
--   [apiSharePublicLink2/uploadToPublicLinkShare.feature:262](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L262)
-
-#### [Accessing non-existing public link should return 404, not 500](https://github.com/owncloud/ocis/issues/1268)
-
--   [apiSharePublicLink2/uploadToPublicLinkShare.feature:66](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L66)
+-   [apiSharePublicLink2/uploadToPublicLinkShare.feature:268](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L268)
 
 #### [Set quota over settings](https://github.com/owncloud/ocis/issues/1290)
 _requires a [CS3 user provisioning api that can update the quota for a user](https://github.com/cs3org/cs3apis/pull/95#issuecomment-772780683)_
--   [apiSharePublicLink2/uploadToPublicLinkShare.feature:144](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L144)
--   [apiSharePublicLink2/uploadToPublicLinkShare.feature:153](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L153)
--   [apiSharePublicLink2/uploadToPublicLinkShare.feature:162](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L162)
+-   [apiSharePublicLink2/uploadToPublicLinkShare.feature:152](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L152)
 -   [apiSharePublicLink2/uploadToPublicLinkShare.feature:171](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L171)
 
 #### [various sharing settings cannot be set](https://github.com/owncloud/ocis/issues/1328)
 
--   [apiSharePublicLink2/uploadToPublicLinkShare.feature:180](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L180)
--   [apiSharePublicLink2/uploadToPublicLinkShare.feature:189](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L189)
--   [apiSharePublicLink2/uploadToPublicLinkShare.feature:199](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L199)
--   [apiSharePublicLink2/uploadToPublicLinkShare.feature:209](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L209)
--   [apiSharePublicLink2/uploadToPublicLinkShare.feature:229](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L229)
--   [apiSharePublicLink2/uploadToPublicLinkShare.feature:245](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L245)
+-   [apiSharePublicLink2/uploadToPublicLinkShare.feature:190](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L190)
+-   [apiSharePublicLink2/uploadToPublicLinkShare.feature:210](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L210)
 
 #### [Resharing does not work with ocis storage](https://github.com/owncloud/product/issues/265)
 
@@ -1674,18 +1603,6 @@ _requires a [CS3 user provisioning api that can update the quota for a user](htt
 -   [apiMain/quota.feature:164](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiMain/quota.feature:164)
 -   [apiMain/quota.feature:178](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiMain/quota.feature:178)
 -   [apiMain/quota.feature:184](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiMain/quota.feature:184)
-
-#### [user-sync endpoint does not exist](https://github.com/owncloud/ocis/issues/1241)
--   [apiMain/userSync.feature:18](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiMain/userSync.feature#L18)
--   [apiMain/userSync.feature:19](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiMain/userSync.feature#L19)
--   [apiMain/userSync.feature:29](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiMain/userSync.feature#L29)
--   [apiMain/userSync.feature:30](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiMain/userSync.feature#L30)
--   [apiMain/userSync.feature:40](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiMain/userSync.feature#L40)
--   [apiMain/userSync.feature:41](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiMain/userSync.feature#L41)
--   [apiMain/userSync.feature:52](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiMain/userSync.feature#L52)
--   [apiMain/userSync.feature:53](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiMain/userSync.feature#L53)
--   [apiMain/userSync.feature:63](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiMain/userSync.feature#L63)
--   [apiMain/userSync.feature:64](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiMain/userSync.feature#L64)
 
 ### Other
 API, search, favorites, config, capabilities, not existing endpoints, CORS and others

--- a/tests/acceptance/expected-failures-on-S3NG-storage.md
+++ b/tests/acceptance/expected-failures-on-S3NG-storage.md
@@ -261,20 +261,18 @@ Scenario Outline: overwriting a file changes its mtime `expected -'1565237893', 
 -   [apiWebdavLocks/folder.feature:120](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/folder.feature#L120)
 -   [apiWebdavLocks/folder.feature:121](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/folder.feature#L121)
 -   [apiWebdavLocks/folder.feature:122](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/folder.feature#L122)
--   [apiWebdavLocks/publicLink.feature:23](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/publicLink.feature#L23)
--   [apiWebdavLocks/publicLink.feature:24](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/publicLink.feature#L24)
--   [apiWebdavLocks/publicLink.feature:25](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/publicLink.feature#L25)
--   [apiWebdavLocks/publicLink.feature:26](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/publicLink.feature#L26)
--   [apiWebdavLocks/publicLink.feature:40](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/publicLink.feature#L40)
--   [apiWebdavLocks/publicLink.feature:41](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/publicLink.feature#L41)
--   [apiWebdavLocks/publicLink.feature:53](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/publicLink.feature#L53)
--   [apiWebdavLocks/publicLink.feature:54](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/publicLink.feature#L54)
--   [apiWebdavLocks/publicLink.feature:68](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/publicLink.feature#L68)
--   [apiWebdavLocks/publicLink.feature:69](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/publicLink.feature#L69)
--   [apiWebdavLocks/publicLink.feature:80](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/publicLink.feature#L80)
--   [apiWebdavLocks/publicLink.feature:81](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/publicLink.feature#L81)
--   [apiWebdavLocks/publicLink.feature:82](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/publicLink.feature#L82)
--   [apiWebdavLocks/publicLink.feature:83](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/publicLink.feature#L83)
+-   [apiWebdavLocks/publicLink.feature:32](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/publicLink.feature#L32)
+-   [apiWebdavLocks/publicLink.feature:33](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/publicLink.feature#L33)
+-   [apiWebdavLocks/publicLink.feature:34](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/publicLink.feature#L34)
+-   [apiWebdavLocks/publicLink.feature:35](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/publicLink.feature#L35)
+-   [apiWebdavLocks/publicLink.feature:49](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/publicLink.feature#L49)
+-   [apiWebdavLocks/publicLink.feature:50](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/publicLink.feature#L50)
+-   [apiWebdavLocks/publicLink.feature:62](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/publicLink.feature#L62)
+-   [apiWebdavLocks/publicLink.feature:63](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/publicLink.feature#L63)
+-   [apiWebdavLocks/publicLink.feature:77](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/publicLink.feature#L77)
+-   [apiWebdavLocks/publicLink.feature:78](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/publicLink.feature#L78)
+-   [apiWebdavLocks/publicLink.feature:97](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/publicLink.feature#L97)
+-   [apiWebdavLocks/publicLink.feature:98](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/publicLink.feature#L98)
 -   [apiWebdavLocks/publicLinkLockdiscovery.feature:22](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/publicLinkLockdiscovery.feature#L22)
 -   [apiWebdavLocks/publicLinkLockdiscovery.feature:23](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/publicLinkLockdiscovery.feature#L23)
 -   [apiWebdavLocks/publicLinkLockdiscovery.feature:37](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/publicLinkLockdiscovery.feature#L37)
@@ -297,10 +295,10 @@ Scenario Outline: overwriting a file changes its mtime `expected -'1565237893', 
 -   [apiWebdavLocks/requestsWithToken.feature:82](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/requestsWithToken.feature#L82)
 -   [apiWebdavLocks/requestsWithToken.feature:83](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/requestsWithToken.feature#L83)
 -   [apiWebdavLocks/requestsWithToken.feature:84](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/requestsWithToken.feature#L84)
--   [apiWebdavLocks/requestsWithToken.feature:100](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/requestsWithToken.feature#L100)
--   [apiWebdavLocks/requestsWithToken.feature:101](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/requestsWithToken.feature#L101)
--   [apiWebdavLocks/requestsWithToken.feature:124](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/requestsWithToken.feature#L124)
--   [apiWebdavLocks/requestsWithToken.feature:125](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/requestsWithToken.feature#L125)
+-   [apiWebdavLocks/requestsWithToken.feature:106](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/requestsWithToken.feature#L106)
+-   [apiWebdavLocks/requestsWithToken.feature:107](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/requestsWithToken.feature#L107)
+-   [apiWebdavLocks/requestsWithToken.feature:130](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/requestsWithToken.feature#L130)
+-   [apiWebdavLocks/requestsWithToken.feature:131](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks/requestsWithToken.feature#L131)
 -   [apiWebdavLocks2/resharedSharesToRoot.feature:29](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks2/resharedSharesToRoot.feature#L29)
 -   [apiWebdavLocks2/resharedSharesToRoot.feature:30](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks2/resharedSharesToRoot.feature#L30)
 -   [apiWebdavLocks2/resharedSharesToRoot.feature:31](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavLocks2/resharedSharesToRoot.feature#L31)
@@ -784,17 +782,16 @@ File and sync features in a shared scenario
 -   [apiShareOperationsToShares/gettingShares.feature:170](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareOperationsToShares/gettingShares.feature#L170)
 -   [apiShareOperationsToShares/gettingShares.feature:171](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareOperationsToShares/gettingShares.feature#L171)
 
--   [apiSharePublicLink1/createPublicLinkShare.feature:737](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature#L737)
--   [apiSharePublicLink1/createPublicLinkShare.feature:748](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature#L748)
+-   [apiSharePublicLink1/createPublicLinkShare.feature:736](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature#L736)
+-   [apiSharePublicLink1/createPublicLinkShare.feature:747](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature#L747)
 
 #### [Cannot set mtime on upload](https://github.com/owncloud/product/issues/271)
 
+-   [apiSharePublicLink1/createPublicLinkShare.feature:717](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature#L717)
 -   [apiSharePublicLink1/createPublicLinkShare.feature:718](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature#L718)
--   [apiSharePublicLink1/createPublicLinkShare.feature:719](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature#L719)
+-   [apiSharePublicLink1/createPublicLinkShare.feature:732](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature#L732)
 -   [apiSharePublicLink1/createPublicLinkShare.feature:733](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature#L733)
--   [apiSharePublicLink1/createPublicLinkShare.feature:734](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature#L734)
 
-#### [Split old public API webdav tests from new public webdav tests](https://github.com/owncloud/ocis-reva/issues/282)
 #### [Public link enforce permissions](https://github.com/owncloud/ocis/issues/1269)
 #### [Previews via webDAV API tests fail on OCIS](https://github.com/owncloud/ocis/issues/187)
 
@@ -805,26 +802,12 @@ File and sync features in a shared scenario
 
 #### [creating public links with permissions fails](https://github.com/owncloud/product/issues/252)
 
--   [apiSharePublicLink1/changingPublicLinkShare.feature:22](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/changingPublicLinkShare.feature#L22)
--   [apiSharePublicLink1/changingPublicLinkShare.feature:23](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/changingPublicLinkShare.feature#L23)
--   [apiSharePublicLink1/changingPublicLinkShare.feature:35](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/changingPublicLinkShare.feature#L35)
--   [apiSharePublicLink1/changingPublicLinkShare.feature:39](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/changingPublicLinkShare.feature#L39)
--   [apiSharePublicLink1/changingPublicLinkShare.feature:49](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/changingPublicLinkShare.feature#L49)
--   [apiSharePublicLink1/changingPublicLinkShare.feature:79](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/changingPublicLinkShare.feature#L79)
--   [apiSharePublicLink1/changingPublicLinkShare.feature:88](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/changingPublicLinkShare.feature#L88)
-
-#### [Old webdav api does not work with public link](https://github.com/owncloud/product/issues/272)
-
--   [apiSharePublicLink1/changingPublicLinkShare.feature:59](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/changingPublicLinkShare.feature#L59)
--   [apiSharePublicLink1/changingPublicLinkShare.feature:97](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/changingPublicLinkShare.feature#L97)
--   [apiSharePublicLink1/changingPublicLinkShare.feature:133](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/changingPublicLinkShare.feature#L133)
--   [apiSharePublicLink1/changingPublicLinkShare.feature:173](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/changingPublicLinkShare.feature#L173)
--   [apiSharePublicLink1/changingPublicLinkShare.feature:214](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/changingPublicLinkShare.feature#L214)
+-   [apiSharePublicLink1/changingPublicLinkShare.feature:30](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/changingPublicLinkShare.feature#L30)
+-   [apiSharePublicLink1/changingPublicLinkShare.feature:51](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/changingPublicLinkShare.feature#L51)
+-   [apiSharePublicLink1/changingPublicLinkShare.feature:90](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/changingPublicLinkShare.feature#L90)
 
 #### [Public link enforce permissions](https://github.com/owncloud/ocis/issues/1269)
 
--   [apiSharePublicLink1/changingPublicLinkShare.feature:233](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/changingPublicLinkShare.feature#L233)
--   [apiSharePublicLink1/changingPublicLinkShare.feature:253](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/changingPublicLinkShare.feature#L253)
 -   [apiSharePublicLink1/createPublicLinkShare.feature:141](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature#L141)
 -   [apiSharePublicLink1/createPublicLinkShare.feature:142](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature#L142)
 -   [apiSharePublicLink1/createPublicLinkShare.feature:220](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature#L220)
@@ -872,8 +855,8 @@ File and sync features in a shared scenario
 
 #### [Public cannot upload file with mtime set on a public link share with new version of WebDAV API](https://github.com/owncloud/core/issues/37605)
 
--   [apiSharePublicLink1/createPublicLinkShare.feature:656](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature#L656)
--   [apiSharePublicLink1/createPublicLinkShare.feature:676](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature#L676)
+-   [apiSharePublicLink1/createPublicLinkShare.feature:673](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature#L673)
+-   [apiSharePublicLink1/createPublicLinkShare.feature:694](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature#L694)
 
 #### [copying a folder within a public link folder to folder with same name as an already existing file overwrites the parent file](https://github.com/owncloud/ocis/issues/1232)
 
@@ -887,10 +870,6 @@ File and sync features in a shared scenario
 -   [apiSharePublicLink2/updatePublicLinkShare.feature:46](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L46)
 -   [apiSharePublicLink2/updatePublicLinkShare.feature:117](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L117)
 -   [apiSharePublicLink2/updatePublicLinkShare.feature:118](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L118)
--   [apiSharePublicLink2/updatePublicLinkShare.feature:133](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L133)
--   [apiSharePublicLink2/updatePublicLinkShare.feature:134](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L134)
--   [apiSharePublicLink2/updatePublicLinkShare.feature:329](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L329)
--   [apiSharePublicLink2/updatePublicLinkShare.feature:330](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L330)
 
 #### [OCIS share permissions not enforced](https://github.com/owncloud/product/issues/270)
 
@@ -899,77 +878,27 @@ File and sync features in a shared scenario
 -   [apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature:181](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature#L181)
 -   [apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature:182](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature#L182)
 
-#### [OCIS old public webdav api doesnt works](https://github.com/owncloud/product/issues/272)
+#### [Adding public upload to a read only shared folder as a receipient is allowed ](https://github.com/owncloud/ocis/issues/2164)
 
--   [apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature:32](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature#L32)
--   [apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature:33](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature#L33)
--   [apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature:52](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature#L52)
--   [apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature:53](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature#L53)
--   [apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature:73](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature#L73)
--   [apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature:74](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature#L74)
--   [apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature:94](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature#L94)
--   [apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature:95](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature#L95)
--   [apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature:116](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature#L116)
--   [apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature:117](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature#L117)
-
-#### [listing received shares does not work](https://github.com/owncloud/ocis-reva/issues/11)
-
--   [apiSharePublicLink2/updatePublicLinkShare.feature:348](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L348)
--   [apiSharePublicLink2/updatePublicLinkShare.feature:349](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L349)
--   [apiSharePublicLink2/updatePublicLinkShare.feature:367](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L367)
--   [apiSharePublicLink2/updatePublicLinkShare.feature:368](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L368)
--   [apiSharePublicLink2/updatePublicLinkShare.feature:386](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L386)
--   [apiSharePublicLink2/updatePublicLinkShare.feature:387](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L387)
--   [apiSharePublicLink2/updatePublicLinkShare.feature:486](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L486)
--   [apiSharePublicLink2/updatePublicLinkShare.feature:487](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L487)
--   [apiSharePublicLink2/updatePublicLinkShare.feature:405](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L405)
--   [apiSharePublicLink2/updatePublicLinkShare.feature:406](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L406)
--   [apiSharePublicLink2/updatePublicLinkShare.feature:424](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L424)
--   [apiSharePublicLink2/updatePublicLinkShare.feature:425](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L425)
--   [apiSharePublicLink2/updatePublicLinkShare.feature:443](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L443)
--   [apiSharePublicLink2/updatePublicLinkShare.feature:444](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L444)
--   [apiSharePublicLink2/updatePublicLinkShare.feature:462](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L462)
--   [apiSharePublicLink2/updatePublicLinkShare.feature:463](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L463)
-
-#### [Public link enforce permissions](https://github.com/owncloud/ocis/issues/1269)
-
--   [apiSharePublicLink2/updatePublicLinkShare.feature:538](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L538)
--   [apiSharePublicLink2/updatePublicLinkShare.feature:539](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L539)
--   [apiSharePublicLink2/uploadToPublicLinkShare.feature:10](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L10)
--   [apiSharePublicLink2/uploadToPublicLinkShare.feature:82](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L82)
--   [apiSharePublicLink2/uploadToPublicLinkShare.feature:101](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L101)
--   [apiSharePublicLink2/uploadToPublicLinkShare.feature:118](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L118)
--   [apiSharePublicLink2/uploadToPublicLinkShare.feature:135](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L135)
+-   [apiSharePublicLink2/updatePublicLinkShare.feature:332](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L332)
+-   [apiSharePublicLink2/updatePublicLinkShare.feature:333](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L333)
+-   [apiSharePublicLink2/updatePublicLinkShare.feature:392](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L392)
+-   [apiSharePublicLink2/updatePublicLinkShare.feature:393](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/updatePublicLinkShare.feature#L393)
 
 #### [Upload-only shares must not overwrite but create a separate file](https://github.com/owncloud/ocis/issues/1267)
 
--   [apiSharePublicLink2/uploadToPublicLinkShare.feature:48](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L48)
--   [apiSharePublicLink2/uploadToPublicLinkShare.feature:49](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L49)
-
-#### [Upload-only shares must not overwrite but create a separate file](https://github.com/owncloud/ocis-reva/issues/286)
-
 -   [apiSharePublicLink2/uploadToPublicLinkShare.feature:24](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L24)
--   [apiSharePublicLink2/uploadToPublicLinkShare.feature:262](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L262)
-
-#### [Accessing non-existing public link should return 404, not 500](https://github.com/owncloud/ocis/issues/1268)
-
--   [apiSharePublicLink2/uploadToPublicLinkShare.feature:66](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L66)
+- [apiSharePublicLink2/uploadToPublicLinkShare.feature:268](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L268)
 
 #### [Set quota over settings](https://github.com/owncloud/ocis/issues/1290)
 _requires a [CS3 user provisioning api that can update the quota for a user](https://github.com/cs3org/cs3apis/pull/95#issuecomment-772780683)_
--   [apiSharePublicLink2/uploadToPublicLinkShare.feature:144](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L144)
--   [apiSharePublicLink2/uploadToPublicLinkShare.feature:153](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L153)
--   [apiSharePublicLink2/uploadToPublicLinkShare.feature:162](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L162)
+-   [apiSharePublicLink2/uploadToPublicLinkShare.feature:152](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L152)
 -   [apiSharePublicLink2/uploadToPublicLinkShare.feature:171](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L171)
 
 #### [various sharing settings cannot be set](https://github.com/owncloud/ocis/issues/1328)
 
--   [apiSharePublicLink2/uploadToPublicLinkShare.feature:180](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L180)
--   [apiSharePublicLink2/uploadToPublicLinkShare.feature:189](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L189)
--   [apiSharePublicLink2/uploadToPublicLinkShare.feature:199](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L199)
--   [apiSharePublicLink2/uploadToPublicLinkShare.feature:209](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L209)
--   [apiSharePublicLink2/uploadToPublicLinkShare.feature:229](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L229)
--   [apiSharePublicLink2/uploadToPublicLinkShare.feature:245](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L245)
+-   [apiSharePublicLink2/uploadToPublicLinkShare.feature:190](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L190)
+-   [apiSharePublicLink2/uploadToPublicLinkShare.feature:210](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L210)
 
 #### [Resharing does not work with ocis storage](https://github.com/owncloud/product/issues/265)
 
@@ -1554,18 +1483,6 @@ Scenario Outline: Retrieving folder quota when quota is set
 -   [apiMain/quota.feature:164](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiMain/quota.feature:164)
 -   [apiMain/quota.feature:178](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiMain/quota.feature:178)
 -   [apiMain/quota.feature:184](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiMain/quota.feature:184)
-
-#### [user-sync endpoint does not exist](https://github.com/owncloud/ocis/issues/1241)
--   [apiMain/userSync.feature:18](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiMain/userSync.feature#L18)
--   [apiMain/userSync.feature:19](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiMain/userSync.feature#L19)
--   [apiMain/userSync.feature:29](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiMain/userSync.feature#L29)
--   [apiMain/userSync.feature:30](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiMain/userSync.feature#L30)
--   [apiMain/userSync.feature:40](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiMain/userSync.feature#L40)
--   [apiMain/userSync.feature:41](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiMain/userSync.feature#L41)
--   [apiMain/userSync.feature:52](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiMain/userSync.feature#L52)
--   [apiMain/userSync.feature:53](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiMain/userSync.feature#L53)
--   [apiMain/userSync.feature:63](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiMain/userSync.feature#L63)
--   [apiMain/userSync.feature:64](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiMain/userSync.feature#L64)
 
 ### Other
 API, search, favorites, config, capabilities, not existing endpoints, CORS and others


### PR DESCRIPTION
## Description
This PR adjust expected failures file after the adjustments of `notToImplementOnOcis` tags for the old public webdav API tests.

## Related Issue
https://github.com/owncloud/ocis/issues/2078

## How Has This Been Tested?
- CI


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
