### PR TITLE
remove user's uuid from trashbin file key

### DIFF
--- a/changelog/unreleased/trashbin-file-keys.md
+++ b/changelog/unreleased/trashbin-file-keys.md
@@ -1,0 +1,6 @@
+Enhancement: Remove the user id from the trashbin key 
+
+We don't want to use the users uuid outside of the backend so I removed the id from the trashbin file key.
+
+https://github.com/cs3org/reva/pull/1793
+

--- a/pkg/storage/utils/decomposedfs/recycle.go
+++ b/pkg/storage/utils/decomposedfs/recycle.go
@@ -103,7 +103,7 @@ func (fs *Decomposedfs) ListRecycle(ctx context.Context) (items []*provider.Recy
 		item := &provider.RecycleItem{
 			Type: getResourceType(md.IsDir()),
 			Size: uint64(md.Size()),
-			Key:  filepath.Base(trashRoot) + ":" + parts[0], // glue using :, a / is interpreted as a path and only the node id will reach the other methods
+			Key:  parts[0],
 		}
 		if deletionTime, err := time.Parse(time.RFC3339Nano, parts[1]); err == nil {
 			item.DeletionTime = &types.Timestamp{

--- a/pkg/storage/utils/decomposedfs/tree/tree.go
+++ b/pkg/storage/utils/decomposedfs/tree/tree.go
@@ -34,6 +34,7 @@ import (
 	"github.com/cs3org/reva/pkg/errtypes"
 	"github.com/cs3org/reva/pkg/storage/utils/decomposedfs/node"
 	"github.com/cs3org/reva/pkg/storage/utils/decomposedfs/xattrs"
+	"github.com/cs3org/reva/pkg/user"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	"github.com/pkg/xattr"
@@ -632,12 +633,8 @@ func (t *Tree) readRecycleItem(ctx context.Context, key string) (n *node.Node, t
 		return nil, "", "", "", errtypes.InternalError("key is empty")
 	}
 
-	kp := strings.SplitN(key, ":", 2)
-	if len(kp) != 2 {
-		appctx.GetLogger(ctx).Error().Err(err).Str("key", key).Msg("malformed key")
-		return
-	}
-	trashItem = filepath.Join(t.lookup.InternalRoot(), "trash", kp[0], kp[1])
+	u := user.ContextMustGetUser(ctx)
+	trashItem = filepath.Join(t.lookup.InternalRoot(), "trash", u.Id.OpaqueId, key)
 
 	var link string
 	link, err = os.Readlink(trashItem)

--- a/pkg/storage/utils/decomposedfs/tree/tree_test.go
+++ b/pkg/storage/utils/decomposedfs/tree/tree_test.go
@@ -115,7 +115,7 @@ var _ = Describe("Tree", func() {
 					_, err := os.Stat(trashPath)
 					Expect(err).ToNot(HaveOccurred())
 
-					_, purgeFunc, err := t.PurgeRecycleItemFunc(env.Ctx, env.Owner.Id.OpaqueId+":"+n.ID)
+					_, purgeFunc, err := t.PurgeRecycleItemFunc(env.Ctx, n.ID)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(purgeFunc()).To(Succeed())
 				})
@@ -139,7 +139,7 @@ var _ = Describe("Tree", func() {
 				})
 
 				It("restores the file to its original location if the targetPath is empty", func() {
-					_, restoreFunc, err := t.RestoreRecycleItemFunc(env.Ctx, env.Owner.Id.OpaqueId+":"+n.ID, "")
+					_, restoreFunc, err := t.RestoreRecycleItemFunc(env.Ctx, n.ID, "")
 					Expect(err).ToNot(HaveOccurred())
 
 					Expect(restoreFunc()).To(Succeed())
@@ -150,7 +150,7 @@ var _ = Describe("Tree", func() {
 				})
 
 				It("restores files to different locations", func() {
-					_, restoreFunc, err := t.RestoreRecycleItemFunc(env.Ctx, env.Owner.Id.OpaqueId+":"+n.ID, "dir1/newLocation")
+					_, restoreFunc, err := t.RestoreRecycleItemFunc(env.Ctx, n.ID, "dir1/newLocation")
 					Expect(err).ToNot(HaveOccurred())
 
 					Expect(restoreFunc()).To(Succeed())
@@ -165,7 +165,7 @@ var _ = Describe("Tree", func() {
 				})
 
 				It("removes the file from the trash", func() {
-					_, restoreFunc, err := t.RestoreRecycleItemFunc(env.Ctx, env.Owner.Id.OpaqueId+":"+n.ID, "")
+					_, restoreFunc, err := t.RestoreRecycleItemFunc(env.Ctx, n.ID, "")
 					Expect(err).ToNot(HaveOccurred())
 
 					Expect(restoreFunc()).To(Succeed())
@@ -203,7 +203,7 @@ var _ = Describe("Tree", func() {
 					_, err := os.Stat(trashPath)
 					Expect(err).ToNot(HaveOccurred())
 
-					_, purgeFunc, err := t.PurgeRecycleItemFunc(env.Ctx, env.Owner.Id.OpaqueId+":"+n.ID)
+					_, purgeFunc, err := t.PurgeRecycleItemFunc(env.Ctx, n.ID)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(purgeFunc()).To(Succeed())
 				})


### PR DESCRIPTION
We don't want to use the users uuid outside of the backend so I removed the id from the trashbin file key.