### PR TITLE
eosfs: add arbitrary metadata support

### DIFF
--- a/changelog/unreleased/eos-arb-metadata.md
+++ b/changelog/unreleased/eos-arb-metadata.md
@@ -1,0 +1,3 @@
+Enhancement: Add arbitrary metadata support to EOS
+
+https://github.com/cs3org/reva/pull/1810


### PR DESCRIPTION
It also change the log namespace to "eosfs" to distinguish from "eos" that is used by the eos driver, just cosmetics.