### PR TITLE
publicshare: check for more errors

### DIFF
--- a/changelog/unreleased/harden-sign-publicshares.md
+++ b/changelog/unreleased/harden-sign-publicshares.md
@@ -1,0 +1,5 @@
+Enhancement: Harden public shares signing
+
+Makes golangci-lint happy as well
+
+https://github.com/cs3org/reva/pull/1811

--- a/docs/content/en/docs/config/packages/auth/manager/oidc/_index.md
+++ b/docs/content/en/docs/config/packages/auth/manager/oidc/_index.md
@@ -9,7 +9,7 @@ description: >
 # _struct: config_
 
 {{% dir name="insecure" type="bool" default=false %}}
-Whether to skip certificate checks when sending requests. [[Ref]](https://github.com/cs3org/reva/tree/master/pkg/auth/manager/oidc/oidc.go#L55)
+Whether to skip certificate checks when sending requests. [[Ref]](https://github.com/cs3org/reva/tree/master/pkg/auth/manager/oidc/oidc.go#L54)
 {{< highlight toml >}}
 [auth.manager.oidc]
 insecure = false
@@ -17,7 +17,7 @@ insecure = false
 {{% /dir %}}
 
 {{% dir name="issuer" type="string" default="" %}}
-The issuer of the OIDC token. [[Ref]](https://github.com/cs3org/reva/tree/master/pkg/auth/manager/oidc/oidc.go#L56)
+The issuer of the OIDC token. [[Ref]](https://github.com/cs3org/reva/tree/master/pkg/auth/manager/oidc/oidc.go#L55)
 {{< highlight toml >}}
 [auth.manager.oidc]
 issuer = ""
@@ -25,7 +25,7 @@ issuer = ""
 {{% /dir %}}
 
 {{% dir name="id_claim" type="string" default="sub" %}}
-The claim containing the ID of the user. [[Ref]](https://github.com/cs3org/reva/tree/master/pkg/auth/manager/oidc/oidc.go#L57)
+The claim containing the ID of the user. [[Ref]](https://github.com/cs3org/reva/tree/master/pkg/auth/manager/oidc/oidc.go#L56)
 {{< highlight toml >}}
 [auth.manager.oidc]
 id_claim = "sub"
@@ -33,7 +33,7 @@ id_claim = "sub"
 {{% /dir %}}
 
 {{% dir name="uid_claim" type="string" default="" %}}
-The claim containing the UID of the user. [[Ref]](https://github.com/cs3org/reva/tree/master/pkg/auth/manager/oidc/oidc.go#L58)
+The claim containing the UID of the user. [[Ref]](https://github.com/cs3org/reva/tree/master/pkg/auth/manager/oidc/oidc.go#L57)
 {{< highlight toml >}}
 [auth.manager.oidc]
 uid_claim = ""
@@ -41,7 +41,7 @@ uid_claim = ""
 {{% /dir %}}
 
 {{% dir name="gid_claim" type="string" default="" %}}
-The claim containing the GID of the user. [[Ref]](https://github.com/cs3org/reva/tree/master/pkg/auth/manager/oidc/oidc.go#L59)
+The claim containing the GID of the user. [[Ref]](https://github.com/cs3org/reva/tree/master/pkg/auth/manager/oidc/oidc.go#L58)
 {{< highlight toml >}}
 [auth.manager.oidc]
 gid_claim = ""
@@ -49,7 +49,7 @@ gid_claim = ""
 {{% /dir %}}
 
 {{% dir name="gatewaysvc" type="string" default="" %}}
-The endpoint at which the GRPC gateway is exposed. [[Ref]](https://github.com/cs3org/reva/tree/master/pkg/auth/manager/oidc/oidc.go#L60)
+The endpoint at which the GRPC gateway is exposed. [[Ref]](https://github.com/cs3org/reva/tree/master/pkg/auth/manager/oidc/oidc.go#L59)
 {{< highlight toml >}}
 [auth.manager.oidc]
 gatewaysvc = ""


### PR DESCRIPTION
Now checks for errors when creating the hashes.

Next step will be to pass the ctx around and log when the (unlikely) hash creation fails to give a clue to the admin of the system about authentication failures when accessing a public share.