### PR TITLE
raise maxCallRecvMsgSize to be able to list 10k files

### DIFF
--- a/changelog/unreleased/raise-max-msg-size.md
+++ b/changelog/unreleased/raise-max-msg-size.md
@@ -1,0 +1,5 @@
+Bugfix: Raise max grpc message size
+
+As a workaround for listing larger folder we raised the `MaxCallRecvMsgSize` to 10MB. This should be enough for ~15k files. The proper fix is implementing ListContainerStream in the gateway, but we needed a way to test the web ui with larger collections.
+
+https://github.com/cs3org/reva/pull/1825

--- a/pkg/rgrpc/todo/pool/pool.go
+++ b/pkg/rgrpc/todo/pool/pool.go
@@ -76,13 +76,21 @@ var (
 	userProviders          = newProvider()
 	groupProviders         = newProvider()
 	dataTxs                = newProvider()
+	maxCallRecvMsgSize     = 10240000
 )
 
 // NewConn creates a new connection to a grpc server
 // with open census tracing support.
 // TODO(labkode): make grpc tls configurable.
+// TODO make maxCallRecvMsgSize configurable, raised from the default 4MB to be able to list 10k files
 func NewConn(endpoint string) (*grpc.ClientConn, error) {
-	conn, err := grpc.Dial(endpoint, grpc.WithInsecure(), grpc.WithStatsHandler(&ocgrpc.ClientHandler{}))
+	conn, err := grpc.Dial(
+		endpoint,
+		grpc.WithInsecure(),
+		grpc.WithStatsHandler(&ocgrpc.ClientHandler{}),
+		grpc.WithDefaultCallOptions(
+			grpc.MaxCallRecvMsgSize(maxCallRecvMsgSize),
+		))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
As a workaround for listing larger folder we raised the `MaxCallRecvMsgSize` to 10MB. This should be enough for ~15k files. The proper fix is implementing ListContainerStream in the gateway, but we needed a way to test the web ui with larger collections.
