### PR TITLE
CI: use golang:alpine3.13 as builder/base to prevent 'make' errors

### DIFF
--- a/Dockerfile.reva
+++ b/Dockerfile.reva
@@ -16,7 +16,7 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
-FROM golang:alpine as builder
+FROM golang:alpine3.13 as builder
 
 RUN apk --no-cache add \
   ca-certificates \

--- a/Dockerfile.revad
+++ b/Dockerfile.revad
@@ -16,7 +16,7 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
-FROM golang:alpine as builder
+FROM golang:alpine3.13 as builder
 
 RUN apk --no-cache add \
   ca-certificates \
@@ -36,7 +36,7 @@ RUN make build-revad-docker && \
 
 RUN mkdir -p /etc/revad/ && echo "" > /etc/revad/revad.toml
 
-FROM golang:alpine
+FROM golang:alpine3.13
 
 RUN apk --no-cache add \
   mailcap

--- a/changelog/unreleased/ci-fix-reva-dockerfile-path.md
+++ b/changelog/unreleased/ci-fix-reva-dockerfile-path.md
@@ -1,6 +1,11 @@
-Bugfix: use the right Dockerfile path for the reva CLI
+Bugfix: correct Dockerfile path for the reva CLI and alpine3.13 as builder
 
 This was introduced on https://github.com/cs3org/reva/commit/117adad while
 porting the configuration on .drone.yml to starlark.
 
+Force golang:alpine3.13 as base image to prevent errors from Make when
+running on Docker <20.10 as it happens on Drone
+ ref.https://gitlab.alpinelinux.org/alpine/aports/-/issues/12396
+
 https://github.com/cs3org/reva/pull/1843
+https://github.com/cs3org/reva/pull/1844


### PR DESCRIPTION
- Can be seen running on https://drone.cernbox.cern.ch/SamuAlfageme/reva/39/1/2 
- Issue appeared 13 days ago as `golang:alpine -> golang:alpine1.14` after https://github.com/docker-library/golang/pull/373 and https://github.com/docker-library/official-images/commit/844e81d7663bf4204492345c5492478a50fc6a49 
  - Reference for the `make` error on https://gitlab.alpinelinux.org/alpine/aports/-/issues/12396 - from https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.14.0#faccessat2: 

  > Use of the faccessat2 syscall has been enabled in musl. [...] Therefore, Alpine Linux 3.14.0 requires one of the following:

  > 1. runc `v1.0.0-rc93`
  > 2. **Docker `20.10.0`**

On `plugin/docker` we run with:  Docker `19.03.8` and runc `1.0.0-rc10` instead