### PR TITLE
Use golang:alpine3.13 for revad-eos docker image

### DIFF
--- a/Dockerfile.revad-eos
+++ b/Dockerfile.revad-eos
@@ -16,7 +16,7 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
-FROM golang:alpine as builder
+FROM golang:alpine3.13 as builder
 
 RUN apk --no-cache add \
   ca-certificates \

--- a/changelog/unreleased/ci-fix-reva-dockerfile-path.md
+++ b/changelog/unreleased/ci-fix-reva-dockerfile-path.md
@@ -9,3 +9,4 @@ running on Docker <20.10 as it happens on Drone
 
 https://github.com/cs3org/reva/pull/1843
 https://github.com/cs3org/reva/pull/1844
+https://github.com/cs3org/reva/pull/1847


### PR DESCRIPTION
https://github.com/cs3org/reva/pull/1844 updated the alpine image version for the reva and revad images but not revad-eos