### PR TITLE
LDAP: numeric uid/gid fallback to nobody(99)

### DIFF
--- a/changelog/unreleased/ldap-nobody-fallback.md
+++ b/changelog/unreleased/ldap-nobody-fallback.md
@@ -1,0 +1,5 @@
+Bugfix: Fill in missing gid/uid number with nobody
+
+When an LDAP server does not provide numeric uid or gid properties for a user we now fall back to a configurable `nobody` id (default 99).
+
+https://github.com/cs3org/reva/pull/1848

--- a/pkg/group/manager/ldap/ldap.go
+++ b/pkg/group/manager/ldap/ldap.go
@@ -61,6 +61,7 @@ type config struct {
 	BindPassword    string     `mapstructure:"bind_password"`
 	Idp             string     `mapstructure:"idp"`
 	Schema          attributes `mapstructure:"schema"`
+	Nobody          int64      `mapstructure:"nobody"`
 }
 
 type attributes struct {
@@ -173,9 +174,13 @@ func (m *manager) GetGroup(ctx context.Context, gid *grouppb.GroupId) (*grouppb.
 	if err != nil {
 		return nil, err
 	}
-	gidNumber, err := strconv.ParseInt(sr.Entries[0].GetEqualFoldAttributeValue(m.c.Schema.GIDNumber), 10, 64)
-	if err != nil {
-		return nil, err
+	gidNumber := m.c.Nobody
+	gidValue := sr.Entries[0].GetEqualFoldAttributeValue(m.c.Schema.GIDNumber)
+	if gidValue != "" {
+		gidNumber, err = strconv.ParseInt(gidValue, 10, 64)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	g := &grouppb.Group{

--- a/pkg/user/manager/ldap/ldap.go
+++ b/pkg/user/manager/ldap/ldap.go
@@ -60,6 +60,7 @@ type config struct {
 	BindPassword    string     `mapstructure:"bind_password"`
 	Idp             string     `mapstructure:"idp"`
 	Schema          attributes `mapstructure:"schema"`
+	Nobody          int64      `mapstructure:"nobody"`
 }
 
 type attributes struct {
@@ -115,6 +116,10 @@ func New(m map[string]interface{}) (user.Manager, error) {
 		c.FindFilter = c.UserFilter
 	}
 	c.GroupFilter = strings.ReplaceAll(c.GroupFilter, "%s", "{{.OpaqueId}}")
+
+	if c.Nobody == 0 {
+		c.Nobody = 99
+	}
 
 	mgr := &manager{
 		c: c,
@@ -176,13 +181,21 @@ func (m *manager) GetUser(ctx context.Context, uid *userpb.UserId) (*userpb.User
 	if err != nil {
 		return nil, err
 	}
-	gidNumber, err := strconv.ParseInt(sr.Entries[0].GetEqualFoldAttributeValue(m.c.Schema.GIDNumber), 10, 64)
-	if err != nil {
-		return nil, err
+	gidNumber := m.c.Nobody
+	gidValue := sr.Entries[0].GetEqualFoldAttributeValue(m.c.Schema.GIDNumber)
+	if gidValue != "" {
+		gidNumber, err = strconv.ParseInt(gidValue, 10, 64)
+		if err != nil {
+			return nil, err
+		}
 	}
-	uidNumber, err := strconv.ParseInt(sr.Entries[0].GetEqualFoldAttributeValue(m.c.Schema.UIDNumber), 10, 64)
-	if err != nil {
-		return nil, err
+	uidNumber := m.c.Nobody
+	uidValue := sr.Entries[0].GetEqualFoldAttributeValue(m.c.Schema.UIDNumber)
+	if uidValue != "" {
+		uidNumber, err = strconv.ParseInt(uidValue, 10, 64)
+		if err != nil {
+			return nil, err
+		}
 	}
 	u := &userpb.User{
 		Id:          id,
@@ -255,13 +268,21 @@ func (m *manager) GetUserByClaim(ctx context.Context, claim, value string) (*use
 	if err != nil {
 		return nil, err
 	}
-	gidNumber, err := strconv.ParseInt(sr.Entries[0].GetEqualFoldAttributeValue(m.c.Schema.GIDNumber), 10, 64)
-	if err != nil {
-		return nil, err
+	gidNumber := m.c.Nobody
+	gidValue := sr.Entries[0].GetEqualFoldAttributeValue(m.c.Schema.GIDNumber)
+	if gidValue != "" {
+		gidNumber, err = strconv.ParseInt(gidValue, 10, 64)
+		if err != nil {
+			return nil, err
+		}
 	}
-	uidNumber, err := strconv.ParseInt(sr.Entries[0].GetEqualFoldAttributeValue(m.c.Schema.UIDNumber), 10, 64)
-	if err != nil {
-		return nil, err
+	uidNumber := m.c.Nobody
+	uidValue := sr.Entries[0].GetEqualFoldAttributeValue(m.c.Schema.UIDNumber)
+	if uidValue != "" {
+		uidNumber, err = strconv.ParseInt(uidValue, 10, 64)
+		if err != nil {
+			return nil, err
+		}
 	}
 	u := &userpb.User{
 		Id:          id,
@@ -315,13 +336,21 @@ func (m *manager) FindUsers(ctx context.Context, query string) ([]*userpb.User, 
 		if err != nil {
 			return nil, err
 		}
-		gidNumber, err := strconv.ParseInt(sr.Entries[0].GetEqualFoldAttributeValue(m.c.Schema.GIDNumber), 10, 64)
-		if err != nil {
-			return nil, err
+		gidNumber := m.c.Nobody
+		gidValue := sr.Entries[0].GetEqualFoldAttributeValue(m.c.Schema.GIDNumber)
+		if gidValue != "" {
+			gidNumber, err = strconv.ParseInt(gidValue, 10, 64)
+			if err != nil {
+				return nil, err
+			}
 		}
-		uidNumber, err := strconv.ParseInt(sr.Entries[0].GetEqualFoldAttributeValue(m.c.Schema.UIDNumber), 10, 64)
-		if err != nil {
-			return nil, err
+		uidNumber := m.c.Nobody
+		uidValue := sr.Entries[0].GetEqualFoldAttributeValue(m.c.Schema.UIDNumber)
+		if uidValue != "" {
+			uidNumber, err = strconv.ParseInt(uidValue, 10, 64)
+			if err != nil {
+				return nil, err
+			}
 		}
 		user := &userpb.User{
 			Id:          id,


### PR DESCRIPTION
When an LDAP server does not provide numeric uid or gid properties for a user we now fall back to a configurable `nobody` id (default 99).