### PR TITLE
Add read-only interceptor to use on storage providers

### DIFF
--- a/changelog/unreleased/read-only-storageprovider-interceptor.md
+++ b/changelog/unreleased/read-only-storageprovider-interceptor.md
@@ -1,0 +1,5 @@
+Enhancement: Add readonly interceptor
+
+The readonly interceptor could be used to configure a storageprovider in readonly mode. This could be handy in some migration scenarios.
+
+https://github.com/cs3org/reva/pull/1849

--- a/internal/grpc/interceptors/loader/loader.go
+++ b/internal/grpc/interceptors/loader/loader.go
@@ -18,4 +18,8 @@
 
 package loader
 
-// Add your own.
+import (
+	// Load core GRPC services
+	_ "github.com/cs3org/reva/internal/grpc/interceptors/readonly"
+	// Add your own service here
+)

--- a/internal/grpc/interceptors/readonly/readonly.go
+++ b/internal/grpc/interceptors/readonly/readonly.go
@@ -1,0 +1,146 @@
+// Copyright 2018-2021 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package readonly
+
+import (
+	"context"
+
+	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+	registry "github.com/cs3org/go-cs3apis/cs3/storage/registry/v1beta1"
+	"github.com/cs3org/reva/pkg/appctx"
+	"github.com/cs3org/reva/pkg/rgrpc"
+	rstatus "github.com/cs3org/reva/pkg/rgrpc/status"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+const (
+	defaultPriority = 200
+)
+
+func init() {
+	rgrpc.RegisterUnaryInterceptor("readonly", NewUnary)
+}
+
+// NewUnary returns a new unary interceptor
+// that checks grpc calls and blocks write requests.
+func NewUnary(map[string]interface{}) (grpc.UnaryServerInterceptor, int, error) {
+	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+		log := appctx.GetLogger(ctx)
+
+		switch req.(type) {
+		// handle known non-write request types
+		case *provider.GetHomeRequest,
+			*provider.GetPathRequest,
+			*provider.GetQuotaRequest,
+			*registry.GetStorageProvidersRequest,
+			*provider.InitiateFileDownloadRequest,
+			*provider.ListFileVersionsRequest,
+			*provider.ListGrantsRequest,
+			*provider.ListRecycleRequest:
+			return handler(ctx, req)
+		case *provider.ListContainerRequest:
+			resp, err := handler(ctx, req)
+			if listResp, ok := resp.(*provider.ListContainerResponse); ok && listResp.Infos != nil {
+				for _, info := range listResp.Infos {
+					// use the existing PermissionsSet and change the writes to false
+					if info.PermissionSet != nil {
+						info.PermissionSet.AddGrant = false
+						info.PermissionSet.CreateContainer = false
+						info.PermissionSet.Delete = false
+						info.PermissionSet.InitiateFileUpload = false
+						info.PermissionSet.Move = false
+						info.PermissionSet.RemoveGrant = false
+						info.PermissionSet.PurgeRecycle = false
+						info.PermissionSet.RestoreFileVersion = false
+						info.PermissionSet.RestoreRecycleItem = false
+						info.PermissionSet.UpdateGrant = false
+					}
+				}
+			}
+			return resp, err
+		case *provider.StatRequest:
+			resp, err := handler(ctx, req)
+			if statResp, ok := resp.(*provider.StatResponse); ok && statResp.Info != nil && statResp.Info.PermissionSet != nil {
+				// use the existing PermissionsSet and change the writes to false
+				statResp.Info.PermissionSet.AddGrant = false
+				statResp.Info.PermissionSet.CreateContainer = false
+				statResp.Info.PermissionSet.Delete = false
+				statResp.Info.PermissionSet.InitiateFileUpload = false
+				statResp.Info.PermissionSet.Move = false
+				statResp.Info.PermissionSet.RemoveGrant = false
+				statResp.Info.PermissionSet.PurgeRecycle = false
+				statResp.Info.PermissionSet.RestoreFileVersion = false
+				statResp.Info.PermissionSet.RestoreRecycleItem = false
+				statResp.Info.PermissionSet.UpdateGrant = false
+			}
+			return resp, err
+		// Don't allow the following requests types
+		case *provider.AddGrantRequest:
+			return &provider.AddGrantResponse{
+				Status: rstatus.NewPermissionDenied(ctx, nil, "permission denied: tried to add grant on readonly storage"),
+			}, nil
+		case *provider.CreateContainerRequest:
+			return &provider.CreateContainerResponse{
+				Status: rstatus.NewPermissionDenied(ctx, nil, "permission denied: tried to create resoure on readonly storage"),
+			}, nil
+		case *provider.CreateHomeRequest:
+			return &provider.CreateHomeResponse{
+				Status: rstatus.NewPermissionDenied(ctx, nil, "permission denied: tried to create home on readonly storage"),
+			}, nil
+		case *provider.DeleteRequest:
+			return &provider.DeleteResponse{
+				Status: rstatus.NewPermissionDenied(ctx, nil, "permission denied: tried to delete resource on readonly storage"),
+			}, nil
+		case *provider.InitiateFileUploadRequest:
+			return &provider.InitiateFileUploadResponse{
+				Status: rstatus.NewPermissionDenied(ctx, nil, "permission denied: tried to upload resource on readonly storage"),
+			}, nil
+		case *provider.MoveRequest:
+			return &provider.MoveResponse{
+				Status: rstatus.NewPermissionDenied(ctx, nil, "permission denied: tried to move resource on readonly storage"),
+			}, nil
+		case *provider.PurgeRecycleRequest:
+			return &provider.PurgeRecycleResponse{
+				Status: rstatus.NewPermissionDenied(ctx, nil, "permission denied: tried to purge recycle on readonly storage"),
+			}, nil
+		case *provider.RemoveGrantRequest:
+			return &provider.RemoveGrantResponse{
+				Status: rstatus.NewPermissionDenied(ctx, nil, "permission denied: tried to remove grant on readonly storage"),
+			}, nil
+		case *provider.RestoreRecycleItemRequest:
+			return &provider.RestoreRecycleItemResponse{
+				Status: rstatus.NewPermissionDenied(ctx, nil, "permission denied: tried to restore recycle item on readonly storage"),
+			}, nil
+		case *provider.SetArbitraryMetadataRequest:
+			return &provider.SetArbitraryMetadataResponse{
+				Status: rstatus.NewPermissionDenied(ctx, nil, "permission denied: tried to set arbitrary metadata on readonly storage"),
+			}, nil
+		case *provider.UnsetArbitraryMetadataRequest:
+			return &provider.UnsetArbitraryMetadataResponse{
+				Status: rstatus.NewPermissionDenied(ctx, nil, "permission denied: tried to unset arbitrary metadata on readonly storage"),
+			}, nil
+		// block unknown request types and return error
+		default:
+			log.Debug().Msg("storage is readonly")
+			return nil, status.Errorf(codes.PermissionDenied, "permission denied: tried to execute an unknown operation: %T!", req)
+		}
+	}, defaultPriority, nil
+}

--- a/internal/http/services/owncloud/ocdav/mkcol.go
+++ b/internal/http/services/owncloud/ocdav/mkcol.go
@@ -19,6 +19,7 @@
 package ocdav
 
 import (
+	"fmt"
 	"io"
 	"net/http"
 	"path"
@@ -85,6 +86,14 @@ func (s *svc) handleMkcol(w http.ResponseWriter, r *http.Request, ns string) {
 	case rpc.Code_CODE_NOT_FOUND:
 		sublog.Debug().Str("path", fn).Interface("status", statRes.Status).Msg("conflict")
 		w.WriteHeader(http.StatusConflict)
+	case rpc.Code_CODE_PERMISSION_DENIED:
+		w.WriteHeader(http.StatusForbidden)
+		m := fmt.Sprintf("Permission denied to create %v", fn)
+		b, err := Marshal(exception{
+			code:    SabredavPermissionDenied,
+			message: m,
+		})
+		HandleWebdavError(&sublog, w, b, err)
 	default:
 		HandleErrorStatus(&sublog, w, res.Status)
 	}

--- a/internal/http/services/owncloud/ocdav/move.go
+++ b/internal/http/services/owncloud/ocdav/move.go
@@ -19,6 +19,7 @@
 package ocdav
 
 import (
+	"fmt"
 	"net/http"
 	"path"
 	"strings"
@@ -76,6 +77,15 @@ func (s *svc) handleMove(w http.ResponseWriter, r *http.Request, ns string) {
 		return
 	}
 	if srcStatRes.Status.Code != rpc.Code_CODE_OK {
+		if srcStatRes.Status.Code == rpc.Code_CODE_NOT_FOUND {
+			w.WriteHeader(http.StatusNotFound)
+			m := fmt.Sprintf("Resource %v not found", srcStatReq.Ref.Path)
+			b, err := Marshal(exception{
+				code:    SabredavNotFound,
+				message: m,
+			})
+			HandleWebdavError(&sublog, w, b, err)
+		}
 		HandleErrorStatus(&sublog, w, srcStatRes.Status)
 		return
 	}
@@ -152,6 +162,15 @@ func (s *svc) handleMove(w http.ResponseWriter, r *http.Request, ns string) {
 	}
 
 	if mRes.Status.Code != rpc.Code_CODE_OK {
+		if mRes.Status.Code == rpc.Code_CODE_PERMISSION_DENIED {
+			w.WriteHeader(http.StatusForbidden)
+			m := fmt.Sprintf("Permission denied to move %v", sourceRef.Path)
+			b, err := Marshal(exception{
+				code:    SabredavPermissionDenied,
+				message: m,
+			})
+			HandleWebdavError(&sublog, w, b, err)
+		}
 		HandleErrorStatus(&sublog, w, mRes.Status)
 		return
 	}

--- a/tests/acceptance/expected-failures-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-on-OCIS-storage.md
@@ -990,14 +990,6 @@ _requires a [CS3 user provisioning api that can update the quota for a user](htt
 #### [remote.php/dav/uploads endpoint does not exist](https://github.com/owncloud/ocis/issues/1321)
 -   [apiShareOperationsToShares2/uploadToShare.feature:256](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareOperationsToShares2/uploadToShare.feature#L256)
 
-#### Copying into a shared folder
-Scenario Outline: Copying a file to a folder with no permissions
--   [apiWebdavProperties1/copyFile.feature:68](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/copyFile.feature#L68)
--   [apiWebdavProperties1/copyFile.feature:69](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/copyFile.feature#L69)
-Scenario Outline: Copying a file to overwrite a file into a folder with no permissions
--   [apiWebdavProperties1/copyFile.feature:90](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/copyFile.feature#L90)
--   [apiWebdavProperties1/copyFile.feature:91](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/copyFile.feature#L91)
-
 #### Share jail related
 Scenario Outline: delete a folder when there is a default folder for received shares
 -   [apiWebdavOperations/deleteFolder.feature:67](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/deleteFolder.feature#L67)
@@ -1977,8 +1969,6 @@ _ocs: api compatibility, return correct status code_
 -   [apiShareManagementBasicToShares/createShareToSharesFolder.feature:445](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareManagementBasicToShares/createShareToSharesFolder.feature#L445)
 
 #### [Trying to copy a file into a readonly share gives HTTP 500 error](https://github.com/owncloud/ocis/issues/2166)
--   [apiWebdavProperties1/copyFile.feature:68](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/copyFile.feature#L68)
--   [apiWebdavProperties1/copyFile.feature:69](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/copyFile.feature#L69)
 -   [apiWebdavProperties1/copyFile.feature:362](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/copyFile.feature#L362)
 -   [apiWebdavProperties1/copyFile.feature:363](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/copyFile.feature#L363)
 -   [apiWebdavProperties1/copyFile.feature:383](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/copyFile.feature#L483)

--- a/tests/acceptance/expected-failures-on-OWNCLOUD-storage.md
+++ b/tests/acceptance/expected-failures-on-OWNCLOUD-storage.md
@@ -1081,15 +1081,6 @@ The following scenarios fail on OWNCLOUD storage but not on OCIS storage:
 #### [remote.php/dav/uploads endpoint does not exist](https://github.com/owncloud/ocis/issues/1321)
 -   [apiShareOperationsToShares2/uploadToShare.feature:256](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareOperationsToShares2/uploadToShare.feature#L256)
 
-#### Copying into a shared folder
-Scenario Outline: Copying a file to a folder with no permissions
--   [apiWebdavProperties1/copyFile.feature:68](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/copyFile.feature#L68)
--   [apiWebdavProperties1/copyFile.feature:69](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/copyFile.feature#L69)
-Scenario Outline: Copying a file to overwrite a file into a folder with no permissions
--   [apiWebdavProperties1/copyFile.feature:90](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/copyFile.feature#L90)
--   [apiWebdavProperties1/copyFile.feature:91](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/copyFile.feature#L91)
-
-
 #### Share jail related
 Scenario Outline: delete a folder when there is a default folder for received shares
 -   [apiWebdavOperations/deleteFolder.feature:67](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/deleteFolder.feature#L67)
@@ -2070,8 +2061,6 @@ _ocs: api compatibility, return correct status code_
 -   [apiShareManagementBasicToShares/createShareToSharesFolder.feature:445](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareManagementBasicToShares/createShareToSharesFolder.feature#L445)
 
 #### [Trying to copy a file into a readonly share gives HTTP 500 error](https://github.com/owncloud/ocis/issues/2166)
--   [apiWebdavProperties1/copyFile.feature:68](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/copyFile.feature#L68)
--   [apiWebdavProperties1/copyFile.feature:69](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/copyFile.feature#L69)
 -   [apiWebdavProperties1/copyFile.feature:362](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/copyFile.feature#L362)
 -   [apiWebdavProperties1/copyFile.feature:363](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/copyFile.feature#L363)
 -   [apiWebdavProperties1/copyFile.feature:383](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/copyFile.feature#L483)

--- a/tests/acceptance/expected-failures-on-S3NG-storage.md
+++ b/tests/acceptance/expected-failures-on-S3NG-storage.md
@@ -981,14 +981,6 @@ _requires a [CS3 user provisioning api that can update the quota for a user](htt
 #### [remote.php/dav/uploads endpoint does not exist](https://github.com/owncloud/ocis/issues/1321)
 -   [apiShareOperationsToShares2/uploadToShare.feature:256](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareOperationsToShares2/uploadToShare.feature#L256)
 
-#### Copying into a shared folder
-Scenario Outline: Copying a file to a folder with no permissions
--   [apiWebdavProperties1/copyFile.feature:68](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/copyFile.feature#L68)
--   [apiWebdavProperties1/copyFile.feature:69](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/copyFile.feature#L69)
-Scenario Outline: Copying a file to overwrite a file into a folder with no permissions
--   [apiWebdavProperties1/copyFile.feature:90](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/copyFile.feature#L90)
--   [apiWebdavProperties1/copyFile.feature:91](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/copyFile.feature#L91)
-
 #### Share jail related
 Scenario Outline: delete a folder when there is a default folder for received shares
 -   [apiWebdavOperations/deleteFolder.feature:67](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/deleteFolder.feature#L67)
@@ -1979,8 +1971,6 @@ _ocs: api compatibility, return correct status code_
 -   [apiShareManagementBasicToShares/createShareToSharesFolder.feature:445](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareManagementBasicToShares/createShareToSharesFolder.feature#L445)
 
 #### [Trying to copy a file into a readonly share gives HTTP 500 error](https://github.com/owncloud/ocis/issues/2166)
--   [apiWebdavProperties1/copyFile.feature:68](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/copyFile.feature#L68)
--   [apiWebdavProperties1/copyFile.feature:69](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/copyFile.feature#L69)
 -   [apiWebdavProperties1/copyFile.feature:362](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/copyFile.feature#L362)
 -   [apiWebdavProperties1/copyFile.feature:363](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/copyFile.feature#L363)
 -   [apiWebdavProperties1/copyFile.feature:383](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/copyFile.feature#L483)


### PR DESCRIPTION
# Description

For migration scenarios it can be handy to use a storage provider in read-only mode. For example if we use the ownCloud SQL driver to connect to a ownCloud Classic, readonly mode is a vital step in the migration process.

## Changes

- [x] Implement `readonly` Interceptor
- [x] Add proper WebDAV Response body also in some error cases

## How it works

- The `read-only` interceptor uses a list of known request types which are allowed.
- Known request types which change data on the storage are blocked and return a grpc error which will be forwarded to WebDAV.
- Unknown Request Types will be blocked and throw a GRPC error
- The interceptor changes the grants on the resources which will cause WebDAV to return read-only permissions.

## WebUI

- The webUI reflects the webdav permissions and "greys out" or hides all actions that would change the files on the storage

## Config

- To enable the interceptor, add it to the storage provider config.

### Example storage-home.toml
```
# This storage-home.toml config file will start a reva service that:
[shared]
jwt_secret = "Pive-Fumkiu4"
gatewaysvc = "localhost:19000"

# - authenticates grpc storage provider requests using the internal jwt token
# - authenticates http upload and download requests requests using basic auth
# - serves the home storage provider on grpc port 12000
# - serves http dataprovider for this storage on port 12001
#   - /data - dataprovider: file up and download
#
# The home storage will inject the username into the path and jail users into
# their home directory

[grpc]
address = "0.0.0.0:12000"
interceptors = [
  "readonly"
]

# This is a storage provider that grants direct access to the wrapped storage
# TODO same storage id as the /oc/ storage provider
# if we have an id, we can directly go to that storage, no need to wrap paths
# we have a locally running dataprovider
# this is where clients can find it
# the context path wrapper reads tho username from the context and prefixes the relative storage path with it
[grpc.services.storageprovider]
driver = "ocis"
mount_path = "/home"
mount_id = "123e4567-e89b-12d3-a456-426655440000"
expose_data_server = true
data_server_url = "http://localhost:12001/data"
enable_home_creation = true

[grpc.services.storageprovider.drivers.ocis]
root = "/var/tmp/reva/data"
enable_home = true
treetime_accounting = true
treesize_accounting = true
#user_layout = 
# do we need owner for users?
#owner = 95cb8724-03b2-11eb-a0a6-c33ef8ef53ad 


[http]
address = "0.0.0.0:12001"

[http.services.dataprovider]
driver = "ocis"
temp_folder = "/var/tmp/reva/tmp"

[http.services.dataprovider.drivers.ocis]
root = "/var/tmp/reva/data"
enable_home = true
treetime_accounting = true
treesize_accounting = true
```
### Known Issue

- Currently we need to add the interceptor to `storagehome` and `storageusers` which share the same physical storage (which is IMO weird and will be changed in the future)