### PR TITLE
be defensive about wrongly quoted etags

### DIFF
--- a/changelog/unreleased/more-robust-etag-handling.md
+++ b/changelog/unreleased/more-robust-etag-handling.md
@@ -1,0 +1,5 @@
+Enhancement: Be defensive about wrongly quoted etags
+
+When ocdav renders etags it will now try to correct them to the definition as *quoted strings* which do not contain `"`. This prevents double or triple quoted etags on the webdav api.
+
+https://github.com/cs3org/reva/pull/1870

--- a/internal/http/services/owncloud/ocdav/propfind.go
+++ b/internal/http/services/owncloud/ocdav/propfind.go
@@ -419,7 +419,7 @@ func (s *svc) mdToPropResponse(ctx context.Context, pf *propfindXML, md *provide
 			// etags must be enclosed in double quotes and cannot contain them.
 			// See https://tools.ietf.org/html/rfc7232#section-2.3 for details
 			// TODO(jfd) handle weak tags that start with 'W/'
-			propstatOK.Prop = append(propstatOK.Prop, s.newProp("d:getetag", md.Etag))
+			propstatOK.Prop = append(propstatOK.Prop, s.newProp("d:getetag", quoteEtag(md.Etag)))
 		}
 
 		if md.PermissionSet != nil {
@@ -712,7 +712,7 @@ func (s *svc) mdToPropResponse(ctx context.Context, pf *propfindXML, md *provide
 				switch pf.Prop[i].Local {
 				case "getetag": // both
 					if md.Etag != "" {
-						propstatOK.Prop = append(propstatOK.Prop, s.newProp("d:getetag", md.Etag))
+						propstatOK.Prop = append(propstatOK.Prop, s.newProp("d:getetag", quoteEtag(md.Etag)))
 					} else {
 						propstatNotFound.Prop = append(propstatNotFound.Prop, s.newProp("d:getetag", ""))
 					}
@@ -814,6 +814,14 @@ func (s *svc) mdToPropResponse(ctx context.Context, pf *propfindXML, md *provide
 	}
 
 	return &response, nil
+}
+
+// be defensive about wrong encoded etags
+func quoteEtag(etag string) string {
+	if strings.HasPrefix(etag, "W/") {
+		return `W/"` + strings.Trim(etag[2:], `"`) + `"`
+	}
+	return `"` + strings.Trim(etag, `"`) + `"`
 }
 
 // a file is only yours if you are the owner


### PR DESCRIPTION
When ocdav renders etags it will now try to correct them to the definition as *quoted strings* which do not contain `"`. This prevents double or triple quoted etags on the webdav api.
