### PR TITLE
Do not send body on failed range request

### DIFF
--- a/changelog/unreleased/no-body-on-failed-range.md
+++ b/changelog/unreleased/no-body-on-failed-range.md
@@ -1,0 +1,5 @@
+Bugfix: Do not send body on failed range request
+
+Instead of send the error in the body of a 416 response we log it. This prevents the go reverse proxy from choking on it and turning it into a 502 Bad Gateway response.
+
+https://github.com/cs3org/reva/pull/1884

--- a/pkg/rhttp/datatx/utils/download/download.go
+++ b/pkg/rhttp/datatx/utils/download/download.go
@@ -68,8 +68,9 @@ func GetOrHeadFile(w http.ResponseWriter, r *http.Request, fs storage.FS) {
 			if err == ErrNoOverlap {
 				w.Header().Set("Content-Range", fmt.Sprintf("bytes */%d", md.Size))
 			}
+			sublog.Error().Err(err).Interface("md", md).Interface("ranges", ranges).Msg("range request not satisfiable")
 			w.WriteHeader(http.StatusRequestedRangeNotSatisfiable)
-			fmt.Fprintln(w, err)
+
 			return
 		}
 		if SumRangesSize(ranges) > int64(md.Size) {


### PR DESCRIPTION
Instead of send the error in the body of a 416 response we log it. This prevents the go reverse proxy from choking on it and turning it into a 502 Bad Gateway response.