### PR TITLE
Add "a" and "l" filters in grappa

### DIFF
--- a/changelog/unreleased/filter-ns-users-groups.md
+++ b/changelog/unreleased/filter-ns-users-groups.md
@@ -1,0 +1,10 @@
+Enhancement: Add "a" and "l" filter for grappa queries
+
+This PR adds the namespace filters "a" and "l" for grappa queries.
+With no filter will look into primary and e-groups, with "a" will look
+into primary/secondary/service/e-groups and with "l" will look into
+lightweight accounts.
+
+
+https://github.com/cs3org/reva/pull/1887
+https://github.com/cs3org/reva/issues/1773

--- a/pkg/cbox/group/rest/rest.go
+++ b/pkg/cbox/group/rest/rest.go
@@ -282,6 +282,21 @@ func (m *manager) findGroupsByFilter(ctx context.Context, url string, groups map
 }
 
 func (m *manager) FindGroups(ctx context.Context, query string) ([]*grouppb.Group, error) {
+
+	// Look at namespaces filters. If the query starts with:
+	// "a" or none => get egroups
+	// other filters => get empty list
+
+	parts := strings.SplitN(query, ":", 2)
+
+	if len(parts) == 2 {
+		if parts[0] == "a" {
+			query = parts[1]
+		} else {
+			return []*grouppb.Group{}, nil
+		}
+	}
+
 	filters := []string{"groupIdentifier"}
 	if emailRegex.MatchString(query) {
 		parts := strings.Split(query, "@")


### PR DESCRIPTION
This PR adds the namespace filters "a" and "l" for grappa queries.

- with no filter: look into primary and e-groups
- `"a"`: look into primary/secondary/service/e-groups
- `"l"`: look into lightweight accounts.

Queries are in the form `[filter:]name`.

Closes #1773