### PR TITLE
fix: chunked upload of existing file creates new version

### DIFF
--- a/changelog/unreleased/chunked-upload-versions.md
+++ b/changelog/unreleased/chunked-upload-versions.md
@@ -1,0 +1,5 @@
+Bugfix: Fix chunked uploads for new versions
+
+Chunked uploads didn't create a new version, when the file to upload already existed.
+
+https://github.com/cs3org/reva/pull/1899

--- a/pkg/storage/utils/decomposedfs/upload.go
+++ b/pkg/storage/utils/decomposedfs/upload.go
@@ -114,16 +114,14 @@ func (fs *Decomposedfs) InitiateUpload(ctx context.Context, ref *provider.Refere
 
 	log := appctx.GetLogger(ctx)
 
-	var relative string // the internal path of the file node
-
-	n, err := fs.lu.NodeFromResource(ctx, ref)
+	n, err := fs.lookupNode(ctx, ref.Path)
 	if err != nil {
 		return nil, err
 	}
 
 	// permissions are checked in NewUpload below
 
-	relative, err = fs.lu.Path(ctx, n)
+	relative, err := fs.lu.Path(ctx, n)
 	if err != nil {
 		return nil, err
 	}
@@ -207,7 +205,7 @@ func (fs *Decomposedfs) NewUpload(ctx context.Context, info tusd.FileInfo) (uplo
 	}
 	info.MetaData["dir"] = filepath.Clean(info.MetaData["dir"])
 
-	n, err := fs.lu.NodeFromPath(ctx, filepath.Join(info.MetaData["dir"], info.MetaData["filename"]))
+	n, err := fs.lookupNode(ctx, filepath.Join(info.MetaData["dir"], info.MetaData["filename"]))
 	if err != nil {
 		return nil, errors.Wrap(err, "Decomposedfs: error wrapping filename")
 	}
@@ -358,6 +356,33 @@ func (fs *Decomposedfs) GetUpload(ctx context.Context, id string) (tusd.Upload, 
 		fs:       fs,
 		ctx:      ctx,
 	}, nil
+}
+
+// lookupNode looks up nodes by path.
+// This method can also handle lookups for paths which contain chunking information.
+func (fs *Decomposedfs) lookupNode(ctx context.Context, path string) (*node.Node, error) {
+	p := path
+	isChunked, err := chunking.IsChunked(path)
+	if err != nil {
+		return nil, err
+	}
+	if isChunked {
+		chunkInfo, err := chunking.GetChunkBLOBInfo(path)
+		if err != nil {
+			return nil, err
+		}
+		p = chunkInfo.Path
+	}
+
+	n, err := fs.lu.NodeFromPath(ctx, p)
+	if err != nil {
+		return nil, err
+	}
+
+	if isChunked {
+		n.Name = filepath.Base(path)
+	}
+	return n, nil
 }
 
 type fileUpload struct {

--- a/tests/acceptance/expected-failures-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-on-OCIS-storage.md
@@ -54,9 +54,6 @@ Basic file management like up and download, move, copy, properties, quota, trash
 -   [apiWebdavUpload1/uploadFile.feature:112](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUpload1/uploadFile.feature#L112)
 -   [apiWebdavUpload1/uploadFile.feature:113](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUpload1/uploadFile.feature#L113)
 
-#### [uploading with old-chunking does not work](https://github.com/owncloud/ocis/issues/1343)
--   [apiWebdavUpload2/uploadFileUsingOldChunking.feature:43](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUpload2/uploadFileUsingOldChunking.feature#L43)
-
 #### [invalid file-names should not be created using the TUS protocol](https://github.com/owncloud/ocis/issues/1001)
 -   [apiWebdavUploadTUS/uploadFile.feature:143](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUploadTUS/uploadFile.feature#L143)
 -   [apiWebdavUploadTUS/uploadFile.feature:144](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUploadTUS/uploadFile.feature#L144)

--- a/tests/acceptance/expected-failures-on-S3NG-storage.md
+++ b/tests/acceptance/expected-failures-on-S3NG-storage.md
@@ -59,9 +59,6 @@ Basic file management like up and download, move, copy, properties, quota, trash
 -   [apiWebdavUpload1/uploadFile.feature:112](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUpload1/uploadFile.feature#L112)
 -   [apiWebdavUpload1/uploadFile.feature:113](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUpload1/uploadFile.feature#L113)
 
-#### [uploading with old-chunking does not work](https://github.com/owncloud/ocis/issues/1343)
--   [apiWebdavUpload2/uploadFileUsingOldChunking.feature:43](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUpload2/uploadFileUsingOldChunking.feature#L43)
-
 #### [invalid file-names should not be created using the TUS protocol](https://github.com/owncloud/ocis/issues/1001)
 -   [apiWebdavUploadTUS/uploadFile.feature:143](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUploadTUS/uploadFile.feature#L135)
 -   [apiWebdavUploadTUS/uploadFile.feature:144](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUploadTUS/uploadFile.feature#L136)


### PR DESCRIPTION
Chunked uploads didn't create a new version, when the file to upload already existed.