### PR TITLE
fix copy over existing resource

### DIFF
--- a/changelog/unreleased/copy-over-existing-file.md
+++ b/changelog/unreleased/copy-over-existing-file.md
@@ -1,0 +1,5 @@
+Bugfix: Fix copy over existing resource
+
+When the target of a copy already exists, the existing resource will be moved to the trashbin before executing the copy.
+
+https://github.com/cs3org/reva/pull/1906

--- a/internal/http/services/owncloud/ocdav/copy.go
+++ b/internal/http/services/owncloud/ocdav/copy.go
@@ -333,6 +333,19 @@ func (s *svc) prepareCopy(ctx context.Context, w http.ResponseWriter, r *http.Re
 			return nil
 		}
 
+		// delete existing tree
+		delReq := &provider.DeleteRequest{Ref: dstRef}
+		delRes, err := client.Delete(ctx, delReq)
+		if err != nil {
+			log.Error().Err(err).Msg("error sending grpc delete request")
+			w.WriteHeader(http.StatusInternalServerError)
+			return nil
+		}
+
+		if delRes.Status.Code != rpc.Code_CODE_OK && delRes.Status.Code != rpc.Code_CODE_NOT_FOUND {
+			HandleErrorStatus(log, w, delRes.Status)
+			return nil
+		}
 	} else {
 		// check if an intermediate path / the parent exists
 		intermediateRef, status, err := intermediateDirRef()

--- a/internal/http/services/owncloud/ocdav/dav.go
+++ b/internal/http/services/owncloud/ocdav/dav.go
@@ -244,6 +244,11 @@ func (h *DavHandler) Handler(s *svc) http.Handler {
 
 		default:
 			w.WriteHeader(http.StatusNotFound)
+			b, err := Marshal(exception{
+				code:    SabredavNotFound,
+				message: "File not found in root",
+			})
+			HandleWebdavError(log, w, b, err)
 		}
 	})
 }

--- a/internal/http/services/owncloud/ocdav/propfind.go
+++ b/internal/http/services/owncloud/ocdav/propfind.go
@@ -162,6 +162,16 @@ func (s *svc) getResourceInfos(ctx context.Context, w http.ResponseWriter, r *ht
 		w.WriteHeader(http.StatusInternalServerError)
 		return nil, nil, false
 	} else if res.Status.Code != rpc.Code_CODE_OK {
+		if res.Status.Code == rpc.Code_CODE_NOT_FOUND {
+			w.WriteHeader(http.StatusNotFound)
+			m := fmt.Sprintf("Resource %v not found", ref.Path)
+			b, err := Marshal(exception{
+				code:    SabredavNotFound,
+				message: m,
+			})
+			HandleWebdavError(&log, w, b, err)
+			return nil, nil, false
+		}
 		HandleErrorStatus(&log, w, res.Status)
 		return nil, nil, false
 	}

--- a/tests/acceptance/expected-failures-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-on-OCIS-storage.md
@@ -77,12 +77,6 @@ Basic file management like up and download, move, copy, properties, quota, trash
 -   [apiWebdavMove1/moveFolder.feature:48](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavMove1/moveFolder.feature#L48)
 
 #### [Getting information about a folder overwritten by a file gives 500 error instead of 404](https://github.com/owncloud/ocis/issues/1239)
--   [apiWebdavProperties1/copyFile.feature:134](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/copyFile.feature#L134)
--   [apiWebdavProperties1/copyFile.feature:135](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/copyFile.feature#L135)
--   [apiWebdavProperties1/copyFile.feature:151](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/copyFile.feature#L151)
--   [apiWebdavProperties1/copyFile.feature:152](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/copyFile.feature#L152)
--   [apiWebdavProperties1/copyFile.feature:207](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/copyFile.feature#L207)
--   [apiWebdavProperties1/copyFile.feature:208](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/copyFile.feature#L208)
 -   [apiWebdavProperties1/copyFile.feature:226](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/copyFile.feature#L226)
 -   [apiWebdavProperties1/copyFile.feature:227](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/copyFile.feature#L227)
 -   [apiWebdavProperties1/copyFile.feature:244](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/copyFile.feature#L244)

--- a/tests/acceptance/expected-failures-on-OWNCLOUD-storage.md
+++ b/tests/acceptance/expected-failures-on-OWNCLOUD-storage.md
@@ -122,12 +122,6 @@ The following scenarios fail on OWNCLOUD storage but not on OCIS storage:
 -   [apiWebdavMove1/moveFolder.feature:48](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavMove1/moveFolder.feature#L48)
 
 #### [Getting information about a folder overwritten by a file gives 500 error instead of 404](https://github.com/owncloud/ocis/issues/1239)
--   [apiWebdavProperties1/copyFile.feature:134](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/copyFile.feature#L134)
--   [apiWebdavProperties1/copyFile.feature:135](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/copyFile.feature#L135)
--   [apiWebdavProperties1/copyFile.feature:151](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/copyFile.feature#L151)
--   [apiWebdavProperties1/copyFile.feature:152](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/copyFile.feature#L152)
--   [apiWebdavProperties1/copyFile.feature:207](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/copyFile.feature#L207)
--   [apiWebdavProperties1/copyFile.feature:208](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/copyFile.feature#L208)
 -   [apiWebdavProperties1/copyFile.feature:226](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/copyFile.feature#L226)
 -   [apiWebdavProperties1/copyFile.feature:227](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/copyFile.feature#L227)
 -   [apiWebdavProperties1/copyFile.feature:244](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/copyFile.feature#L244)

--- a/tests/acceptance/expected-failures-on-S3NG-storage.md
+++ b/tests/acceptance/expected-failures-on-S3NG-storage.md
@@ -82,12 +82,6 @@ Basic file management like up and download, move, copy, properties, quota, trash
 -   [apiWebdavMove1/moveFolder.feature:48](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavMove1/moveFolder.feature#L48)
 
 #### [Getting information about a folder overwritten by a file gives 500 error instead of 404](https://github.com/owncloud/ocis/issues/1239)
--   [apiWebdavProperties1/copyFile.feature:134](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/copyFile.feature#L134)
--   [apiWebdavProperties1/copyFile.feature:135](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/copyFile.feature#L135)
--   [apiWebdavProperties1/copyFile.feature:151](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/copyFile.feature#L151)
--   [apiWebdavProperties1/copyFile.feature:152](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/copyFile.feature#L152)
--   [apiWebdavProperties1/copyFile.feature:207](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/copyFile.feature#L207)
--   [apiWebdavProperties1/copyFile.feature:208](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/copyFile.feature#L208)
 -   [apiWebdavProperties1/copyFile.feature:226](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/copyFile.feature#L226)
 -   [apiWebdavProperties1/copyFile.feature:227](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/copyFile.feature#L227)
 -   [apiWebdavProperties1/copyFile.feature:244](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/copyFile.feature#L244)

--- a/tests/acceptance/features/apiOcisSpecific/apiSharePublicLink2-copyFromPublicLink.feature
+++ b/tests/acceptance/features/apiOcisSpecific/apiSharePublicLink2-copyFromPublicLink.feature
@@ -8,22 +8,6 @@ Feature: copying from public link share
 
   @issue-ocis-reva-373 @issue-core-37683 @skipOnOcis-OCIS-Storage
   # after fixing all issues delete this Scenario and use the one from oC10 core
-  Scenario: Copy folder within a public link folder to the same folder name as an already existing file
-    Given user "Alice" has created folder "/PARENT/testFolder"
-    And user "Alice" has uploaded file with content "some data" to "/PARENT/testFolder/testfile.txt"
-    And user "Alice" has uploaded file with content "some data 1" to "/PARENT/copy1.txt"
-    And user "Alice" has created a public link share with settings
-      | path        | /PARENT                   |
-      | permissions | read,update,create,delete |
-    When the public copies folder "/testFolder" to "/copy1.txt" using the new public WebDAV API
-    Then the HTTP status code should be "204"
-    And as "Alice" folder "/PARENT/testFolder" should exist
-    And as "Alice" file "/PARENT/copy1.txt" should exist
-    And the content of file "/PARENT/testFolder/testfile.txt" for user "Alice" should be "some data"
-    And the content of file "/PARENT/copy1.txt" for user "Alice" should be "some data 1"
-
-  @issue-ocis-reva-373 @issue-core-37683 @skipOnOcis-OCIS-Storage
-  # after fixing all issues delete this Scenario and use the one from oC10 core
   Scenario: Copy file within a public link folder to a file with name same as an existing folder
     Given user "Alice" has uploaded file with content "some data" to "/PARENT/testfile.txt"
     And user "Alice" has created folder "/PARENT/new-folder"
@@ -36,32 +20,3 @@ Feature: copying from public link share
     And as "Alice" file "/PARENT/testfile.txt" should exist
     And as "Alice" file "/PARENT/new-folder" should exist
     And the content of file "/PARENT/testfile.txt" for user "Alice" should be "some data"
-
-  @issue-ocis-reva-368 @skipOnOcis-OCIS-Storage
-  # after fixing all issues delete this Scenario and use the one from oC10 core
-  Scenario Outline: Copy file within a public link folder to a file with unusual destination names
-    Given user "Alice" has uploaded file with content "some data" to "/PARENT/testfile.txt"
-    And user "Alice" has created a public link share with settings
-      | path        | /PARENT                   |
-      | permissions | read,update,create,delete |
-    When the public copies file "/testfile.txt" to "/<destination-file-name>" using the new public WebDAV API
-    Then the HTTP status code should be "204"
-    And as "Alice" file "/PARENT/<destination-file-name>" should exist
-    And the content of file "/PARENT/<destination-file-name>" for user "Alice" should be "some data"
-    Examples:
-      | destination-file-name |
-      | testfile.txt          |
-      |                       |
-
-  @issue-ocis-reva-368 @skipOnOcis-OCIS-Storage
-  # after fixing all issues delete this Scenario and use the one from oC10 core
-  Scenario: Copy folder within a public link folder to a folder with unusual destination names
-    Given user "Alice" has created folder "/PARENT/testFolder"
-    And user "Alice" has uploaded file with content "some data" to "/PARENT/testFolder/testfile.txt"
-    And user "Alice" has created a public link share with settings
-      | path        | /PARENT                   |
-      | permissions | read,update,create,delete |
-    When the public copies folder "/testFolder" to "/testFolder" using the new public WebDAV API
-    Then the HTTP status code should be "204"
-    And as "Alice" folder "/PARENT/testFolder" should exist
-    And the content of file "/PARENT/testFolder/testfile.txt" for user "Alice" should be "some data"

--- a/tests/acceptance/features/apiOcisSpecific/apiWebdavProperties2-getFileProperties.feature
+++ b/tests/acceptance/features/apiOcisSpecific/apiWebdavProperties2-getFileProperties.feature
@@ -32,12 +32,3 @@ Feature: get file properties
       | old         |
       | new         |
 
-  @issue-ocis-reva-163
-  # after fixing all issues delete this Scenario and use the one from oC10 core
-  Scenario Outline: Do a PROPFIND to a non-existing URL
-    And user "Alice" requests "<url>" with "PROPFIND" using basic auth
-    Then the body of the response should be empty
-    Examples:
-      | url                                  |
-      | /remote.php/dav/files/does-not-exist |
-      | /remote.php/dav/does-not-exist       |


### PR DESCRIPTION
When the target of a copy already exists, the existing resource will be moved to the trash-bin before executing the copy.