### PR TITLE
Do not overwrite more specific matches when finding storage providers

### DIFF
--- a/changelog/unreleased/fix-finding-storage-providers.md
+++ b/changelog/unreleased/fix-finding-storage-providers.md
@@ -1,0 +1,7 @@
+Bugfix: Do not overwrite more specific matches when finding storage providers
+
+Depending on the order of rules in the registry it could happend that more specific matches (e.g. /home/Shares) were
+overwritten by more general ones (e.g. /home). This PR makes sure that the registry always returns the most specific
+match.
+
+https://github.com/cs3org/reva/pull/1937

--- a/pkg/storage/registry/static/static.go
+++ b/pkg/storage/registry/static/static.go
@@ -179,6 +179,10 @@ func (b *reg) FindProviders(ctx context.Context, ref *provider.Reference) ([]*re
 				continue
 			}
 			if m := r.FindString(fn); m != "" {
+				if match != nil && len(match.ProviderPath) > len(m) {
+					// Do not overwrite existing longer match
+					continue
+				}
 				match = &registrypb.ProviderInfo{
 					ProviderPath: m,
 					Address:      addr,

--- a/pkg/storage/registry/static/static_test.go
+++ b/pkg/storage/registry/static/static_test.go
@@ -33,7 +33,7 @@ import (
 
 var _ = Describe("Static", func() {
 
-	totalProviders, rootProviders, eosProviders := 32, 30, 28
+	totalProviders, rootProviders, eosProviders := 33, 31, 29
 
 	handler, err := static.New(map[string]interface{}{
 		"home_provider": "/home",
@@ -74,6 +74,9 @@ var _ = Describe("Static", func() {
 			},
 			"123e4567-e89b-12d3-a456-426655440001": map[string]interface{}{
 				"address": "home-01-home",
+			},
+			"/eos/": map[string]interface{}{
+				"address": "unspecific-rule-that-should-never-been-hit",
 			},
 		},
 	})


### PR DESCRIPTION

Depending on the order of rules in the registry it could happend that more specific matches (e.g. /home/Shares) were
overwritten by more general ones (e.g. /home). This PR makes sure that the registry always returns the most specific
match.