### PR TITLE
s3ng: Provide objectSize when uploading to reduce memory usage

### DIFF
--- a/changelog/unreleased/provide-size-for-s3-upload.md
+++ b/changelog/unreleased/provide-size-for-s3-upload.md
@@ -1,0 +1,7 @@
+Enhancement: Reduce memory usage when uploading with S3ng storage
+
+The memory usage could be high when uploading files using the S3ng storage.
+By providing the actual file size when triggering `PutObject`, 
+the overall memory usage is reduced.
+
+https://github.com/cs3org/reva/pull/1940


### PR DESCRIPTION
According to the [documentation](https://github.com/minio/minio-go/blob/410eb9e1392ce96323f1ecc11915141a51d0dc72/api-put-object.go#L200) for `PutObject`, setting `objectSize` to `-1` causes a multipart Put operation until the input stream reaches EOF, which can result in high memory usage. Something similar has already been reported in https://github.com/minio/minio-go/issues/1496

This PR changes the behavior so it tries to determine the file size before uploading it. Should the given `io.Reader` not be a file, it falls back to using `-1`.

In my testing this change has reduced the memory usage when uploading files to OICS quite a bit: From over 1GB for a single user, down to <300MB.

Closes #1933