### PR TITLE
fix TUS uploads with transfer token only

### DIFF
--- a/changelog/unreleased/tus-upload-with-transfer-token-only.md
+++ b/changelog/unreleased/tus-upload-with-transfer-token-only.md
@@ -1,0 +1,5 @@
+Bugfix: Fix TUS uploads with transfer token only
+
+TUS uploads had been stopped when the user JWT token expired, even if only the transfer token should be validated. Now uploads will continue as intended.
+
+https://github.com/cs3org/reva/pull/1941

--- a/cmd/reva/upload.go
+++ b/cmd/reva/upload.go
@@ -176,9 +176,6 @@ func uploadCommand() *command {
 			if err != nil {
 				return err
 			}
-			if token, ok := ctxpkg.ContextGetToken(ctx); ok {
-				c.Header.Add(ctxpkg.TokenHeader, token)
-			}
 			c.Header.Add(datagateway.TokenTransportHeader, p.Token)
 			tusc, err := tus.NewClient(dataServerURL, c)
 			if err != nil {

--- a/internal/http/services/datagateway/datagateway.go
+++ b/internal/http/services/datagateway/datagateway.go
@@ -109,7 +109,9 @@ func (s *svc) Handler() http.Handler {
 }
 
 func (s *svc) Unprotected() []string {
-	return []string{}
+	return []string{
+		"/",
+	}
 }
 
 func (s *svc) setHandler() {

--- a/internal/http/services/dataprovider/dataprovider.go
+++ b/internal/http/services/dataprovider/dataprovider.go
@@ -125,7 +125,9 @@ func (s *svc) Close() error {
 }
 
 func (s *svc) Unprotected() []string {
-	return []string{}
+	return []string{
+		"/tus",
+	}
 }
 
 func (s *svc) Prefix() string {


### PR DESCRIPTION
TUS uploads had been stopped when the user JWT token expired, even if only the transfer token should be validated. Now uploads will continue as intended.

fixes owncloud/ocis#1205