### PR TITLE
[WIP] connect ocs users endpoint to CS3 admin api

### DIFF
--- a/internal/http/services/owncloud/ocs/handlers/cloud/user/user.go
+++ b/internal/http/services/owncloud/ocs/handlers/cloud/user/user.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 
 	"github.com/cs3org/reva/internal/http/services/owncloud/ocs/response"
+	"github.com/cs3org/reva/pkg/rhttp/router"
 	"github.com/cs3org/reva/pkg/user"
 )
 
@@ -40,17 +41,57 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	response.WriteOCSSuccess(w, r, &User{
-		ID:          u.Username,
-		DisplayName: u.DisplayName,
-		Email:       u.Mail,
-	})
+	var head string
+	head, r.URL.Path = router.ShiftPath(r.URL.Path)
+	switch head {
+	case "":
+		response.WriteOCSSuccess(w, r, &User{
+			// FIXME Enabled?
+			UserID:            u.Username,
+			DisplayName:       u.DisplayName,
+			LegacyDisplayName: u.DisplayName,
+			Email:             u.Mail,
+			UIDNumber:         u.UidNumber,
+			GIDNumber:         u.GidNumber,
+		})
+		return
+	case "signing-key":
+		// FIXME where do we store the signing key?
+		// is it still nededed?  the `oc:downloadURL` webdav property is also filled ... with a different signature
+		response.WriteOCSError(w, r, response.MetaUnknownError.StatusCode, "Not implemented", nil)
+		return
+	default:
+		response.WriteOCSError(w, r, response.MetaNotFound.StatusCode, "Not found", nil)
+		return
+	}
 }
 
+// TODO move this to the data package and align with the user package
 // User holds user data
 type User struct {
-	// TODO needs better naming, clarify if we need a userid, a username or both
-	ID          string `json:"id" xml:"id"`
-	DisplayName string `json:"display-name" xml:"display-name"`
-	Email       string `json:"email" xml:"email"`
+	Enabled           string `json:"enabled" xml:"enabled"`
+	UserID            string `json:"id" xml:"id"` // UserID is mapped to the preferred_name attribute in accounts
+	DisplayName       string `json:"display-name" xml:"display-name"`
+	LegacyDisplayName string `json:"displayname" xml:"displayname"`
+	Email             string `json:"email" xml:"email"`
+	Quota             *Quota `json:"quota" xml:"quota"`
+	UIDNumber         int64  `json:"uidnumber" xml:"uidnumber"`
+	GIDNumber         int64  `json:"gidnumber" xml:"gidnumber"`
+}
+
+// TODO move this to the data package and align with the user package
+// Quota holds quota information
+type Quota struct {
+	Free       int64   `json:"free" xml:"free"`
+	Used       int64   `json:"used" xml:"used"`
+	Total      int64   `json:"total" xml:"total"`
+	Relative   float32 `json:"relative" xml:"relative"`
+	Definition string  `json:"definition" xml:"definition"`
+}
+
+// TODO move this to the data package and align with the user package
+// SigningKey holds the Payload for a GetSigningKey response
+type SigningKey struct {
+	User       string `json:"user" xml:"user"`
+	SigningKey string `json:"signing-key" xml:"signing-key"`
 }


### PR DESCRIPTION
We want to move user management out of the core of ocis as we focus on an external identity management. That being said, the tests need a working provisioning API, which we will move from the ocis ocs implementation to reva, dropping an ocs implementation from ocis altogether. It has to live with the owncloud flavoured webdav anyway and splitting these services up is no longer necessary and makes configuration of the proxy unnecessarily complex and error prone.

- [ ] add stubs for endpoints and methods that should be implemented
- signing-key
  - [ ] ~~detemine where to store it when it was generated? put it in a storage? user properties?~~
  -  no longer needed https://github.com/owncloud/ocis/issues/2374
  - [ ] how can the ocis proxy access it?
- [ ] how can we differentiate users from admins in reva (ocis has roles) @ishank011 maybe? Some endpoints need to check if the user has adimn powers as not all user provisioning endpoints are allowed to be used by mere mortals.
- [ ] unit tests!