### PR TITLE
decomposedfs: make owner type optional

### DIFF
--- a/changelog/unreleased/owner-type-is-optional.md
+++ b/changelog/unreleased/owner-type-is-optional.md
@@ -1,0 +1,5 @@
+Bugfix: owner type is optional
+
+When reading the user from the extended attributes the user type might not be set, in this case we now return a user with an invalid type, which correctly reflects the state on disk.
+
+https://github.com/cs3org/reva/pull/1978


### PR DESCRIPTION
When reading the user from the extended attributes the user type might not be set, in this case we now return a user with an invalid type, which correctly reflects the state on disk.
