### PR TITLE
Move user context methods into separate package

### DIFF
--- a/changelog/unreleased/userctx-package.md
+++ b/changelog/unreleased/userctx-package.md
@@ -1,0 +1,3 @@
+Change: Move user context methods into a separate `userctx` package
+
+https://github.com/cs3org/reva/pull/1982

--- a/cmd/reva/download.go
+++ b/cmd/reva/download.go
@@ -30,9 +30,9 @@ import (
 	rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	"github.com/cs3org/reva/internal/http/services/datagateway"
+	ctxpkg "github.com/cs3org/reva/pkg/ctx"
 	"github.com/cs3org/reva/pkg/errtypes"
 	"github.com/cs3org/reva/pkg/rhttp"
-	tokenpkg "github.com/cs3org/reva/pkg/token"
 	"github.com/cs3org/reva/pkg/utils"
 	"github.com/pkg/errors"
 	"github.com/studio-b12/gowebdav"
@@ -188,7 +188,7 @@ func checkDownloadWebdavRef(protocols []*gateway.FileDownloadProtocol) (io.Reade
 	}
 
 	c := gowebdav.NewClient(p.DownloadEndpoint, "", "")
-	c.SetHeader(tokenpkg.TokenHeader, token)
+	c.SetHeader(ctxpkg.TokenHeader, token)
 
 	reader, err := c.ReadStream(filePath)
 	if err != nil {

--- a/cmd/reva/grpc.go
+++ b/cmd/reva/grpc.go
@@ -28,7 +28,7 @@ import (
 
 	gateway "github.com/cs3org/go-cs3apis/cs3/gateway/v1beta1"
 	rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
-	"github.com/cs3org/reva/pkg/token"
+	ctxpkg "github.com/cs3org/reva/pkg/ctx"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 )
@@ -41,8 +41,8 @@ func getAuthContext() context.Context {
 		log.Println(err)
 		return ctx
 	}
-	ctx = token.ContextSetToken(ctx, t)
-	ctx = metadata.AppendToOutgoingContext(ctx, token.TokenHeader, t)
+	ctx = ctxpkg.ContextSetToken(ctx, t)
+	ctx = metadata.AppendToOutgoingContext(ctx, ctxpkg.TokenHeader, t)
 	return ctx
 }
 

--- a/cmd/reva/upload.go
+++ b/cmd/reva/upload.go
@@ -34,8 +34,8 @@ import (
 	rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	typespb "github.com/cs3org/go-cs3apis/cs3/types/v1beta1"
+	ctxpkg "github.com/cs3org/reva/pkg/ctx"
 	"github.com/cs3org/reva/pkg/errtypes"
-	tokenpkg "github.com/cs3org/reva/pkg/token"
 	"github.com/eventials/go-tus"
 	"github.com/eventials/go-tus/memorystore"
 	"github.com/studio-b12/gowebdav"
@@ -176,8 +176,8 @@ func uploadCommand() *command {
 			if err != nil {
 				return err
 			}
-			if token, ok := tokenpkg.ContextGetToken(ctx); ok {
-				c.Header.Add(tokenpkg.TokenHeader, token)
+			if token, ok := ctxpkg.ContextGetToken(ctx); ok {
+				c.Header.Add(ctxpkg.TokenHeader, token)
 			}
 			c.Header.Add(datagateway.TokenTransportHeader, p.Token)
 			tusc, err := tus.NewClient(dataServerURL, c)
@@ -272,7 +272,7 @@ func checkUploadWebdavRef(protocols []*gateway.FileUploadProtocol, md os.FileInf
 	}
 
 	c := gowebdav.NewClient(p.UploadEndpoint, "", "")
-	c.SetHeader(tokenpkg.TokenHeader, token)
+	c.SetHeader(ctxpkg.TokenHeader, token)
 	c.SetHeader("Upload-Length", strconv.FormatInt(md.Size(), 10))
 
 	if err = c.WriteStream(filePath, fd, 0700); err != nil {

--- a/internal/grpc/interceptors/auth/auth.go
+++ b/internal/grpc/interceptors/auth/auth.go
@@ -28,7 +28,7 @@ import (
 	"github.com/cs3org/reva/pkg/sharedconf"
 	"github.com/cs3org/reva/pkg/token"
 	tokenmgr "github.com/cs3org/reva/pkg/token/manager/registry"
-	"github.com/cs3org/reva/pkg/user"
+	"github.com/cs3org/reva/pkg/userctx"
 	"github.com/cs3org/reva/pkg/utils"
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
@@ -94,7 +94,7 @@ func NewUnary(m map[string]interface{}, unprotected []string) (grpc.UnaryServerI
 			if ok {
 				u, err := dismantleToken(ctx, tkn, req, tokenManager, conf.GatewayAddr)
 				if err == nil {
-					ctx = user.ContextSetUser(ctx, u)
+					ctx = userctx.ContextSetUser(ctx, u)
 				}
 			}
 			return handler(ctx, req)
@@ -124,7 +124,7 @@ func NewUnary(m map[string]interface{}, unprotected []string) (grpc.UnaryServerI
 			trace.StringAttribute("token", tkn))
 		span.AddAttributes(trace.StringAttribute("user", u.String()), trace.StringAttribute("token", tkn))
 
-		ctx = user.ContextSetUser(ctx, u)
+		ctx = userctx.ContextSetUser(ctx, u)
 		return handler(ctx, req)
 	}
 	return interceptor, nil
@@ -165,7 +165,7 @@ func NewStream(m map[string]interface{}, unprotected []string) (grpc.StreamServe
 			if ok {
 				u, err := dismantleToken(ctx, tkn, ss, tokenManager, conf.GatewayAddr)
 				if err == nil {
-					ctx = user.ContextSetUser(ctx, u)
+					ctx = userctx.ContextSetUser(ctx, u)
 					ss = newWrappedServerStream(ctx, ss)
 				}
 			}
@@ -188,7 +188,7 @@ func NewStream(m map[string]interface{}, unprotected []string) (grpc.StreamServe
 		}
 
 		// store user and core access token in context.
-		ctx = user.ContextSetUser(ctx, u)
+		ctx = userctx.ContextSetUser(ctx, u)
 		wrapped := newWrappedServerStream(ctx, ss)
 		return handler(srv, wrapped)
 	}

--- a/internal/grpc/interceptors/token/token.go
+++ b/internal/grpc/interceptors/token/token.go
@@ -21,7 +21,7 @@ package token
 import (
 	"context"
 
-	"github.com/cs3org/reva/pkg/token"
+	ctxpkg "github.com/cs3org/reva/pkg/ctx"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 )
@@ -32,11 +32,11 @@ func NewUnary() grpc.UnaryServerInterceptor {
 	interceptor := func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
 		md, ok := metadata.FromIncomingContext(ctx)
 		if ok && md != nil {
-			if val, ok := md[token.TokenHeader]; ok {
+			if val, ok := md[ctxpkg.TokenHeader]; ok {
 				if len(val) > 0 && val[0] != "" {
 					tkn := val[0]
-					ctx = token.ContextSetToken(ctx, tkn)
-					ctx = metadata.AppendToOutgoingContext(ctx, token.TokenHeader, tkn)
+					ctx = ctxpkg.ContextSetToken(ctx, tkn)
+					ctx = metadata.AppendToOutgoingContext(ctx, ctxpkg.TokenHeader, tkn)
 				}
 			}
 		}
@@ -54,11 +54,11 @@ func NewStream() grpc.StreamServerInterceptor {
 
 		md, ok := metadata.FromIncomingContext(ss.Context())
 		if ok && md != nil {
-			if val, ok := md[token.TokenHeader]; ok {
+			if val, ok := md[ctxpkg.TokenHeader]; ok {
 				if len(val) > 0 && val[0] != "" {
 					tkn := val[0]
-					ctx = token.ContextSetToken(ctx, tkn)
-					ctx = metadata.AppendToOutgoingContext(ctx, token.TokenHeader, tkn)
+					ctx = ctxpkg.ContextSetToken(ctx, tkn)
+					ctx = metadata.AppendToOutgoingContext(ctx, ctxpkg.TokenHeader, tkn)
 				}
 			}
 		}

--- a/internal/grpc/services/gateway/appprovider.go
+++ b/internal/grpc/services/gateway/appprovider.go
@@ -32,10 +32,10 @@ import (
 	storageprovider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	typespb "github.com/cs3org/go-cs3apis/cs3/types/v1beta1"
 	"github.com/cs3org/reva/pkg/appctx"
+	ctxpkg "github.com/cs3org/reva/pkg/ctx"
 	"github.com/cs3org/reva/pkg/errtypes"
 	"github.com/cs3org/reva/pkg/rgrpc/status"
 	"github.com/cs3org/reva/pkg/rgrpc/todo/pool"
-	"github.com/cs3org/reva/pkg/token"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -157,8 +157,8 @@ func (s *svc) openFederatedShares(ctx context.Context, targetURL string, vm gate
 	}
 
 	gatewayClient := gateway.NewGatewayAPIClient(conn)
-	remoteCtx := token.ContextSetToken(context.Background(), ep.token)
-	remoteCtx = metadata.AppendToOutgoingContext(remoteCtx, token.TokenHeader, ep.token)
+	remoteCtx := ctxpkg.ContextSetToken(context.Background(), ep.token)
+	remoteCtx = metadata.AppendToOutgoingContext(remoteCtx, ctxpkg.TokenHeader, ep.token)
 
 	res, err := gatewayClient.OpenInApp(remoteCtx, appProviderReq)
 	if err != nil {
@@ -171,7 +171,7 @@ func (s *svc) openFederatedShares(ctx context.Context, targetURL string, vm gate
 func (s *svc) openLocalResources(ctx context.Context, ri *storageprovider.ResourceInfo,
 	vm gateway.OpenInAppRequest_ViewMode, app string) (*providerpb.OpenInAppResponse, error) {
 
-	accessToken, ok := token.ContextGetToken(ctx)
+	accessToken, ok := ctxpkg.ContextGetToken(ctx)
 	if !ok || accessToken == "" {
 		return &providerpb.OpenInAppResponse{
 			Status: status.NewUnauthenticated(ctx, errtypes.InvalidCredentials("Access token is invalid or empty"), ""),

--- a/internal/grpc/services/gateway/authprovider.go
+++ b/internal/grpc/services/gateway/authprovider.go
@@ -34,11 +34,10 @@ import (
 	storageprovider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	"github.com/cs3org/reva/pkg/appctx"
 	"github.com/cs3org/reva/pkg/auth/scope"
+	ctxpkg "github.com/cs3org/reva/pkg/ctx"
 	"github.com/cs3org/reva/pkg/errtypes"
 	"github.com/cs3org/reva/pkg/rgrpc/status"
 	"github.com/cs3org/reva/pkg/rgrpc/todo/pool"
-	tokenpkg "github.com/cs3org/reva/pkg/token"
-	userpkg "github.com/cs3org/reva/pkg/userctx"
 	"github.com/cs3org/reva/pkg/utils"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc/metadata"
@@ -113,9 +112,9 @@ func (s *svc) Authenticate(ctx context.Context, req *gateway.AuthenticateRequest
 		return res, nil
 	}
 
-	ctx = tokenpkg.ContextSetToken(ctx, token)
-	ctx = userpkg.ContextSetUser(ctx, res.User)
-	ctx = metadata.AppendToOutgoingContext(ctx, tokenpkg.TokenHeader, token)
+	ctx = ctxpkg.ContextSetToken(ctx, token)
+	ctx = ctxpkg.ContextSetUser(ctx, res.User)
+	ctx = metadata.AppendToOutgoingContext(ctx, ctxpkg.TokenHeader, token)
 	scope, err := s.expandScopes(ctx, res.TokenScope)
 	if err != nil {
 		err = errors.Wrap(err, "authsvc: error expanding token scope")
@@ -144,9 +143,9 @@ func (s *svc) Authenticate(ctx context.Context, req *gateway.AuthenticateRequest
 
 	// we need to pass the token to authenticate the CreateHome request.
 	// TODO(labkode): appending to existing context will not pass the token.
-	ctx = tokenpkg.ContextSetToken(ctx, token)
-	ctx = userpkg.ContextSetUser(ctx, res.User)
-	ctx = metadata.AppendToOutgoingContext(ctx, tokenpkg.TokenHeader, token) // TODO(jfd): hardcoded metadata key. use  PerRPCCredentials?
+	ctx = ctxpkg.ContextSetToken(ctx, token)
+	ctx = ctxpkg.ContextSetUser(ctx, res.User)
+	ctx = metadata.AppendToOutgoingContext(ctx, ctxpkg.TokenHeader, token) // TODO(jfd): hardcoded metadata key. use  PerRPCCredentials?
 
 	// create home directory
 	createHomeRes, err := s.CreateHome(ctx, &storageprovider.CreateHomeRequest{})

--- a/internal/grpc/services/gateway/authprovider.go
+++ b/internal/grpc/services/gateway/authprovider.go
@@ -38,7 +38,7 @@ import (
 	"github.com/cs3org/reva/pkg/rgrpc/status"
 	"github.com/cs3org/reva/pkg/rgrpc/todo/pool"
 	tokenpkg "github.com/cs3org/reva/pkg/token"
-	userpkg "github.com/cs3org/reva/pkg/user"
+	userpkg "github.com/cs3org/reva/pkg/userctx"
 	"github.com/cs3org/reva/pkg/utils"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc/metadata"

--- a/internal/grpc/services/gateway/webdavstorageprovider.go
+++ b/internal/grpc/services/gateway/webdavstorageprovider.go
@@ -28,8 +28,8 @@ import (
 	ocmprovider "github.com/cs3org/go-cs3apis/cs3/ocm/provider/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	types "github.com/cs3org/go-cs3apis/cs3/types/v1beta1"
+	ctxpkg "github.com/cs3org/reva/pkg/ctx"
 	"github.com/cs3org/reva/pkg/errtypes"
-	"github.com/cs3org/reva/pkg/token"
 	"github.com/pkg/errors"
 	"github.com/studio-b12/gowebdav"
 )
@@ -56,7 +56,7 @@ func (s *svc) webdavRefStat(ctx context.Context, targetURL string, nameQueries .
 	}
 
 	c := gowebdav.NewClient(webdavEP, "", "")
-	c.SetHeader(token.TokenHeader, ep.token)
+	c.SetHeader(ctxpkg.TokenHeader, ep.token)
 
 	// TODO(ishank011): We need to call PROPFIND ourselves as we need to retrieve
 	// ownloud-specific fields to get the resource ID and permissions.
@@ -83,7 +83,7 @@ func (s *svc) webdavRefLs(ctx context.Context, targetURL string, nameQueries ...
 	}
 
 	c := gowebdav.NewClient(webdavEP, "", "")
-	c.SetHeader(token.TokenHeader, ep.token)
+	c.SetHeader(ctxpkg.TokenHeader, ep.token)
 
 	// TODO(ishank011): We need to call PROPFIND ourselves as we need to retrieve
 	// ownloud-specific fields to get the resource ID and permissions.
@@ -116,7 +116,7 @@ func (s *svc) webdavRefMkdir(ctx context.Context, targetURL string, nameQueries 
 	}
 
 	c := gowebdav.NewClient(webdavEP, "", "")
-	c.SetHeader(token.TokenHeader, ep.token)
+	c.SetHeader(ctxpkg.TokenHeader, ep.token)
 
 	err = c.Mkdir(ep.filePath, 0700)
 	if err != nil {
@@ -149,7 +149,7 @@ func (s *svc) webdavRefMove(ctx context.Context, targetURL, src, destination str
 	}
 
 	c := gowebdav.NewClient(srcWebdavEP, "", "")
-	c.SetHeader(token.TokenHeader, srcEP.token)
+	c.SetHeader(ctxpkg.TokenHeader, srcEP.token)
 
 	err = c.Rename(srcEP.filePath, destEP.filePath, true)
 	if err != nil {
@@ -174,7 +174,7 @@ func (s *svc) webdavRefDelete(ctx context.Context, targetURL string, nameQueries
 	}
 
 	c := gowebdav.NewClient(webdavEP, "", "")
-	c.SetHeader(token.TokenHeader, ep.token)
+	c.SetHeader(ctxpkg.TokenHeader, ep.token)
 
 	err = c.Remove(ep.filePath)
 	if err != nil {

--- a/internal/grpc/services/preferences/preferences.go
+++ b/internal/grpc/services/preferences/preferences.go
@@ -26,9 +26,9 @@ import (
 
 	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	preferences "github.com/cs3org/go-cs3apis/cs3/preferences/v1beta1"
+	ctxpkg "github.com/cs3org/reva/pkg/ctx"
 	"github.com/cs3org/reva/pkg/rgrpc"
 	"github.com/cs3org/reva/pkg/rgrpc/status"
-	"github.com/cs3org/reva/pkg/userctx"
 	"github.com/pkg/errors"
 )
 
@@ -67,7 +67,7 @@ func (s *service) Register(ss *grpc.Server) {
 }
 
 func getUser(ctx context.Context) (*userpb.User, error) {
-	u, ok := userctx.ContextGetUser(ctx)
+	u, ok := ctxpkg.ContextGetUser(ctx)
 	if !ok {
 		err := errors.Wrap(contextUserRequiredErr("userrequired"), "preferences: error getting user from ctx")
 		return nil, err

--- a/internal/grpc/services/preferences/preferences.go
+++ b/internal/grpc/services/preferences/preferences.go
@@ -28,7 +28,7 @@ import (
 	preferences "github.com/cs3org/go-cs3apis/cs3/preferences/v1beta1"
 	"github.com/cs3org/reva/pkg/rgrpc"
 	"github.com/cs3org/reva/pkg/rgrpc/status"
-	"github.com/cs3org/reva/pkg/user"
+	"github.com/cs3org/reva/pkg/userctx"
 	"github.com/pkg/errors"
 )
 
@@ -67,7 +67,7 @@ func (s *service) Register(ss *grpc.Server) {
 }
 
 func getUser(ctx context.Context) (*userpb.User, error) {
-	u, ok := user.ContextGetUser(ctx)
+	u, ok := userctx.ContextGetUser(ctx)
 	if !ok {
 		err := errors.Wrap(contextUserRequiredErr("userrequired"), "preferences: error getting user from ctx")
 		return nil, err

--- a/internal/grpc/services/publicshareprovider/publicshareprovider.go
+++ b/internal/grpc/services/publicshareprovider/publicshareprovider.go
@@ -24,12 +24,12 @@ import (
 	link "github.com/cs3org/go-cs3apis/cs3/sharing/link/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	"github.com/cs3org/reva/pkg/appctx"
+	ctxpkg "github.com/cs3org/reva/pkg/ctx"
 	"github.com/cs3org/reva/pkg/errtypes"
 	"github.com/cs3org/reva/pkg/publicshare"
 	"github.com/cs3org/reva/pkg/publicshare/manager/registry"
 	"github.com/cs3org/reva/pkg/rgrpc"
 	"github.com/cs3org/reva/pkg/rgrpc/status"
-	"github.com/cs3org/reva/pkg/userctx"
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
@@ -110,7 +110,7 @@ func (s *service) CreatePublicShare(ctx context.Context, req *link.CreatePublicS
 	log := appctx.GetLogger(ctx)
 	log.Info().Str("publicshareprovider", "create").Msg("create public share")
 
-	u, ok := userctx.ContextGetUser(ctx)
+	u, ok := ctxpkg.ContextGetUser(ctx)
 	if !ok {
 		log.Error().Msg("error getting user from context")
 	}
@@ -131,7 +131,7 @@ func (s *service) RemovePublicShare(ctx context.Context, req *link.RemovePublicS
 	log := appctx.GetLogger(ctx)
 	log.Info().Str("publicshareprovider", "remove").Msg("remove public share")
 
-	user := userctx.ContextMustGetUser(ctx)
+	user := ctxpkg.ContextMustGetUser(ctx)
 	err := s.sm.RevokePublicShare(ctx, user, req.Ref)
 	if err != nil {
 		return &link.RemovePublicShareResponse{
@@ -174,7 +174,7 @@ func (s *service) GetPublicShare(ctx context.Context, req *link.GetPublicShareRe
 	log := appctx.GetLogger(ctx)
 	log.Info().Str("publicshareprovider", "get").Msg("get public share")
 
-	u, ok := userctx.ContextGetUser(ctx)
+	u, ok := ctxpkg.ContextGetUser(ctx)
 	if !ok {
 		log.Error().Msg("error getting user from context")
 	}
@@ -193,7 +193,7 @@ func (s *service) GetPublicShare(ctx context.Context, req *link.GetPublicShareRe
 func (s *service) ListPublicShares(ctx context.Context, req *link.ListPublicSharesRequest) (*link.ListPublicSharesResponse, error) {
 	log := appctx.GetLogger(ctx)
 	log.Info().Str("publicshareprovider", "list").Msg("list public share")
-	user, _ := userctx.ContextGetUser(ctx)
+	user, _ := ctxpkg.ContextGetUser(ctx)
 
 	shares, err := s.sm.ListPublicShares(ctx, user, req.Filters, &provider.ResourceInfo{}, req.GetSign())
 	if err != nil {
@@ -214,7 +214,7 @@ func (s *service) UpdatePublicShare(ctx context.Context, req *link.UpdatePublicS
 	log := appctx.GetLogger(ctx)
 	log.Info().Str("publicshareprovider", "update").Msg("update public share")
 
-	u, ok := userctx.ContextGetUser(ctx)
+	u, ok := ctxpkg.ContextGetUser(ctx)
 	if !ok {
 		log.Error().Msg("error getting user from context")
 	}

--- a/internal/grpc/services/publicshareprovider/publicshareprovider.go
+++ b/internal/grpc/services/publicshareprovider/publicshareprovider.go
@@ -29,7 +29,7 @@ import (
 	"github.com/cs3org/reva/pkg/publicshare/manager/registry"
 	"github.com/cs3org/reva/pkg/rgrpc"
 	"github.com/cs3org/reva/pkg/rgrpc/status"
-	"github.com/cs3org/reva/pkg/user"
+	"github.com/cs3org/reva/pkg/userctx"
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
@@ -110,7 +110,7 @@ func (s *service) CreatePublicShare(ctx context.Context, req *link.CreatePublicS
 	log := appctx.GetLogger(ctx)
 	log.Info().Str("publicshareprovider", "create").Msg("create public share")
 
-	u, ok := user.ContextGetUser(ctx)
+	u, ok := userctx.ContextGetUser(ctx)
 	if !ok {
 		log.Error().Msg("error getting user from context")
 	}
@@ -131,7 +131,7 @@ func (s *service) RemovePublicShare(ctx context.Context, req *link.RemovePublicS
 	log := appctx.GetLogger(ctx)
 	log.Info().Str("publicshareprovider", "remove").Msg("remove public share")
 
-	user := user.ContextMustGetUser(ctx)
+	user := userctx.ContextMustGetUser(ctx)
 	err := s.sm.RevokePublicShare(ctx, user, req.Ref)
 	if err != nil {
 		return &link.RemovePublicShareResponse{
@@ -174,7 +174,7 @@ func (s *service) GetPublicShare(ctx context.Context, req *link.GetPublicShareRe
 	log := appctx.GetLogger(ctx)
 	log.Info().Str("publicshareprovider", "get").Msg("get public share")
 
-	u, ok := user.ContextGetUser(ctx)
+	u, ok := userctx.ContextGetUser(ctx)
 	if !ok {
 		log.Error().Msg("error getting user from context")
 	}
@@ -193,7 +193,7 @@ func (s *service) GetPublicShare(ctx context.Context, req *link.GetPublicShareRe
 func (s *service) ListPublicShares(ctx context.Context, req *link.ListPublicSharesRequest) (*link.ListPublicSharesResponse, error) {
 	log := appctx.GetLogger(ctx)
 	log.Info().Str("publicshareprovider", "list").Msg("list public share")
-	user, _ := user.ContextGetUser(ctx)
+	user, _ := userctx.ContextGetUser(ctx)
 
 	shares, err := s.sm.ListPublicShares(ctx, user, req.Filters, &provider.ResourceInfo{}, req.GetSign())
 	if err != nil {
@@ -214,7 +214,7 @@ func (s *service) UpdatePublicShare(ctx context.Context, req *link.UpdatePublicS
 	log := appctx.GetLogger(ctx)
 	log.Info().Str("publicshareprovider", "update").Msg("update public share")
 
-	u, ok := user.ContextGetUser(ctx)
+	u, ok := userctx.ContextGetUser(ctx)
 	if !ok {
 		log.Error().Msg("error getting user from context")
 	}

--- a/internal/grpc/services/usershareprovider/usershareprovider.go
+++ b/internal/grpc/services/usershareprovider/usershareprovider.go
@@ -25,12 +25,12 @@ import (
 	collaboration "github.com/cs3org/go-cs3apis/cs3/sharing/collaboration/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	"github.com/cs3org/reva/pkg/appctx"
+	ctxpkg "github.com/cs3org/reva/pkg/ctx"
 	"github.com/cs3org/reva/pkg/errtypes"
 	"github.com/cs3org/reva/pkg/rgrpc"
 	"github.com/cs3org/reva/pkg/rgrpc/status"
 	"github.com/cs3org/reva/pkg/share"
 	"github.com/cs3org/reva/pkg/share/manager/registry"
-	"github.com/cs3org/reva/pkg/userctx"
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
@@ -109,7 +109,7 @@ func New(m map[string]interface{}, ss *grpc.Server) (rgrpc.Service, error) {
 }
 
 func (s *service) CreateShare(ctx context.Context, req *collaboration.CreateShareRequest) (*collaboration.CreateShareResponse, error) {
-	u := userctx.ContextMustGetUser(ctx)
+	u := ctxpkg.ContextMustGetUser(ctx)
 	if req.Grant.Grantee.Type == provider.GranteeType_GRANTEE_TYPE_USER && req.Grant.Grantee.GetUserId().Idp == "" {
 		// use logged in user Idp as default.
 		g := &userpb.UserId{OpaqueId: req.Grant.Grantee.GetUserId().OpaqueId, Idp: u.Id.Idp, Type: userpb.UserType_USER_TYPE_PRIMARY}

--- a/internal/grpc/services/usershareprovider/usershareprovider.go
+++ b/internal/grpc/services/usershareprovider/usershareprovider.go
@@ -30,7 +30,7 @@ import (
 	"github.com/cs3org/reva/pkg/rgrpc/status"
 	"github.com/cs3org/reva/pkg/share"
 	"github.com/cs3org/reva/pkg/share/manager/registry"
-	"github.com/cs3org/reva/pkg/user"
+	"github.com/cs3org/reva/pkg/userctx"
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
@@ -109,7 +109,7 @@ func New(m map[string]interface{}, ss *grpc.Server) (rgrpc.Service, error) {
 }
 
 func (s *service) CreateShare(ctx context.Context, req *collaboration.CreateShareRequest) (*collaboration.CreateShareResponse, error) {
-	u := user.ContextMustGetUser(ctx)
+	u := userctx.ContextMustGetUser(ctx)
 	if req.Grant.Grantee.Type == provider.GranteeType_GRANTEE_TYPE_USER && req.Grant.Grantee.GetUserId().Idp == "" {
 		// use logged in user Idp as default.
 		g := &userpb.UserId{OpaqueId: req.Grant.Grantee.GetUserId().OpaqueId, Idp: u.Id.Idp, Type: userpb.UserType_USER_TYPE_PRIMARY}

--- a/internal/http/interceptors/auth/auth.go
+++ b/internal/http/interceptors/auth/auth.go
@@ -36,7 +36,7 @@ import (
 	"github.com/cs3org/reva/pkg/sharedconf"
 	"github.com/cs3org/reva/pkg/token"
 	tokenmgr "github.com/cs3org/reva/pkg/token/manager/registry"
-	"github.com/cs3org/reva/pkg/user"
+	"github.com/cs3org/reva/pkg/userctx"
 	"github.com/cs3org/reva/pkg/utils"
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
@@ -253,7 +253,7 @@ func New(m map[string]interface{}, unprotected []string) (global.Middleware, err
 			}
 
 			// store user and core access token in context.
-			ctx = user.ContextSetUser(ctx, u)
+			ctx = userctx.ContextSetUser(ctx, u)
 			ctx = token.ContextSetToken(ctx, tkn)
 			ctx = metadata.AppendToOutgoingContext(ctx, token.TokenHeader, tkn) // TODO(jfd): hardcoded metadata key. use  PerRPCCredentials?
 

--- a/internal/http/interceptors/auth/auth.go
+++ b/internal/http/interceptors/auth/auth.go
@@ -30,13 +30,12 @@ import (
 	"github.com/cs3org/reva/pkg/appctx"
 	"github.com/cs3org/reva/pkg/auth"
 	"github.com/cs3org/reva/pkg/auth/scope"
+	ctxpkg "github.com/cs3org/reva/pkg/ctx"
 	"github.com/cs3org/reva/pkg/rgrpc/status"
 	"github.com/cs3org/reva/pkg/rgrpc/todo/pool"
 	"github.com/cs3org/reva/pkg/rhttp/global"
 	"github.com/cs3org/reva/pkg/sharedconf"
-	"github.com/cs3org/reva/pkg/token"
 	tokenmgr "github.com/cs3org/reva/pkg/token/manager/registry"
-	"github.com/cs3org/reva/pkg/userctx"
 	"github.com/cs3org/reva/pkg/utils"
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
@@ -253,9 +252,9 @@ func New(m map[string]interface{}, unprotected []string) (global.Middleware, err
 			}
 
 			// store user and core access token in context.
-			ctx = userctx.ContextSetUser(ctx, u)
-			ctx = token.ContextSetToken(ctx, tkn)
-			ctx = metadata.AppendToOutgoingContext(ctx, token.TokenHeader, tkn) // TODO(jfd): hardcoded metadata key. use  PerRPCCredentials?
+			ctx = ctxpkg.ContextSetUser(ctx, u)
+			ctx = ctxpkg.ContextSetToken(ctx, tkn)
+			ctx = metadata.AppendToOutgoingContext(ctx, ctxpkg.TokenHeader, tkn) // TODO(jfd): hardcoded metadata key. use  PerRPCCredentials?
 
 			r = r.WithContext(ctx)
 			h.ServeHTTP(w, r)

--- a/internal/http/interceptors/auth/tokenwriter/strategy/header/header.go
+++ b/internal/http/interceptors/auth/tokenwriter/strategy/header/header.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/cs3org/reva/internal/http/interceptors/auth/tokenwriter/registry"
 	"github.com/cs3org/reva/pkg/auth"
-	"github.com/cs3org/reva/pkg/token"
+	ctxpkg "github.com/cs3org/reva/pkg/ctx"
 )
 
 func init() {
@@ -36,7 +36,7 @@ type strategy struct {
 
 // New returns a new token writer strategy that stores token in a header.
 func New(m map[string]interface{}) (auth.TokenWriter, error) {
-	return &strategy{header: token.TokenHeader}, nil
+	return &strategy{header: ctxpkg.TokenHeader}, nil
 }
 
 func (s *strategy) WriteToken(token string, w http.ResponseWriter) {

--- a/internal/http/interceptors/providerauthorizer/providerauthorizer.go
+++ b/internal/http/interceptors/providerauthorizer/providerauthorizer.go
@@ -24,11 +24,11 @@ import (
 
 	ocmprovider "github.com/cs3org/go-cs3apis/cs3/ocm/provider/v1beta1"
 	"github.com/cs3org/reva/pkg/appctx"
+	ctxpkg "github.com/cs3org/reva/pkg/ctx"
 	"github.com/cs3org/reva/pkg/ocm/provider"
 	"github.com/cs3org/reva/pkg/ocm/provider/authorizer/registry"
 	"github.com/cs3org/reva/pkg/rhttp/global"
 	"github.com/cs3org/reva/pkg/rhttp/router"
-	"github.com/cs3org/reva/pkg/userctx"
 	"github.com/cs3org/reva/pkg/utils"
 	"github.com/mitchellh/mapstructure"
 )
@@ -84,7 +84,7 @@ func New(m map[string]interface{}, unprotected []string, ocmPrefix string) (glob
 			}
 
 			err = authorizer.IsProviderAllowed(ctx, &ocmprovider.ProviderInfo{
-				Domain: userctx.ContextMustGetUser(ctx).Id.Idp,
+				Domain: ctxpkg.ContextMustGetUser(ctx).Id.Idp,
 			})
 			if err != nil {
 				log.Error().Err(err).Msg("provider not registered in OCM")

--- a/internal/http/interceptors/providerauthorizer/providerauthorizer.go
+++ b/internal/http/interceptors/providerauthorizer/providerauthorizer.go
@@ -28,7 +28,7 @@ import (
 	"github.com/cs3org/reva/pkg/ocm/provider/authorizer/registry"
 	"github.com/cs3org/reva/pkg/rhttp/global"
 	"github.com/cs3org/reva/pkg/rhttp/router"
-	"github.com/cs3org/reva/pkg/user"
+	"github.com/cs3org/reva/pkg/userctx"
 	"github.com/cs3org/reva/pkg/utils"
 	"github.com/mitchellh/mapstructure"
 )
@@ -84,7 +84,7 @@ func New(m map[string]interface{}, unprotected []string, ocmPrefix string) (glob
 			}
 
 			err = authorizer.IsProviderAllowed(ctx, &ocmprovider.ProviderInfo{
-				Domain: user.ContextMustGetUser(ctx).Id.Idp,
+				Domain: userctx.ContextMustGetUser(ctx).Id.Idp,
 			})
 			if err != nil {
 				log.Error().Err(err).Msg("provider not registered in OCM")

--- a/internal/http/services/ocmd/invites.go
+++ b/internal/http/services/ocmd/invites.go
@@ -29,10 +29,10 @@ import (
 	ocmprovider "github.com/cs3org/go-cs3apis/cs3/ocm/provider/v1beta1"
 	rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
 	"github.com/cs3org/reva/pkg/appctx"
+	ctxpkg "github.com/cs3org/reva/pkg/ctx"
 	"github.com/cs3org/reva/pkg/rgrpc/todo/pool"
 	"github.com/cs3org/reva/pkg/rhttp/router"
 	"github.com/cs3org/reva/pkg/smtpclient"
-	"github.com/cs3org/reva/pkg/userctx"
 	"github.com/cs3org/reva/pkg/utils"
 )
 
@@ -88,7 +88,7 @@ func (h *invitesHandler) generateInviteToken(w http.ResponseWriter, r *http.Requ
 
 	if r.FormValue("recipient") != "" && h.smtpCredentials != nil {
 
-		usr := userctx.ContextMustGetUser(ctx)
+		usr := ctxpkg.ContextMustGetUser(ctx)
 
 		// TODO: the message body needs to point to the meshdirectory service
 		subject := fmt.Sprintf("ScienceMesh: %s wants to collaborate with you", usr.DisplayName)

--- a/internal/http/services/ocmd/invites.go
+++ b/internal/http/services/ocmd/invites.go
@@ -32,7 +32,7 @@ import (
 	"github.com/cs3org/reva/pkg/rgrpc/todo/pool"
 	"github.com/cs3org/reva/pkg/rhttp/router"
 	"github.com/cs3org/reva/pkg/smtpclient"
-	"github.com/cs3org/reva/pkg/user"
+	"github.com/cs3org/reva/pkg/userctx"
 	"github.com/cs3org/reva/pkg/utils"
 )
 
@@ -88,7 +88,7 @@ func (h *invitesHandler) generateInviteToken(w http.ResponseWriter, r *http.Requ
 
 	if r.FormValue("recipient") != "" && h.smtpCredentials != nil {
 
-		usr := user.ContextMustGetUser(ctx)
+		usr := userctx.ContextMustGetUser(ctx)
 
 		// TODO: the message body needs to point to the meshdirectory service
 		subject := fmt.Sprintf("ScienceMesh: %s wants to collaborate with you", usr.DisplayName)

--- a/internal/http/services/owncloud/ocdav/dav.go
+++ b/internal/http/services/owncloud/ocdav/dav.go
@@ -33,8 +33,8 @@ import (
 	"github.com/cs3org/reva/pkg/rgrpc/todo/pool"
 	"github.com/cs3org/reva/pkg/rhttp/router"
 	tokenpkg "github.com/cs3org/reva/pkg/token"
-	"github.com/cs3org/reva/pkg/user"
-	ctxuser "github.com/cs3org/reva/pkg/user"
+	"github.com/cs3org/reva/pkg/userctx"
+	ctxuser "github.com/cs3org/reva/pkg/userctx"
 	"google.golang.org/grpc/metadata"
 )
 
@@ -205,7 +205,7 @@ func (h *DavHandler) Handler(s *svc) http.Handler {
 			}
 
 			ctx = tokenpkg.ContextSetToken(ctx, res.Token)
-			ctx = user.ContextSetUser(ctx, res.User)
+			ctx = userctx.ContextSetUser(ctx, res.User)
 			ctx = metadata.AppendToOutgoingContext(ctx, tokenpkg.TokenHeader, res.Token)
 
 			r = r.WithContext(ctx)

--- a/internal/http/services/owncloud/ocdav/dav.go
+++ b/internal/http/services/owncloud/ocdav/dav.go
@@ -30,11 +30,9 @@ import (
 	rpcv1beta1 "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	"github.com/cs3org/reva/pkg/appctx"
+	ctxpkg "github.com/cs3org/reva/pkg/ctx"
 	"github.com/cs3org/reva/pkg/rgrpc/todo/pool"
 	"github.com/cs3org/reva/pkg/rhttp/router"
-	tokenpkg "github.com/cs3org/reva/pkg/token"
-	"github.com/cs3org/reva/pkg/userctx"
-	ctxuser "github.com/cs3org/reva/pkg/userctx"
 	"google.golang.org/grpc/metadata"
 )
 
@@ -97,7 +95,7 @@ func (h *DavHandler) Handler(s *svc) http.Handler {
 		// https://github.com/owncloud/core/blob/18475dac812064b21dabcc50f25ef3ffe55691a5/tests/acceptance/features/apiWebdavOperations/propfind.feature
 		if r.URL.Path == "/files" {
 			log.Debug().Str("path", r.URL.Path).Msg("method not allowed")
-			contextUser, ok := ctxuser.ContextGetUser(ctx)
+			contextUser, ok := ctxpkg.ContextGetUser(ctx)
 			if ok {
 				r.URL.Path = path.Join(r.URL.Path, contextUser.Username)
 			}
@@ -137,7 +135,7 @@ func (h *DavHandler) Handler(s *svc) http.Handler {
 			requestUserID, r.URL.Path = router.ShiftPath(r.URL.Path)
 
 			// note: some requests like OPTIONS don't forward the user
-			contextUser, ok := ctxuser.ContextGetUser(ctx)
+			contextUser, ok := ctxpkg.ContextGetUser(ctx)
 			if ok && isOwner(requestUserID, contextUser) {
 				// use home storage handler when user was detected
 				base := path.Join(ctx.Value(ctxKeyBaseURI).(string), "files", requestUserID)
@@ -204,9 +202,9 @@ func (h *DavHandler) Handler(s *svc) http.Handler {
 				return
 			}
 
-			ctx = tokenpkg.ContextSetToken(ctx, res.Token)
-			ctx = userctx.ContextSetUser(ctx, res.User)
-			ctx = metadata.AppendToOutgoingContext(ctx, tokenpkg.TokenHeader, res.Token)
+			ctx = ctxpkg.ContextSetToken(ctx, res.Token)
+			ctx = ctxpkg.ContextSetUser(ctx, res.User)
+			ctx = metadata.AppendToOutgoingContext(ctx, ctxpkg.TokenHeader, res.Token)
 
 			r = r.WithContext(ctx)
 

--- a/internal/http/services/owncloud/ocdav/ocdav.go
+++ b/internal/http/services/owncloud/ocdav/ocdav.go
@@ -40,7 +40,7 @@ import (
 	"github.com/cs3org/reva/pkg/rhttp/router"
 	"github.com/cs3org/reva/pkg/sharedconf"
 	"github.com/cs3org/reva/pkg/storage/utils/templates"
-	ctxuser "github.com/cs3org/reva/pkg/user"
+	ctxuser "github.com/cs3org/reva/pkg/userctx"
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"

--- a/internal/http/services/owncloud/ocdav/ocdav.go
+++ b/internal/http/services/owncloud/ocdav/ocdav.go
@@ -34,13 +34,13 @@ import (
 	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	"github.com/cs3org/reva/pkg/appctx"
+	ctxpkg "github.com/cs3org/reva/pkg/ctx"
 	"github.com/cs3org/reva/pkg/rgrpc/todo/pool"
 	"github.com/cs3org/reva/pkg/rhttp"
 	"github.com/cs3org/reva/pkg/rhttp/global"
 	"github.com/cs3org/reva/pkg/rhttp/router"
 	"github.com/cs3org/reva/pkg/sharedconf"
 	"github.com/cs3org/reva/pkg/storage/utils/templates"
-	ctxuser "github.com/cs3org/reva/pkg/userctx"
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
@@ -223,7 +223,7 @@ func applyLayout(ctx context.Context, ns string, useLoggedInUserNS bool, request
 	// is not the same as the logged in user. In that case, we'll treat fileOwner
 	// as the username whose files are to be accessed and use that in the
 	// namespace template.
-	u, ok := ctxuser.ContextGetUser(ctx)
+	u, ok := ctxpkg.ContextGetUser(ctx)
 	if !ok || !useLoggedInUserNS {
 		requestUserID, _ := router.ShiftPath(requestPath)
 		u = &userpb.User{

--- a/internal/http/services/owncloud/ocdav/propfind.go
+++ b/internal/http/services/owncloud/ocdav/propfind.go
@@ -41,7 +41,7 @@ import (
 	"github.com/cs3org/reva/internal/grpc/services/storageprovider"
 	"github.com/cs3org/reva/internal/http/services/owncloud/ocs/conversions"
 	"github.com/cs3org/reva/pkg/appctx"
-	ctxuser "github.com/cs3org/reva/pkg/user"
+	ctxuser "github.com/cs3org/reva/pkg/userctx"
 	"github.com/cs3org/reva/pkg/utils"
 	"github.com/rs/zerolog"
 )

--- a/internal/http/services/owncloud/ocdav/propfind.go
+++ b/internal/http/services/owncloud/ocdav/propfind.go
@@ -41,7 +41,7 @@ import (
 	"github.com/cs3org/reva/internal/grpc/services/storageprovider"
 	"github.com/cs3org/reva/internal/http/services/owncloud/ocs/conversions"
 	"github.com/cs3org/reva/pkg/appctx"
-	ctxuser "github.com/cs3org/reva/pkg/userctx"
+	ctxpkg "github.com/cs3org/reva/pkg/ctx"
 	"github.com/cs3org/reva/pkg/utils"
 	"github.com/rs/zerolog"
 )
@@ -568,10 +568,10 @@ func (s *svc) mdToPropResponse(ctx context.Context, pf *propfindXML, md *provide
 				case "public-link-share-owner":
 					if ls != nil && ls.Owner != nil {
 						if isCurrentUserOwner(ctx, ls.Owner) {
-							u := ctxuser.ContextMustGetUser(ctx)
+							u := ctxpkg.ContextMustGetUser(ctx)
 							propstatOK.Prop = append(propstatOK.Prop, s.newProp("oc:public-link-share-owner", u.Username))
 						} else {
-							u, _ := ctxuser.ContextGetUser(ctx)
+							u, _ := ctxpkg.ContextGetUser(ctx)
 							sublog.Error().Interface("share", ls).Interface("user", u).Msg("the current user in the context should be the owner of a public link share")
 							propstatNotFound.Prop = append(propstatNotFound.Prop, s.newProp("oc:public-link-share-owner", ""))
 						}
@@ -600,7 +600,7 @@ func (s *svc) mdToPropResponse(ctx context.Context, pf *propfindXML, md *provide
 				case "owner-id": // phoenix only
 					if md.Owner != nil {
 						if isCurrentUserOwner(ctx, md.Owner) {
-							u := ctxuser.ContextMustGetUser(ctx)
+							u := ctxpkg.ContextMustGetUser(ctx)
 							propstatOK.Prop = append(propstatOK.Prop, s.newProp("oc:owner-id", u.Username))
 						} else {
 							sublog.Debug().Msg("TODO fetch user username")
@@ -673,7 +673,7 @@ func (s *svc) mdToPropResponse(ctx context.Context, pf *propfindXML, md *provide
 				case "owner-display-name": // phoenix only
 					if md.Owner != nil {
 						if isCurrentUserOwner(ctx, md.Owner) {
-							u := ctxuser.ContextMustGetUser(ctx)
+							u := ctxpkg.ContextMustGetUser(ctx)
 							propstatOK.Prop = append(propstatOK.Prop, s.newProp("oc:owner-display-name", u.DisplayName))
 						} else {
 							sublog.Debug().Msg("TODO fetch user displayname")
@@ -836,7 +836,7 @@ func quoteEtag(etag string) string {
 
 // a file is only yours if you are the owner
 func isCurrentUserOwner(ctx context.Context, owner *userv1beta1.UserId) bool {
-	contextUser, ok := ctxuser.ContextGetUser(ctx)
+	contextUser, ok := ctxpkg.ContextGetUser(ctx)
 	if ok && contextUser.Id != nil && owner != nil &&
 		contextUser.Id.Idp == owner.Idp &&
 		contextUser.Id.OpaqueId == owner.OpaqueId {

--- a/internal/http/services/owncloud/ocdav/trashbin.go
+++ b/internal/http/services/owncloud/ocdav/trashbin.go
@@ -36,7 +36,7 @@ import (
 	"github.com/cs3org/reva/pkg/appctx"
 	"github.com/cs3org/reva/pkg/rgrpc/todo/pool"
 	"github.com/cs3org/reva/pkg/rhttp/router"
-	ctxuser "github.com/cs3org/reva/pkg/user"
+	ctxuser "github.com/cs3org/reva/pkg/userctx"
 	"github.com/cs3org/reva/pkg/utils"
 	"go.opencensus.io/trace"
 )

--- a/internal/http/services/owncloud/ocdav/trashbin.go
+++ b/internal/http/services/owncloud/ocdav/trashbin.go
@@ -34,9 +34,9 @@ import (
 	rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	"github.com/cs3org/reva/pkg/appctx"
+	ctxpkg "github.com/cs3org/reva/pkg/ctx"
 	"github.com/cs3org/reva/pkg/rgrpc/todo/pool"
 	"github.com/cs3org/reva/pkg/rhttp/router"
-	ctxuser "github.com/cs3org/reva/pkg/userctx"
 	"github.com/cs3org/reva/pkg/utils"
 	"go.opencensus.io/trace"
 )
@@ -71,7 +71,7 @@ func (h *TrashbinHandler) Handler(s *svc) http.Handler {
 			return
 		}
 
-		u, ok := ctxuser.ContextGetUser(ctx)
+		u, ok := ctxpkg.ContextGetUser(ctx)
 		if !ok {
 			w.WriteHeader(http.StatusBadRequest)
 			return

--- a/internal/http/services/owncloud/ocs/handlers/cloud/user/user.go
+++ b/internal/http/services/owncloud/ocs/handlers/cloud/user/user.go
@@ -23,7 +23,7 @@ import (
 	"net/http"
 
 	"github.com/cs3org/reva/internal/http/services/owncloud/ocs/response"
-	"github.com/cs3org/reva/pkg/user"
+	"github.com/cs3org/reva/pkg/userctx"
 )
 
 // The Handler renders the user endpoint
@@ -34,7 +34,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
 	// TODO move user to handler parameter?
-	u, ok := user.ContextGetUser(ctx)
+	u, ok := userctx.ContextGetUser(ctx)
 	if !ok {
 		response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "missing user in context", fmt.Errorf("missing user in context"))
 		return

--- a/internal/http/services/owncloud/ocs/handlers/cloud/user/user.go
+++ b/internal/http/services/owncloud/ocs/handlers/cloud/user/user.go
@@ -23,7 +23,7 @@ import (
 	"net/http"
 
 	"github.com/cs3org/reva/internal/http/services/owncloud/ocs/response"
-	"github.com/cs3org/reva/pkg/userctx"
+	ctxpkg "github.com/cs3org/reva/pkg/ctx"
 )
 
 // The Handler renders the user endpoint
@@ -34,7 +34,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
 	// TODO move user to handler parameter?
-	u, ok := userctx.ContextGetUser(ctx)
+	u, ok := ctxpkg.ContextGetUser(ctx)
 	if !ok {
 		response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "missing user in context", fmt.Errorf("missing user in context"))
 		return

--- a/internal/http/services/owncloud/ocs/handlers/cloud/users/users.go
+++ b/internal/http/services/owncloud/ocs/handlers/cloud/users/users.go
@@ -32,7 +32,7 @@ import (
 	"github.com/cs3org/reva/pkg/appctx"
 	"github.com/cs3org/reva/pkg/rgrpc/todo/pool"
 	"github.com/cs3org/reva/pkg/rhttp/router"
-	ctxuser "github.com/cs3org/reva/pkg/user"
+	ctxuser "github.com/cs3org/reva/pkg/userctx"
 )
 
 // Handler renders user data for the user id given in the url path

--- a/internal/http/services/owncloud/ocs/handlers/cloud/users/users.go
+++ b/internal/http/services/owncloud/ocs/handlers/cloud/users/users.go
@@ -30,9 +30,9 @@ import (
 	"github.com/cs3org/reva/internal/http/services/owncloud/ocs/config"
 	"github.com/cs3org/reva/internal/http/services/owncloud/ocs/response"
 	"github.com/cs3org/reva/pkg/appctx"
+	ctxpkg "github.com/cs3org/reva/pkg/ctx"
 	"github.com/cs3org/reva/pkg/rgrpc/todo/pool"
 	"github.com/cs3org/reva/pkg/rhttp/router"
-	ctxuser "github.com/cs3org/reva/pkg/userctx"
 )
 
 // Handler renders user data for the user id given in the url path
@@ -53,7 +53,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	user, r.URL.Path = router.ShiftPath(r.URL.Path)
 
 	// FIXME use ldap to fetch user info
-	u, ok := ctxuser.ContextGetUser(ctx)
+	u, ok := ctxpkg.ContextGetUser(ctx)
 	if !ok {
 		response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "missing user in context", fmt.Errorf("missing user in context"))
 		return

--- a/pkg/app/provider/wopi/wopi.go
+++ b/pkg/app/provider/wopi/wopi.go
@@ -37,9 +37,9 @@ import (
 	"github.com/cs3org/reva/pkg/app"
 	"github.com/cs3org/reva/pkg/app/provider/registry"
 	"github.com/cs3org/reva/pkg/appctx"
+	ctxpkg "github.com/cs3org/reva/pkg/ctx"
 	"github.com/cs3org/reva/pkg/mime"
 	"github.com/cs3org/reva/pkg/rhttp"
-	"github.com/cs3org/reva/pkg/userctx"
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
 )
@@ -129,7 +129,7 @@ func (p *wopiProvider) GetAppURL(ctx context.Context, resource *provider.Resourc
 	// TODO the folder URL should be resolved as e.g. `'https://cernbox.cern.ch/index.php/apps/files/?dir=' + filepath.Dir(req.Ref.GetPath())`
 	// or should be deprecated/removed altogether, needs discussion and decision.
 	// q.Add("folderurl", "...")
-	u, ok := userctx.ContextGetUser(ctx)
+	u, ok := ctxpkg.ContextGetUser(ctx)
 	if ok { // else defaults to "Anonymous Guest"
 		q.Add("username", u.Username)
 	}

--- a/pkg/app/provider/wopi/wopi.go
+++ b/pkg/app/provider/wopi/wopi.go
@@ -39,7 +39,7 @@ import (
 	"github.com/cs3org/reva/pkg/appctx"
 	"github.com/cs3org/reva/pkg/mime"
 	"github.com/cs3org/reva/pkg/rhttp"
-	"github.com/cs3org/reva/pkg/user"
+	"github.com/cs3org/reva/pkg/userctx"
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
 )
@@ -129,7 +129,7 @@ func (p *wopiProvider) GetAppURL(ctx context.Context, resource *provider.Resourc
 	// TODO the folder URL should be resolved as e.g. `'https://cernbox.cern.ch/index.php/apps/files/?dir=' + filepath.Dir(req.Ref.GetPath())`
 	// or should be deprecated/removed altogether, needs discussion and decision.
 	// q.Add("folderurl", "...")
-	u, ok := user.ContextGetUser(ctx)
+	u, ok := userctx.ContextGetUser(ctx)
 	if ok { // else defaults to "Anonymous Guest"
 		q.Add("username", u.Username)
 	}

--- a/pkg/appauth/manager/json/json.go
+++ b/pkg/appauth/manager/json/json.go
@@ -32,8 +32,8 @@ import (
 	typespb "github.com/cs3org/go-cs3apis/cs3/types/v1beta1"
 	"github.com/cs3org/reva/pkg/appauth"
 	"github.com/cs3org/reva/pkg/appauth/manager/registry"
+	ctxpkg "github.com/cs3org/reva/pkg/ctx"
 	"github.com/cs3org/reva/pkg/errtypes"
-	"github.com/cs3org/reva/pkg/userctx"
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
 	"github.com/sethvargo/go-password/password"
@@ -137,7 +137,7 @@ func (mgr *jsonManager) GenerateAppPassword(ctx context.Context, scope map[strin
 	if err != nil {
 		return nil, errors.Wrap(err, "error creating new token")
 	}
-	userID := userctx.ContextMustGetUser(ctx).GetId()
+	userID := ctxpkg.ContextMustGetUser(ctx).GetId()
 	ctime := now()
 
 	password := string(tokenHashed)
@@ -171,7 +171,7 @@ func (mgr *jsonManager) GenerateAppPassword(ctx context.Context, scope map[strin
 }
 
 func (mgr *jsonManager) ListAppPasswords(ctx context.Context) ([]*apppb.AppPassword, error) {
-	userID := userctx.ContextMustGetUser(ctx).GetId()
+	userID := ctxpkg.ContextMustGetUser(ctx).GetId()
 	mgr.Lock()
 	defer mgr.Unlock()
 	appPasswords := []*apppb.AppPassword{}
@@ -182,7 +182,7 @@ func (mgr *jsonManager) ListAppPasswords(ctx context.Context) ([]*apppb.AppPassw
 }
 
 func (mgr *jsonManager) InvalidateAppPassword(ctx context.Context, password string) error {
-	userID := userctx.ContextMustGetUser(ctx).GetId()
+	userID := ctxpkg.ContextMustGetUser(ctx).GetId()
 	mgr.Lock()
 	defer mgr.Unlock()
 

--- a/pkg/appauth/manager/json/json.go
+++ b/pkg/appauth/manager/json/json.go
@@ -33,7 +33,7 @@ import (
 	"github.com/cs3org/reva/pkg/appauth"
 	"github.com/cs3org/reva/pkg/appauth/manager/registry"
 	"github.com/cs3org/reva/pkg/errtypes"
-	"github.com/cs3org/reva/pkg/user"
+	"github.com/cs3org/reva/pkg/userctx"
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
 	"github.com/sethvargo/go-password/password"
@@ -137,7 +137,7 @@ func (mgr *jsonManager) GenerateAppPassword(ctx context.Context, scope map[strin
 	if err != nil {
 		return nil, errors.Wrap(err, "error creating new token")
 	}
-	userID := user.ContextMustGetUser(ctx).GetId()
+	userID := userctx.ContextMustGetUser(ctx).GetId()
 	ctime := now()
 
 	password := string(tokenHashed)
@@ -171,7 +171,7 @@ func (mgr *jsonManager) GenerateAppPassword(ctx context.Context, scope map[strin
 }
 
 func (mgr *jsonManager) ListAppPasswords(ctx context.Context) ([]*apppb.AppPassword, error) {
-	userID := user.ContextMustGetUser(ctx).GetId()
+	userID := userctx.ContextMustGetUser(ctx).GetId()
 	mgr.Lock()
 	defer mgr.Unlock()
 	appPasswords := []*apppb.AppPassword{}
@@ -182,7 +182,7 @@ func (mgr *jsonManager) ListAppPasswords(ctx context.Context) ([]*apppb.AppPassw
 }
 
 func (mgr *jsonManager) InvalidateAppPassword(ctx context.Context, password string) error {
-	userID := user.ContextMustGetUser(ctx).GetId()
+	userID := userctx.ContextMustGetUser(ctx).GetId()
 	mgr.Lock()
 	defer mgr.Unlock()
 

--- a/pkg/appauth/manager/json/json_test.go
+++ b/pkg/appauth/manager/json/json_test.go
@@ -32,7 +32,7 @@ import (
 	apppb "github.com/cs3org/go-cs3apis/cs3/auth/applications/v1beta1"
 	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	typespb "github.com/cs3org/go-cs3apis/cs3/types/v1beta1"
-	"github.com/cs3org/reva/pkg/userctx"
+	ctxpkg "github.com/cs3org/reva/pkg/ctx"
 	"github.com/gdexlab/go-render/render"
 	"github.com/sethvargo/go-password/password"
 	"golang.org/x/crypto/bcrypt"
@@ -141,7 +141,7 @@ func TestNewManager(t *testing.T) {
 
 func TestGenerateAppPassword(t *testing.T) {
 	userTest := &userpb.User{Id: &userpb.UserId{Idp: "0"}, Username: "Test User"}
-	ctx := userctx.ContextSetUser(context.Background(), userTest)
+	ctx := ctxpkg.ContextSetUser(context.Background(), userTest)
 	tempDir := createTempDir(t, "jsonappauth_test")
 	defer os.RemoveAll(tempDir)
 
@@ -293,7 +293,7 @@ func TestGenerateAppPassword(t *testing.T) {
 func TestListAppPasswords(t *testing.T) {
 	user0Test := &userpb.User{Id: &userpb.UserId{Idp: "0"}}
 	user1Test := &userpb.User{Id: &userpb.UserId{Idp: "1"}}
-	ctx := userctx.ContextSetUser(context.Background(), user0Test)
+	ctx := ctxpkg.ContextSetUser(context.Background(), user0Test)
 	tempDir := createTempDir(t, "jsonappauth_test")
 	defer os.RemoveAll(tempDir)
 
@@ -420,7 +420,7 @@ func TestListAppPasswords(t *testing.T) {
 
 func TestInvalidateAppPassword(t *testing.T) {
 	userTest := &userpb.User{Id: &userpb.UserId{Idp: "0"}}
-	ctx := userctx.ContextSetUser(context.Background(), userTest)
+	ctx := ctxpkg.ContextSetUser(context.Background(), userTest)
 	tempDir := createTempDir(t, "jsonappauth_test")
 	defer os.RemoveAll(tempDir)
 
@@ -546,7 +546,7 @@ func TestInvalidateAppPassword(t *testing.T) {
 
 func TestGetAppPassword(t *testing.T) {
 	userTest := &userpb.User{Id: &userpb.UserId{Idp: "0"}}
-	ctx := userctx.ContextSetUser(context.Background(), userTest)
+	ctx := ctxpkg.ContextSetUser(context.Background(), userTest)
 	tempDir := createTempDir(t, "jsonappauth_test")
 	defer os.RemoveAll(tempDir)
 

--- a/pkg/appauth/manager/json/json_test.go
+++ b/pkg/appauth/manager/json/json_test.go
@@ -32,7 +32,7 @@ import (
 	apppb "github.com/cs3org/go-cs3apis/cs3/auth/applications/v1beta1"
 	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	typespb "github.com/cs3org/go-cs3apis/cs3/types/v1beta1"
-	"github.com/cs3org/reva/pkg/user"
+	"github.com/cs3org/reva/pkg/userctx"
 	"github.com/gdexlab/go-render/render"
 	"github.com/sethvargo/go-password/password"
 	"golang.org/x/crypto/bcrypt"
@@ -141,7 +141,7 @@ func TestNewManager(t *testing.T) {
 
 func TestGenerateAppPassword(t *testing.T) {
 	userTest := &userpb.User{Id: &userpb.UserId{Idp: "0"}, Username: "Test User"}
-	ctx := user.ContextSetUser(context.Background(), userTest)
+	ctx := userctx.ContextSetUser(context.Background(), userTest)
 	tempDir := createTempDir(t, "jsonappauth_test")
 	defer os.RemoveAll(tempDir)
 
@@ -293,7 +293,7 @@ func TestGenerateAppPassword(t *testing.T) {
 func TestListAppPasswords(t *testing.T) {
 	user0Test := &userpb.User{Id: &userpb.UserId{Idp: "0"}}
 	user1Test := &userpb.User{Id: &userpb.UserId{Idp: "1"}}
-	ctx := user.ContextSetUser(context.Background(), user0Test)
+	ctx := userctx.ContextSetUser(context.Background(), user0Test)
 	tempDir := createTempDir(t, "jsonappauth_test")
 	defer os.RemoveAll(tempDir)
 
@@ -420,7 +420,7 @@ func TestListAppPasswords(t *testing.T) {
 
 func TestInvalidateAppPassword(t *testing.T) {
 	userTest := &userpb.User{Id: &userpb.UserId{Idp: "0"}}
-	ctx := user.ContextSetUser(context.Background(), userTest)
+	ctx := userctx.ContextSetUser(context.Background(), userTest)
 	tempDir := createTempDir(t, "jsonappauth_test")
 	defer os.RemoveAll(tempDir)
 
@@ -546,7 +546,7 @@ func TestInvalidateAppPassword(t *testing.T) {
 
 func TestGetAppPassword(t *testing.T) {
 	userTest := &userpb.User{Id: &userpb.UserId{Idp: "0"}}
-	ctx := user.ContextSetUser(context.Background(), userTest)
+	ctx := userctx.ContextSetUser(context.Background(), userTest)
 	tempDir := createTempDir(t, "jsonappauth_test")
 	defer os.RemoveAll(tempDir)
 

--- a/pkg/cbox/share/sql/sql.go
+++ b/pkg/cbox/share/sql/sql.go
@@ -31,10 +31,10 @@ import (
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	typespb "github.com/cs3org/go-cs3apis/cs3/types/v1beta1"
 	conversions "github.com/cs3org/reva/pkg/cbox/utils"
+	ctxpkg "github.com/cs3org/reva/pkg/ctx"
 	"github.com/cs3org/reva/pkg/errtypes"
 	"github.com/cs3org/reva/pkg/share"
 	"github.com/cs3org/reva/pkg/share/manager/registry"
-	"github.com/cs3org/reva/pkg/userctx"
 	"github.com/cs3org/reva/pkg/utils"
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
@@ -88,7 +88,7 @@ func parseConfig(m map[string]interface{}) (*config, error) {
 }
 
 func (m *mgr) Share(ctx context.Context, md *provider.ResourceInfo, g *collaboration.ShareGrant) (*collaboration.Share, error) {
-	user := userctx.ContextMustGetUser(ctx)
+	user := ctxpkg.ContextMustGetUser(ctx)
 
 	// do not allow share to myself or the owner if share is for a user
 	// TODO(labkode): should not this be caught already at the gw level?
@@ -159,7 +159,7 @@ func (m *mgr) Share(ctx context.Context, md *provider.ResourceInfo, g *collabora
 }
 
 func (m *mgr) getByID(ctx context.Context, id *collaboration.ShareId) (*collaboration.Share, error) {
-	uid := conversions.FormatUserID(userctx.ContextMustGetUser(ctx).Id)
+	uid := conversions.FormatUserID(ctxpkg.ContextMustGetUser(ctx).Id)
 	s := conversions.DBShare{ID: id.OpaqueId}
 	query := "select coalesce(uid_owner, '') as uid_owner, coalesce(uid_initiator, '') as uid_initiator, coalesce(share_with, '') as share_with, coalesce(fileid_prefix, '') as fileid_prefix, coalesce(item_source, '') as item_source, stime, permissions, share_type FROM oc_share WHERE (orphan = 0 or orphan IS NULL) AND id=? AND (uid_owner=? or uid_initiator=?)"
 	if err := m.db.QueryRow(query, id.OpaqueId, uid, uid).Scan(&s.UIDOwner, &s.UIDInitiator, &s.ShareWith, &s.Prefix, &s.ItemSource, &s.STime, &s.Permissions, &s.ShareType); err != nil {
@@ -173,7 +173,7 @@ func (m *mgr) getByID(ctx context.Context, id *collaboration.ShareId) (*collabor
 
 func (m *mgr) getByKey(ctx context.Context, key *collaboration.ShareKey) (*collaboration.Share, error) {
 	owner := conversions.FormatUserID(key.Owner)
-	uid := conversions.FormatUserID(userctx.ContextMustGetUser(ctx).Id)
+	uid := conversions.FormatUserID(ctxpkg.ContextMustGetUser(ctx).Id)
 
 	s := conversions.DBShare{}
 	shareType, shareWith := conversions.FormatGrantee(key.Grantee)
@@ -207,7 +207,7 @@ func (m *mgr) GetShare(ctx context.Context, ref *collaboration.ShareReference) (
 }
 
 func (m *mgr) Unshare(ctx context.Context, ref *collaboration.ShareReference) error {
-	uid := conversions.FormatUserID(userctx.ContextMustGetUser(ctx).Id)
+	uid := conversions.FormatUserID(ctxpkg.ContextMustGetUser(ctx).Id)
 	var query string
 	params := []interface{}{}
 	switch {
@@ -245,7 +245,7 @@ func (m *mgr) Unshare(ctx context.Context, ref *collaboration.ShareReference) er
 
 func (m *mgr) UpdateShare(ctx context.Context, ref *collaboration.ShareReference, p *collaboration.SharePermissions) (*collaboration.Share, error) {
 	permissions := conversions.SharePermToInt(p.Permissions)
-	uid := conversions.FormatUserID(userctx.ContextMustGetUser(ctx).Id)
+	uid := conversions.FormatUserID(ctxpkg.ContextMustGetUser(ctx).Id)
 
 	var query string
 	params := []interface{}{}
@@ -275,7 +275,7 @@ func (m *mgr) UpdateShare(ctx context.Context, ref *collaboration.ShareReference
 }
 
 func (m *mgr) ListShares(ctx context.Context, filters []*collaboration.ListSharesRequest_Filter) ([]*collaboration.Share, error) {
-	uid := conversions.FormatUserID(userctx.ContextMustGetUser(ctx).Id)
+	uid := conversions.FormatUserID(ctxpkg.ContextMustGetUser(ctx).Id)
 	query := "select coalesce(uid_owner, '') as uid_owner, coalesce(uid_initiator, '') as uid_initiator, coalesce(share_with, '') as share_with, coalesce(fileid_prefix, '') as fileid_prefix, coalesce(item_source, '') as item_source, id, stime, permissions, share_type FROM oc_share WHERE (orphan = 0 or orphan IS NULL) AND (uid_owner=? or uid_initiator=?) AND (share_type=? OR share_type=?)"
 	var filterQuery string
 	params := []interface{}{uid, uid, 0, 1}
@@ -315,7 +315,7 @@ func (m *mgr) ListShares(ctx context.Context, filters []*collaboration.ListShare
 
 // we list the shares that are targeted to the user in context or to the user groups.
 func (m *mgr) ListReceivedShares(ctx context.Context) ([]*collaboration.ReceivedShare, error) {
-	user := userctx.ContextMustGetUser(ctx)
+	user := ctxpkg.ContextMustGetUser(ctx)
 	uid := conversions.FormatUserID(user.Id)
 
 	params := []interface{}{uid, uid, uid, uid}
@@ -352,7 +352,7 @@ func (m *mgr) ListReceivedShares(ctx context.Context) ([]*collaboration.Received
 }
 
 func (m *mgr) getReceivedByID(ctx context.Context, id *collaboration.ShareId) (*collaboration.ReceivedShare, error) {
-	user := userctx.ContextMustGetUser(ctx)
+	user := ctxpkg.ContextMustGetUser(ctx)
 	uid := conversions.FormatUserID(user.Id)
 
 	params := []interface{}{uid, id.OpaqueId, uid}
@@ -377,7 +377,7 @@ func (m *mgr) getReceivedByID(ctx context.Context, id *collaboration.ShareId) (*
 }
 
 func (m *mgr) getReceivedByKey(ctx context.Context, key *collaboration.ShareKey) (*collaboration.ReceivedShare, error) {
-	user := userctx.ContextMustGetUser(ctx)
+	user := ctxpkg.ContextMustGetUser(ctx)
 	uid := conversions.FormatUserID(user.Id)
 
 	shareType, shareWith := conversions.FormatGrantee(key.Grantee)
@@ -424,7 +424,7 @@ func (m *mgr) GetReceivedShare(ctx context.Context, ref *collaboration.ShareRefe
 }
 
 func (m *mgr) UpdateReceivedShare(ctx context.Context, ref *collaboration.ShareReference, f *collaboration.UpdateReceivedShareRequest_UpdateField) (*collaboration.ReceivedShare, error) {
-	user := userctx.ContextMustGetUser(ctx)
+	user := ctxpkg.ContextMustGetUser(ctx)
 
 	rs, err := m.GetReceivedShare(ctx, ref)
 	if err != nil {

--- a/pkg/cbox/storage/eoshomewrapper/eoshomewrapper.go
+++ b/pkg/cbox/storage/eoshomewrapper/eoshomewrapper.go
@@ -25,10 +25,10 @@ import (
 
 	"github.com/Masterminds/sprig"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+	ctxpkg "github.com/cs3org/reva/pkg/ctx"
 	"github.com/cs3org/reva/pkg/storage"
 	"github.com/cs3org/reva/pkg/storage/fs/registry"
 	"github.com/cs3org/reva/pkg/storage/utils/eosfs"
-	"github.com/cs3org/reva/pkg/userctx"
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
 )
@@ -113,7 +113,7 @@ func (w *wrapper) ListFolder(ctx context.Context, ref *provider.Reference, mdKey
 }
 
 func (w *wrapper) getMountID(ctx context.Context, r *provider.ResourceInfo) string {
-	u := userctx.ContextMustGetUser(ctx)
+	u := ctxpkg.ContextMustGetUser(ctx)
 	b := bytes.Buffer{}
 	if err := w.mountIDTemplate.Execute(&b, u); err != nil {
 		return ""

--- a/pkg/cbox/storage/eoshomewrapper/eoshomewrapper.go
+++ b/pkg/cbox/storage/eoshomewrapper/eoshomewrapper.go
@@ -28,7 +28,7 @@ import (
 	"github.com/cs3org/reva/pkg/storage"
 	"github.com/cs3org/reva/pkg/storage/fs/registry"
 	"github.com/cs3org/reva/pkg/storage/utils/eosfs"
-	"github.com/cs3org/reva/pkg/user"
+	"github.com/cs3org/reva/pkg/userctx"
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
 )
@@ -113,7 +113,7 @@ func (w *wrapper) ListFolder(ctx context.Context, ref *provider.Reference, mdKey
 }
 
 func (w *wrapper) getMountID(ctx context.Context, r *provider.ResourceInfo) string {
-	u := user.ContextMustGetUser(ctx)
+	u := userctx.ContextMustGetUser(ctx)
 	b := bytes.Buffer{}
 	if err := w.mountIDTemplate.Execute(&b, u); err != nil {
 		return ""

--- a/pkg/ctx/tokenctx.go
+++ b/pkg/ctx/tokenctx.go
@@ -16,29 +16,34 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-package header
+package ctx
 
 import (
-	"net/http"
-
-	"github.com/cs3org/reva/internal/http/interceptors/auth/token/registry"
-	"github.com/cs3org/reva/pkg/auth"
-	ctxpkg "github.com/cs3org/reva/pkg/ctx"
+	"context"
 )
 
-func init() {
-	registry.Register("header", New)
+// TokenHeader is the header to be used across grpc and http services
+// to forward the access token.
+const TokenHeader = "x-access-token"
+
+const tokenKey key = iota
+
+// ContextGetToken returns the token if set in the given context.
+func ContextGetToken(ctx context.Context) (string, bool) {
+	u, ok := ctx.Value(tokenKey).(string)
+	return u, ok
 }
 
-type strategy struct {
-	header string
+// ContextMustGetToken panics if token is not in context.
+func ContextMustGetToken(ctx context.Context) string {
+	u, ok := ContextGetToken(ctx)
+	if !ok {
+		panic("token not found in context")
+	}
+	return u
 }
 
-// New returns a new auth strategy that checks for basic auth.
-func New(m map[string]interface{}) (auth.TokenStrategy, error) {
-	return &strategy{header: ctxpkg.TokenHeader}, nil
-}
-
-func (s *strategy) GetToken(r *http.Request) string {
-	return r.Header.Get(s.header)
+// ContextSetToken stores the token in the context.
+func ContextSetToken(ctx context.Context, t string) context.Context {
+	return context.WithValue(ctx, tokenKey, t)
 }

--- a/pkg/ctx/tokenctx.go
+++ b/pkg/ctx/tokenctx.go
@@ -26,8 +26,6 @@ import (
 // to forward the access token.
 const TokenHeader = "x-access-token"
 
-const tokenKey key = iota
-
 // ContextGetToken returns the token if set in the given context.
 func ContextGetToken(ctx context.Context) (string, bool) {
 	u, ok := ctx.Value(tokenKey).(string)

--- a/pkg/ctx/userctx.go
+++ b/pkg/ctx/userctx.go
@@ -16,7 +16,7 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-package userctx
+package ctx
 
 import (
 	"context"

--- a/pkg/ctx/userctx.go
+++ b/pkg/ctx/userctx.go
@@ -28,6 +28,7 @@ type key int
 
 const (
 	userKey key = iota
+	tokenKey
 	idKey
 )
 

--- a/pkg/ocm/invite/manager/json/json.go
+++ b/pkg/ocm/invite/manager/json/json.go
@@ -39,7 +39,7 @@ import (
 	"github.com/cs3org/reva/pkg/ocm/invite/manager/registry"
 	"github.com/cs3org/reva/pkg/ocm/invite/token"
 	"github.com/cs3org/reva/pkg/rhttp"
-	"github.com/cs3org/reva/pkg/user"
+	"github.com/cs3org/reva/pkg/userctx"
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
 )
@@ -178,7 +178,7 @@ func (model *inviteModel) Save() error {
 
 func (m *manager) GenerateToken(ctx context.Context) (*invitepb.InviteToken, error) {
 
-	contexUser := user.ContextMustGetUser(ctx)
+	contexUser := userctx.ContextMustGetUser(ctx)
 	inviteToken, err := token.CreateToken(m.config.Expiration, contexUser.GetId())
 	if err != nil {
 		return nil, err
@@ -199,7 +199,7 @@ func (m *manager) GenerateToken(ctx context.Context) (*invitepb.InviteToken, err
 
 func (m *manager) ForwardInvite(ctx context.Context, invite *invitepb.InviteToken, originProvider *ocmprovider.ProviderInfo) error {
 
-	contextUser := user.ContextMustGetUser(ctx)
+	contextUser := userctx.ContextMustGetUser(ctx)
 	requestBody := url.Values{
 		"token":             {invite.GetToken()},
 		"userID":            {contextUser.GetId().GetOpaqueId()},
@@ -275,7 +275,7 @@ func (m *manager) AcceptInvite(ctx context.Context, invite *invitepb.InviteToken
 
 func (m *manager) GetAcceptedUser(ctx context.Context, remoteUserID *userpb.UserId) (*userpb.User, error) {
 
-	userKey := user.ContextMustGetUser(ctx).GetId().GetOpaqueId()
+	userKey := userctx.ContextMustGetUser(ctx).GetId().GetOpaqueId()
 	for _, acceptedUser := range m.model.AcceptedUsers[userKey] {
 		if (acceptedUser.Id.GetOpaqueId() == remoteUserID.OpaqueId) && (remoteUserID.Idp == "" || acceptedUser.Id.GetIdp() == remoteUserID.Idp) {
 			return acceptedUser, nil
@@ -286,7 +286,7 @@ func (m *manager) GetAcceptedUser(ctx context.Context, remoteUserID *userpb.User
 
 func (m *manager) FindAcceptedUsers(ctx context.Context, query string) ([]*userpb.User, error) {
 	users := []*userpb.User{}
-	userKey := user.ContextMustGetUser(ctx).GetId().GetOpaqueId()
+	userKey := userctx.ContextMustGetUser(ctx).GetId().GetOpaqueId()
 	for _, acceptedUser := range m.model.AcceptedUsers[userKey] {
 		if query == "" || userContains(acceptedUser, query) {
 			users = append(users, acceptedUser)

--- a/pkg/ocm/invite/manager/json/json.go
+++ b/pkg/ocm/invite/manager/json/json.go
@@ -34,12 +34,12 @@ import (
 	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	invitepb "github.com/cs3org/go-cs3apis/cs3/ocm/invite/v1beta1"
 	ocmprovider "github.com/cs3org/go-cs3apis/cs3/ocm/provider/v1beta1"
+	ctxpkg "github.com/cs3org/reva/pkg/ctx"
 	"github.com/cs3org/reva/pkg/errtypes"
 	"github.com/cs3org/reva/pkg/ocm/invite"
 	"github.com/cs3org/reva/pkg/ocm/invite/manager/registry"
 	"github.com/cs3org/reva/pkg/ocm/invite/token"
 	"github.com/cs3org/reva/pkg/rhttp"
-	"github.com/cs3org/reva/pkg/userctx"
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
 )
@@ -178,7 +178,7 @@ func (model *inviteModel) Save() error {
 
 func (m *manager) GenerateToken(ctx context.Context) (*invitepb.InviteToken, error) {
 
-	contexUser := userctx.ContextMustGetUser(ctx)
+	contexUser := ctxpkg.ContextMustGetUser(ctx)
 	inviteToken, err := token.CreateToken(m.config.Expiration, contexUser.GetId())
 	if err != nil {
 		return nil, err
@@ -199,7 +199,7 @@ func (m *manager) GenerateToken(ctx context.Context) (*invitepb.InviteToken, err
 
 func (m *manager) ForwardInvite(ctx context.Context, invite *invitepb.InviteToken, originProvider *ocmprovider.ProviderInfo) error {
 
-	contextUser := userctx.ContextMustGetUser(ctx)
+	contextUser := ctxpkg.ContextMustGetUser(ctx)
 	requestBody := url.Values{
 		"token":             {invite.GetToken()},
 		"userID":            {contextUser.GetId().GetOpaqueId()},
@@ -275,7 +275,7 @@ func (m *manager) AcceptInvite(ctx context.Context, invite *invitepb.InviteToken
 
 func (m *manager) GetAcceptedUser(ctx context.Context, remoteUserID *userpb.UserId) (*userpb.User, error) {
 
-	userKey := userctx.ContextMustGetUser(ctx).GetId().GetOpaqueId()
+	userKey := ctxpkg.ContextMustGetUser(ctx).GetId().GetOpaqueId()
 	for _, acceptedUser := range m.model.AcceptedUsers[userKey] {
 		if (acceptedUser.Id.GetOpaqueId() == remoteUserID.OpaqueId) && (remoteUserID.Idp == "" || acceptedUser.Id.GetIdp() == remoteUserID.Idp) {
 			return acceptedUser, nil
@@ -286,7 +286,7 @@ func (m *manager) GetAcceptedUser(ctx context.Context, remoteUserID *userpb.User
 
 func (m *manager) FindAcceptedUsers(ctx context.Context, query string) ([]*userpb.User, error) {
 	users := []*userpb.User{}
-	userKey := userctx.ContextMustGetUser(ctx).GetId().GetOpaqueId()
+	userKey := ctxpkg.ContextMustGetUser(ctx).GetId().GetOpaqueId()
 	for _, acceptedUser := range m.model.AcceptedUsers[userKey] {
 		if query == "" || userContains(acceptedUser, query) {
 			users = append(users, acceptedUser)

--- a/pkg/ocm/invite/manager/memory/memory.go
+++ b/pkg/ocm/invite/manager/memory/memory.go
@@ -28,7 +28,7 @@ import (
 	"time"
 
 	"github.com/cs3org/reva/pkg/errtypes"
-	"github.com/cs3org/reva/pkg/user"
+	"github.com/cs3org/reva/pkg/userctx"
 
 	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	invitepb "github.com/cs3org/go-cs3apis/cs3/ocm/invite/v1beta1"
@@ -87,7 +87,7 @@ type config struct {
 
 func (m *manager) GenerateToken(ctx context.Context) (*invitepb.InviteToken, error) {
 
-	ctxUser := user.ContextMustGetUser(ctx)
+	ctxUser := userctx.ContextMustGetUser(ctx)
 	inviteToken, err := token.CreateToken(m.Config.Expiration, ctxUser.GetId())
 	if err != nil {
 		return nil, errors.Wrap(err, "memory: error creating token")
@@ -99,7 +99,7 @@ func (m *manager) GenerateToken(ctx context.Context) (*invitepb.InviteToken, err
 
 func (m *manager) ForwardInvite(ctx context.Context, invite *invitepb.InviteToken, originProvider *ocmprovider.ProviderInfo) error {
 
-	contextUser := user.ContextMustGetUser(ctx)
+	contextUser := userctx.ContextMustGetUser(ctx)
 	requestBody := url.Values{
 		"token":             {invite.GetToken()},
 		"userID":            {contextUser.GetId().GetOpaqueId()},
@@ -172,7 +172,7 @@ func (m *manager) AcceptInvite(ctx context.Context, invite *invitepb.InviteToken
 }
 
 func (m *manager) GetAcceptedUser(ctx context.Context, remoteUserID *userpb.UserId) (*userpb.User, error) {
-	currUser := user.ContextMustGetUser(ctx).GetId().GetOpaqueId()
+	currUser := userctx.ContextMustGetUser(ctx).GetId().GetOpaqueId()
 	usersList, ok := m.AcceptedUsers.Load(currUser)
 	if !ok {
 		return nil, errtypes.NotFound(remoteUserID.OpaqueId)
@@ -188,7 +188,7 @@ func (m *manager) GetAcceptedUser(ctx context.Context, remoteUserID *userpb.User
 }
 
 func (m *manager) FindAcceptedUsers(ctx context.Context, query string) ([]*userpb.User, error) {
-	currUser := user.ContextMustGetUser(ctx).GetId().GetOpaqueId()
+	currUser := userctx.ContextMustGetUser(ctx).GetId().GetOpaqueId()
 	usersList, ok := m.AcceptedUsers.Load(currUser)
 	if !ok {
 		return []*userpb.User{}, nil

--- a/pkg/ocm/invite/manager/memory/memory.go
+++ b/pkg/ocm/invite/manager/memory/memory.go
@@ -27,8 +27,8 @@ import (
 	"sync"
 	"time"
 
+	ctxpkg "github.com/cs3org/reva/pkg/ctx"
 	"github.com/cs3org/reva/pkg/errtypes"
-	"github.com/cs3org/reva/pkg/userctx"
 
 	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	invitepb "github.com/cs3org/go-cs3apis/cs3/ocm/invite/v1beta1"
@@ -87,7 +87,7 @@ type config struct {
 
 func (m *manager) GenerateToken(ctx context.Context) (*invitepb.InviteToken, error) {
 
-	ctxUser := userctx.ContextMustGetUser(ctx)
+	ctxUser := ctxpkg.ContextMustGetUser(ctx)
 	inviteToken, err := token.CreateToken(m.Config.Expiration, ctxUser.GetId())
 	if err != nil {
 		return nil, errors.Wrap(err, "memory: error creating token")
@@ -99,7 +99,7 @@ func (m *manager) GenerateToken(ctx context.Context) (*invitepb.InviteToken, err
 
 func (m *manager) ForwardInvite(ctx context.Context, invite *invitepb.InviteToken, originProvider *ocmprovider.ProviderInfo) error {
 
-	contextUser := userctx.ContextMustGetUser(ctx)
+	contextUser := ctxpkg.ContextMustGetUser(ctx)
 	requestBody := url.Values{
 		"token":             {invite.GetToken()},
 		"userID":            {contextUser.GetId().GetOpaqueId()},
@@ -172,7 +172,7 @@ func (m *manager) AcceptInvite(ctx context.Context, invite *invitepb.InviteToken
 }
 
 func (m *manager) GetAcceptedUser(ctx context.Context, remoteUserID *userpb.UserId) (*userpb.User, error) {
-	currUser := userctx.ContextMustGetUser(ctx).GetId().GetOpaqueId()
+	currUser := ctxpkg.ContextMustGetUser(ctx).GetId().GetOpaqueId()
 	usersList, ok := m.AcceptedUsers.Load(currUser)
 	if !ok {
 		return nil, errtypes.NotFound(remoteUserID.OpaqueId)
@@ -188,7 +188,7 @@ func (m *manager) GetAcceptedUser(ctx context.Context, remoteUserID *userpb.User
 }
 
 func (m *manager) FindAcceptedUsers(ctx context.Context, query string) ([]*userpb.User, error) {
-	currUser := userctx.ContextMustGetUser(ctx).GetId().GetOpaqueId()
+	currUser := ctxpkg.ContextMustGetUser(ctx).GetId().GetOpaqueId()
 	usersList, ok := m.AcceptedUsers.Load(currUser)
 	if !ok {
 		return []*userpb.User{}, nil

--- a/pkg/ocm/share/manager/json/json.go
+++ b/pkg/ocm/share/manager/json/json.go
@@ -36,12 +36,11 @@ import (
 	ocm "github.com/cs3org/go-cs3apis/cs3/sharing/ocm/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	typespb "github.com/cs3org/go-cs3apis/cs3/types/v1beta1"
+	ctxpkg "github.com/cs3org/reva/pkg/ctx"
 	"github.com/cs3org/reva/pkg/errtypes"
 	"github.com/cs3org/reva/pkg/ocm/share"
 	"github.com/cs3org/reva/pkg/ocm/share/manager/registry"
 	"github.com/cs3org/reva/pkg/rhttp"
-	tokenpkg "github.com/cs3org/reva/pkg/token"
-	"github.com/cs3org/reva/pkg/userctx"
 	"github.com/cs3org/reva/pkg/utils"
 	"github.com/google/uuid"
 	"github.com/mitchellh/mapstructure"
@@ -232,7 +231,7 @@ func (m *mgr) Share(ctx context.Context, md *provider.ResourceId, g *ocm.ShareGr
 			},
 		}
 	} else {
-		userID = userctx.ContextMustGetUser(ctx).GetId()
+		userID = ctxpkg.ContextMustGetUser(ctx).GetId()
 	}
 
 	// do not allow share to myself if share is for a user
@@ -269,7 +268,7 @@ func (m *mgr) Share(ctx context.Context, md *provider.ResourceId, g *ocm.ShareGr
 	}
 
 	if isOwnersMeshProvider {
-		token, ok := tokenpkg.ContextGetToken(ctx)
+		token, ok := ctxpkg.ContextGetToken(ctx)
 		if !ok {
 			return nil, errors.New("Could not get token from context")
 		}
@@ -295,7 +294,7 @@ func (m *mgr) Share(ctx context.Context, md *provider.ResourceId, g *ocm.ShareGr
 					"name": "webdav",
 					"options": map[string]string{
 						"permissions": pm,
-						"token":       tokenpkg.ContextMustGetToken(ctx),
+						"token":       ctxpkg.ContextMustGetToken(ctx),
 					},
 				},
 			)
@@ -438,7 +437,7 @@ func (m *mgr) get(ctx context.Context, ref *ocm.ShareReference) (s *ocm.Share, e
 	}
 
 	// check if we are the owner
-	user := userctx.ContextMustGetUser(ctx)
+	user := ctxpkg.ContextMustGetUser(ctx)
 	if utils.UserEqual(user.Id, s.Owner) || utils.UserEqual(user.Id, s.Creator) {
 		return s, nil
 	}
@@ -465,7 +464,7 @@ func (m *mgr) Unshare(ctx context.Context, ref *ocm.ShareReference) error {
 		return err
 	}
 
-	user := userctx.ContextMustGetUser(ctx)
+	user := ctxpkg.ContextMustGetUser(ctx)
 	for id, s := range m.model.Shares {
 		var share ocm.Share
 		if err := utils.UnmarshalJSONToProtoV1([]byte(s.(string)), &share); err != nil {
@@ -508,7 +507,7 @@ func (m *mgr) UpdateShare(ctx context.Context, ref *ocm.ShareReference, p *ocm.S
 		return nil, err
 	}
 
-	user := userctx.ContextMustGetUser(ctx)
+	user := ctxpkg.ContextMustGetUser(ctx)
 	for id, s := range m.model.Shares {
 		var share ocm.Share
 		if err := utils.UnmarshalJSONToProtoV1([]byte(s.(string)), &share); err != nil {
@@ -548,7 +547,7 @@ func (m *mgr) ListShares(ctx context.Context, filters []*ocm.ListOCMSharesReques
 		return nil, err
 	}
 
-	user := userctx.ContextMustGetUser(ctx)
+	user := ctxpkg.ContextMustGetUser(ctx)
 	for _, s := range m.model.Shares {
 		var share ocm.Share
 		if err := utils.UnmarshalJSONToProtoV1([]byte(s.(string)), &share); err != nil {
@@ -584,7 +583,7 @@ func (m *mgr) ListReceivedShares(ctx context.Context) ([]*ocm.ReceivedShare, err
 		return nil, err
 	}
 
-	user := userctx.ContextMustGetUser(ctx)
+	user := ctxpkg.ContextMustGetUser(ctx)
 	for _, s := range m.model.ReceivedShares {
 		var rs ocm.ReceivedShare
 		if err := utils.UnmarshalJSONToProtoV1([]byte(s.(string)), &rs); err != nil {
@@ -623,7 +622,7 @@ func (m *mgr) getReceived(ctx context.Context, ref *ocm.ShareReference) (*ocm.Re
 		return nil, err
 	}
 
-	user := userctx.ContextMustGetUser(ctx)
+	user := ctxpkg.ContextMustGetUser(ctx)
 	for _, s := range m.model.ReceivedShares {
 		var rs ocm.ReceivedShare
 		if err := utils.UnmarshalJSONToProtoV1([]byte(s.(string)), &rs); err != nil {

--- a/pkg/ocm/share/manager/json/json.go
+++ b/pkg/ocm/share/manager/json/json.go
@@ -41,7 +41,7 @@ import (
 	"github.com/cs3org/reva/pkg/ocm/share/manager/registry"
 	"github.com/cs3org/reva/pkg/rhttp"
 	tokenpkg "github.com/cs3org/reva/pkg/token"
-	"github.com/cs3org/reva/pkg/user"
+	"github.com/cs3org/reva/pkg/userctx"
 	"github.com/cs3org/reva/pkg/utils"
 	"github.com/google/uuid"
 	"github.com/mitchellh/mapstructure"
@@ -232,7 +232,7 @@ func (m *mgr) Share(ctx context.Context, md *provider.ResourceId, g *ocm.ShareGr
 			},
 		}
 	} else {
-		userID = user.ContextMustGetUser(ctx).GetId()
+		userID = userctx.ContextMustGetUser(ctx).GetId()
 	}
 
 	// do not allow share to myself if share is for a user
@@ -438,7 +438,7 @@ func (m *mgr) get(ctx context.Context, ref *ocm.ShareReference) (s *ocm.Share, e
 	}
 
 	// check if we are the owner
-	user := user.ContextMustGetUser(ctx)
+	user := userctx.ContextMustGetUser(ctx)
 	if utils.UserEqual(user.Id, s.Owner) || utils.UserEqual(user.Id, s.Creator) {
 		return s, nil
 	}
@@ -465,7 +465,7 @@ func (m *mgr) Unshare(ctx context.Context, ref *ocm.ShareReference) error {
 		return err
 	}
 
-	user := user.ContextMustGetUser(ctx)
+	user := userctx.ContextMustGetUser(ctx)
 	for id, s := range m.model.Shares {
 		var share ocm.Share
 		if err := utils.UnmarshalJSONToProtoV1([]byte(s.(string)), &share); err != nil {
@@ -508,7 +508,7 @@ func (m *mgr) UpdateShare(ctx context.Context, ref *ocm.ShareReference, p *ocm.S
 		return nil, err
 	}
 
-	user := user.ContextMustGetUser(ctx)
+	user := userctx.ContextMustGetUser(ctx)
 	for id, s := range m.model.Shares {
 		var share ocm.Share
 		if err := utils.UnmarshalJSONToProtoV1([]byte(s.(string)), &share); err != nil {
@@ -548,7 +548,7 @@ func (m *mgr) ListShares(ctx context.Context, filters []*ocm.ListOCMSharesReques
 		return nil, err
 	}
 
-	user := user.ContextMustGetUser(ctx)
+	user := userctx.ContextMustGetUser(ctx)
 	for _, s := range m.model.Shares {
 		var share ocm.Share
 		if err := utils.UnmarshalJSONToProtoV1([]byte(s.(string)), &share); err != nil {
@@ -584,7 +584,7 @@ func (m *mgr) ListReceivedShares(ctx context.Context) ([]*ocm.ReceivedShare, err
 		return nil, err
 	}
 
-	user := user.ContextMustGetUser(ctx)
+	user := userctx.ContextMustGetUser(ctx)
 	for _, s := range m.model.ReceivedShares {
 		var rs ocm.ReceivedShare
 		if err := utils.UnmarshalJSONToProtoV1([]byte(s.(string)), &rs); err != nil {
@@ -623,7 +623,7 @@ func (m *mgr) getReceived(ctx context.Context, ref *ocm.ShareReference) (*ocm.Re
 		return nil, err
 	}
 
-	user := user.ContextMustGetUser(ctx)
+	user := userctx.ContextMustGetUser(ctx)
 	for _, s := range m.model.ReceivedShares {
 		var rs ocm.ReceivedShare
 		if err := utils.UnmarshalJSONToProtoV1([]byte(s.(string)), &rs); err != nil {

--- a/pkg/rhttp/client.go
+++ b/pkg/rhttp/client.go
@@ -26,7 +26,7 @@ import (
 
 	"go.opencensus.io/plugin/ochttp"
 
-	"github.com/cs3org/reva/pkg/token"
+	ctxpkg "github.com/cs3org/reva/pkg/ctx"
 	"github.com/pkg/errors"
 )
 
@@ -60,9 +60,9 @@ func NewRequest(ctx context.Context, method, url string, body io.Reader) (*http.
 	}
 
 	// TODO(labkode): make header / auth configurable
-	tkn, ok := token.ContextGetToken(ctx)
+	tkn, ok := ctxpkg.ContextGetToken(ctx)
 	if ok {
-		httpReq.Header.Set(token.TokenHeader, tkn)
+		httpReq.Header.Set(ctxpkg.TokenHeader, tkn)
 	}
 
 	httpReq = httpReq.WithContext(ctx)

--- a/pkg/sdk/common/net/net.go
+++ b/pkg/sdk/common/net/net.go
@@ -20,7 +20,7 @@ package net
 
 import (
 	"github.com/cs3org/reva/internal/http/services/datagateway"
-	"github.com/cs3org/reva/pkg/token"
+	ctxpkg "github.com/cs3org/reva/pkg/ctx"
 )
 
 type ctxKey int
@@ -29,7 +29,7 @@ const (
 	// AccessTokenIndex specifies the index of the Reva access token in a context.
 	AccessTokenIndex ctxKey = iota
 	// AccessTokenName specifies the name of the Reva access token used during requests.
-	AccessTokenName = token.TokenHeader
+	AccessTokenName = ctxpkg.TokenHeader
 	// TransportTokenName specifies the name of the Reva transport token used during data transfers.
 	TransportTokenName = datagateway.TokenTransportHeader
 )

--- a/pkg/share/cache/cbox/cbox.go
+++ b/pkg/share/cache/cbox/cbox.go
@@ -29,7 +29,7 @@ import (
 	"github.com/cs3org/reva/pkg/share/cache"
 	"github.com/cs3org/reva/pkg/share/cache/registry"
 	"github.com/cs3org/reva/pkg/storage/fs/eos"
-	"github.com/cs3org/reva/pkg/user"
+	"github.com/cs3org/reva/pkg/userctx"
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
 
@@ -108,7 +108,7 @@ func (m *manager) GetResourceInfos() ([]*provider.ResourceInfo, error) {
 			return nil, err
 		}
 
-		ctx := user.ContextSetUser(context.Background(), &userpb.User{
+		ctx := userctx.ContextSetUser(context.Background(), &userpb.User{
 			Id: &userpb.UserId{
 				OpaqueId: "root",
 			},

--- a/pkg/share/cache/cbox/cbox.go
+++ b/pkg/share/cache/cbox/cbox.go
@@ -26,10 +26,10 @@ import (
 	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	types "github.com/cs3org/go-cs3apis/cs3/types/v1beta1"
+	ctxpkg "github.com/cs3org/reva/pkg/ctx"
 	"github.com/cs3org/reva/pkg/share/cache"
 	"github.com/cs3org/reva/pkg/share/cache/registry"
 	"github.com/cs3org/reva/pkg/storage/fs/eos"
-	"github.com/cs3org/reva/pkg/userctx"
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
 
@@ -108,7 +108,7 @@ func (m *manager) GetResourceInfos() ([]*provider.ResourceInfo, error) {
 			return nil, err
 		}
 
-		ctx := userctx.ContextSetUser(context.Background(), &userpb.User{
+		ctx := ctxpkg.ContextSetUser(context.Background(), &userpb.User{
 			Id: &userpb.UserId{
 				OpaqueId: "root",
 			},

--- a/pkg/share/manager/json/json.go
+++ b/pkg/share/manager/json/json.go
@@ -31,12 +31,12 @@ import (
 	typespb "github.com/cs3org/go-cs3apis/cs3/types/v1beta1"
 	"github.com/cs3org/reva/pkg/errtypes"
 	"github.com/cs3org/reva/pkg/share"
+	"github.com/cs3org/reva/pkg/userctx"
 	"github.com/google/uuid"
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
 
 	"github.com/cs3org/reva/pkg/share/manager/registry"
-	"github.com/cs3org/reva/pkg/user"
 	"github.com/cs3org/reva/pkg/utils"
 )
 
@@ -177,7 +177,7 @@ func genID() string {
 
 func (m *mgr) Share(ctx context.Context, md *provider.ResourceInfo, g *collaboration.ShareGrant) (*collaboration.Share, error) {
 	id := genID()
-	user := user.ContextMustGetUser(ctx)
+	user := userctx.ContextMustGetUser(ctx)
 	now := time.Now().UnixNano()
 	ts := &typespb.Timestamp{
 		Seconds: uint64(now / 1000000000),
@@ -267,7 +267,7 @@ func (m *mgr) get(ctx context.Context, ref *collaboration.ShareReference) (s *co
 	}
 
 	// check if we are the owner
-	user := user.ContextMustGetUser(ctx)
+	user := userctx.ContextMustGetUser(ctx)
 	if utils.UserEqual(user.Id, s.Owner) || utils.UserEqual(user.Id, s.Creator) {
 		return s, nil
 	}
@@ -299,7 +299,7 @@ func (m *mgr) GetShare(ctx context.Context, ref *collaboration.ShareReference) (
 func (m *mgr) Unshare(ctx context.Context, ref *collaboration.ShareReference) error {
 	m.Lock()
 	defer m.Unlock()
-	user := user.ContextMustGetUser(ctx)
+	user := userctx.ContextMustGetUser(ctx)
 	for i, s := range m.model.Shares {
 		if sharesEqual(ref, s) {
 			if utils.UserEqual(user.Id, s.Owner) || utils.UserEqual(user.Id, s.Creator) {
@@ -333,7 +333,7 @@ func sharesEqual(ref *collaboration.ShareReference, s *collaboration.Share) bool
 func (m *mgr) UpdateShare(ctx context.Context, ref *collaboration.ShareReference, p *collaboration.SharePermissions) (*collaboration.Share, error) {
 	m.Lock()
 	defer m.Unlock()
-	user := user.ContextMustGetUser(ctx)
+	user := userctx.ContextMustGetUser(ctx)
 	for i, s := range m.model.Shares {
 		if sharesEqual(ref, s) {
 			if utils.UserEqual(user.Id, s.Owner) || utils.UserEqual(user.Id, s.Creator) {
@@ -358,7 +358,7 @@ func (m *mgr) ListShares(ctx context.Context, filters []*collaboration.ListShare
 	var ss []*collaboration.Share
 	m.Lock()
 	defer m.Unlock()
-	user := user.ContextMustGetUser(ctx)
+	user := userctx.ContextMustGetUser(ctx)
 	for _, s := range m.model.Shares {
 		if utils.UserEqual(user.Id, s.Owner) || utils.UserEqual(user.Id, s.Creator) {
 			// no filter we return earlier
@@ -385,7 +385,7 @@ func (m *mgr) ListReceivedShares(ctx context.Context) ([]*collaboration.Received
 	var rss []*collaboration.ReceivedShare
 	m.Lock()
 	defer m.Unlock()
-	user := user.ContextMustGetUser(ctx)
+	user := userctx.ContextMustGetUser(ctx)
 	for _, s := range m.model.Shares {
 		if utils.UserEqual(user.Id, s.Owner) || utils.UserEqual(user.Id, s.Creator) {
 			// omit shares created by me
@@ -413,7 +413,7 @@ func (m *mgr) convert(ctx context.Context, s *collaboration.Share) *collaboratio
 		Share: s,
 		State: collaboration.ShareState_SHARE_STATE_PENDING,
 	}
-	user := user.ContextMustGetUser(ctx)
+	user := userctx.ContextMustGetUser(ctx)
 	if v, ok := m.model.State[user.Id.String()]; ok {
 		if state, ok := v[s.Id.String()]; ok {
 			rs.State = state
@@ -429,7 +429,7 @@ func (m *mgr) GetReceivedShare(ctx context.Context, ref *collaboration.ShareRefe
 func (m *mgr) getReceived(ctx context.Context, ref *collaboration.ShareReference) (*collaboration.ReceivedShare, error) {
 	m.Lock()
 	defer m.Unlock()
-	user := user.ContextMustGetUser(ctx)
+	user := userctx.ContextMustGetUser(ctx)
 	for _, s := range m.model.Shares {
 		if sharesEqual(ref, s) {
 			if s.Grantee.Type == provider.GranteeType_GRANTEE_TYPE_USER && utils.UserEqual(user.Id, s.Grantee.GetUserId()) {
@@ -454,7 +454,7 @@ func (m *mgr) UpdateReceivedShare(ctx context.Context, ref *collaboration.ShareR
 		return nil, err
 	}
 
-	user := user.ContextMustGetUser(ctx)
+	user := userctx.ContextMustGetUser(ctx)
 	m.Lock()
 	defer m.Unlock()
 

--- a/pkg/share/manager/json/json.go
+++ b/pkg/share/manager/json/json.go
@@ -29,9 +29,9 @@ import (
 	collaboration "github.com/cs3org/go-cs3apis/cs3/sharing/collaboration/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	typespb "github.com/cs3org/go-cs3apis/cs3/types/v1beta1"
+	ctxpkg "github.com/cs3org/reva/pkg/ctx"
 	"github.com/cs3org/reva/pkg/errtypes"
 	"github.com/cs3org/reva/pkg/share"
-	"github.com/cs3org/reva/pkg/userctx"
 	"github.com/google/uuid"
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
@@ -177,7 +177,7 @@ func genID() string {
 
 func (m *mgr) Share(ctx context.Context, md *provider.ResourceInfo, g *collaboration.ShareGrant) (*collaboration.Share, error) {
 	id := genID()
-	user := userctx.ContextMustGetUser(ctx)
+	user := ctxpkg.ContextMustGetUser(ctx)
 	now := time.Now().UnixNano()
 	ts := &typespb.Timestamp{
 		Seconds: uint64(now / 1000000000),
@@ -267,7 +267,7 @@ func (m *mgr) get(ctx context.Context, ref *collaboration.ShareReference) (s *co
 	}
 
 	// check if we are the owner
-	user := userctx.ContextMustGetUser(ctx)
+	user := ctxpkg.ContextMustGetUser(ctx)
 	if utils.UserEqual(user.Id, s.Owner) || utils.UserEqual(user.Id, s.Creator) {
 		return s, nil
 	}
@@ -299,7 +299,7 @@ func (m *mgr) GetShare(ctx context.Context, ref *collaboration.ShareReference) (
 func (m *mgr) Unshare(ctx context.Context, ref *collaboration.ShareReference) error {
 	m.Lock()
 	defer m.Unlock()
-	user := userctx.ContextMustGetUser(ctx)
+	user := ctxpkg.ContextMustGetUser(ctx)
 	for i, s := range m.model.Shares {
 		if sharesEqual(ref, s) {
 			if utils.UserEqual(user.Id, s.Owner) || utils.UserEqual(user.Id, s.Creator) {
@@ -333,7 +333,7 @@ func sharesEqual(ref *collaboration.ShareReference, s *collaboration.Share) bool
 func (m *mgr) UpdateShare(ctx context.Context, ref *collaboration.ShareReference, p *collaboration.SharePermissions) (*collaboration.Share, error) {
 	m.Lock()
 	defer m.Unlock()
-	user := userctx.ContextMustGetUser(ctx)
+	user := ctxpkg.ContextMustGetUser(ctx)
 	for i, s := range m.model.Shares {
 		if sharesEqual(ref, s) {
 			if utils.UserEqual(user.Id, s.Owner) || utils.UserEqual(user.Id, s.Creator) {
@@ -358,7 +358,7 @@ func (m *mgr) ListShares(ctx context.Context, filters []*collaboration.ListShare
 	var ss []*collaboration.Share
 	m.Lock()
 	defer m.Unlock()
-	user := userctx.ContextMustGetUser(ctx)
+	user := ctxpkg.ContextMustGetUser(ctx)
 	for _, s := range m.model.Shares {
 		if utils.UserEqual(user.Id, s.Owner) || utils.UserEqual(user.Id, s.Creator) {
 			// no filter we return earlier
@@ -385,7 +385,7 @@ func (m *mgr) ListReceivedShares(ctx context.Context) ([]*collaboration.Received
 	var rss []*collaboration.ReceivedShare
 	m.Lock()
 	defer m.Unlock()
-	user := userctx.ContextMustGetUser(ctx)
+	user := ctxpkg.ContextMustGetUser(ctx)
 	for _, s := range m.model.Shares {
 		if utils.UserEqual(user.Id, s.Owner) || utils.UserEqual(user.Id, s.Creator) {
 			// omit shares created by me
@@ -413,7 +413,7 @@ func (m *mgr) convert(ctx context.Context, s *collaboration.Share) *collaboratio
 		Share: s,
 		State: collaboration.ShareState_SHARE_STATE_PENDING,
 	}
-	user := userctx.ContextMustGetUser(ctx)
+	user := ctxpkg.ContextMustGetUser(ctx)
 	if v, ok := m.model.State[user.Id.String()]; ok {
 		if state, ok := v[s.Id.String()]; ok {
 			rs.State = state
@@ -429,7 +429,7 @@ func (m *mgr) GetReceivedShare(ctx context.Context, ref *collaboration.ShareRefe
 func (m *mgr) getReceived(ctx context.Context, ref *collaboration.ShareReference) (*collaboration.ReceivedShare, error) {
 	m.Lock()
 	defer m.Unlock()
-	user := userctx.ContextMustGetUser(ctx)
+	user := ctxpkg.ContextMustGetUser(ctx)
 	for _, s := range m.model.Shares {
 		if sharesEqual(ref, s) {
 			if s.Grantee.Type == provider.GranteeType_GRANTEE_TYPE_USER && utils.UserEqual(user.Id, s.Grantee.GetUserId()) {
@@ -454,7 +454,7 @@ func (m *mgr) UpdateReceivedShare(ctx context.Context, ref *collaboration.ShareR
 		return nil, err
 	}
 
-	user := userctx.ContextMustGetUser(ctx)
+	user := ctxpkg.ContextMustGetUser(ctx)
 	m.Lock()
 	defer m.Unlock()
 

--- a/pkg/share/manager/memory/memory.go
+++ b/pkg/share/manager/memory/memory.go
@@ -26,8 +26,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	ctxpkg "github.com/cs3org/reva/pkg/ctx"
 	"github.com/cs3org/reva/pkg/share"
-	"github.com/cs3org/reva/pkg/userctx"
 
 	collaboration "github.com/cs3org/go-cs3apis/cs3/sharing/collaboration/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
@@ -68,7 +68,7 @@ func (m *manager) add(ctx context.Context, s *collaboration.Share) {
 
 func (m *manager) Share(ctx context.Context, md *provider.ResourceInfo, g *collaboration.ShareGrant) (*collaboration.Share, error) {
 	id := atomic.AddUint64(&counter, 1)
-	user := userctx.ContextMustGetUser(ctx)
+	user := ctxpkg.ContextMustGetUser(ctx)
 	now := time.Now().UnixNano()
 	ts := &typespb.Timestamp{
 		Seconds: uint64(now / 1000000000),
@@ -147,7 +147,7 @@ func (m *manager) get(ctx context.Context, ref *collaboration.ShareReference) (s
 	}
 
 	// check if we are the owner
-	user := userctx.ContextMustGetUser(ctx)
+	user := ctxpkg.ContextMustGetUser(ctx)
 	if utils.UserEqual(user.Id, s.Owner) || utils.UserEqual(user.Id, s.Creator) {
 		return s, nil
 	}
@@ -168,7 +168,7 @@ func (m *manager) GetShare(ctx context.Context, ref *collaboration.ShareReferenc
 func (m *manager) Unshare(ctx context.Context, ref *collaboration.ShareReference) error {
 	m.lock.Lock()
 	defer m.lock.Unlock()
-	user := userctx.ContextMustGetUser(ctx)
+	user := ctxpkg.ContextMustGetUser(ctx)
 	for i, s := range m.shares {
 		if sharesEqual(ref, s) {
 			if utils.UserEqual(user.Id, s.Owner) || utils.UserEqual(user.Id, s.Creator) {
@@ -198,7 +198,7 @@ func sharesEqual(ref *collaboration.ShareReference, s *collaboration.Share) bool
 func (m *manager) UpdateShare(ctx context.Context, ref *collaboration.ShareReference, p *collaboration.SharePermissions) (*collaboration.Share, error) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
-	user := userctx.ContextMustGetUser(ctx)
+	user := ctxpkg.ContextMustGetUser(ctx)
 	for i, s := range m.shares {
 		if sharesEqual(ref, s) {
 			if utils.UserEqual(user.Id, s.Owner) || utils.UserEqual(user.Id, s.Creator) {
@@ -219,7 +219,7 @@ func (m *manager) ListShares(ctx context.Context, filters []*collaboration.ListS
 	var ss []*collaboration.Share
 	m.lock.Lock()
 	defer m.lock.Unlock()
-	user := userctx.ContextMustGetUser(ctx)
+	user := ctxpkg.ContextMustGetUser(ctx)
 	for _, s := range m.shares {
 		if utils.UserEqual(user.Id, s.Owner) || utils.UserEqual(user.Id, s.Creator) {
 			// no filter we return earlier
@@ -246,7 +246,7 @@ func (m *manager) ListReceivedShares(ctx context.Context) ([]*collaboration.Rece
 	var rss []*collaboration.ReceivedShare
 	m.lock.Lock()
 	defer m.lock.Unlock()
-	user := userctx.ContextMustGetUser(ctx)
+	user := ctxpkg.ContextMustGetUser(ctx)
 	for _, s := range m.shares {
 		if utils.UserEqual(user.Id, s.Owner) || utils.UserEqual(user.Id, s.Creator) {
 			// omit shares created by me
@@ -274,7 +274,7 @@ func (m *manager) convert(ctx context.Context, s *collaboration.Share) *collabor
 		Share: s,
 		State: collaboration.ShareState_SHARE_STATE_PENDING,
 	}
-	user := userctx.ContextMustGetUser(ctx)
+	user := ctxpkg.ContextMustGetUser(ctx)
 	if v, ok := m.shareState[user.Id.String()]; ok {
 		if state, ok := v[s.Id]; ok {
 			rs.State = state
@@ -290,7 +290,7 @@ func (m *manager) GetReceivedShare(ctx context.Context, ref *collaboration.Share
 func (m *manager) getReceived(ctx context.Context, ref *collaboration.ShareReference) (*collaboration.ReceivedShare, error) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
-	user := userctx.ContextMustGetUser(ctx)
+	user := ctxpkg.ContextMustGetUser(ctx)
 	for _, s := range m.shares {
 		if sharesEqual(ref, s) {
 			if s.Grantee.Type == provider.GranteeType_GRANTEE_TYPE_USER && utils.UserEqual(user.Id, s.Grantee.GetUserId()) {
@@ -315,7 +315,7 @@ func (m *manager) UpdateReceivedShare(ctx context.Context, ref *collaboration.Sh
 		return nil, err
 	}
 
-	user := userctx.ContextMustGetUser(ctx)
+	user := ctxpkg.ContextMustGetUser(ctx)
 	m.lock.Lock()
 	defer m.lock.Unlock()
 

--- a/pkg/share/manager/memory/memory.go
+++ b/pkg/share/manager/memory/memory.go
@@ -27,13 +27,13 @@ import (
 	"time"
 
 	"github.com/cs3org/reva/pkg/share"
+	"github.com/cs3org/reva/pkg/userctx"
 
 	collaboration "github.com/cs3org/go-cs3apis/cs3/sharing/collaboration/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	typespb "github.com/cs3org/go-cs3apis/cs3/types/v1beta1"
 	"github.com/cs3org/reva/pkg/errtypes"
 	"github.com/cs3org/reva/pkg/share/manager/registry"
-	"github.com/cs3org/reva/pkg/user"
 	"github.com/cs3org/reva/pkg/utils"
 )
 
@@ -68,7 +68,7 @@ func (m *manager) add(ctx context.Context, s *collaboration.Share) {
 
 func (m *manager) Share(ctx context.Context, md *provider.ResourceInfo, g *collaboration.ShareGrant) (*collaboration.Share, error) {
 	id := atomic.AddUint64(&counter, 1)
-	user := user.ContextMustGetUser(ctx)
+	user := userctx.ContextMustGetUser(ctx)
 	now := time.Now().UnixNano()
 	ts := &typespb.Timestamp{
 		Seconds: uint64(now / 1000000000),
@@ -147,7 +147,7 @@ func (m *manager) get(ctx context.Context, ref *collaboration.ShareReference) (s
 	}
 
 	// check if we are the owner
-	user := user.ContextMustGetUser(ctx)
+	user := userctx.ContextMustGetUser(ctx)
 	if utils.UserEqual(user.Id, s.Owner) || utils.UserEqual(user.Id, s.Creator) {
 		return s, nil
 	}
@@ -168,7 +168,7 @@ func (m *manager) GetShare(ctx context.Context, ref *collaboration.ShareReferenc
 func (m *manager) Unshare(ctx context.Context, ref *collaboration.ShareReference) error {
 	m.lock.Lock()
 	defer m.lock.Unlock()
-	user := user.ContextMustGetUser(ctx)
+	user := userctx.ContextMustGetUser(ctx)
 	for i, s := range m.shares {
 		if sharesEqual(ref, s) {
 			if utils.UserEqual(user.Id, s.Owner) || utils.UserEqual(user.Id, s.Creator) {
@@ -198,7 +198,7 @@ func sharesEqual(ref *collaboration.ShareReference, s *collaboration.Share) bool
 func (m *manager) UpdateShare(ctx context.Context, ref *collaboration.ShareReference, p *collaboration.SharePermissions) (*collaboration.Share, error) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
-	user := user.ContextMustGetUser(ctx)
+	user := userctx.ContextMustGetUser(ctx)
 	for i, s := range m.shares {
 		if sharesEqual(ref, s) {
 			if utils.UserEqual(user.Id, s.Owner) || utils.UserEqual(user.Id, s.Creator) {
@@ -219,7 +219,7 @@ func (m *manager) ListShares(ctx context.Context, filters []*collaboration.ListS
 	var ss []*collaboration.Share
 	m.lock.Lock()
 	defer m.lock.Unlock()
-	user := user.ContextMustGetUser(ctx)
+	user := userctx.ContextMustGetUser(ctx)
 	for _, s := range m.shares {
 		if utils.UserEqual(user.Id, s.Owner) || utils.UserEqual(user.Id, s.Creator) {
 			// no filter we return earlier
@@ -246,7 +246,7 @@ func (m *manager) ListReceivedShares(ctx context.Context) ([]*collaboration.Rece
 	var rss []*collaboration.ReceivedShare
 	m.lock.Lock()
 	defer m.lock.Unlock()
-	user := user.ContextMustGetUser(ctx)
+	user := userctx.ContextMustGetUser(ctx)
 	for _, s := range m.shares {
 		if utils.UserEqual(user.Id, s.Owner) || utils.UserEqual(user.Id, s.Creator) {
 			// omit shares created by me
@@ -274,7 +274,7 @@ func (m *manager) convert(ctx context.Context, s *collaboration.Share) *collabor
 		Share: s,
 		State: collaboration.ShareState_SHARE_STATE_PENDING,
 	}
-	user := user.ContextMustGetUser(ctx)
+	user := userctx.ContextMustGetUser(ctx)
 	if v, ok := m.shareState[user.Id.String()]; ok {
 		if state, ok := v[s.Id]; ok {
 			rs.State = state
@@ -290,7 +290,7 @@ func (m *manager) GetReceivedShare(ctx context.Context, ref *collaboration.Share
 func (m *manager) getReceived(ctx context.Context, ref *collaboration.ShareReference) (*collaboration.ReceivedShare, error) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
-	user := user.ContextMustGetUser(ctx)
+	user := userctx.ContextMustGetUser(ctx)
 	for _, s := range m.shares {
 		if sharesEqual(ref, s) {
 			if s.Grantee.Type == provider.GranteeType_GRANTEE_TYPE_USER && utils.UserEqual(user.Id, s.Grantee.GetUserId()) {
@@ -315,7 +315,7 @@ func (m *manager) UpdateReceivedShare(ctx context.Context, ref *collaboration.Sh
 		return nil, err
 	}
 
-	user := user.ContextMustGetUser(ctx)
+	user := userctx.ContextMustGetUser(ctx)
 	m.lock.Lock()
 	defer m.lock.Unlock()
 

--- a/pkg/share/manager/sql/sql.go
+++ b/pkg/share/manager/sql/sql.go
@@ -33,7 +33,7 @@ import (
 	"github.com/cs3org/reva/pkg/errtypes"
 	"github.com/cs3org/reva/pkg/share"
 	"github.com/cs3org/reva/pkg/share/manager/registry"
-	"github.com/cs3org/reva/pkg/user"
+	"github.com/cs3org/reva/pkg/userctx"
 	"github.com/cs3org/reva/pkg/utils"
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
@@ -100,7 +100,7 @@ func parseConfig(m map[string]interface{}) (*config, error) {
 }
 
 func (m *mgr) Share(ctx context.Context, md *provider.ResourceInfo, g *collaboration.ShareGrant) (*collaboration.Share, error) {
-	user := user.ContextMustGetUser(ctx)
+	user := userctx.ContextMustGetUser(ctx)
 
 	// do not allow share to myself or the owner if share is for a user
 	// TODO(labkode): should not this be caught already at the gw level?
@@ -196,7 +196,7 @@ func (m *mgr) GetShare(ctx context.Context, ref *collaboration.ShareReference) (
 }
 
 func (m *mgr) Unshare(ctx context.Context, ref *collaboration.ShareReference) error {
-	uid := user.ContextMustGetUser(ctx).Username
+	uid := userctx.ContextMustGetUser(ctx).Username
 	var query string
 	params := []interface{}{}
 	switch {
@@ -237,7 +237,7 @@ func (m *mgr) Unshare(ctx context.Context, ref *collaboration.ShareReference) er
 
 func (m *mgr) UpdateShare(ctx context.Context, ref *collaboration.ShareReference, p *collaboration.SharePermissions) (*collaboration.Share, error) {
 	permissions := sharePermToInt(p.Permissions)
-	uid := user.ContextMustGetUser(ctx).Username
+	uid := userctx.ContextMustGetUser(ctx).Username
 
 	var query string
 	params := []interface{}{}
@@ -270,7 +270,7 @@ func (m *mgr) UpdateShare(ctx context.Context, ref *collaboration.ShareReference
 }
 
 func (m *mgr) ListShares(ctx context.Context, filters []*collaboration.ListSharesRequest_Filter) ([]*collaboration.Share, error) {
-	uid := user.ContextMustGetUser(ctx).Username
+	uid := userctx.ContextMustGetUser(ctx).Username
 	query := "select coalesce(uid_owner, '') as uid_owner, coalesce(uid_initiator, '') as uid_initiator, coalesce(share_with, '') as share_with, coalesce(item_source, '') as item_source, id, stime, permissions, share_type FROM oc_share WHERE (uid_owner=? or uid_initiator=?) AND (share_type=? OR share_type=?)"
 	var filterQuery string
 	params := []interface{}{uid, uid, 0, 1}
@@ -316,7 +316,7 @@ func (m *mgr) ListShares(ctx context.Context, filters []*collaboration.ListShare
 
 // we list the shares that are targeted to the user in context or to the user groups.
 func (m *mgr) ListReceivedShares(ctx context.Context) ([]*collaboration.ReceivedShare, error) {
-	user := user.ContextMustGetUser(ctx)
+	user := userctx.ContextMustGetUser(ctx)
 	uid := user.Username
 
 	params := []interface{}{uid, uid, uid}
@@ -412,7 +412,7 @@ func (m *mgr) UpdateReceivedShare(ctx context.Context, ref *collaboration.ShareR
 }
 
 func (m *mgr) getByID(ctx context.Context, id *collaboration.ShareId) (*collaboration.Share, error) {
-	uid := user.ContextMustGetUser(ctx).Username
+	uid := userctx.ContextMustGetUser(ctx).Username
 	s := DBShare{ID: id.OpaqueId}
 	query := "select coalesce(uid_owner, '') as uid_owner, coalesce(uid_initiator, '') as uid_initiator, coalesce(share_with, '') as share_with, coalesce(item_source, '') as item_source, stime, permissions, share_type FROM oc_share WHERE id=? AND (uid_owner=? or uid_initiator=?)"
 	if err := m.db.QueryRow(query, id.OpaqueId, uid, uid).Scan(&s.UIDOwner, &s.UIDInitiator, &s.ShareWith, &s.ItemSource, &s.STime, &s.Permissions, &s.ShareType); err != nil {
@@ -429,7 +429,7 @@ func (m *mgr) getByKey(ctx context.Context, key *collaboration.ShareKey) (*colla
 	if err != nil {
 		return nil, err
 	}
-	uid := user.ContextMustGetUser(ctx).Username
+	uid := userctx.ContextMustGetUser(ctx).Username
 
 	s := DBShare{}
 	shareType, shareWith, err := m.formatGrantee(ctx, key.Grantee)
@@ -447,7 +447,7 @@ func (m *mgr) getByKey(ctx context.Context, key *collaboration.ShareKey) (*colla
 }
 
 func (m *mgr) getReceivedByID(ctx context.Context, id *collaboration.ShareId) (*collaboration.ReceivedShare, error) {
-	user := user.ContextMustGetUser(ctx)
+	user := userctx.ContextMustGetUser(ctx)
 	uid := user.Username
 
 	params := []interface{}{id.OpaqueId, uid}
@@ -472,7 +472,7 @@ func (m *mgr) getReceivedByID(ctx context.Context, id *collaboration.ShareId) (*
 }
 
 func (m *mgr) getReceivedByKey(ctx context.Context, key *collaboration.ShareKey) (*collaboration.ReceivedShare, error) {
-	user := user.ContextMustGetUser(ctx)
+	user := userctx.ContextMustGetUser(ctx)
 	uid := user.Username
 
 	shareType, shareWith, err := m.formatGrantee(ctx, key.Grantee)

--- a/pkg/share/manager/sql/sql_test.go
+++ b/pkg/share/manager/sql/sql_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/cs3org/reva/pkg/share"
 	sqlmanager "github.com/cs3org/reva/pkg/share/manager/sql"
 	mocks "github.com/cs3org/reva/pkg/share/manager/sql/mocks"
-	ruser "github.com/cs3org/reva/pkg/user"
+	ruser "github.com/cs3org/reva/pkg/userctx"
 
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/stretchr/testify/mock"

--- a/pkg/share/manager/sql/sql_test.go
+++ b/pkg/share/manager/sql/sql_test.go
@@ -28,10 +28,10 @@ import (
 	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	collaboration "github.com/cs3org/go-cs3apis/cs3/sharing/collaboration/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+	ruser "github.com/cs3org/reva/pkg/ctx"
 	"github.com/cs3org/reva/pkg/share"
 	sqlmanager "github.com/cs3org/reva/pkg/share/manager/sql"
 	mocks "github.com/cs3org/reva/pkg/share/manager/sql/mocks"
-	ruser "github.com/cs3org/reva/pkg/userctx"
 
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/stretchr/testify/mock"

--- a/pkg/storage/fs/owncloud/owncloud.go
+++ b/pkg/storage/fs/owncloud/owncloud.go
@@ -38,6 +38,7 @@ import (
 	types "github.com/cs3org/go-cs3apis/cs3/types/v1beta1"
 	"github.com/cs3org/reva/internal/grpc/services/storageprovider"
 	"github.com/cs3org/reva/pkg/appctx"
+	ctxpkg "github.com/cs3org/reva/pkg/ctx"
 	"github.com/cs3org/reva/pkg/errtypes"
 	"github.com/cs3org/reva/pkg/logger"
 	"github.com/cs3org/reva/pkg/mime"
@@ -48,7 +49,6 @@ import (
 	"github.com/cs3org/reva/pkg/storage/utils/ace"
 	"github.com/cs3org/reva/pkg/storage/utils/chunking"
 	"github.com/cs3org/reva/pkg/storage/utils/templates"
-	"github.com/cs3org/reva/pkg/userctx"
 	"github.com/gomodule/redigo/redis"
 	"github.com/google/uuid"
 	"github.com/mitchellh/mapstructure"
@@ -261,7 +261,7 @@ func (fs *ocfs) scanFiles(ctx context.Context, conn redis.Conn) {
 // TODO the path handed to a storage provider should not contain the username
 func (fs *ocfs) toInternalPath(ctx context.Context, sp string) (ip string) {
 	if fs.c.EnableHome {
-		u := userctx.ContextMustGetUser(ctx)
+		u := ctxpkg.ContextMustGetUser(ctx)
 		layout := templates.WithUser(u, fs.c.UserLayout)
 		// The inner filepath.Join prevents the path from breaking out of
 		// <fs.c.DataDirectory>/<layout>/files/
@@ -301,7 +301,7 @@ func (fs *ocfs) toInternalPath(ctx context.Context, sp string) (ip string) {
 
 func (fs *ocfs) toInternalShadowPath(ctx context.Context, sp string) (internal string) {
 	if fs.c.EnableHome {
-		u := userctx.ContextMustGetUser(ctx)
+		u := ctxpkg.ContextMustGetUser(ctx)
 		layout := templates.WithUser(u, fs.c.UserLayout)
 		internal = filepath.Join(fs.c.DataDirectory, layout, "shadow_files", sp)
 	} else {
@@ -373,7 +373,7 @@ func (fs *ocfs) getVersionsPath(ctx context.Context, ip string) string {
 
 // owncloud stores trashed items in the files_trashbin subfolder of a users home
 func (fs *ocfs) getRecyclePath(ctx context.Context) (string, error) {
-	u, ok := userctx.ContextGetUser(ctx)
+	u, ok := ctxpkg.ContextGetUser(ctx)
 	if !ok {
 		err := errors.Wrap(errtypes.UserRequired("userrequired"), "error getting user from ctx")
 		return "", err
@@ -383,7 +383,7 @@ func (fs *ocfs) getRecyclePath(ctx context.Context) (string, error) {
 }
 
 func (fs *ocfs) getVersionRecyclePath(ctx context.Context) (string, error) {
-	u, ok := userctx.ContextGetUser(ctx)
+	u, ok := ctxpkg.ContextGetUser(ctx)
 	if !ok {
 		err := errors.Wrap(errtypes.UserRequired("userrequired"), "error getting user from ctx")
 		return "", err
@@ -394,7 +394,7 @@ func (fs *ocfs) getVersionRecyclePath(ctx context.Context) (string, error) {
 
 func (fs *ocfs) toStoragePath(ctx context.Context, ip string) (sp string) {
 	if fs.c.EnableHome {
-		u := userctx.ContextMustGetUser(ctx)
+		u := ctxpkg.ContextMustGetUser(ctx)
 		layout := templates.WithUser(u, fs.c.UserLayout)
 		trim := filepath.Join(fs.c.DataDirectory, layout, "files")
 		sp = strings.TrimPrefix(ip, trim)
@@ -431,7 +431,7 @@ func (fs *ocfs) toStoragePath(ctx context.Context, ip string) (sp string) {
 
 func (fs *ocfs) toStorageShadowPath(ctx context.Context, ip string) (sp string) {
 	if fs.c.EnableHome {
-		u := userctx.ContextMustGetUser(ctx)
+		u := ctxpkg.ContextMustGetUser(ctx)
 		layout := templates.WithUser(u, fs.c.UserLayout)
 		trim := filepath.Join(fs.c.DataDirectory, layout, "shadow_files")
 		sp = strings.TrimPrefix(ip, trim)
@@ -473,7 +473,7 @@ func (fs *ocfs) getOwner(ip string) string {
 
 // TODO cache user lookup
 func (fs *ocfs) getUser(ctx context.Context, usernameOrID string) (id *userpb.User, err error) {
-	u := userctx.ContextMustGetUser(ctx)
+	u := ctxpkg.ContextMustGetUser(ctx)
 	// check if username matches and id is set
 	if u.Username == usernameOrID && u.Id != nil && u.Id.OpaqueId != "" {
 		return u, nil
@@ -535,7 +535,7 @@ func (fs *ocfs) permissionSet(ctx context.Context, owner *userpb.UserId) *provid
 			Stat: true,
 		}
 	}
-	u, ok := userctx.ContextGetUser(ctx)
+	u, ok := ctxpkg.ContextGetUser(ctx)
 	if !ok {
 		return &provider.ResourcePermissions{
 			// no permissions
@@ -619,7 +619,7 @@ func (fs *ocfs) convertToResourceInfo(ctx context.Context, fi os.FileInfo, ip st
 
 	if _, ok := mdKeysMap[favoriteKey]; returnAllKeys || ok {
 		favorite := ""
-		if u, ok := userctx.ContextGetUser(ctx); ok {
+		if u, ok := ctxpkg.ContextGetUser(ctx); ok {
 			// the favorite flag is specific to the user, so we need to incorporate the userid
 			if uid := u.GetId(); uid != nil {
 				fa := fmt.Sprintf("%s%s@%s", favPrefix, uid.GetOpaqueId(), uid.GetIdp())
@@ -872,7 +872,7 @@ func extractACEsFromAttrs(ctx context.Context, ip string, attrs []string) (entri
 // for the node based on all acls in the tree up to the root
 func (fs *ocfs) readPermissions(ctx context.Context, ip string) (p *provider.ResourcePermissions, err error) {
 
-	u, ok := userctx.ContextGetUser(ctx)
+	u, ok := ctxpkg.ContextGetUser(ctx)
 	if !ok {
 		appctx.GetLogger(ctx).Debug().Str("ipath", ip).Msg("no user in context, returning default permissions")
 		return defaultPermissions, nil
@@ -1124,7 +1124,7 @@ func (fs *ocfs) GetQuota(ctx context.Context) (uint64, uint64, error) {
 }
 
 func (fs *ocfs) CreateHome(ctx context.Context) error {
-	u, ok := userctx.ContextGetUser(ctx)
+	u, ok := ctxpkg.ContextGetUser(ctx)
 	if !ok {
 		err := errors.Wrap(errtypes.UserRequired("userrequired"), "error getting user from ctx")
 		return err
@@ -1315,7 +1315,7 @@ func (fs *ocfs) SetArbitraryMetadata(ctx context.Context, ref *provider.Referenc
 			// 5. app? = a:<aid>: for apps?
 			// obviously this only is secure when the u/s/g/a namespaces are not accessible by users in the filesystem
 			// public tags can be mapped to extended attributes
-			if u, ok := userctx.ContextGetUser(ctx); ok {
+			if u, ok := ctxpkg.ContextGetUser(ctx); ok {
 				// the favorite flag is specific to the user, so we need to incorporate the userid
 				if uid := u.GetId(); uid != nil {
 					fa := fmt.Sprintf("%s%s@%s", favPrefix, uid.GetOpaqueId(), uid.GetIdp())
@@ -1409,7 +1409,7 @@ func (fs *ocfs) UnsetArbitraryMetadata(ctx context.Context, ref *provider.Refere
 	for _, k := range keys {
 		switch k {
 		case "http://owncloud.org/ns/favorite":
-			if u, ok := userctx.ContextGetUser(ctx); ok {
+			if u, ok := ctxpkg.ContextGetUser(ctx); ok {
 				// the favorite flag is specific to the user, so we need to incorporate the userid
 				if uid := u.GetId(); uid != nil {
 					fa := fmt.Sprintf("%s%s@%s", favPrefix, uid.GetOpaqueId(), uid.GetIdp())

--- a/pkg/storage/fs/owncloud/owncloud.go
+++ b/pkg/storage/fs/owncloud/owncloud.go
@@ -48,7 +48,7 @@ import (
 	"github.com/cs3org/reva/pkg/storage/utils/ace"
 	"github.com/cs3org/reva/pkg/storage/utils/chunking"
 	"github.com/cs3org/reva/pkg/storage/utils/templates"
-	"github.com/cs3org/reva/pkg/user"
+	"github.com/cs3org/reva/pkg/userctx"
 	"github.com/gomodule/redigo/redis"
 	"github.com/google/uuid"
 	"github.com/mitchellh/mapstructure"
@@ -261,7 +261,7 @@ func (fs *ocfs) scanFiles(ctx context.Context, conn redis.Conn) {
 // TODO the path handed to a storage provider should not contain the username
 func (fs *ocfs) toInternalPath(ctx context.Context, sp string) (ip string) {
 	if fs.c.EnableHome {
-		u := user.ContextMustGetUser(ctx)
+		u := userctx.ContextMustGetUser(ctx)
 		layout := templates.WithUser(u, fs.c.UserLayout)
 		// The inner filepath.Join prevents the path from breaking out of
 		// <fs.c.DataDirectory>/<layout>/files/
@@ -301,7 +301,7 @@ func (fs *ocfs) toInternalPath(ctx context.Context, sp string) (ip string) {
 
 func (fs *ocfs) toInternalShadowPath(ctx context.Context, sp string) (internal string) {
 	if fs.c.EnableHome {
-		u := user.ContextMustGetUser(ctx)
+		u := userctx.ContextMustGetUser(ctx)
 		layout := templates.WithUser(u, fs.c.UserLayout)
 		internal = filepath.Join(fs.c.DataDirectory, layout, "shadow_files", sp)
 	} else {
@@ -373,7 +373,7 @@ func (fs *ocfs) getVersionsPath(ctx context.Context, ip string) string {
 
 // owncloud stores trashed items in the files_trashbin subfolder of a users home
 func (fs *ocfs) getRecyclePath(ctx context.Context) (string, error) {
-	u, ok := user.ContextGetUser(ctx)
+	u, ok := userctx.ContextGetUser(ctx)
 	if !ok {
 		err := errors.Wrap(errtypes.UserRequired("userrequired"), "error getting user from ctx")
 		return "", err
@@ -383,7 +383,7 @@ func (fs *ocfs) getRecyclePath(ctx context.Context) (string, error) {
 }
 
 func (fs *ocfs) getVersionRecyclePath(ctx context.Context) (string, error) {
-	u, ok := user.ContextGetUser(ctx)
+	u, ok := userctx.ContextGetUser(ctx)
 	if !ok {
 		err := errors.Wrap(errtypes.UserRequired("userrequired"), "error getting user from ctx")
 		return "", err
@@ -394,7 +394,7 @@ func (fs *ocfs) getVersionRecyclePath(ctx context.Context) (string, error) {
 
 func (fs *ocfs) toStoragePath(ctx context.Context, ip string) (sp string) {
 	if fs.c.EnableHome {
-		u := user.ContextMustGetUser(ctx)
+		u := userctx.ContextMustGetUser(ctx)
 		layout := templates.WithUser(u, fs.c.UserLayout)
 		trim := filepath.Join(fs.c.DataDirectory, layout, "files")
 		sp = strings.TrimPrefix(ip, trim)
@@ -431,7 +431,7 @@ func (fs *ocfs) toStoragePath(ctx context.Context, ip string) (sp string) {
 
 func (fs *ocfs) toStorageShadowPath(ctx context.Context, ip string) (sp string) {
 	if fs.c.EnableHome {
-		u := user.ContextMustGetUser(ctx)
+		u := userctx.ContextMustGetUser(ctx)
 		layout := templates.WithUser(u, fs.c.UserLayout)
 		trim := filepath.Join(fs.c.DataDirectory, layout, "shadow_files")
 		sp = strings.TrimPrefix(ip, trim)
@@ -473,7 +473,7 @@ func (fs *ocfs) getOwner(ip string) string {
 
 // TODO cache user lookup
 func (fs *ocfs) getUser(ctx context.Context, usernameOrID string) (id *userpb.User, err error) {
-	u := user.ContextMustGetUser(ctx)
+	u := userctx.ContextMustGetUser(ctx)
 	// check if username matches and id is set
 	if u.Username == usernameOrID && u.Id != nil && u.Id.OpaqueId != "" {
 		return u, nil
@@ -535,7 +535,7 @@ func (fs *ocfs) permissionSet(ctx context.Context, owner *userpb.UserId) *provid
 			Stat: true,
 		}
 	}
-	u, ok := user.ContextGetUser(ctx)
+	u, ok := userctx.ContextGetUser(ctx)
 	if !ok {
 		return &provider.ResourcePermissions{
 			// no permissions
@@ -619,7 +619,7 @@ func (fs *ocfs) convertToResourceInfo(ctx context.Context, fi os.FileInfo, ip st
 
 	if _, ok := mdKeysMap[favoriteKey]; returnAllKeys || ok {
 		favorite := ""
-		if u, ok := user.ContextGetUser(ctx); ok {
+		if u, ok := userctx.ContextGetUser(ctx); ok {
 			// the favorite flag is specific to the user, so we need to incorporate the userid
 			if uid := u.GetId(); uid != nil {
 				fa := fmt.Sprintf("%s%s@%s", favPrefix, uid.GetOpaqueId(), uid.GetIdp())
@@ -872,7 +872,7 @@ func extractACEsFromAttrs(ctx context.Context, ip string, attrs []string) (entri
 // for the node based on all acls in the tree up to the root
 func (fs *ocfs) readPermissions(ctx context.Context, ip string) (p *provider.ResourcePermissions, err error) {
 
-	u, ok := user.ContextGetUser(ctx)
+	u, ok := userctx.ContextGetUser(ctx)
 	if !ok {
 		appctx.GetLogger(ctx).Debug().Str("ipath", ip).Msg("no user in context, returning default permissions")
 		return defaultPermissions, nil
@@ -1124,7 +1124,7 @@ func (fs *ocfs) GetQuota(ctx context.Context) (uint64, uint64, error) {
 }
 
 func (fs *ocfs) CreateHome(ctx context.Context) error {
-	u, ok := user.ContextGetUser(ctx)
+	u, ok := userctx.ContextGetUser(ctx)
 	if !ok {
 		err := errors.Wrap(errtypes.UserRequired("userrequired"), "error getting user from ctx")
 		return err
@@ -1315,7 +1315,7 @@ func (fs *ocfs) SetArbitraryMetadata(ctx context.Context, ref *provider.Referenc
 			// 5. app? = a:<aid>: for apps?
 			// obviously this only is secure when the u/s/g/a namespaces are not accessible by users in the filesystem
 			// public tags can be mapped to extended attributes
-			if u, ok := user.ContextGetUser(ctx); ok {
+			if u, ok := userctx.ContextGetUser(ctx); ok {
 				// the favorite flag is specific to the user, so we need to incorporate the userid
 				if uid := u.GetId(); uid != nil {
 					fa := fmt.Sprintf("%s%s@%s", favPrefix, uid.GetOpaqueId(), uid.GetIdp())
@@ -1409,7 +1409,7 @@ func (fs *ocfs) UnsetArbitraryMetadata(ctx context.Context, ref *provider.Refere
 	for _, k := range keys {
 		switch k {
 		case "http://owncloud.org/ns/favorite":
-			if u, ok := user.ContextGetUser(ctx); ok {
+			if u, ok := userctx.ContextGetUser(ctx); ok {
 				// the favorite flag is specific to the user, so we need to incorporate the userid
 				if uid := u.GetId(); uid != nil {
 					fa := fmt.Sprintf("%s%s@%s", favPrefix, uid.GetOpaqueId(), uid.GetIdp())

--- a/pkg/storage/fs/owncloud/upload.go
+++ b/pkg/storage/fs/owncloud/upload.go
@@ -35,11 +35,11 @@ import (
 	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	"github.com/cs3org/reva/pkg/appctx"
+	ctxpkg "github.com/cs3org/reva/pkg/ctx"
 	"github.com/cs3org/reva/pkg/errtypes"
 	"github.com/cs3org/reva/pkg/logger"
 	"github.com/cs3org/reva/pkg/storage/utils/chunking"
 	"github.com/cs3org/reva/pkg/storage/utils/templates"
-	"github.com/cs3org/reva/pkg/userctx"
 	"github.com/cs3org/reva/pkg/utils"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
@@ -205,7 +205,7 @@ func (fs *ocfs) NewUpload(ctx context.Context, info tusd.FileInfo) (upload tusd.
 	if err != nil {
 		return nil, errors.Wrap(err, "ocfs: error resolving upload path")
 	}
-	usr := userctx.ContextMustGetUser(ctx)
+	usr := ctxpkg.ContextMustGetUser(ctx)
 	info.Storage = map[string]string{
 		"Type":                "OwnCloudStore",
 		"BinPath":             binPath,
@@ -254,7 +254,7 @@ func (fs *ocfs) NewUpload(ctx context.Context, info tusd.FileInfo) (upload tusd.
 }
 
 func (fs *ocfs) getUploadPath(ctx context.Context, uploadID string) (string, error) {
-	u, ok := userctx.ContextGetUser(ctx)
+	u, ok := ctxpkg.ContextGetUser(ctx)
 	if !ok {
 		err := errors.Wrap(errtypes.UserRequired("userrequired"), "error getting user from ctx")
 		return "", err
@@ -292,7 +292,7 @@ func (fs *ocfs) GetUpload(ctx context.Context, id string) (tusd.Upload, error) {
 		Username: info.Storage["UserName"],
 	}
 
-	ctx = userctx.ContextSetUser(ctx, u)
+	ctx = ctxpkg.ContextSetUser(ctx, u)
 	// TODO configure the logger the same way ... store and add traceid in file info
 
 	var opts []logger.Option

--- a/pkg/storage/fs/owncloud/upload.go
+++ b/pkg/storage/fs/owncloud/upload.go
@@ -39,7 +39,7 @@ import (
 	"github.com/cs3org/reva/pkg/logger"
 	"github.com/cs3org/reva/pkg/storage/utils/chunking"
 	"github.com/cs3org/reva/pkg/storage/utils/templates"
-	"github.com/cs3org/reva/pkg/user"
+	"github.com/cs3org/reva/pkg/userctx"
 	"github.com/cs3org/reva/pkg/utils"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
@@ -205,7 +205,7 @@ func (fs *ocfs) NewUpload(ctx context.Context, info tusd.FileInfo) (upload tusd.
 	if err != nil {
 		return nil, errors.Wrap(err, "ocfs: error resolving upload path")
 	}
-	usr := user.ContextMustGetUser(ctx)
+	usr := userctx.ContextMustGetUser(ctx)
 	info.Storage = map[string]string{
 		"Type":                "OwnCloudStore",
 		"BinPath":             binPath,
@@ -254,7 +254,7 @@ func (fs *ocfs) NewUpload(ctx context.Context, info tusd.FileInfo) (upload tusd.
 }
 
 func (fs *ocfs) getUploadPath(ctx context.Context, uploadID string) (string, error) {
-	u, ok := user.ContextGetUser(ctx)
+	u, ok := userctx.ContextGetUser(ctx)
 	if !ok {
 		err := errors.Wrap(errtypes.UserRequired("userrequired"), "error getting user from ctx")
 		return "", err
@@ -292,7 +292,7 @@ func (fs *ocfs) GetUpload(ctx context.Context, id string) (tusd.Upload, error) {
 		Username: info.Storage["UserName"],
 	}
 
-	ctx = user.ContextSetUser(ctx, u)
+	ctx = userctx.ContextSetUser(ctx, u)
 	// TODO configure the logger the same way ... store and add traceid in file info
 
 	var opts []logger.Option

--- a/pkg/storage/fs/owncloudsql/owncloudsql.go
+++ b/pkg/storage/fs/owncloudsql/owncloudsql.go
@@ -43,6 +43,7 @@ import (
 	"github.com/cs3org/reva/internal/grpc/services/storageprovider"
 	conversions "github.com/cs3org/reva/internal/http/services/owncloud/ocs/conversions"
 	"github.com/cs3org/reva/pkg/appctx"
+	ctxpkg "github.com/cs3org/reva/pkg/ctx"
 	"github.com/cs3org/reva/pkg/errtypes"
 	"github.com/cs3org/reva/pkg/logger"
 	"github.com/cs3org/reva/pkg/mime"
@@ -53,7 +54,6 @@ import (
 	"github.com/cs3org/reva/pkg/storage/fs/registry"
 	"github.com/cs3org/reva/pkg/storage/utils/chunking"
 	"github.com/cs3org/reva/pkg/storage/utils/templates"
-	"github.com/cs3org/reva/pkg/userctx"
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
 	"github.com/pkg/xattr"
@@ -205,7 +205,7 @@ func (fs *owncloudsqlfs) Shutdown(ctx context.Context) error {
 // TODO the path handed to a storage provider should not contain the username
 func (fs *owncloudsqlfs) toInternalPath(ctx context.Context, sp string) (ip string) {
 	if fs.c.EnableHome {
-		u := userctx.ContextMustGetUser(ctx)
+		u := ctxpkg.ContextMustGetUser(ctx)
 		layout := templates.WithUser(u, fs.c.UserLayout)
 		ip = filepath.Join(fs.c.DataDirectory, layout, "files", sp)
 	} else {
@@ -278,7 +278,7 @@ func (fs *owncloudsqlfs) getVersionsPath(ctx context.Context, ip string) string 
 
 // owncloudsql stores trashed items in the files_trashbin subfolder of a users home
 func (fs *owncloudsqlfs) getRecyclePath(ctx context.Context) (string, error) {
-	u, ok := userctx.ContextGetUser(ctx)
+	u, ok := ctxpkg.ContextGetUser(ctx)
 	if !ok {
 		err := errors.Wrap(errtypes.UserRequired("userrequired"), "error getting user from ctx")
 		return "", err
@@ -292,7 +292,7 @@ func (fs *owncloudsqlfs) getRecyclePathForUser(user string) (string, error) {
 }
 
 func (fs *owncloudsqlfs) getVersionRecyclePath(ctx context.Context) (string, error) {
-	u, ok := userctx.ContextGetUser(ctx)
+	u, ok := ctxpkg.ContextGetUser(ctx)
 	if !ok {
 		err := errors.Wrap(errtypes.UserRequired("userrequired"), "error getting user from ctx")
 		return "", err
@@ -311,7 +311,7 @@ func (fs *owncloudsqlfs) toDatabasePath(ip string) string {
 
 func (fs *owncloudsqlfs) toStoragePath(ctx context.Context, ip string) (sp string) {
 	if fs.c.EnableHome {
-		u := userctx.ContextMustGetUser(ctx)
+		u := ctxpkg.ContextMustGetUser(ctx)
 		layout := templates.WithUser(u, fs.c.UserLayout)
 		trim := filepath.Join(fs.c.DataDirectory, layout, "files")
 		sp = strings.TrimPrefix(ip, trim)
@@ -358,7 +358,7 @@ func (fs *owncloudsqlfs) getOwner(ip string) string {
 
 // TODO cache user lookup
 func (fs *owncloudsqlfs) getUser(ctx context.Context, usernameOrID string) (id *userpb.User, err error) {
-	u := userctx.ContextMustGetUser(ctx)
+	u := ctxpkg.ContextMustGetUser(ctx)
 	// check if username matches and id is set
 	if u.Username == usernameOrID && u.Id != nil && u.Id.OpaqueId != "" {
 		return u, nil
@@ -420,7 +420,7 @@ func (fs *owncloudsqlfs) permissionSet(ctx context.Context, owner *userpb.UserId
 			Stat: true,
 		}
 	}
-	u, ok := userctx.ContextGetUser(ctx)
+	u, ok := ctxpkg.ContextGetUser(ctx)
 	if !ok {
 		return &provider.ResourcePermissions{
 			// no permissions
@@ -596,7 +596,7 @@ func (fs *owncloudsqlfs) AddGrant(ctx context.Context, ref *provider.Reference, 
 }
 
 func (fs *owncloudsqlfs) readPermissions(ctx context.Context, ip string) (p *provider.ResourcePermissions, err error) {
-	u, ok := userctx.ContextGetUser(ctx)
+	u, ok := ctxpkg.ContextGetUser(ctx)
 	if !ok {
 		appctx.GetLogger(ctx).Debug().Str("ipath", ip).Msg("no user in context, returning default permissions")
 		return defaultPermissions, nil
@@ -652,7 +652,7 @@ func (fs *owncloudsqlfs) GetQuota(ctx context.Context) (uint64, uint64, error) {
 }
 
 func (fs *owncloudsqlfs) CreateHome(ctx context.Context) error {
-	u, ok := userctx.ContextGetUser(ctx)
+	u, ok := ctxpkg.ContextGetUser(ctx)
 	if !ok {
 		err := errors.Wrap(errtypes.UserRequired("userrequired"), "error getting user from ctx")
 		return err
@@ -866,7 +866,7 @@ func (fs *owncloudsqlfs) SetArbitraryMetadata(ctx context.Context, ref *provider
 			// 5. app? = a:<aid>: for apps?
 			// obviously this only is secure when the u/s/g/a namespaces are not accessible by users in the filesystem
 			// public tags can be mapped to extended attributes
-			if u, ok := userctx.ContextGetUser(ctx); ok {
+			if u, ok := ctxpkg.ContextGetUser(ctx); ok {
 				// the favorite flag is specific to the user, so we need to incorporate the userid
 				if uid := u.GetId(); uid != nil {
 					fa := fmt.Sprintf("%s%s@%s", favPrefix, uid.GetOpaqueId(), uid.GetIdp())
@@ -960,7 +960,7 @@ func (fs *owncloudsqlfs) UnsetArbitraryMetadata(ctx context.Context, ref *provid
 	for _, k := range keys {
 		switch k {
 		case "http://owncloud.org/ns/favorite":
-			if u, ok := userctx.ContextGetUser(ctx); ok {
+			if u, ok := ctxpkg.ContextGetUser(ctx); ok {
 				// the favorite flag is specific to the user, so we need to incorporate the userid
 				if uid := u.GetId(); uid != nil {
 					fa := fmt.Sprintf("%s%s@%s", favPrefix, uid.GetOpaqueId(), uid.GetIdp())
@@ -1605,7 +1605,7 @@ func (fs *owncloudsqlfs) PurgeRecycleItem(ctx context.Context, key, path string)
 	if err != nil {
 		return err
 	}
-	err = fs.filecache.PurgeRecycleItem(userctx.ContextMustGetUser(ctx).Username, base, ttime, false)
+	err = fs.filecache.PurgeRecycleItem(ctxpkg.ContextMustGetUser(ctx).Username, base, ttime, false)
 	if err != nil {
 		return err
 	}
@@ -1649,7 +1649,7 @@ func (fs *owncloudsqlfs) EmptyRecycle(ctx context.Context) error {
 		return errors.Wrap(err, "owncloudsql: error deleting recycle files versions")
 	}
 
-	u := userctx.ContextMustGetUser(ctx)
+	u := ctxpkg.ContextMustGetUser(ctx)
 	err = fs.filecache.EmptyRecycle(u.Username)
 	if err != nil {
 		return errors.Wrap(err, "owncloudsql: error deleting recycle items from the database")
@@ -1680,7 +1680,7 @@ func (fs *owncloudsqlfs) convertToRecycleItem(ctx context.Context, md os.FileInf
 		log.Error().Str("path", md.Name()).Msg("invalid trash item key")
 	}
 
-	u := userctx.ContextMustGetUser(ctx)
+	u := ctxpkg.ContextMustGetUser(ctx)
 	item, err := fs.filecache.GetRecycleItem(u.Username, base, ttime)
 	if err != nil {
 		log := appctx.GetLogger(ctx)
@@ -1749,7 +1749,7 @@ func (fs *owncloudsqlfs) RestoreRecycleItem(ctx context.Context, key, path strin
 	src := filepath.Join(recyclePath, filepath.Clean(key))
 
 	if restoreRef.Path == "" {
-		u := userctx.ContextMustGetUser(ctx)
+		u := ctxpkg.ContextMustGetUser(ctx)
 		item, err := fs.filecache.GetRecycleItem(u.Username, base, ttime)
 		if err != nil {
 			log := appctx.GetLogger(ctx)
@@ -1774,7 +1774,7 @@ func (fs *owncloudsqlfs) RestoreRecycleItem(ctx context.Context, key, path strin
 	if err != nil {
 		return err
 	}
-	err = fs.filecache.DeleteRecycleItem(userctx.ContextMustGetUser(ctx).Username, base, ttime)
+	err = fs.filecache.DeleteRecycleItem(ctxpkg.ContextMustGetUser(ctx).Username, base, ttime)
 	if err != nil {
 		return err
 	}

--- a/pkg/storage/fs/owncloudsql/owncloudsql.go
+++ b/pkg/storage/fs/owncloudsql/owncloudsql.go
@@ -53,7 +53,7 @@ import (
 	"github.com/cs3org/reva/pkg/storage/fs/registry"
 	"github.com/cs3org/reva/pkg/storage/utils/chunking"
 	"github.com/cs3org/reva/pkg/storage/utils/templates"
-	"github.com/cs3org/reva/pkg/user"
+	"github.com/cs3org/reva/pkg/userctx"
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
 	"github.com/pkg/xattr"
@@ -205,7 +205,7 @@ func (fs *owncloudsqlfs) Shutdown(ctx context.Context) error {
 // TODO the path handed to a storage provider should not contain the username
 func (fs *owncloudsqlfs) toInternalPath(ctx context.Context, sp string) (ip string) {
 	if fs.c.EnableHome {
-		u := user.ContextMustGetUser(ctx)
+		u := userctx.ContextMustGetUser(ctx)
 		layout := templates.WithUser(u, fs.c.UserLayout)
 		ip = filepath.Join(fs.c.DataDirectory, layout, "files", sp)
 	} else {
@@ -278,7 +278,7 @@ func (fs *owncloudsqlfs) getVersionsPath(ctx context.Context, ip string) string 
 
 // owncloudsql stores trashed items in the files_trashbin subfolder of a users home
 func (fs *owncloudsqlfs) getRecyclePath(ctx context.Context) (string, error) {
-	u, ok := user.ContextGetUser(ctx)
+	u, ok := userctx.ContextGetUser(ctx)
 	if !ok {
 		err := errors.Wrap(errtypes.UserRequired("userrequired"), "error getting user from ctx")
 		return "", err
@@ -292,7 +292,7 @@ func (fs *owncloudsqlfs) getRecyclePathForUser(user string) (string, error) {
 }
 
 func (fs *owncloudsqlfs) getVersionRecyclePath(ctx context.Context) (string, error) {
-	u, ok := user.ContextGetUser(ctx)
+	u, ok := userctx.ContextGetUser(ctx)
 	if !ok {
 		err := errors.Wrap(errtypes.UserRequired("userrequired"), "error getting user from ctx")
 		return "", err
@@ -311,7 +311,7 @@ func (fs *owncloudsqlfs) toDatabasePath(ip string) string {
 
 func (fs *owncloudsqlfs) toStoragePath(ctx context.Context, ip string) (sp string) {
 	if fs.c.EnableHome {
-		u := user.ContextMustGetUser(ctx)
+		u := userctx.ContextMustGetUser(ctx)
 		layout := templates.WithUser(u, fs.c.UserLayout)
 		trim := filepath.Join(fs.c.DataDirectory, layout, "files")
 		sp = strings.TrimPrefix(ip, trim)
@@ -358,7 +358,7 @@ func (fs *owncloudsqlfs) getOwner(ip string) string {
 
 // TODO cache user lookup
 func (fs *owncloudsqlfs) getUser(ctx context.Context, usernameOrID string) (id *userpb.User, err error) {
-	u := user.ContextMustGetUser(ctx)
+	u := userctx.ContextMustGetUser(ctx)
 	// check if username matches and id is set
 	if u.Username == usernameOrID && u.Id != nil && u.Id.OpaqueId != "" {
 		return u, nil
@@ -420,7 +420,7 @@ func (fs *owncloudsqlfs) permissionSet(ctx context.Context, owner *userpb.UserId
 			Stat: true,
 		}
 	}
-	u, ok := user.ContextGetUser(ctx)
+	u, ok := userctx.ContextGetUser(ctx)
 	if !ok {
 		return &provider.ResourcePermissions{
 			// no permissions
@@ -596,7 +596,7 @@ func (fs *owncloudsqlfs) AddGrant(ctx context.Context, ref *provider.Reference, 
 }
 
 func (fs *owncloudsqlfs) readPermissions(ctx context.Context, ip string) (p *provider.ResourcePermissions, err error) {
-	u, ok := user.ContextGetUser(ctx)
+	u, ok := userctx.ContextGetUser(ctx)
 	if !ok {
 		appctx.GetLogger(ctx).Debug().Str("ipath", ip).Msg("no user in context, returning default permissions")
 		return defaultPermissions, nil
@@ -652,7 +652,7 @@ func (fs *owncloudsqlfs) GetQuota(ctx context.Context) (uint64, uint64, error) {
 }
 
 func (fs *owncloudsqlfs) CreateHome(ctx context.Context) error {
-	u, ok := user.ContextGetUser(ctx)
+	u, ok := userctx.ContextGetUser(ctx)
 	if !ok {
 		err := errors.Wrap(errtypes.UserRequired("userrequired"), "error getting user from ctx")
 		return err
@@ -866,7 +866,7 @@ func (fs *owncloudsqlfs) SetArbitraryMetadata(ctx context.Context, ref *provider
 			// 5. app? = a:<aid>: for apps?
 			// obviously this only is secure when the u/s/g/a namespaces are not accessible by users in the filesystem
 			// public tags can be mapped to extended attributes
-			if u, ok := user.ContextGetUser(ctx); ok {
+			if u, ok := userctx.ContextGetUser(ctx); ok {
 				// the favorite flag is specific to the user, so we need to incorporate the userid
 				if uid := u.GetId(); uid != nil {
 					fa := fmt.Sprintf("%s%s@%s", favPrefix, uid.GetOpaqueId(), uid.GetIdp())
@@ -960,7 +960,7 @@ func (fs *owncloudsqlfs) UnsetArbitraryMetadata(ctx context.Context, ref *provid
 	for _, k := range keys {
 		switch k {
 		case "http://owncloud.org/ns/favorite":
-			if u, ok := user.ContextGetUser(ctx); ok {
+			if u, ok := userctx.ContextGetUser(ctx); ok {
 				// the favorite flag is specific to the user, so we need to incorporate the userid
 				if uid := u.GetId(); uid != nil {
 					fa := fmt.Sprintf("%s%s@%s", favPrefix, uid.GetOpaqueId(), uid.GetIdp())
@@ -1605,7 +1605,7 @@ func (fs *owncloudsqlfs) PurgeRecycleItem(ctx context.Context, key, path string)
 	if err != nil {
 		return err
 	}
-	err = fs.filecache.PurgeRecycleItem(user.ContextMustGetUser(ctx).Username, base, ttime, false)
+	err = fs.filecache.PurgeRecycleItem(userctx.ContextMustGetUser(ctx).Username, base, ttime, false)
 	if err != nil {
 		return err
 	}
@@ -1649,7 +1649,7 @@ func (fs *owncloudsqlfs) EmptyRecycle(ctx context.Context) error {
 		return errors.Wrap(err, "owncloudsql: error deleting recycle files versions")
 	}
 
-	u := user.ContextMustGetUser(ctx)
+	u := userctx.ContextMustGetUser(ctx)
 	err = fs.filecache.EmptyRecycle(u.Username)
 	if err != nil {
 		return errors.Wrap(err, "owncloudsql: error deleting recycle items from the database")
@@ -1680,7 +1680,7 @@ func (fs *owncloudsqlfs) convertToRecycleItem(ctx context.Context, md os.FileInf
 		log.Error().Str("path", md.Name()).Msg("invalid trash item key")
 	}
 
-	u := user.ContextMustGetUser(ctx)
+	u := userctx.ContextMustGetUser(ctx)
 	item, err := fs.filecache.GetRecycleItem(u.Username, base, ttime)
 	if err != nil {
 		log := appctx.GetLogger(ctx)
@@ -1749,7 +1749,7 @@ func (fs *owncloudsqlfs) RestoreRecycleItem(ctx context.Context, key, path strin
 	src := filepath.Join(recyclePath, filepath.Clean(key))
 
 	if restoreRef.Path == "" {
-		u := user.ContextMustGetUser(ctx)
+		u := userctx.ContextMustGetUser(ctx)
 		item, err := fs.filecache.GetRecycleItem(u.Username, base, ttime)
 		if err != nil {
 			log := appctx.GetLogger(ctx)
@@ -1774,7 +1774,7 @@ func (fs *owncloudsqlfs) RestoreRecycleItem(ctx context.Context, key, path strin
 	if err != nil {
 		return err
 	}
-	err = fs.filecache.DeleteRecycleItem(user.ContextMustGetUser(ctx).Username, base, ttime)
+	err = fs.filecache.DeleteRecycleItem(userctx.ContextMustGetUser(ctx).Username, base, ttime)
 	if err != nil {
 		return err
 	}

--- a/pkg/storage/fs/owncloudsql/upload.go
+++ b/pkg/storage/fs/owncloudsql/upload.go
@@ -32,12 +32,12 @@ import (
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	conversions "github.com/cs3org/reva/internal/http/services/owncloud/ocs/conversions"
 	"github.com/cs3org/reva/pkg/appctx"
+	ctxpkg "github.com/cs3org/reva/pkg/ctx"
 	"github.com/cs3org/reva/pkg/errtypes"
 	"github.com/cs3org/reva/pkg/logger"
 	"github.com/cs3org/reva/pkg/mime"
 	"github.com/cs3org/reva/pkg/storage/utils/chunking"
 	"github.com/cs3org/reva/pkg/storage/utils/templates"
-	"github.com/cs3org/reva/pkg/userctx"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
@@ -201,7 +201,7 @@ func (fs *owncloudsqlfs) NewUpload(ctx context.Context, info tusd.FileInfo) (upl
 	if err != nil {
 		return nil, errors.Wrap(err, "owncloudsql: error resolving upload path")
 	}
-	usr := userctx.ContextMustGetUser(ctx)
+	usr := ctxpkg.ContextMustGetUser(ctx)
 	storageID, err := fs.getStorage(ip)
 	if err != nil {
 		return nil, err
@@ -256,7 +256,7 @@ func (fs *owncloudsqlfs) NewUpload(ctx context.Context, info tusd.FileInfo) (upl
 }
 
 func (fs *owncloudsqlfs) getUploadPath(ctx context.Context, uploadID string) (string, error) {
-	u, ok := userctx.ContextGetUser(ctx)
+	u, ok := ctxpkg.ContextGetUser(ctx)
 	if !ok {
 		err := errors.Wrap(errtypes.UserRequired("userrequired"), "error getting user from ctx")
 		return "", err
@@ -293,7 +293,7 @@ func (fs *owncloudsqlfs) GetUpload(ctx context.Context, id string) (tusd.Upload,
 		Username: info.Storage["UserName"],
 	}
 
-	ctx = userctx.ContextSetUser(ctx, u)
+	ctx = ctxpkg.ContextSetUser(ctx, u)
 	// TODO configure the logger the same way ... store and add traceid in file info
 
 	var opts []logger.Option

--- a/pkg/storage/fs/owncloudsql/upload.go
+++ b/pkg/storage/fs/owncloudsql/upload.go
@@ -37,7 +37,7 @@ import (
 	"github.com/cs3org/reva/pkg/mime"
 	"github.com/cs3org/reva/pkg/storage/utils/chunking"
 	"github.com/cs3org/reva/pkg/storage/utils/templates"
-	"github.com/cs3org/reva/pkg/user"
+	"github.com/cs3org/reva/pkg/userctx"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
@@ -201,7 +201,7 @@ func (fs *owncloudsqlfs) NewUpload(ctx context.Context, info tusd.FileInfo) (upl
 	if err != nil {
 		return nil, errors.Wrap(err, "owncloudsql: error resolving upload path")
 	}
-	usr := user.ContextMustGetUser(ctx)
+	usr := userctx.ContextMustGetUser(ctx)
 	storageID, err := fs.getStorage(ip)
 	if err != nil {
 		return nil, err
@@ -256,7 +256,7 @@ func (fs *owncloudsqlfs) NewUpload(ctx context.Context, info tusd.FileInfo) (upl
 }
 
 func (fs *owncloudsqlfs) getUploadPath(ctx context.Context, uploadID string) (string, error) {
-	u, ok := user.ContextGetUser(ctx)
+	u, ok := userctx.ContextGetUser(ctx)
 	if !ok {
 		err := errors.Wrap(errtypes.UserRequired("userrequired"), "error getting user from ctx")
 		return "", err
@@ -293,7 +293,7 @@ func (fs *owncloudsqlfs) GetUpload(ctx context.Context, id string) (tusd.Upload,
 		Username: info.Storage["UserName"],
 	}
 
-	ctx = user.ContextSetUser(ctx, u)
+	ctx = userctx.ContextSetUser(ctx, u)
 	// TODO configure the logger the same way ... store and add traceid in file info
 
 	var opts []logger.Option

--- a/pkg/storage/registry/static/static.go
+++ b/pkg/storage/registry/static/static.go
@@ -26,12 +26,12 @@ import (
 
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	registrypb "github.com/cs3org/go-cs3apis/cs3/storage/registry/v1beta1"
+	ctxpkg "github.com/cs3org/reva/pkg/ctx"
 	"github.com/cs3org/reva/pkg/errtypes"
 	"github.com/cs3org/reva/pkg/sharedconf"
 	"github.com/cs3org/reva/pkg/storage"
 	"github.com/cs3org/reva/pkg/storage/registry/registry"
 	"github.com/cs3org/reva/pkg/storage/utils/templates"
-	"github.com/cs3org/reva/pkg/userctx"
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
 )
@@ -96,7 +96,7 @@ type reg struct {
 func getProviderAddr(ctx context.Context, r rule) string {
 	addr := r.Address
 	if addr == "" {
-		if u, ok := userctx.ContextGetUser(ctx); ok {
+		if u, ok := ctxpkg.ContextGetUser(ctx); ok {
 			layout := templates.WithUser(u, r.Mapping)
 			for k, v := range r.Aliases {
 				if match, _ := regexp.MatchString("^"+k, layout); match {

--- a/pkg/storage/registry/static/static.go
+++ b/pkg/storage/registry/static/static.go
@@ -31,7 +31,7 @@ import (
 	"github.com/cs3org/reva/pkg/storage"
 	"github.com/cs3org/reva/pkg/storage/registry/registry"
 	"github.com/cs3org/reva/pkg/storage/utils/templates"
-	"github.com/cs3org/reva/pkg/user"
+	"github.com/cs3org/reva/pkg/userctx"
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
 )
@@ -96,7 +96,7 @@ type reg struct {
 func getProviderAddr(ctx context.Context, r rule) string {
 	addr := r.Address
 	if addr == "" {
-		if u, ok := user.ContextGetUser(ctx); ok {
+		if u, ok := userctx.ContextGetUser(ctx); ok {
 			layout := templates.WithUser(u, r.Mapping)
 			for k, v := range r.Aliases {
 				if match, _ := regexp.MatchString("^"+k, layout); match {

--- a/pkg/storage/registry/static/static_test.go
+++ b/pkg/storage/registry/static/static_test.go
@@ -25,7 +25,7 @@ import (
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	registrypb "github.com/cs3org/go-cs3apis/cs3/storage/registry/v1beta1"
 	"github.com/cs3org/reva/pkg/storage/registry/static"
-	"github.com/cs3org/reva/pkg/user"
+	"github.com/cs3org/reva/pkg/userctx"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -82,12 +82,12 @@ var _ = Describe("Static", func() {
 	})
 	Expect(err).ToNot(HaveOccurred())
 
-	ctxAlice := user.ContextSetUser(context.Background(), &userpb.User{
+	ctxAlice := userctx.ContextSetUser(context.Background(), &userpb.User{
 		Id: &userpb.UserId{
 			OpaqueId: "alice",
 		},
 	})
-	ctxRobert := user.ContextSetUser(context.Background(), &userpb.User{
+	ctxRobert := userctx.ContextSetUser(context.Background(), &userpb.User{
 		Id: &userpb.UserId{
 			OpaqueId: "robert",
 		},

--- a/pkg/storage/registry/static/static_test.go
+++ b/pkg/storage/registry/static/static_test.go
@@ -24,8 +24,8 @@ import (
 	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	registrypb "github.com/cs3org/go-cs3apis/cs3/storage/registry/v1beta1"
+	ctxpkg "github.com/cs3org/reva/pkg/ctx"
 	"github.com/cs3org/reva/pkg/storage/registry/static"
-	"github.com/cs3org/reva/pkg/userctx"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -82,12 +82,12 @@ var _ = Describe("Static", func() {
 	})
 	Expect(err).ToNot(HaveOccurred())
 
-	ctxAlice := userctx.ContextSetUser(context.Background(), &userpb.User{
+	ctxAlice := ctxpkg.ContextSetUser(context.Background(), &userpb.User{
 		Id: &userpb.UserId{
 			OpaqueId: "alice",
 		},
 	})
-	ctxRobert := userctx.ContextSetUser(context.Background(), &userpb.User{
+	ctxRobert := ctxpkg.ContextSetUser(context.Background(), &userpb.User{
 		Id: &userpb.UserId{
 			OpaqueId: "robert",
 		},

--- a/pkg/storage/utils/decomposedfs/decomposedfs.go
+++ b/pkg/storage/utils/decomposedfs/decomposedfs.go
@@ -45,7 +45,7 @@ import (
 	"github.com/cs3org/reva/pkg/storage/utils/decomposedfs/tree"
 	"github.com/cs3org/reva/pkg/storage/utils/decomposedfs/xattrs"
 	"github.com/cs3org/reva/pkg/storage/utils/templates"
-	"github.com/cs3org/reva/pkg/user"
+	"github.com/cs3org/reva/pkg/userctx"
 	"github.com/cs3org/reva/pkg/utils"
 	"github.com/pkg/errors"
 	"github.com/pkg/xattr"
@@ -202,7 +202,7 @@ func (fs *Decomposedfs) CreateHome(ctx context.Context) (err error) {
 	}
 
 	// update the owner
-	u := user.ContextMustGetUser(ctx)
+	u := userctx.ContextMustGetUser(ctx)
 	if err = h.WriteMetadata(u.Id); err != nil {
 		return
 	}
@@ -246,7 +246,7 @@ func (fs *Decomposedfs) GetHome(ctx context.Context) (string, error) {
 	if !fs.o.EnableHome || fs.o.UserLayout == "" {
 		return "", errtypes.NotSupported("Decomposedfs: GetHome() home supported disabled")
 	}
-	u := user.ContextMustGetUser(ctx)
+	u := userctx.ContextMustGetUser(ctx)
 	layout := templates.WithUser(u, fs.o.UserLayout)
 	return filepath.Join(fs.o.Root, layout), nil // TODO use a namespace?
 }
@@ -535,7 +535,7 @@ func (fs *Decomposedfs) ListStorageSpaces(ctx context.Context, filter []*provide
 
 	spaces := make([]*provider.StorageSpace, 0, len(matches))
 
-	u, ok := user.ContextGetUser(ctx)
+	u, ok := userctx.ContextGetUser(ctx)
 	if !ok {
 		appctx.GetLogger(ctx).Debug().Msg("expected user in context")
 		return spaces, nil

--- a/pkg/storage/utils/decomposedfs/decomposedfs.go
+++ b/pkg/storage/utils/decomposedfs/decomposedfs.go
@@ -36,6 +36,7 @@ import (
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	types "github.com/cs3org/go-cs3apis/cs3/types/v1beta1"
 	"github.com/cs3org/reva/pkg/appctx"
+	ctxpkg "github.com/cs3org/reva/pkg/ctx"
 	"github.com/cs3org/reva/pkg/errtypes"
 	"github.com/cs3org/reva/pkg/logger"
 	"github.com/cs3org/reva/pkg/storage"
@@ -45,7 +46,6 @@ import (
 	"github.com/cs3org/reva/pkg/storage/utils/decomposedfs/tree"
 	"github.com/cs3org/reva/pkg/storage/utils/decomposedfs/xattrs"
 	"github.com/cs3org/reva/pkg/storage/utils/templates"
-	"github.com/cs3org/reva/pkg/userctx"
 	"github.com/cs3org/reva/pkg/utils"
 	"github.com/pkg/errors"
 	"github.com/pkg/xattr"
@@ -202,7 +202,7 @@ func (fs *Decomposedfs) CreateHome(ctx context.Context) (err error) {
 	}
 
 	// update the owner
-	u := userctx.ContextMustGetUser(ctx)
+	u := ctxpkg.ContextMustGetUser(ctx)
 	if err = h.WriteMetadata(u.Id); err != nil {
 		return
 	}
@@ -246,7 +246,7 @@ func (fs *Decomposedfs) GetHome(ctx context.Context) (string, error) {
 	if !fs.o.EnableHome || fs.o.UserLayout == "" {
 		return "", errtypes.NotSupported("Decomposedfs: GetHome() home supported disabled")
 	}
-	u := userctx.ContextMustGetUser(ctx)
+	u := ctxpkg.ContextMustGetUser(ctx)
 	layout := templates.WithUser(u, fs.o.UserLayout)
 	return filepath.Join(fs.o.Root, layout), nil // TODO use a namespace?
 }
@@ -535,7 +535,7 @@ func (fs *Decomposedfs) ListStorageSpaces(ctx context.Context, filter []*provide
 
 	spaces := make([]*provider.StorageSpace, 0, len(matches))
 
-	u, ok := userctx.ContextGetUser(ctx)
+	u, ok := ctxpkg.ContextGetUser(ctx)
 	if !ok {
 		appctx.GetLogger(ctx).Debug().Msg("expected user in context")
 		return spaces, nil

--- a/pkg/storage/utils/decomposedfs/decomposedfs_concurrency_test.go
+++ b/pkg/storage/utils/decomposedfs/decomposedfs_concurrency_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/cs3org/reva/pkg/storage"
 	"github.com/cs3org/reva/pkg/storage/utils/decomposedfs"
 	treemocks "github.com/cs3org/reva/pkg/storage/utils/decomposedfs/tree/mocks"
-	"github.com/cs3org/reva/pkg/user"
+	"github.com/cs3org/reva/pkg/userctx"
 	"github.com/cs3org/reva/tests/helpers"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -69,7 +69,7 @@ var _ = Describe("Decomposed", func() {
 				"physics-lovers",
 			},
 		}
-		ctx = user.ContextSetUser(context.Background(), u)
+		ctx = userctx.ContextSetUser(context.Background(), u)
 
 		bs := &treemocks.Blobstore{}
 		fs, err = decomposedfs.NewDefault(options, bs)

--- a/pkg/storage/utils/decomposedfs/decomposedfs_concurrency_test.go
+++ b/pkg/storage/utils/decomposedfs/decomposedfs_concurrency_test.go
@@ -28,10 +28,10 @@ import (
 
 	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+	ctxpkg "github.com/cs3org/reva/pkg/ctx"
 	"github.com/cs3org/reva/pkg/storage"
 	"github.com/cs3org/reva/pkg/storage/utils/decomposedfs"
 	treemocks "github.com/cs3org/reva/pkg/storage/utils/decomposedfs/tree/mocks"
-	"github.com/cs3org/reva/pkg/userctx"
 	"github.com/cs3org/reva/tests/helpers"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -69,7 +69,7 @@ var _ = Describe("Decomposed", func() {
 				"physics-lovers",
 			},
 		}
-		ctx = userctx.ContextSetUser(context.Background(), u)
+		ctx = ctxpkg.ContextSetUser(context.Background(), u)
 
 		bs := &treemocks.Blobstore{}
 		fs, err = decomposedfs.NewDefault(options, bs)

--- a/pkg/storage/utils/decomposedfs/lookup.go
+++ b/pkg/storage/utils/decomposedfs/lookup.go
@@ -30,7 +30,7 @@ import (
 	"github.com/cs3org/reva/pkg/storage/utils/decomposedfs/node"
 	"github.com/cs3org/reva/pkg/storage/utils/decomposedfs/options"
 	"github.com/cs3org/reva/pkg/storage/utils/templates"
-	"github.com/cs3org/reva/pkg/user"
+	"github.com/cs3org/reva/pkg/userctx"
 )
 
 // Lookup implements transformations from filepath to node and back
@@ -165,7 +165,7 @@ func (lu *Lookup) InternalPath(id string) string {
 }
 
 func (lu *Lookup) mustGetUserLayout(ctx context.Context) string {
-	u := user.ContextMustGetUser(ctx)
+	u := userctx.ContextMustGetUser(ctx)
 	return templates.WithUser(u, lu.Options.UserLayout)
 }
 

--- a/pkg/storage/utils/decomposedfs/lookup.go
+++ b/pkg/storage/utils/decomposedfs/lookup.go
@@ -26,11 +26,11 @@ import (
 
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	"github.com/cs3org/reva/pkg/appctx"
+	ctxpkg "github.com/cs3org/reva/pkg/ctx"
 	"github.com/cs3org/reva/pkg/errtypes"
 	"github.com/cs3org/reva/pkg/storage/utils/decomposedfs/node"
 	"github.com/cs3org/reva/pkg/storage/utils/decomposedfs/options"
 	"github.com/cs3org/reva/pkg/storage/utils/templates"
-	"github.com/cs3org/reva/pkg/userctx"
 )
 
 // Lookup implements transformations from filepath to node and back
@@ -165,7 +165,7 @@ func (lu *Lookup) InternalPath(id string) string {
 }
 
 func (lu *Lookup) mustGetUserLayout(ctx context.Context) string {
-	u := userctx.ContextMustGetUser(ctx)
+	u := ctxpkg.ContextMustGetUser(ctx)
 	return templates.WithUser(u, lu.Options.UserLayout)
 }
 

--- a/pkg/storage/utils/decomposedfs/metadata.go
+++ b/pkg/storage/utils/decomposedfs/metadata.go
@@ -28,7 +28,7 @@ import (
 	"github.com/cs3org/reva/pkg/errtypes"
 	"github.com/cs3org/reva/pkg/storage/utils/decomposedfs/node"
 	"github.com/cs3org/reva/pkg/storage/utils/decomposedfs/xattrs"
-	"github.com/cs3org/reva/pkg/user"
+	"github.com/cs3org/reva/pkg/userctx"
 	"github.com/cs3org/reva/pkg/utils"
 	"github.com/pkg/errors"
 	"github.com/pkg/xattr"
@@ -84,7 +84,7 @@ func (fs *Decomposedfs) SetArbitraryMetadata(ctx context.Context, ref *provider.
 		}
 		if val, ok := md.Metadata[node.FavoriteKey]; ok {
 			delete(md.Metadata, node.FavoriteKey)
-			if u, ok := user.ContextGetUser(ctx); ok {
+			if u, ok := userctx.ContextGetUser(ctx); ok {
 				if uid := u.GetId(); uid != nil {
 					if err := n.SetFavorite(uid, val); err != nil {
 						sublog.Error().Err(err).
@@ -151,7 +151,7 @@ func (fs *Decomposedfs) UnsetArbitraryMetadata(ctx context.Context, ref *provide
 	for _, k := range keys {
 		switch k {
 		case node.FavoriteKey:
-			if u, ok := user.ContextGetUser(ctx); ok {
+			if u, ok := userctx.ContextGetUser(ctx); ok {
 				// the favorite flag is specific to the user, so we need to incorporate the userid
 				if uid := u.GetId(); uid != nil {
 					fa := fmt.Sprintf("%s:%s:%s@%s", xattrs.FavPrefix, utils.UserTypeToString(uid.GetType()), uid.GetOpaqueId(), uid.GetIdp())

--- a/pkg/storage/utils/decomposedfs/metadata.go
+++ b/pkg/storage/utils/decomposedfs/metadata.go
@@ -25,10 +25,10 @@ import (
 
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	"github.com/cs3org/reva/pkg/appctx"
+	ctxpkg "github.com/cs3org/reva/pkg/ctx"
 	"github.com/cs3org/reva/pkg/errtypes"
 	"github.com/cs3org/reva/pkg/storage/utils/decomposedfs/node"
 	"github.com/cs3org/reva/pkg/storage/utils/decomposedfs/xattrs"
-	"github.com/cs3org/reva/pkg/userctx"
 	"github.com/cs3org/reva/pkg/utils"
 	"github.com/pkg/errors"
 	"github.com/pkg/xattr"
@@ -84,7 +84,7 @@ func (fs *Decomposedfs) SetArbitraryMetadata(ctx context.Context, ref *provider.
 		}
 		if val, ok := md.Metadata[node.FavoriteKey]; ok {
 			delete(md.Metadata, node.FavoriteKey)
-			if u, ok := userctx.ContextGetUser(ctx); ok {
+			if u, ok := ctxpkg.ContextGetUser(ctx); ok {
 				if uid := u.GetId(); uid != nil {
 					if err := n.SetFavorite(uid, val); err != nil {
 						sublog.Error().Err(err).
@@ -151,7 +151,7 @@ func (fs *Decomposedfs) UnsetArbitraryMetadata(ctx context.Context, ref *provide
 	for _, k := range keys {
 		switch k {
 		case node.FavoriteKey:
-			if u, ok := userctx.ContextGetUser(ctx); ok {
+			if u, ok := ctxpkg.ContextGetUser(ctx); ok {
 				// the favorite flag is specific to the user, so we need to incorporate the userid
 				if uid := u.GetId(); uid != nil {
 					fa := fmt.Sprintf("%s:%s:%s@%s", xattrs.FavPrefix, utils.UserTypeToString(uid.GetType()), uid.GetOpaqueId(), uid.GetIdp())

--- a/pkg/storage/utils/decomposedfs/node/node.go
+++ b/pkg/storage/utils/decomposedfs/node/node.go
@@ -42,11 +42,11 @@ import (
 	types "github.com/cs3org/go-cs3apis/cs3/types/v1beta1"
 	"github.com/cs3org/reva/internal/grpc/services/storageprovider"
 	"github.com/cs3org/reva/pkg/appctx"
+	ctxpkg "github.com/cs3org/reva/pkg/ctx"
 	"github.com/cs3org/reva/pkg/errtypes"
 	"github.com/cs3org/reva/pkg/mime"
 	"github.com/cs3org/reva/pkg/storage/utils/ace"
 	"github.com/cs3org/reva/pkg/storage/utils/decomposedfs/xattrs"
-	"github.com/cs3org/reva/pkg/userctx"
 	"github.com/cs3org/reva/pkg/utils"
 )
 
@@ -326,7 +326,7 @@ func (n *Node) Owner() (*userpb.UserId, error) {
 // PermissionSet returns the permission set for the current user
 // the parent nodes are not taken into account
 func (n *Node) PermissionSet(ctx context.Context) provider.ResourcePermissions {
-	u, ok := userctx.ContextGetUser(ctx)
+	u, ok := ctxpkg.ContextGetUser(ctx)
 	if !ok {
 		appctx.GetLogger(ctx).Debug().Interface("node", n).Msg("no user in context, returning default permissions")
 		return NoPermissions()
@@ -541,7 +541,7 @@ func (n *Node) AsResourceInfo(ctx context.Context, rp *provider.ResourcePermissi
 	// read favorite flag for the current user
 	if _, ok := mdKeysMap[FavoriteKey]; returnAllKeys || ok {
 		favorite := ""
-		if u, ok := userctx.ContextGetUser(ctx); ok {
+		if u, ok := ctxpkg.ContextGetUser(ctx); ok {
 			// the favorite flag is specific to the user, so we need to incorporate the userid
 			if uid := u.GetId(); uid != nil {
 				fa := fmt.Sprintf("%s:%s:%s@%s", xattrs.FavPrefix, utils.UserTypeToString(uid.GetType()), uid.GetOpaqueId(), uid.GetIdp())

--- a/pkg/storage/utils/decomposedfs/node/node.go
+++ b/pkg/storage/utils/decomposedfs/node/node.go
@@ -46,7 +46,7 @@ import (
 	"github.com/cs3org/reva/pkg/mime"
 	"github.com/cs3org/reva/pkg/storage/utils/ace"
 	"github.com/cs3org/reva/pkg/storage/utils/decomposedfs/xattrs"
-	"github.com/cs3org/reva/pkg/user"
+	"github.com/cs3org/reva/pkg/userctx"
 	"github.com/cs3org/reva/pkg/utils"
 )
 
@@ -326,7 +326,7 @@ func (n *Node) Owner() (*userpb.UserId, error) {
 // PermissionSet returns the permission set for the current user
 // the parent nodes are not taken into account
 func (n *Node) PermissionSet(ctx context.Context) provider.ResourcePermissions {
-	u, ok := user.ContextGetUser(ctx)
+	u, ok := userctx.ContextGetUser(ctx)
 	if !ok {
 		appctx.GetLogger(ctx).Debug().Interface("node", n).Msg("no user in context, returning default permissions")
 		return NoPermissions()
@@ -541,7 +541,7 @@ func (n *Node) AsResourceInfo(ctx context.Context, rp *provider.ResourcePermissi
 	// read favorite flag for the current user
 	if _, ok := mdKeysMap[FavoriteKey]; returnAllKeys || ok {
 		favorite := ""
-		if u, ok := user.ContextGetUser(ctx); ok {
+		if u, ok := userctx.ContextGetUser(ctx); ok {
 			// the favorite flag is specific to the user, so we need to incorporate the userid
 			if uid := u.GetId(); uid != nil {
 				fa := fmt.Sprintf("%s:%s:%s@%s", xattrs.FavPrefix, utils.UserTypeToString(uid.GetType()), uid.GetOpaqueId(), uid.GetIdp())

--- a/pkg/storage/utils/decomposedfs/node/permissions.go
+++ b/pkg/storage/utils/decomposedfs/node/permissions.go
@@ -27,7 +27,7 @@ import (
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	"github.com/cs3org/reva/pkg/appctx"
 	"github.com/cs3org/reva/pkg/storage/utils/decomposedfs/xattrs"
-	"github.com/cs3org/reva/pkg/user"
+	"github.com/cs3org/reva/pkg/userctx"
 	"github.com/pkg/errors"
 	"github.com/pkg/xattr"
 )
@@ -96,7 +96,7 @@ func NewPermissions(lu PathLookup) *Permissions {
 
 // AssemblePermissions will assemble the permissions for the current user on the given node, taking into account all parent nodes
 func (p *Permissions) AssemblePermissions(ctx context.Context, n *Node) (ap provider.ResourcePermissions, err error) {
-	u, ok := user.ContextGetUser(ctx)
+	u, ok := userctx.ContextGetUser(ctx)
 	if !ok {
 		appctx.GetLogger(ctx).Debug().Interface("node", n).Msg("no user in context, returning default permissions")
 		return NoPermissions(), nil
@@ -257,7 +257,7 @@ func (p *Permissions) HasPermission(ctx context.Context, n *Node, check func(*pr
 }
 
 func (p *Permissions) getUserAndPermissions(ctx context.Context, n *Node) (*userv1beta1.User, *provider.ResourcePermissions) {
-	u, ok := user.ContextGetUser(ctx)
+	u, ok := userctx.ContextGetUser(ctx)
 	if !ok {
 		appctx.GetLogger(ctx).Debug().Interface("node", n).Msg("no user in context, returning default permissions")
 		perms := NoPermissions()

--- a/pkg/storage/utils/decomposedfs/node/permissions.go
+++ b/pkg/storage/utils/decomposedfs/node/permissions.go
@@ -26,8 +26,8 @@ import (
 	userv1beta1 "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	"github.com/cs3org/reva/pkg/appctx"
+	ctxpkg "github.com/cs3org/reva/pkg/ctx"
 	"github.com/cs3org/reva/pkg/storage/utils/decomposedfs/xattrs"
-	"github.com/cs3org/reva/pkg/userctx"
 	"github.com/pkg/errors"
 	"github.com/pkg/xattr"
 )
@@ -96,7 +96,7 @@ func NewPermissions(lu PathLookup) *Permissions {
 
 // AssemblePermissions will assemble the permissions for the current user on the given node, taking into account all parent nodes
 func (p *Permissions) AssemblePermissions(ctx context.Context, n *Node) (ap provider.ResourcePermissions, err error) {
-	u, ok := userctx.ContextGetUser(ctx)
+	u, ok := ctxpkg.ContextGetUser(ctx)
 	if !ok {
 		appctx.GetLogger(ctx).Debug().Interface("node", n).Msg("no user in context, returning default permissions")
 		return NoPermissions(), nil
@@ -257,7 +257,7 @@ func (p *Permissions) HasPermission(ctx context.Context, n *Node, check func(*pr
 }
 
 func (p *Permissions) getUserAndPermissions(ctx context.Context, n *Node) (*userv1beta1.User, *provider.ResourcePermissions) {
-	u, ok := userctx.ContextGetUser(ctx)
+	u, ok := ctxpkg.ContextGetUser(ctx)
 	if !ok {
 		appctx.GetLogger(ctx).Debug().Interface("node", n).Msg("no user in context, returning default permissions")
 		perms := NoPermissions()

--- a/pkg/storage/utils/decomposedfs/recycle.go
+++ b/pkg/storage/utils/decomposedfs/recycle.go
@@ -32,7 +32,7 @@ import (
 	"github.com/cs3org/reva/pkg/errtypes"
 	"github.com/cs3org/reva/pkg/storage/utils/decomposedfs/node"
 	"github.com/cs3org/reva/pkg/storage/utils/decomposedfs/xattrs"
-	"github.com/cs3org/reva/pkg/user"
+	"github.com/cs3org/reva/pkg/userctx"
 	"github.com/pkg/errors"
 	"github.com/pkg/xattr"
 )
@@ -159,7 +159,7 @@ func (fs *Decomposedfs) createTrashItem(ctx context.Context, parentNode, interme
 	// for now we can only really check if the current user is the owner
 	if attrBytes, err := xattr.Get(nodePath, xattrs.OwnerIDAttr); err == nil {
 		if fs.o.EnableHome {
-			u := user.ContextMustGetUser(ctx)
+			u := userctx.ContextMustGetUser(ctx)
 			if u.Id.OpaqueId != string(attrBytes) {
 				log.Warn().Str("trashRoot", trashRoot).Str("link", trashnode).Msg("trash item not owned by current user, skipping")
 				// continue
@@ -241,7 +241,7 @@ func (fs *Decomposedfs) listTrashRoot(ctx context.Context) ([]*provider.RecycleI
 		// for now we can only really check if the current user is the owner
 		if attrBytes, err = xattr.Get(nodePath, xattrs.OwnerIDAttr); err == nil {
 			if fs.o.EnableHome {
-				u := user.ContextMustGetUser(ctx)
+				u := userctx.ContextMustGetUser(ctx)
 				if u.Id.OpaqueId != string(attrBytes) {
 					log.Warn().Str("trashRoot", trashRoot).Str("name", names[i]).Str("link", trashnode).Msg("trash item not owned by current user, skipping")
 					continue
@@ -306,7 +306,7 @@ func (fs *Decomposedfs) PurgeRecycleItem(ctx context.Context, key, path string) 
 
 // EmptyRecycle empties the trash
 func (fs *Decomposedfs) EmptyRecycle(ctx context.Context) error {
-	u, ok := user.ContextGetUser(ctx)
+	u, ok := userctx.ContextGetUser(ctx)
 	// TODO what permission should we check? we could check the root node of the user? or the owner permissions on his home root node?
 	// The current impl will wipe your own trash. or when no user provided the trash of 'root'
 	if !ok {
@@ -326,7 +326,7 @@ func getResourceType(isDir bool) provider.ResourceType {
 
 func (fs *Decomposedfs) getRecycleRoot(ctx context.Context) string {
 	if fs.o.EnableHome {
-		u := user.ContextMustGetUser(ctx)
+		u := userctx.ContextMustGetUser(ctx)
 		// TODO use layout, see Tree.Delete() for problem
 		return filepath.Join(fs.o.Root, "trash", u.Id.OpaqueId)
 	}

--- a/pkg/storage/utils/decomposedfs/recycle.go
+++ b/pkg/storage/utils/decomposedfs/recycle.go
@@ -29,10 +29,10 @@ import (
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	types "github.com/cs3org/go-cs3apis/cs3/types/v1beta1"
 	"github.com/cs3org/reva/pkg/appctx"
+	ctxpkg "github.com/cs3org/reva/pkg/ctx"
 	"github.com/cs3org/reva/pkg/errtypes"
 	"github.com/cs3org/reva/pkg/storage/utils/decomposedfs/node"
 	"github.com/cs3org/reva/pkg/storage/utils/decomposedfs/xattrs"
-	"github.com/cs3org/reva/pkg/userctx"
 	"github.com/pkg/errors"
 	"github.com/pkg/xattr"
 )
@@ -159,7 +159,7 @@ func (fs *Decomposedfs) createTrashItem(ctx context.Context, parentNode, interme
 	// for now we can only really check if the current user is the owner
 	if attrBytes, err := xattr.Get(nodePath, xattrs.OwnerIDAttr); err == nil {
 		if fs.o.EnableHome {
-			u := userctx.ContextMustGetUser(ctx)
+			u := ctxpkg.ContextMustGetUser(ctx)
 			if u.Id.OpaqueId != string(attrBytes) {
 				log.Warn().Str("trashRoot", trashRoot).Str("link", trashnode).Msg("trash item not owned by current user, skipping")
 				// continue
@@ -241,7 +241,7 @@ func (fs *Decomposedfs) listTrashRoot(ctx context.Context) ([]*provider.RecycleI
 		// for now we can only really check if the current user is the owner
 		if attrBytes, err = xattr.Get(nodePath, xattrs.OwnerIDAttr); err == nil {
 			if fs.o.EnableHome {
-				u := userctx.ContextMustGetUser(ctx)
+				u := ctxpkg.ContextMustGetUser(ctx)
 				if u.Id.OpaqueId != string(attrBytes) {
 					log.Warn().Str("trashRoot", trashRoot).Str("name", names[i]).Str("link", trashnode).Msg("trash item not owned by current user, skipping")
 					continue
@@ -306,7 +306,7 @@ func (fs *Decomposedfs) PurgeRecycleItem(ctx context.Context, key, path string) 
 
 // EmptyRecycle empties the trash
 func (fs *Decomposedfs) EmptyRecycle(ctx context.Context) error {
-	u, ok := userctx.ContextGetUser(ctx)
+	u, ok := ctxpkg.ContextGetUser(ctx)
 	// TODO what permission should we check? we could check the root node of the user? or the owner permissions on his home root node?
 	// The current impl will wipe your own trash. or when no user provided the trash of 'root'
 	if !ok {
@@ -326,7 +326,7 @@ func getResourceType(isDir bool) provider.ResourceType {
 
 func (fs *Decomposedfs) getRecycleRoot(ctx context.Context) string {
 	if fs.o.EnableHome {
-		u := userctx.ContextMustGetUser(ctx)
+		u := ctxpkg.ContextMustGetUser(ctx)
 		// TODO use layout, see Tree.Delete() for problem
 		return filepath.Join(fs.o.Root, "trash", u.Id.OpaqueId)
 	}

--- a/pkg/storage/utils/decomposedfs/testhelpers/helpers.go
+++ b/pkg/storage/utils/decomposedfs/testhelpers/helpers.go
@@ -27,6 +27,7 @@ import (
 	"github.com/stretchr/testify/mock"
 
 	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
+	ruser "github.com/cs3org/reva/pkg/ctx"
 	"github.com/cs3org/reva/pkg/storage"
 	"github.com/cs3org/reva/pkg/storage/utils/decomposedfs"
 	"github.com/cs3org/reva/pkg/storage/utils/decomposedfs/mocks"
@@ -34,7 +35,6 @@ import (
 	"github.com/cs3org/reva/pkg/storage/utils/decomposedfs/options"
 	"github.com/cs3org/reva/pkg/storage/utils/decomposedfs/tree"
 	treemocks "github.com/cs3org/reva/pkg/storage/utils/decomposedfs/tree/mocks"
-	ruser "github.com/cs3org/reva/pkg/userctx"
 	"github.com/cs3org/reva/tests/helpers"
 )
 

--- a/pkg/storage/utils/decomposedfs/testhelpers/helpers.go
+++ b/pkg/storage/utils/decomposedfs/testhelpers/helpers.go
@@ -34,7 +34,7 @@ import (
 	"github.com/cs3org/reva/pkg/storage/utils/decomposedfs/options"
 	"github.com/cs3org/reva/pkg/storage/utils/decomposedfs/tree"
 	treemocks "github.com/cs3org/reva/pkg/storage/utils/decomposedfs/tree/mocks"
-	ruser "github.com/cs3org/reva/pkg/user"
+	ruser "github.com/cs3org/reva/pkg/userctx"
 	"github.com/cs3org/reva/tests/helpers"
 )
 

--- a/pkg/storage/utils/decomposedfs/tree/tree.go
+++ b/pkg/storage/utils/decomposedfs/tree/tree.go
@@ -34,7 +34,7 @@ import (
 	"github.com/cs3org/reva/pkg/errtypes"
 	"github.com/cs3org/reva/pkg/storage/utils/decomposedfs/node"
 	"github.com/cs3org/reva/pkg/storage/utils/decomposedfs/xattrs"
-	"github.com/cs3org/reva/pkg/user"
+	"github.com/cs3org/reva/pkg/userctx"
 	"github.com/cs3org/reva/pkg/utils"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
@@ -715,7 +715,7 @@ func (t *Tree) readRecycleItem(ctx context.Context, key, path string) (n *node.N
 		return nil, "", "", "", errtypes.InternalError("key is empty")
 	}
 
-	u := user.ContextMustGetUser(ctx)
+	u := userctx.ContextMustGetUser(ctx)
 	trashItem = filepath.Join(t.lookup.InternalRoot(), "trash", u.Id.OpaqueId, key, path)
 
 	var link string

--- a/pkg/storage/utils/decomposedfs/tree/tree.go
+++ b/pkg/storage/utils/decomposedfs/tree/tree.go
@@ -31,10 +31,10 @@ import (
 	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	"github.com/cs3org/reva/pkg/appctx"
+	ctxpkg "github.com/cs3org/reva/pkg/ctx"
 	"github.com/cs3org/reva/pkg/errtypes"
 	"github.com/cs3org/reva/pkg/storage/utils/decomposedfs/node"
 	"github.com/cs3org/reva/pkg/storage/utils/decomposedfs/xattrs"
-	"github.com/cs3org/reva/pkg/userctx"
 	"github.com/cs3org/reva/pkg/utils"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
@@ -715,7 +715,7 @@ func (t *Tree) readRecycleItem(ctx context.Context, key, path string) (n *node.N
 		return nil, "", "", "", errtypes.InternalError("key is empty")
 	}
 
-	u := userctx.ContextMustGetUser(ctx)
+	u := ctxpkg.ContextMustGetUser(ctx)
 	trashItem = filepath.Join(t.lookup.InternalRoot(), "trash", u.Id.OpaqueId, key, path)
 
 	var link string

--- a/pkg/storage/utils/decomposedfs/upload.go
+++ b/pkg/storage/utils/decomposedfs/upload.go
@@ -41,7 +41,7 @@ import (
 	"github.com/cs3org/reva/pkg/logger"
 	"github.com/cs3org/reva/pkg/storage/utils/chunking"
 	"github.com/cs3org/reva/pkg/storage/utils/decomposedfs/node"
-	"github.com/cs3org/reva/pkg/user"
+	"github.com/cs3org/reva/pkg/userctx"
 	"github.com/cs3org/reva/pkg/utils"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
@@ -244,7 +244,7 @@ func (fs *Decomposedfs) NewUpload(ctx context.Context, info tusd.FileInfo) (uplo
 	if err != nil {
 		return nil, errors.Wrap(err, "Decomposedfs: error resolving upload path")
 	}
-	usr := user.ContextMustGetUser(ctx)
+	usr := userctx.ContextMustGetUser(ctx)
 
 	owner, err := p.Owner()
 	if err != nil {
@@ -337,7 +337,7 @@ func (fs *Decomposedfs) GetUpload(ctx context.Context, id string) (tusd.Upload, 
 		Username: info.Storage["UserName"],
 	}
 
-	ctx = user.ContextSetUser(ctx, u)
+	ctx = userctx.ContextSetUser(ctx, u)
 	// TODO configure the logger the same way ... store and add traceid in file info
 
 	var opts []logger.Option

--- a/pkg/storage/utils/decomposedfs/upload.go
+++ b/pkg/storage/utils/decomposedfs/upload.go
@@ -37,11 +37,11 @@ import (
 	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	"github.com/cs3org/reva/pkg/appctx"
+	ctxpkg "github.com/cs3org/reva/pkg/ctx"
 	"github.com/cs3org/reva/pkg/errtypes"
 	"github.com/cs3org/reva/pkg/logger"
 	"github.com/cs3org/reva/pkg/storage/utils/chunking"
 	"github.com/cs3org/reva/pkg/storage/utils/decomposedfs/node"
-	"github.com/cs3org/reva/pkg/userctx"
 	"github.com/cs3org/reva/pkg/utils"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
@@ -244,7 +244,7 @@ func (fs *Decomposedfs) NewUpload(ctx context.Context, info tusd.FileInfo) (uplo
 	if err != nil {
 		return nil, errors.Wrap(err, "Decomposedfs: error resolving upload path")
 	}
-	usr := userctx.ContextMustGetUser(ctx)
+	usr := ctxpkg.ContextMustGetUser(ctx)
 
 	owner, err := p.Owner()
 	if err != nil {
@@ -337,7 +337,7 @@ func (fs *Decomposedfs) GetUpload(ctx context.Context, id string) (tusd.Upload, 
 		Username: info.Storage["UserName"],
 	}
 
-	ctx = userctx.ContextSetUser(ctx, u)
+	ctx = ctxpkg.ContextSetUser(ctx, u)
 	// TODO configure the logger the same way ... store and add traceid in file info
 
 	var opts []logger.Option

--- a/pkg/storage/utils/decomposedfs/upload_test.go
+++ b/pkg/storage/utils/decomposedfs/upload_test.go
@@ -29,13 +29,13 @@ import (
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	"github.com/stretchr/testify/mock"
 
+	ruser "github.com/cs3org/reva/pkg/ctx"
 	"github.com/cs3org/reva/pkg/storage"
 	"github.com/cs3org/reva/pkg/storage/utils/decomposedfs"
 	"github.com/cs3org/reva/pkg/storage/utils/decomposedfs/mocks"
 	"github.com/cs3org/reva/pkg/storage/utils/decomposedfs/options"
 	"github.com/cs3org/reva/pkg/storage/utils/decomposedfs/tree"
 	treemocks "github.com/cs3org/reva/pkg/storage/utils/decomposedfs/tree/mocks"
-	ruser "github.com/cs3org/reva/pkg/userctx"
 	"github.com/cs3org/reva/tests/helpers"
 
 	. "github.com/onsi/ginkgo"

--- a/pkg/storage/utils/decomposedfs/upload_test.go
+++ b/pkg/storage/utils/decomposedfs/upload_test.go
@@ -35,7 +35,7 @@ import (
 	"github.com/cs3org/reva/pkg/storage/utils/decomposedfs/options"
 	"github.com/cs3org/reva/pkg/storage/utils/decomposedfs/tree"
 	treemocks "github.com/cs3org/reva/pkg/storage/utils/decomposedfs/tree/mocks"
-	ruser "github.com/cs3org/reva/pkg/user"
+	ruser "github.com/cs3org/reva/pkg/userctx"
 	"github.com/cs3org/reva/tests/helpers"
 
 	. "github.com/onsi/ginkgo"

--- a/pkg/storage/utils/eosfs/eosfs.go
+++ b/pkg/storage/utils/eosfs/eosfs.go
@@ -38,6 +38,7 @@ import (
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	types "github.com/cs3org/go-cs3apis/cs3/types/v1beta1"
 	"github.com/cs3org/reva/pkg/appctx"
+	ctxpkg "github.com/cs3org/reva/pkg/ctx"
 	"github.com/cs3org/reva/pkg/eosclient"
 	"github.com/cs3org/reva/pkg/eosclient/eosbinary"
 	"github.com/cs3org/reva/pkg/eosclient/eosgrpc"
@@ -50,7 +51,6 @@ import (
 	"github.com/cs3org/reva/pkg/storage/utils/chunking"
 	"github.com/cs3org/reva/pkg/storage/utils/grants"
 	"github.com/cs3org/reva/pkg/storage/utils/templates"
-	"github.com/cs3org/reva/pkg/userctx"
 	"github.com/pkg/errors"
 )
 
@@ -240,7 +240,7 @@ func (fs *eosfs) Shutdown(ctx context.Context) error {
 }
 
 func getUser(ctx context.Context) (*userpb.User, error) {
-	u, ok := userctx.ContextGetUser(ctx)
+	u, ok := ctxpkg.ContextGetUser(ctx)
 	if !ok {
 		err := errors.Wrap(errtypes.UserRequired(""), "eosfs: error getting user from ctx")
 		return nil, err
@@ -1557,7 +1557,7 @@ func (fs *eosfs) convertToFileReference(ctx context.Context, eosFileInfo *eoscli
 
 // permissionSet returns the permission set for the current user
 func (fs *eosfs) permissionSet(ctx context.Context, eosFileInfo *eosclient.FileInfo, owner *userpb.UserId) *provider.ResourcePermissions {
-	u, ok := userctx.ContextGetUser(ctx)
+	u, ok := ctxpkg.ContextGetUser(ctx)
 	if !ok || u.Id == nil {
 		return &provider.ResourcePermissions{
 			// no permissions

--- a/pkg/storage/utils/eosfs/eosfs.go
+++ b/pkg/storage/utils/eosfs/eosfs.go
@@ -50,7 +50,7 @@ import (
 	"github.com/cs3org/reva/pkg/storage/utils/chunking"
 	"github.com/cs3org/reva/pkg/storage/utils/grants"
 	"github.com/cs3org/reva/pkg/storage/utils/templates"
-	"github.com/cs3org/reva/pkg/user"
+	"github.com/cs3org/reva/pkg/userctx"
 	"github.com/pkg/errors"
 )
 
@@ -240,7 +240,7 @@ func (fs *eosfs) Shutdown(ctx context.Context) error {
 }
 
 func getUser(ctx context.Context) (*userpb.User, error) {
-	u, ok := user.ContextGetUser(ctx)
+	u, ok := userctx.ContextGetUser(ctx)
 	if !ok {
 		err := errors.Wrap(errtypes.UserRequired(""), "eosfs: error getting user from ctx")
 		return nil, err
@@ -1557,7 +1557,7 @@ func (fs *eosfs) convertToFileReference(ctx context.Context, eosFileInfo *eoscli
 
 // permissionSet returns the permission set for the current user
 func (fs *eosfs) permissionSet(ctx context.Context, eosFileInfo *eosclient.FileInfo, owner *userpb.UserId) *provider.ResourcePermissions {
-	u, ok := user.ContextGetUser(ctx)
+	u, ok := userctx.ContextGetUser(ctx)
 	if !ok || u.Id == nil {
 		return &provider.ResourcePermissions{
 			// no permissions

--- a/pkg/storage/utils/eosfs/eosfs_test.go
+++ b/pkg/storage/utils/eosfs/eosfs_test.go
@@ -29,8 +29,8 @@ import (
 
 	userv1beta1 "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+	ctxpkg "github.com/cs3org/reva/pkg/ctx"
 	"github.com/cs3org/reva/pkg/eosclient"
-	"github.com/cs3org/reva/pkg/user"
 	"github.com/gdexlab/go-render/render"
 	"github.com/thanhpk/randstr"
 )
@@ -257,7 +257,7 @@ func TestAddGrant(t *testing.T) {
 	for _, test := range testCases {
 
 		t.Run(test.description, func(t *testing.T) {
-			ctx := user.ContextSetUser(context.TODO(), &userv1beta1.User{
+			ctx := ctxpkg.ContextSetUser(context.TODO(), &userv1beta1.User{
 				UidNumber: 138406,
 				GidNumber: 2763,
 			})

--- a/pkg/storage/utils/localfs/localfs.go
+++ b/pkg/storage/utils/localfs/localfs.go
@@ -35,6 +35,7 @@ import (
 	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	types "github.com/cs3org/go-cs3apis/cs3/types/v1beta1"
+	ctxpkg "github.com/cs3org/reva/pkg/ctx"
 	"github.com/cs3org/reva/pkg/errtypes"
 	"github.com/cs3org/reva/pkg/mime"
 	"github.com/cs3org/reva/pkg/storage"
@@ -42,7 +43,6 @@ import (
 	"github.com/cs3org/reva/pkg/storage/utils/chunking"
 	"github.com/cs3org/reva/pkg/storage/utils/grants"
 	"github.com/cs3org/reva/pkg/storage/utils/templates"
-	"github.com/cs3org/reva/pkg/userctx"
 	"github.com/cs3org/reva/pkg/utils"
 	"github.com/pkg/errors"
 )
@@ -153,7 +153,7 @@ func (fs *localfs) resolve(ctx context.Context, ref *provider.Reference) (p stri
 }
 
 func getUser(ctx context.Context) (*userpb.User, error) {
-	u, ok := userctx.ContextGetUser(ctx)
+	u, ok := ctxpkg.ContextGetUser(ctx)
 	if !ok {
 		err := errors.Wrap(errtypes.UserRequired(""), "local: error getting user from ctx")
 		return nil, err
@@ -273,7 +273,7 @@ func (fs *localfs) isShareFolderChild(ctx context.Context, p string) bool {
 
 // permissionSet returns the permission set for the current user
 func (fs *localfs) permissionSet(ctx context.Context, owner *userpb.UserId) *provider.ResourcePermissions {
-	u, ok := userctx.ContextGetUser(ctx)
+	u, ok := ctxpkg.ContextGetUser(ctx)
 	if !ok {
 		return &provider.ResourcePermissions{
 			// no permissions

--- a/pkg/storage/utils/localfs/localfs.go
+++ b/pkg/storage/utils/localfs/localfs.go
@@ -42,7 +42,7 @@ import (
 	"github.com/cs3org/reva/pkg/storage/utils/chunking"
 	"github.com/cs3org/reva/pkg/storage/utils/grants"
 	"github.com/cs3org/reva/pkg/storage/utils/templates"
-	"github.com/cs3org/reva/pkg/user"
+	"github.com/cs3org/reva/pkg/userctx"
 	"github.com/cs3org/reva/pkg/utils"
 	"github.com/pkg/errors"
 )
@@ -153,7 +153,7 @@ func (fs *localfs) resolve(ctx context.Context, ref *provider.Reference) (p stri
 }
 
 func getUser(ctx context.Context) (*userpb.User, error) {
-	u, ok := user.ContextGetUser(ctx)
+	u, ok := userctx.ContextGetUser(ctx)
 	if !ok {
 		err := errors.Wrap(errtypes.UserRequired(""), "local: error getting user from ctx")
 		return nil, err
@@ -273,7 +273,7 @@ func (fs *localfs) isShareFolderChild(ctx context.Context, p string) bool {
 
 // permissionSet returns the permission set for the current user
 func (fs *localfs) permissionSet(ctx context.Context, owner *userpb.UserId) *provider.ResourcePermissions {
-	u, ok := user.ContextGetUser(ctx)
+	u, ok := userctx.ContextGetUser(ctx)
 	if !ok {
 		return &provider.ResourcePermissions{
 			// no permissions

--- a/pkg/storage/utils/localfs/upload.go
+++ b/pkg/storage/utils/localfs/upload.go
@@ -31,7 +31,7 @@ import (
 	"github.com/cs3org/reva/pkg/appctx"
 	"github.com/cs3org/reva/pkg/errtypes"
 	"github.com/cs3org/reva/pkg/storage/utils/chunking"
-	"github.com/cs3org/reva/pkg/user"
+	"github.com/cs3org/reva/pkg/userctx"
 	"github.com/cs3org/reva/pkg/utils"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
@@ -173,7 +173,7 @@ func (fs *localfs) NewUpload(ctx context.Context, info tusd.FileInfo) (upload tu
 	if err != nil {
 		return nil, errors.Wrap(err, "localfs: error resolving upload path")
 	}
-	usr := user.ContextMustGetUser(ctx)
+	usr := userctx.ContextMustGetUser(ctx)
 	info.Storage = map[string]string{
 		"Type":                "LocalStore",
 		"BinPath":             binPath,
@@ -256,7 +256,7 @@ func (fs *localfs) GetUpload(ctx context.Context, id string) (tusd.Upload, error
 		Username: info.Storage["UserName"],
 	}
 
-	ctx = user.ContextSetUser(ctx, u)
+	ctx = userctx.ContextSetUser(ctx, u)
 
 	return &fileUpload{
 		info:     info,

--- a/pkg/storage/utils/localfs/upload.go
+++ b/pkg/storage/utils/localfs/upload.go
@@ -29,9 +29,9 @@ import (
 	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	"github.com/cs3org/reva/pkg/appctx"
+	ctxpkg "github.com/cs3org/reva/pkg/ctx"
 	"github.com/cs3org/reva/pkg/errtypes"
 	"github.com/cs3org/reva/pkg/storage/utils/chunking"
-	"github.com/cs3org/reva/pkg/userctx"
 	"github.com/cs3org/reva/pkg/utils"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
@@ -173,7 +173,7 @@ func (fs *localfs) NewUpload(ctx context.Context, info tusd.FileInfo) (upload tu
 	if err != nil {
 		return nil, errors.Wrap(err, "localfs: error resolving upload path")
 	}
-	usr := userctx.ContextMustGetUser(ctx)
+	usr := ctxpkg.ContextMustGetUser(ctx)
 	info.Storage = map[string]string{
 		"Type":                "LocalStore",
 		"BinPath":             binPath,
@@ -256,7 +256,7 @@ func (fs *localfs) GetUpload(ctx context.Context, id string) (tusd.Upload, error
 		Username: info.Storage["UserName"],
 	}
 
-	ctx = userctx.ContextSetUser(ctx, u)
+	ctx = ctxpkg.ContextSetUser(ctx, u)
 
 	return &fileUpload{
 		info:     info,

--- a/pkg/token/token.go
+++ b/pkg/token/token.go
@@ -25,36 +25,8 @@ import (
 	user "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 )
 
-// TokenHeader is the header to be used across grpc and http services
-// to forward the access token.
-const TokenHeader = "x-access-token"
-
-type key int
-
-const tokenKey key = iota
-
 // Manager is the interface to implement to sign and verify tokens
 type Manager interface {
 	MintToken(ctx context.Context, u *user.User, scope map[string]*auth.Scope) (string, error)
 	DismantleToken(ctx context.Context, token string) (*user.User, map[string]*auth.Scope, error)
-}
-
-// ContextGetToken returns the token if set in the given context.
-func ContextGetToken(ctx context.Context) (string, bool) {
-	u, ok := ctx.Value(tokenKey).(string)
-	return u, ok
-}
-
-// ContextMustGetToken panics if token is not in context.
-func ContextMustGetToken(ctx context.Context) string {
-	u, ok := ContextGetToken(ctx)
-	if !ok {
-		panic("token not found in context")
-	}
-	return u
-}
-
-// ContextSetToken stores the token in the context.
-func ContextSetToken(ctx context.Context, t string) context.Context {
-	return context.WithValue(ctx, tokenKey, t)
 }

--- a/pkg/user/user.go
+++ b/pkg/user/user.go
@@ -25,44 +25,6 @@ import (
 	"github.com/cs3org/reva/pkg/plugin"
 )
 
-type key int
-
-const (
-	userKey key = iota
-	idKey
-)
-
-// ContextGetUser returns the user if set in the given context.
-func ContextGetUser(ctx context.Context) (*userpb.User, bool) {
-	u, ok := ctx.Value(userKey).(*userpb.User)
-	return u, ok
-}
-
-// ContextMustGetUser panics if user is not in context.
-func ContextMustGetUser(ctx context.Context) *userpb.User {
-	u, ok := ContextGetUser(ctx)
-	if !ok {
-		panic("user not found in context")
-	}
-	return u
-}
-
-// ContextSetUser stores the user in the context.
-func ContextSetUser(ctx context.Context, u *userpb.User) context.Context {
-	return context.WithValue(ctx, userKey, u)
-}
-
-// ContextGetUserID returns the user if set in the given context.
-func ContextGetUserID(ctx context.Context) (*userpb.UserId, bool) {
-	u, ok := ctx.Value(idKey).(*userpb.UserId)
-	return u, ok
-}
-
-// ContextSetUserID stores the userid in the context.
-func ContextSetUserID(ctx context.Context, id *userpb.UserId) context.Context {
-	return context.WithValue(ctx, idKey, id)
-}
-
 // Manager is the interface to implement to manipulate users.
 type Manager interface {
 	plugin.Plugin

--- a/pkg/userctx/userctx.go
+++ b/pkg/userctx/userctx.go
@@ -1,0 +1,45 @@
+package userctx
+
+import (
+	"context"
+
+	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
+)
+
+type key int
+
+const (
+	userKey key = iota
+	idKey
+)
+
+// ContextGetUser returns the user if set in the given context.
+func ContextGetUser(ctx context.Context) (*userpb.User, bool) {
+	u, ok := ctx.Value(userKey).(*userpb.User)
+	return u, ok
+}
+
+// ContextMustGetUser panics if user is not in context.
+func ContextMustGetUser(ctx context.Context) *userpb.User {
+	u, ok := ContextGetUser(ctx)
+	if !ok {
+		panic("user not found in context")
+	}
+	return u
+}
+
+// ContextSetUser stores the user in the context.
+func ContextSetUser(ctx context.Context, u *userpb.User) context.Context {
+	return context.WithValue(ctx, userKey, u)
+}
+
+// ContextGetUserID returns the user if set in the given context.
+func ContextGetUserID(ctx context.Context) (*userpb.UserId, bool) {
+	u, ok := ctx.Value(idKey).(*userpb.UserId)
+	return u, ok
+}
+
+// ContextSetUserID stores the userid in the context.
+func ContextSetUserID(ctx context.Context, id *userpb.UserId) context.Context {
+	return context.WithValue(ctx, idKey, id)
+}

--- a/pkg/userctx/userctx.go
+++ b/pkg/userctx/userctx.go
@@ -1,3 +1,21 @@
+// Copyright 2018-2021 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
 package userctx
 
 import (

--- a/tests/integration/grpc/storageprovider_test.go
+++ b/tests/integration/grpc/storageprovider_test.go
@@ -35,7 +35,7 @@ import (
 	"github.com/cs3org/reva/pkg/storage/fs/owncloud"
 	"github.com/cs3org/reva/pkg/token"
 	jwt "github.com/cs3org/reva/pkg/token/manager/jwt"
-	ruser "github.com/cs3org/reva/pkg/user"
+	ruser "github.com/cs3org/reva/pkg/userctx"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/tests/integration/grpc/storageprovider_test.go
+++ b/tests/integration/grpc/storageprovider_test.go
@@ -30,12 +30,11 @@ import (
 	rpcv1beta1 "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
 	storagep "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	"github.com/cs3org/reva/pkg/auth/scope"
+	ctxpkg "github.com/cs3org/reva/pkg/ctx"
 	"github.com/cs3org/reva/pkg/rgrpc/todo/pool"
 	"github.com/cs3org/reva/pkg/storage/fs/ocis"
 	"github.com/cs3org/reva/pkg/storage/fs/owncloud"
-	"github.com/cs3org/reva/pkg/token"
 	jwt "github.com/cs3org/reva/pkg/token/manager/jwt"
-	ruser "github.com/cs3org/reva/pkg/userctx"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -86,9 +85,9 @@ var _ = Describe("storage providers", func() {
 		Expect(err).ToNot(HaveOccurred())
 		t, err := tokenManager.MintToken(ctx, user, scope)
 		Expect(err).ToNot(HaveOccurred())
-		ctx = token.ContextSetToken(ctx, t)
-		ctx = metadata.AppendToOutgoingContext(ctx, token.TokenHeader, t)
-		ctx = ruser.ContextSetUser(ctx, user)
+		ctx = ctxpkg.ContextSetToken(ctx, t)
+		ctx = metadata.AppendToOutgoingContext(ctx, ctxpkg.TokenHeader, t)
+		ctx = ctxpkg.ContextSetUser(ctx, user)
 
 		revads, err = startRevads(dependencies, variables)
 		Expect(err).ToNot(HaveOccurred())
@@ -510,7 +509,7 @@ var _ = Describe("storage providers", func() {
 				content1 := ioutil.NopCloser(bytes.NewReader([]byte("1")))
 				content2 := ioutil.NopCloser(bytes.NewReader([]byte("22")))
 
-				ctx := ruser.ContextSetUser(context.Background(), user)
+				ctx := ctxpkg.ContextSetUser(context.Background(), user)
 
 				err = fs.CreateHome(ctx)
 				Expect(err).ToNot(HaveOccurred())
@@ -578,7 +577,7 @@ var _ = Describe("storage providers", func() {
 				content1 := ioutil.NopCloser(bytes.NewReader([]byte("1")))
 				content2 := ioutil.NopCloser(bytes.NewReader([]byte("22")))
 
-				ctx := ruser.ContextSetUser(context.Background(), user)
+				ctx := ctxpkg.ContextSetUser(context.Background(), user)
 
 				err = fs.CreateHome(ctx)
 				Expect(err).ToNot(HaveOccurred())

--- a/tests/integration/grpc/userprovider_test.go
+++ b/tests/integration/grpc/userprovider_test.go
@@ -24,10 +24,9 @@ import (
 	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
 	"github.com/cs3org/reva/pkg/auth/scope"
+	ctxpkg "github.com/cs3org/reva/pkg/ctx"
 	"github.com/cs3org/reva/pkg/rgrpc/todo/pool"
-	"github.com/cs3org/reva/pkg/token"
 	jwt "github.com/cs3org/reva/pkg/token/manager/jwt"
-	ruser "github.com/cs3org/reva/pkg/userctx"
 	"google.golang.org/grpc/metadata"
 
 	. "github.com/onsi/ginkgo"
@@ -63,9 +62,9 @@ var _ = Describe("user providers", func() {
 		Expect(err).ToNot(HaveOccurred())
 		t, err := tokenManager.MintToken(ctx, user, scope)
 		Expect(err).ToNot(HaveOccurred())
-		ctx = token.ContextSetToken(ctx, t)
-		ctx = metadata.AppendToOutgoingContext(ctx, token.TokenHeader, t)
-		ctx = ruser.ContextSetUser(ctx, user)
+		ctx = ctxpkg.ContextSetToken(ctx, t)
+		ctx = metadata.AppendToOutgoingContext(ctx, ctxpkg.TokenHeader, t)
+		ctx = ctxpkg.ContextSetUser(ctx, user)
 
 		revads, err = startRevads(dependencies, map[string]string{})
 		Expect(err).ToNot(HaveOccurred())

--- a/tests/integration/grpc/userprovider_test.go
+++ b/tests/integration/grpc/userprovider_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/cs3org/reva/pkg/rgrpc/todo/pool"
 	"github.com/cs3org/reva/pkg/token"
 	jwt "github.com/cs3org/reva/pkg/token/manager/jwt"
-	ruser "github.com/cs3org/reva/pkg/user"
+	ruser "github.com/cs3org/reva/pkg/userctx"
 	"google.golang.org/grpc/metadata"
 
 	. "github.com/onsi/ginkgo"


### PR DESCRIPTION
This PR moves the user-context methods out of the user pkg into a separate `userctx` package. 

Signed-off-by: Jimil Desai <jimildesai42@gmail.com>