### PR TITLE
implement url translation for legacy urls

### DIFF
--- a/changelog/unreleased/legacy-path-translations.md
+++ b/changelog/unreleased/legacy-path-translations.md
@@ -1,0 +1,5 @@
+Enhancement: Add redirects from OC10 URL formats
+
+Added redirectors for ownCloud 10 URLs. This allows users to continue to use their bookmarks from ownCloud 10 in ocis.
+
+https://github.com/cs3org/reva/pull/1989

--- a/internal/http/services/owncloud/ocdav/ocdav.go
+++ b/internal/http/services/owncloud/ocdav/ocdav.go
@@ -153,7 +153,7 @@ func (s *svc) Close() error {
 }
 
 func (s *svc) Unprotected() []string {
-	return []string{"/status.php", "/remote.php/dav/public-files/"}
+	return []string{"/status.php", "/remote.php/dav/public-files/", "/apps/files/", "/index.php/f/", "/index.php/s/"}
 }
 
 func (s *svc) Handler() http.Handler {
@@ -187,7 +187,20 @@ func (s *svc) Handler() http.Handler {
 
 			// yet, add it to baseURI
 			base = path.Join(base, "remote.php")
-
+		case "apps":
+			head, r.URL.Path = router.ShiftPath(r.URL.Path)
+			if head == "files" {
+				s.handleLegacyPath(w, r)
+				return
+			}
+		case "index.php":
+			head, r.URL.Path = router.ShiftPath(r.URL.Path)
+			if head == "s" {
+				token := r.URL.Path
+				url := s.c.PublicURL + path.Join("#", head, token)
+				http.Redirect(w, r, url, http.StatusMovedPermanently)
+				return
+			}
 		}
 		switch head {
 		// the old `/webdav` endpoint uses remote.php/webdav/$path

--- a/internal/http/services/owncloud/ocdav/redirect.go
+++ b/internal/http/services/owncloud/ocdav/redirect.go
@@ -1,0 +1,32 @@
+// Copyright 2018-2021 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package ocdav
+
+import (
+	"net/http"
+	"net/url"
+	"path"
+)
+
+func (s *svc) handleLegacyPath(w http.ResponseWriter, r *http.Request) {
+	query := r.URL.Query()
+	dir := query.Get("dir")
+	url := s.c.PublicURL + path.Join("#", "/files/list/all", url.PathEscape(dir))
+	http.Redirect(w, r, url, http.StatusMovedPermanently)
+}


### PR DESCRIPTION
First draft of the URL translation for OC10 URLS.
This implements a redirect from the old OC10 URL format to the current format we use in oCIS web. Currently only the public link and the old files app URL work because we don't do any file lookups by id yet. If this needs to be supported we would need to figure out how to lookup file based on their OC10 id.

To test this you need to apply this diff to oCIS and add a replace for reva to the go.mod file:

```diff
diff --git a/proxy/pkg/proxy/proxy.go b/proxy/pkg/proxy/proxy.go
index b066e9631..1d73b08b5 100644
--- a/proxy/pkg/proxy/proxy.go
+++ b/proxy/pkg/proxy/proxy.go
@@ -328,6 +328,10 @@ func defaultPolicies() []config.Policy {
                                        Endpoint: "/index.php/",
                                        Backend:  "http://localhost:9140",
                                },
+                               {
+                                       Endpoint: "/apps/files/",
+                                       Backend:  "http://localhost:9140",
+                               },
                                {
                                        Endpoint: "/data",
                                        Backend:  "http://localhost:9140",
```