### PR TITLE
Check if symlink exists instead of spamming the console

### DIFF
--- a/changelog/unreleased/remove-prints-for-spaces.md
+++ b/changelog/unreleased/remove-prints-for-spaces.md
@@ -1,0 +1,5 @@
+Bugfix: Check if symlink exists instead of spamming the console
+
+The logs have been spammed with messages like `could not create symlink for ...` when using the decomposedfs, eg. with the oCIS storage. We now check if the link exists before trying to create it.
+
+https://github.com/cs3org/reva/pull/1992


### PR DESCRIPTION
The logs have been spammed with messages like `could not create symlink for ...` when using the decomposedfs, eg. with the oCIS storage. We now check if the link exists before trying to create it.

deprecates https://github.com/cs3org/reva/pull/1988