### PR TITLE
fix owncloudsql GetMD

### DIFF
--- a/changelog/unreleased/fix-owncloudsql-getmd.md
+++ b/changelog/unreleased/fix-owncloudsql-getmd.md
@@ -1,0 +1,5 @@
+Bugfix: fix owncloudsql GetMD
+
+The GetMD call internally was not prefixing the path when looking up resources by id.
+
+https://github.com/cs3org/reva/pull/1993

--- a/pkg/storage/fs/owncloudsql/owncloudsql.go
+++ b/pkg/storage/fs/owncloudsql/owncloudsql.go
@@ -575,7 +575,7 @@ func (fs *owncloudsqlfs) resolve(ctx context.Context, ref *provider.Reference) (
 			}
 			p = filepath.Join(owner, p)
 		}
-		return p, nil
+		return fs.toInternalPath(ctx, p), nil
 	}
 
 	if ref.GetPath() != "" {


### PR DESCRIPTION
The GetMD call internally was not prefixing the path when looking up resources by id.

cc @aduffeck 