### PR TITLE
'machine' authentication to impersonate users through a shared secret

### DIFF
--- a/changelog/unreleased/machine-auth.md
+++ b/changelog/unreleased/machine-auth.md
@@ -1,0 +1,7 @@
+Enhancement: Machine auth provider
+
+Adds a new authentication method used to impersonate users,
+using a shared secret, called api-key.
+
+
+https://github.com/cs3org/reva/pull/2028

--- a/pkg/auth/manager/loader/loader.go
+++ b/pkg/auth/manager/loader/loader.go
@@ -25,6 +25,7 @@ import (
 	_ "github.com/cs3org/reva/pkg/auth/manager/impersonator"
 	_ "github.com/cs3org/reva/pkg/auth/manager/json"
 	_ "github.com/cs3org/reva/pkg/auth/manager/ldap"
+	_ "github.com/cs3org/reva/pkg/auth/manager/machine"
 	_ "github.com/cs3org/reva/pkg/auth/manager/oidc"
 	_ "github.com/cs3org/reva/pkg/auth/manager/publicshares"
 	// Add your own here

--- a/pkg/auth/manager/machine/machine.go
+++ b/pkg/auth/manager/machine/machine.go
@@ -65,6 +65,7 @@ func New(conf map[string]interface{}) (auth.Manager, error) {
 	return m, nil
 }
 
+// Authenticate impersonate an user if the provided secret is equal to the api-key
 func (m *manager) Authenticate(ctx context.Context, username, secret string) (*user.User, map[string]*authpb.Scope, error) {
 	if m.APIKey != secret {
 		return nil, nil, errtypes.InvalidCredentials("")

--- a/pkg/auth/manager/machine/machine.go
+++ b/pkg/auth/manager/machine/machine.go
@@ -1,0 +1,99 @@
+// Copyright 2018-2021 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package machine
+
+import (
+	"context"
+
+	authpb "github.com/cs3org/go-cs3apis/cs3/auth/provider/v1beta1"
+	user "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
+	rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
+	"github.com/cs3org/reva/pkg/auth"
+	"github.com/cs3org/reva/pkg/auth/manager/registry"
+	"github.com/cs3org/reva/pkg/auth/scope"
+	"github.com/cs3org/reva/pkg/errtypes"
+	"github.com/cs3org/reva/pkg/rgrpc/todo/pool"
+	"github.com/mitchellh/mapstructure"
+	"github.com/pkg/errors"
+)
+
+// 'machine' is an authentication method used to impersonate users.
+// To impersonate the given user it's only needed an api-key, saved
+// in a config file.
+
+type manager struct {
+	APIKey      string `mapstructure:"api_key"`
+	GatewayAddr string `mapstructure:"gateway_addr"`
+}
+
+func init() {
+	registry.Register("machine", New)
+}
+
+// Configure parses the map conf
+func (m *manager) Configure(conf map[string]interface{}) error {
+	err := mapstructure.Decode(conf, m)
+	if err != nil {
+		return errors.Wrap(err, "error decoding conf")
+	}
+	return nil
+}
+
+// New creates a new manager for the 'machine' authentication
+func New(conf map[string]interface{}) (auth.Manager, error) {
+	m := &manager{}
+	err := m.Configure(conf)
+	if err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
+func (m *manager) Authenticate(ctx context.Context, username, secret string) (*user.User, map[string]*authpb.Scope, error) {
+	if m.APIKey != secret {
+		return nil, nil, errtypes.InvalidCredentials("")
+	}
+
+	gtw, err := pool.GetGatewayServiceClient(m.GatewayAddr)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	userResponse, err := gtw.GetUserByClaim(ctx, &user.GetUserByClaimRequest{
+		Claim: "username",
+		Value: username,
+	})
+
+	switch {
+	case err != nil:
+		return nil, nil, err
+	case userResponse.Status.Code == rpc.Code_CODE_NOT_FOUND:
+		return nil, nil, errtypes.NotFound(userResponse.Status.Message)
+	case userResponse.Status.Code != rpc.Code_CODE_OK:
+		return nil, nil, errtypes.InternalError(userResponse.Status.Message)
+	}
+
+	scope, err := scope.AddOwnerScope(nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return userResponse.GetUser(), scope, nil
+
+}


### PR DESCRIPTION
This PR adds a new authentication provider, called machine, in order to impersonate
an user through a shared secret, stored in the reva configuration.

Example:

```
$ reva -insecure -host localhost:19000 login  -username einstein -api-key qwerty123 machine
OK
$ reva -insecure -host localhost:19000 whoami
id:<idp:"localhost:20080" opaque_id:"4c510ada-c86b-4815-8820-42cdf82c3d51" type:USER_TYPE_PRIMARY > username:"einstein" mail:"einstein@example.org" display_name:"Albert Einstein" groups:"sailing-lovers" groups:"violin-haters" groups:"physics-lovers" 
$ reva -insecure -host localhost:19000 login  -username marie -api-key qwerty123 machine
OK
$ reva -insecure -host localhost:19000 whoami
id:<idp:"localhost:20080" opaque_id:"f7fbf8c8-139b-4376-b307-cf0a8c2d0d9c" type:USER_TYPE_PRIMARY > username:"marie" mail:"marie@example.org" display_name:"Marie Curie" groups:"radium-lovers" groups:"polonium-lovers" groups:"physics-lovers"
```