### PR TITLE
fix http: superfluous response.WriteHeader call

### DIFF
--- a/changelog/unreleased/superfluous-response-write-header.md
+++ b/changelog/unreleased/superfluous-response-write-header.md
@@ -1,0 +1,5 @@
+Bugfix: Fix superfluous WriteHeader on file upload 
+
+Removes superfluous Writeheader on file upload and therefore removes the error message "http: superfluous response.WriteHeader call from github.com/cs3org/reva/internal/http/interceptors/log.(*responseLogger).WriteHeader (log.go:154)"
+
+https://github.com/cs3org/reva/pull/2030

--- a/internal/http/services/datagateway/datagateway.go
+++ b/internal/http/services/datagateway/datagateway.go
@@ -239,7 +239,6 @@ func (s *svc) doGet(w http.ResponseWriter, r *http.Request) {
 	defer httpRes.Body.Close()
 
 	copyHeader(w.Header(), httpRes.Header)
-	w.WriteHeader(httpRes.StatusCode)
 	switch httpRes.StatusCode {
 	case http.StatusOK:
 	case http.StatusPartialContent:


### PR DESCRIPTION
fix error message on file upload `http: superfluous response.WriteHeader call from github.com/cs3org/reva/internal/http/interceptors/log.(*responseLogger).WriteHeader (log.go:154)`