### PR TITLE
fix the storageid of shares

### DIFF
--- a/changelog/unreleased/fix-storageid-shares.md
+++ b/changelog/unreleased/fix-storageid-shares.md
@@ -1,0 +1,5 @@
+Bugfix: Fix the storage id of shares
+
+The storageid in the share object contained an incorrect value.
+
+https://github.com/cs3org/reva/pull/2033

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/shares.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/shares.go
@@ -56,6 +56,10 @@ import (
 	"github.com/pkg/errors"
 )
 
+const (
+	storageIDPrefix string = "shared::"
+)
+
 // Handler implements the shares part of the ownCloud sharing API
 type Handler struct {
 	gatewayAddr            string
@@ -732,7 +736,6 @@ func (h *Handler) addFileInfo(ctx context.Context, s *conversions.ShareData, inf
 		}
 		s.MimeType = parsedMt
 		// TODO STime:     &types.Timestamp{Seconds: info.Mtime.Seconds, Nanos: info.Mtime.Nanos},
-		s.StorageID = info.Id.StorageId + "!" + info.Id.OpaqueId
 		// TODO Storage: int
 		s.ItemSource = wrapResourceID(info.Id)
 		s.FileSource = s.ItemSource
@@ -742,6 +745,7 @@ func (h *Handler) addFileInfo(ctx context.Context, s *conversions.ShareData, inf
 			s.FileTarget = path.Join(h.sharePrefix, path.Base(info.Path))
 		}
 		s.Path = path.Join("/", path.Base(info.Path)) // TODO hm this might have to be relative to the users home ... depends on the webdav_namespace config
+		s.StorageID = storageIDPrefix + s.FileTarget
 		// TODO FileParent:
 		// item type
 		s.ItemType = conversions.ResourceType(info.GetType()).String()

--- a/tests/acceptance/expected-failures-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-on-OCIS-storage.md
@@ -327,7 +327,6 @@ File and sync features in a shared scenario
 
 #### [Response is empty when accepting a share](https://github.com/owncloud/product/issues/207)
 
-- [apiShareManagementToShares/acceptShares.feature:82](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareManagementToShares/acceptShares.feature#L82)
 - [apiShareManagementToShares/acceptShares.feature:207](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareManagementToShares/acceptShares.feature#L207)
 - [apiShareManagementToShares/acceptShares.feature:261](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareManagementToShares/acceptShares.feature#L261)
 

--- a/tests/acceptance/expected-failures-on-S3NG-storage.md
+++ b/tests/acceptance/expected-failures-on-S3NG-storage.md
@@ -330,7 +330,6 @@ File and sync features in a shared scenario
 
 #### [Response is empty when accepting a share](https://github.com/owncloud/product/issues/207)
 
-- [apiShareManagementToShares/acceptShares.feature:82](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareManagementToShares/acceptShares.feature#L82)
 - [apiShareManagementToShares/acceptShares.feature:207](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareManagementToShares/acceptShares.feature#L207)
 - [apiShareManagementToShares/acceptShares.feature:261](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareManagementToShares/acceptShares.feature#L261)
 


### PR DESCRIPTION
The storageid in the share object contained an incorrect value.