### PR TITLE
Fail initialization if app is unsupported

### DIFF
--- a/changelog/unreleased/appprovider-unsupported.md
+++ b/changelog/unreleased/appprovider-unsupported.md
@@ -1,0 +1,5 @@
+Enhancement: fail initialization of a WOPI AppProvider if
+the underlying app is not WOPI-compliant nor it is supported
+by the WOPI bridge extensions
+
+https://github.com/cs3org/reva/pull/2034

--- a/pkg/app/provider/wopi/wopi.go
+++ b/pkg/app/provider/wopi/wopi.go
@@ -136,9 +136,6 @@ func (p *wopiProvider) GetAppURL(ctx context.Context, resource *provider.Resourc
 	q.Add("fileid", resource.GetId().OpaqueId)
 	q.Add("endpoint", resource.GetId().StorageId)
 	q.Add("viewmode", viewMode.String())
-	// TODO the folder URL should be resolved as e.g. `'https://cernbox.cern.ch/index.php/apps/files/?dir=' + filepath.Dir(req.Ref.GetPath())`
-	// or should be deprecated/removed altogether, needs discussion and decision.
-	// q.Add("folderurl", "...")
 	u, ok := ctxpkg.ContextGetUser(ctx)
 	if ok { // else defaults to "Anonymous Guest"
 		q.Add("username", u.Username)

--- a/pkg/app/provider/wopi/wopi.go
+++ b/pkg/app/provider/wopi/wopi.go
@@ -287,17 +287,18 @@ func getAppURLs(c *config) (map[string]map[string]string, error) {
 
 		// scrape app's home page to find the appname
 		if !strings.Contains(buf.String(), c.AppName) {
-			// || (c.AppName != "CodiMD" && c.AppName != "Etherpad") {
 			return nil, errors.New("Application server at " + c.AppURL + " does not match this AppProvider for " + c.AppName)
 		}
 
 		// register the supported mimetypes in the AppRegistry: this is hardcoded for the time being
-		if c.AppName == "CodiMD" {
+		switch c.AppName {
+		case "CodiMD":
 			appURLs = getCodimdExtensions(c.AppURL)
-		} else if c.AppName == "Etherpad" {
+		case "Etherpad":
 			appURLs = getEtherpadExtensions(c.AppURL)
+		default:
+			return nil, errors.New("Application server " + c.AppName + " running at " + c.AppURL + " is unsupported")
 		}
-
 	}
 	return appURLs, nil
 }
@@ -370,7 +371,7 @@ func getCodimdExtensions(appURL string) map[string]map[string]string {
 func getEtherpadExtensions(appURL string) map[string]map[string]string {
 	appURLs := make(map[string]map[string]string)
 	appURLs["edit"] = map[string]string{
-		".etherpad": appURL,
+		".epd": appURL,
 	}
 	return appURLs
 }


### PR DESCRIPTION
A mini PR to improve error handling when an app is not WOPI-compliant nor it is supported by the WOPI bridge extensions