### PR TITLE
Mention go minimal version

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Read the [getting started guide](https://reva.link/docs/getting-started/) and th
 
 
 ## Build and run it yourself
-You need to have [Go](https://golang.org/doc/install), [git](https://git-scm.com/) and [make](https://en.wikipedia.org/wiki/Make_(software)) installed. Some of these commands may require `sudo`, depending on your system setup.
+You need to have [Go](https://golang.org/doc/install) (version 1.16 or higher), [git](https://git-scm.com/) and [make](https://en.wikipedia.org/wiki/Make_(software)) installed. Some of these commands may require `sudo`, depending on your system setup.
 
 ```
 $ git clone https://github.com/cs3org/reva


### PR DESCRIPTION
If you try to build reva with the go version 1.13 which ships standard with Ubuntu, you'll get this error during `make build`:
```
build github.com/cs3org/reva/cmd/revad: cannot load embed: malformed module path "embed": missing dot in first path element
```

The use of `embed` requires go >= 1.16, see https://blog.jetbrains.com/go/2021/06/09/how-to-use-go-embed-in-go-1-16/