### PR TITLE
Implement folder download as archive

### DIFF
--- a/changelog/unreleased/archiver-service.md
+++ b/changelog/unreleased/archiver-service.md
@@ -3,6 +3,5 @@ Enhancement: Implement folder download as archive
 Adds a new http service which will create an archive
 (platform dependent, zip in windows and tar in linux) given a list of file.
 
-
 https://github.com/cs3org/reva/issues/1698
 https://github.com/cs3org/reva/pull/2066

--- a/changelog/unreleased/archiver-service.md
+++ b/changelog/unreleased/archiver-service.md
@@ -1,0 +1,8 @@
+Enhancement: Implement folder download as archive
+
+Adds a new http service which will create an archive
+(platform dependent, zip in windows and tar in linux) given a list of file.
+
+
+https://github.com/cs3org/reva/issues/1698
+https://github.com/cs3org/reva/pull/2066

--- a/internal/http/services/archiver/archiver.go
+++ b/internal/http/services/archiver/archiver.go
@@ -1,0 +1,163 @@
+// Copyright 2018-2021 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package archiver
+
+import (
+	"archive/tar"
+	"context"
+	"io"
+	"net/http"
+	"time"
+
+	gateway "github.com/cs3org/go-cs3apis/cs3/gateway/v1beta1"
+	rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
+	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+	"github.com/cs3org/reva/internal/http/services/datagateway"
+	"github.com/cs3org/reva/pkg/errtypes"
+	"github.com/cs3org/reva/pkg/rhttp"
+	"github.com/cs3org/reva/pkg/rhttp/global"
+	"github.com/cs3org/reva/pkg/storage/utils/walk"
+	"github.com/rs/zerolog"
+)
+
+type svc struct {
+	config     *Config
+	httpClient *http.Client
+	gtwClient  gateway.GatewayAPIClient
+}
+
+// Config holds the config options that need to be passed down to all ocdav handlers
+type Config struct {
+	Prefix     string `mapstructure:"prefix"`
+	GatewaySvc string `mapstructure:"gatewaysvc"`
+}
+
+func init() {
+	global.Register("archiver", New)
+}
+
+func New(conf map[string]interface{}, log *zerolog.Logger) (global.Service, error) {
+	return nil, nil
+}
+
+func (s *svc) Handler() http.Handler {
+	return nil
+}
+
+func (s *svc) Prefix() string {
+	return s.config.Prefix
+}
+
+func (s *svc) Close() error {
+	return nil
+}
+
+func (s *svc) Unprotected() []string {
+	return nil
+}
+
+func (s *svc) createTar(ctx context.Context, files []string, dst io.Writer) error {
+	w := tar.NewWriter(dst)
+
+	for _, root := range files {
+
+		err := walk.Walk(ctx, root, s.gtwClient, func(path string, info *provider.ResourceInfo, err error) error {
+			if err != nil {
+				return err
+			}
+
+			tarHeader := tar.Header{
+				Name:    path,
+				ModTime: time.Unix(int64(info.Mtime.Seconds), 0),
+			}
+
+			isDir := info.Type == provider.ResourceType_RESOURCE_TYPE_CONTAINER
+
+			if isDir {
+				// the resource is a folder
+				tarHeader.Mode = 0755
+				tarHeader.Typeflag = tar.TypeDir
+			} else {
+				tarHeader.Mode = 0644
+				tarHeader.Typeflag = tar.TypeReg
+				tarHeader.Size = int64(info.Size)
+			}
+
+			err = w.WriteHeader(&tarHeader)
+			if err != nil {
+				return err
+			}
+
+			if !isDir {
+				err = s.downloadFile(ctx, path, w)
+				if err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+
+		if err != nil {
+			return err
+		}
+
+	}
+	return nil
+}
+
+func (s *svc) downloadFile(ctx context.Context, path string, dst io.Writer) error {
+	downReq, err := s.gtwClient.InitiateFileDownload(ctx, &provider.InitiateFileDownloadRequest{
+		Ref: &provider.Reference{
+			Path: path,
+		},
+	})
+
+	switch {
+	case err != nil:
+		return err
+	case downReq.Status.Code != rpc.Code_CODE_OK:
+		return errtypes.InternalError(downReq.Status.Message)
+	}
+
+	var endpoint, token string
+	for _, p := range downReq.Protocols {
+		if p.Protocol == "simple" {
+			endpoint, token = p.DownloadEndpoint, p.Token
+		}
+	}
+
+	httpReq, err := rhttp.NewRequest(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return err
+	}
+	httpReq.Header.Set(datagateway.TokenTransportHeader, token)
+
+	httpRes, err := s.httpClient.Do(httpReq)
+	if err != nil {
+		return err
+	}
+	defer httpRes.Body.Close()
+
+	if httpRes.StatusCode != http.StatusOK {
+		return errtypes.InternalError(httpRes.Status)
+	}
+
+	_, err = io.Copy(dst, httpRes.Body)
+	return err
+}

--- a/internal/http/services/archiver/archiver.go
+++ b/internal/http/services/archiver/archiver.go
@@ -127,6 +127,8 @@ func (s *svc) Handler() http.Handler {
 			files = append(files, strings.TrimSuffix(p, "/"))
 		}
 
+		userAgent := ua.Parse(r.Header.Get("User-Agent"))
+
 		archiveName := "download"
 		if len(files) == 0 {
 			// we need to archive the whole dir
@@ -134,9 +136,13 @@ func (s *svc) Handler() http.Handler {
 			archiveName = path.Base(dir)
 		}
 
-		s.log.Debug().Msg("Requested the following files/folders to archive: " + render.Render(files))
+		if userAgent.OS == ua.Windows {
+			archiveName += ".zip"
+		} else {
+			archiveName += ".tar"
+		}
 
-		userAgent := ua.Parse(r.Header.Get("User-Agent"))
+		s.log.Debug().Msg("Requested the following files/folders to archive: " + render.Render(files))
 
 		rw.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=\"%s\"", archiveName))
 		rw.Header().Set("Content-Transfer-Encoding", "binary")

--- a/internal/http/services/archiver/archiver.go
+++ b/internal/http/services/archiver/archiver.go
@@ -71,6 +71,7 @@ func init() {
 	global.Register("archiver", New)
 }
 
+// New creates a new archiver service
 func New(conf map[string]interface{}, log *zerolog.Logger) (global.Service, error) {
 	c := &Config{}
 	err := mapstructure.Decode(conf, c)
@@ -192,7 +193,7 @@ func (s *svc) createTar(ctx context.Context, dir string, files []string, dst io.
 				return err
 			}
 
-			filesCount += 1
+			filesCount++
 			if filesCount > s.config.MaxNumFiles {
 				return errMaxFileCount
 			}
@@ -255,7 +256,7 @@ func (s *svc) createZip(ctx context.Context, dir string, files []string, dst io.
 				return err
 			}
 
-			filesCount += 1
+			filesCount++
 			if filesCount > s.config.MaxNumFiles {
 				return errMaxFileCount
 			}

--- a/internal/http/services/archiver/archiver.go
+++ b/internal/http/services/archiver/archiver.go
@@ -38,7 +38,7 @@ import (
 	"github.com/cs3org/reva/pkg/rhttp"
 	"github.com/cs3org/reva/pkg/rhttp/global"
 	"github.com/cs3org/reva/pkg/sharedconf"
-	"github.com/cs3org/reva/pkg/storage/utils/walk"
+	"github.com/cs3org/reva/pkg/storage/utils/walker"
 	"github.com/gdexlab/go-render/render"
 	ua "github.com/mileusna/useragent"
 	"github.com/mitchellh/mapstructure"
@@ -188,7 +188,7 @@ func (s *svc) createTar(ctx context.Context, dir string, files []string, dst io.
 
 	for _, root := range files {
 
-		err := walk.Walk(ctx, root, s.gtwClient, func(path string, info *provider.ResourceInfo, err error) error {
+		err := walker.Walk(ctx, root, s.gtwClient, func(path string, info *provider.ResourceInfo, err error) error {
 			if err != nil {
 				return err
 			}
@@ -251,7 +251,7 @@ func (s *svc) createZip(ctx context.Context, dir string, files []string, dst io.
 
 	for _, root := range files {
 
-		err := walk.Walk(ctx, root, s.gtwClient, func(path string, info *provider.ResourceInfo, err error) error {
+		err := walker.Walk(ctx, root, s.gtwClient, func(path string, info *provider.ResourceInfo, err error) error {
 			if err != nil {
 				return err
 			}

--- a/internal/http/services/archiver/archiver.go
+++ b/internal/http/services/archiver/archiver.go
@@ -37,6 +37,7 @@ import (
 	"github.com/cs3org/reva/pkg/rgrpc/todo/pool"
 	"github.com/cs3org/reva/pkg/rhttp"
 	"github.com/cs3org/reva/pkg/rhttp/global"
+	"github.com/cs3org/reva/pkg/sharedconf"
 	"github.com/cs3org/reva/pkg/storage/utils/walk"
 	"github.com/gdexlab/go-render/render"
 	ua "github.com/mileusna/useragent"
@@ -92,6 +93,8 @@ func (c *Config) init() {
 	if c.Prefix == "" {
 		c.Prefix = "download_archive"
 	}
+
+	c.GatewaySvc = sharedconf.GetGatewaySVC(c.GatewaySvc)
 }
 
 func (s *svc) Handler() http.Handler {

--- a/internal/http/services/archiver/archiver.go
+++ b/internal/http/services/archiver/archiver.go
@@ -173,6 +173,7 @@ func (s *svc) Unprotected() []string {
 	return nil
 }
 
+// create a new tar containing the files in the `files` list, which are in the directory `dir`
 func (s *svc) createTar(ctx context.Context, dir string, files []string, dst io.Writer) error {
 	w := tar.NewWriter(dst)
 
@@ -235,6 +236,7 @@ func (s *svc) createTar(ctx context.Context, dir string, files []string, dst io.
 	return w.Close()
 }
 
+// create a new zip containing the files in the `files` list, which are in the directory `dir`
 func (s *svc) createZip(ctx context.Context, dir string, files []string, dst io.Writer) error {
 	w := zip.NewWriter(dst)
 

--- a/internal/http/services/loader/loader.go
+++ b/internal/http/services/loader/loader.go
@@ -21,6 +21,7 @@ package loader
 import (
 	// Load core HTTP services
 	_ "github.com/cs3org/reva/internal/http/services/appprovider"
+	_ "github.com/cs3org/reva/internal/http/services/archiver"
 	_ "github.com/cs3org/reva/internal/http/services/datagateway"
 	_ "github.com/cs3org/reva/internal/http/services/dataprovider"
 	_ "github.com/cs3org/reva/internal/http/services/helloworld"

--- a/pkg/storage/utils/walk/walk.go
+++ b/pkg/storage/utils/walk/walk.go
@@ -30,8 +30,17 @@ import (
 	"github.com/cs3org/reva/pkg/errtypes"
 )
 
+// WalkFunc is the type of function called by Walk to visit each file or directory
+//
+// Each time the Walk function meet a file/folder path is set to the full path of this.
+// The err argument reports an error related to the path, and the function can decide the action to
+// do with this.
+//
+// The error result returned by the function controls how Walk continues. If the function returns the special value SkipDir, Walk skips the current directory.
+// Otherwise, if the function returns a non-nil error, Walk stops entirely and returns that error.
 type WalkFunc func(path string, info *provider.ResourceInfo, err error) error
 
+// Walk walks the file tree rooted at root, calling fn for each file or folder in the tree, including the root.
 func Walk(ctx context.Context, root string, gtw gateway.GatewayAPIClient, fn WalkFunc) error {
 	info, err := stat(ctx, root, gtw)
 

--- a/pkg/storage/utils/walk/walk.go
+++ b/pkg/storage/utils/walk/walk.go
@@ -1,3 +1,21 @@
+// Copyright 2018-2021 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
 package walk
 
 import (

--- a/pkg/storage/utils/walk/walk.go
+++ b/pkg/storage/utils/walk/walk.go
@@ -1,0 +1,86 @@
+package walk
+
+import (
+	"context"
+	"path/filepath"
+
+	gateway "github.com/cs3org/go-cs3apis/cs3/gateway/v1beta1"
+	rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
+	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+	"github.com/cs3org/reva/pkg/errtypes"
+)
+
+type WalkFunc func(path string, info *provider.ResourceInfo, err error) error
+
+func Walk(ctx context.Context, root string, gtw gateway.GatewayAPIClient, fn WalkFunc) error {
+	info, err := stat(ctx, root, gtw)
+
+	if err != nil {
+		return fn(root, nil, err)
+	}
+
+	err = walkRecursively(ctx, root, info, gtw, fn)
+
+	if err == filepath.SkipDir {
+		return nil
+	}
+
+	return err
+}
+
+func walkRecursively(ctx context.Context, path string, info *provider.ResourceInfo, gtw gateway.GatewayAPIClient, fn WalkFunc) error {
+
+	if info.Type != provider.ResourceType_RESOURCE_TYPE_CONTAINER {
+		return fn(path, info, nil)
+	}
+
+	list, err := readDir(ctx, path, gtw)
+	errFn := fn(path, info, err)
+
+	if err != nil || errFn != nil {
+		return errFn
+	}
+
+	for _, file := range list {
+		err = walkRecursively(ctx, file.Path, file, gtw, fn)
+		if err != nil && (file.Type != provider.ResourceType_RESOURCE_TYPE_CONTAINER || err != filepath.SkipDir) {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func readDir(ctx context.Context, path string, gtw gateway.GatewayAPIClient) ([]*provider.ResourceInfo, error) {
+	resp, err := gtw.ListContainer(ctx, &provider.ListContainerRequest{
+		Ref: &provider.Reference{
+			Path: path,
+		},
+	})
+
+	switch {
+	case err != nil:
+		return nil, err
+	case resp.Status.Code != rpc.Code_CODE_OK:
+		return nil, errtypes.InternalError(resp.Status.Message)
+	}
+
+	return resp.Infos, nil
+}
+
+func stat(ctx context.Context, path string, gtw gateway.GatewayAPIClient) (*provider.ResourceInfo, error) {
+	resp, err := gtw.Stat(ctx, &provider.StatRequest{
+		Ref: &provider.Reference{
+			Path: path,
+		},
+	})
+
+	switch {
+	case err != nil:
+		return nil, err
+	case resp.Status.Code != rpc.Code_CODE_OK:
+		return nil, errtypes.InternalError(resp.Status.Message)
+	}
+
+	return resp.Info, nil
+}

--- a/pkg/storage/utils/walk/walk.go
+++ b/pkg/storage/utils/walk/walk.go
@@ -2,11 +2,13 @@ package walk
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 
 	gateway "github.com/cs3org/go-cs3apis/cs3/gateway/v1beta1"
 	rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+
 	"github.com/cs3org/reva/pkg/errtypes"
 )
 
@@ -61,8 +63,10 @@ func readDir(ctx context.Context, path string, gtw gateway.GatewayAPIClient) ([]
 	switch {
 	case err != nil:
 		return nil, err
+	case resp.Status.Code == rpc.Code_CODE_NOT_FOUND:
+		return nil, errtypes.NotFound(path)
 	case resp.Status.Code != rpc.Code_CODE_OK:
-		return nil, errtypes.InternalError(resp.Status.Message)
+		return nil, errtypes.InternalError(fmt.Sprintf("error reading dir %s", path))
 	}
 
 	return resp.Infos, nil
@@ -78,8 +82,10 @@ func stat(ctx context.Context, path string, gtw gateway.GatewayAPIClient) (*prov
 	switch {
 	case err != nil:
 		return nil, err
+	case resp.Status.Code == rpc.Code_CODE_NOT_FOUND:
+		return nil, errtypes.NotFound(path)
 	case resp.Status.Code != rpc.Code_CODE_OK:
-		return nil, errtypes.InternalError(resp.Status.Message)
+		return nil, errtypes.InternalError(fmt.Sprintf("error getting stats from %s", path))
 	}
 
 	return resp.Info, nil

--- a/pkg/storage/utils/walker/walker.go
+++ b/pkg/storage/utils/walker/walker.go
@@ -16,7 +16,7 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-package walk
+package walker
 
 import (
 	"context"


### PR DESCRIPTION
Add a new http service which will create an archive (platform dependent, zip in windows and tar in linux) given a list of file.

The service for default listen on `/download_archive` and accept the following parameters in the query list:
 - `dir` = where the files/folders are
 - `file` = file/directory to add in the archive (can be specified multiple times)
If the file parameter is not provided, it will be created an archive with all the files and folders in `dir`.

It is possible specify the max_num_files and max_size configs as thresholds, that if exceed will cause an abort of the archive generation.

Closes #1698