### PR TITLE
Implement listing favorites via the dav report API

### DIFF
--- a/changelog/unreleased/list-favorites.md
+++ b/changelog/unreleased/list-favorites.md
@@ -1,0 +1,6 @@
+Enhancement: Implement listing favorites via the dav report API 
+
+Added filter-files to the dav REPORT API. This enables the listing of
+favorites.
+
+https://github.com/cs3org/reva/pull/2071

--- a/internal/http/services/owncloud/ocdav/propfind.go
+++ b/internal/http/services/owncloud/ocdav/propfind.go
@@ -134,7 +134,7 @@ func (s *svc) handleSpacesPropfind(w http.ResponseWriter, r *http.Request, space
 }
 
 func (s *svc) propfindResponse(ctx context.Context, w http.ResponseWriter, r *http.Request, namespace string, pf propfindXML, parentInfo *provider.ResourceInfo, resourceInfos []*provider.ResourceInfo, log zerolog.Logger) {
-	propRes, err := s.formatPropfind(ctx, &pf, resourceInfos, namespace)
+	propRes, err := s.multistatusResponse(ctx, &pf, resourceInfos, namespace)
 	if err != nil {
 		log.Error().Err(err).Msg("error formatting propfind")
 		w.WriteHeader(http.StatusInternalServerError)
@@ -342,7 +342,7 @@ func readPropfind(r io.Reader) (pf propfindXML, status int, err error) {
 	return pf, 0, nil
 }
 
-func (s *svc) formatPropfind(ctx context.Context, pf *propfindXML, mds []*provider.ResourceInfo, ns string) (string, error) {
+func (s *svc) multistatusResponse(ctx context.Context, pf *propfindXML, mds []*provider.ResourceInfo, ns string) (string, error) {
 	responses := make([]*responseXML, 0, len(mds))
 	for i := range mds {
 		res, err := s.mdToPropResponse(ctx, pf, mds[i], ns)

--- a/internal/http/services/owncloud/ocdav/proppatch.go
+++ b/internal/http/services/owncloud/ocdav/proppatch.go
@@ -30,6 +30,7 @@ import (
 	rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	"github.com/cs3org/reva/pkg/appctx"
+	ctxpkg "github.com/cs3org/reva/pkg/ctx"
 	rtrace "github.com/cs3org/reva/pkg/trace"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
@@ -232,6 +233,19 @@ func (s *svc) handleProppatch(ctx context.Context, w http.ResponseWriter, r *htt
 					HandleErrorStatus(&log, w, res.Status)
 					return nil, nil, false
 				}
+				if key == "http://owncloud.org/ns/favorite" {
+					statRes, err := c.Stat(ctx, &provider.StatRequest{Ref: ref})
+					if err != nil {
+						w.WriteHeader(http.StatusInternalServerError)
+						return nil, nil, false
+					}
+					currentUser := ctxpkg.ContextMustGetUser(ctx)
+					err = s.favoritesManager.UnsetFavorite(ctx, currentUser.Id, statRes.Info.Id)
+					if err != nil {
+						w.WriteHeader(http.StatusInternalServerError)
+						return nil, nil, false
+					}
+				}
 				removedProps = append(removedProps, propNameXML)
 			} else {
 				sreq.ArbitraryMetadata.Metadata[key] = value
@@ -259,6 +273,20 @@ func (s *svc) handleProppatch(ctx context.Context, w http.ResponseWriter, r *htt
 
 				acceptedProps = append(acceptedProps, propNameXML)
 				delete(sreq.ArbitraryMetadata.Metadata, key)
+
+				if key == "http://owncloud.org/ns/favorite" {
+					statRes, err := c.Stat(ctx, &provider.StatRequest{Ref: ref})
+					if err != nil {
+						w.WriteHeader(http.StatusInternalServerError)
+						return nil, nil, false
+					}
+					currentUser := ctxpkg.ContextMustGetUser(ctx)
+					err = s.favoritesManager.SetFavorite(ctx, currentUser.Id, statRes.Info.Id)
+					if err != nil {
+						w.WriteHeader(http.StatusInternalServerError)
+						return nil, nil, false
+					}
+				}
 			}
 		}
 		// FIXME: in case of error, need to set all properties back to the original state,

--- a/internal/http/services/owncloud/ocdav/publicfile.go
+++ b/internal/http/services/owncloud/ocdav/publicfile.go
@@ -186,7 +186,7 @@ func (s *svc) handlePropfindOnToken(w http.ResponseWriter, r *http.Request, ns s
 
 	infos := s.getPublicFileInfos(onContainer, depth == "0", tokenStatInfo)
 
-	propRes, err := s.formatPropfind(ctx, &pf, infos, ns)
+	propRes, err := s.multistatusResponse(ctx, &pf, infos, ns)
 	if err != nil {
 		sublog.Error().Err(err).Msg("error formatting propfind")
 		w.WriteHeader(http.StatusInternalServerError)

--- a/internal/http/services/owncloud/ocdav/report.go
+++ b/internal/http/services/owncloud/ocdav/report.go
@@ -24,6 +24,12 @@ import (
 	"net/http"
 
 	"github.com/cs3org/reva/pkg/appctx"
+	ctxpkg "github.com/cs3org/reva/pkg/ctx"
+)
+
+const (
+	elementNameSearchFiles = "search-files"
+	elementNameFilterFiles = "filter-files"
 )
 
 func (s *svc) handleReport(w http.ResponseWriter, r *http.Request, ns string) {
@@ -39,6 +45,11 @@ func (s *svc) handleReport(w http.ResponseWriter, r *http.Request, ns string) {
 	}
 	if rep.SearchFiles != nil {
 		s.doSearchFiles(w, r, rep.SearchFiles)
+		return
+	}
+
+	if rep.FilterFiles != nil {
+		s.doFilterFiles(w, r, rep.FilterFiles, ns)
 		return
 	}
 
@@ -59,9 +70,39 @@ func (s *svc) doSearchFiles(w http.ResponseWriter, r *http.Request, sf *reportSe
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
+func (s *svc) doFilterFiles(w http.ResponseWriter, r *http.Request, ff *reportFilterFiles, namespace string) {
+	ctx := r.Context()
+	log := appctx.GetLogger(ctx)
+
+	if ff.Rules.Favorite {
+		// List the users favorite resources.
+		currentUser := ctxpkg.ContextMustGetUser(ctx)
+		favorites, err := s.favoritesManager.ListFavorites(ctx, currentUser.Id)
+		if err != nil {
+			log.Error().Err(err).Msg("error getting favorites")
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		responsesXML, err := s.multistatusResponse(ctx, &propfindXML{Prop: ff.Prop}, favorites, namespace)
+		if err != nil {
+			log.Error().Err(err).Msg("error formatting propfind")
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set(HeaderDav, "1, 3, extended-mkcol")
+		w.Header().Set(HeaderContentType, "application/xml; charset=utf-8")
+		w.WriteHeader(http.StatusMultiStatus)
+		if _, err := w.Write([]byte(responsesXML)); err != nil {
+			log.Err(err).Msg("error writing response")
+		}
+	}
+}
+
 type report struct {
 	SearchFiles *reportSearchFiles
 	// FilterFiles TODO add this for tag based search
+	FilterFiles *reportFilterFiles `xml:"filter-files"`
 }
 type reportSearchFiles struct {
 	XMLName xml.Name                `xml:"search-files"`
@@ -73,6 +114,18 @@ type reportSearchFilesSearch struct {
 	Pattern string `xml:"search"`
 	Limit   int    `xml:"limit"`
 	Offset  int    `xml:"offset"`
+}
+
+type reportFilterFiles struct {
+	XMLName xml.Name               `xml:"filter-files"`
+	Lang    string                 `xml:"xml:lang,attr,omitempty"`
+	Prop    propfindProps          `xml:"DAV: prop"`
+	Rules   reportFilterFilesRules `xml:"filter-rules"`
+}
+
+type reportFilterFilesRules struct {
+	Favorite  bool `xml:"favorite"`
+	SystemTag int  `xml:"systemtag"`
 }
 
 func readReport(r io.Reader) (rep *report, status int, err error) {
@@ -89,13 +142,20 @@ func readReport(r io.Reader) (rep *report, status int, err error) {
 		}
 
 		if v, ok := t.(xml.StartElement); ok {
-			if v.Name.Local == "search-files" {
+			if v.Name.Local == elementNameSearchFiles {
 				var repSF reportSearchFiles
 				err = decoder.DecodeElement(&repSF, &v)
 				if err != nil {
 					return nil, http.StatusBadRequest, err
 				}
 				rep.SearchFiles = &repSF
+			} else if v.Name.Local == elementNameFilterFiles {
+				var repFF reportFilterFiles
+				err = decoder.DecodeElement(&repFF, &v)
+				if err != nil {
+					return nil, http.StatusBadRequest, err
+				}
+				rep.FilterFiles = &repFF
 			}
 		}
 	}

--- a/internal/http/services/owncloud/ocdav/report_test.go
+++ b/internal/http/services/owncloud/ocdav/report_test.go
@@ -1,0 +1,63 @@
+// Copyright 2018-2021 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package ocdav
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestUnmarshallReportFilterFiles(t *testing.T) {
+	ffXML := `<oc:filter-files  xmlns:d="DAV:" xmlns:oc="http://owncloud.org/ns">
+    <d:prop>
+        <d:getlastmodified />
+        <d:getetag />
+        <d:getcontenttype />
+        <d:resourcetype />
+        <oc:fileid />
+        <oc:permissions />
+        <oc:size />
+        <d:getcontentlength />
+        <oc:tags />
+        <oc:favorite />
+        <d:lockdiscovery />
+        <oc:comments-unread />
+        <oc:owner-display-name />
+        <oc:share-types />
+    </d:prop>
+    <oc:filter-rules>
+        <oc:favorite>1</oc:favorite>
+    </oc:filter-rules>
+</oc:filter-files>`
+
+	reader := strings.NewReader(ffXML)
+
+	report, status, err := readReport(reader)
+	if status != 0 || err != nil {
+		t.Error("Failed to unmarshal filter-files xml")
+	}
+
+	if report.FilterFiles == nil {
+		t.Error("Failed to unmarshal filter-files xml. FilterFiles is nil")
+	}
+
+	if report.FilterFiles.Rules.Favorite == false {
+		t.Error("Failed to correctly unmarshal filter-rules. Favorite is expected to be true.")
+	}
+}

--- a/internal/http/services/owncloud/ocdav/versions.go
+++ b/internal/http/services/owncloud/ocdav/versions.go
@@ -164,7 +164,7 @@ func (h *VersionsHandler) doListVersions(w http.ResponseWriter, r *http.Request,
 		infos = append(infos, vi)
 	}
 
-	propRes, err := s.formatPropfind(ctx, &pf, infos, "")
+	propRes, err := s.multistatusResponse(ctx, &pf, infos, "")
 	if err != nil {
 		sublog.Error().Err(err).Msg("error formatting propfind")
 		w.WriteHeader(http.StatusInternalServerError)

--- a/pkg/storage/favorite/favorite.go
+++ b/pkg/storage/favorite/favorite.go
@@ -1,0 +1,78 @@
+// Copyright 2018-2021 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package favorite
+
+import (
+	"context"
+
+	user "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
+	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+	"github.com/cs3org/reva/pkg/storage"
+)
+
+// Manager defines an interface for a favorites manager.
+type Manager interface {
+	// ListFavorites returns all resources that were favorited by a user.
+	ListFavorites(ctx context.Context, userID *user.UserId) ([]*provider.ResourceInfo, error)
+	// SetFavorite marks a resource as favorited by a user.
+	SetFavorite(ctx context.Context, userID *user.UserId, resourceID *provider.ResourceId) error
+	// UnsetFavorite unmarks a resource as favorited by a user.
+	UnsetFavorite(ctx context.Context, userID *user.UserId, resourceID *provider.ResourceId) error
+}
+
+// NewInMemoryManager returns an instance of a favorites manager using an in-memory storage.
+func NewInMemoryManager(fs storage.FS) Manager {
+	return InMemoryManager{fs: fs, favorites: make(map[string]map[string]struct{})}
+}
+
+// InMemoryManager implements the Manager interface to manage favorites using an in-memory storage.
+type InMemoryManager struct {
+	fs        storage.FS
+	favorites map[string]map[string]struct{}
+}
+
+// ListFavorites returns all resources that were favorited by a user.
+func (m InMemoryManager) ListFavorites(ctx context.Context, userID *user.UserId) ([]*provider.ResourceInfo, error) {
+	favorites := make([]*provider.ResourceInfo, 0, len(m.favorites[userID.OpaqueId]))
+	for id := range m.favorites[userID.OpaqueId] {
+		info, err := m.fs.GetMD(ctx, &provider.Reference{ResourceId: &provider.ResourceId{OpaqueId: id}}, []string{})
+		if err != nil {
+			continue
+		}
+		favorites = append(favorites, info)
+	}
+	return favorites, nil
+}
+
+// SetFavorite marks a resource as favorited by a user.
+func (m InMemoryManager) SetFavorite(_ context.Context, userID *user.UserId, resourceID *provider.ResourceId) error {
+	if m.favorites[userID.OpaqueId] == nil {
+		m.favorites[userID.OpaqueId] = make(map[string]struct{})
+	}
+	m.favorites[userID.OpaqueId][resourceID.OpaqueId] = struct{}{}
+
+	return nil
+}
+
+// UnsetFavorite unmarks a resource as favorited by a user.
+func (m InMemoryManager) UnsetFavorite(_ context.Context, userID *user.UserId, resourceID *provider.ResourceId) error {
+	delete(m.favorites[userID.OpaqueId], resourceID.OpaqueId)
+
+	return nil
+}

--- a/pkg/storage/favorite/favorite_test.go
+++ b/pkg/storage/favorite/favorite_test.go
@@ -1,0 +1,143 @@
+// Copyright 2018-2021 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package favorite
+
+import (
+	"context"
+	"testing"
+
+	user "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
+	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+
+	ctxpkg "github.com/cs3org/reva/pkg/ctx"
+	"github.com/cs3org/reva/pkg/storage"
+)
+
+type environment struct {
+	userOne    *user.User
+	userOneCtx context.Context
+
+	userTwo    *user.User
+	userTwoCtx context.Context
+
+	userThree    *user.User
+	userThreeCtx context.Context
+
+	resourceInfoOne *provider.ResourceInfo
+	resourceInfoTwo *provider.ResourceInfo
+
+	fs storage.FS
+}
+
+func createEnvironment() environment {
+	userOne := &user.User{Id: &user.UserId{OpaqueId: "userOne"}}
+	userTwo := &user.User{Id: &user.UserId{OpaqueId: "userTwo"}}
+	userThree := &user.User{Id: &user.UserId{OpaqueId: "userThree"}}
+
+	resourceInfoOne := &provider.ResourceInfo{Id: &provider.ResourceId{OpaqueId: "resourceInfoOne"}}
+	resourceInfoTwo := &provider.ResourceInfo{Id: &provider.ResourceId{OpaqueId: "resourceInfoTwo"}}
+
+	return environment{
+		userOne:      userOne,
+		userOneCtx:   ctxpkg.ContextSetUser(context.Background(), userOne),
+		userTwo:      userTwo,
+		userTwoCtx:   ctxpkg.ContextSetUser(context.Background(), userTwo),
+		userThree:    userThree,
+		userThreeCtx: ctxpkg.ContextSetUser(context.Background(), userThree),
+
+		resourceInfoOne: resourceInfoOne,
+		resourceInfoTwo: resourceInfoTwo,
+
+		fs: storage.InMemoryFS{Resources: map[string]map[string]*provider.ResourceInfo{
+			userOne.Id.OpaqueId: {
+				resourceInfoOne.Id.OpaqueId: resourceInfoOne,
+			},
+			userTwo.Id.OpaqueId: {
+				resourceInfoOne.Id.OpaqueId: resourceInfoOne,
+				resourceInfoTwo.Id.OpaqueId: resourceInfoTwo,
+			},
+		}},
+	}
+}
+
+func TestListFavorite(t *testing.T) {
+	env := createEnvironment()
+	sut := NewInMemoryManager(env.fs)
+
+	favorites, _ := sut.ListFavorites(env.userOneCtx, env.userOne.Id)
+	if len(favorites) != 0 {
+		t.Error("ListFavorites should not return anything when a user hasn't set a favorite")
+	}
+
+	_ = sut.SetFavorite(env.userOneCtx, env.userOne.Id, env.resourceInfoOne.Id)
+	_ = sut.SetFavorite(env.userTwoCtx, env.userTwo.Id, env.resourceInfoOne.Id)
+	_ = sut.SetFavorite(env.userTwoCtx, env.userTwo.Id, env.resourceInfoTwo.Id)
+
+	favorites, _ = sut.ListFavorites(env.userOneCtx, env.userOne.Id)
+	if len(favorites) != 1 {
+		t.Errorf("Expected %d favorites got %d", 1, len(favorites))
+	}
+
+	favorites, _ = sut.ListFavorites(env.userTwoCtx, env.userTwo.Id)
+	if len(favorites) != 2 {
+		t.Errorf("Expected %d favorites got %d", 2, len(favorites))
+	}
+
+	favorites, _ = sut.ListFavorites(env.userThreeCtx, env.userThree.Id)
+	if len(favorites) != 0 {
+		t.Errorf("Expected %d favorites got %d", 0, len(favorites))
+	}
+}
+
+func TestSetFavorite(t *testing.T) {
+	env := createEnvironment()
+
+	sut := NewInMemoryManager(env.fs)
+
+	favorites, _ := sut.ListFavorites(env.userOneCtx, env.userOne.Id)
+	lenBefore := len(favorites)
+
+	_ = sut.SetFavorite(env.userOneCtx, env.userOne.Id, env.resourceInfoOne.Id)
+
+	favorites, _ = sut.ListFavorites(env.userOneCtx, env.userOne.Id)
+	lenAfter := len(favorites)
+
+	if lenAfter-lenBefore != 1 {
+		t.Errorf("Setting a favorite should add 1 favorite but actually added %d", lenAfter-lenBefore)
+	}
+}
+
+func TestUnsetFavorite(t *testing.T) {
+	env := createEnvironment()
+
+	sut := NewInMemoryManager(env.fs)
+
+	_ = sut.SetFavorite(env.userOneCtx, env.userOne.Id, env.resourceInfoOne.Id)
+	favorites, _ := sut.ListFavorites(env.userOneCtx, env.userOne.Id)
+	lenBefore := len(favorites)
+
+	_ = sut.UnsetFavorite(env.userOneCtx, env.userOne.Id, env.resourceInfoOne.Id)
+
+	favorites, _ = sut.ListFavorites(env.userOneCtx, env.userOne.Id)
+	lenAfter := len(favorites)
+
+	if lenAfter-lenBefore != -1 {
+		t.Errorf("Setting a favorite should remove 1 favorite but actually removed %d", lenAfter-lenBefore)
+	}
+}

--- a/pkg/storage/memory.go
+++ b/pkg/storage/memory.go
@@ -1,0 +1,58 @@
+// Copyright 2018-2021 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package storage
+
+import (
+	"context"
+
+	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+	ctxpkg "github.com/cs3org/reva/pkg/ctx"
+	"github.com/cs3org/reva/pkg/errtypes"
+)
+
+// InMemoryFS is supposed to be a storage.FS implementation which can be used in unit tests which depend on a storage.
+// Not all methods are implemented but can be added when required.
+// The data is only stored in memory.
+type InMemoryFS struct {
+	FS
+	// Resources acts as the in memory storage.
+	// The expected layout is as follows:
+	//
+	// Resources: map[string]map[string]*provider.ResourceInfo{
+	// 	userOne.Id.OpaqueId: {
+	// 		resourceInfoOne.Id.OpaqueId: resourceInfoOne,
+	// 	},
+	// 	userTwo.Id.OpaqueId: {
+	// 		resourceInfoOne.Id.OpaqueId: resourceInfoOne,
+	// 		resourceInfoTwo.Id.OpaqueId: resourceInfoTwo,
+	// 	},
+	// }
+	Resources map[string]map[string]*provider.ResourceInfo
+}
+
+// GetMD looks up the ResourceInfo by a Reference
+func (fs InMemoryFS) GetMD(ctx context.Context, ref *provider.Reference, _ []string) (*provider.ResourceInfo, error) {
+	user := ctxpkg.ContextMustGetUser(ctx)
+	if infos, ok := fs.Resources[user.Id.OpaqueId]; ok {
+		if info, ok := infos[ref.ResourceId.OpaqueId]; ok {
+			return info, nil
+		}
+	}
+	return nil, errtypes.NotFound(ref.ResourceId.OpaqueId)
+}

--- a/tests/acceptance/expected-failures-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-on-OCIS-storage.md
@@ -1007,18 +1007,12 @@ Scenario Outline: search for entry with emoji by pattern
 -   [apiWebdavOperations/search.feature:255](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L255) Scenario: search for entries across various folders by tags using REPORT method
 
 And other missing implementation of favorites
--   [apiFavorites/favorites.feature:91](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiFavorites/favorites.feature#L91)
--   [apiFavorites/favorites.feature:92](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiFavorites/favorites.feature#L92)
--   [apiFavorites/favorites.feature:112](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiFavorites/favorites.feature#L112)
--   [apiFavorites/favorites.feature:113](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiFavorites/favorites.feature#L113)
 -   [apiFavorites/favorites.feature:128](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiFavorites/favorites.feature#L128)
 -   [apiFavorites/favorites.feature:129](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiFavorites/favorites.feature#L129)
 -   [apiFavorites/favorites.feature:148](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiFavorites/favorites.feature#L148)
 -   [apiFavorites/favorites.feature:149](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiFavorites/favorites.feature#L149)
 -   [apiFavorites/favorites.feature:176](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiFavorites/favorites.feature#L176)
 -   [apiFavorites/favorites.feature:177](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiFavorites/favorites.feature#L177)
--   [apiFavorites/favorites.feature:217](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiFavorites/favorites.feature#L217)
--   [apiFavorites/favorites.feature:218](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiFavorites/favorites.feature#L218)
 -   [apiFavorites/favoritesSharingToShares.feature:21](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiFavorites/favoritesSharingToShares.feature#L21)
 -   [apiFavorites/favoritesSharingToShares.feature:22](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiFavorites/favoritesSharingToShares.feature#L22)
 -   [apiFavorites/favoritesSharingToShares.feature:35](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiFavorites/favoritesSharingToShares.feature#L35)

--- a/tests/acceptance/expected-failures-on-S3NG-storage.md
+++ b/tests/acceptance/expected-failures-on-S3NG-storage.md
@@ -1006,18 +1006,12 @@ Scenario Outline: search for entry with emoji by pattern
 -   [apiWebdavOperations/search.feature:255](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L255) Scenario: search for entries across various folders by tags using REPORT method
 
 And other missing implementation of favorites
--   [apiFavorites/favorites.feature:91](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiFavorites/favorites.feature#L91)
--   [apiFavorites/favorites.feature:92](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiFavorites/favorites.feature#L92)
--   [apiFavorites/favorites.feature:112](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiFavorites/favorites.feature#L112)
--   [apiFavorites/favorites.feature:113](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiFavorites/favorites.feature#L113)
 -   [apiFavorites/favorites.feature:128](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiFavorites/favorites.feature#L128)
 -   [apiFavorites/favorites.feature:129](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiFavorites/favorites.feature#L129)
 -   [apiFavorites/favorites.feature:148](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiFavorites/favorites.feature#L148)
 -   [apiFavorites/favorites.feature:149](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiFavorites/favorites.feature#L149)
 -   [apiFavorites/favorites.feature:176](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiFavorites/favorites.feature#L176)
 -   [apiFavorites/favorites.feature:177](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiFavorites/favorites.feature#L177)
--   [apiFavorites/favorites.feature:217](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiFavorites/favorites.feature#L217)
--   [apiFavorites/favorites.feature:218](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiFavorites/favorites.feature#L218)
 -   [apiFavorites/favoritesSharingToShares.feature:21](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiFavorites/favoritesSharingToShares.feature#L21)
 -   [apiFavorites/favoritesSharingToShares.feature:22](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiFavorites/favoritesSharingToShares.feature#L22)
 -   [apiFavorites/favoritesSharingToShares.feature:35](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiFavorites/favoritesSharingToShares.feature#L35)

--- a/tests/oc-integration-tests/drone/frontend.toml
+++ b/tests/oc-integration-tests/drone/frontend.toml
@@ -59,6 +59,13 @@ files_namespace = "/oc"
 # - the oc js sdk is hardcoded to the remote.php/webdav so it will see the new tree
 # - TODO android? no sync ... but will see different tree
 webdav_namespace = "/home"
+driver = "ocis"
+
+[http.services.ocdav.drivers.ocis]
+root = "/drone/src/tmp/reva/data"
+enable_home = true
+treetime_accounting = true
+treesize_accounting = true
 
 [http.services.ocs]
 

--- a/tests/oc-integration-tests/local/frontend.toml
+++ b/tests/oc-integration-tests/local/frontend.toml
@@ -59,6 +59,13 @@ files_namespace = "/users"
 # - the oc js sdk is hardcoded to the remote.php/webdav so it will see the new tree
 # - TODO android? no sync ... but will see different tree
 webdav_namespace = "/home"
+driver = "ocis"
+
+[http.services.ocdav.drivers.ocis]
+root = "/drone/src/tmp/reva/data"
+enable_home = true
+treetime_accounting = true
+treesize_accounting = true
 
 [http.services.ocs]
 


### PR DESCRIPTION
I added filter-files to the dav REPORT API. This enables the listing of
favorites.

This PR also includes a new in-memory `storage.FS` implementation which I use for the unit tests of the favorite package but it can also be extended and used for other unit tests depending on a storage.