### PR TITLE
Fix opening a readonly filetype with WOPI

### DIFF
--- a/changelog/unreleased/fix-wopi-readonly-filetype.md
+++ b/changelog/unreleased/fix-wopi-readonly-filetype.md
@@ -1,0 +1,7 @@
+Bugfix: Fix opening a readonly filetype with WOPI
+
+This change fixes the opening of filetypes that
+are only supported to be viewed and not to be edited
+by some WOPI compliant office suites.
+
+https://github.com/cs3org/reva/pull/2073

--- a/pkg/app/provider/wopi/wopi.go
+++ b/pkg/app/provider/wopi/wopi.go
@@ -149,7 +149,7 @@ func (p *wopiProvider) GetAppURL(ctx context.Context, resource *provider.Resourc
 			q.Add("appviewurl", viewAppURL)
 		}
 	}
-	if editAppURLs, ok := p.appURLs["edit"]; !ok {
+	if editAppURLs, ok := p.appURLs["edit"]; ok {
 		if editAppURL, ok := editAppURLs[ext]; ok {
 			q.Add("appurl", editAppURL)
 		}

--- a/pkg/app/provider/wopi/wopi.go
+++ b/pkg/app/provider/wopi/wopi.go
@@ -142,16 +142,29 @@ func (p *wopiProvider) GetAppURL(ctx context.Context, resource *provider.Resourc
 	}
 
 	q.Add("appname", p.conf.AppName)
-	q.Add("appurl", p.appURLs["edit"][ext])
+
+	var viewAppURL string
+	if viewAppURLs, ok := p.appURLs["view"]; ok {
+		if viewAppURL, ok = viewAppURLs[ext]; ok {
+			q.Add("appviewurl", viewAppURL)
+		}
+	}
+	if editAppURLs, ok := p.appURLs["edit"]; !ok {
+		if editAppURL, ok := editAppURLs[ext]; ok {
+			q.Add("appurl", editAppURL)
+		}
+	} else {
+		// assuming that an view action is always available in the /hosting/discovery manifest
+		// eg. Collabora does support viewing jpgs but no editing
+		// eg. OnlyOffice does support viewing pdfs but no editing
+		// there is no known case of supporting edit only without view
+		q.Add("appurl", viewAppURL)
+	}
 
 	if p.conf.AppIntURL != "" {
 		q.Add("appinturl", p.conf.AppIntURL)
 	}
-	if viewExts, ok := p.appURLs["view"]; ok {
-		if url, ok := viewExts[ext]; ok {
-			q.Add("appviewurl", url)
-		}
-	}
+
 	httpReq.URL.RawQuery = q.Encode()
 
 	if p.conf.AppAPIKey != "" {

--- a/pkg/app/provider/wopi/wopi.go
+++ b/pkg/app/provider/wopi/wopi.go
@@ -153,12 +153,16 @@ func (p *wopiProvider) GetAppURL(ctx context.Context, resource *provider.Resourc
 		if editAppURL, ok := editAppURLs[ext]; ok {
 			q.Add("appurl", editAppURL)
 		}
-	} else {
+	}
+	if q.Get("appurl") == "" {
 		// assuming that an view action is always available in the /hosting/discovery manifest
 		// eg. Collabora does support viewing jpgs but no editing
 		// eg. OnlyOffice does support viewing pdfs but no editing
 		// there is no known case of supporting edit only without view
 		q.Add("appurl", viewAppURL)
+	}
+	if q.Get("appurl") == "" && q.Get("appviewurl") == "" {
+		return nil, errors.New("wopi: neither edit nor view app url found")
 	}
 
 	if p.conf.AppIntURL != "" {


### PR DESCRIPTION
Eg. JPG or PNG are supported to be opened by Collabora - but in view mode only. "/app/open" request currently fails because the WOPI driver assuems that an edit vie mode always exists.