### PR TITLE
make owncloudsql leverage existing filecache index

### DIFF
--- a/changelog/unreleased/owncloudsql-leverage-existing-filecache-index.md
+++ b/changelog/unreleased/owncloudsql-leverage-existing-filecache-index.md
@@ -1,0 +1,5 @@
+Enhancement: make owncloudsql leverage existing filecache index
+
+When listing folders the SQL query now uses an existing index on the filecache table.
+
+https://github.com/cs3org/reva/pull/2075

--- a/pkg/storage/fs/owncloudsql/filecache/filecache.go
+++ b/pkg/storage/fs/owncloudsql/filecache/filecache.go
@@ -260,15 +260,17 @@ func (c *Cache) List(storage interface{}, p string) ([]*File, error) {
 		return nil, err
 	}
 
-	rows, err := c.db.Query(`
+	var rows *sql.Rows
+	phash := fmt.Sprintf("%x", md5.Sum([]byte(strings.Trim(p, "/"))))
+	rows, err = c.db.Query(`
 		SELECT
 			fc.fileid, fc.storage, fc.path, fc.parent, fc.permissions, fc.mimetype, fc.mimepart,
 			mt.mimetype, fc.size, fc.mtime, fc.storage_mtime, fc.encrypted, fc.unencrypted_size,
 			fc.name, fc.etag, fc.checksum
 		FROM oc_filecache fc
 		LEFT JOIN oc_mimetypes mt ON fc.mimetype = mt.id
-		WHERE path != '' AND path LIKE ? AND PATH NOT LIKE ? AND storage = ?
-	`, p+"%", p+"%/%", storageID)
+		WHERE storage = ? AND parent = (SELECT fileid FROM oc_filecache WHERE storage = ? AND path_hash=?) AND name IS NOT NULL
+	`, storageID, storageID, phash)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
When listing folders the SQL query now uses an existing index on the filecache table.

cc @aduffeck 