### PR TITLE
Fix chi routing

### DIFF
--- a/changelog/unreleased/fix-chi-routing.md
+++ b/changelog/unreleased/fix-chi-routing.md
@@ -1,0 +1,5 @@
+Bugfix: Fix chi routing
+
+Chi routes based on the URL.RawPath, which is not updated by the shiftPath based routing used in reva. By setting the RawPath to an empty string chi will fall pack to URL.Path, allowing it to match percent encoded path segments, e.g. when trying to match emails or multibyte characters.
+
+https://github.com/cs3org/reva/pull/2076

--- a/internal/http/services/owncloud/ocs/ocs.go
+++ b/internal/http/services/owncloud/ocs/ocs.go
@@ -138,6 +138,8 @@ func (s *svc) Handler() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		log := appctx.GetLogger(r.Context())
 		log.Debug().Str("path", r.URL.Path).Msg("ocs routing")
+		// unset raw path, otherwise chi uses it to route and then fails to match percent encoded path segments
+		r.URL.RawPath = ""
 		s.router.ServeHTTP(w, r)
 	})
 }


### PR DESCRIPTION
Chi routes based on the URL.RawPath, which is not updated by the shiftPath based routing used in reva. By setting the RawPath to an empty string chi will fall pack to URL.Path, allowing it to match percent encoded path segments, e.g. when trying to match emails or multibyte characters.