### PR TITLE
Fix concurrent registration of mimetypes

### DIFF
--- a/changelog/unreleased/fix-concurrent-mimetype-map.md
+++ b/changelog/unreleased/fix-concurrent-mimetype-map.md
@@ -1,0 +1,5 @@
+Bugfix: Fix concurrent registration of mimetypes
+
+We fixed registering mimetypes in the mime package when starting multiple storage providers in the same process.
+
+https://github.com/cs3org/reva/pull/2077

--- a/pkg/mime/mime.go
+++ b/pkg/mime/mime.go
@@ -20,23 +20,24 @@ package mime
 
 import (
 	"path"
+	"sync"
 
 	gomime "github.com/cubewise-code/go-mime"
 )
 
 const defaultMimeDir = "httpd/unix-directory"
 
-var mimes map[string]string
+var mimes sync.Map
 
 func init() {
-	mimes = map[string]string{}
+	mimes = sync.Map{}
 }
 
 // RegisterMime is a package level function that registers
 // a mime type with the given extension.
 // TODO(labkode): check that we do not override mime type mappings?
 func RegisterMime(ext, mime string) {
-	mimes[ext] = mime
+	mimes.Store(ext, mime)
 }
 
 // Detect returns the mimetype associated with the given filename.
@@ -61,5 +62,8 @@ func Detect(isDir bool, fn string) string {
 }
 
 func getCustomMime(ext string) string {
-	return mimes[ext]
+	if m, ok := mimes.Load(ext); ok {
+		return m.(string)
+	}
+	return ""
 }


### PR DESCRIPTION
We fixed registering mimetypes in the mime package when starting multiple storage providers in the same process.

we ran into this eg in https://drone.owncloud.com/owncloud/ocis/6739/22/3
```
latest: Pulling from owncloudci/alpine | 0s
-- | --
2 | Digest: sha256:732aef441244719f2d27e0e6323a8bc045a5a68dd714d412da78d01a8d102922 | 0s
3 | Status: Image is up to date for owncloudci/alpine:latest | 0s
4 | + apk add mailcap | 1s
5 | fetch https://dl-cdn.alpinelinux.org/alpine/v3.14/main/x86_64/APKINDEX.tar.gz | 1s
6 | fetch https://dl-cdn.alpinelinux.org/alpine/v3.14/community/x86_64/APKINDEX.tar.gz | 1s
7 | OK: 49 MiB in 48 packages | 1s
8 | + ocis/bin/ocis server | 1s
9 | fatal error: concurrent map writes | 1s
10 | fatal error: concurrent map writes | 1s
11 |   | 1s
12 | goroutine 338 [running]: | 1s
13 | runtime.throw(0x38f7549, 0x15) | 1s
14 | /usr/local/go/src/runtime/panic.go:1117 +0x72 fp=0xc0011efba0 sp=0xc0011efb70 pc=0x121c0f2 | 1s
15 | runtime.mapassign_faststr(0x3416aa0, 0xc00046a510, 0x38cc717, 0x4, 0x132a505) | 1s
16 | /usr/local/go/src/runtime/map_faststr.go:291 +0x3d8 fp=0xc0011efc08 sp=0xc0011efba0 pc=0x11f82d8 | 1s
17 | github.com/cs3org/reva/pkg/mime.RegisterMime(...) | 1s
18 | /go/pkg/mod/github.com/cs3org/reva@v1.13.0/pkg/mime/mime.go:39 | 1s
19 | github.com/cs3org/reva/internal/grpc/services/storageprovider.registerMimeTypes(0xc001e20420) | 1s
20 | /go/pkg/mod/github.com/cs3org/reva@v1.13.0/internal/grpc/services/storageprovider/storageprovider.go:200 +0xd8 fp=0xc0011efcb0 sp=0xc0011efc08 pc=0x2753978 | 1s
21 | github.com/cs3org/reva/internal/grpc/services/storageprovider.New(0xc00173bf50, 0x0, 0x38e5b31, 0xf, 0xc00181ca48, 0x68d2031d4695329c) | 1s
22 | /go/pkg/mod/github.com/cs3org/reva@v1.13.0/internal/grpc/services/storageprovider/storageprovider.go:183 +0x1b0 fp=0xc0011efd48 sp=0xc0011efcb0 pc=0x27535b0 | 1s
23 | github.com/cs3org/reva/pkg/rgrpc.(*Server).registerServices(0xc0011db710, 0x38cd0fb, 0x38cd08b) | 1s
24 | /go/pkg/mod/github.com/cs3org/reva@v1.13.0/pkg/rgrpc/rgrpc.go:177 +0x24f fp=0xc0011eff00 sp=0xc0011efd48 pc=0x26be9cf | 1s
25 | github.com/cs3org/reva/pkg/rgrpc.(*Server).Start(0xc0011db710, 0x4007a80, 0xc0007e2420, 0x4, 0xc00180b3b8) | 1s
26 | /go/pkg/mod/github.com/cs3org/reva@v1.13.0/pkg/rgrpc/rgrpc.go:140 +0x2f fp=0xc0011eff78 sp=0xc0011eff00 pc=0x26be30f | 1s
27 | github.com/cs3org/reva/cmd/revad/runtime.start.func2(0xc00173be00, 0xc001e20060, 0xc000656780, 0xc00168c210) | 1s
28 | /go/pkg/mod/github.com/cs3org/reva@v1.13.0/cmd/revad/runtime/runtime.go:198 +0xc9 fp=0xc0011effc0 sp=0xc0011eff78 pc=0x2db04e9 | 1s
29 | runtime.goexit() | 1s
30 | /usr/local/go/src/runtime/asm_amd64.s:1371 +0x1 fp=0xc0011effc8 sp=0xc0011effc0 pc=0x12575e1 | 1s
31 | created by github.com/cs3org/reva/cmd/revad/runtime.start | 1s
32 | /go/pkg/mod/github.com/cs3org/reva@v1.13.0/cmd/revad/runtime/runtime.go:197 +0x176
```

cc @rhafer @wkloucek as you ran into this