### PR TITLE
limit the data exposed to resourceinfo and publicshare scopes

### DIFF
--- a/changelog/unreleased/limit-scope-content.md
+++ b/changelog/unreleased/limit-scope-content.md
@@ -1,0 +1,7 @@
+Enhancement: Limit publicshare and resourceinfo scope content 
+
+We changed the publicshare and resourceinfo scopes to contain only necessary values.
+This reduces the size of the resulting token and also limits the amount of data which can be leaked.
+
+https://github.com/owncloud/ocis/issues/2479
+https://github.com/cs3org/reva/pull/2093

--- a/pkg/auth/scope/publicshare.go
+++ b/pkg/auth/scope/publicshare.go
@@ -91,7 +91,9 @@ func checkPublicShareRef(s *link.PublicShare, ref *link.PublicShareReference) bo
 // AddPublicShareScope adds the scope to allow access to a public share and
 // the shared resource.
 func AddPublicShareScope(share *link.PublicShare, role authpb.Role, scopes map[string]*authpb.Scope) (map[string]*authpb.Scope, error) {
-	val, err := utils.MarshalProtoV1ToJSON(share)
+	// Create a new "scope share" to only expose the required fields `ResourceId` and `Token` to the scope.
+	scopeShare := &link.PublicShare{ResourceId: share.ResourceId, Token: share.Token}
+	val, err := utils.MarshalProtoV1ToJSON(scopeShare)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/auth/scope/resourceinfo.go
+++ b/pkg/auth/scope/resourceinfo.go
@@ -102,7 +102,9 @@ func checkResourcePath(path string) bool {
 
 // AddResourceInfoScope adds the scope to allow access to a resource info object.
 func AddResourceInfoScope(r *provider.ResourceInfo, role authpb.Role, scopes map[string]*authpb.Scope) (map[string]*authpb.Scope, error) {
-	val, err := utils.MarshalProtoV1ToJSON(r)
+	// Create a new "scope info" to only expose the required fields `Id` and `Path` to the scope.
+	scopeInfo := &provider.ResourceInfo{Id: r.Id, Path: r.Path}
+	val, err := utils.MarshalProtoV1ToJSON(scopeInfo)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
We changed the publicshare and resourceinfo scopes to contain only necessary values.
This reduces the size of the resulting token and also limits the amount of data which can be leaked.

Needed for: https://github.com/owncloud/ocis/issues/2479