### PR TITLE
[docs-only] Generate cato docs and downgrade go-prompt to v0.2.5

### DIFF
--- a/docs/content/en/docs/config/packages/app/provider/wopi/_index.md
+++ b/docs/content/en/docs/config/packages/app/provider/wopi/_index.md
@@ -72,11 +72,11 @@ jwt_secret = ""
 {{< /highlight >}}
 {{% /dir %}}
 
-{{% dir name="app_desktop_only" type="bool" default= %}}
+{{% dir name="app_desktop_only" type="bool" default=false %}}
 Specifies if the app can be opened only on desktop. [[Ref]](https://github.com/cs3org/reva/tree/master/pkg/app/provider/wopi/wopi.go#L66)
 {{< highlight toml >}}
 [app.provider.wopi]
-app_desktop_only = 
+app_desktop_only = false
 {{< /highlight >}}
 {{% /dir %}}
 

--- a/docs/content/en/docs/config/packages/share/_index.md
+++ b/docs/content/en/docs/config/packages/share/_index.md
@@ -1,0 +1,7 @@
+---
+title: "share"
+linkTitle: "share"
+weight: 10
+description: >
+  Configuration for the share service
+---

--- a/docs/content/en/docs/config/packages/share/manager/_index.md
+++ b/docs/content/en/docs/config/packages/share/manager/_index.md
@@ -1,0 +1,7 @@
+---
+title: "manager"
+linkTitle: "manager"
+weight: 10
+description: >
+  Configuration for the manager service
+---

--- a/docs/content/en/docs/config/packages/share/manager/nextcloud/_index.md
+++ b/docs/content/en/docs/config/packages/share/manager/nextcloud/_index.md
@@ -1,0 +1,18 @@
+---
+title: "nextcloud"
+linkTitle: "nextcloud"
+weight: 10
+description: >
+  Configuration for the nextcloud service
+---
+
+# _struct: ShareManagerConfig_
+
+{{% dir name="endpoint" type="string" default="" %}}
+The Nextcloud backend endpoint for user check [[Ref]](https://github.com/cs3org/reva/tree/master/pkg/share/manager/nextcloud/nextcloud.go#L55)
+{{< highlight toml >}}
+[share.manager.nextcloud]
+endpoint = ""
+{{< /highlight >}}
+{{% /dir %}}
+

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/aws/aws-sdk-go v1.40.46
 	github.com/beevik/etree v1.1.0
 	github.com/bluele/gcache v0.0.2
-	github.com/c-bata/go-prompt v0.2.6
+	github.com/c-bata/go-prompt v0.2.5
 	github.com/cheggaaa/pb v1.0.29
 	github.com/coreos/go-oidc v2.2.1+incompatible
 	github.com/cs3org/cato v0.0.0-20200828125504-e418fc54dd5e

--- a/go.sum
+++ b/go.sum
@@ -76,6 +76,8 @@ github.com/bluele/gcache v0.0.2 h1:WcbfdXICg7G/DGBh1PFfcirkWOQV+v077yF1pSy3DGw=
 github.com/bluele/gcache v0.0.2/go.mod h1:m15KV+ECjptwSPxKhOhQoAFQVtUFjTVkc3H8o0t/fp0=
 github.com/bmizerany/pat v0.0.0-20170815010413-6226ea591a40 h1:y4B3+GPxKlrigF1ha5FFErxK+sr6sWxQovRMzwMhejo=
 github.com/bmizerany/pat v0.0.0-20170815010413-6226ea591a40/go.mod h1:8rLXio+WjiTceGBHIoTvn60HIbs7Hm7bcHjyrSqYB9c=
+github.com/c-bata/go-prompt v0.2.5 h1:3zg6PecEywxNn0xiqcXHD96fkbxghD+gdB2tbsYfl+Y=
+github.com/c-bata/go-prompt v0.2.5/go.mod h1:vFnjEGDIIA/Lib7giyE4E9c50Lvl8j0S+7FVlAwDAVw=
 github.com/c-bata/go-prompt v0.2.6 h1:POP+nrHE+DfLYx370bedwNhsqmpCUynWPxuHi0C5vZI=
 github.com/c-bata/go-prompt v0.2.6/go.mod h1:/LMAke8wD2FsNu9EXNdHxNLbd9MedkPnCdfpU9wwHfY=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
@@ -386,6 +388,8 @@ github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/term v1.1.0 h1:xIAAdCMh3QIAy+5FrE8Ad8XoDhEU4ufwbaSozViP9kk=
+github.com/pkg/term v1.1.0/go.mod h1:E25nymQcrSllhX42Ok8MRm1+hyBdHY0dCeiKZ9jpNGw=
 github.com/pkg/term v1.2.0-beta.2 h1:L3y/h2jkuBVFdWiJvNfYfKmzcCnILw7mJWm2JQuMppw=
 github.com/pkg/term v1.2.0-beta.2/go.mod h1:E25nymQcrSllhX42Ok8MRm1+hyBdHY0dCeiKZ9jpNGw=
 github.com/pkg/xattr v0.4.3 h1:5Jx4GCg5ABtqWZH8WLzeI4fOtM1HyX4RBawuCoua1es=

--- a/pkg/app/provider/wopi/wopi.go
+++ b/pkg/app/provider/wopi/wopi.go
@@ -63,7 +63,7 @@ type config struct {
 	AppIntURL           string `mapstructure:"app_int_url" docs:";The internal app URL in case of dockerized deployments. Defaults to AppURL"`
 	AppAPIKey           string `mapstructure:"app_api_key" docs:";The API key used by the app, if applicable."`
 	JWTSecret           string `mapstructure:"jwt_secret" docs:";The JWT secret to be used to retrieve the token TTL."`
-	AppDesktopOnly      bool   `mapstructure:"app_desktop_only" docs:";Specifies if the app can be opened only on desktop."`
+	AppDesktopOnly      bool   `mapstructure:"app_desktop_only" docs:"false;Specifies if the app can be opened only on desktop."`
 	InsecureConnections bool   `mapstructure:"insecure_connections"`
 }
 


### PR DESCRIPTION
https://github.com/c-bata/go-prompt/issues/228