### PR TITLE
add as default app while registering and skip unset mimetypes

### DIFF
--- a/changelog/unreleased/app-registry-defaults.md
+++ b/changelog/unreleased/app-registry-defaults.md
@@ -1,0 +1,7 @@
+Bugfix: Add as default app while registering and skip unset mimetypes
+
+We fixed that app providers will be set as default app while registering if configured.
+Also we changed the behaviour that listing supported mimetypes only displays allowed / configured mimetypes.
+
+https://github.com/cs3org/reva/pull/2114
+https://github.com/cs3org/reva/pull/2095


### PR DESCRIPTION
https://github.com/cs3org/reva/pull/2095 didn't set default apps for me. Also listing supported mimetypes always failed for me unless I configured _all_ supported mimetypes of eg. Collabora.

My fix sets default apps while registering the app providers according to the config.
My fix skips all mimetypes not listed in the config.