### PR TITLE
fix app open when multiple app providers are present

### DIFF
--- a/changelog/unreleased/app-registry-multiple-providers.md
+++ b/changelog/unreleased/app-registry-multiple-providers.md
@@ -1,0 +1,7 @@
+Bugfix: Fix app open when multiple app providers are present
+
+We've fixed the gateway behavior, that when multiple app providers are present, it always returned that we have duplicate names for app providers.
+This was due the call to GetAllProviders() without any subsequent filtering by name. Now this filter mechanism is in place and the duplicate app providers error will only appear if a real duplicate is found.
+
+https://github.com/cs3org/reva/issues/2095
+https://github.com/cs3org/reva/pull/2117

--- a/internal/grpc/services/gateway/appprovider.go
+++ b/internal/grpc/services/gateway/appprovider.go
@@ -295,13 +295,7 @@ func (s *svc) findAppProvider(ctx context.Context, ri *storageprovider.ResourceI
 
 	// if we only have one app provider we verify that it matches the requested app name
 	if len(res.Providers) == 1 {
-		p := res.Providers[0]
-		if p.Name == app {
-			return p, nil
-		}
-		// we return error if we return the wrong app provider
-		err = errtypes.InternalError(fmt.Sprintf("gateway: user asked for app %q and we gave %q", app, p.Name))
-		return nil, err
+		return res.Providers[0], nil
 	}
 
 	// we should never arrive to the point of having more than one

--- a/internal/grpc/services/gateway/appprovider.go
+++ b/internal/grpc/services/gateway/appprovider.go
@@ -275,6 +275,16 @@ func (s *svc) findAppProvider(ctx context.Context, ri *storageprovider.ResourceI
 		return nil, err
 	}
 
+	// as long as the above mentioned GetAppProviderByName(app) method is not available
+	// we need to apply a manual filter
+	filteredProviders := []*registry.ProviderInfo{}
+	for _, p := range res.Providers {
+		if p.Name == app {
+			filteredProviders = append(filteredProviders, p)
+		}
+	}
+	res.Providers = filteredProviders
+
 	// if the list of app providers is empty means we expect a CODE_NOT_FOUND in the response
 	if res.Status.Code != rpc.Code_CODE_OK {
 		if res.Status.Code == rpc.Code_CODE_NOT_FOUND {


### PR DESCRIPTION
Bugfix: Fix app open when multiple app providers are present

We've fixed the gateway behavior, that when multiple app providers are present, it always returned that we have duplicate names for app providers.
This was due the call to GetAllProviders() without any subsequent filtering by name. Now this filter mechanism is in place and the duplicate app providers error will only appear if a real duplicate is found.


Introduced in https://github.com/cs3org/reva/issues/2095
