### PR TITLE
[docs] Add code comments to RestoreRecycleItem

### DIFF
--- a/pkg/storage/fs/nextcloud/nextcloud_server_mock.go
+++ b/pkg/storage/fs/nextcloud/nextcloud_server_mock.go
@@ -116,7 +116,7 @@ var responses = map[string]Response{
 	`POST /apps/sciencemesh/~einstein/api/storage/ListGrants {"path":"/subdir"} GRANT-REMOVED`: {200, `[]`, serverStateEmpty},
 
 	`POST /apps/sciencemesh/~einstein/api/storage/ListRecycle {"key":"","path":"/"} EMPTY`:   {200, `[]`, serverStateEmpty},
-	`POST /apps/sciencemesh/~einstein/api/storage/ListRecycle {"key":"","path":"/"} RECYCLE`: {200, `[{"opaque":{},"key":"some-deleted-version","ref":{"resource_id":{},"path":"/subdir"},"size":12345,"deletion_time":{"seconds":1234567890}}]`, serverStateRecycle},
+	`POST /apps/sciencemesh/~einstein/api/storage/ListRecycle {"key":"","path":"/"} RECYCLE`: {200, `[{"opaque":{},"key":"some-recycle-item","ref":{"resource_id":{},"path":"/subdir"},"size":12345,"deletion_time":{"seconds":1234567890}}]`, serverStateRecycle},
 
 	`POST /apps/sciencemesh/~einstein/api/storage/ListRevisions {"path":"/versionedFile"} EMPTY`:         {200, `[{"opaque":{"map":{"some":{"value":"ZGF0YQ=="}}},"key":"version-12","size":1,"mtime":1234567890,"etag":"deadb00f"}]`, serverStateEmpty},
 	`POST /apps/sciencemesh/~einstein/api/storage/ListRevisions {"path":"/versionedFile"} FILE-RESTORED`: {200, `[{"opaque":{"map":{"some":{"value":"ZGF0YQ=="}}},"key":"version-12","size":1,"mtime":1234567890,"etag":"deadb00f"},{"opaque":{"map":{"different":{"value":"c3R1ZmY="}}},"key":"asdf","size":2,"mtime":1234567890,"etag":"deadbeef"}]`, serverStateFileRestored},
@@ -125,9 +125,9 @@ var responses = map[string]Response{
 
 	`POST /apps/sciencemesh/~einstein/api/storage/RemoveGrant {"path":"/subdir"} GRANT-ADDED`: {200, ``, serverStateGrantRemoved},
 
-	`POST /apps/sciencemesh/~einstein/api/storage/RestoreRecycleItem null`:                                                                              {200, ``, serverStateSubdir},
-	`POST /apps/sciencemesh/~einstein/api/storage/RestoreRecycleItem {"key":"some-deleted-version","path":"/","restoreRef":{"path":"/subdirRestored"}}`: {200, ``, serverStateFileRestored},
-	`POST /apps/sciencemesh/~einstein/api/storage/RestoreRecycleItem {"key":"some-deleted-version","path":"/","restoreRef":null}`:                       {200, ``, serverStateFileRestored},
+	`POST /apps/sciencemesh/~einstein/api/storage/RestoreRecycleItem null`:                                                                           {200, ``, serverStateSubdir},
+	`POST /apps/sciencemesh/~einstein/api/storage/RestoreRecycleItem {"key":"some-recycle-item","path":"/","restoreRef":{"path":"/subdirRestored"}}`: {200, ``, serverStateFileRestored},
+	`POST /apps/sciencemesh/~einstein/api/storage/RestoreRecycleItem {"key":"some-recycle-item","path":"/","restoreRef":null}`:                       {200, ``, serverStateFileRestored},
 
 	`POST /apps/sciencemesh/~einstein/api/storage/RestoreRevision {"ref":{"path":"/versionedFile"},"key":"version-12"}`: {200, ``, serverStateFileRestored},
 
@@ -150,7 +150,7 @@ var responses = map[string]Response{
 	`POST /apps/sciencemesh/~tester/api/storage/ListRevisions {"resource_id":{"storage_id":"storage-id","opaque_id":"opaque-id"},"path":"/some/path"}`:                                                                                                                    {200, `[{"opaque":{"map":{"some":{"value":"ZGF0YQ=="}}},"key":"version-12","size":12345,"mtime":1234567890,"etag":"deadb00f"},{"opaque":{"map":{"different":{"value":"c3R1ZmY="}}},"key":"asdf","size":12345,"mtime":1234567890,"etag":"deadbeef"}]`, serverStateEmpty},
 	`GET /apps/sciencemesh/~tester/api/storage/DownloadRevision/some%2Frevision/some/file/path.txt `:                                                                                                                                                                      {200, `the contents of that revision`, serverStateEmpty},
 	`POST /apps/sciencemesh/~tester/api/storage/RestoreRevision {"ref":{"resource_id":{"storage_id":"storage-id","opaque_id":"opaque-id"},"path":"some/file/path.txt"},"key":"asdf"}`:                                                                                     {200, ``, serverStateEmpty},
-	`POST /apps/sciencemesh/~tester/api/storage/ListRecycle {"key":"asdf","path":"/some/file.txt"}`:                                                                                                                                                                       {200, `[{"opaque":{},"key":"some-deleted-version","ref":{"resource_id":{},"path":"/some/file.txt"},"size":12345,"deletion_time":{"seconds":1234567890}}]`, serverStateEmpty},
+	`POST /apps/sciencemesh/~tester/api/storage/ListRecycle {"key":"asdf","path":"/some/file.txt"}`:                                                                                                                                                                       {200, `[{"opaque":{},"key":"some-recycle-item","ref":{"resource_id":{},"path":"/some/file.txt"},"size":12345,"deletion_time":{"seconds":1234567890}}]`, serverStateEmpty},
 	`POST /apps/sciencemesh/~tester/api/storage/RestoreRecycleItem {"key":"asdf","path":"original/location/when/deleted.txt","restoreRef":{"resource_id":{"storage_id":"storage-id","opaque_id":"opaque-id"},"path":"some/file/path.txt"}}`:                               {200, ``, serverStateEmpty},
 	`POST /apps/sciencemesh/~tester/api/storage/PurgeRecycleItem {"key":"asdf","path":"original/location/when/deleted.txt"}`:                                                                                                                                              {200, ``, serverStateEmpty},
 	`POST /apps/sciencemesh/~tester/api/storage/EmptyRecycle `:                                                                                                                                                                                                            {200, ``, serverStateEmpty},

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -43,7 +43,7 @@ type FS interface {
 	DownloadRevision(ctx context.Context, ref *provider.Reference, key string) (io.ReadCloser, error)
 	RestoreRevision(ctx context.Context, ref *provider.Reference, key string) error
 	ListRecycle(ctx context.Context, key, path string) ([]*provider.RecycleItem, error)
-	RestoreRecycleItem(ctx context.Context, key /* used as path */, path /* unused */ string, restoreRef /* optional */ *provider.Reference) error
+	RestoreRecycleItem(ctx context.Context, key /* the recycle item's original path */, path /* the user's homedir path */ string, restoreRef /* optional */ *provider.Reference) error
 	PurgeRecycleItem(ctx context.Context, key, path string) error
 	EmptyRecycle(ctx context.Context) error
 	GetPathByID(ctx context.Context, id *provider.ResourceId) (string, error)

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -43,7 +43,7 @@ type FS interface {
 	DownloadRevision(ctx context.Context, ref *provider.Reference, key string) (io.ReadCloser, error)
 	RestoreRevision(ctx context.Context, ref *provider.Reference, key string) error
 	ListRecycle(ctx context.Context, key, path string) ([]*provider.RecycleItem, error)
-	RestoreRecycleItem(ctx context.Context, key, path string, restoreRef *provider.Reference) error
+	RestoreRecycleItem(ctx context.Context, key /* used as path */, path /* unused */ string, restoreRef /* optional */ *provider.Reference) error
 	PurgeRecycleItem(ctx context.Context, key, path string) error
 	EmptyRecycle(ctx context.Context) error
 	GetPathByID(ctx context.Context, id *provider.ResourceId) (string, error)

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -43,7 +43,7 @@ type FS interface {
 	DownloadRevision(ctx context.Context, ref *provider.Reference, key string) (io.ReadCloser, error)
 	RestoreRevision(ctx context.Context, ref *provider.Reference, key string) error
 	ListRecycle(ctx context.Context, key, path string) ([]*provider.RecycleItem, error)
-	RestoreRecycleItem(ctx context.Context, key /* the recycle item's original path */, path /* the user's homedir path */ string, restoreRef /* optional */ *provider.Reference) error
+	RestoreRecycleItem(ctx context.Context, key /* RecycleItem.Key (from ListRecycle) */, path /* the user's homedir path */ string, restoreRef /* optional */ *provider.Reference) error
 	PurgeRecycleItem(ctx context.Context, key, path string) error
 	EmptyRecycle(ctx context.Context) error
 	GetPathByID(ctx context.Context, id *provider.ResourceId) (string, error)


### PR DESCRIPTION
* Looking at the [reva-cli function for RestoreRecycleItem](https://github.com/cs3org/reva/blob/6823079c17027133bba040dcbdc8d29731a4349d/cmd/reva/recycle-restore.go#L32), it asks for `key` but for `Ref.Path` it just uses the result from `client.GetHome`.
* Looking at the [gateway service storage provider](https://github.com/cs3org/reva/blob/6823079c17027133bba040dcbdc8d29731a4349d/internal/grpc/services/gateway/storageprovider.go#L2105) it uses Ref (which reva-cli sets to the current user's home) to find the storage provider.
* Looking at the [storage service storage provider/](https://github.com/cs3org/reva/blob/6823079c17027133bba040dcbdc8d29731a4349d/internal/grpc/services/storageprovider/storageprovider.go#L893) it passes:
    * `req.Key` as `key`
    * `req.Ref.Path` as `path`
    * `req.RestoreRef` as `restoreRef`
* Looking at e.g. the ownCloud storage driver, [it uses](https://github.com/cs3org/reva/blob/6823079c17027133bba040dcbdc8d29731a4349d/pkg/storage/fs/owncloud/owncloud.go#L2199) `key` (not `path`!) as the original path of the recycle item to be restored.
* This makes sense because the end-user who issues the command through reva-cli can influence the value of `key` but not the value of `path`.
* It's confusing though, that it's called `key`.

So based on this spelonking, it looks like storage drivers should:
* look at `key` to know the path (string) of the file to be restored
* ignore `path`
* _if_ `restoreRef` is defined, restore to `restoreRef.Path`, otherwise just restore to `key` (i.e. where the recycle item originally came from).