### PR TITLE
Bugfix: Make TUS capabilities configurable

### DIFF
--- a/changelog/unreleased/configurable-tus-capabilities.md
+++ b/changelog/unreleased/configurable-tus-capabilities.md
@@ -1,0 +1,5 @@
+Bugfix: Make TUS capabilities configurable
+
+We've fixed the configuration for the TUS capabilities, which will now take the given configuration instead of always using hardcoded defaults.
+
+https://github.com/cs3org/reva/pull/2135

--- a/internal/http/services/owncloud/ocs/handlers/cloud/capabilities/uploads.go
+++ b/internal/http/services/owncloud/ocs/handlers/cloud/capabilities/uploads.go
@@ -67,12 +67,13 @@ func setCapabilitiesForChunkProtocol(cp chunkProtocol, c *data.CapabilitiesData)
 		c.Capabilities.Dav.Chunking = ""
 
 		// TODO: infer from various TUS handlers from all known storages
-		c.Capabilities.Files.TusSupport = &data.CapabilitiesFilesTusSupport{
-			Version:            "1.0.0",
-			Resumable:          "1.0.0",
-			Extension:          "creation,creation-with-upload",
-			MaxChunkSize:       0,
-			HTTPMethodOverride: "",
-		}
+		// until now we take the manually configured tus options
+		// c.Capabilities.Files.TusSupport = &data.CapabilitiesFilesTusSupport{
+		// 	Version:            "1.0.0",
+		// 	Resumable:          "1.0.0",
+		// 	Extension:          "creation,creation-with-upload",
+		// 	MaxChunkSize:       0,
+		// 	HTTPMethodOverride: "",
+		// }
 	}
 }


### PR DESCRIPTION
We've fixed the configuration for the TUS capabilities, which will now take the given configuration instead of always using hardcoded defaults.
