### PR TITLE
Return OK when trying to delete a non existing reference

### DIFF
--- a/changelog/unreleased/fix-declining-unaccepted-share.md
+++ b/changelog/unreleased/fix-declining-unaccepted-share.md
@@ -1,0 +1,6 @@
+Bugfix: Return OK when trying to delete a non existing reference
+
+When the gateway declines a share we can ignore a non existing reference.
+
+https://github.com/cs3org/reva/pull/2154
+https://github.com/owncloud/ocis/pull/2603


### PR DESCRIPTION
When the gateway declines a share we can ignore a non existing reference.

unblocks: https://github.com/owncloud/ocis/pull/2603
