### PR TITLE
AppProvider: provide a consistent userid to WOPI

### DIFF
--- a/changelog/unreleased/wopi-consistent-userid.md
+++ b/changelog/unreleased/wopi-consistent-userid.md
@@ -1,0 +1,6 @@
+Enhancement: pass an extra query parameter to WOPI /openinapp with a
+unique and consistent over time user identifier. The Reva token used so far
+is not consistent (it's per session) and also too long.
+
+https://github.com/cs3org/reva/pull/2155
+https://github.com/cs3org/wopiserver/pull/48

--- a/pkg/app/provider/wopi/wopi.go
+++ b/pkg/app/provider/wopi/wopi.go
@@ -139,6 +139,7 @@ func (p *wopiProvider) GetAppURL(ctx context.Context, resource *provider.Resourc
 	u, ok := ctxpkg.ContextGetUser(ctx)
 	if ok { // else defaults to "Guest xyz"
 		q.Add("username", u.Username)
+		q.Add("userid", u.Id.OpaqueId+"@"+u.Id.Idp)
 	}
 
 	q.Add("appname", p.conf.AppName)


### PR DESCRIPTION
Details in https://github.com/cs3org/wopiserver/pull/48

This is a one liner to add an extra query parameter (when applicable) as required by WOPI.