### PR TITLE
augment the id of newly created spaces

### DIFF
--- a/changelog/unreleased/augment-spaces-id.md
+++ b/changelog/unreleased/augment-spaces-id.md
@@ -1,0 +1,5 @@
+Enhancement: Augment the Id of new spaces
+
+Newly created spaces were missing the Root reference and the storage id in the space id.
+
+https://github.com/cs3org/reva/issues/2158

--- a/internal/grpc/services/storageprovider/storageprovider.go
+++ b/internal/grpc/services/storageprovider/storageprovider.go
@@ -433,7 +433,14 @@ func (s *service) CreateHome(ctx context.Context, req *provider.CreateHomeReques
 
 // CreateStorageSpace creates a storage space
 func (s *service) CreateStorageSpace(ctx context.Context, req *provider.CreateStorageSpaceRequest) (*provider.CreateStorageSpaceResponse, error) {
-	return s.storage.CreateStorageSpace(ctx, req)
+	resp, err := s.storage.CreateStorageSpace(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	resp.StorageSpace.Root = &provider.ResourceId{StorageId: s.mountID, OpaqueId: resp.StorageSpace.Id.OpaqueId}
+	resp.StorageSpace.Id = &provider.StorageSpaceId{OpaqueId: s.mountID + "!" + resp.StorageSpace.Id.OpaqueId}
+	return resp, nil
 }
 
 func hasNodeID(s *provider.StorageSpace) bool {


### PR DESCRIPTION
Newly created spaces were missing the Root reference and the storage id in the space id.

I introduced this change because I want to return the newly created space in the graph-api and need the Id and Root for that.