### PR TITLE
fix the returned permissions for webdav uploads

### DIFF
--- a/changelog/unreleased/fix-webdav-upload-permissions.md
+++ b/changelog/unreleased/fix-webdav-upload-permissions.md
@@ -1,0 +1,7 @@
+Bugfix: Fix the returned permissions for webdav uploads
+
+We've fixed the returned permissions for webdav uploads. It did not consider 
+shares and public links for the permission calculation, but does so now.
+
+https://github.com/cs3org/reva/pull/2179
+https://github.com/cs3org/reva/pull/2151


### PR DESCRIPTION
Uploading a file gives now following permissions:
- share (editor role): SDNVW
- user home: RDNVW

fixes https://github.com/owncloud/ocis/issues/2626