### PR TITLE
Remove OCDAV options namespace parameter

### DIFF
--- a/changelog/unreleased/ocdav-remove-options-namespace.md
+++ b/changelog/unreleased/ocdav-remove-options-namespace.md
@@ -1,0 +1,5 @@
+Enhancement: Remove OCDAV options namespace parameter
+
+We dropped the namespace parameter, as it is not used in the options handler.
+
+https://github.com/cs3org/reva/pull/2180

--- a/internal/http/services/owncloud/ocdav/avatars.go
+++ b/internal/http/services/owncloud/ocdav/avatars.go
@@ -44,7 +44,7 @@ func (h *AvatarsHandler) Handler(s *svc) http.Handler {
 			// no need for the user, and we need to be able
 			// to answer preflight checks, which have no auth headers
 			r.URL.Path = "/" // always use / ... we just want the options answered so phoenix doesnt hiccup
-			s.handleOptions(w, r, "avatars")
+			s.handleOptions(w, r)
 			return
 		}
 

--- a/internal/http/services/owncloud/ocdav/options.go
+++ b/internal/http/services/owncloud/ocdav/options.go
@@ -23,7 +23,7 @@ import (
 	"strings"
 )
 
-func (s *svc) handleOptions(w http.ResponseWriter, r *http.Request, ns string) {
+func (s *svc) handleOptions(w http.ResponseWriter, r *http.Request) {
 	allow := "OPTIONS, LOCK, GET, HEAD, POST, DELETE, PROPPATCH, COPY,"
 	allow += " MOVE, UNLOCK, PROPFIND, MKCOL, REPORT, SEARCH,"
 	allow += " PUT" // TODO(jfd): only for files ... but we cannot create the full path without a user ... which we only have when credentials are sent

--- a/internal/http/services/owncloud/ocdav/publicfile.go
+++ b/internal/http/services/owncloud/ocdav/publicfile.go
@@ -62,7 +62,7 @@ func (h *PublicFileHandler) Handler(s *svc) http.Handler {
 			case http.MethodGet:
 				s.handlePathGet(w, r, h.namespace)
 			case http.MethodOptions:
-				s.handleOptions(w, r, h.namespace)
+				s.handleOptions(w, r)
 			case http.MethodHead:
 				s.handlePathHead(w, r, h.namespace)
 			case http.MethodPut:
@@ -76,7 +76,7 @@ func (h *PublicFileHandler) Handler(s *svc) http.Handler {
 			case MethodPropfind:
 				s.handlePropfindOnToken(w, r, h.namespace, true)
 			case http.MethodOptions:
-				s.handleOptions(w, r, h.namespace)
+				s.handleOptions(w, r)
 			case http.MethodHead:
 				s.handlePathHead(w, r, h.namespace)
 			default:

--- a/internal/http/services/owncloud/ocdav/spaces.go
+++ b/internal/http/services/owncloud/ocdav/spaces.go
@@ -46,7 +46,7 @@ func (h *SpacesHandler) Handler(s *svc) http.Handler {
 		// log := appctx.GetLogger(ctx)
 
 		if r.Method == http.MethodOptions {
-			s.handleOptions(w, r, "spaces")
+			s.handleOptions(w, r)
 			return
 		}
 
@@ -83,7 +83,7 @@ func (h *SpacesHandler) Handler(s *svc) http.Handler {
 		case http.MethodPost:
 			s.handleSpacesTusPost(w, r, spaceID)
 		case http.MethodOptions:
-			s.handleOptions(w, r, spaceID)
+			s.handleOptions(w, r)
 		case http.MethodHead:
 			s.handleSpacesHead(w, r, spaceID)
 		case http.MethodDelete:

--- a/internal/http/services/owncloud/ocdav/trashbin.go
+++ b/internal/http/services/owncloud/ocdav/trashbin.go
@@ -59,7 +59,7 @@ func (h *TrashbinHandler) Handler(s *svc) http.Handler {
 		log := appctx.GetLogger(ctx)
 
 		if r.Method == http.MethodOptions {
-			s.handleOptions(w, r, "trashbin")
+			s.handleOptions(w, r)
 			return
 		}
 

--- a/internal/http/services/owncloud/ocdav/versions.go
+++ b/internal/http/services/owncloud/ocdav/versions.go
@@ -60,7 +60,7 @@ func (h *VersionsHandler) Handler(s *svc, rid *provider.ResourceId) http.Handler
 		var key string
 		key, r.URL.Path = router.ShiftPath(r.URL.Path)
 		if r.Method == http.MethodOptions {
-			s.handleOptions(w, r, "versions")
+			s.handleOptions(w, r)
 			return
 		}
 		if key == "" && r.Method == MethodPropfind {

--- a/internal/http/services/owncloud/ocdav/webdav.go
+++ b/internal/http/services/owncloud/ocdav/webdav.go
@@ -116,7 +116,7 @@ func (h *WebDavHandler) Handler(s *svc) http.Handler {
 		case http.MethodPost:
 			s.handlePathTusPost(w, r, ns)
 		case http.MethodOptions:
-			s.handleOptions(w, r, ns)
+			s.handleOptions(w, r)
 		case http.MethodHead:
 			s.handlePathHead(w, r, ns)
 		case http.MethodDelete:


### PR DESCRIPTION
We dropped the namespace parameter, as it is not used in the options handler.
