### PR TITLE
Add config to EOS fs for allowing recycle operations on arbitrary paths

### DIFF
--- a/changelog/unreleased/recycle-bin-arbitrary-paths.md
+++ b/changelog/unreleased/recycle-bin-arbitrary-paths.md
@@ -1,3 +1,4 @@
 Enhancement: Allow access to recycle bin for arbitrary paths outside homes
 
 https://github.com/cs3org/reva/pull/2165
+https://github.com/cs3org/reva/pull/2188

--- a/pkg/cbox/storage/eoshomewrapper/eoshomewrapper.go
+++ b/pkg/cbox/storage/eoshomewrapper/eoshomewrapper.go
@@ -16,7 +16,7 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-package eoshome
+package eoshomewrapper
 
 import (
 	"bytes"

--- a/pkg/cbox/storage/eoswrapper/eoswrapper.go
+++ b/pkg/cbox/storage/eoswrapper/eoswrapper.go
@@ -16,7 +16,7 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-package eoshome
+package eoswrapper
 
 import (
 	"bytes"
@@ -63,6 +63,11 @@ func parseConfig(m map[string]interface{}) (*eosfs.Config, string, error) {
 	// default to version invariance if not configured
 	if _, ok := m["version_invariant"]; !ok {
 		c.VersionInvariant = true
+	}
+
+	// allow recycle operations for project spaces
+	if !c.EnableHome && strings.HasPrefix(c.Namespace, eosProjectsNamespace) {
+		c.AllowPathRecycleOperations = true
 	}
 
 	t, ok := m["mount_id_template"].(string)

--- a/pkg/storage/utils/eosfs/config.go
+++ b/pkg/storage/utils/eosfs/config.go
@@ -134,6 +134,12 @@ type Config struct {
 	// the HTTP chunked encoding
 	WriteUsesLocalTemp bool `mapstructure:"write_uses_local_temp"`
 
+	// Whether to allow recycle operations on base paths.
+	// If set to true, we'll look up the owner of the passed path and perform
+	// operations on that user's recycle bin.
+	// Only considered when EnableHome is false.
+	AllowPathRecycleOperations bool `mapstructure:"allow_path_recycle_operations"`
+
 	// HTTP connections to EOS: max number of idle conns
 	MaxIdleConns int `mapstructure:"max_idle_conns"`
 

--- a/pkg/storage/utils/eosfs/eosfs.go
+++ b/pkg/storage/utils/eosfs/eosfs.go
@@ -1469,7 +1469,7 @@ func (fs *eosfs) EmptyRecycle(ctx context.Context) error {
 func (fs *eosfs) ListRecycle(ctx context.Context, basePath, key, relativePath string) ([]*provider.RecycleItem, error) {
 	var auth eosclient.Authorization
 
-	if !fs.conf.EnableHome && basePath != "/" {
+	if !fs.conf.EnableHome && fs.conf.AllowPathRecycleOperations && basePath != "/" {
 		// We need to access the recycle bin for a non-home reference.
 		// We'll get the owner of the particular resource and impersonate them
 		// if we have access to it.
@@ -1520,7 +1520,7 @@ func (fs *eosfs) ListRecycle(ctx context.Context, basePath, key, relativePath st
 func (fs *eosfs) RestoreRecycleItem(ctx context.Context, basePath, key, relativePath string, restoreRef *provider.Reference) error {
 	var auth eosclient.Authorization
 
-	if !fs.conf.EnableHome && basePath != "/" {
+	if !fs.conf.EnableHome && fs.conf.AllowPathRecycleOperations && basePath != "/" {
 		// We need to access the recycle bin for a non-home reference.
 		// We'll get the owner of the particular resource and impersonate them
 		// if we have access to it.


### PR DESCRIPTION
In EOS fs, if we want to perform recycle operations on arbitrary paths, we check if the current user has appropriate permissions on the path, and if they do, impersonate the owner of the path.

This introduces a security issue that if a user tries to access the recycle bin associated with the path to a folder shared with them, reva will check that the user has access to that path and then allow them to list the recycle bin of the creator of the share. As a protection for this, we introduce a new config variable to allow such operations, so that these can only be enabled for storage providers which support shared spaces and not user homes.