### PR TITLE
Fix share permission on a file in sql (cbox pkg) share driver

### DIFF
--- a/changelog/unreleased/fix-cbox-write-permission-single-file.md
+++ b/changelog/unreleased/fix-cbox-write-permission-single-file.md
@@ -1,0 +1,3 @@
+Bugfix: Fix share permission on a single file in sql share driver (cbox pkg)
+
+https://github.com/cs3org/reva/pull/2231

--- a/pkg/cbox/utils/conversions.go
+++ b/pkg/cbox/utils/conversions.go
@@ -101,9 +101,9 @@ func ResourceTypeToItem(r provider.ResourceType) string {
 // SharePermToInt maps read/write permissions to an integer
 func SharePermToInt(p *provider.ResourcePermissions) int {
 	var perm int
-	if p.CreateContainer {
+	if p.CreateContainer || p.InitiateFileUpload {
 		perm = 15
-	} else if p.ListContainer {
+	} else if p.ListContainer || p.InitiateFileDownload {
 		perm = 1
 	}
 	// TODO map denials and resharing; currently, denials are mapped to 0


### PR DESCRIPTION
While creating a share permission with write permission, the cbox/sql share driver converted this to a permission value that corresponds to a viewer role. This PR fix this.