### PR TITLE
Specify a list of allowed folders/files to be archived

### DIFF
--- a/changelog/unreleased/select-folders-to-be-archived.md
+++ b/changelog/unreleased/select-folders-to-be-archived.md
@@ -1,0 +1,6 @@
+Enhancement: Specify a list of allowed folders/files to be archived
+
+Adds a configuration to the archiver service in order to specify
+a list of folders (as regex) that can be archived.
+
+https://github.com/cs3org/reva/pull/2235

--- a/internal/http/services/archiver/handler.go
+++ b/internal/http/services/archiver/handler.go
@@ -212,6 +212,7 @@ func (s *svc) Handler() http.Handler {
 		if err != nil {
 			s.log.Error().Msg(err.Error())
 			rw.WriteHeader(http.StatusBadRequest)
+			rw.Write([]byte(err.Error()))
 			return
 		}
 
@@ -222,6 +223,7 @@ func (s *svc) Handler() http.Handler {
 		if err != nil {
 			s.log.Error().Msg(err.Error())
 			rw.WriteHeader(http.StatusInternalServerError)
+			rw.Write([]byte(err.Error()))
 			return
 		}
 

--- a/internal/http/services/archiver/handler.go
+++ b/internal/http/services/archiver/handler.go
@@ -212,7 +212,7 @@ func (s *svc) Handler() http.Handler {
 		if err != nil {
 			s.log.Error().Msg(err.Error())
 			rw.WriteHeader(http.StatusBadRequest)
-			rw.Write([]byte(err.Error()))
+			_, _ = rw.Write([]byte(err.Error()))
 			return
 		}
 
@@ -223,7 +223,7 @@ func (s *svc) Handler() http.Handler {
 		if err != nil {
 			s.log.Error().Msg(err.Error())
 			rw.WriteHeader(http.StatusInternalServerError)
-			rw.Write([]byte(err.Error()))
+			_, _ = rw.Write([]byte(err.Error()))
 			return
 		}
 


### PR DESCRIPTION
This PR adds a configuration to the archiver service in order to specify a list of folders (as regex) that can be archived.