### PR TITLE
[tests-only] Bump core commit id for tests

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The test runner source for API tests
-CORE_COMMITID=9216217c4ae968f7dece7dc109d93ff7e3b10e4b
+CORE_COMMITID=2c22f94daa5a1a891e7d6e0bb97e0ad82afce039
 CORE_BRANCH=master


### PR DESCRIPTION
Bumps the commit id to the same place as oCIS https://github.com/owncloud/ocis/pull/2727

There were some test changes/enhancements to Provisioning API tests, but we don't run those in `cs3org/reva` - so there are changes to expected-failures in the oCIS PR, but not in this reva PR.