### PR TITLE
Remove search-files capability from defaults

### DIFF
--- a/changelog/unreleased/capability-search-files
+++ b/changelog/unreleased/capability-search-files
@@ -1,0 +1,5 @@
+Bugfix: Don't announce search-files capability
+
+The `dav.reports` capability contained  a `search-files` report which is currently not implemented. We removed it from the defaults.
+
+https://github.com/cs3org/reva/pull/2245

--- a/internal/http/services/owncloud/ocs/handlers/cloud/capabilities/capabilities.go
+++ b/internal/http/services/owncloud/ocs/handlers/cloud/capabilities/capabilities.go
@@ -121,7 +121,7 @@ func (h *Handler) Init(c *config.Config) {
 		h.c.Capabilities.Dav.Trashbin = "1.0"
 	}
 	if h.c.Capabilities.Dav.Reports == nil {
-		h.c.Capabilities.Dav.Reports = []string{"search-files"}
+		h.c.Capabilities.Dav.Reports = []string{}
 	}
 
 	// sharing


### PR DESCRIPTION
The dav `REPORT` request for searching files is not implemented, yet, see https://github.com/cs3org/reva/blob/bb40f54e57dc1710365a68599b1389f30f5f7458/internal/http/services/owncloud/ocdav/report.go#L74

This PR removes the respective capability so that clients don't assume that search is available.