### PR TITLE
Add oc team to owncloud internal

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,5 @@
 *				@labkode @ishank011
+internal/http/services/owncloud @cs3org/owncloud-team
 pkg/auth/manager/owncloudsql	  @cs3org/owncloud-team
 pkg/storage/fs/owncloudsql      @cs3org/owncloud-team
 pkg/storage/fs/owncloud   	  @cs3org/owncloud-team


### PR DESCRIPTION
@labkode  @ishank011 

I think it makes sense to also add the oc team as codeowners for ocdav and ocs.