### PR TITLE
fix restoring versions

### DIFF
--- a/changelog/unreleased/fix-restoring-version.md
+++ b/changelog/unreleased/fix-restoring-version.md
@@ -1,0 +1,7 @@
+Bugfix: Fix restoring versions
+
+Restoring a version would not remove that version from the version list.
+Now the behavior is compatible to ownCloud 10.
+
+https://github.com/owncloud/ocis/issues/1214
+https://github.com/cs3org/reva/pull/2270

--- a/pkg/storage/utils/decomposedfs/decomposedfs.go
+++ b/pkg/storage/utils/decomposedfs/decomposedfs.go
@@ -517,22 +517,3 @@ func (fs *Decomposedfs) Download(ctx context.Context, ref *provider.Reference) (
 	}
 	return reader, nil
 }
-
-func (fs *Decomposedfs) copyMD(s string, t string) (err error) {
-	var attrs []string
-	if attrs, err = xattr.List(s); err != nil {
-		return err
-	}
-	for i := range attrs {
-		if strings.HasPrefix(attrs[i], xattrs.OcisPrefix) {
-			var d []byte
-			if d, err = xattr.Get(s, attrs[i]); err != nil {
-				return err
-			}
-			if err = xattr.Set(t, attrs[i], d); err != nil {
-				return err
-			}
-		}
-	}
-	return nil
-}

--- a/pkg/storage/utils/decomposedfs/revisions.go
+++ b/pkg/storage/utils/decomposedfs/revisions.go
@@ -180,25 +180,8 @@ func (fs *Decomposedfs) RestoreRevision(ctx context.Context, ref *provider.Refer
 		// copy old revision to current location
 
 		revisionPath := fs.lu.InternalPath(revisionKey)
-		var revision, destination *os.File
-		revision, err = os.Open(revisionPath)
-		if err != nil {
-			return
-		}
-		defer revision.Close()
 
-		destination, err = os.OpenFile(nodePath, os.O_CREATE|os.O_WRONLY, defaultFilePerm)
-		if err != nil {
-			return
-		}
-		defer destination.Close()
-		_, err = io.Copy(destination, revision)
-		if err != nil {
-			return
-		}
-
-		err = fs.copyMD(revisionPath, nodePath)
-		if err != nil {
+		if err = os.Rename(revisionPath, nodePath); err != nil {
 			return
 		}
 


### PR DESCRIPTION
Restoring a version would not remove that version from the version list.
Now the behavior is compatible to ownCloud 10.

Fixes: https://github.com/owncloud/ocis/issues/1214