### PR TITLE
Fix content disposition

### DIFF
--- a/changelog/unreleased/fix-content-disposition.md
+++ b/changelog/unreleased/fix-content-disposition.md
@@ -1,0 +1,4 @@
+Bugfix: Fix content disposition header for public links files
+
+https://github.com/cs3org/reva/pull/2303
+https://github.com/cs3org/reva/pull/2297

--- a/changelog/unreleased/fix-public-share-paths.md
+++ b/changelog/unreleased/fix-public-share-paths.md
@@ -1,3 +1,0 @@
-Bugfix: Fix public link paths for file shares
-
-https://github.com/cs3org/reva/pull/2297

--- a/internal/grpc/services/publicstorageprovider/publicstorageprovider.go
+++ b/internal/grpc/services/publicstorageprovider/publicstorageprovider.go
@@ -154,12 +154,7 @@ func (s *service) translatePublicRefToCS3Ref(ctx context.Context, ref *provider.
 		return nil, "", nil, st, nil
 	}
 
-	p := shareInfo.Path
-	if shareInfo.Type != provider.ResourceType_RESOURCE_TYPE_FILE {
-		p = path.Join("/", shareInfo.Path, relativePath)
-	}
-	cs3Ref := &provider.Reference{Path: p}
-
+	cs3Ref := &provider.Reference{Path: path.Join("/", shareInfo.Path, relativePath)}
 	log.Debug().
 		Interface("sourceRef", ref).
 		Interface("cs3Ref", cs3Ref).

--- a/internal/http/services/owncloud/ocdav/get.go
+++ b/internal/http/services/owncloud/ocdav/get.go
@@ -124,7 +124,7 @@ func (s *svc) handleGet(ctx context.Context, w http.ResponseWriter, r *http.Requ
 
 	w.Header().Set(HeaderContentType, info.MimeType)
 	w.Header().Set(HeaderContentDisposistion, "attachment; filename*=UTF-8''"+
-		path.Base(info.Path)+"; filename=\""+path.Base(info.Path)+"\"")
+		path.Base(r.RequestURI)+"; filename=\""+path.Base(r.RequestURI)+"\"")
 	w.Header().Set(HeaderETag, info.Etag)
 	w.Header().Set(HeaderOCFileID, wrapResourceID(info.Id))
 	w.Header().Set(HeaderOCETag, info.Etag)

--- a/internal/http/services/owncloud/ocdav/publicfile.go
+++ b/internal/http/services/owncloud/ocdav/publicfile.go
@@ -55,6 +55,7 @@ func (h *PublicFileHandler) Handler(s *svc) http.Handler {
 				return
 			}
 
+			r.URL.Path = path.Base(r.URL.Path)
 			switch r.Method {
 			case MethodPropfind:
 				s.handlePropfindOnToken(w, r, h.namespace, false)
@@ -119,6 +120,9 @@ func (s *svc) adjustResourcePathInURL(w http.ResponseWriter, r *http.Request) bo
 		w.WriteHeader(http.StatusConflict)
 		return false
 	}
+
+	// adjust path in request URL to point at the parent
+	r.URL.Path = path.Dir(r.URL.Path)
 
 	return true
 }


### PR DESCRIPTION
This supersedes https://github.com/cs3org/reva/pull/2297 by taking the requested filename from the RequestURI. This better reflects the request intent while keeping paths correct inside reva.

cc @C0rby @ishank011 @labkode

Tested with running the oc-acceptance tests with `DEBUG_ACCEPTANCE_API_CALLS=1` for `BEHAT_FEATURE='tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature:41'`
```
        │ ### AUTH: :
        │ ### REQUEST: GET http://localhost:20080/remote.php/dav/public-files/jZxKoheUyZuPHTx/randomfile.txt
        │ Headers:
        │ Host: localhost:20080
        │ X-Requested-With: XMLHttpRequest
        │ Range: bytes=0-9
        │ Body:
        │ string(0) ""
        │ 
        │ ### END REQUEST
        │ ### RESPONSE
        │ Status: 206
        │ Headers:
        │ Access-Control-Allow-Origin: *
        │ Content-Disposition: attachment; filename*=UTF-8''randomfile.txt; filename="randomfile.txt"
        │ Content-Length: 10
        │ Content-Range: bytes 0-9/11
        │ Content-Security-Policy: default-src 'none';
        │ Content-Type: text/plain
        │ Etag: "ea0f28cd2ec02041e462e7a108450312"
        │ Last-Modified: Mon, 22 Nov 2021 14:14:29 +0000
        │ Oc-Etag: "ea0f28cd2ec02041e462e7a108450312"
        │ Oc-Fileid: ZTFhNzNlZGUtNTQ5Yi00MjI2LWFiZGYtNDBlNjljYTgyMzBkOmpaeEtvaGVVeVp1UEhUeC84NThhNDAxOS1iMDRmLTQ1YmMtODI4MS1iNWVkZjcwYmIxYjI=
        │ Vary: Origin
        │ X-Content-Type-Options: nosniff
        │ X-Download-Options: noopen
        │ X-Frame-Options: SAMEORIGIN
        │ X-Permitted-Cross-Domain-Policies: none
        │ X-Robots-Tag: none
        │ X-Xss-Protection: 1; mode=block
        │ Date: Mon, 22 Nov 2021 14:14:30 GMT
        │ Body:
        │ string(10) "Random dat"
        │ 
        │ ### END RESPONSE
```