### PR TITLE
[tests-only] Bump core commit id for tests

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The test runner source for API tests
-CORE_COMMITID=6a55f750d8a3f34c6c7772355f9281ffb8ffb4ca
+CORE_COMMITID=762780a23c9eadda4fb5fa8db99eba66a5100b6e
 CORE_BRANCH=master


### PR DESCRIPTION
Bump core commit id to the latest for tests

## Related Issue
part of https://github.com/owncloud/QA/issues/699
