### PR TITLE
Make sure /app/new takes target as absolute path

### DIFF
--- a/changelog/unreleased/app-abspath.md
+++ b/changelog/unreleased/app-abspath.md
@@ -1,0 +1,5 @@
+Bugfix: Make sure /app/new takes `target` as absolute path
+
+A mini-PR to make the `target` parameter absolute (by prepending `/` if missing).
+
+https://github.com/cs3org/reva/pull/2305

--- a/internal/http/services/appprovider/appprovider.go
+++ b/internal/http/services/appprovider/appprovider.go
@@ -153,6 +153,13 @@ func (s *svc) handleNew(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// TODO(lopresti) if target is relative, currently the gateway fails to identify a storage provider (?)
+	// and just returns a CODE_INTERNAL error on InitiateFileUpload.
+	// Therefore for now make sure the target is absolute.
+	if target[0] != '/' {
+		target = "/" + target
+	}
+
 	// Create empty file via storageprovider
 	createReq := &provider.InitiateFileUploadRequest{
 		Ref: &provider.Reference{Path: target},

--- a/internal/http/services/ocmd/reqres.go
+++ b/internal/http/services/ocmd/reqres.go
@@ -57,12 +57,13 @@ type APIError struct {
 }
 
 // WriteError handles writing error responses
-func WriteError(w http.ResponseWriter, r *http.Request, code APIErrorCode, message string, err error) {
-	if err != nil {
-		appctx.GetLogger(r.Context()).Error().Err(err).Msg(message)
+func WriteError(w http.ResponseWriter, r *http.Request, code APIErrorCode, message string, e error) {
+	if e != nil {
+		appctx.GetLogger(r.Context()).Error().Err(e).Msg(message)
 	}
 
 	var encoded []byte
+	var err error
 	w.Header().Set("Content-Type", "application/json")
 	encoded, err = json.MarshalIndent(APIError{Code: code, Message: message}, "", "  ")
 


### PR DESCRIPTION
A mini-PR to make the `target` parameter absolute (by prepending `/` if missing).

The real issue here is that a relative `target` seems to make the gateway fail to identify a storage provider, and the `InitiateFileUpload` request fails with `CODE_INTERNAL`. And the web frontend happened to send requests with relative paths.

Independently from fixing the web frontend, this patch protects the app provider.