### PR TITLE
Bugfix: Remove early finish for zero byte file uploads

### DIFF
--- a/changelog/unreleased/fix-skip-early-empty-file-creation.md
+++ b/changelog/unreleased/fix-skip-early-empty-file-creation.md
@@ -1,0 +1,7 @@
+Bugfix: Remove early finish for zero byte file uploads
+
+We've fixed the upload of zero byte files by removing the
+early upload finishing mechanism.
+
+https://github.com/cs3org/reva/issues/2309
+https://github.com/owncloud/ocis/issues/2609

--- a/pkg/storage/fs/owncloud/upload.go
+++ b/pkg/storage/fs/owncloud/upload.go
@@ -53,7 +53,7 @@ var defaultFilePerm = os.FileMode(0664)
 func (fs *ocfs) Upload(ctx context.Context, ref *provider.Reference, r io.ReadCloser) error {
 	upload, err := fs.GetUpload(ctx, ref.GetPath())
 	if err != nil {
-			return errors.Wrap(err, "ocfs: error retrieving upload")
+		return errors.Wrap(err, "ocfs: error retrieving upload")
 	}
 
 	uploadInfo := upload.(*fileUpload)

--- a/pkg/storage/fs/owncloud/upload.go
+++ b/pkg/storage/fs/owncloud/upload.go
@@ -53,18 +53,7 @@ var defaultFilePerm = os.FileMode(0664)
 func (fs *ocfs) Upload(ctx context.Context, ref *provider.Reference, r io.ReadCloser) error {
 	upload, err := fs.GetUpload(ctx, ref.GetPath())
 	if err != nil {
-		// Upload corresponding to this ID was not found.
-		// Assume that this corresponds to the resource path to which the file has to be uploaded.
-
-		// Set the length to 0 and set SizeIsDeferred to true
-		metadata := map[string]string{"sizedeferred": "true"}
-		uploadIDs, err := fs.InitiateUpload(ctx, ref, 0, metadata)
-		if err != nil {
-			return err
-		}
-		if upload, err = fs.GetUpload(ctx, uploadIDs["simple"]); err != nil {
 			return errors.Wrap(err, "ocfs: error retrieving upload")
-		}
 	}
 
 	uploadInfo := upload.(*fileUpload)
@@ -232,16 +221,6 @@ func (fs *ocfs) NewUpload(ctx context.Context, info tusd.FileInfo) (upload tusd.
 		infoPath: filepath.Join(fs.c.UploadInfoDir, info.ID+".info"),
 		fs:       fs,
 		ctx:      ctx,
-	}
-
-	if !info.SizeIsDeferred && info.Size == 0 {
-		log.Debug().Interface("info", info).Msg("ocfs: finishing upload for empty file")
-		// no need to create info file and finish directly
-		err := u.FinishUpload(ctx)
-		if err != nil {
-			return nil, err
-		}
-		return u, nil
 	}
 
 	// writeInfo creates the file by itself if necessary

--- a/pkg/storage/utils/decomposedfs/decomposedfs_concurrency_test.go
+++ b/pkg/storage/utils/decomposedfs/decomposedfs_concurrency_test.go
@@ -19,8 +19,8 @@
 package decomposedfs_test
 
 import (
+	"bytes"
 	"context"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path"
@@ -35,6 +35,7 @@ import (
 	"github.com/cs3org/reva/tests/helpers"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/pkg/errors"
 )
 
 var _ = Describe("Decomposed", func() {
@@ -85,21 +86,9 @@ var _ = Describe("Decomposed", func() {
 	Describe("concurrent", func() {
 		Describe("Upload", func() {
 			var (
-				f, f1 *os.File
+				r1 = []byte("test")
+				r2 = []byte("another run")
 			)
-
-			BeforeEach(func() {
-				// Prepare two test files for upload
-				err := ioutil.WriteFile(fmt.Sprintf("%s/%s", tmpRoot, "f.lol"), []byte("test"), 0644)
-				Expect(err).ToNot(HaveOccurred())
-				f, err = os.Open(fmt.Sprintf("%s/%s", tmpRoot, "f.lol"))
-				Expect(err).ToNot(HaveOccurred())
-
-				err = ioutil.WriteFile(fmt.Sprintf("%s/%s", tmpRoot, "f1.lol"), []byte("another run"), 0644)
-				Expect(err).ToNot(HaveOccurred())
-				f1, err = os.Open(fmt.Sprintf("%s/%s", tmpRoot, "f1.lol"))
-				Expect(err).ToNot(HaveOccurred())
-			})
 
 			PIt("generates two revisions", func() {
 				// runtime.GOMAXPROCS(1) // uncomment to remove concurrency and see revisions working.
@@ -108,13 +97,13 @@ var _ = Describe("Decomposed", func() {
 
 				// upload file with contents: "test"
 				go func(wg *sync.WaitGroup) {
-					_ = fs.Upload(ctx, &provider.Reference{Path: "uploaded.txt"}, f)
+					_ = uploadHelper(ctx, fs, &provider.Reference{Path: "uploaded.txt"}, r1)
 					wg.Done()
 				}(wg)
 
 				// upload file with contents: "another run"
 				go func(wg *sync.WaitGroup) {
-					_ = fs.Upload(ctx, &provider.Reference{Path: "uploaded.txt"}, f1)
+					_ = uploadHelper(ctx, fs, &provider.Reference{Path: "uploaded.txt"}, r2)
 					wg.Done()
 				}(wg)
 
@@ -151,3 +140,17 @@ var _ = Describe("Decomposed", func() {
 		})
 	})
 })
+
+func uploadHelper(ctx context.Context, fs storage.FS, ref *provider.Reference, content []byte) error {
+	uploadIds, err := fs.InitiateUpload(ctx, ref, 0, map[string]string{})
+	if err != nil {
+		return err
+	}
+	uploadID, ok := uploadIds["simple"]
+	if !ok {
+		return errors.New("simple upload method not available")
+	}
+	uploadRef := &provider.Reference{Path: "/" + uploadID}
+	err = fs.Upload(ctx, uploadRef, ioutil.NopCloser(bytes.NewReader(content)))
+	return err
+}

--- a/pkg/storage/utils/decomposedfs/decomposedfs_concurrency_test.go
+++ b/pkg/storage/utils/decomposedfs/decomposedfs_concurrency_test.go
@@ -19,7 +19,6 @@
 package decomposedfs_test
 
 import (
-	"bytes"
 	"context"
 	"io/ioutil"
 	"os"
@@ -35,7 +34,6 @@ import (
 	"github.com/cs3org/reva/tests/helpers"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/pkg/errors"
 )
 
 var _ = Describe("Decomposed", func() {
@@ -97,13 +95,13 @@ var _ = Describe("Decomposed", func() {
 
 				// upload file with contents: "test"
 				go func(wg *sync.WaitGroup) {
-					_ = uploadHelper(ctx, fs, &provider.Reference{Path: "uploaded.txt"}, r1)
+					_ = helpers.Upload(ctx, fs, &provider.Reference{Path: "uploaded.txt"}, r1)
 					wg.Done()
 				}(wg)
 
 				// upload file with contents: "another run"
 				go func(wg *sync.WaitGroup) {
-					_ = uploadHelper(ctx, fs, &provider.Reference{Path: "uploaded.txt"}, r2)
+					_ = helpers.Upload(ctx, fs, &provider.Reference{Path: "uploaded.txt"}, r2)
 					wg.Done()
 				}(wg)
 
@@ -140,17 +138,3 @@ var _ = Describe("Decomposed", func() {
 		})
 	})
 })
-
-func uploadHelper(ctx context.Context, fs storage.FS, ref *provider.Reference, content []byte) error {
-	uploadIds, err := fs.InitiateUpload(ctx, ref, 0, map[string]string{})
-	if err != nil {
-		return err
-	}
-	uploadID, ok := uploadIds["simple"]
-	if !ok {
-		return errors.New("simple upload method not available")
-	}
-	uploadRef := &provider.Reference{Path: "/" + uploadID}
-	err = fs.Upload(ctx, uploadRef, ioutil.NopCloser(bytes.NewReader(content)))
-	return err
-}

--- a/pkg/storage/utils/decomposedfs/upload.go
+++ b/pkg/storage/utils/decomposedfs/upload.go
@@ -57,18 +57,7 @@ var defaultFilePerm = os.FileMode(0664)
 func (fs *Decomposedfs) Upload(ctx context.Context, ref *provider.Reference, r io.ReadCloser) (err error) {
 	upload, err := fs.GetUpload(ctx, ref.GetPath())
 	if err != nil {
-		// Upload corresponding to this ID was not found.
-		// Assume that this corresponds to the resource path to which the file has to be uploaded.
-
-		// Set the length to 0 and set SizeIsDeferred to true
-		metadata := map[string]string{"sizedeferred": "true"}
-		uploadIDs, err := fs.InitiateUpload(ctx, ref, 0, metadata)
-		if err != nil {
-			return err
-		}
-		if upload, err = fs.GetUpload(ctx, uploadIDs["simple"]); err != nil {
-			return errors.Wrap(err, "Decomposedfs: error retrieving upload")
-		}
+		return errors.Wrap(err, "Decomposedfs: error retrieving upload")
 	}
 
 	uploadInfo := upload.(*fileUpload)
@@ -295,16 +284,6 @@ func (fs *Decomposedfs) NewUpload(ctx context.Context, info tusd.FileInfo) (uplo
 		infoPath: filepath.Join(fs.o.Root, "uploads", info.ID+".info"),
 		fs:       fs,
 		ctx:      ctx,
-	}
-
-	if !info.SizeIsDeferred && info.Size == 0 {
-		log.Debug().Interface("info", info).Msg("Decomposedfs: finishing upload for empty file")
-		// no need to create info file and finish directly
-		err := u.FinishUpload(ctx)
-		if err != nil {
-			return nil, err
-		}
-		return u, nil
 	}
 
 	// writeInfo creates the file by itself if necessary

--- a/pkg/storage/utils/decomposedfs/upload_test.go
+++ b/pkg/storage/utils/decomposedfs/upload_test.go
@@ -25,27 +25,32 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"testing"
 
 	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
-	"github.com/cs3org/reva/pkg/errtypes"
-	"github.com/cs3org/reva/pkg/storage/utils/decomposedfs/node"
-	"github.com/cs3org/reva/pkg/storage/utils/decomposedfs/xattrs"
-	"github.com/pkg/xattr"
-	"github.com/stretchr/testify/mock"
-
 	ruser "github.com/cs3org/reva/pkg/ctx"
+	"github.com/cs3org/reva/pkg/errtypes"
 	"github.com/cs3org/reva/pkg/storage"
 	"github.com/cs3org/reva/pkg/storage/utils/decomposedfs"
 	"github.com/cs3org/reva/pkg/storage/utils/decomposedfs/mocks"
+	"github.com/cs3org/reva/pkg/storage/utils/decomposedfs/node"
 	"github.com/cs3org/reva/pkg/storage/utils/decomposedfs/options"
 	"github.com/cs3org/reva/pkg/storage/utils/decomposedfs/tree"
 	treemocks "github.com/cs3org/reva/pkg/storage/utils/decomposedfs/tree/mocks"
+	"github.com/cs3org/reva/pkg/storage/utils/decomposedfs/xattrs"
 	"github.com/cs3org/reva/tests/helpers"
+	"github.com/pkg/xattr"
+	"github.com/stretchr/testify/mock"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
+
+func TestFileUploads(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "File uploads")
+}
 
 var _ = Describe("File uploads", func() {
 	var (
@@ -98,8 +103,8 @@ var _ = Describe("File uploads", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	Context("quota exceeded", func() {
-		Describe("InitiateUpload", func() {
+	Context("the user's quota is exceeded", func() {
+		When("the user wants to initiate a file upload", func() {
 			It("fails", func() {
 				var originalFunc = node.CheckQuota
 				node.CheckQuota = func(spaceRoot *node.Node, fileSize uint64) (quotaSufficient bool, err error) {
@@ -112,12 +117,12 @@ var _ = Describe("File uploads", func() {
 		})
 	})
 
-	Context("with insufficient permissions", func() {
+	Context("the user has insufficient permissions", func() {
 		BeforeEach(func() {
 			permissions.On("HasPermission", mock.Anything, mock.Anything, mock.Anything).Return(false, nil)
 		})
 
-		Describe("InitiateUpload", func() {
+		When("the user wants to initiate a file upload", func() {
 			It("fails", func() {
 				_, err := fs.InitiateUpload(ctx, ref, 10, map[string]string{})
 				Expect(err).To(MatchError("error: permission denied: root/foo"))
@@ -143,7 +148,7 @@ var _ = Describe("File uploads", func() {
 			permissions.On("HasPermission", mock.Anything, mock.Anything, mock.Anything).Return(false, nil)
 		})
 
-		Describe("InitiateUpload", func() {
+		When("the user wants to initiate a file upload", func() {
 			It("fails", func() {
 				h, err := lookup.HomeNode(ctx)
 				Expect(err).ToNot(HaveOccurred())
@@ -157,25 +162,27 @@ var _ = Describe("File uploads", func() {
 	Context("with sufficient permissions", func() {
 		BeforeEach(func() {
 			permissions.On("HasPermission", mock.Anything, mock.Anything, mock.Anything).Return(true, nil)
+			permissions.On("AssemblePermissions", mock.Anything, mock.Anything).
+				Return(provider.ResourcePermissions{
+					ListContainer: true,
+				}, nil)
 		})
 
-		Describe("InitiateUpload", func() {
-			It("returns uploadIds for simple and tus uploads", func() {
+		When("the user wants to upload a non zero byte file", func() {
+			It("succeeds", func() {
+				var (
+					fileContent = []byte("0123456789")
+				)
+
 				uploadIds, err := fs.InitiateUpload(ctx, ref, 10, map[string]string{})
 
 				Expect(err).ToNot(HaveOccurred())
 				Expect(len(uploadIds)).To(Equal(2))
 				Expect(uploadIds["simple"]).ToNot(BeEmpty())
 				Expect(uploadIds["tus"]).ToNot(BeEmpty())
-			})
-		})
 
-		Describe("Upload", func() {
-			var (
-				fileContent = []byte("0123456789")
-			)
+				uploadRef := &provider.Reference{Path: "/" + uploadIds["simple"]}
 
-			It("stores the blob in the blobstore", func() {
 				bs.On("Upload", mock.AnythingOfType("string"), mock.AnythingOfType("*os.File")).
 					Return(nil).
 					Run(func(args mock.Arguments) {
@@ -186,10 +193,56 @@ var _ = Describe("File uploads", func() {
 						Expect(data).To(Equal([]byte("0123456789")))
 					})
 
-				err := fs.Upload(ctx, ref, ioutil.NopCloser(bytes.NewReader(fileContent)))
-				Expect(err).ToNot(HaveOccurred())
+				err = fs.Upload(ctx, uploadRef, ioutil.NopCloser(bytes.NewReader(fileContent)))
 
+				Expect(err).ToNot(HaveOccurred())
 				bs.AssertCalled(GinkgoT(), "Upload", mock.Anything, mock.Anything)
+
+				rootRef := &provider.Reference{Path: "/"}
+				resources, err := fs.ListFolder(ctx, rootRef, []string{})
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(len(resources)).To(Equal(1))
+				Expect(resources[0].Path).To(Equal(ref.Path))
+			})
+		})
+
+		When("the user wants to upload a zero byte file", func() {
+			It("succeeds", func() {
+				var (
+					fileContent = []byte("")
+				)
+
+				uploadIds, err := fs.InitiateUpload(ctx, ref, 0, map[string]string{})
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(len(uploadIds)).To(Equal(2))
+				Expect(uploadIds["simple"]).ToNot(BeEmpty())
+				Expect(uploadIds["tus"]).ToNot(BeEmpty())
+
+				uploadRef := &provider.Reference{Path: "/" + uploadIds["simple"]}
+
+				bs.On("Upload", mock.AnythingOfType("string"), mock.AnythingOfType("*os.File")).
+					Return(nil).
+					Run(func(args mock.Arguments) {
+						reader := args.Get(1).(io.Reader)
+						data, err := ioutil.ReadAll(reader)
+
+						Expect(err).ToNot(HaveOccurred())
+						Expect(data).To(Equal([]byte("")))
+					})
+
+				err = fs.Upload(ctx, uploadRef, ioutil.NopCloser(bytes.NewReader(fileContent)))
+
+				Expect(err).ToNot(HaveOccurred())
+				bs.AssertCalled(GinkgoT(), "Upload", mock.Anything, mock.Anything)
+
+				rootRef := &provider.Reference{Path: "/"}
+				resources, err := fs.ListFolder(ctx, rootRef, []string{})
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(len(resources)).To(Equal(1))
+				Expect(resources[0].Path).To(Equal(ref.Path))
 			})
 		})
 	})

--- a/pkg/storage/utils/decomposedfs/upload_test.go
+++ b/pkg/storage/utils/decomposedfs/upload_test.go
@@ -25,7 +25,6 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
-	"testing"
 
 	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
@@ -46,11 +45,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
-
-func TestFileUploads(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "File uploads")
-}
 
 var _ = Describe("File uploads", func() {
 	var (

--- a/pkg/storage/utils/localfs/upload.go
+++ b/pkg/storage/utils/localfs/upload.go
@@ -43,18 +43,7 @@ var defaultFilePerm = os.FileMode(0664)
 func (fs *localfs) Upload(ctx context.Context, ref *provider.Reference, r io.ReadCloser) error {
 	upload, err := fs.GetUpload(ctx, ref.GetPath())
 	if err != nil {
-		// Upload corresponding to this ID was not found.
-		// Assume that this corresponds to the resource path to which the file has to be uploaded.
-
-		// Set the length to 0 and set SizeIsDeferred to true
-		metadata := map[string]string{"sizedeferred": "true"}
-		uploadIDs, err := fs.InitiateUpload(ctx, ref, 0, metadata)
-		if err != nil {
-			return err
-		}
-		if upload, err = fs.GetUpload(ctx, uploadIDs["simple"]); err != nil {
-			return errors.Wrap(err, "localfs: error retrieving upload")
-		}
+		return errors.Wrap(err, "localfs: error retrieving upload")
 	}
 
 	uploadInfo := upload.(*fileUpload)
@@ -199,16 +188,6 @@ func (fs *localfs) NewUpload(ctx context.Context, info tusd.FileInfo) (upload tu
 		infoPath: binPath + ".info",
 		fs:       fs,
 		ctx:      ctx,
-	}
-
-	if !info.SizeIsDeferred && info.Size == 0 {
-		log.Debug().Interface("info", info).Msg("localfs: finishing upload for empty file")
-		// no need to create info file and finish directly
-		err := u.FinishUpload(ctx)
-		if err != nil {
-			return nil, err
-		}
-		return u, nil
 	}
 
 	// writeInfo creates the file by itself if necessary

--- a/tests/helpers/helpers.go
+++ b/tests/helpers/helpers.go
@@ -51,6 +51,7 @@ func TempDir(name string) (string, error) {
 	return tmpRoot, nil
 }
 
+// Upload can be used to initiate an upload and do the upload to a storage.FS in one step
 func Upload(ctx context.Context, fs storage.FS, ref *provider.Reference, content []byte) error {
 	uploadIds, err := fs.InitiateUpload(ctx, ref, 0, map[string]string{})
 	if err != nil {

--- a/tests/helpers/helpers.go
+++ b/tests/helpers/helpers.go
@@ -19,10 +19,16 @@
 package helpers
 
 import (
+	"bytes"
+	"context"
+	"errors"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
+
+	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+	"github.com/cs3org/reva/pkg/storage"
 )
 
 // TempDir creates a temporary directory in tmp/ and returns its path
@@ -43,4 +49,18 @@ func TempDir(name string) (string, error) {
 	}
 
 	return tmpRoot, nil
+}
+
+func Upload(ctx context.Context, fs storage.FS, ref *provider.Reference, content []byte) error {
+	uploadIds, err := fs.InitiateUpload(ctx, ref, 0, map[string]string{})
+	if err != nil {
+		return err
+	}
+	uploadID, ok := uploadIds["simple"]
+	if !ok {
+		return errors.New("simple upload method not available")
+	}
+	uploadRef := &provider.Reference{Path: "/" + uploadID}
+	err = fs.Upload(ctx, uploadRef, ioutil.NopCloser(bytes.NewReader(content)))
+	return err
 }

--- a/tests/integration/grpc/storageprovider_test.go
+++ b/tests/integration/grpc/storageprovider_test.go
@@ -513,7 +513,7 @@ var _ = Describe("storage providers", func() {
 
 				err = fs.CreateHome(ctx)
 				Expect(err).ToNot(HaveOccurred())
-				err = helpers.Upload()(ctx, fs, versionedFileRef, content1)
+				err = helpers.Upload(ctx, fs, versionedFileRef, content1)
 				Expect(err).ToNot(HaveOccurred())
 				err = helpers.Upload(ctx, fs, versionedFileRef, content2)
 				Expect(err).ToNot(HaveOccurred())

--- a/tests/integration/grpc/storageprovider_test.go
+++ b/tests/integration/grpc/storageprovider_test.go
@@ -19,9 +19,7 @@
 package grpc_test
 
 import (
-	"bytes"
 	"context"
-	"io/ioutil"
 	"os"
 
 	"google.golang.org/grpc/metadata"
@@ -32,11 +30,10 @@ import (
 	"github.com/cs3org/reva/pkg/auth/scope"
 	ctxpkg "github.com/cs3org/reva/pkg/ctx"
 	"github.com/cs3org/reva/pkg/rgrpc/todo/pool"
-	"github.com/cs3org/reva/pkg/storage"
 	"github.com/cs3org/reva/pkg/storage/fs/ocis"
 	"github.com/cs3org/reva/pkg/storage/fs/owncloud"
 	jwt "github.com/cs3org/reva/pkg/token/manager/jwt"
-	"github.com/pkg/errors"
+	"github.com/cs3org/reva/tests/helpers"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -516,9 +513,9 @@ var _ = Describe("storage providers", func() {
 
 				err = fs.CreateHome(ctx)
 				Expect(err).ToNot(HaveOccurred())
-				err = uploadHelper(ctx, fs, versionedFileRef, content1)
+				err = helpers.Upload()(ctx, fs, versionedFileRef, content1)
 				Expect(err).ToNot(HaveOccurred())
-				err = uploadHelper(ctx, fs, versionedFileRef, content2)
+				err = helpers.Upload(ctx, fs, versionedFileRef, content2)
 				Expect(err).ToNot(HaveOccurred())
 			})
 
@@ -574,9 +571,9 @@ var _ = Describe("storage providers", func() {
 
 				err = fs.CreateHome(ctx)
 				Expect(err).ToNot(HaveOccurred())
-				err = uploadHelper(ctx, fs, versionedFileRef, content1)
+				err = helpers.Upload(ctx, fs, versionedFileRef, content1)
 				Expect(err).ToNot(HaveOccurred())
-				err = uploadHelper(ctx, fs, versionedFileRef, content2)
+				err = helpers.Upload(ctx, fs, versionedFileRef, content2)
 				Expect(err).ToNot(HaveOccurred())
 			})
 
@@ -642,9 +639,9 @@ var _ = Describe("storage providers", func() {
 
 				err = fs.CreateHome(ctx)
 				Expect(err).ToNot(HaveOccurred())
-				err = uploadHelper(ctx, fs, versionedFileRef, content1)
+				err = helpers.Upload(ctx, fs, versionedFileRef, content1)
 				Expect(err).ToNot(HaveOccurred())
-				err = uploadHelper(ctx, fs, versionedFileRef, content2)
+				err = helpers.Upload(ctx, fs, versionedFileRef, content2)
 				Expect(err).ToNot(HaveOccurred())
 			})
 
@@ -652,17 +649,3 @@ var _ = Describe("storage providers", func() {
 		})
 	})
 })
-
-func uploadHelper(ctx context.Context, fs storage.FS, ref *storagep.Reference, content []byte) error {
-	uploadIds, err := fs.InitiateUpload(ctx, ref, 0, map[string]string{})
-	if err != nil {
-		return err
-	}
-	uploadID, ok := uploadIds["simple"]
-	if !ok {
-		return errors.New("simple upload method not available")
-	}
-	uploadRef := &storagep.Reference{Path: "/" + uploadID}
-	err = fs.Upload(ctx, uploadRef, ioutil.NopCloser(bytes.NewReader(content)))
-	return err
-}


### PR DESCRIPTION
Bugfix: Remove early finish for zero byte file uploads

We've fixed the upload of zero byte files by removing the
early upload finishing mechanism.

fixes https://github.com/owncloud/ocis/issues/2609

continuation of https://github.com/cs3org/reva/pull/2055