### PR TITLE
fix app provider for editor public links

### DIFF
--- a/changelog/unreleased/fix-public-link-wopi.md
+++ b/changelog/unreleased/fix-public-link-wopi.md
@@ -1,0 +1,7 @@
+Bugfix: Fix app provider for editor public links
+
+Fixed opening the app provider in public links with the editor permission.
+The app provider failed to open the file in read write mode.
+
+https://github.com/owncloud/ocis/issues/2803
+https://github.com/cs3org/reva/pull/2310

--- a/internal/grpc/services/publicstorageprovider/publicstorageprovider.go
+++ b/internal/grpc/services/publicstorageprovider/publicstorageprovider.go
@@ -108,7 +108,16 @@ func New(m map[string]interface{}, ss *grpc.Server) (rgrpc.Service, error) {
 }
 
 func (s *service) SetArbitraryMetadata(ctx context.Context, req *provider.SetArbitraryMetadataRequest) (*provider.SetArbitraryMetadataResponse, error) {
-	return nil, gstatus.Errorf(codes.Unimplemented, "method not implemented")
+	ref, _, _, st, err := s.translatePublicRefToCS3Ref(ctx, req.Ref)
+	switch {
+	case err != nil:
+		return nil, err
+	case st != nil:
+		return &provider.SetArbitraryMetadataResponse{
+			Status: st,
+		}, nil
+	}
+	return s.gateway.SetArbitraryMetadata(ctx, &provider.SetArbitraryMetadataRequest{Opaque: req.Opaque, Ref: ref, ArbitraryMetadata: req.ArbitraryMetadata})
 }
 
 func (s *service) UnsetArbitraryMetadata(ctx context.Context, req *provider.UnsetArbitraryMetadataRequest) (*provider.UnsetArbitraryMetadataResponse, error) {


### PR DESCRIPTION
Fixed opening the app provider in public links with the editor permission.
The app provider failed to open the file in read write mode.

fixes: https://github.com/owncloud/ocis/issues/2803