### PR TITLE
OIDC: fallback to "email" if IDP doesn't provide "preferred_username" claim

### DIFF
--- a/changelog/unreleased/user-claim-fallback.md
+++ b/changelog/unreleased/user-claim-fallback.md
@@ -1,0 +1,6 @@
+Enhancement: OIDC: fallback if IDP doesn't provide "preferred_username" claim
+
+Some IDPs don't support the "preferred_username" claim.  Fallback to the
+"email" claim in that case.
+
+https://github.com/cs3org/reva/pull/2314


### PR DESCRIPTION
Some IDPs (e.g. Authelia) don't add the "preferred_username" claim. Fallback to the "email" claim in that case.

See also: https://github.com/owncloud/ocis/issues/2644