### PR TITLE
Public link propfind

### DIFF
--- a/changelog/unreleased/public-link-propfind.md
+++ b/changelog/unreleased/public-link-propfind.md
@@ -1,0 +1,6 @@
+Enhancement: Add new attributes to public link propfinds
+
+Added a new property "oc:signature-auth" to public link propfinds.
+This is a necessary change to be able to support archive downloads in password protected public links.
+
+https://github.com/cs3org/reva/pull/2315

--- a/internal/http/services/owncloud/ocdav/publicfile.go
+++ b/internal/http/services/owncloud/ocdav/publicfile.go
@@ -177,9 +177,6 @@ func (s *svc) handlePropfindOnToken(w http.ResponseWriter, r *http.Request, ns s
 		w.WriteHeader(http.StatusNotFound)
 		return
 	}
-	// adjust path
-	tokenStatInfo.Path = path.Join("/", tokenStatInfo.Path, path.Base(pathRes.Path))
-
 	infos := s.getPublicFileInfos(onContainer, depth == "0", tokenStatInfo)
 
 	propRes, err := s.multistatusResponse(ctx, &pf, infos, ns, nil)


### PR DESCRIPTION
Added a new property "oc:signature-auth" to public link propfinds.
This is a necessary change to be able to support archive downloads in password protected public links.

Together with this PR https://github.com/owncloud/ocis/pull/2831 and some changes in the web client, archive downloads in password protected public links will be possible.