### PR TITLE
fix public share type in propfinds

### DIFF
--- a/changelog/unreleased/fix-propfind-sharetype.md
+++ b/changelog/unreleased/fix-propfind-sharetype.md
@@ -1,0 +1,5 @@
+Bugfix: Fix the share types in propfinds
+
+The share types for public links were not correctly added to propfinds.
+
+https://github.com/cs3org/reva/pull/2316

--- a/internal/http/services/owncloud/ocdav/propfind.go
+++ b/internal/http/services/owncloud/ocdav/propfind.go
@@ -159,7 +159,7 @@ func (s *svc) propfindResponse(ctx context.Context, w http.ResponseWriter, r *ht
 	var linkshares map[string]struct{}
 	listResp, err := client.ListPublicShares(ctx, &link.ListPublicSharesRequest{Filters: filters})
 	if err == nil {
-		linkshares := make(map[string]struct{})
+		linkshares = make(map[string]struct{}, len(listResp.Share))
 		for i := range listResp.Share {
 			linkshares[listResp.Share[i].ResourceId.OpaqueId] = struct{}{}
 		}


### PR DESCRIPTION
The share types for public links were not correctly added to propfinds.
With this fix the share indicators for public links in the web ui will work again.