### PR TITLE
[build-deps] add owncloud-team to codeowners of unreleased changelogs

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,5 @@
 *				@labkode @ishank011
+changelog/unreleased      @cs3org/owncloud-team
 pkg/auth/manager/owncloudsql	  @cs3org/owncloud-team
 pkg/storage/fs/owncloudsql      @cs3org/owncloud-team
 pkg/storage/fs/owncloud   	  @cs3org/owncloud-team


### PR DESCRIPTION
without being code owners for `changelogs/unreleased`, PRs with a changelog item (which is required) can't be merged by ownCloud