### PR TITLE
fix decomposedfs upload

### DIFF
--- a/changelog/unreleased/fix-decomposedfs-upload.md
+++ b/changelog/unreleased/fix-decomposedfs-upload.md
@@ -1,0 +1,5 @@
+Bugfix: fix decomposedfs upload
+
+The FS.Upload() implementation needs to handle direct uploads that did not initiate a unpload.
+
+https://github.com/cs3org/reva/pull/2330

--- a/pkg/rhttp/datatx/manager/spaces/spaces.go
+++ b/pkg/rhttp/datatx/manager/spaces/spaces.go
@@ -20,8 +20,6 @@ package spaces
 
 import (
 	"net/http"
-	"path"
-	"strings"
 
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	"github.com/cs3org/reva/pkg/appctx"
@@ -78,10 +76,8 @@ func (m *manager) Handler(fs storage.FS) (http.Handler, error) {
 		case "GET", "HEAD":
 			download.GetOrHeadFile(w, r, fs, spaceID)
 		case "PUT":
-			// make a clean relative path
-			fn := path.Clean(strings.TrimLeft(r.URL.Path, "/"))
+			fn := utils.MakeRelativePath(r.URL.Path)
 			defer r.Body.Close()
-
 			// TODO refactor: pass Reference to Upload & GetOrHeadFile
 			// build a storage space reference
 			storageid, opaqeid := utils.SplitStorageSpaceID(spaceID)

--- a/pkg/storage/utils/decomposedfs/upload.go
+++ b/pkg/storage/utils/decomposedfs/upload.go
@@ -58,7 +58,19 @@ var defaultFilePerm = os.FileMode(0664)
 func (fs *Decomposedfs) Upload(ctx context.Context, ref *provider.Reference, r io.ReadCloser) (err error) {
 	upload, err := fs.GetUpload(ctx, ref.GetPath())
 	if err != nil {
-		return errors.Wrap(err, "Decomposedfs: error retrieving upload")
+		// Upload corresponding to this ID was not found.
+		// Assume that this corresponds to the resource path to which the file has to be uploaded.
+
+		// Set the length to 0 and set SizeIsDeferred to true
+		metadata := map[string]string{"sizedeferred": "true"}
+		uploadIDs, err := fs.InitiateUpload(ctx, ref, 0, metadata)
+		if err != nil {
+			return err
+		}
+		upload, err = fs.GetUpload(ctx, uploadIDs["simple"])
+		if err != nil {
+			return errors.Wrap(err, "Decomposedfs: error retrieving upload")
+		}
 	}
 
 	uploadInfo := upload.(*fileUpload)


### PR DESCRIPTION
The FS.Upload() implementation needs to handle direct uploads that did not initiate a unpload.

fixes ocis spaces registry PR https://github.com/owncloud/ocis/pull/2739

ocis makes direct PUT `/data/spaces/spaceid!spaceid/relative/path/to/file.json`  requests to the metadata storage data provider. No initiate upload call ... we did that to save requests. Might be better to just use TUS with the `creation-with-upload` extension.

For now this allows us to create users with ocis and the accounts service.