### PR TITLE
[tests-only] [edge] Bump core commit id for tests

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The test runner source for API tests
-CORE_COMMITID=918845e387e18e0ecd765458bc721b2b571b9024
+CORE_COMMITID=4bbd91de68aefdf94c03d2920a3353702f856280
 CORE_BRANCH=acceptance-test-changes-waiting-2021-11


### PR DESCRIPTION
cherry-pick of #2331 to `edge` branch.

First see what CI does. Then we can discuss how we manage this sort of thing.
