### PR TITLE
handle sending all permissions when creating public links

### DIFF
--- a/changelog/unreleased/handle-public-link-permissions-all.md
+++ b/changelog/unreleased/handle-public-link-permissions-all.md
@@ -1,0 +1,5 @@
+Bugfix: handle sending all permissions when creating public links
+
+For backwards compatability we now reduce permissions to readonly when a create public link carries all permissions.
+
+https://github.com/cs3org/reva/issues/2336

--- a/changelog/unreleased/handle-public-link-permissions-all.md
+++ b/changelog/unreleased/handle-public-link-permissions-all.md
@@ -3,3 +3,4 @@ Bugfix: handle sending all permissions when creating public links
 For backwards compatability we now reduce permissions to readonly when a create public link carries all permissions.
 
 https://github.com/cs3org/reva/issues/2336
+https://github.com/owncloud/ocis/issues/1269

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/public.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/public.go
@@ -423,6 +423,13 @@ func (h *Handler) removePublicShare(w http.ResponseWriter, r *http.Request, shar
 }
 
 func ocPublicPermToCs3(permKey int, h *Handler) (*provider.ResourcePermissions, error) {
+
+	if permKey == 31 {
+		// apiSharePublicLink1/createPublicLinkShare.feature:109
+		// Scenario Outline: Trying to create a new public link share of a file with edit permissions only grants read access using the public WebDAV API
+		permKey = 1
+	}
+
 	// TODO refactor this ocPublicPermToRole[permKey] check into a conversions.NewPublicSharePermissions?
 	// not all permissions are possible for public shares
 	_, ok := ocPublicPermToRole[permKey]

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/public.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/public.go
@@ -422,13 +422,17 @@ func (h *Handler) removePublicShare(w http.ResponseWriter, r *http.Request, shar
 	response.WriteOCSSuccess(w, r, nil)
 }
 
+// for public links oc10 api decreases all permissions to read: stay compatible!
+func decreasePermissionsIfNecessary(perm int) int {
+	if perm == int(conversions.PermissionAll) {
+		perm = int(conversions.PermissionRead)
+	}
+	return perm
+}
+
 func ocPublicPermToCs3(permKey int, h *Handler) (*provider.ResourcePermissions, error) {
 
-	if permKey == 31 {
-		// apiSharePublicLink1/createPublicLinkShare.feature:109
-		// Scenario Outline: Trying to create a new public link share of a file with edit permissions only grants read access using the public WebDAV API
-		permKey = 1
-	}
+	permKey = decreasePermissionsIfNecessary(permKey)
 
 	// TODO refactor this ocPublicPermToRole[permKey] check into a conversions.NewPublicSharePermissions?
 	// not all permissions are possible for public shares

--- a/tests/acceptance/expected-failures-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-on-OCIS-storage.md
@@ -382,11 +382,6 @@ The first two tests work against ocis. There must be something wrong in the CI s
 -   [apiSharePublicLink1/changingPublicLinkShare.feature:51](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/changingPublicLinkShare.feature#L51)
 -   [apiSharePublicLink1/changingPublicLinkShare.feature:90](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/changingPublicLinkShare.feature#L90)
 
-#### [Public link enforce permissions](https://github.com/owncloud/ocis/issues/1269)
-
--   [apiSharePublicLink1/createPublicLinkShare.feature:141](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature#L141)
--   [apiSharePublicLink1/createPublicLinkShare.feature:142](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature#L142)
-
 #### [various sharing settings cannot be set](https://github.com/owncloud/ocis/issues/1328)
 
 -   [apiSharePublicLink1/createPublicLinkShare.feature:319](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature#L319)

--- a/tests/acceptance/expected-failures-on-S3NG-storage.md
+++ b/tests/acceptance/expected-failures-on-S3NG-storage.md
@@ -392,11 +392,6 @@ File and sync features in a shared scenario
 -   [apiSharePublicLink1/changingPublicLinkShare.feature:51](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/changingPublicLinkShare.feature#L51)
 -   [apiSharePublicLink1/changingPublicLinkShare.feature:90](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/changingPublicLinkShare.feature#L90)
 
-#### [Public link enforce permissions](https://github.com/owncloud/ocis/issues/1269)
-
--   [apiSharePublicLink1/createPublicLinkShare.feature:141](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature#L141)
--   [apiSharePublicLink1/createPublicLinkShare.feature:142](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature#L142)
-
 #### [various sharing settings cannot be set](https://github.com/owncloud/ocis/issues/1328)
 
 -   [apiSharePublicLink1/createPublicLinkShare.feature:319](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature#L319)


### PR DESCRIPTION
For backwards compatability we now reduce permissions to readonly when a create public link carries all permissions.

Adresses https://github.com/owncloud/ocis/issues/1269#issuecomment-646278608