### PR TITLE
remove unused user agent filter

### DIFF
--- a/changelog/unreleased/remove-unused-user-agent-filter.md
+++ b/changelog/unreleased/remove-unused-user-agent-filter.md
@@ -1,0 +1,5 @@
+Change: We removed the unused `allowed_user_agents` config option
+
+It was not used anywhere in the code, but three places had the config option. Dropping it before it spreads further.
+
+https://github.com/cs3org/reva/pull/2338

--- a/internal/grpc/services/gateway/gateway.go
+++ b/internal/grpc/services/gateway/gateway.go
@@ -70,7 +70,6 @@ type config struct {
 	HomeMapping         string                            `mapstructure:"home_mapping"`
 	TokenManagers       map[string]map[string]interface{} `mapstructure:"token_managers"`
 	EtagCacheTTL        int                               `mapstructure:"etag_cache_ttl"`
-	AllowedUserAgents   map[string][]string               `mapstructure:"allowed_user_agents"` // map[path][]user-agent
 	CreateHomeCacheTTL  int                               `mapstructure:"create_home_cache_ttl"`
 	ProviderCacheTTL    int                               `mapstructure:"provider_cache_ttl"`
 	StatCacheTTL        int                               `mapstructure:"stat_cache_ttl"`

--- a/pkg/storage/registry/spaces/Readme.md
+++ b/pkg/storage/registry/spaces/Readme.md
@@ -24,7 +24,6 @@ A rule has several properties:
 *   `address` The ip address of the CS3 storage provider
 *   `path_template` TODO -> rename to space\_path or space\_mount\_point
 *   `aliases` unused?
-*   `allowed_user_agents` unused? FIXME this seems to be used to route requests based on user agent
 
 It also carries filters that are sent with a ListStorageSpaces call to a storage provider
 

--- a/pkg/storage/registry/spaces/spaces.go
+++ b/pkg/storage/registry/spaces/spaces.go
@@ -53,12 +53,11 @@ func init() {
 }
 
 type provider struct {
-	Mapping           string            `mapstructure:"mapping"`
-	MountPath         string            `mapstructure:"mount_path"`
-	Aliases           map[string]string `mapstructure:"aliases"`
-	AllowedUserAgents []string          `mapstructure:"allowed_user_agents"`
-	PathTemplate      string            `mapstructure:"path_template"`
-	template          *template.Template
+	Mapping      string            `mapstructure:"mapping"`
+	MountPath    string            `mapstructure:"mount_path"`
+	Aliases      map[string]string `mapstructure:"aliases"`
+	PathTemplate string            `mapstructure:"path_template"`
+	template     *template.Template
 	// filters
 	SpaceType      string `mapstructure:"space_type"`
 	SpaceOwnerSelf bool   `mapstructure:"space_owner_self"`

--- a/pkg/storage/registry/static/static.go
+++ b/pkg/storage/registry/static/static.go
@@ -44,12 +44,11 @@ func init() {
 var bracketRegex = regexp.MustCompile(`\[(.*?)\]`)
 
 type rule struct {
-	Mapping           string            `mapstructure:"mapping"`
-	Address           string            `mapstructure:"address"`
-	ProviderID        string            `mapstructure:"provider_id"`
-	ProviderPath      string            `mapstructure:"provider_path"`
-	Aliases           map[string]string `mapstructure:"aliases"`
-	AllowedUserAgents []string          `mapstructure:"allowed_user_agents"`
+	Mapping      string            `mapstructure:"mapping"`
+	Address      string            `mapstructure:"address"`
+	ProviderID   string            `mapstructure:"provider_id"`
+	ProviderPath string            `mapstructure:"provider_path"`
+	Aliases      map[string]string `mapstructure:"aliases"`
 }
 
 type config struct {


### PR DESCRIPTION
I removed the unused `allowed_user_agents` config option. It isnot used anywhere in the code, but three places had the config option. Dropping it before it spreads further. We can bring it back in a clean way later.