### PR TITLE
Use permissions API in decomposedfs

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -719,6 +719,7 @@ def litmusOcisSpacesDav():
                     "/drone/src/cmd/revad/revad -c gateway.toml &",
                     "/drone/src/cmd/revad/revad -c storage-home-ocis.toml &",
                     "/drone/src/cmd/revad/revad -c storage-users-ocis.toml &",
+                    "/drone/src/cmd/revad/revad -c permissions-ocis-ci.toml &",
                     "/drone/src/cmd/revad/revad -c users.toml",
                 ],
             },

--- a/changelog/unreleased/cs3-permissions-service.md
+++ b/changelog/unreleased/cs3-permissions-service.md
@@ -1,0 +1,5 @@
+Enhancement: Use CS3 permissions API
+
+Added calls to the CS3 permissions API to the decomposedfs in order to check the user permissions.
+
+https://github.com/cs3org/reva/pull/2341

--- a/cmd/revad/runtime/loader.go
+++ b/cmd/revad/runtime/loader.go
@@ -38,6 +38,7 @@ import (
 	_ "github.com/cs3org/reva/pkg/ocm/invite/manager/loader"
 	_ "github.com/cs3org/reva/pkg/ocm/provider/authorizer/loader"
 	_ "github.com/cs3org/reva/pkg/ocm/share/manager/loader"
+	_ "github.com/cs3org/reva/pkg/permission/manager/loader"
 	_ "github.com/cs3org/reva/pkg/publicshare/manager/loader"
 	_ "github.com/cs3org/reva/pkg/rhttp/datatx/manager/loader"
 	_ "github.com/cs3org/reva/pkg/share/cache/loader"

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/cheggaaa/pb v1.0.29
 	github.com/coreos/go-oidc v2.2.1+incompatible
 	github.com/cs3org/cato v0.0.0-20200828125504-e418fc54dd5e
-	github.com/cs3org/go-cs3apis v0.0.0-20211214102047-7ce3134d7bf8
+	github.com/cs3org/go-cs3apis v0.0.0-20211214102128-4e8745ab1654
 	github.com/cubewise-code/go-mime v0.0.0-20200519001935-8c5762b177d8
 	github.com/dgraph-io/ristretto v0.1.0
 	github.com/eventials/go-tus v0.0.0-20200718001131-45c7ec8f5d59

--- a/go.sum
+++ b/go.sum
@@ -136,8 +136,8 @@ github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSV
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/cs3org/cato v0.0.0-20200828125504-e418fc54dd5e h1:tqSPWQeueWTKnJVMJffz4pz0o1WuQxJ28+5x5JgaHD8=
 github.com/cs3org/cato v0.0.0-20200828125504-e418fc54dd5e/go.mod h1:XJEZ3/EQuI3BXTp/6DUzFr850vlxq11I6satRtz0YQ4=
-github.com/cs3org/go-cs3apis v0.0.0-20211214102047-7ce3134d7bf8 h1:PqOprF37OvwCbAN5W23znknGk6N/LMayqLAeP904FHE=
-github.com/cs3org/go-cs3apis v0.0.0-20211214102047-7ce3134d7bf8/go.mod h1:UXha4TguuB52H14EMoSsCqDj7k8a/t7g4gVP+bgY5LY=
+github.com/cs3org/go-cs3apis v0.0.0-20211214102128-4e8745ab1654 h1:ha5tiuuFyDrwKUrVEc3TrRDFgTKVQ9NGDRmEP0PRPno=
+github.com/cs3org/go-cs3apis v0.0.0-20211214102128-4e8745ab1654/go.mod h1:UXha4TguuB52H14EMoSsCqDj7k8a/t7g4gVP+bgY5LY=
 github.com/cubewise-code/go-mime v0.0.0-20200519001935-8c5762b177d8 h1:Z9lwXumT5ACSmJ7WGnFl+OMLLjpz5uR2fyz7dC255FI=
 github.com/cubewise-code/go-mime v0.0.0-20200519001935-8c5762b177d8/go.mod h1:4abs/jPXcmJzYoYGF91JF9Uq9s/KL5n1jvFDix8KcqY=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/internal/grpc/services/gateway/gateway.go
+++ b/internal/grpc/services/gateway/gateway.go
@@ -71,6 +71,7 @@ type config struct {
 	EtagCacheTTL        int                               `mapstructure:"etag_cache_ttl"`
 	AllowedUserAgents   map[string][]string               `mapstructure:"allowed_user_agents"` // map[path][]user-agent
 	CreateHomeCacheTTL  int                               `mapstructure:"create_home_cache_ttl"`
+	PermissionsEndpoint string                            `mapstructure:"permissionssvc"`
 }
 
 // sets defaults

--- a/internal/grpc/services/gateway/gateway.go
+++ b/internal/grpc/services/gateway/gateway.go
@@ -57,6 +57,7 @@ type config struct {
 	GroupProviderEndpoint         string `mapstructure:"groupprovidersvc"`
 	DataTxEndpoint                string `mapstructure:"datatx"`
 	DataGatewayEndpoint           string `mapstructure:"datagateway"`
+	PermissionsEndpoint           string `mapstructure:"permissionssvc"`
 	CommitShareToStorageGrant     bool   `mapstructure:"commit_share_to_storage_grant"`
 	CommitShareToStorageRef       bool   `mapstructure:"commit_share_to_storage_ref"`
 	DisableHomeCreationOnLogin    bool   `mapstructure:"disable_home_creation_on_login"`
@@ -71,7 +72,6 @@ type config struct {
 	EtagCacheTTL        int                               `mapstructure:"etag_cache_ttl"`
 	AllowedUserAgents   map[string][]string               `mapstructure:"allowed_user_agents"` // map[path][]user-agent
 	CreateHomeCacheTTL  int                               `mapstructure:"create_home_cache_ttl"`
-	PermissionsEndpoint string                            `mapstructure:"permissionssvc"`
 }
 
 // sets defaults

--- a/internal/grpc/services/gateway/permissions.go
+++ b/internal/grpc/services/gateway/permissions.go
@@ -1,0 +1,39 @@
+// Copyright 2018-2021 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package gateway
+
+import (
+	"context"
+
+	permissions "github.com/cs3org/go-cs3apis/cs3/permissions/v1beta1"
+	"github.com/cs3org/reva/pkg/rgrpc/status"
+	"github.com/cs3org/reva/pkg/rgrpc/todo/pool"
+	"github.com/pkg/errors"
+)
+
+func (s *svc) CheckPermission(ctx context.Context, req *permissions.CheckPermissionRequest) (*permissions.CheckPermissionResponse, error) {
+	c, err := pool.GetPermissionsClient(s.c.PermissionsEndpoint)
+	if err != nil {
+		err = errors.Wrap(err, "gateway: error calling GetPermissionssClient")
+		return &permissions.CheckPermissionResponse{
+			Status: status.NewInternal(ctx, err, "error getting permissions client"),
+		}, nil
+	}
+	return c.CheckPermission(ctx, req)
+}

--- a/internal/grpc/services/loader/loader.go
+++ b/internal/grpc/services/loader/loader.go
@@ -33,6 +33,7 @@ import (
 	_ "github.com/cs3org/reva/internal/grpc/services/ocminvitemanager"
 	_ "github.com/cs3org/reva/internal/grpc/services/ocmproviderauthorizer"
 	_ "github.com/cs3org/reva/internal/grpc/services/ocmshareprovider"
+	_ "github.com/cs3org/reva/internal/grpc/services/permissions"
 	_ "github.com/cs3org/reva/internal/grpc/services/preferences"
 	_ "github.com/cs3org/reva/internal/grpc/services/publicshareprovider"
 	_ "github.com/cs3org/reva/internal/grpc/services/publicstorageprovider"

--- a/internal/grpc/services/permissions/permissions.go
+++ b/internal/grpc/services/permissions/permissions.go
@@ -1,0 +1,104 @@
+// Copyright 2021 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package permissions
+
+import (
+	"context"
+	"fmt"
+
+	permissions "github.com/cs3org/go-cs3apis/cs3/permissions/v1beta1"
+	rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
+	"github.com/cs3org/reva/pkg/permission"
+	"github.com/cs3org/reva/pkg/permission/manager/registry"
+	"github.com/cs3org/reva/pkg/rgrpc"
+	"github.com/mitchellh/mapstructure"
+	"github.com/pkg/errors"
+	"google.golang.org/grpc"
+)
+
+func init() {
+	rgrpc.Register("permissions", New)
+}
+
+type config struct {
+	Driver  string                            `mapstructure:"driver" docs:"localhome;The permission driver to be used."`
+	Drivers map[string]map[string]interface{} `mapstructure:"drivers" docs:"url:pkg/permission/permission.go"`
+}
+
+func parseConfig(m map[string]interface{}) (*config, error) {
+	c := &config{}
+	if err := mapstructure.Decode(m, c); err != nil {
+		err = errors.Wrap(err, "error decoding conf")
+		return nil, err
+	}
+	return c, nil
+}
+
+type service struct {
+	manager permission.Manager
+}
+
+// New returns a new PermissionsServiceServer
+func New(m map[string]interface{}, ss *grpc.Server) (rgrpc.Service, error) {
+	c, err := parseConfig(m)
+	if err != nil {
+		return nil, err
+	}
+
+	f, ok := registry.NewFuncs[c.Driver]
+	if !ok {
+		return nil, fmt.Errorf("could not get permission manager '%s'", c.Driver)
+	}
+	manager, err := f(c.Drivers[c.Driver])
+	if err != nil {
+		return nil, err
+	}
+
+	service := &service{manager: manager}
+	return service, nil
+}
+
+func (s *service) Close() error {
+	return nil
+}
+
+func (s *service) UnprotectedEndpoints() []string {
+	return []string{}
+}
+
+func (s *service) Register(ss *grpc.Server) {
+	permissions.RegisterPermissionsAPIServer(ss, s)
+}
+
+func (s *service) CheckPermission(ctx context.Context, req *permissions.CheckPermissionRequest) (*permissions.CheckPermissionResponse, error) {
+	var subject string
+	switch ref := req.SubjectRef.Spec.(type) {
+	case *permissions.SubjectReference_UserId:
+		subject = ref.UserId.OpaqueId
+	case *permissions.SubjectReference_GroupId:
+		subject = ref.GroupId.OpaqueId
+	}
+	var status *rpc.Status
+	if ok := s.manager.CheckPermission(req.Permission, subject, req.Ref); ok {
+		status = &rpc.Status{Code: rpc.Code_CODE_OK}
+	} else {
+		status = &rpc.Status{Code: rpc.Code_CODE_PERMISSION_DENIED}
+	}
+	return &permissions.CheckPermissionResponse{Status: status}, nil
+}

--- a/internal/grpc/services/storageprovider/storageprovider.go
+++ b/internal/grpc/services/storageprovider/storageprovider.go
@@ -20,7 +20,6 @@ package storageprovider
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/url"
 	"os"
@@ -579,19 +578,7 @@ func hasNodeID(s *provider.StorageSpace) bool {
 func (s *service) ListStorageSpaces(ctx context.Context, req *provider.ListStorageSpacesRequest) (*provider.ListStorageSpacesResponse, error) {
 	log := appctx.GetLogger(ctx)
 
-	// This is just a quick hack to get the users permission into reva.
-	// Replace this as soon as we have a proper system to check the users permissions.
-	opaque := req.Opaque
-	var permissions map[string]struct{}
-	if opaque != nil {
-		entry := opaque.Map["permissions"]
-		err := json.Unmarshal(entry.Value, &permissions)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	spaces, err := s.storage.ListStorageSpaces(ctx, req.Filters, permissions)
+	spaces, err := s.storage.ListStorageSpaces(ctx, req.Filters)
 	if err != nil {
 		var st *rpc.Status
 		switch err.(type) {

--- a/pkg/permission/manager/demo/demo.go
+++ b/pkg/permission/manager/demo/demo.go
@@ -16,7 +16,7 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-package ocisci
+package demo
 
 import (
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
@@ -25,10 +25,10 @@ import (
 )
 
 func init() {
-	registry.Register("ocisci", New)
+	registry.Register("demo", New)
 }
 
-// New returns a new permission manager specific for the CI
+// New returns a new demo permission manager
 func New(c map[string]interface{}) (permission.Manager, error) {
 	return manager{}, nil
 }
@@ -37,7 +37,7 @@ type manager struct {
 }
 
 func (m manager) CheckPermission(permission string, subject string, ref *provider.Reference) bool {
-	// We can currently return false all the time.
+	// We can currently return true all the time.
 	// Once we beginn testing roles we need to somehow check the roles of the users here
-	return false
+	return true
 }

--- a/pkg/permission/manager/loader/loader.go
+++ b/pkg/permission/manager/loader/loader.go
@@ -16,24 +16,10 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-package gateway
+package loader
 
 import (
-	"context"
-
-	permissions "github.com/cs3org/go-cs3apis/cs3/permissions/v1beta1"
-	"github.com/cs3org/reva/pkg/rgrpc/status"
-	"github.com/cs3org/reva/pkg/rgrpc/todo/pool"
-	"github.com/pkg/errors"
+	// Load permission manager drivers
+	_ "github.com/cs3org/reva/pkg/permission/manager/ocisci"
+	// Add your own here
 )
-
-func (s *svc) CheckPermission(ctx context.Context, req *permissions.CheckPermissionRequest) (*permissions.CheckPermissionResponse, error) {
-	c, err := pool.GetPermissionsClient(s.c.PermissionsEndpoint)
-	if err != nil {
-		err = errors.Wrap(err, "gateway: error calling GetPermissionssClient")
-		return &permissions.CheckPermissionResponse{
-			Status: status.NewInternal(ctx, err, "error getting permissions client"),
-		}, nil
-	}
-	return c.CheckPermission(ctx, req)
-}

--- a/pkg/permission/manager/loader/loader.go
+++ b/pkg/permission/manager/loader/loader.go
@@ -20,6 +20,6 @@ package loader
 
 import (
 	// Load permission manager drivers
-	_ "github.com/cs3org/reva/pkg/permission/manager/ocisci"
+	_ "github.com/cs3org/reva/pkg/permission/manager/demo"
 	// Add your own here
 )

--- a/pkg/permission/manager/ocisci/ocisci.go
+++ b/pkg/permission/manager/ocisci/ocisci.go
@@ -16,24 +16,28 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-package gateway
+package ocisci
 
 import (
-	"context"
-
-	permissions "github.com/cs3org/go-cs3apis/cs3/permissions/v1beta1"
-	"github.com/cs3org/reva/pkg/rgrpc/status"
-	"github.com/cs3org/reva/pkg/rgrpc/todo/pool"
-	"github.com/pkg/errors"
+	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+	"github.com/cs3org/reva/pkg/permission"
+	"github.com/cs3org/reva/pkg/permission/manager/registry"
 )
 
-func (s *svc) CheckPermission(ctx context.Context, req *permissions.CheckPermissionRequest) (*permissions.CheckPermissionResponse, error) {
-	c, err := pool.GetPermissionsClient(s.c.PermissionsEndpoint)
-	if err != nil {
-		err = errors.Wrap(err, "gateway: error calling GetPermissionssClient")
-		return &permissions.CheckPermissionResponse{
-			Status: status.NewInternal(ctx, err, "error getting permissions client"),
-		}, nil
-	}
-	return c.CheckPermission(ctx, req)
+func init() {
+	registry.Register("ocisci", New)
+}
+
+// New returns a new permission manager specific for the CI
+func New(c map[string]interface{}) (permission.Manager, error) {
+	return manager{}, nil
+}
+
+type manager struct {
+}
+
+func (m manager) CheckPermission(permission string, subject string, ref *provider.Reference) bool {
+	// We can currently return false all the time.
+	// Once we beginn testing roles we need to somehow check the roles of the users here
+	return false
 }

--- a/pkg/permission/manager/registry/registry.go
+++ b/pkg/permission/manager/registry/registry.go
@@ -16,24 +16,19 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-package gateway
+package registry
 
-import (
-	"context"
+import "github.com/cs3org/reva/pkg/permission"
 
-	permissions "github.com/cs3org/go-cs3apis/cs3/permissions/v1beta1"
-	"github.com/cs3org/reva/pkg/rgrpc/status"
-	"github.com/cs3org/reva/pkg/rgrpc/todo/pool"
-	"github.com/pkg/errors"
-)
+// NewFunc is the function that permission managers
+// should register at init time.
+type NewFunc func(map[string]interface{}) (permission.Manager, error)
 
-func (s *svc) CheckPermission(ctx context.Context, req *permissions.CheckPermissionRequest) (*permissions.CheckPermissionResponse, error) {
-	c, err := pool.GetPermissionsClient(s.c.PermissionsEndpoint)
-	if err != nil {
-		err = errors.Wrap(err, "gateway: error calling GetPermissionssClient")
-		return &permissions.CheckPermissionResponse{
-			Status: status.NewInternal(ctx, err, "error getting permissions client"),
-		}, nil
-	}
-	return c.CheckPermission(ctx, req)
+// NewFuncs is a map containing all the registered share managers.
+var NewFuncs = map[string]NewFunc{}
+
+// Register registers a new permission manager new function.
+// Not safe for concurrent use. Safe for use from package init.
+func Register(name string, f NewFunc) {
+	NewFuncs[name] = f
 }

--- a/pkg/permission/permission.go
+++ b/pkg/permission/permission.go
@@ -16,24 +16,13 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-package gateway
+package permission
 
 import (
-	"context"
-
-	permissions "github.com/cs3org/go-cs3apis/cs3/permissions/v1beta1"
-	"github.com/cs3org/reva/pkg/rgrpc/status"
-	"github.com/cs3org/reva/pkg/rgrpc/todo/pool"
-	"github.com/pkg/errors"
+	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 )
 
-func (s *svc) CheckPermission(ctx context.Context, req *permissions.CheckPermissionRequest) (*permissions.CheckPermissionResponse, error) {
-	c, err := pool.GetPermissionsClient(s.c.PermissionsEndpoint)
-	if err != nil {
-		err = errors.Wrap(err, "gateway: error calling GetPermissionssClient")
-		return &permissions.CheckPermissionResponse{
-			Status: status.NewInternal(ctx, err, "error getting permissions client"),
-		}, nil
-	}
-	return c.CheckPermission(ctx, req)
+// Manager defines the interface for the permission service driver
+type Manager interface {
+	CheckPermission(permission string, subject string, ref *provider.Reference) bool
 }

--- a/pkg/rgrpc/todo/pool/pool.go
+++ b/pkg/rgrpc/todo/pool/pool.go
@@ -32,6 +32,7 @@ import (
 	ocmcore "github.com/cs3org/go-cs3apis/cs3/ocm/core/v1beta1"
 	invitepb "github.com/cs3org/go-cs3apis/cs3/ocm/invite/v1beta1"
 	ocmprovider "github.com/cs3org/go-cs3apis/cs3/ocm/provider/v1beta1"
+	permissions "github.com/cs3org/go-cs3apis/cs3/permissions/v1beta1"
 	preferences "github.com/cs3org/go-cs3apis/cs3/preferences/v1beta1"
 	collaboration "github.com/cs3org/go-cs3apis/cs3/sharing/collaboration/v1beta1"
 	link "github.com/cs3org/go-cs3apis/cs3/sharing/link/v1beta1"
@@ -70,6 +71,7 @@ var (
 	ocmCores               = newProvider()
 	publicShareProviders   = newProvider()
 	preferencesProviders   = newProvider()
+	permissionsProviders   = newProvider()
 	appRegistries          = newProvider()
 	appProviders           = newProvider()
 	storageRegistries      = newProvider()
@@ -346,6 +348,25 @@ func GetPreferencesClient(endpoint string) (preferences.PreferencesAPIClient, er
 
 	v := preferences.NewPreferencesAPIClient(conn)
 	preferencesProviders.conn[endpoint] = v
+	return v, nil
+}
+
+// GetPermissionsClient returns a new PermissionsClient.
+func GetPermissionsClient(endpoint string) (permissions.PermissionsAPIClient, error) {
+	permissionsProviders.m.Lock()
+	defer permissionsProviders.m.Unlock()
+
+	if c, ok := permissionsProviders.conn[endpoint]; ok {
+		return c.(permissions.PermissionsAPIClient), nil
+	}
+
+	conn, err := NewConn(endpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	v := permissions.NewPermissionsAPIClient(conn)
+	permissionsProviders.conn[endpoint] = v
 	return v, nil
 }
 

--- a/pkg/storage/fs/nextcloud/nextcloud.go
+++ b/pkg/storage/fs/nextcloud/nextcloud.go
@@ -783,7 +783,7 @@ func (nc *StorageDriver) Unlock(ctx context.Context, ref *provider.Reference) er
 }
 
 // ListStorageSpaces as defined in the storage.FS interface
-func (nc *StorageDriver) ListStorageSpaces(ctx context.Context, f []*provider.ListStorageSpacesRequest_Filter, _ map[string]struct{}) ([]*provider.StorageSpace, error) {
+func (nc *StorageDriver) ListStorageSpaces(ctx context.Context, f []*provider.ListStorageSpacesRequest_Filter) ([]*provider.StorageSpace, error) {
 	bodyStr, _ := json.Marshal(f)
 	_, respBody, err := nc.do(ctx, Action{"ListStorageSpaces", string(bodyStr)})
 	if err != nil {

--- a/pkg/storage/fs/nextcloud/nextcloud_test.go
+++ b/pkg/storage/fs/nextcloud/nextcloud_test.go
@@ -987,7 +987,7 @@ var _ = Describe("Nextcloud", func() {
 				},
 			}
 			filters := []*provider.ListStorageSpacesRequest_Filter{filter1, filter2, filter3}
-			spaces, err := nc.ListStorageSpaces(ctx, filters, nil)
+			spaces, err := nc.ListStorageSpaces(ctx, filters)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(len(spaces)).To(Equal(1))
 			// https://github.com/cs3org/go-cs3apis/blob/970eec3/cs3/storage/provider/v1beta1/resources.pb.go#L1341-L1366

--- a/pkg/storage/fs/owncloud/owncloud.go
+++ b/pkg/storage/fs/owncloud/owncloud.go
@@ -2255,7 +2255,7 @@ func (fs *ocfs) RestoreRecycleItem(ctx context.Context, basePath, key, relativeP
 	return fs.propagate(ctx, tgt)
 }
 
-func (fs *ocfs) ListStorageSpaces(ctx context.Context, filter []*provider.ListStorageSpacesRequest_Filter, _ map[string]struct{}) ([]*provider.StorageSpace, error) {
+func (fs *ocfs) ListStorageSpaces(ctx context.Context, filter []*provider.ListStorageSpacesRequest_Filter) ([]*provider.StorageSpace, error) {
 	return nil, errtypes.NotSupported("list storage spaces")
 }
 

--- a/pkg/storage/fs/owncloudsql/owncloudsql.go
+++ b/pkg/storage/fs/owncloudsql/owncloudsql.go
@@ -1950,7 +1950,7 @@ func (fs *owncloudsqlfs) HashFile(path string) (string, string, string, error) {
 	}
 }
 
-func (fs *owncloudsqlfs) ListStorageSpaces(ctx context.Context, filter []*provider.ListStorageSpacesRequest_Filter, _ map[string]struct{}) ([]*provider.StorageSpace, error) {
+func (fs *owncloudsqlfs) ListStorageSpaces(ctx context.Context, filter []*provider.ListStorageSpacesRequest_Filter) ([]*provider.StorageSpace, error) {
 	// TODO(corby): Implement
 	return nil, errtypes.NotSupported("list storage spaces")
 }

--- a/pkg/storage/fs/s3/s3.go
+++ b/pkg/storage/fs/s3/s3.go
@@ -702,7 +702,7 @@ func (fs *s3FS) RestoreRecycleItem(ctx context.Context, basePath, key, relativeP
 	return errtypes.NotSupported("restore recycle")
 }
 
-func (fs *s3FS) ListStorageSpaces(ctx context.Context, filter []*provider.ListStorageSpacesRequest_Filter, _ map[string]struct{}) ([]*provider.StorageSpace, error) {
+func (fs *s3FS) ListStorageSpaces(ctx context.Context, filter []*provider.ListStorageSpacesRequest_Filter) ([]*provider.StorageSpace, error) {
 	return nil, errtypes.NotSupported("list storage spaces")
 }
 

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -62,7 +62,7 @@ type FS interface {
 	GetLock(ctx context.Context, ref *provider.Reference) (*provider.Lock, error)
 	RefreshLock(ctx context.Context, ref *provider.Reference, lock *provider.Lock) error
 	Unlock(ctx context.Context, ref *provider.Reference) error
-	ListStorageSpaces(ctx context.Context, filter []*provider.ListStorageSpacesRequest_Filter, permissions map[string]struct{}) ([]*provider.StorageSpace, error)
+	ListStorageSpaces(ctx context.Context, filter []*provider.ListStorageSpacesRequest_Filter) ([]*provider.StorageSpace, error)
 	CreateStorageSpace(ctx context.Context, req *provider.CreateStorageSpaceRequest) (*provider.CreateStorageSpaceResponse, error)
 	UpdateStorageSpace(ctx context.Context, req *provider.UpdateStorageSpaceRequest) (*provider.UpdateStorageSpaceResponse, error)
 }

--- a/pkg/storage/utils/decomposedfs/decomposedfs.go
+++ b/pkg/storage/utils/decomposedfs/decomposedfs.go
@@ -39,6 +39,7 @@ import (
 	ctxpkg "github.com/cs3org/reva/pkg/ctx"
 	"github.com/cs3org/reva/pkg/errtypes"
 	"github.com/cs3org/reva/pkg/logger"
+	"github.com/cs3org/reva/pkg/sharedconf"
 	"github.com/cs3org/reva/pkg/storage"
 	"github.com/cs3org/reva/pkg/storage/utils/chunking"
 	"github.com/cs3org/reva/pkg/storage/utils/decomposedfs/node"
@@ -101,6 +102,8 @@ func NewDefault(m map[string]interface{}, bs tree.Blobstore) (storage.FS, error)
 	lu.Options = o
 
 	tp := tree.New(o.Root, o.TreeTimeAccounting, o.TreeSizeAccounting, lu, bs)
+
+	o.GatewayAddr = sharedconf.GetGatewaySVC(o.GatewayAddr)
 	return New(o, lu, p, tp)
 }
 

--- a/pkg/storage/utils/decomposedfs/options/options.go
+++ b/pkg/storage/utils/decomposedfs/options/options.go
@@ -53,6 +53,8 @@ type Options struct {
 	Owner     string `mapstructure:"owner"`
 	OwnerIDP  string `mapstructure:"owner_idp"`
 	OwnerType string `mapstructure:"owner_type"`
+
+	GatewayAddr string `mapstructure:"gateway_addr"`
 }
 
 // New returns a new Options instance for the given configuration

--- a/pkg/storage/utils/eosfs/eosfs.go
+++ b/pkg/storage/utils/eosfs/eosfs.go
@@ -1628,7 +1628,7 @@ func (fs *eosfs) RestoreRecycleItem(ctx context.Context, basePath, key, relative
 	return fs.c.RestoreDeletedEntry(ctx, auth, key)
 }
 
-func (fs *eosfs) ListStorageSpaces(ctx context.Context, filter []*provider.ListStorageSpacesRequest_Filter, _ map[string]struct{}) ([]*provider.StorageSpace, error) {
+func (fs *eosfs) ListStorageSpaces(ctx context.Context, filter []*provider.ListStorageSpacesRequest_Filter) ([]*provider.StorageSpace, error) {
 	return nil, errtypes.NotSupported("list storage spaces")
 }
 

--- a/pkg/storage/utils/localfs/localfs.go
+++ b/pkg/storage/utils/localfs/localfs.go
@@ -1286,7 +1286,7 @@ func (fs *localfs) RestoreRecycleItem(ctx context.Context, basePath, key, relati
 	return fs.propagate(ctx, localRestorePath)
 }
 
-func (fs *localfs) ListStorageSpaces(ctx context.Context, filter []*provider.ListStorageSpacesRequest_Filter, _ map[string]struct{}) ([]*provider.StorageSpace, error) {
+func (fs *localfs) ListStorageSpaces(ctx context.Context, filter []*provider.ListStorageSpacesRequest_Filter) ([]*provider.StorageSpace, error) {
 	return nil, errtypes.NotSupported("list storage spaces")
 }
 

--- a/tests/oc-integration-tests/drone/frontend.toml
+++ b/tests/oc-integration-tests/drone/frontend.toml
@@ -59,6 +59,7 @@ files_namespace = "/users"
 webdav_namespace = "/home"
 
 [http.services.ocs]
+storage_registry_svc = "localhost:19000"
 
 [http.services.ocs.capabilities.capabilities.core.status]
 version = "10.0.11.5"

--- a/tests/oc-integration-tests/drone/frontend.toml
+++ b/tests/oc-integration-tests/drone/frontend.toml
@@ -59,7 +59,6 @@ files_namespace = "/users"
 webdav_namespace = "/home"
 
 [http.services.ocs]
-storage_registry_svc = "localhost:19000"
 
 [http.services.ocs.capabilities.capabilities.core.status]
 version = "10.0.11.5"

--- a/tests/oc-integration-tests/drone/gateway.toml
+++ b/tests/oc-integration-tests/drone/gateway.toml
@@ -30,6 +30,8 @@ ocmcoresvc = "localhost:14000"
 ocmshareprovidersvc = "localhost:14000"
 ocminvitemanagersvc = "localhost:14000"
 ocmproviderauthorizersvc = "localhost:14000"
+# permissions
+permissionssvc = "localhost:10000"
 # other
 commit_share_to_storage_grant = true
 commit_share_to_storage_ref = true

--- a/tests/oc-integration-tests/drone/permissions-ocis-ci.toml
+++ b/tests/oc-integration-tests/drone/permissions-ocis-ci.toml
@@ -1,0 +1,12 @@
+# This config file will start a reva service that:
+# - serves the ocis ci permissions service
+[shared]
+jwt_secret = "Pive-Fumkiu4"
+
+[grpc]
+address = "0.0.0.0:10000"
+
+[grpc.services.permissions]
+driver = "ocisci"
+
+[grpc.services.publicshareprovider.drivers.ocisci]

--- a/tests/oc-integration-tests/drone/permissions-ocis-ci.toml
+++ b/tests/oc-integration-tests/drone/permissions-ocis-ci.toml
@@ -7,6 +7,6 @@ jwt_secret = "Pive-Fumkiu4"
 address = "0.0.0.0:10000"
 
 [grpc.services.permissions]
-driver = "ocisci"
+driver = "demo"
 
 [grpc.services.publicshareprovider.drivers.ocisci]

--- a/tests/oc-integration-tests/drone/storage-home-ocis.toml
+++ b/tests/oc-integration-tests/drone/storage-home-ocis.toml
@@ -23,12 +23,14 @@ mount_id = "123e4567-e89b-12d3-a456-426655440000"
 expose_data_server = true
 data_server_url = "http://revad-services:12001/data"
 enable_home_creation = true
+gateway_addr = "0.0.0.0:19000"
 
 [grpc.services.storageprovider.drivers.ocis]
 root = "/drone/src/tmp/reva/data"
 enable_home = true
 treetime_accounting = true
 treesize_accounting = true
+gateway_addr = "0.0.0.0:19000"
 
 # we have a locally running dataprovider
 [http]

--- a/tests/oc-integration-tests/drone/storage-users-ocis.toml
+++ b/tests/oc-integration-tests/drone/storage-users-ocis.toml
@@ -19,12 +19,14 @@ mount_path = "/users"
 mount_id = "123e4567-e89b-12d3-a456-426655440000"
 expose_data_server = true
 data_server_url = "http://revad-services:11001/data"
+gateway_addr = "0.0.0.0:19000"
 
 [grpc.services.storageprovider.drivers.ocis]
 root = "/drone/src/tmp/reva/data"
 treetime_accounting = true
 treesize_accounting = true
 userprovidersvc = "localhost:18000"
+gateway_addr = "0.0.0.0:19000"
 
 # we have a locally running dataprovider
 [http]

--- a/tests/oc-integration-tests/local/frontend.toml
+++ b/tests/oc-integration-tests/local/frontend.toml
@@ -50,7 +50,6 @@ webdav_namespace = "/home"
 
 # serve /ocs which contains the sharing and user provisioning api of owncloud classic
 [http.services.ocs]
-storage_registry_svc = "localhost:19000"
 
 [http.services.ocs.capabilities.capabilities.core.status]
 version = "10.0.11.5"

--- a/tests/oc-integration-tests/local/frontend.toml
+++ b/tests/oc-integration-tests/local/frontend.toml
@@ -50,6 +50,7 @@ webdav_namespace = "/home"
 
 # serve /ocs which contains the sharing and user provisioning api of owncloud classic
 [http.services.ocs]
+storage_registry_svc = "localhost:19000"
 
 [http.services.ocs.capabilities.capabilities.core.status]
 version = "10.0.11.5"

--- a/tests/oc-integration-tests/local/gateway.toml
+++ b/tests/oc-integration-tests/local/gateway.toml
@@ -30,6 +30,8 @@ ocmcoresvc = "localhost:14000"
 ocmshareprovidersvc = "localhost:14000"
 ocminvitemanagersvc = "localhost:14000"
 ocmproviderauthorizersvc = "localhost:14000"
+# permissions
+permissionssvc = "localhost:10000"
 # other
 commit_share_to_storage_grant = true
 commit_share_to_storage_ref = true

--- a/tests/oc-integration-tests/local/permissions-ocis-ci.toml
+++ b/tests/oc-integration-tests/local/permissions-ocis-ci.toml
@@ -1,0 +1,12 @@
+# This config file will start a reva service that:
+# - serves the ocis ci permissions service
+[shared]
+jwt_secret = "Pive-Fumkiu4"
+
+[grpc]
+address = "0.0.0.0:10000"
+
+[grpc.services.permissions]
+driver = "ocisci"
+
+[grpc.services.publicshareprovider.drivers.ocisci]

--- a/tests/oc-integration-tests/local/permissions-ocis-ci.toml
+++ b/tests/oc-integration-tests/local/permissions-ocis-ci.toml
@@ -7,6 +7,6 @@ jwt_secret = "Pive-Fumkiu4"
 address = "0.0.0.0:10000"
 
 [grpc.services.permissions]
-driver = "ocisci"
+driver = "demo"
 
 [grpc.services.publicshareprovider.drivers.ocisci]

--- a/tests/oc-integration-tests/local/storage-home.toml
+++ b/tests/oc-integration-tests/local/storage-home.toml
@@ -30,6 +30,7 @@ root = "/var/tmp/reva/data"
 enable_home = true
 treetime_accounting = true
 treesize_accounting = true
+gateway_addr = "0.0.0.0:19000"
 #user_layout = 
 # do we need owner for users?
 #owner = 95cb8724-03b2-11eb-a0a6-c33ef8ef53ad 

--- a/tests/oc-integration-tests/local/storage-users.toml
+++ b/tests/oc-integration-tests/local/storage-users.toml
@@ -38,3 +38,4 @@ root = "/var/tmp/reva/data"
 enable_home = false
 treetime_accounting = true
 treesize_accounting = true
+gateway_addr = "0.0.0.0:19000"


### PR DESCRIPTION
This PR is part of the introduction of the permissions API to the CS3 APIs.
It demonstrates the usage of the permissions API for the use case `ListStorageSpaces`. A user with the permission `list-all-spaces` should be able to see all spaces. 