### PR TITLE
allow multiple space type filters on decomposedfs

### DIFF
--- a/changelog/unreleased/decomposedfs-allow-multiple-space-type-filters.md
+++ b/changelog/unreleased/decomposedfs-allow-multiple-space-type-filters.md
@@ -1,0 +1,5 @@
+Enhancement: Allow multiple space type fileters on decomposedfs
+
+The decomposedfs driver now evaluates multiple space type filters when listing storage spaces.
+
+https://github.com/cs3org/reva/pull/2343


### PR DESCRIPTION
The decomposedfs driver now evaluates multiple space type filters when listing storage spaces.
