### PR TITLE
allow listing all storage spaces

### DIFF
--- a/changelog/unreleased/spaces-registry-allow-list-all.md
+++ b/changelog/unreleased/spaces-registry-allow-list-all.md
@@ -1,5 +1,5 @@
 Enhancement: allow listing all storage spaces
 
-To implement the drives api we allow listing all spaces by sending a spaceid `*!*`. This is a workaround until a proper filter to list all storage spaces a user has access to / can manage is implemented, or we make that the implicit default filter.
+To implement the drives api we now list all spaces when no filter is given. The Provider info will not contain any spaces as the client is responsible for looking up the spaces.
 
 https://github.com/cs3org/reva/pull/2344

--- a/changelog/unreleased/spaces-registry-allow-list-all.md
+++ b/changelog/unreleased/spaces-registry-allow-list-all.md
@@ -1,0 +1,5 @@
+Enhancement: allow listing all storage spaces
+
+To implement the drives api we allow listing all spaces by sending a spaceid `*!*`. This is a workaround until a proper filter to list all storage spaces a user has access to / can manage is implemented, or we make that the implicit default filter.
+
+https://github.com/cs3org/reva/pull/2344

--- a/pkg/storage/registry/spaces/spaces_test.go
+++ b/pkg/storage/registry/spaces/spaces_test.go
@@ -37,7 +37,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("Static", func() {
+var _ = Describe("Spaces", func() {
 	var (
 		handler   storage.Registry
 		ctxAlice  context.Context
@@ -278,11 +278,11 @@ var _ = Describe("Static", func() {
 		})
 
 		Describe("ListProviders", func() {
-			It("returns an empty list when no filters are set", func() {
+			It("returns all providers when no filter is set", func() {
 				filters := map[string]string{}
 				providers, err := handler.ListProviders(ctxAlice, filters)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(len(providers)).To(Equal(0))
+				Expect(len(providers)).To(Equal(3))
 			})
 
 			It("filters by path", func() {


### PR DESCRIPTION
To implement the drives api we now listing all spaces when no filter is given. The Provider info will not contain any spaces as the client is responsible for looking up the spaces.

@aduffeck @kobergj @C0rby this really starts getting ugly because it starts to tap into the permission system. I'd like to discuss how to proceed.
