### PR TITLE
Switch LDAP test to use entryUUID as unique id for groups

### DIFF
--- a/changelog/unreleased/ldap-group-id.md
+++ b/changelog/unreleased/ldap-group-id.md
@@ -1,0 +1,6 @@
+Enhancement: Don't assume that the LDAP groupid in reva matches the name
+
+This allows using attributes like e.g. `entryUUID` or any custom id attribute
+as the id for groups.
+
+https://github.com/cs3org/reva/pull/2345

--- a/pkg/group/manager/ldap/ldap.go
+++ b/pkg/group/manager/ldap/ldap.go
@@ -311,7 +311,7 @@ func (m *manager) GetMembers(ctx context.Context, gid *grouppb.GroupId) ([]*user
 		m.c.BaseDN,
 		ldap.ScopeWholeSubtree, ldap.NeverDerefAliases, 0, 0, false,
 		m.getMemberFilter(gid),
-		[]string{m.c.Schema.CN}, // TODO use DN to look up user id
+		[]string{m.c.Schema.GID}, // TODO use DN to look up user id
 		nil,
 	)
 

--- a/pkg/user/manager/ldap/ldap.go
+++ b/pkg/user/manager/ldap/ldap.go
@@ -75,6 +75,8 @@ type attributes struct {
 	UIDNumber string `mapstructure:"uidNumber"`
 	// GIDNumber is a numeric id that maps to a filesystem gid, eg. 654321
 	GIDNumber string `mapstructure:"gidNumber"`
+	// GID is an immutable group id
+	GID string `mapstructure:"gid"`
 }
 
 // Default attributes (Active Directory)
@@ -86,6 +88,7 @@ var ldapDefaults = attributes{
 	DisplayName: "displayName",
 	UIDNumber:   "uidNumber",
 	GIDNumber:   "gidNumber",
+	GID:         "cn",
 }
 
 func parseConfig(m map[string]interface{}) (*config, error) {
@@ -392,7 +395,7 @@ func (m *manager) getLDAPUserGroups(ctx context.Context, conn *ldap.Conn, userEn
 		m.c.BaseDN,
 		ldap.ScopeWholeSubtree, ldap.NeverDerefAliases, 0, 0, false,
 		m.getGroupFilter(username),
-		[]string{m.c.Schema.CN}, // TODO use DN to look up group id
+		[]string{m.c.Schema.GID}, // TODO use DN to look up group id
 		nil,
 	)
 
@@ -407,7 +410,7 @@ func (m *manager) getLDAPUserGroups(ctx context.Context, conn *ldap.Conn, userEn
 		// FIXME this makes the users groups use the cn, not an immutable id
 		// FIXME 1. use the memberof or members attribute of a user to get the groups
 		// FIXME 2. ook up the id for each group
-		groups = append(groups, entry.GetEqualFoldAttributeValue(m.c.Schema.CN))
+		groups = append(groups, entry.GetEqualFoldAttributeValue(m.c.Schema.GID))
 	}
 	return groups, nil
 }

--- a/tests/oc-integration-tests/drone/ldap-users.toml
+++ b/tests/oc-integration-tests/drone/ldap-users.toml
@@ -47,6 +47,7 @@ uid="entryuuid"
 displayName="displayName"
 dn="dn"
 cn="cn"
+gid="entryuuid"
 
 [grpc.services.groupprovider]
 driver = "ldap"
@@ -56,16 +57,16 @@ hostname="ldap"
 port=636
 insecure=true
 base_dn="dc=owncloud,dc=com"
-groupfilter="(&(objectclass=posixGroup)(|(gid={{.OpaqueId}})(cn={{.OpaqueId}})))"
+groupfilter="(&(objectclass=posixGroup)(|(entryuuid={{.OpaqueId}})(cn={{.OpaqueId}})))"
 findfilter="(&(objectclass=posixGroup)(|(cn={{query}}*)(displayname={{query}}*)(mail={{query}}*)))"
 attributefilter="(&(objectclass=posixGroup)({{attr}}={{value}}))"
-memberfilter="(&(objectclass=posixAccount)(cn={{.OpaqueId}}))"
+memberfilter="(&(objectclass=posixAccount)(entryuuid={{.OpaqueId}}))"
 bind_username="cn=admin,dc=owncloud,dc=com"
 bind_password="admin"
 idp="http://localhost:20080"
 
 [grpc.services.groupprovider.drivers.ldap.schema]
-gid="cn"
+gid="entryuuid"
 displayName="cn"
 dn="dn"
 cn="cn"

--- a/tests/oc-integration-tests/local-mesh/ldap-users.toml
+++ b/tests/oc-integration-tests/local-mesh/ldap-users.toml
@@ -48,6 +48,7 @@ uid="uid"
 displayName="displayName"
 dn="dn"
 cn="cn"
+gid="entryuuid"
 
 [grpc.services.groupprovider]
 driver = "ldap"
@@ -57,16 +58,16 @@ hostname="localhost"
 port=636
 insecure=true
 base_dn="dc=owncloud,dc=com"
-groupfilter="(&(objectclass=posixGroup)(|(gid={{.OpaqueId}})(cn={{.OpaqueId}})))"
+groupfilter="(&(objectclass=posixGroup)(|(entryuuid={{.OpaqueId}})(cn={{.OpaqueId}})))"
 findfilter="(&(objectclass=posixGroup)(|(cn={{query}}*)(displayname={{query}}*)(mail={{query}}*)))"
 attributefilter="(&(objectclass=posixGroup)({{attr}}={{value}}))"
-memberfilter="(&(objectclass=posixAccount)(cn={{.OpaqueId}}))"
+memberfilter="(&(objectclass=posixAccount)(entryuuid={{.OpaqueId}}))"
 bind_username="cn=admin,dc=owncloud,dc=com"
 bind_password="admin"
 idp="http://localhost:40080"
 
 [grpc.services.groupprovider.drivers.ldap.schema]
-gid="cn"
+gid="entryuuid"
 displayName="cn"
 dn="dn"
 cn="cn"

--- a/tests/oc-integration-tests/local/ldap-users.toml
+++ b/tests/oc-integration-tests/local/ldap-users.toml
@@ -51,6 +51,7 @@ uid="entryuuid"
 displayName="displayName"
 dn="dn"
 cn="cn"
+gid="entryuuid"
 
 [grpc.services.groupprovider]
 driver = "ldap"
@@ -60,16 +61,16 @@ hostname="openldap"
 port=636
 insecure=true
 base_dn="dc=owncloud,dc=com"
-groupfilter="(&(objectclass=posixGroup)(|(gid={{.OpaqueId}})(cn={{.OpaqueId}})))"
+groupfilter="(&(objectclass=posixGroup)(|(entryuuid={{.OpaqueId}})(cn={{.OpaqueId}})))"
 findfilter="(&(objectclass=posixGroup)(|(cn={{query}}*)(displayname={{query}}*)(mail={{query}}*)))"
 attributefilter="(&(objectclass=posixGroup)({{attr}}={{value}}))"
-memberfilter="(&(objectclass=posixAccount)(cn={{.OpaqueId}}))"
+memberfilter="(&(objectclass=posixAccount)(entryuuid={{.OpaqueId}}))"
 bind_username="cn=admin,dc=owncloud,dc=com"
 bind_password="admin"
 idp="http://localhost:20080"
 
 [grpc.services.groupprovider.drivers.ldap.schema]
-gid="cn"
+gid="entryuuid"
 displayName="cn"
 dn="dn"
 cn="cn"


### PR DESCRIPTION
The entryUUID attribute is generated by the LDAP server. By using this
me can make sure that a group gets a different IDs with every
test. So that we can avoid setting DELETE_USER_DATA_CMD to delete
the USER data after each test in the long run.

Also fix the user- and group-providers to use the correct attribute
mapping when searching for groups by id (was using CN in some places)