### PR TITLE
Parse URL path to determine file name

### DIFF
--- a/changelog/unreleased/fix-content-disposition.md
+++ b/changelog/unreleased/fix-content-disposition.md
@@ -3,3 +3,4 @@ Bugfix: Fix content disposition header for public links files
 https://github.com/cs3org/reva/pull/2303
 https://github.com/cs3org/reva/pull/2297
 https://github.com/cs3org/reva/pull/2332
+https://github.com/cs3org/reva/pull/2346

--- a/docs/content/en/docs/config/packages/auth/manager/oidcmapping/_index.md
+++ b/docs/content/en/docs/config/packages/auth/manager/oidcmapping/_index.md
@@ -1,0 +1,66 @@
+---
+title: "oidcmapping"
+linkTitle: "oidcmapping"
+weight: 10
+description: >
+  Configuration for the oidcmapping service
+---
+
+# _struct: config_
+
+{{% dir name="insecure" type="bool" default=false %}}
+Whether to skip certificate checks when sending requests. [[Ref]](https://github.com/cs3org/reva/tree/master/pkg/auth/manager/oidcmapping/oidcmapping.go#L57)
+{{< highlight toml >}}
+[auth.manager.oidcmapping]
+insecure = false
+{{< /highlight >}}
+{{% /dir %}}
+
+{{% dir name="issuer" type="string" default="" %}}
+The issuer of the OIDC token. [[Ref]](https://github.com/cs3org/reva/tree/master/pkg/auth/manager/oidcmapping/oidcmapping.go#L58)
+{{< highlight toml >}}
+[auth.manager.oidcmapping]
+issuer = ""
+{{< /highlight >}}
+{{% /dir %}}
+
+{{% dir name="id_claim" type="string" default="sub" %}}
+The claim containing the ID of the user. [[Ref]](https://github.com/cs3org/reva/tree/master/pkg/auth/manager/oidcmapping/oidcmapping.go#L59)
+{{< highlight toml >}}
+[auth.manager.oidcmapping]
+id_claim = "sub"
+{{< /highlight >}}
+{{% /dir %}}
+
+{{% dir name="uid_claim" type="string" default="" %}}
+The claim containing the UID of the user. [[Ref]](https://github.com/cs3org/reva/tree/master/pkg/auth/manager/oidcmapping/oidcmapping.go#L60)
+{{< highlight toml >}}
+[auth.manager.oidcmapping]
+uid_claim = ""
+{{< /highlight >}}
+{{% /dir %}}
+
+{{% dir name="gid_claim" type="string" default="" %}}
+The claim containing the GID of the user. [[Ref]](https://github.com/cs3org/reva/tree/master/pkg/auth/manager/oidcmapping/oidcmapping.go#L61)
+{{< highlight toml >}}
+[auth.manager.oidcmapping]
+gid_claim = ""
+{{< /highlight >}}
+{{% /dir %}}
+
+{{% dir name="userprovidersvc" type="string" default="" %}}
+The endpoint at which the GRPC userprovider is exposed. [[Ref]](https://github.com/cs3org/reva/tree/master/pkg/auth/manager/oidcmapping/oidcmapping.go#L62)
+{{< highlight toml >}}
+[auth.manager.oidcmapping]
+userprovidersvc = ""
+{{< /highlight >}}
+{{% /dir %}}
+
+{{% dir name="usersmapping" type="string" default="" %}}
+ The OIDC users mapping file path [[Ref]](https://github.com/cs3org/reva/tree/master/pkg/auth/manager/oidcmapping/oidcmapping.go#L63)
+{{< highlight toml >}}
+[auth.manager.oidcmapping]
+usersmapping = ""
+{{< /highlight >}}
+{{% /dir %}}
+

--- a/internal/http/services/owncloud/ocdav/get.go
+++ b/internal/http/services/owncloud/ocdav/get.go
@@ -124,7 +124,7 @@ func (s *svc) handleGet(ctx context.Context, w http.ResponseWriter, r *http.Requ
 
 	w.Header().Set(HeaderContentType, info.MimeType)
 	w.Header().Set(HeaderContentDisposistion, "attachment; filename*=UTF-8''"+
-		path.Base(r.RequestURI)+"; filename=\""+path.Base(r.RequestURI)+"\"")
+		path.Base(r.URL.Path)+"; filename=\""+path.Base(r.URL.Path)+"\"")
 	w.Header().Set(HeaderETag, info.Etag)
 	w.Header().Set(HeaderOCFileID, wrapResourceID(info.Id))
 	w.Header().Set(HeaderOCETag, info.Etag)


### PR DESCRIPTION
When URL signing is not supported, download requests can look like `GET /remote.php/webdav/.../file.txt?access_token=xyz`, resulting in the downloaded file having the name `file.txt?access_token=xyz`