### PR TITLE
fix-archiver

### DIFF
--- a/changelog/unreleased/fix-archiver.md
+++ b/changelog/unreleased/fix-archiver.md
@@ -1,0 +1,5 @@
+Bugfix: make archiver handle spaces protocol
+
+The archiver can now handle the spaces protocol
+
+https://github.com/cs3org/reva/pull/2348

--- a/pkg/storage/utils/downloader/downloader.go
+++ b/pkg/storage/utils/downloader/downloader.go
@@ -77,7 +77,10 @@ func (r *revaDownloader) Download(ctx context.Context, path string, dst io.Write
 
 	p, err := getDownloadProtocol(downResp.Protocols, "simple")
 	if err != nil {
-		return err
+		p, err = getDownloadProtocol(downResp.Protocols, "spaces")
+		if err != nil {
+			return err
+		}
 	}
 
 	httpReq, err := rhttp.NewRequest(ctx, http.MethodGet, p.DownloadEndpoint, nil)


### PR DESCRIPTION
The archiver can now handle the spaces protocol. The ocis testsuite caught this one in https://drone.owncloud.com/owncloud/ocis/8266/21/6