### PR TITLE
Log traces only when these are available

### DIFF
--- a/changelog/unreleased/fix-traces-logging.md
+++ b/changelog/unreleased/fix-traces-logging.md
@@ -1,0 +1,5 @@
+Bugfix: If a trace is not available do not log default trace value
+
+Prevent from logging `traceid=0000000000000000` if there is no traceid for the given span.
+
+https://github.com/cs3org/reva/pull/2352

--- a/internal/grpc/interceptors/appctx/appctx.go
+++ b/internal/grpc/interceptors/appctx/appctx.go
@@ -81,11 +81,8 @@ func (ss *wrappedServerStream) Context() context.Context {
 }
 
 func getTraceIDFromSpan(span trace.Span) string {
-	traceID := ""
-	if span.SpanContext().TraceID() == [16]byte{} {
-		traceID = ""
-	} else {
-		traceID = span.SpanContext().TraceID().String()
+	if span.SpanContext().TraceID() != [16]byte{} {
+		return span.SpanContext().TraceID().String()
 	}
-	return traceID
+	return ""
 }

--- a/internal/grpc/interceptors/appctx/appctx.go
+++ b/internal/grpc/interceptors/appctx/appctx.go
@@ -81,8 +81,8 @@ func (ss *wrappedServerStream) Context() context.Context {
 }
 
 func getTraceIDFromSpan(span trace.Span) string {
-	if span.SpanContext().TraceID() != [16]byte{} {
-		return span.SpanContext().TraceID().String()
+	if b := span.SpanContext().TraceID(); b != [16]byte{} {
+		return b.String()
 	}
 	return ""
 }

--- a/internal/grpc/services/appregistry/appregistry_test.go
+++ b/internal/grpc/services/appregistry/appregistry_test.go
@@ -76,7 +76,7 @@ func Test_ListAppProviders(t *testing.T) {
 			want: &registrypb.ListAppProvidersResponse{
 				Status: &rpcv1beta1.Status{
 					Code:    1,
-					Trace:   "00000000000000000000000000000000",
+					Trace:   "",
 					Message: "",
 				},
 				Providers: []*registrypb.ProviderInfo{
@@ -98,7 +98,7 @@ func Test_ListAppProviders(t *testing.T) {
 			want: &registrypb.ListAppProvidersResponse{
 				Status: &rpcv1beta1.Status{
 					Code:  1,
-					Trace: "00000000000000000000000000000000",
+					Trace: "",
 				},
 				Providers: []*registrypb.ProviderInfo{},
 			},
@@ -112,7 +112,7 @@ func Test_ListAppProviders(t *testing.T) {
 			want: &registrypb.ListAppProvidersResponse{
 				Status: &rpcv1beta1.Status{
 					Code:    1,
-					Trace:   "00000000000000000000000000000000",
+					Trace:   "",
 					Message: "",
 				},
 				Providers: []*registrypb.ProviderInfo{},
@@ -218,7 +218,7 @@ func Test_GetAppProviders(t *testing.T) {
 			want: &registrypb.GetAppProvidersResponse{
 				Status: &rpcv1beta1.Status{
 					Code:    1,
-					Trace:   "00000000000000000000000000000000",
+					Trace:   "",
 					Message: "",
 				},
 				Providers: []*registrypb.ProviderInfo{
@@ -235,7 +235,7 @@ func Test_GetAppProviders(t *testing.T) {
 			want: &registrypb.GetAppProvidersResponse{
 				Status: &rpcv1beta1.Status{
 					Code:    1,
-					Trace:   "00000000000000000000000000000000",
+					Trace:   "",
 					Message: "",
 				},
 				Providers: []*registrypb.ProviderInfo{
@@ -252,7 +252,7 @@ func Test_GetAppProviders(t *testing.T) {
 			want: &registrypb.GetAppProvidersResponse{
 				Status: &rpcv1beta1.Status{
 					Code:    15,
-					Trace:   "00000000000000000000000000000000",
+					Trace:   "",
 					Message: "error looking for the app provider",
 				},
 				Providers: nil,
@@ -264,7 +264,7 @@ func Test_GetAppProviders(t *testing.T) {
 			want: &registrypb.GetAppProvidersResponse{
 				Status: &rpcv1beta1.Status{
 					Code:    15,
-					Trace:   "00000000000000000000000000000000",
+					Trace:   "",
 					Message: "error looking for the app provider",
 				},
 				Providers: nil,
@@ -276,7 +276,7 @@ func Test_GetAppProviders(t *testing.T) {
 			want: &registrypb.GetAppProvidersResponse{
 				Status: &rpcv1beta1.Status{
 					Code:    15,
-					Trace:   "00000000000000000000000000000000",
+					Trace:   "",
 					Message: "error looking for the app provider",
 				},
 				Providers: nil,
@@ -288,7 +288,7 @@ func Test_GetAppProviders(t *testing.T) {
 			want: &registrypb.GetAppProvidersResponse{
 				Status: &rpcv1beta1.Status{
 					Code:    15,
-					Trace:   "00000000000000000000000000000000",
+					Trace:   "",
 					Message: "error looking for the app provider",
 				},
 				Providers: nil,

--- a/internal/http/interceptors/appctx/appctx.go
+++ b/internal/http/interceptors/appctx/appctx.go
@@ -49,9 +49,19 @@ func handler(log zerolog.Logger, h http.Handler) http.Handler {
 			ctx, span = rtrace.Provider.Tracer("http").Start(ctx, "http interceptor")
 		}
 
-		sub := log.With().Str("traceid", span.SpanContext().TraceID().String()).Logger()
+		sub := log.With().Str("traceid", getTraceIDFromSpan(span)).Logger()
 		ctx = appctx.WithLogger(ctx, &sub)
 		r = r.WithContext(ctx)
 		h.ServeHTTP(w, r)
 	})
+}
+
+func getTraceIDFromSpan(span trace.Span) string {
+	traceID := ""
+	if span.SpanContext().TraceID() == [16]byte{} {
+		traceID = ""
+	} else {
+		traceID = span.SpanContext().TraceID().String()
+	}
+	return traceID
 }

--- a/internal/http/interceptors/appctx/appctx.go
+++ b/internal/http/interceptors/appctx/appctx.go
@@ -57,8 +57,8 @@ func handler(log zerolog.Logger, h http.Handler) http.Handler {
 }
 
 func getTraceIDFromSpan(span trace.Span) string {
-	if span.SpanContext().TraceID() != [16]byte{} {
-		return span.SpanContext().TraceID().String()
+	if b := span.SpanContext().TraceID(); b != [16]byte{} {
+		return b.String()
 	}
 
 	return ""

--- a/internal/http/interceptors/appctx/appctx.go
+++ b/internal/http/interceptors/appctx/appctx.go
@@ -57,11 +57,9 @@ func handler(log zerolog.Logger, h http.Handler) http.Handler {
 }
 
 func getTraceIDFromSpan(span trace.Span) string {
-	traceID := ""
-	if span.SpanContext().TraceID() == [16]byte{} {
-		traceID = ""
-	} else {
-		traceID = span.SpanContext().TraceID().String()
+	if span.SpanContext().TraceID() != [16]byte{} {
+		return span.SpanContext().TraceID().String()
 	}
-	return traceID
+
+	return ""
 }

--- a/pkg/rgrpc/status/status.go
+++ b/pkg/rgrpc/status/status.go
@@ -204,5 +204,9 @@ func NewErrorFromCode(code rpc.Code, pkgname string) error {
 // internal function to attach the trace to a context
 func getTrace(ctx context.Context) string {
 	span := trace.SpanFromContext(ctx)
+	if span.SpanContext().TraceID() == [16]byte{} {
+		return ""
+	}
+
 	return span.SpanContext().TraceID().String()
 }

--- a/pkg/rgrpc/status/status.go
+++ b/pkg/rgrpc/status/status.go
@@ -204,8 +204,8 @@ func NewErrorFromCode(code rpc.Code, pkgname string) error {
 // internal function to attach the trace to a context
 func getTrace(ctx context.Context) string {
 	span := trace.SpanFromContext(ctx)
-	if span.SpanContext().TraceID() != [16]byte{} {
-		return span.SpanContext().TraceID().String()
+	if b := span.SpanContext().TraceID(); b != [16]byte{} {
+		return b.String()
 	}
 
 	return ""

--- a/pkg/rgrpc/status/status.go
+++ b/pkg/rgrpc/status/status.go
@@ -204,9 +204,9 @@ func NewErrorFromCode(code rpc.Code, pkgname string) error {
 // internal function to attach the trace to a context
 func getTrace(ctx context.Context) string {
 	span := trace.SpanFromContext(ctx)
-	if span.SpanContext().TraceID() == [16]byte{} {
-		return ""
+	if span.SpanContext().TraceID() != [16]byte{} {
+		return span.SpanContext().TraceID().String()
 	}
 
-	return span.SpanContext().TraceID().String()
+	return ""
 }


### PR DESCRIPTION
Prevent from logging `traceid=0000000000000000`. Now logs would appear as:

![image](https://user-images.githubusercontent.com/6905948/145593715-2380d95d-62f7-490b-84ea-85f4fa59916a.png)


when traces are enabled, then the output looks like:

![image](https://user-images.githubusercontent.com/6905948/145593763-acc4ffd3-62e3-42f1-9a7d-3598a5983944.png)

as god intended.