### PR TITLE
reduce logging output

### DIFF
--- a/changelog/unreleased/reduce-log-output.md
+++ b/changelog/unreleased/reduce-log-output.md
@@ -1,0 +1,6 @@
+Change: Reduce log output
+
+Reduced log output. Some errors or warnings were logged multiple times or even unnecesarily. 
+
+
+https://github.com/cs3org/reva/pull/2353

--- a/internal/grpc/interceptors/auth/auth.go
+++ b/internal/grpc/interceptors/auth/auth.go
@@ -242,7 +242,7 @@ func dismantleToken(ctx context.Context, tkn string, req interface{}, mgr token.
 func getUserGroups(ctx context.Context, u *userpb.User, client gatewayv1beta1.GatewayAPIClient) ([]string, error) {
 	if groupsIf, err := userGroupsCache.Get(u.Id.OpaqueId); err == nil {
 		log := appctx.GetLogger(ctx)
-		log.Info().Msgf("user groups found in cache %s", u.Id.OpaqueId)
+		log.Info().Str("userid", u.Id.OpaqueId).Msg("user groups found in cache")
 		return groupsIf.([]string), nil
 	}
 

--- a/internal/grpc/interceptors/auth/scope.go
+++ b/internal/grpc/interceptors/auth/scope.go
@@ -63,7 +63,7 @@ func expandAndVerifyScope(ctx context.Context, req interface{}, tokenScope map[s
 		// trying to impersonate the owner, since the share manager doesn't know the
 		// share path.
 		if ref.GetPath() != "" {
-			log.Info().Msgf("resolving path reference to ID to check token scope %+v", ref.GetPath())
+			log.Info().Str("path", ref.GetPath()).Msg("resolving path reference to ID to check token scope")
 			for k := range tokenScope {
 				switch {
 				case strings.HasPrefix(k, "publicshare"):
@@ -138,7 +138,7 @@ func expandAndVerifyScope(ctx context.Context, req interface{}, tokenScope map[s
 		// It's a share ref
 		// The request might be coming from a share created for a lightweight account
 		// after the token was minted.
-		log.Info().Msgf("resolving share reference against received shares to verify token scope %+v", ref)
+		log.Info().Interface("reference", ref).Msg("resolving share reference against received shares to verify token scope")
 		client, err := pool.GetGatewayServiceClient(gatewayAddr)
 		if err != nil {
 			return err

--- a/internal/grpc/services/applicationauth/applicationauth.go
+++ b/internal/grpc/services/applicationauth/applicationauth.go
@@ -106,7 +106,7 @@ func (s *service) GenerateAppPassword(ctx context.Context, req *appauthpb.Genera
 	pwd, err := s.am.GenerateAppPassword(ctx, req.TokenScope, req.Label, req.Expiration)
 	if err != nil {
 		return &appauthpb.GenerateAppPasswordResponse{
-			Status: status.NewInternal(ctx, err, "error generating app password"),
+			Status: status.NewInternal(ctx, "error generating app password"),
 		}, nil
 	}
 
@@ -120,7 +120,7 @@ func (s *service) ListAppPasswords(ctx context.Context, req *appauthpb.ListAppPa
 	pwds, err := s.am.ListAppPasswords(ctx)
 	if err != nil {
 		return &appauthpb.ListAppPasswordsResponse{
-			Status: status.NewInternal(ctx, err, "error listing app passwords"),
+			Status: status.NewInternal(ctx, "error listing app passwords"),
 		}, nil
 	}
 
@@ -134,7 +134,7 @@ func (s *service) InvalidateAppPassword(ctx context.Context, req *appauthpb.Inva
 	err := s.am.InvalidateAppPassword(ctx, req.Password)
 	if err != nil {
 		return &appauthpb.InvalidateAppPasswordResponse{
-			Status: status.NewInternal(ctx, err, "error invalidating app password"),
+			Status: status.NewInternal(ctx, "error invalidating app password"),
 		}, nil
 	}
 
@@ -147,7 +147,7 @@ func (s *service) GetAppPassword(ctx context.Context, req *appauthpb.GetAppPassw
 	pwd, err := s.am.GetAppPassword(ctx, req.User, req.Password)
 	if err != nil {
 		return &appauthpb.GetAppPasswordResponse{
-			Status: status.NewInternal(ctx, err, "error getting app password via username/password"),
+			Status: status.NewInternal(ctx, "error getting app password via username/password"),
 		}, nil
 	}
 

--- a/internal/grpc/services/appprovider/appprovider.go
+++ b/internal/grpc/services/appprovider/appprovider.go
@@ -20,7 +20,6 @@ package appprovider
 
 import (
 	"context"
-	"errors"
 	"os"
 	"strconv"
 	"time"
@@ -173,7 +172,7 @@ func (s *service) OpenInApp(ctx context.Context, req *providerpb.OpenInAppReques
 	appURL, err := s.provider.GetAppURL(ctx, req.ResourceInfo, req.ViewMode, req.AccessToken)
 	if err != nil {
 		res := &providerpb.OpenInAppResponse{
-			Status: status.NewInternal(ctx, errors.New("appprovider: error calling GetAppURL"), err.Error()),
+			Status: status.NewInternal(ctx, err.Error()),
 		}
 		return res, nil
 	}

--- a/internal/grpc/services/appprovider/appprovider.go
+++ b/internal/grpc/services/appprovider/appprovider.go
@@ -106,7 +106,7 @@ func (s *service) registerProvider() {
 	log := logger.New().With().Int("pid", os.Getpid()).Logger()
 	pInfo, err := s.provider.GetAppProviderInfo(ctx)
 	if err != nil {
-		log.Error().Err(err).Msgf("error registering app provider: could not get provider info")
+		log.Error().Err(err).Msg("error registering app provider: could not get provider info")
 		return
 	}
 	pInfo.Address = s.conf.AppProviderURL
@@ -122,7 +122,7 @@ func (s *service) registerProvider() {
 
 	client, err := pool.GetGatewayServiceClient(s.conf.GatewaySvc)
 	if err != nil {
-		log.Error().Err(err).Msgf("error registering app provider: could not get gateway client")
+		log.Error().Err(err).Msg("error registering app provider: could not get gateway client")
 		return
 	}
 	req := &registrypb.AddAppProviderRequest{Provider: pInfo}
@@ -140,12 +140,12 @@ func (s *service) registerProvider() {
 
 	res, err := client.AddAppProvider(ctx, req)
 	if err != nil {
-		log.Error().Err(err).Msgf("error registering app provider: error calling add app provider")
+		log.Error().Err(err).Msg("error registering app provider: error calling add app provider")
 		return
 	}
 	if res.Status.Code != rpc.Code_CODE_OK {
 		err = status.NewErrorFromCode(res.Status.Code, "appprovider")
-		log.Error().Err(err).Msgf("error registering app provider: add app provider returned error")
+		log.Error().Err(err).Msg("error registering app provider: add app provider returned error")
 		return
 	}
 }

--- a/internal/grpc/services/appregistry/appregistry.go
+++ b/internal/grpc/services/appregistry/appregistry.go
@@ -103,7 +103,7 @@ func (s *svc) GetAppProviders(ctx context.Context, req *registrypb.GetAppProvide
 	p, err := s.reg.FindProviders(ctx, req.ResourceInfo.MimeType)
 	if err != nil {
 		return &registrypb.GetAppProvidersResponse{
-			Status: status.NewInternal(ctx, err, "error looking for the app provider"),
+			Status: status.NewInternal(ctx, "error looking for the app provider"),
 		}, nil
 	}
 
@@ -118,7 +118,7 @@ func (s *svc) AddAppProvider(ctx context.Context, req *registrypb.AddAppProvider
 	err := s.reg.AddProvider(ctx, req.Provider)
 	if err != nil {
 		return &registrypb.AddAppProviderResponse{
-			Status: status.NewInternal(ctx, err, "error adding the app provider"),
+			Status: status.NewInternal(ctx, "error adding the app provider"),
 		}, nil
 	}
 
@@ -132,7 +132,7 @@ func (s *svc) ListAppProviders(ctx context.Context, req *registrypb.ListAppProvi
 	providers, err := s.reg.ListProviders(ctx)
 	if err != nil {
 		return &registrypb.ListAppProvidersResponse{
-			Status: status.NewInternal(ctx, err, "error listing the app providers"),
+			Status: status.NewInternal(ctx, "error listing the app providers"),
 		}, nil
 	}
 
@@ -147,7 +147,7 @@ func (s *svc) ListSupportedMimeTypes(ctx context.Context, req *registrypb.ListSu
 	mimeTypes, err := s.reg.ListSupportedMimeTypes(ctx)
 	if err != nil {
 		return &registrypb.ListSupportedMimeTypesResponse{
-			Status: status.NewInternal(ctx, err, "error listing the supported mime types"),
+			Status: status.NewInternal(ctx, "error listing the supported mime types"),
 		}, nil
 	}
 
@@ -169,7 +169,7 @@ func (s *svc) GetDefaultAppProviderForMimeType(ctx context.Context, req *registr
 	provider, err := s.reg.GetDefaultProviderForMimeType(ctx, req.MimeType)
 	if err != nil {
 		return &registrypb.GetDefaultAppProviderForMimeTypeResponse{
-			Status: status.NewInternal(ctx, err, "error getting the default app provider for the mimetype"),
+			Status: status.NewInternal(ctx, "error getting the default app provider for the mimetype"),
 		}, nil
 	}
 
@@ -184,7 +184,7 @@ func (s *svc) SetDefaultAppProviderForMimeType(ctx context.Context, req *registr
 	err := s.reg.SetDefaultProviderForMimeType(ctx, req.MimeType, req.Provider)
 	if err != nil {
 		return &registrypb.SetDefaultAppProviderForMimeTypeResponse{
-			Status: status.NewInternal(ctx, err, "error setting the default app provider for the mimetype"),
+			Status: status.NewInternal(ctx, "error setting the default app provider for the mimetype"),
 		}, nil
 	}
 

--- a/internal/grpc/services/authprovider/authprovider.go
+++ b/internal/grpc/services/authprovider/authprovider.go
@@ -138,7 +138,7 @@ func (s *service) Authenticate(ctx context.Context, req *provider.AuthenticateRe
 	u, scope, err := s.authmgr.Authenticate(ctx, username, password)
 	switch v := err.(type) {
 	case nil:
-		log.Info().Msgf("user %s authenticated", u.String())
+		log.Info().Str("user", u.String()).Msg("user authenticated")
 		return &provider.AuthenticateResponse{
 			Status:     status.NewOK(ctx),
 			User:       u,
@@ -149,6 +149,7 @@ func (s *service) Authenticate(ctx context.Context, req *provider.AuthenticateRe
 			Status: status.NewPermissionDenied(ctx, v, "wrong password"),
 		}, nil
 	case errtypes.NotFound:
+		log.Debug().Str("client_id", username).Msg("unknown client id")
 		return &provider.AuthenticateResponse{
 			Status: status.NewNotFound(ctx, "unknown client id"),
 		}, nil

--- a/internal/grpc/services/authregistry/authregistry.go
+++ b/internal/grpc/services/authregistry/authregistry.go
@@ -105,7 +105,7 @@ func (s *service) ListAuthProviders(ctx context.Context, req *registrypb.ListAut
 	pinfos, err := s.reg.ListProviders(ctx)
 	if err != nil {
 		return &registrypb.ListAuthProvidersResponse{
-			Status: status.NewInternal(ctx, err, "error getting list of auth providers"),
+			Status: status.NewInternal(ctx, "error getting list of auth providers"),
 		}, nil
 	}
 
@@ -120,7 +120,7 @@ func (s *service) GetAuthProvider(ctx context.Context, req *registrypb.GetAuthPr
 	pinfo, err := s.reg.GetProvider(ctx, req.Type)
 	if err != nil {
 		return &registrypb.GetAuthProviderResponse{
-			Status: status.NewInternal(ctx, err, "error getting auth provider for type: "+req.Type),
+			Status: status.NewInternal(ctx, "error getting auth provider for type: "+req.Type),
 		}, nil
 	}
 

--- a/internal/grpc/services/gateway/applicationauth.go
+++ b/internal/grpc/services/gateway/applicationauth.go
@@ -30,9 +30,8 @@ import (
 func (s *svc) GenerateAppPassword(ctx context.Context, req *appauthpb.GenerateAppPasswordRequest) (*appauthpb.GenerateAppPasswordResponse, error) {
 	c, err := pool.GetAppAuthProviderServiceClient(s.c.ApplicationAuthEndpoint)
 	if err != nil {
-		err = errors.Wrap(err, "gateway: error calling GetAppAuthProviderServiceClient")
 		return &appauthpb.GenerateAppPasswordResponse{
-			Status: status.NewInternal(ctx, err, "error getting app auth provider client"),
+			Status: status.NewInternal(ctx, "error getting app auth provider client"),
 		}, nil
 	}
 
@@ -47,9 +46,8 @@ func (s *svc) GenerateAppPassword(ctx context.Context, req *appauthpb.GenerateAp
 func (s *svc) ListAppPasswords(ctx context.Context, req *appauthpb.ListAppPasswordsRequest) (*appauthpb.ListAppPasswordsResponse, error) {
 	c, err := pool.GetAppAuthProviderServiceClient(s.c.ApplicationAuthEndpoint)
 	if err != nil {
-		err = errors.Wrap(err, "gateway: error calling GetAppAuthProviderServiceClient")
 		return &appauthpb.ListAppPasswordsResponse{
-			Status: status.NewInternal(ctx, err, "error getting app auth provider client"),
+			Status: status.NewInternal(ctx, "error getting app auth provider client"),
 		}, nil
 	}
 
@@ -64,9 +62,8 @@ func (s *svc) ListAppPasswords(ctx context.Context, req *appauthpb.ListAppPasswo
 func (s *svc) InvalidateAppPassword(ctx context.Context, req *appauthpb.InvalidateAppPasswordRequest) (*appauthpb.InvalidateAppPasswordResponse, error) {
 	c, err := pool.GetAppAuthProviderServiceClient(s.c.ApplicationAuthEndpoint)
 	if err != nil {
-		err = errors.Wrap(err, "gateway: error calling GetAppAuthProviderServiceClient")
 		return &appauthpb.InvalidateAppPasswordResponse{
-			Status: status.NewInternal(ctx, err, "error getting app auth provider client"),
+			Status: status.NewInternal(ctx, "error getting app auth provider client"),
 		}, nil
 	}
 
@@ -81,9 +78,8 @@ func (s *svc) InvalidateAppPassword(ctx context.Context, req *appauthpb.Invalida
 func (s *svc) GetAppPassword(ctx context.Context, req *appauthpb.GetAppPasswordRequest) (*appauthpb.GetAppPasswordResponse, error) {
 	c, err := pool.GetAppAuthProviderServiceClient(s.c.ApplicationAuthEndpoint)
 	if err != nil {
-		err = errors.Wrap(err, "gateway: error calling GetAppAuthProviderServiceClient")
 		return &appauthpb.GetAppPasswordResponse{
-			Status: status.NewInternal(ctx, err, "error getting app auth provider client"),
+			Status: status.NewInternal(ctx, "error getting app auth provider client"),
 		}, nil
 	}
 

--- a/internal/grpc/services/gateway/appprovider.go
+++ b/internal/grpc/services/gateway/appprovider.go
@@ -51,7 +51,7 @@ func (s *svc) OpenInApp(ctx context.Context, req *gateway.OpenInAppRequest) (*pr
 	})
 	if err != nil {
 		return &providerpb.OpenInAppResponse{
-			Status: status.NewInternal(ctx, err, "gateway: error calling Stat on the resource path for the app provider: "+req.Ref.GetPath()),
+			Status: status.NewInternal(ctx, "gateway: error calling Stat on the resource path for the app provider: "+req.Ref.GetPath()),
 		}, nil
 	}
 	if statRes.Status.Code != rpc.Code_CODE_OK {
@@ -67,7 +67,7 @@ func (s *svc) OpenInApp(ctx context.Context, req *gateway.OpenInAppRequest) (*pr
 		uri, err := url.Parse(fileInfo.Target)
 		if err != nil {
 			return &providerpb.OpenInAppResponse{
-				Status: status.NewInternal(ctx, err, "gateway: error parsing target uri: "+fileInfo.Target),
+				Status: status.NewInternal(ctx, "gateway: error parsing target uri: "+fileInfo.Target),
 			}, nil
 		}
 		if uri.Scheme == "webdav" {
@@ -80,13 +80,12 @@ func (s *svc) OpenInApp(ctx context.Context, req *gateway.OpenInAppRequest) (*pr
 		})
 		if err != nil {
 			return &providerpb.OpenInAppResponse{
-				Status: status.NewInternal(ctx, err, "gateway: error calling Stat on the resource path for the app provider: "+req.Ref.GetPath()),
+				Status: status.NewInternal(ctx, "gateway: error calling Stat on the resource path for the app provider: "+req.Ref.GetPath()),
 			}, nil
 		}
 		if res.Status.Code != rpc.Code_CODE_OK {
-			err := status.NewErrorFromCode(res.Status.GetCode(), "gateway")
 			return &providerpb.OpenInAppResponse{
-				Status: status.NewInternal(ctx, err, "Stat failed on the resource path for the app provider: "+req.Ref.GetPath()),
+				Status: status.NewInternal(ctx, "Stat failed on the resource path for the app provider: "+req.Ref.GetPath()),
 			}, nil
 		}
 		fileInfo = res.Info

--- a/internal/grpc/services/gateway/appregistry.go
+++ b/internal/grpc/services/gateway/appregistry.go
@@ -30,9 +30,8 @@ import (
 func (s *svc) GetAppProviders(ctx context.Context, req *registry.GetAppProvidersRequest) (*registry.GetAppProvidersResponse, error) {
 	c, err := pool.GetAppRegistryClient(s.c.AppRegistryEndpoint)
 	if err != nil {
-		err = errors.Wrap(err, "gateway: error calling GetAppRegistryClient")
 		return &registry.GetAppProvidersResponse{
-			Status: status.NewInternal(ctx, err, "error getting app registry client"),
+			Status: status.NewInternal(ctx, "error getting app registry client"),
 		}, nil
 	}
 
@@ -47,9 +46,8 @@ func (s *svc) GetAppProviders(ctx context.Context, req *registry.GetAppProviders
 func (s *svc) AddAppProvider(ctx context.Context, req *registry.AddAppProviderRequest) (*registry.AddAppProviderResponse, error) {
 	c, err := pool.GetAppRegistryClient(s.c.AppRegistryEndpoint)
 	if err != nil {
-		err = errors.Wrap(err, "gateway: error calling GetAppRegistryClient")
 		return &registry.AddAppProviderResponse{
-			Status: status.NewInternal(ctx, err, "error getting app registry client"),
+			Status: status.NewInternal(ctx, "error getting app registry client"),
 		}, nil
 	}
 
@@ -64,9 +62,8 @@ func (s *svc) AddAppProvider(ctx context.Context, req *registry.AddAppProviderRe
 func (s *svc) ListAppProviders(ctx context.Context, req *registry.ListAppProvidersRequest) (*registry.ListAppProvidersResponse, error) {
 	c, err := pool.GetAppRegistryClient(s.c.AppRegistryEndpoint)
 	if err != nil {
-		err = errors.Wrap(err, "gateway: error calling GetAppRegistryClient")
 		return &registry.ListAppProvidersResponse{
-			Status: status.NewInternal(ctx, err, "error getting app registry client"),
+			Status: status.NewInternal(ctx, "error getting app registry client"),
 		}, nil
 	}
 
@@ -81,9 +78,8 @@ func (s *svc) ListAppProviders(ctx context.Context, req *registry.ListAppProvide
 func (s *svc) ListSupportedMimeTypes(ctx context.Context, req *registry.ListSupportedMimeTypesRequest) (*registry.ListSupportedMimeTypesResponse, error) {
 	c, err := pool.GetAppRegistryClient(s.c.AppRegistryEndpoint)
 	if err != nil {
-		err = errors.Wrap(err, "gateway: error calling GetAppRegistryClient")
 		return &registry.ListSupportedMimeTypesResponse{
-			Status: status.NewInternal(ctx, err, "error getting app registry client"),
+			Status: status.NewInternal(ctx, "error getting app registry client"),
 		}, nil
 	}
 
@@ -98,9 +94,8 @@ func (s *svc) ListSupportedMimeTypes(ctx context.Context, req *registry.ListSupp
 func (s *svc) GetDefaultAppProviderForMimeType(ctx context.Context, req *registry.GetDefaultAppProviderForMimeTypeRequest) (*registry.GetDefaultAppProviderForMimeTypeResponse, error) {
 	c, err := pool.GetAppRegistryClient(s.c.AppRegistryEndpoint)
 	if err != nil {
-		err = errors.Wrap(err, "gateway: error calling GetAppRegistryClient")
 		return &registry.GetDefaultAppProviderForMimeTypeResponse{
-			Status: status.NewInternal(ctx, err, "error getting app registry client"),
+			Status: status.NewInternal(ctx, "error getting app registry client"),
 		}, nil
 	}
 
@@ -115,9 +110,8 @@ func (s *svc) GetDefaultAppProviderForMimeType(ctx context.Context, req *registr
 func (s *svc) SetDefaultAppProviderForMimeType(ctx context.Context, req *registry.SetDefaultAppProviderForMimeTypeRequest) (*registry.SetDefaultAppProviderForMimeTypeResponse, error) {
 	c, err := pool.GetAppRegistryClient(s.c.AppRegistryEndpoint)
 	if err != nil {
-		err = errors.Wrap(err, "gateway: error calling GetAppRegistryClient")
 		return &registry.SetDefaultAppProviderForMimeTypeResponse{
-			Status: status.NewInternal(ctx, err, "error getting app registry client"),
+			Status: status.NewInternal(ctx, "error getting app registry client"),
 		}, nil
 	}
 

--- a/internal/grpc/services/gateway/authprovider.go
+++ b/internal/grpc/services/gateway/authprovider.go
@@ -50,9 +50,8 @@ func (s *svc) Authenticate(ctx context.Context, req *gateway.AuthenticateRequest
 	// find auth provider
 	c, err := s.findAuthProvider(ctx, req.Type)
 	if err != nil {
-		err = errtypes.NotFound("gateway: error finding auth provider for type: " + req.Type)
 		return &gateway.AuthenticateResponse{
-			Status: status.NewInternal(ctx, err, "error getting auth provider client"),
+			Status: status.NewInternal(ctx, "error getting auth provider client"),
 		}, nil
 	}
 
@@ -64,7 +63,7 @@ func (s *svc) Authenticate(ctx context.Context, req *gateway.AuthenticateRequest
 	switch {
 	case err != nil:
 		return &gateway.AuthenticateResponse{
-			Status: status.NewInternal(ctx, err, fmt.Sprintf("gateway: error calling Authenticate for type: %s", req.Type)),
+			Status: status.NewInternal(ctx, fmt.Sprintf("gateway: error calling Authenticate for type: %s", req.Type)),
 		}, nil
 	case res.Status.Code == rpc.Code_CODE_PERMISSION_DENIED:
 		fallthrough
@@ -76,9 +75,8 @@ func (s *svc) Authenticate(ctx context.Context, req *gateway.AuthenticateRequest
 			Status: res.Status,
 		}, nil
 	case res.Status.Code != rpc.Code_CODE_OK:
-		err := status.NewErrorFromCode(res.Status.Code, "gateway")
 		return &gateway.AuthenticateResponse{
-			Status: status.NewInternal(ctx, err, fmt.Sprintf("error authenticating credentials to auth provider for type: %s", req.Type)),
+			Status: status.NewInternal(ctx, fmt.Sprintf("error authenticating credentials to auth provider for type: %s", req.Type)),
 		}, nil
 	}
 
@@ -87,7 +85,7 @@ func (s *svc) Authenticate(ctx context.Context, req *gateway.AuthenticateRequest
 		err := errtypes.NotFound("gateway: user after Authenticate is nil")
 		log.Err(err).Msg("user is nil")
 		return &gateway.AuthenticateResponse{
-			Status: status.NewInternal(ctx, err, "user is nil"),
+			Status: status.NewInternal(ctx, "user is nil"),
 		}, nil
 	}
 
@@ -95,7 +93,7 @@ func (s *svc) Authenticate(ctx context.Context, req *gateway.AuthenticateRequest
 		err := errtypes.NotFound("gateway: uid after Authenticate is nil")
 		log.Err(err).Msg("user id is nil")
 		return &gateway.AuthenticateResponse{
-			Status: status.NewInternal(ctx, err, "user id is nil"),
+			Status: status.NewInternal(ctx, "user id is nil"),
 		}, nil
 	}
 
@@ -111,7 +109,6 @@ func (s *svc) Authenticate(ctx context.Context, req *gateway.AuthenticateRequest
 	// token obtained from the updated scope in the context.
 	token, err := s.tokenmgr.MintToken(ctx, &u, res.TokenScope)
 	if err != nil {
-		err = errors.Wrap(err, "authsvc: error in MintToken")
 		res := &gateway.AuthenticateResponse{
 			Status: status.NewUnauthenticated(ctx, err, "error creating access token"),
 		}
@@ -159,7 +156,7 @@ func (s *svc) Authenticate(ctx context.Context, req *gateway.AuthenticateRequest
 		if err != nil {
 			log.Err(err).Msg("error calling CreateHome")
 			return &gateway.AuthenticateResponse{
-				Status: status.NewInternal(ctx, err, "error creating user home"),
+				Status: status.NewInternal(ctx, "error creating user home"),
 			}, nil
 		}
 
@@ -167,7 +164,7 @@ func (s *svc) Authenticate(ctx context.Context, req *gateway.AuthenticateRequest
 			err := status.NewErrorFromCode(createHomeRes.Status.Code, "gateway")
 			log.Err(err).Msg("error calling Createhome")
 			return &gateway.AuthenticateResponse{
-				Status: status.NewInternal(ctx, err, "error creating user home"),
+				Status: status.NewInternal(ctx, "error creating user home"),
 			}, nil
 		}
 		if s.c.CreateHomeCacheTTL > 0 {

--- a/internal/grpc/services/gateway/authregistry.go
+++ b/internal/grpc/services/gateway/authregistry.go
@@ -26,30 +26,26 @@ import (
 	rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
 	"github.com/cs3org/reva/pkg/rgrpc/status"
 	"github.com/cs3org/reva/pkg/rgrpc/todo/pool"
-	"github.com/pkg/errors"
 )
 
 func (s *svc) ListAuthProviders(ctx context.Context, req *registry.ListAuthProvidersRequest) (*gateway.ListAuthProvidersResponse, error) {
 	c, err := pool.GetAuthRegistryServiceClient(s.c.AuthRegistryEndpoint)
 	if err != nil {
-		err = errors.Wrap(err, "gateway: error getting auth registry client")
 		return &gateway.ListAuthProvidersResponse{
-			Status: status.NewInternal(ctx, err, "gateway"),
+			Status: status.NewInternal(ctx, "gateway"),
 		}, nil
 	}
 
 	res, err := c.ListAuthProviders(ctx, req)
 	if err != nil {
-		err = errors.Wrap(err, "gateway: error calling ListAuthProviders")
 		return &gateway.ListAuthProvidersResponse{
-			Status: status.NewInternal(ctx, err, "gateway"),
+			Status: status.NewInternal(ctx, "gateway"),
 		}, nil
 	}
 
 	if res.Status.Code != rpc.Code_CODE_OK {
-		err := status.NewErrorFromCode(res.Status.Code, "gateway")
 		return &gateway.ListAuthProvidersResponse{
-			Status: status.NewInternal(ctx, err, "gateway"),
+			Status: status.NewInternal(ctx, "gateway"),
 		}, nil
 	}
 

--- a/internal/grpc/services/gateway/datatx.go
+++ b/internal/grpc/services/gateway/datatx.go
@@ -30,9 +30,8 @@ import (
 func (s *svc) CreateTransfer(ctx context.Context, req *datatx.CreateTransferRequest) (*datatx.CreateTransferResponse, error) {
 	c, err := pool.GetDataTxClient(s.c.DataTxEndpoint)
 	if err != nil {
-		err = errors.Wrap(err, "gateway: error calling GetOCMShareProviderClient")
 		return &datatx.CreateTransferResponse{
-			Status: status.NewInternal(ctx, err, "error getting data transfer client"),
+			Status: status.NewInternal(ctx, "error getting data transfer client"),
 		}, nil
 	}
 
@@ -47,9 +46,8 @@ func (s *svc) CreateTransfer(ctx context.Context, req *datatx.CreateTransferRequ
 func (s *svc) GetTransferStatus(ctx context.Context, req *datatx.GetTransferStatusRequest) (*datatx.GetTransferStatusResponse, error) {
 	c, err := pool.GetDataTxClient(s.c.DataTxEndpoint)
 	if err != nil {
-		err = errors.Wrap(err, "gateway: error calling GetOCMShareProviderClient")
 		return &datatx.GetTransferStatusResponse{
-			Status: status.NewInternal(ctx, err, "error getting data transfer client"),
+			Status: status.NewInternal(ctx, "error getting data transfer client"),
 		}, nil
 	}
 
@@ -64,9 +62,8 @@ func (s *svc) GetTransferStatus(ctx context.Context, req *datatx.GetTransferStat
 func (s *svc) CancelTransfer(ctx context.Context, req *datatx.CancelTransferRequest) (*datatx.CancelTransferResponse, error) {
 	c, err := pool.GetDataTxClient(s.c.DataTxEndpoint)
 	if err != nil {
-		err = errors.Wrap(err, "gateway: error calling GetOCMShareProviderClient")
 		return &datatx.CancelTransferResponse{
-			Status: status.NewInternal(ctx, err, "error getting data transfer client"),
+			Status: status.NewInternal(ctx, "error getting data transfer client"),
 		}, nil
 	}
 

--- a/internal/grpc/services/gateway/groupprovider.go
+++ b/internal/grpc/services/gateway/groupprovider.go
@@ -31,7 +31,7 @@ func (s *svc) GetGroup(ctx context.Context, req *group.GetGroupRequest) (*group.
 	c, err := pool.GetGroupProviderServiceClient(s.c.GroupProviderEndpoint)
 	if err != nil {
 		return &group.GetGroupResponse{
-			Status: status.NewInternal(ctx, err, "error getting auth client"),
+			Status: status.NewInternal(ctx, "error getting auth client"),
 		}, nil
 	}
 
@@ -47,7 +47,7 @@ func (s *svc) GetGroupByClaim(ctx context.Context, req *group.GetGroupByClaimReq
 	c, err := pool.GetGroupProviderServiceClient(s.c.GroupProviderEndpoint)
 	if err != nil {
 		return &group.GetGroupByClaimResponse{
-			Status: status.NewInternal(ctx, err, "error getting auth client"),
+			Status: status.NewInternal(ctx, "error getting auth client"),
 		}, nil
 	}
 
@@ -63,7 +63,7 @@ func (s *svc) FindGroups(ctx context.Context, req *group.FindGroupsRequest) (*gr
 	c, err := pool.GetGroupProviderServiceClient(s.c.GroupProviderEndpoint)
 	if err != nil {
 		return &group.FindGroupsResponse{
-			Status: status.NewInternal(ctx, err, "error getting auth client"),
+			Status: status.NewInternal(ctx, "error getting auth client"),
 		}, nil
 	}
 
@@ -79,7 +79,7 @@ func (s *svc) GetMembers(ctx context.Context, req *group.GetMembersRequest) (*gr
 	c, err := pool.GetGroupProviderServiceClient(s.c.GroupProviderEndpoint)
 	if err != nil {
 		return &group.GetMembersResponse{
-			Status: status.NewInternal(ctx, err, "error getting auth client"),
+			Status: status.NewInternal(ctx, "error getting auth client"),
 		}, nil
 	}
 
@@ -95,7 +95,7 @@ func (s *svc) HasMember(ctx context.Context, req *group.HasMemberRequest) (*grou
 	c, err := pool.GetGroupProviderServiceClient(s.c.GroupProviderEndpoint)
 	if err != nil {
 		return &group.HasMemberResponse{
-			Status: status.NewInternal(ctx, err, "error getting auth client"),
+			Status: status.NewInternal(ctx, "error getting auth client"),
 		}, nil
 	}
 

--- a/internal/grpc/services/gateway/ocmcore.go
+++ b/internal/grpc/services/gateway/ocmcore.go
@@ -31,7 +31,7 @@ func (s *svc) CreateOCMCoreShare(ctx context.Context, req *ocmcore.CreateOCMCore
 	c, err := pool.GetOCMCoreClient(s.c.OCMCoreEndpoint)
 	if err != nil {
 		return &ocmcore.CreateOCMCoreShareResponse{
-			Status: status.NewInternal(ctx, err, "error getting ocm core client"),
+			Status: status.NewInternal(ctx, "error getting ocm core client"),
 		}, nil
 	}
 

--- a/internal/grpc/services/gateway/ocminvitemanager.go
+++ b/internal/grpc/services/gateway/ocminvitemanager.go
@@ -31,7 +31,7 @@ func (s *svc) GenerateInviteToken(ctx context.Context, req *invitepb.GenerateInv
 	c, err := pool.GetOCMInviteManagerClient(s.c.OCMInviteManagerEndpoint)
 	if err != nil {
 		return &invitepb.GenerateInviteTokenResponse{
-			Status: status.NewInternal(ctx, err, "error getting user invite provider client"),
+			Status: status.NewInternal(ctx, "error getting user invite provider client"),
 		}, nil
 	}
 
@@ -47,7 +47,7 @@ func (s *svc) ForwardInvite(ctx context.Context, req *invitepb.ForwardInviteRequ
 	c, err := pool.GetOCMInviteManagerClient(s.c.OCMInviteManagerEndpoint)
 	if err != nil {
 		return &invitepb.ForwardInviteResponse{
-			Status: status.NewInternal(ctx, err, "error getting user invite provider client"),
+			Status: status.NewInternal(ctx, "error getting user invite provider client"),
 		}, nil
 	}
 
@@ -63,7 +63,7 @@ func (s *svc) AcceptInvite(ctx context.Context, req *invitepb.AcceptInviteReques
 	c, err := pool.GetOCMInviteManagerClient(s.c.OCMInviteManagerEndpoint)
 	if err != nil {
 		return &invitepb.AcceptInviteResponse{
-			Status: status.NewInternal(ctx, err, "error getting user invite provider client"),
+			Status: status.NewInternal(ctx, "error getting user invite provider client"),
 		}, nil
 	}
 
@@ -79,7 +79,7 @@ func (s *svc) GetAcceptedUser(ctx context.Context, req *invitepb.GetAcceptedUser
 	c, err := pool.GetOCMInviteManagerClient(s.c.OCMInviteManagerEndpoint)
 	if err != nil {
 		return &invitepb.GetAcceptedUserResponse{
-			Status: status.NewInternal(ctx, err, "error getting user invite provider client"),
+			Status: status.NewInternal(ctx, "error getting user invite provider client"),
 		}, nil
 	}
 
@@ -95,7 +95,7 @@ func (s *svc) FindAcceptedUsers(ctx context.Context, req *invitepb.FindAcceptedU
 	c, err := pool.GetOCMInviteManagerClient(s.c.OCMInviteManagerEndpoint)
 	if err != nil {
 		return &invitepb.FindAcceptedUsersResponse{
-			Status: status.NewInternal(ctx, err, "error getting user invite provider client"),
+			Status: status.NewInternal(ctx, "error getting user invite provider client"),
 		}, nil
 	}
 

--- a/internal/grpc/services/gateway/ocmproviderauthorizer.go
+++ b/internal/grpc/services/gateway/ocmproviderauthorizer.go
@@ -31,7 +31,7 @@ func (s *svc) IsProviderAllowed(ctx context.Context, req *ocmprovider.IsProvider
 	c, err := pool.GetOCMProviderAuthorizerClient(s.c.OCMProviderAuthorizerEndpoint)
 	if err != nil {
 		return &ocmprovider.IsProviderAllowedResponse{
-			Status: status.NewInternal(ctx, err, "error getting ocm authorizer provider client"),
+			Status: status.NewInternal(ctx, "error getting ocm authorizer provider client"),
 		}, nil
 	}
 
@@ -47,7 +47,7 @@ func (s *svc) GetInfoByDomain(ctx context.Context, req *ocmprovider.GetInfoByDom
 	c, err := pool.GetOCMProviderAuthorizerClient(s.c.OCMProviderAuthorizerEndpoint)
 	if err != nil {
 		return &ocmprovider.GetInfoByDomainResponse{
-			Status: status.NewInternal(ctx, err, "error getting ocm authorizer provider client"),
+			Status: status.NewInternal(ctx, "error getting ocm authorizer provider client"),
 		}, nil
 	}
 
@@ -63,7 +63,7 @@ func (s *svc) ListAllProviders(ctx context.Context, req *ocmprovider.ListAllProv
 	c, err := pool.GetOCMProviderAuthorizerClient(s.c.OCMProviderAuthorizerEndpoint)
 	if err != nil {
 		return &ocmprovider.ListAllProvidersResponse{
-			Status: status.NewInternal(ctx, err, "error getting ocm authorizer provider client"),
+			Status: status.NewInternal(ctx, "error getting ocm authorizer provider client"),
 		}, nil
 	}
 

--- a/internal/grpc/services/gateway/ocmshareprovider.go
+++ b/internal/grpc/services/gateway/ocmshareprovider.go
@@ -39,7 +39,7 @@ func (s *svc) CreateOCMShare(ctx context.Context, req *ocm.CreateOCMShareRequest
 	c, err := pool.GetOCMShareProviderClient(s.c.OCMShareProviderEndpoint)
 	if err != nil {
 		return &ocm.CreateOCMShareResponse{
-			Status: status.NewInternal(ctx, err, "error getting user share provider client"),
+			Status: status.NewInternal(ctx, "error getting user share provider client"),
 		}, nil
 	}
 
@@ -73,7 +73,7 @@ func (s *svc) RemoveOCMShare(ctx context.Context, req *ocm.RemoveOCMShareRequest
 	c, err := pool.GetOCMShareProviderClient(s.c.OCMShareProviderEndpoint)
 	if err != nil {
 		return &ocm.RemoveOCMShareResponse{
-			Status: status.NewInternal(ctx, err, "error getting user share provider client"),
+			Status: status.NewInternal(ctx, "error getting user share provider client"),
 		}, nil
 	}
 
@@ -90,7 +90,7 @@ func (s *svc) RemoveOCMShare(ctx context.Context, req *ocm.RemoveOCMShareRequest
 
 		if getShareRes.Status.Code != rpc.Code_CODE_OK {
 			res := &ocm.RemoveOCMShareResponse{
-				Status: status.NewInternal(ctx, status.NewErrorFromCode(getShareRes.Status.Code, "gateway"),
+				Status: status.NewInternal(ctx,
 					"error getting share when committing to the storage"),
 			}
 			return res, nil
@@ -134,9 +134,8 @@ func (s *svc) GetOCMShare(ctx context.Context, req *ocm.GetOCMShareRequest) (*oc
 func (s *svc) getOCMShare(ctx context.Context, req *ocm.GetOCMShareRequest) (*ocm.GetOCMShareResponse, error) {
 	c, err := pool.GetOCMShareProviderClient(s.c.OCMShareProviderEndpoint)
 	if err != nil {
-		err = errors.Wrap(err, "gateway: error calling GetOCMShareProviderClient")
 		return &ocm.GetOCMShareResponse{
-			Status: status.NewInternal(ctx, err, "error getting user share provider client"),
+			Status: status.NewInternal(ctx, "error getting user share provider client"),
 		}, nil
 	}
 
@@ -152,9 +151,8 @@ func (s *svc) getOCMShare(ctx context.Context, req *ocm.GetOCMShareRequest) (*oc
 func (s *svc) ListOCMShares(ctx context.Context, req *ocm.ListOCMSharesRequest) (*ocm.ListOCMSharesResponse, error) {
 	c, err := pool.GetOCMShareProviderClient(s.c.OCMShareProviderEndpoint)
 	if err != nil {
-		err = errors.Wrap(err, "gateway: error calling GetOCMShareProviderClient")
 		return &ocm.ListOCMSharesResponse{
-			Status: status.NewInternal(ctx, err, "error getting user share provider client"),
+			Status: status.NewInternal(ctx, "error getting user share provider client"),
 		}, nil
 	}
 
@@ -169,9 +167,8 @@ func (s *svc) ListOCMShares(ctx context.Context, req *ocm.ListOCMSharesRequest) 
 func (s *svc) UpdateOCMShare(ctx context.Context, req *ocm.UpdateOCMShareRequest) (*ocm.UpdateOCMShareResponse, error) {
 	c, err := pool.GetOCMShareProviderClient(s.c.OCMShareProviderEndpoint)
 	if err != nil {
-		err = errors.Wrap(err, "gateway: error calling GetOCMShareProviderClient")
 		return &ocm.UpdateOCMShareResponse{
-			Status: status.NewInternal(ctx, err, "error getting share provider client"),
+			Status: status.NewInternal(ctx, "error getting share provider client"),
 		}, nil
 	}
 
@@ -186,9 +183,8 @@ func (s *svc) UpdateOCMShare(ctx context.Context, req *ocm.UpdateOCMShareRequest
 func (s *svc) ListReceivedOCMShares(ctx context.Context, req *ocm.ListReceivedOCMSharesRequest) (*ocm.ListReceivedOCMSharesResponse, error) {
 	c, err := pool.GetOCMShareProviderClient(s.c.OCMShareProviderEndpoint)
 	if err != nil {
-		err = errors.Wrap(err, "gateway: error calling GetOCMShareProviderClient")
 		return &ocm.ListReceivedOCMSharesResponse{
-			Status: status.NewInternal(ctx, err, "error getting share provider client"),
+			Status: status.NewInternal(ctx, "error getting share provider client"),
 		}, nil
 	}
 
@@ -204,9 +200,8 @@ func (s *svc) UpdateReceivedOCMShare(ctx context.Context, req *ocm.UpdateReceive
 	log := appctx.GetLogger(ctx)
 	c, err := pool.GetOCMShareProviderClient(s.c.OCMShareProviderEndpoint)
 	if err != nil {
-		err = errors.Wrap(err, "gateway: error calling GetOCMShareProviderClient")
 		return &ocm.UpdateReceivedOCMShareResponse{
-			Status: status.NewInternal(ctx, err, "error getting share provider client"),
+			Status: status.NewInternal(ctx, "error getting share provider client"),
 		}, nil
 	}
 
@@ -288,9 +283,8 @@ func (s *svc) UpdateReceivedOCMShare(ctx context.Context, req *ocm.UpdateReceive
 func (s *svc) GetReceivedOCMShare(ctx context.Context, req *ocm.GetReceivedOCMShareRequest) (*ocm.GetReceivedOCMShareResponse, error) {
 	c, err := pool.GetOCMShareProviderClient(s.c.OCMShareProviderEndpoint)
 	if err != nil {
-		err = errors.Wrap(err, "gateway: error calling GetOCMShareProviderClient")
 		return &ocm.GetReceivedOCMShareResponse{
-			Status: status.NewInternal(ctx, err, "error getting share provider client"),
+			Status: status.NewInternal(ctx, "error getting share provider client"),
 		}, nil
 	}
 
@@ -317,15 +311,13 @@ func (s *svc) createOCMReference(ctx context.Context, share *ocm.Share) (*rpc.St
 		token = string(tokenOpaque.Value)
 	default:
 		log.Error().Str("decoder", tokenOpaque.Decoder).Msg("createOCMReference: opaque entry decoder not recognized")
-		err := errtypes.NotSupported("opaque entry decoder not recognized: " + tokenOpaque.Decoder)
-		return status.NewInternal(ctx, err, "invalid opaque entry decoder"), nil
+		return status.NewInternal(ctx, "invalid opaque entry decoder"), nil
 	}
 
 	homeRes, err := s.GetHome(ctx, &provider.GetHomeRequest{})
 	if err != nil {
 		log.Error().Err(err).Msg("createOCMReference: error calling GetHome")
-		err := errors.Wrap(err, "gateway: error calling GetHome")
-		return status.NewInternal(ctx, err, "error updating received share"), nil
+		return status.NewInternal(ctx, "error updating received share"), nil
 	}
 
 	var refPath, targetURI string
@@ -337,12 +329,11 @@ func (s *svc) createOCMReference(ctx context.Context, share *ocm.Share) (*rpc.St
 		})
 		if err != nil {
 			log.Error().Err(err).Msg("createOCMReference: error creating transfers directory")
-			return status.NewInternal(ctx, err, "error creating transfers directory"), nil
+			return status.NewInternal(ctx, "error creating transfers directory"), nil
 		}
 		if createTransferDir.Status.Code != rpc.Code_CODE_OK && createTransferDir.Status.Code != rpc.Code_CODE_ALREADY_EXISTS {
 			log.Error().Interface("status", createTransferDir.Status).Msg("createOCMReference: error creating transfers directory")
-			err := status.NewErrorFromCode(createTransferDir.Status.GetCode(), "gateway")
-			return status.NewInternal(ctx, err, "error creating transfers directory"), nil
+			return status.NewInternal(ctx, "error creating transfers directory"), nil
 		}
 
 		refPath = path.Join(homeRes.Path, s.c.DataTransfersFolder, path.Base(share.Name))
@@ -365,7 +356,7 @@ func (s *svc) createOCMReference(ctx context.Context, share *ocm.Share) (*rpc.St
 		if _, ok := err.(errtypes.IsNotFound); ok {
 			return status.NewNotFound(ctx, "storage provider not found"), nil
 		}
-		return status.NewInternal(ctx, err, "error finding storage provider"), nil
+		return status.NewInternal(ctx, "error finding storage provider"), nil
 	}
 
 	spaceID := ""
@@ -399,8 +390,7 @@ func (s *svc) createOCMReference(ctx context.Context, share *ocm.Share) (*rpc.St
 
 	if createRefRes.Status.Code != rpc.Code_CODE_OK {
 		log.Error().Interface("status", createRefRes.Status).Msg("createOCMReference: error calling CreateReference")
-		err := status.NewErrorFromCode(createRefRes.Status.GetCode(), "gateway")
-		return status.NewInternal(ctx, err, "error updating received share"), nil
+		return status.NewInternal(ctx, "error updating received share"), nil
 	}
 
 	return status.NewOK(ctx), nil

--- a/internal/grpc/services/gateway/preferences.go
+++ b/internal/grpc/services/gateway/preferences.go
@@ -30,9 +30,8 @@ import (
 func (s *svc) SetKey(ctx context.Context, req *preferences.SetKeyRequest) (*preferences.SetKeyResponse, error) {
 	c, err := pool.GetPreferencesClient(s.c.PreferencesEndpoint)
 	if err != nil {
-		err = errors.Wrap(err, "gateway: error calling GetPreferencesClient")
 		return &preferences.SetKeyResponse{
-			Status: status.NewInternal(ctx, err, "error getting preferences client"),
+			Status: status.NewInternal(ctx, "error getting preferences client"),
 		}, nil
 	}
 
@@ -47,9 +46,8 @@ func (s *svc) SetKey(ctx context.Context, req *preferences.SetKeyRequest) (*pref
 func (s *svc) GetKey(ctx context.Context, req *preferences.GetKeyRequest) (*preferences.GetKeyResponse, error) {
 	c, err := pool.GetPreferencesClient(s.c.PreferencesEndpoint)
 	if err != nil {
-		err = errors.Wrap(err, "gateway: error calling GetPreferencesClient")
 		return &preferences.GetKeyResponse{
-			Status: status.NewInternal(ctx, err, "error getting preferences client"),
+			Status: status.NewInternal(ctx, "error getting preferences client"),
 		}, nil
 	}
 

--- a/internal/grpc/services/gateway/storageprovider.go
+++ b/internal/grpc/services/gateway/storageprovider.go
@@ -124,7 +124,7 @@ func (s *svc) CreateHome(ctx context.Context, req *provider.CreateHomeRequest) (
 	res, err := s.CreateStorageSpace(ctx, createReq)
 	if err != nil {
 		return &provider.CreateHomeResponse{
-			Status: status.NewInternal(ctx, err, "error calling CreateHome"),
+			Status: status.NewInternal(ctx, "error calling CreateHome"),
 		}, nil
 	}
 	if res.Status.Code != rpc.Code_CODE_OK && res.Status.Code != rpc.Code_CODE_ALREADY_EXISTS {
@@ -201,7 +201,7 @@ func (s *svc) CreateStorageSpace(ctx context.Context, req *provider.CreateStorag
 	if err != nil {
 		log.Err(err).Msg("gateway: error creating storage space on storage provider")
 		return &provider.CreateStorageSpaceResponse{
-			Status: status.NewInternal(ctx, err, "error calling CreateStorageSpace"),
+			Status: status.NewInternal(ctx, "error calling CreateStorageSpace"),
 		}, nil
 	}
 
@@ -334,7 +334,7 @@ func (s *svc) UpdateStorageSpace(ctx context.Context, req *provider.UpdateStorag
 	if err != nil {
 		log.Err(err).Msg("gateway: error creating update space on storage provider")
 		return &provider.UpdateStorageSpaceResponse{
-			Status: status.NewInternal(ctx, err, "error calling UpdateStorageSpace"),
+			Status: status.NewInternal(ctx, "error calling UpdateStorageSpace"),
 		}, nil
 	}
 	RemoveFromCache(s.statCache, ctxpkg.ContextMustGetUser(ctx), res.StorageSpace.Root)
@@ -359,7 +359,7 @@ func (s *svc) DeleteStorageSpace(ctx context.Context, req *provider.DeleteStorag
 	if err != nil {
 		log.Err(err).Msg("gateway: error deleting storage space on storage provider")
 		return &provider.DeleteStorageSpaceResponse{
-			Status: status.NewInternal(ctx, err, "error calling DeleteStorageSpace"),
+			Status: status.NewInternal(ctx, "error calling DeleteStorageSpace"),
 		}, nil
 	}
 
@@ -458,7 +458,7 @@ func (s *svc) InitiateFileDownload(ctx context.Context, req *provider.InitiateFi
 			u, err := url.Parse(protocols[p].DownloadEndpoint)
 			if err != nil {
 				return &gateway.InitiateFileDownloadResponse{
-					Status: status.NewInternal(ctx, err, "wrong format for download endpoint"),
+					Status: status.NewInternal(ctx, "wrong format for download endpoint"),
 				}, nil
 			}
 
@@ -467,7 +467,7 @@ func (s *svc) InitiateFileDownload(ctx context.Context, req *provider.InitiateFi
 			token, err := s.sign(ctx, target)
 			if err != nil {
 				return &gateway.InitiateFileDownloadResponse{
-					Status: status.NewInternal(ctx, err, "error creating signature for download"),
+					Status: status.NewInternal(ctx, "error creating signature for download"),
 				}, nil
 			}
 
@@ -521,7 +521,7 @@ func (s *svc) InitiateFileUpload(ctx context.Context, req *provider.InitiateFile
 			u, err := url.Parse(protocols[p].UploadEndpoint)
 			if err != nil {
 				return &gateway.InitiateFileUploadResponse{
-					Status: status.NewInternal(ctx, err, "wrong format for upload endpoint"),
+					Status: status.NewInternal(ctx, "wrong format for upload endpoint"),
 				}, nil
 			}
 
@@ -530,7 +530,7 @@ func (s *svc) InitiateFileUpload(ctx context.Context, req *provider.InitiateFile
 			token, err := s.sign(ctx, target)
 			if err != nil {
 				return &gateway.InitiateFileUploadResponse{
-					Status: status.NewInternal(ctx, err, "error creating signature for upload"),
+					Status: status.NewInternal(ctx, "error creating signature for upload"),
 				}, nil
 			}
 
@@ -1099,7 +1099,7 @@ func (s *svc) ListRecycle(ctx context.Context, req *provider.ListRecycleRequest)
 		c, err := s.getStorageProviderClient(ctx, providerInfos[i])
 		if err != nil {
 			return &provider.ListRecycleResponse{
-				Status: status.NewInternal(ctx, err, "gateway: could not get storage provider client"),
+				Status: status.NewInternal(ctx, "gateway: could not get storage provider client"),
 			}, nil
 		}
 
@@ -1308,7 +1308,7 @@ func (s *svc) RestoreRecycleItem(ctx context.Context, req *provider.RestoreRecyc
 	c, err := s.getStorageProviderClient(ctx, srcProvider)
 	if err != nil {
 		return &provider.RestoreRecycleItemResponse{
-			Status: status.NewInternal(ctx, err, "gateway: could not get storage provider client"),
+			Status: status.NewInternal(ctx, "gateway: could not get storage provider client"),
 		}, nil
 	}
 

--- a/internal/grpc/services/gateway/userprovider.go
+++ b/internal/grpc/services/gateway/userprovider.go
@@ -31,7 +31,7 @@ func (s *svc) GetUser(ctx context.Context, req *user.GetUserRequest) (*user.GetU
 	c, err := pool.GetUserProviderServiceClient(s.c.UserProviderEndpoint)
 	if err != nil {
 		return &user.GetUserResponse{
-			Status: status.NewInternal(ctx, err, "error getting auth client"),
+			Status: status.NewInternal(ctx, "error getting auth client"),
 		}, nil
 	}
 
@@ -47,7 +47,7 @@ func (s *svc) GetUserByClaim(ctx context.Context, req *user.GetUserByClaimReques
 	c, err := pool.GetUserProviderServiceClient(s.c.UserProviderEndpoint)
 	if err != nil {
 		return &user.GetUserByClaimResponse{
-			Status: status.NewInternal(ctx, err, "error getting auth client"),
+			Status: status.NewInternal(ctx, "error getting auth client"),
 		}, nil
 	}
 
@@ -63,7 +63,7 @@ func (s *svc) FindUsers(ctx context.Context, req *user.FindUsersRequest) (*user.
 	c, err := pool.GetUserProviderServiceClient(s.c.UserProviderEndpoint)
 	if err != nil {
 		return &user.FindUsersResponse{
-			Status: status.NewInternal(ctx, err, "error getting auth client"),
+			Status: status.NewInternal(ctx, "error getting auth client"),
 		}, nil
 	}
 
@@ -79,7 +79,7 @@ func (s *svc) GetUserGroups(ctx context.Context, req *user.GetUserGroupsRequest)
 	c, err := pool.GetUserProviderServiceClient(s.c.UserProviderEndpoint)
 	if err != nil {
 		return &user.GetUserGroupsResponse{
-			Status: status.NewInternal(ctx, err, "error getting auth client"),
+			Status: status.NewInternal(ctx, "error getting auth client"),
 		}, nil
 	}
 

--- a/internal/grpc/services/gateway/usershareprovider.go
+++ b/internal/grpc/services/gateway/usershareprovider.go
@@ -42,8 +42,11 @@ import (
 func (s *svc) CreateShare(ctx context.Context, req *collaboration.CreateShareRequest) (*collaboration.CreateShareResponse, error) {
 	c, err := pool.GetUserShareProviderClient(s.c.UserShareProviderEndpoint)
 	if err != nil {
+		appctx.GetLogger(ctx).
+			Err(err).
+			Msg("CreateShare: failed to get user share provider")
 		return &collaboration.CreateShareResponse{
-			Status: status.NewInternal(ctx, err, "error getting user share provider client"),
+			Status: status.NewInternal(ctx, "error getting user share provider client"),
 		}, nil
 	}
 
@@ -96,8 +99,11 @@ func (s *svc) CreateShare(ctx context.Context, req *collaboration.CreateShareReq
 func (s *svc) RemoveShare(ctx context.Context, req *collaboration.RemoveShareRequest) (*collaboration.RemoveShareResponse, error) {
 	c, err := pool.GetUserShareProviderClient(s.c.UserShareProviderEndpoint)
 	if err != nil {
+		appctx.GetLogger(ctx).
+			Err(err).
+			Msg("RemoveShare: failed to get user share provider")
 		return &collaboration.RemoveShareResponse{
-			Status: status.NewInternal(ctx, err, "error getting user share provider client"),
+			Status: status.NewInternal(ctx, "error getting user share provider client"),
 		}, nil
 	}
 
@@ -114,7 +120,7 @@ func (s *svc) RemoveShare(ctx context.Context, req *collaboration.RemoveShareReq
 
 		if getShareRes.Status.Code != rpc.Code_CODE_OK {
 			res := &collaboration.RemoveShareResponse{
-				Status: status.NewInternal(ctx, status.NewErrorFromCode(getShareRes.Status.Code, "gateway"),
+				Status: status.NewInternal(ctx,
 					"error getting share when committing to the storage"),
 			}
 			return res, nil
@@ -162,9 +168,11 @@ func (s *svc) GetShare(ctx context.Context, req *collaboration.GetShareRequest) 
 func (s *svc) getShare(ctx context.Context, req *collaboration.GetShareRequest) (*collaboration.GetShareResponse, error) {
 	c, err := pool.GetUserShareProviderClient(s.c.UserShareProviderEndpoint)
 	if err != nil {
-		err = errors.Wrap(err, "gateway: error calling GetUserShareProviderClient")
+		appctx.GetLogger(ctx).
+			Err(err).
+			Msg("getShare: failed to get user share provider")
 		return &collaboration.GetShareResponse{
-			Status: status.NewInternal(ctx, err, "error getting user share provider client"),
+			Status: status.NewInternal(ctx, "error getting user share provider client"),
 		}, nil
 	}
 
@@ -180,9 +188,11 @@ func (s *svc) getShare(ctx context.Context, req *collaboration.GetShareRequest) 
 func (s *svc) ListShares(ctx context.Context, req *collaboration.ListSharesRequest) (*collaboration.ListSharesResponse, error) {
 	c, err := pool.GetUserShareProviderClient(s.c.UserShareProviderEndpoint)
 	if err != nil {
-		err = errors.Wrap(err, "gateway: error calling GetUserShareProviderClient")
+		appctx.GetLogger(ctx).
+			Err(err).
+			Msg("ListShares: failed to get user share provider")
 		return &collaboration.ListSharesResponse{
-			Status: status.NewInternal(ctx, err, "error getting user share provider client"),
+			Status: status.NewInternal(ctx, "error getting user share provider client"),
 		}, nil
 	}
 
@@ -197,9 +207,11 @@ func (s *svc) ListShares(ctx context.Context, req *collaboration.ListSharesReque
 func (s *svc) UpdateShare(ctx context.Context, req *collaboration.UpdateShareRequest) (*collaboration.UpdateShareResponse, error) {
 	c, err := pool.GetUserShareProviderClient(s.c.UserShareProviderEndpoint)
 	if err != nil {
-		err = errors.Wrap(err, "gateway: error calling GetUserShareProviderClient")
+		appctx.GetLogger(ctx).
+			Err(err).
+			Msg("UpdateShare: failed to get user share provider")
 		return &collaboration.UpdateShareResponse{
-			Status: status.NewInternal(ctx, err, "error getting share provider client"),
+			Status: status.NewInternal(ctx, "error getting share provider client"),
 		}, nil
 	}
 
@@ -242,9 +254,11 @@ func (s *svc) UpdateShare(ctx context.Context, req *collaboration.UpdateShareReq
 func (s *svc) ListReceivedShares(ctx context.Context, req *collaboration.ListReceivedSharesRequest) (*collaboration.ListReceivedSharesResponse, error) {
 	c, err := pool.GetUserShareProviderClient(s.c.UserShareProviderEndpoint)
 	if err != nil {
-		err = errors.Wrap(err, "gateway: error calling GetUserShareProviderClient")
+		appctx.GetLogger(ctx).
+			Err(err).
+			Msg("ListReceivedShares: failed to get user share provider")
 		return &collaboration.ListReceivedSharesResponse{
-			Status: status.NewInternal(ctx, err, "error getting share provider client"),
+			Status: status.NewInternal(ctx, "error getting share provider client"),
 		}, nil
 	}
 
@@ -258,9 +272,11 @@ func (s *svc) ListReceivedShares(ctx context.Context, req *collaboration.ListRec
 func (s *svc) GetReceivedShare(ctx context.Context, req *collaboration.GetReceivedShareRequest) (*collaboration.GetReceivedShareResponse, error) {
 	c, err := pool.GetUserShareProviderClient(s.c.UserShareProviderEndpoint)
 	if err != nil {
-		err := errors.Wrap(err, "gateway: error getting user share provider client")
+		appctx.GetLogger(ctx).
+			Err(err).
+			Msg("GetReceivedShare: failed to get user share provider")
 		return &collaboration.GetReceivedShareResponse{
-			Status: status.NewInternal(ctx, err, "error getting received share"),
+			Status: status.NewInternal(ctx, "error getting received share"),
 		}, nil
 	}
 
@@ -303,9 +319,11 @@ func (s *svc) UpdateReceivedShare(ctx context.Context, req *collaboration.Update
 
 	c, err := pool.GetUserShareProviderClient(s.c.UserShareProviderEndpoint)
 	if err != nil {
-		err = errors.Wrap(err, "gateway: error calling GetUserShareProviderClient")
+		appctx.GetLogger(ctx).
+			Err(err).
+			Msg("UpdateReceivedShare: failed to get user share provider")
 		return &collaboration.UpdateReceivedShareResponse{
-			Status: status.NewInternal(ctx, err, "error getting share provider client"),
+			Status: status.NewInternal(ctx, "error getting share provider client"),
 		}, nil
 	}
 
@@ -319,30 +337,31 @@ func (s *svc) removeReference(ctx context.Context, resourceID *provider.Resource
 	idReference := &provider.Reference{ResourceId: resourceID}
 	storageProvider, _, err := s.find(ctx, idReference)
 	if err != nil {
-		log.Error().Err(err).Interface("reference", idReference).Msg("removeReference: storage provider not found")
+		appctx.GetLogger(ctx).
+			Err(err).
+			Interface("reference", idReference).
+			Msg("removeReference: failed to get storage provider")
 		if _, ok := err.(errtypes.IsNotFound); ok {
 			return status.NewNotFound(ctx, "storage provider not found")
 		}
-		return status.NewInternal(ctx, err, "error finding storage provider")
+		return status.NewInternal(ctx, "error finding storage provider")
 	}
 
 	statRes, err := storageProvider.Stat(ctx, &provider.StatRequest{Ref: idReference})
 	if err != nil {
 		log.Error().Err(err).Interface("reference", idReference).Msg("removeReference: error calling Stat")
-		return status.NewInternal(ctx, err, "gateway: error calling Stat for the share resource id: "+resourceID.String())
+		return status.NewInternal(ctx, "gateway: error calling Stat for the share resource id: "+resourceID.String())
 	}
 
 	// FIXME how can we delete a reference if the original resource was deleted?
 	if statRes.Status.Code != rpc.Code_CODE_OK {
 		log.Error().Interface("status", statRes.Status).Interface("reference", idReference).Msg("removeReference: error calling Stat")
-		err := status.NewErrorFromCode(statRes.Status.GetCode(), "gateway")
-		return status.NewInternal(ctx, err, "could not delete share reference")
+		return status.NewInternal(ctx, "could not delete share reference")
 	}
 
 	homeRes, err := s.GetHome(ctx, &provider.GetHomeRequest{})
 	if err != nil {
-		err := errors.Wrap(err, "gateway: error calling GetHome")
-		return status.NewInternal(ctx, err, "could not delete share reference")
+		return status.NewInternal(ctx, "could not delete share reference")
 	}
 
 	sharePath := path.Join(homeRes.Path, s.c.ShareFolder, path.Base(statRes.Info.Path))
@@ -351,10 +370,14 @@ func (s *svc) removeReference(ctx context.Context, resourceID *provider.Resource
 	sharePathRef := &provider.Reference{Path: sharePath}
 	homeProvider, providerInfo, err := s.find(ctx, sharePathRef)
 	if err != nil {
+		appctx.GetLogger(ctx).
+			Err(err).
+			Interface("reference", sharePathRef).
+			Msg("removeReference: failed to get storage provider for share ref")
 		if _, ok := err.(errtypes.IsNotFound); ok {
 			return status.NewNotFound(ctx, "storage provider not found")
 		}
-		return status.NewInternal(ctx, err, "error finding storage provider")
+		return status.NewInternal(ctx, "error finding storage provider")
 	}
 
 	spaceID := ""
@@ -387,7 +410,7 @@ func (s *svc) removeReference(ctx context.Context, resourceID *provider.Resource
 
 	deleteResp, err := homeProvider.Delete(ctx, deleteReq)
 	if err != nil {
-		return status.NewInternal(ctx, err, "could not delete share reference")
+		return status.NewInternal(ctx, "could not delete share reference")
 	}
 
 	switch deleteResp.Status.Code {
@@ -397,8 +420,7 @@ func (s *svc) removeReference(ctx context.Context, resourceID *provider.Resource
 		// This is fine, we wanted to delete it anyway
 		return status.NewOK(ctx)
 	default:
-		err := status.NewErrorFromCode(deleteResp.Status.GetCode(), "gateway")
-		return status.NewInternal(ctx, err, "could not delete share reference")
+		return status.NewInternal(ctx, "could not delete share reference")
 	}
 
 	log.Debug().Str("share_path", sharePath).Msg("share reference successfully removed")
@@ -418,10 +440,14 @@ func (s *svc) denyGrant(ctx context.Context, id *provider.ResourceId, g *provide
 
 	c, _, err := s.find(ctx, ref)
 	if err != nil {
+		appctx.GetLogger(ctx).
+			Err(err).
+			Interface("reference", ref).
+			Msg("denyGrant: failed to get storage provider")
 		if _, ok := err.(errtypes.IsNotFound); ok {
 			return status.NewNotFound(ctx, "storage provider not found"), nil
 		}
-		return status.NewInternal(ctx, err, "error finding storage provider"), nil
+		return status.NewInternal(ctx, "error finding storage provider"), nil
 	}
 
 	grantRes, err := c.DenyGrant(ctx, grantReq)
@@ -429,7 +455,7 @@ func (s *svc) denyGrant(ctx context.Context, id *provider.ResourceId, g *provide
 		return nil, errors.Wrap(err, "gateway: error calling DenyGrant")
 	}
 	if grantRes.Status.Code != rpc.Code_CODE_OK {
-		return status.NewInternal(ctx, status.NewErrorFromCode(grantRes.Status.Code, "gateway"),
+		return status.NewInternal(ctx,
 			"error committing share to storage grant"), nil
 	}
 
@@ -451,10 +477,14 @@ func (s *svc) addGrant(ctx context.Context, id *provider.ResourceId, g *provider
 
 	c, _, err := s.find(ctx, ref)
 	if err != nil {
+		appctx.GetLogger(ctx).
+			Err(err).
+			Interface("reference", ref).
+			Msg("addGrant: failed to get storage provider")
 		if _, ok := err.(errtypes.IsNotFound); ok {
 			return status.NewNotFound(ctx, "storage provider not found"), nil
 		}
-		return status.NewInternal(ctx, err, "error finding storage provider"), nil
+		return status.NewInternal(ctx, "error finding storage provider"), nil
 	}
 
 	grantRes, err := c.AddGrant(ctx, grantReq)
@@ -462,7 +492,7 @@ func (s *svc) addGrant(ctx context.Context, id *provider.ResourceId, g *provider
 		return nil, errors.Wrap(err, "gateway: error calling AddGrant")
 	}
 	if grantRes.Status.Code != rpc.Code_CODE_OK {
-		return status.NewInternal(ctx, status.NewErrorFromCode(grantRes.Status.Code, "gateway"),
+		return status.NewInternal(ctx,
 			"error committing share to storage grant"), nil
 	}
 
@@ -483,10 +513,14 @@ func (s *svc) updateGrant(ctx context.Context, id *provider.ResourceId, g *provi
 
 	c, _, err := s.find(ctx, ref)
 	if err != nil {
+		appctx.GetLogger(ctx).
+			Err(err).
+			Interface("reference", ref).
+			Msg("updateGrant: failed to get storage provider")
 		if _, ok := err.(errtypes.IsNotFound); ok {
 			return status.NewNotFound(ctx, "storage provider not found"), nil
 		}
-		return status.NewInternal(ctx, err, "error finding storage provider"), nil
+		return status.NewInternal(ctx, "error finding storage provider"), nil
 	}
 
 	grantRes, err := c.UpdateGrant(ctx, grantReq)
@@ -494,7 +528,7 @@ func (s *svc) updateGrant(ctx context.Context, id *provider.ResourceId, g *provi
 		return nil, errors.Wrap(err, "gateway: error calling UpdateGrant")
 	}
 	if grantRes.Status.Code != rpc.Code_CODE_OK {
-		return status.NewInternal(ctx, status.NewErrorFromCode(grantRes.Status.Code, "gateway"),
+		return status.NewInternal(ctx,
 			"error committing share to storage grant"), nil
 	}
 
@@ -516,10 +550,14 @@ func (s *svc) removeGrant(ctx context.Context, id *provider.ResourceId, g *provi
 
 	c, _, err := s.find(ctx, ref)
 	if err != nil {
+		appctx.GetLogger(ctx).
+			Err(err).
+			Interface("reference", ref).
+			Msg("removeGrant: failed to get storage provider")
 		if _, ok := err.(errtypes.IsNotFound); ok {
 			return status.NewNotFound(ctx, "storage provider not found"), nil
 		}
-		return status.NewInternal(ctx, err, "error finding storage provider"), nil
+		return status.NewInternal(ctx, "error finding storage provider"), nil
 	}
 
 	grantRes, err := c.RemoveGrant(ctx, grantReq)
@@ -527,7 +565,7 @@ func (s *svc) removeGrant(ctx context.Context, id *provider.ResourceId, g *provi
 		return nil, errors.Wrap(err, "gateway: error calling RemoveGrant")
 	}
 	if grantRes.Status.Code != rpc.Code_CODE_OK {
-		return status.NewInternal(ctx, status.NewErrorFromCode(grantRes.Status.Code, "gateway"),
+		return status.NewInternal(ctx,
 			"error removing storage grant"), nil
 	}
 

--- a/internal/grpc/services/groupprovider/groupprovider.go
+++ b/internal/grpc/services/groupprovider/groupprovider.go
@@ -107,8 +107,7 @@ func (s *service) GetGroup(ctx context.Context, req *grouppb.GetGroupRequest) (*
 		if _, ok := err.(errtypes.NotFound); ok {
 			res.Status = status.NewNotFound(ctx, "group not found")
 		} else {
-			err = errors.Wrap(err, "groupprovidersvc: error getting group")
-			res.Status = status.NewInternal(ctx, err, "error getting group")
+			res.Status = status.NewInternal(ctx, "error getting group")
 		}
 		return res, nil
 	}
@@ -126,8 +125,7 @@ func (s *service) GetGroupByClaim(ctx context.Context, req *grouppb.GetGroupByCl
 		if _, ok := err.(errtypes.NotFound); ok {
 			res.Status = status.NewNotFound(ctx, fmt.Sprintf("group not found %s %s", req.Claim, req.Value))
 		} else {
-			err = errors.Wrap(err, "groupprovidersvc: error getting group by claim")
-			res.Status = status.NewInternal(ctx, err, "error getting group by claim")
+			res.Status = status.NewInternal(ctx, "error getting group by claim")
 		}
 		return res, nil
 	}
@@ -141,9 +139,8 @@ func (s *service) GetGroupByClaim(ctx context.Context, req *grouppb.GetGroupByCl
 func (s *service) FindGroups(ctx context.Context, req *grouppb.FindGroupsRequest) (*grouppb.FindGroupsResponse, error) {
 	groups, err := s.groupmgr.FindGroups(ctx, req.Filter)
 	if err != nil {
-		err = errors.Wrap(err, "groupprovidersvc: error finding groups")
 		return &grouppb.FindGroupsResponse{
-			Status: status.NewInternal(ctx, err, "error finding groups"),
+			Status: status.NewInternal(ctx, "error finding groups"),
 		}, nil
 	}
 
@@ -161,9 +158,8 @@ func (s *service) FindGroups(ctx context.Context, req *grouppb.FindGroupsRequest
 func (s *service) GetMembers(ctx context.Context, req *grouppb.GetMembersRequest) (*grouppb.GetMembersResponse, error) {
 	members, err := s.groupmgr.GetMembers(ctx, req.GroupId)
 	if err != nil {
-		err = errors.Wrap(err, "groupprovidersvc: error getting group members")
 		return &grouppb.GetMembersResponse{
-			Status: status.NewInternal(ctx, err, "error getting group members"),
+			Status: status.NewInternal(ctx, "error getting group members"),
 		}, nil
 	}
 
@@ -176,9 +172,8 @@ func (s *service) GetMembers(ctx context.Context, req *grouppb.GetMembersRequest
 func (s *service) HasMember(ctx context.Context, req *grouppb.HasMemberRequest) (*grouppb.HasMemberResponse, error) {
 	ok, err := s.groupmgr.HasMember(ctx, req.GroupId, req.UserId)
 	if err != nil {
-		err = errors.Wrap(err, "groupprovidersvc: error checking for group member")
 		return &grouppb.HasMemberResponse{
-			Status: status.NewInternal(ctx, err, "error checking for group member"),
+			Status: status.NewInternal(ctx, "error checking for group member"),
 		}, nil
 	}
 

--- a/internal/grpc/services/ocmcore/ocmcore.go
+++ b/internal/grpc/services/ocmcore/ocmcore.go
@@ -110,9 +110,8 @@ func (s *service) UnprotectedEndpoints() []string {
 func (s *service) CreateOCMCoreShare(ctx context.Context, req *ocmcore.CreateOCMCoreShareRequest) (*ocmcore.CreateOCMCoreShareResponse, error) {
 	parts := strings.Split(req.ProviderId, ":")
 	if len(parts) < 2 {
-		err := errtypes.BadRequest("resource ID does not follow the layout storageid:opaqueid " + req.ProviderId)
 		return &ocmcore.CreateOCMCoreShareResponse{
-			Status: status.NewInternal(ctx, err, "error decoding resource ID"),
+			Status: status.NewInternal(ctx, "error decoding resource ID"),
 		}, nil
 	}
 
@@ -125,7 +124,7 @@ func (s *service) CreateOCMCoreShare(ctx context.Context, req *ocmcore.CreateOCM
 	permOpaque, ok := req.Protocol.Opaque.Map["permissions"]
 	if !ok {
 		return &ocmcore.CreateOCMCoreShareResponse{
-			Status: status.NewInternal(ctx, errtypes.BadRequest("resource permissions not set"), ""),
+			Status: status.NewInternal(ctx, "resource permissions not set"),
 		}, nil
 	}
 	switch permOpaque.Decoder {
@@ -133,13 +132,12 @@ func (s *service) CreateOCMCoreShare(ctx context.Context, req *ocmcore.CreateOCM
 		err := json.Unmarshal(permOpaque.Value, &resourcePermissions)
 		if err != nil {
 			return &ocmcore.CreateOCMCoreShareResponse{
-				Status: status.NewInternal(ctx, err, "error decoding resource permissions"),
+				Status: status.NewInternal(ctx, "error decoding resource permissions"),
 			}, nil
 		}
 	default:
-		err := errtypes.NotSupported("opaque entry decoder not recognized")
 		return &ocmcore.CreateOCMCoreShareResponse{
-			Status: status.NewInternal(ctx, err, "invalid opaque entry decoder"),
+			Status: status.NewInternal(ctx, "invalid opaque entry decoder"),
 		}, nil
 	}
 
@@ -147,16 +145,15 @@ func (s *service) CreateOCMCoreShare(ctx context.Context, req *ocmcore.CreateOCM
 	tokenOpaque, ok := req.Protocol.Opaque.Map["token"]
 	if !ok {
 		return &ocmcore.CreateOCMCoreShareResponse{
-			Status: status.NewInternal(ctx, errtypes.PermissionDenied("token not set"), ""),
+			Status: status.NewInternal(ctx, "token not set"),
 		}, nil
 	}
 	switch tokenOpaque.Decoder {
 	case "plain":
 		token = string(tokenOpaque.Value)
 	default:
-		err := errtypes.NotSupported("opaque entry decoder not recognized: " + tokenOpaque.Decoder)
 		return &ocmcore.CreateOCMCoreShareResponse{
-			Status: status.NewInternal(ctx, err, "invalid opaque entry decoder"),
+			Status: status.NewInternal(ctx, "invalid opaque entry decoder"),
 		}, nil
 	}
 
@@ -183,7 +180,7 @@ func (s *service) CreateOCMCoreShare(ctx context.Context, req *ocmcore.CreateOCM
 	share, err := s.sm.Share(ctx, resource, grant, req.Name, nil, "", req.Owner, token, shareType)
 	if err != nil {
 		return &ocmcore.CreateOCMCoreShareResponse{
-			Status: status.NewInternal(ctx, err, "error creating ocm core share"),
+			Status: status.NewInternal(ctx, "error creating ocm core share"),
 		}, nil
 	}
 

--- a/internal/grpc/services/ocminvitemanager/ocminvitemanager.go
+++ b/internal/grpc/services/ocminvitemanager/ocminvitemanager.go
@@ -105,7 +105,7 @@ func (s *service) GenerateInviteToken(ctx context.Context, req *invitepb.Generat
 	token, err := s.im.GenerateToken(ctx)
 	if err != nil {
 		return &invitepb.GenerateInviteTokenResponse{
-			Status: status.NewInternal(ctx, err, "error generating invite token"),
+			Status: status.NewInternal(ctx, "error generating invite token"),
 		}, nil
 	}
 
@@ -119,7 +119,7 @@ func (s *service) ForwardInvite(ctx context.Context, req *invitepb.ForwardInvite
 	err := s.im.ForwardInvite(ctx, req.InviteToken, req.OriginSystemProvider)
 	if err != nil {
 		return &invitepb.ForwardInviteResponse{
-			Status: status.NewInternal(ctx, err, "error forwarding invite"),
+			Status: status.NewInternal(ctx, "error forwarding invite"),
 		}, nil
 	}
 
@@ -132,7 +132,7 @@ func (s *service) AcceptInvite(ctx context.Context, req *invitepb.AcceptInviteRe
 	err := s.im.AcceptInvite(ctx, req.InviteToken, req.RemoteUser)
 	if err != nil {
 		return &invitepb.AcceptInviteResponse{
-			Status: status.NewInternal(ctx, err, "error accepting invite"),
+			Status: status.NewInternal(ctx, "error accepting invite"),
 		}, nil
 	}
 
@@ -145,7 +145,7 @@ func (s *service) GetAcceptedUser(ctx context.Context, req *invitepb.GetAccepted
 	remoteUser, err := s.im.GetAcceptedUser(ctx, req.RemoteUserId)
 	if err != nil {
 		return &invitepb.GetAcceptedUserResponse{
-			Status: status.NewInternal(ctx, err, "error fetching remote user details"),
+			Status: status.NewInternal(ctx, "error fetching remote user details"),
 		}, nil
 	}
 
@@ -159,7 +159,7 @@ func (s *service) FindAcceptedUsers(ctx context.Context, req *invitepb.FindAccep
 	acceptedUsers, err := s.im.FindAcceptedUsers(ctx, req.Filter)
 	if err != nil {
 		return &invitepb.FindAcceptedUsersResponse{
-			Status: status.NewInternal(ctx, err, "error finding remote users"),
+			Status: status.NewInternal(ctx, "error finding remote users"),
 		}, nil
 	}
 

--- a/internal/grpc/services/ocmproviderauthorizer/ocmproviderauthorizer.go
+++ b/internal/grpc/services/ocmproviderauthorizer/ocmproviderauthorizer.go
@@ -108,7 +108,7 @@ func (s *service) GetInfoByDomain(ctx context.Context, req *ocmprovider.GetInfoB
 	domainInfo, err := s.pa.GetInfoByDomain(ctx, req.Domain)
 	if err != nil {
 		return &ocmprovider.GetInfoByDomainResponse{
-			Status: status.NewInternal(ctx, err, "error getting provider info"),
+			Status: status.NewInternal(ctx, "error getting provider info"),
 		}, nil
 	}
 
@@ -122,7 +122,7 @@ func (s *service) IsProviderAllowed(ctx context.Context, req *ocmprovider.IsProv
 	err := s.pa.IsProviderAllowed(ctx, req.Provider)
 	if err != nil {
 		return &ocmprovider.IsProviderAllowedResponse{
-			Status: status.NewInternal(ctx, err, "error verifying mesh provider"),
+			Status: status.NewInternal(ctx, "error verifying mesh provider"),
 		}, nil
 	}
 
@@ -135,7 +135,7 @@ func (s *service) ListAllProviders(ctx context.Context, req *ocmprovider.ListAll
 	providers, err := s.pa.ListAllProviders(ctx)
 	if err != nil {
 		return &ocmprovider.ListAllProvidersResponse{
-			Status: status.NewInternal(ctx, err, "error retrieving mesh providers"),
+			Status: status.NewInternal(ctx, "error retrieving mesh providers"),
 		}, nil
 	}
 

--- a/internal/grpc/services/ocmshareprovider/ocmshareprovider.go
+++ b/internal/grpc/services/ocmshareprovider/ocmshareprovider.go
@@ -106,7 +106,7 @@ func (s *service) CreateOCMShare(ctx context.Context, req *ocm.CreateOCMShareReq
 
 	if req.Opaque == nil {
 		return &ocm.CreateOCMShareResponse{
-			Status: status.NewInternal(ctx, errtypes.BadRequest("can't find resource permissions"), ""),
+			Status: status.NewInternal(ctx, "can't find resource permissions"),
 		}, nil
 	}
 
@@ -114,16 +114,15 @@ func (s *service) CreateOCMShare(ctx context.Context, req *ocm.CreateOCMShareReq
 	permOpaque, ok := req.Opaque.Map["permissions"]
 	if !ok {
 		return &ocm.CreateOCMShareResponse{
-			Status: status.NewInternal(ctx, errtypes.BadRequest("resource permissions not set"), ""),
+			Status: status.NewInternal(ctx, "resource permissions not set"),
 		}, nil
 	}
 	switch permOpaque.Decoder {
 	case "plain":
 		permissions = string(permOpaque.Value)
 	default:
-		err := errtypes.NotSupported("opaque entry decoder not recognized: " + permOpaque.Decoder)
 		return &ocm.CreateOCMShareResponse{
-			Status: status.NewInternal(ctx, err, "invalid opaque entry decoder"),
+			Status: status.NewInternal(ctx, "invalid opaque entry decoder"),
 		}, nil
 	}
 
@@ -131,16 +130,15 @@ func (s *service) CreateOCMShare(ctx context.Context, req *ocm.CreateOCMShareReq
 	nameOpaque, ok := req.Opaque.Map["name"]
 	if !ok {
 		return &ocm.CreateOCMShareResponse{
-			Status: status.NewInternal(ctx, errtypes.BadRequest("resource name not set"), ""),
+			Status: status.NewInternal(ctx, "resource name not set"),
 		}, nil
 	}
 	switch nameOpaque.Decoder {
 	case "plain":
 		name = string(nameOpaque.Value)
 	default:
-		err := errtypes.NotSupported("opaque entry decoder not recognized: " + nameOpaque.Decoder)
 		return &ocm.CreateOCMShareResponse{
-			Status: status.NewInternal(ctx, err, "invalid opaque entry decoder"),
+			Status: status.NewInternal(ctx, "invalid opaque entry decoder"),
 		}, nil
 	}
 
@@ -154,9 +152,8 @@ func (s *service) CreateOCMShare(ctx context.Context, req *ocm.CreateOCMShareReq
 				sharetype = ocm.Share_SHARE_TYPE_TRANSFER
 			}
 		default:
-			err := errors.New("protocol decoder not recognized")
 			return &ocm.CreateOCMShareResponse{
-				Status: status.NewInternal(ctx, err, "error creating share"),
+				Status: status.NewInternal(ctx, "error creating share"),
 			}, nil
 		}
 	}
@@ -164,7 +161,7 @@ func (s *service) CreateOCMShare(ctx context.Context, req *ocm.CreateOCMShareReq
 	share, err := s.sm.Share(ctx, req.ResourceId, req.Grant, name, req.RecipientMeshProvider, permissions, nil, "", sharetype)
 	if err != nil {
 		return &ocm.CreateOCMShareResponse{
-			Status: status.NewInternal(ctx, err, "error creating share"),
+			Status: status.NewInternal(ctx, "error creating share"),
 		}, nil
 	}
 
@@ -179,7 +176,7 @@ func (s *service) RemoveOCMShare(ctx context.Context, req *ocm.RemoveOCMShareReq
 	err := s.sm.Unshare(ctx, req.Ref)
 	if err != nil {
 		return &ocm.RemoveOCMShareResponse{
-			Status: status.NewInternal(ctx, err, "error removing share"),
+			Status: status.NewInternal(ctx, "error removing share"),
 		}, nil
 	}
 
@@ -192,7 +189,7 @@ func (s *service) GetOCMShare(ctx context.Context, req *ocm.GetOCMShareRequest) 
 	share, err := s.sm.GetShare(ctx, req.Ref)
 	if err != nil {
 		return &ocm.GetOCMShareResponse{
-			Status: status.NewInternal(ctx, err, "error getting share"),
+			Status: status.NewInternal(ctx, "error getting share"),
 		}, nil
 	}
 
@@ -206,7 +203,7 @@ func (s *service) ListOCMShares(ctx context.Context, req *ocm.ListOCMSharesReque
 	shares, err := s.sm.ListShares(ctx, req.Filters) // TODO(labkode): add filter to share manager
 	if err != nil {
 		return &ocm.ListOCMSharesResponse{
-			Status: status.NewInternal(ctx, err, "error listing shares"),
+			Status: status.NewInternal(ctx, "error listing shares"),
 		}, nil
 	}
 
@@ -221,7 +218,7 @@ func (s *service) UpdateOCMShare(ctx context.Context, req *ocm.UpdateOCMShareReq
 	_, err := s.sm.UpdateShare(ctx, req.Ref, req.Field.GetPermissions()) // TODO(labkode): check what to update
 	if err != nil {
 		return &ocm.UpdateOCMShareResponse{
-			Status: status.NewInternal(ctx, err, "error updating share"),
+			Status: status.NewInternal(ctx, "error updating share"),
 		}, nil
 	}
 
@@ -235,7 +232,7 @@ func (s *service) ListReceivedOCMShares(ctx context.Context, req *ocm.ListReceiv
 	shares, err := s.sm.ListReceivedShares(ctx)
 	if err != nil {
 		return &ocm.ListReceivedOCMSharesResponse{
-			Status: status.NewInternal(ctx, err, "error listing received shares"),
+			Status: status.NewInternal(ctx, "error listing received shares"),
 		}, nil
 	}
 
@@ -250,7 +247,7 @@ func (s *service) UpdateReceivedOCMShare(ctx context.Context, req *ocm.UpdateRec
 	_, err := s.sm.UpdateReceivedShare(ctx, req.Share, req.UpdateMask) // TODO(labkode): check what to update
 	if err != nil {
 		return &ocm.UpdateReceivedOCMShareResponse{
-			Status: status.NewInternal(ctx, err, "error updating received share"),
+			Status: status.NewInternal(ctx, "error updating received share"),
 		}, nil
 	}
 
@@ -264,7 +261,7 @@ func (s *service) GetReceivedOCMShare(ctx context.Context, req *ocm.GetReceivedO
 	share, err := s.sm.GetReceivedShare(ctx, req.Ref)
 	if err != nil {
 		return &ocm.GetReceivedOCMShareResponse{
-			Status: status.NewInternal(ctx, err, "error getting received share"),
+			Status: status.NewInternal(ctx, "error getting received share"),
 		}, nil
 	}
 

--- a/internal/grpc/services/publicshareprovider/publicshareprovider.go
+++ b/internal/grpc/services/publicshareprovider/publicshareprovider.go
@@ -166,7 +166,7 @@ func (s *service) RemovePublicShare(ctx context.Context, req *link.RemovePublicS
 	err := s.sm.RevokePublicShare(ctx, user, req.Ref)
 	if err != nil {
 		return &link.RemovePublicShareResponse{
-			Status: status.NewInternal(ctx, err, "error deleting public share"),
+			Status: status.NewInternal(ctx, "error deleting public share"),
 		}, err
 	}
 	return &link.RemovePublicShareResponse{
@@ -196,7 +196,7 @@ func (s *service) GetPublicShareByToken(ctx context.Context, req *link.GetPublic
 		}, nil
 	default:
 		return &link.GetPublicShareByTokenResponse{
-			Status: status.NewInternal(ctx, v, "unexpected error"),
+			Status: status.NewInternal(ctx, "unexpected error"),
 		}, nil
 	}
 }
@@ -230,7 +230,7 @@ func (s *service) ListPublicShares(ctx context.Context, req *link.ListPublicShar
 	if err != nil {
 		log.Err(err).Msg("error listing shares")
 		return &link.ListPublicSharesResponse{
-			Status: status.NewInternal(ctx, err, "error listing public shares"),
+			Status: status.NewInternal(ctx, "error listing public shares"),
 		}, nil
 	}
 

--- a/internal/grpc/services/publicstorageprovider/publicstorageprovider.go
+++ b/internal/grpc/services/publicstorageprovider/publicstorageprovider.go
@@ -124,18 +124,18 @@ func (s *service) InitiateFileDownload(ctx context.Context, req *provider.Initia
 	statRes, err := s.Stat(ctx, statReq)
 	if err != nil {
 		return &provider.InitiateFileDownloadResponse{
-			Status: status.NewInternal(ctx, err, "gateway: error stating ref:"+req.Ref.String()),
+			Status: status.NewInternal(ctx, err, "InitiateFileDownload: error stating ref:"+req.Ref.String()),
 		}, nil
 	}
 	if statRes.Status.Code != rpc.Code_CODE_OK {
 		if statRes.Status.Code == rpc.Code_CODE_NOT_FOUND {
 			return &provider.InitiateFileDownloadResponse{
-				Status: status.NewNotFound(ctx, "gateway: file not found"),
+				Status: status.NewNotFound(ctx, "InitiateFileDownload: file not found"),
 			}, nil
 		}
 		err := status.NewErrorFromCode(statRes.Status.Code, "gateway")
 		return &provider.InitiateFileDownloadResponse{
-			Status: status.NewInternal(ctx, err, "gateway: error stating ref"),
+			Status: status.NewInternal(ctx, err, "InitiateFileDownload: error stating ref"),
 		}, nil
 	}
 
@@ -201,7 +201,7 @@ func (s *service) initiateFileDownload(ctx context.Context, req *provider.Initia
 	dRes, err := s.gateway.InitiateFileDownload(ctx, dReq)
 	if err != nil {
 		return &provider.InitiateFileDownloadResponse{
-			Status: status.NewInternal(ctx, err, "gateway: error calling InitiateFileDownload"),
+			Status: status.NewInternal(ctx, err, "initiateFileDownload: error calling InitiateFileDownload"),
 		}, nil
 	}
 
@@ -254,7 +254,7 @@ func (s *service) InitiateFileUpload(ctx context.Context, req *provider.Initiate
 	uRes, err := s.gateway.InitiateFileUpload(ctx, uReq)
 	if err != nil {
 		return &provider.InitiateFileUploadResponse{
-			Status: status.NewInternal(ctx, err, "gateway: error calling InitiateFileUpload"),
+			Status: status.NewInternal(ctx, err, "InitiateFileUpload: error calling InitiateFileUpload"),
 		}, nil
 	}
 
@@ -386,7 +386,7 @@ func (s *service) CreateContainer(ctx context.Context, req *provider.CreateConta
 	})
 	if err != nil {
 		return &provider.CreateContainerResponse{
-			Status: status.NewInternal(ctx, err, "gateway: error calling CreateContainer for ref:"+req.Ref.String()),
+			Status: status.NewInternal(ctx, err, "createContainer: error calling CreateContainer for ref:"+req.Ref.String()),
 		}, nil
 	}
 	if res.Status.Code == rpc.Code_CODE_INTERNAL {
@@ -426,7 +426,7 @@ func (s *service) Delete(ctx context.Context, req *provider.DeleteRequest) (*pro
 	})
 	if err != nil {
 		return &provider.DeleteResponse{
-			Status: status.NewInternal(ctx, err, "gateway: error calling Delete for ref:"+req.Ref.String()),
+			Status: status.NewInternal(ctx, err, "Delete: error calling Delete for ref:"+req.Ref.String()),
 		}, nil
 	}
 	if res.Status.Code == rpc.Code_CODE_INTERNAL {
@@ -489,7 +489,7 @@ func (s *service) Move(ctx context.Context, req *provider.MoveRequest) (*provide
 	})
 	if err != nil {
 		return &provider.MoveResponse{
-			Status: status.NewInternal(ctx, err, "gateway: error calling Move for source ref "+req.Source.String()+" to destination ref "+req.Destination.String()),
+			Status: status.NewInternal(ctx, err, "Move: error calling Move for source ref "+req.Source.String()+" to destination ref "+req.Destination.String()),
 		}, nil
 	}
 	if res.Status.Code == rpc.Code_CODE_INTERNAL {
@@ -545,7 +545,7 @@ func (s *service) Stat(ctx context.Context, req *provider.StatRequest) (*provide
 	statResponse, err := s.gateway.Stat(ctx, &provider.StatRequest{Ref: ref})
 	if err != nil {
 		return &provider.StatResponse{
-			Status: status.NewInternal(ctx, err, "gateway: error calling Stat for ref:"+req.Ref.String()),
+			Status: status.NewInternal(ctx, err, "Stat: error calling Stat for ref:"+req.Ref.String()),
 		}, nil
 	}
 
@@ -632,7 +632,7 @@ func (s *service) ListContainer(ctx context.Context, req *provider.ListContainer
 	)
 	if err != nil {
 		return &provider.ListContainerResponse{
-			Status: status.NewInternal(ctx, err, "gateway: error calling ListContainer for ref:"+req.Ref.String()),
+			Status: status.NewInternal(ctx, err, "ListContainer: error calling ListContainer for ref:"+req.Ref.String()),
 		}, nil
 	}
 

--- a/internal/grpc/services/publicstorageprovider/publicstorageprovider.go
+++ b/internal/grpc/services/publicstorageprovider/publicstorageprovider.go
@@ -124,7 +124,7 @@ func (s *service) InitiateFileDownload(ctx context.Context, req *provider.Initia
 	statRes, err := s.Stat(ctx, statReq)
 	if err != nil {
 		return &provider.InitiateFileDownloadResponse{
-			Status: status.NewInternal(ctx, err, "InitiateFileDownload: error stating ref:"+req.Ref.String()),
+			Status: status.NewInternal(ctx, "InitiateFileDownload: error stating ref:"+req.Ref.String()),
 		}, nil
 	}
 	if statRes.Status.Code != rpc.Code_CODE_OK {
@@ -133,9 +133,8 @@ func (s *service) InitiateFileDownload(ctx context.Context, req *provider.Initia
 				Status: status.NewNotFound(ctx, "InitiateFileDownload: file not found"),
 			}, nil
 		}
-		err := status.NewErrorFromCode(statRes.Status.Code, "gateway")
 		return &provider.InitiateFileDownloadResponse{
-			Status: status.NewInternal(ctx, err, "InitiateFileDownload: error stating ref"),
+			Status: status.NewInternal(ctx, "InitiateFileDownload: error stating ref"),
 		}, nil
 	}
 
@@ -201,7 +200,7 @@ func (s *service) initiateFileDownload(ctx context.Context, req *provider.Initia
 	dRes, err := s.gateway.InitiateFileDownload(ctx, dReq)
 	if err != nil {
 		return &provider.InitiateFileDownloadResponse{
-			Status: status.NewInternal(ctx, err, "initiateFileDownload: error calling InitiateFileDownload"),
+			Status: status.NewInternal(ctx, "initiateFileDownload: error calling InitiateFileDownload"),
 		}, nil
 	}
 
@@ -254,7 +253,7 @@ func (s *service) InitiateFileUpload(ctx context.Context, req *provider.Initiate
 	uRes, err := s.gateway.InitiateFileUpload(ctx, uReq)
 	if err != nil {
 		return &provider.InitiateFileUploadResponse{
-			Status: status.NewInternal(ctx, err, "InitiateFileUpload: error calling InitiateFileUpload"),
+			Status: status.NewInternal(ctx, "InitiateFileUpload: error calling InitiateFileUpload"),
 		}, nil
 	}
 
@@ -386,7 +385,7 @@ func (s *service) CreateContainer(ctx context.Context, req *provider.CreateConta
 	})
 	if err != nil {
 		return &provider.CreateContainerResponse{
-			Status: status.NewInternal(ctx, err, "createContainer: error calling CreateContainer for ref:"+req.Ref.String()),
+			Status: status.NewInternal(ctx, "createContainer: error calling CreateContainer for ref:"+req.Ref.String()),
 		}, nil
 	}
 	if res.Status.Code == rpc.Code_CODE_INTERNAL {
@@ -426,7 +425,7 @@ func (s *service) Delete(ctx context.Context, req *provider.DeleteRequest) (*pro
 	})
 	if err != nil {
 		return &provider.DeleteResponse{
-			Status: status.NewInternal(ctx, err, "Delete: error calling Delete for ref:"+req.Ref.String()),
+			Status: status.NewInternal(ctx, "Delete: error calling Delete for ref:"+req.Ref.String()),
 		}, nil
 	}
 	if res.Status.Code == rpc.Code_CODE_INTERNAL {
@@ -489,7 +488,7 @@ func (s *service) Move(ctx context.Context, req *provider.MoveRequest) (*provide
 	})
 	if err != nil {
 		return &provider.MoveResponse{
-			Status: status.NewInternal(ctx, err, "Move: error calling Move for source ref "+req.Source.String()+" to destination ref "+req.Destination.String()),
+			Status: status.NewInternal(ctx, "Move: error calling Move for source ref "+req.Source.String()+" to destination ref "+req.Destination.String()),
 		}, nil
 	}
 	if res.Status.Code == rpc.Code_CODE_INTERNAL {
@@ -545,7 +544,7 @@ func (s *service) Stat(ctx context.Context, req *provider.StatRequest) (*provide
 	statResponse, err := s.gateway.Stat(ctx, &provider.StatRequest{Ref: ref})
 	if err != nil {
 		return &provider.StatResponse{
-			Status: status.NewInternal(ctx, err, "Stat: error calling Stat for ref:"+req.Ref.String()),
+			Status: status.NewInternal(ctx, "Stat: error calling Stat for ref:"+req.Ref.String()),
 		}, nil
 	}
 
@@ -632,7 +631,7 @@ func (s *service) ListContainer(ctx context.Context, req *provider.ListContainer
 	)
 	if err != nil {
 		return &provider.ListContainerResponse{
-			Status: status.NewInternal(ctx, err, "ListContainer: error calling ListContainer for ref:"+req.Ref.String()),
+			Status: status.NewInternal(ctx, "ListContainer: error calling ListContainer for ref:"+req.Ref.String()),
 		}, nil
 	}
 

--- a/internal/grpc/services/sharesstorageprovider/sharesstorageprovider.go
+++ b/internal/grpc/services/sharesstorageprovider/sharesstorageprovider.go
@@ -429,7 +429,7 @@ func (s *service) Delete(ctx context.Context, req *provider.DeleteRequest) (*pro
 		err := s.rejectReceivedShare(ctx, receivedShare)
 		if err != nil {
 			return &provider.DeleteResponse{
-				Status: status.NewInternal(ctx, err, "sharesstorageprovider: error rejecting share"),
+				Status: status.NewInternal(ctx, "sharesstorageprovider: error rejecting share"),
 			}, nil
 		}
 		return &provider.DeleteResponse{
@@ -485,7 +485,7 @@ func (s *service) Move(ctx context.Context, req *provider.MoveRequest) (*provide
 		})
 		if err != nil {
 			return &provider.MoveResponse{
-				Status: status.NewInternal(ctx, err, "sharesstorageprovider: can not change mountpoint of share"),
+				Status: status.NewInternal(ctx, "sharesstorageprovider: can not change mountpoint of share"),
 			}, nil
 		}
 		return &provider.MoveResponse{

--- a/internal/grpc/services/storageprovider/storageprovider.go
+++ b/internal/grpc/services/storageprovider/storageprovider.go
@@ -197,6 +197,11 @@ func (s *service) SetArbitraryMetadata(ctx context.Context, req *provider.SetArb
 		default:
 			st = status.NewInternal(ctx, err, "error setting arbitrary metadata: "+req.Ref.String())
 		}
+		appctx.GetLogger(ctx).
+			Error().
+			Err(err).
+			Interface("status", st).
+			Msg("failed to set arbitrary metadata")
 		return &provider.SetArbitraryMetadataResponse{
 			Status: st,
 		}, nil
@@ -219,6 +224,11 @@ func (s *service) UnsetArbitraryMetadata(ctx context.Context, req *provider.Unse
 		default:
 			st = status.NewInternal(ctx, err, "error unsetting arbitrary metadata: "+req.Ref.String())
 		}
+		appctx.GetLogger(ctx).
+			Error().
+			Err(err).
+			Interface("status", st).
+			Msg("failed to unset arbitrary metadata")
 		return &provider.UnsetArbitraryMetadataResponse{
 			Status: st,
 		}, nil
@@ -276,6 +286,7 @@ func (s *service) InitiateFileUpload(ctx context.Context, req *provider.Initiate
 			var err error
 			uploadLength, err = strconv.ParseInt(string(req.Opaque.Map["Upload-Length"].Value), 10, 64)
 			if err != nil {
+				log.Error().Err(err).Msg("error parsing upload length")
 				return &provider.InitiateFileUploadResponse{
 					Status: status.NewInternal(ctx, err, "error parsing upload length"),
 				}, nil
@@ -314,6 +325,10 @@ func (s *service) InitiateFileUpload(ctx context.Context, req *provider.Initiate
 		default:
 			st = status.NewInternal(ctx, err, "error getting upload id: "+req.Ref.String())
 		}
+		log.Error().
+			Err(err).
+			Interface("status", st).
+			Msg("failed to initiate upload")
 		return &provider.InitiateFileUploadResponse{
 			Status: st,
 		}, nil
@@ -348,6 +363,10 @@ func (s *service) GetPath(ctx context.Context, req *provider.GetPathRequest) (*p
 	// TODO(labkode): check that the storage ID is the same as the storage provider id.
 	fn, err := s.storage.GetPathByID(ctx, req.ResourceId)
 	if err != nil {
+		appctx.GetLogger(ctx).Error().
+			Err(err).
+			Interface("resource_id", req.ResourceId).
+			Msg("error getting path by id")
 		return &provider.GetPathResponse{
 			Status: status.NewInternal(ctx, err, "error getting path by id"),
 		}, nil
@@ -394,6 +413,12 @@ func (s *service) CreateStorageSpace(ctx context.Context, req *provider.CreateSt
 		default:
 			st = status.NewInternal(ctx, err, "error listing spaces")
 		}
+		appctx.GetLogger(ctx).
+			Error().
+			Err(err).
+			Interface("status", st).
+			Interface("request", req).
+			Msg("failed to create storage space")
 		return &provider.CreateStorageSpaceResponse{
 			Status: st,
 		}, nil
@@ -430,6 +455,11 @@ func (s *service) ListStorageSpaces(ctx context.Context, req *provider.ListStora
 		default:
 			st = status.NewInternal(ctx, err, "error listing spaces")
 		}
+		log.Error().
+			Err(err).
+			Interface("status", st).
+			Interface("filters", req.Filters).
+			Msg("failed to list storage spaces")
 		return &provider.ListStorageSpacesResponse{
 			Status: st,
 		}, nil
@@ -448,7 +478,16 @@ func (s *service) ListStorageSpaces(ctx context.Context, req *provider.ListStora
 }
 
 func (s *service) UpdateStorageSpace(ctx context.Context, req *provider.UpdateStorageSpaceRequest) (*provider.UpdateStorageSpaceResponse, error) {
-	return s.storage.UpdateStorageSpace(ctx, req)
+	res, err := s.storage.UpdateStorageSpace(ctx, req)
+	if err != nil {
+		appctx.GetLogger(ctx).
+			Error().
+			Err(err).
+			Interface("req", req).
+			Msg("failed to update storage space")
+		return nil, err
+	}
+	return res, nil
 }
 
 func (s *service) DeleteStorageSpace(ctx context.Context, req *provider.DeleteStorageSpaceRequest) (*provider.DeleteStorageSpaceResponse, error) {
@@ -462,6 +501,12 @@ func (s *service) DeleteStorageSpace(ctx context.Context, req *provider.DeleteSt
 		default:
 			st = status.NewInternal(ctx, err, "error deleting space: "+req.Id.String())
 		}
+		appctx.GetLogger(ctx).
+			Error().
+			Err(err).
+			Interface("status", st).
+			Interface("storage_space_id", req.Id).
+			Msg("failed to delete storage space")
 		return &provider.DeleteStorageSpaceResponse{
 			Status: st,
 		}, nil
@@ -486,6 +531,12 @@ func (s *service) CreateContainer(ctx context.Context, req *provider.CreateConta
 		default:
 			st = status.NewInternal(ctx, err, "error creating container: "+req.Ref.String())
 		}
+		appctx.GetLogger(ctx).
+			Error().
+			Err(err).
+			Interface("status", st).
+			Interface("reference", req.Ref).
+			Msg("failed to create container")
 		return &provider.CreateContainerResponse{
 			Status: st,
 		}, nil
@@ -523,6 +574,12 @@ func (s *service) Delete(ctx context.Context, req *provider.DeleteRequest) (*pro
 		default:
 			st = status.NewInternal(ctx, err, "error deleting file: "+req.Ref.String())
 		}
+		appctx.GetLogger(ctx).
+			Error().
+			Err(err).
+			Interface("status", st).
+			Interface("reference", req.Ref).
+			Msg("failed to delete")
 		return &provider.DeleteResponse{
 			Status: st,
 		}, nil
@@ -545,6 +602,13 @@ func (s *service) Move(ctx context.Context, req *provider.MoveRequest) (*provide
 		default:
 			st = status.NewInternal(ctx, err, "error moving: "+req.Source.String())
 		}
+		appctx.GetLogger(ctx).
+			Error().
+			Err(err).
+			Interface("status", st).
+			Interface("source_reference", req.Source).
+			Interface("target_reference", req.Destination).
+			Msg("failed to move")
 		return &provider.MoveResponse{
 			Status: st,
 		}, nil
@@ -576,6 +640,12 @@ func (s *service) Stat(ctx context.Context, req *provider.StatRequest) (*provide
 		default:
 			st = status.NewInternal(ctx, err, "error statting: "+req.Ref.String())
 		}
+		appctx.GetLogger(ctx).
+			Error().
+			Err(err).
+			Interface("status", st).
+			Interface("reference", req.Ref).
+			Msg("failed to stat")
 		return &provider.StatResponse{
 			Status: st,
 		}, nil
@@ -603,6 +673,11 @@ func (s *service) ListContainerStream(req *provider.ListContainerStreamRequest, 
 		default:
 			st = status.NewInternal(ctx, err, "error listing container: "+req.Ref.String())
 		}
+		log.Error().
+			Err(err).
+			Interface("status", st).
+			Interface("reference", req.Ref).
+			Msg("failed to list folder (stream)")
 		res := &provider.ListContainerStreamResponse{
 			Status: st,
 		}
@@ -639,6 +714,12 @@ func (s *service) ListContainer(ctx context.Context, req *provider.ListContainer
 		default:
 			st = status.NewInternal(ctx, err, "error listing container: "+req.Ref.String())
 		}
+		appctx.GetLogger(ctx).
+			Error().
+			Err(err).
+			Interface("status", st).
+			Interface("reference", req.Ref).
+			Msg("failed to list folder")
 		return &provider.ListContainerResponse{
 			Status: st,
 		}, nil
@@ -663,6 +744,12 @@ func (s *service) ListFileVersions(ctx context.Context, req *provider.ListFileVe
 		default:
 			st = status.NewInternal(ctx, err, "error listing file versions: "+req.Ref.String())
 		}
+		appctx.GetLogger(ctx).
+			Error().
+			Err(err).
+			Interface("status", st).
+			Interface("reference", req.Ref).
+			Msg("failed to list file versions")
 		return &provider.ListFileVersionsResponse{
 			Status: st,
 		}, nil
@@ -688,6 +775,13 @@ func (s *service) RestoreFileVersion(ctx context.Context, req *provider.RestoreF
 		default:
 			st = status.NewInternal(ctx, err, "error restoring version: "+req.Ref.String())
 		}
+		appctx.GetLogger(ctx).
+			Error().
+			Err(err).
+			Interface("status", st).
+			Interface("reference", req.Ref).
+			Str("key", req.Key).
+			Msg("failed to restore file version")
 		return &provider.RestoreFileVersionResponse{
 			Status: st,
 		}, nil
@@ -715,6 +809,12 @@ func (s *service) ListRecycleStream(req *provider.ListRecycleStreamRequest, ss p
 		default:
 			st = status.NewInternal(ctx, err, "error listing recycle stream")
 		}
+		log.Error().
+			Err(err).
+			Interface("status", st).
+			Interface("reference", req.Ref).
+			Str("key", req.Key).
+			Msg("failed to list recycle (stream)")
 		res := &provider.ListRecycleStreamResponse{
 			Status: st,
 		}
@@ -752,6 +852,13 @@ func (s *service) ListRecycle(ctx context.Context, req *provider.ListRecycleRequ
 		default:
 			st = status.NewInternal(ctx, err, "error listing recycle")
 		}
+		appctx.GetLogger(ctx).
+			Error().
+			Err(err).
+			Interface("status", st).
+			Interface("reference", req.Ref).
+			Str("key", req.Key).
+			Msg("failed to list recycle")
 		return &provider.ListRecycleResponse{
 			Status: st,
 		}, nil
@@ -777,6 +884,13 @@ func (s *service) RestoreRecycleItem(ctx context.Context, req *provider.RestoreR
 		default:
 			st = status.NewInternal(ctx, err, "error restoring recycle bin item")
 		}
+		appctx.GetLogger(ctx).
+			Error().
+			Err(err).
+			Interface("status", st).
+			Interface("reference", req.Ref).
+			Str("key", req.Key).
+			Msg("failed to restore recycle item")
 		return &provider.RestoreRecycleItemResponse{
 			Status: st,
 		}, nil
@@ -802,6 +916,13 @@ func (s *service) PurgeRecycle(ctx context.Context, req *provider.PurgeRecycleRe
 			default:
 				st = status.NewInternal(ctx, err, "error purging recycle item")
 			}
+			appctx.GetLogger(ctx).
+				Error().
+				Err(err).
+				Interface("status", st).
+				Interface("reference", req.Ref).
+				Str("key", req.Key).
+				Msg("failed to purge recycle item")
 			return &provider.PurgeRecycleResponse{
 				Status: st,
 			}, nil
@@ -817,6 +938,13 @@ func (s *service) PurgeRecycle(ctx context.Context, req *provider.PurgeRecycleRe
 		default:
 			st = status.NewInternal(ctx, err, "error purging recycle bin")
 		}
+		appctx.GetLogger(ctx).
+			Error().
+			Err(err).
+			Interface("status", st).
+			Interface("reference", req.Ref).
+			Str("key", req.Key).
+			Msg("failed to empty recycle")
 		return &provider.PurgeRecycleResponse{
 			Status: st,
 		}, nil
@@ -840,6 +968,12 @@ func (s *service) ListGrants(ctx context.Context, req *provider.ListGrantsReques
 		default:
 			st = status.NewInternal(ctx, err, "error listing grants")
 		}
+		appctx.GetLogger(ctx).
+			Error().
+			Err(err).
+			Interface("status", st).
+			Interface("reference", req.Ref).
+			Msg("failed to list grants")
 		return &provider.ListGrantsResponse{
 			Status: st,
 		}, nil
@@ -871,6 +1005,12 @@ func (s *service) DenyGrant(ctx context.Context, req *provider.DenyGrantRequest)
 		default:
 			st = status.NewInternal(ctx, err, "error setting grants")
 		}
+		appctx.GetLogger(ctx).
+			Error().
+			Err(err).
+			Interface("status", st).
+			Interface("reference", req.Ref).
+			Msg("failed to deny grant")
 		return &provider.DenyGrantResponse{
 			Status: st,
 		}, nil
@@ -901,6 +1041,12 @@ func (s *service) AddGrant(ctx context.Context, req *provider.AddGrantRequest) (
 		default:
 			st = status.NewInternal(ctx, err, "error setting grants")
 		}
+		appctx.GetLogger(ctx).
+			Error().
+			Err(err).
+			Interface("status", st).
+			Interface("reference", req.Ref).
+			Msg("failed to add grant")
 		return &provider.AddGrantResponse{
 			Status: st,
 		}, nil
@@ -930,6 +1076,12 @@ func (s *service) UpdateGrant(ctx context.Context, req *provider.UpdateGrantRequ
 		default:
 			st = status.NewInternal(ctx, err, "error updating grant")
 		}
+		appctx.GetLogger(ctx).
+			Error().
+			Err(err).
+			Interface("status", st).
+			Interface("reference", req.Ref).
+			Msg("failed to update grant")
 		return &provider.UpdateGrantResponse{
 			Status: st,
 		}, nil
@@ -959,6 +1111,12 @@ func (s *service) RemoveGrant(ctx context.Context, req *provider.RemoveGrantRequ
 		default:
 			st = status.NewInternal(ctx, err, "error removing grant")
 		}
+		appctx.GetLogger(ctx).
+			Error().
+			Err(err).
+			Interface("status", st).
+			Interface("reference", req.Ref).
+			Msg("failed to remove grant")
 		return &provider.RemoveGrantResponse{
 			Status: st,
 		}, nil
@@ -976,14 +1134,13 @@ func (s *service) CreateReference(ctx context.Context, req *provider.CreateRefer
 	// parse uri is valid
 	u, err := url.Parse(req.TargetUri)
 	if err != nil {
-		log.Err(err).Msg("invalid target uri")
+		log.Error().Err(err).Msg("invalid target uri")
 		return &provider.CreateReferenceResponse{
 			Status: status.NewInvalidArg(ctx, "target uri is invalid: "+err.Error()),
 		}, nil
 	}
 
 	if err := s.storage.CreateReference(ctx, req.Ref.GetPath(), u); err != nil {
-		log.Err(err).Msg("error calling CreateReference")
 		var st *rpc.Status
 		switch err.(type) {
 		case errtypes.IsNotFound:
@@ -993,6 +1150,11 @@ func (s *service) CreateReference(ctx context.Context, req *provider.CreateRefer
 		default:
 			st = status.NewInternal(ctx, err, "error creating reference")
 		}
+		log.Error().
+			Err(err).
+			Interface("status", st).
+			Interface("reference", req.Ref).
+			Msg("failed to create reference")
 		return &provider.CreateReferenceResponse{
 			Status: st,
 		}, nil
@@ -1021,6 +1183,12 @@ func (s *service) GetQuota(ctx context.Context, req *provider.GetQuotaRequest) (
 		default:
 			st = status.NewInternal(ctx, err, "error getting quota")
 		}
+		appctx.GetLogger(ctx).
+			Error().
+			Err(err).
+			Interface("status", st).
+			Interface("reference", req.Ref).
+			Msg("failed to get quota")
 		return &provider.GetQuotaResponse{
 			Status: st,
 		}, nil

--- a/internal/grpc/services/storageprovider/storageprovider.go
+++ b/internal/grpc/services/storageprovider/storageprovider.go
@@ -195,7 +195,7 @@ func (s *service) SetArbitraryMetadata(ctx context.Context, req *provider.SetArb
 		case errtypes.PermissionDenied:
 			st = status.NewPermissionDenied(ctx, err, "permission denied")
 		default:
-			st = status.NewInternal(ctx, err, "error setting arbitrary metadata: "+req.Ref.String())
+			st = status.NewInternal(ctx, "error setting arbitrary metadata: "+req.Ref.String())
 		}
 		appctx.GetLogger(ctx).
 			Error().
@@ -222,7 +222,7 @@ func (s *service) UnsetArbitraryMetadata(ctx context.Context, req *provider.Unse
 		case errtypes.PermissionDenied:
 			st = status.NewPermissionDenied(ctx, err, "permission denied")
 		default:
-			st = status.NewInternal(ctx, err, "error unsetting arbitrary metadata: "+req.Ref.String())
+			st = status.NewInternal(ctx, "error unsetting arbitrary metadata: "+req.Ref.String())
 		}
 		appctx.GetLogger(ctx).
 			Error().
@@ -275,7 +275,7 @@ func (s *service) InitiateFileUpload(ctx context.Context, req *provider.Initiate
 	log := appctx.GetLogger(ctx)
 	if req.Ref.GetPath() == "/" {
 		return &provider.InitiateFileUploadResponse{
-			Status: status.NewInternal(ctx, errtypes.BadRequest("can't upload to mount path"), "can't upload to mount path"),
+			Status: status.NewInternal(ctx, "can't upload to mount path"),
 		}, nil
 	}
 
@@ -288,7 +288,7 @@ func (s *service) InitiateFileUpload(ctx context.Context, req *provider.Initiate
 			if err != nil {
 				log.Error().Err(err).Msg("error parsing upload length")
 				return &provider.InitiateFileUploadResponse{
-					Status: status.NewInternal(ctx, err, "error parsing upload length"),
+					Status: status.NewInternal(ctx, "error parsing upload length"),
 				}, nil
 			}
 		}
@@ -323,7 +323,7 @@ func (s *service) InitiateFileUpload(ctx context.Context, req *provider.Initiate
 		case errtypes.InsufficientStorage:
 			st = status.NewInsufficientStorage(ctx, err, "insufficient storage")
 		default:
-			st = status.NewInternal(ctx, err, "error getting upload id: "+req.Ref.String())
+			st = status.NewInternal(ctx, "error getting upload id: "+req.Ref.String())
 		}
 		log.Error().
 			Err(err).
@@ -368,7 +368,7 @@ func (s *service) GetPath(ctx context.Context, req *provider.GetPathRequest) (*p
 			Interface("resource_id", req.ResourceId).
 			Msg("error getting path by id")
 		return &provider.GetPathResponse{
-			Status: status.NewInternal(ctx, err, "error getting path by id"),
+			Status: status.NewInternal(ctx, "error getting path by id"),
 		}, nil
 	}
 	res := &provider.GetPathResponse{
@@ -400,7 +400,7 @@ func (s *service) CreateStorageSpace(ctx context.Context, req *provider.CreateSt
 			// if trying to create a user home fall back to CreateHome
 			if u, ok := ctxpkg.ContextGetUser(ctx); ok && req.Type == "personal" && utils.UserEqual(req.GetOwner().Id, u.Id) {
 				if err := s.storage.CreateHome(ctx); err != nil {
-					st = status.NewInternal(ctx, err, "error creating home")
+					st = status.NewInternal(ctx, "error creating home")
 				} else {
 					st = status.NewOK(ctx)
 					// TODO we cannot return a space, but the gateway currently does not expect one...
@@ -411,7 +411,7 @@ func (s *service) CreateStorageSpace(ctx context.Context, req *provider.CreateSt
 		case errtypes.AlreadyExists:
 			st = status.NewAlreadyExists(ctx, err, "already exists")
 		default:
-			st = status.NewInternal(ctx, err, "error listing spaces")
+			st = status.NewInternal(ctx, "error listing spaces")
 		}
 		appctx.GetLogger(ctx).
 			Error().
@@ -453,7 +453,7 @@ func (s *service) ListStorageSpaces(ctx context.Context, req *provider.ListStora
 		case errtypes.NotSupported:
 			st = status.NewUnimplemented(ctx, err, "not implemented")
 		default:
-			st = status.NewInternal(ctx, err, "error listing spaces")
+			st = status.NewInternal(ctx, "error listing spaces")
 		}
 		log.Error().
 			Err(err).
@@ -499,7 +499,7 @@ func (s *service) DeleteStorageSpace(ctx context.Context, req *provider.DeleteSt
 		case errtypes.PermissionDenied:
 			st = status.NewPermissionDenied(ctx, err, "permission denied")
 		default:
-			st = status.NewInternal(ctx, err, "error deleting space: "+req.Id.String())
+			st = status.NewInternal(ctx, "error deleting space: "+req.Id.String())
 		}
 		appctx.GetLogger(ctx).
 			Error().
@@ -529,7 +529,7 @@ func (s *service) CreateContainer(ctx context.Context, req *provider.CreateConta
 		case errtypes.PermissionDenied:
 			st = status.NewPermissionDenied(ctx, err, "permission denied")
 		default:
-			st = status.NewInternal(ctx, err, "error creating container: "+req.Ref.String())
+			st = status.NewInternal(ctx, "error creating container: "+req.Ref.String())
 		}
 		appctx.GetLogger(ctx).
 			Error().
@@ -551,7 +551,7 @@ func (s *service) CreateContainer(ctx context.Context, req *provider.CreateConta
 func (s *service) Delete(ctx context.Context, req *provider.DeleteRequest) (*provider.DeleteResponse, error) {
 	if req.Ref.GetPath() == "/" {
 		return &provider.DeleteResponse{
-			Status: status.NewInternal(ctx, errtypes.BadRequest("can't delete mount path"), "can't delete mount path"),
+			Status: status.NewInternal(ctx, "can't delete mount path"),
 		}, nil
 	}
 
@@ -572,7 +572,7 @@ func (s *service) Delete(ctx context.Context, req *provider.DeleteRequest) (*pro
 		case errtypes.PermissionDenied:
 			st = status.NewPermissionDenied(ctx, err, "permission denied")
 		default:
-			st = status.NewInternal(ctx, err, "error deleting file: "+req.Ref.String())
+			st = status.NewInternal(ctx, "error deleting file: "+req.Ref.String())
 		}
 		appctx.GetLogger(ctx).
 			Error().
@@ -600,7 +600,7 @@ func (s *service) Move(ctx context.Context, req *provider.MoveRequest) (*provide
 		case errtypes.PermissionDenied:
 			st = status.NewPermissionDenied(ctx, err, "permission denied")
 		default:
-			st = status.NewInternal(ctx, err, "error moving: "+req.Source.String())
+			st = status.NewInternal(ctx, "error moving: "+req.Source.String())
 		}
 		appctx.GetLogger(ctx).
 			Error().
@@ -638,7 +638,7 @@ func (s *service) Stat(ctx context.Context, req *provider.StatRequest) (*provide
 		case errtypes.PermissionDenied:
 			st = status.NewPermissionDenied(ctx, err, "permission denied")
 		default:
-			st = status.NewInternal(ctx, err, "error statting: "+req.Ref.String())
+			st = status.NewInternal(ctx, "error statting: "+req.Ref.String())
 		}
 		appctx.GetLogger(ctx).
 			Error().
@@ -671,7 +671,7 @@ func (s *service) ListContainerStream(req *provider.ListContainerStreamRequest, 
 		case errtypes.PermissionDenied:
 			st = status.NewPermissionDenied(ctx, err, "permission denied")
 		default:
-			st = status.NewInternal(ctx, err, "error listing container: "+req.Ref.String())
+			st = status.NewInternal(ctx, "error listing container: "+req.Ref.String())
 		}
 		log.Error().
 			Err(err).
@@ -712,7 +712,7 @@ func (s *service) ListContainer(ctx context.Context, req *provider.ListContainer
 		case errtypes.PermissionDenied:
 			st = status.NewPermissionDenied(ctx, err, "permission denied")
 		default:
-			st = status.NewInternal(ctx, err, "error listing container: "+req.Ref.String())
+			st = status.NewInternal(ctx, "error listing container: "+req.Ref.String())
 		}
 		appctx.GetLogger(ctx).
 			Error().
@@ -742,7 +742,7 @@ func (s *service) ListFileVersions(ctx context.Context, req *provider.ListFileVe
 		case errtypes.PermissionDenied:
 			st = status.NewPermissionDenied(ctx, err, "permission denied")
 		default:
-			st = status.NewInternal(ctx, err, "error listing file versions: "+req.Ref.String())
+			st = status.NewInternal(ctx, "error listing file versions: "+req.Ref.String())
 		}
 		appctx.GetLogger(ctx).
 			Error().
@@ -773,7 +773,7 @@ func (s *service) RestoreFileVersion(ctx context.Context, req *provider.RestoreF
 		case errtypes.PermissionDenied:
 			st = status.NewPermissionDenied(ctx, err, "permission denied")
 		default:
-			st = status.NewInternal(ctx, err, "error restoring version: "+req.Ref.String())
+			st = status.NewInternal(ctx, "error restoring version: "+req.Ref.String())
 		}
 		appctx.GetLogger(ctx).
 			Error().
@@ -807,7 +807,7 @@ func (s *service) ListRecycleStream(req *provider.ListRecycleStreamRequest, ss p
 		case errtypes.PermissionDenied:
 			st = status.NewPermissionDenied(ctx, err, "permission denied")
 		default:
-			st = status.NewInternal(ctx, err, "error listing recycle stream")
+			st = status.NewInternal(ctx, "error listing recycle stream")
 		}
 		log.Error().
 			Err(err).
@@ -850,7 +850,7 @@ func (s *service) ListRecycle(ctx context.Context, req *provider.ListRecycleRequ
 		case errtypes.PermissionDenied:
 			st = status.NewPermissionDenied(ctx, err, "permission denied")
 		default:
-			st = status.NewInternal(ctx, err, "error listing recycle")
+			st = status.NewInternal(ctx, "error listing recycle")
 		}
 		appctx.GetLogger(ctx).
 			Error().
@@ -882,7 +882,7 @@ func (s *service) RestoreRecycleItem(ctx context.Context, req *provider.RestoreR
 		case errtypes.PermissionDenied:
 			st = status.NewPermissionDenied(ctx, err, "permission denied")
 		default:
-			st = status.NewInternal(ctx, err, "error restoring recycle bin item")
+			st = status.NewInternal(ctx, "error restoring recycle bin item")
 		}
 		appctx.GetLogger(ctx).
 			Error().
@@ -914,7 +914,7 @@ func (s *service) PurgeRecycle(ctx context.Context, req *provider.PurgeRecycleRe
 			case errtypes.PermissionDenied:
 				st = status.NewPermissionDenied(ctx, err, "permission denied")
 			default:
-				st = status.NewInternal(ctx, err, "error purging recycle item")
+				st = status.NewInternal(ctx, "error purging recycle item")
 			}
 			appctx.GetLogger(ctx).
 				Error().
@@ -936,7 +936,7 @@ func (s *service) PurgeRecycle(ctx context.Context, req *provider.PurgeRecycleRe
 		case errtypes.PermissionDenied:
 			st = status.NewPermissionDenied(ctx, err, "permission denied")
 		default:
-			st = status.NewInternal(ctx, err, "error purging recycle bin")
+			st = status.NewInternal(ctx, "error purging recycle bin")
 		}
 		appctx.GetLogger(ctx).
 			Error().
@@ -966,7 +966,7 @@ func (s *service) ListGrants(ctx context.Context, req *provider.ListGrantsReques
 		case errtypes.PermissionDenied:
 			st = status.NewPermissionDenied(ctx, err, "permission denied")
 		default:
-			st = status.NewInternal(ctx, err, "error listing grants")
+			st = status.NewInternal(ctx, "error listing grants")
 		}
 		appctx.GetLogger(ctx).
 			Error().
@@ -1003,7 +1003,7 @@ func (s *service) DenyGrant(ctx context.Context, req *provider.DenyGrantRequest)
 		case errtypes.PermissionDenied:
 			st = status.NewPermissionDenied(ctx, err, "permission denied")
 		default:
-			st = status.NewInternal(ctx, err, "error setting grants")
+			st = status.NewInternal(ctx, "error setting grants")
 		}
 		appctx.GetLogger(ctx).
 			Error().
@@ -1039,7 +1039,7 @@ func (s *service) AddGrant(ctx context.Context, req *provider.AddGrantRequest) (
 		case errtypes.PermissionDenied:
 			st = status.NewPermissionDenied(ctx, err, "permission denied")
 		default:
-			st = status.NewInternal(ctx, err, "error setting grants")
+			st = status.NewInternal(ctx, "error setting grants")
 		}
 		appctx.GetLogger(ctx).
 			Error().
@@ -1074,7 +1074,7 @@ func (s *service) UpdateGrant(ctx context.Context, req *provider.UpdateGrantRequ
 		case errtypes.PermissionDenied:
 			st = status.NewPermissionDenied(ctx, err, "permission denied")
 		default:
-			st = status.NewInternal(ctx, err, "error updating grant")
+			st = status.NewInternal(ctx, "error updating grant")
 		}
 		appctx.GetLogger(ctx).
 			Error().
@@ -1109,7 +1109,7 @@ func (s *service) RemoveGrant(ctx context.Context, req *provider.RemoveGrantRequ
 		case errtypes.PermissionDenied:
 			st = status.NewPermissionDenied(ctx, err, "permission denied")
 		default:
-			st = status.NewInternal(ctx, err, "error removing grant")
+			st = status.NewInternal(ctx, "error removing grant")
 		}
 		appctx.GetLogger(ctx).
 			Error().
@@ -1148,7 +1148,7 @@ func (s *service) CreateReference(ctx context.Context, req *provider.CreateRefer
 		case errtypes.PermissionDenied:
 			st = status.NewPermissionDenied(ctx, err, "permission denied")
 		default:
-			st = status.NewInternal(ctx, err, "error creating reference")
+			st = status.NewInternal(ctx, "error creating reference")
 		}
 		log.Error().
 			Err(err).
@@ -1181,7 +1181,7 @@ func (s *service) GetQuota(ctx context.Context, req *provider.GetQuotaRequest) (
 		case errtypes.PermissionDenied:
 			st = status.NewPermissionDenied(ctx, err, "permission denied")
 		default:
-			st = status.NewInternal(ctx, err, "error getting quota")
+			st = status.NewInternal(ctx, "error getting quota")
 		}
 		appctx.GetLogger(ctx).
 			Error().

--- a/internal/grpc/services/storageregistry/storageregistry.go
+++ b/internal/grpc/services/storageregistry/storageregistry.go
@@ -107,7 +107,7 @@ func (s *service) ListStorageProviders(ctx context.Context, req *registrypb.List
 	pinfos, err := s.reg.ListProviders(ctx, sdk.DecodeOpaqueMap(req.Opaque))
 	if err != nil {
 		return &registrypb.ListStorageProvidersResponse{
-			Status: status.NewInternal(ctx, err, "error getting list of storage providers"),
+			Status: status.NewInternal(ctx, "error getting list of storage providers"),
 		}, nil
 	}
 
@@ -135,7 +135,7 @@ func (s *service) GetStorageProviders(ctx context.Context, req *registrypb.GetSt
 			}, nil
 		default:
 			return &registrypb.GetStorageProvidersResponse{
-				Status: status.NewInternal(ctx, err, "error finding storage provider"),
+				Status: status.NewInternal(ctx, "error finding storage provider"),
 			}, nil
 		}
 	}

--- a/internal/grpc/services/userprovider/userprovider.go
+++ b/internal/grpc/services/userprovider/userprovider.go
@@ -131,8 +131,7 @@ func (s *service) GetUser(ctx context.Context, req *userpb.GetUserRequest) (*use
 		if _, ok := err.(errtypes.NotFound); ok {
 			res.Status = status.NewNotFound(ctx, "user not found")
 		} else {
-			err = errors.Wrap(err, "userprovidersvc: error getting user")
-			res.Status = status.NewInternal(ctx, err, "error getting user")
+			res.Status = status.NewInternal(ctx, "error getting user")
 		}
 		return res, nil
 	}
@@ -151,8 +150,7 @@ func (s *service) GetUserByClaim(ctx context.Context, req *userpb.GetUserByClaim
 		if _, ok := err.(errtypes.NotFound); ok {
 			res.Status = status.NewNotFound(ctx, fmt.Sprintf("user not found %s %s", req.Claim, req.Value))
 		} else {
-			err = errors.Wrap(err, "userprovidersvc: error getting user by claim")
-			res.Status = status.NewInternal(ctx, err, "error getting user by claim")
+			res.Status = status.NewInternal(ctx, "error getting user by claim")
 		}
 		return res, nil
 	}
@@ -167,9 +165,8 @@ func (s *service) GetUserByClaim(ctx context.Context, req *userpb.GetUserByClaim
 func (s *service) FindUsers(ctx context.Context, req *userpb.FindUsersRequest) (*userpb.FindUsersResponse, error) {
 	users, err := s.usermgr.FindUsers(ctx, req.Filter)
 	if err != nil {
-		err = errors.Wrap(err, "userprovidersvc: error finding users")
 		res := &userpb.FindUsersResponse{
-			Status: status.NewInternal(ctx, err, "error finding users"),
+			Status: status.NewInternal(ctx, "error finding users"),
 		}
 		return res, nil
 	}
@@ -189,9 +186,8 @@ func (s *service) FindUsers(ctx context.Context, req *userpb.FindUsersRequest) (
 func (s *service) GetUserGroups(ctx context.Context, req *userpb.GetUserGroupsRequest) (*userpb.GetUserGroupsResponse, error) {
 	groups, err := s.usermgr.GetUserGroups(ctx, req.UserId)
 	if err != nil {
-		err = errors.Wrap(err, "userprovidersvc: error getting user groups")
 		res := &userpb.GetUserGroupsResponse{
-			Status: status.NewInternal(ctx, err, "error getting user groups"),
+			Status: status.NewInternal(ctx, "error getting user groups"),
 		}
 		return res, nil
 	}

--- a/internal/grpc/services/usershareprovider/usershareprovider.go
+++ b/internal/grpc/services/usershareprovider/usershareprovider.go
@@ -150,7 +150,7 @@ func (s *service) CreateShare(ctx context.Context, req *collaboration.CreateShar
 	share, err := s.sm.Share(ctx, req.ResourceInfo, req.Grant)
 	if err != nil {
 		return &collaboration.CreateShareResponse{
-			Status: status.NewInternal(ctx, err, "error creating share"),
+			Status: status.NewInternal(ctx, "error creating share"),
 		}, nil
 	}
 
@@ -165,7 +165,7 @@ func (s *service) RemoveShare(ctx context.Context, req *collaboration.RemoveShar
 	err := s.sm.Unshare(ctx, req.Ref)
 	if err != nil {
 		return &collaboration.RemoveShareResponse{
-			Status: status.NewInternal(ctx, err, "error removing share"),
+			Status: status.NewInternal(ctx, "error removing share"),
 		}, nil
 	}
 
@@ -178,7 +178,7 @@ func (s *service) GetShare(ctx context.Context, req *collaboration.GetShareReque
 	share, err := s.sm.GetShare(ctx, req.Ref)
 	if err != nil {
 		return &collaboration.GetShareResponse{
-			Status: status.NewInternal(ctx, err, "error getting share"),
+			Status: status.NewInternal(ctx, "error getting share"),
 		}, nil
 	}
 
@@ -192,7 +192,7 @@ func (s *service) ListShares(ctx context.Context, req *collaboration.ListSharesR
 	shares, err := s.sm.ListShares(ctx, req.Filters) // TODO(labkode): add filter to share manager
 	if err != nil {
 		return &collaboration.ListSharesResponse{
-			Status: status.NewInternal(ctx, err, "error listing shares"),
+			Status: status.NewInternal(ctx, "error listing shares"),
 		}, nil
 	}
 
@@ -207,7 +207,7 @@ func (s *service) UpdateShare(ctx context.Context, req *collaboration.UpdateShar
 	share, err := s.sm.UpdateShare(ctx, req.Ref, req.Field.GetPermissions()) // TODO(labkode): check what to update
 	if err != nil {
 		return &collaboration.UpdateShareResponse{
-			Status: status.NewInternal(ctx, err, "error updating share"),
+			Status: status.NewInternal(ctx, "error updating share"),
 		}, nil
 	}
 
@@ -233,7 +233,7 @@ func (s *service) ListReceivedShares(ctx context.Context, req *collaboration.Lis
 	shares, err := s.sm.ListReceivedShares(ctx, req.Filters) // TODO(labkode): check what to update
 	if err != nil {
 		return &collaboration.ListReceivedSharesResponse{
-			Status: status.NewInternal(ctx, err, "error listing received shares"),
+			Status: status.NewInternal(ctx, "error listing received shares"),
 		}, nil
 	}
 
@@ -251,7 +251,7 @@ func (s *service) GetReceivedShare(ctx context.Context, req *collaboration.GetRe
 	if err != nil {
 		log.Err(err).Msg("error getting received share")
 		return &collaboration.GetReceivedShareResponse{
-			Status: status.NewInternal(ctx, err, "error getting received share"),
+			Status: status.NewInternal(ctx, "error getting received share"),
 		}, nil
 	}
 
@@ -288,7 +288,7 @@ func (s *service) UpdateReceivedShare(ctx context.Context, req *collaboration.Up
 	share, err := s.sm.UpdateReceivedShare(ctx, req.Share, req.UpdateMask)
 	if err != nil {
 		return &collaboration.UpdateReceivedShareResponse{
-			Status: status.NewInternal(ctx, err, "error updating received share"),
+			Status: status.NewInternal(ctx, "error updating received share"),
 		}, nil
 	}
 

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/shares.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/shares.go
@@ -1010,6 +1010,7 @@ func (h *Handler) logProblems(s *rpc.Status, e error, msg string) {
 	if e != nil {
 		// errors need to be taken care of
 		log.Error().Err(e).Msg(msg)
+		return
 	}
 	if s != nil && s.Code != rpc.Code_CODE_OK {
 		switch s.Code {

--- a/pkg/rgrpc/status/status.go
+++ b/pkg/rgrpc/status/status.go
@@ -40,10 +40,8 @@ func NewOK(ctx context.Context) *rpc.Status {
 	}
 }
 
-// NewNotFound returns a Status with CODE_NOT_FOUND and logs the msg.
+// NewNotFound returns a Status with CODE_NOT_FOUND.
 func NewNotFound(ctx context.Context, msg string) *rpc.Status {
-	// log := appctx.GetLogger(ctx).With().CallerWithSkipFrameCount(3).Logger()
-	// log.Warn().Msg(msg)
 	return &rpc.Status{
 		Code:    rpc.Code_CODE_NOT_FOUND,
 		Message: msg,
@@ -51,10 +49,8 @@ func NewNotFound(ctx context.Context, msg string) *rpc.Status {
 	}
 }
 
-// NewInvalid returns a Status with CODE_INVALID_ARGUMENT and logs the msg.
+// NewInvalid returns a Status with CODE_INVALID_ARGUMENT.
 func NewInvalid(ctx context.Context, msg string) *rpc.Status {
-	// log := appctx.GetLogger(ctx).With().CallerWithSkipFrameCount(3).Logger()
-	// log.Warn().Msg(msg)
 	return &rpc.Status{
 		Code:    rpc.Code_CODE_INVALID_ARGUMENT,
 		Message: msg,
@@ -62,16 +58,8 @@ func NewInvalid(ctx context.Context, msg string) *rpc.Status {
 	}
 }
 
-// NewInternal returns a Status with CODE_INTERNAL and logs the msg.
-// In this case, err MUST be filled for tracking purposes.
-func NewInternal(ctx context.Context, err error, msg string) *rpc.Status {
-	if err == nil {
-		panic("Internal error triggered without an error context")
-	}
-
-	// log := appctx.GetLogger(ctx).With().CallerWithSkipFrameCount(3).Logger()
-	// log.Err(err).Msg(msg)
-
+// NewInternal returns a Status with CODE_INTERNAL.
+func NewInternal(ctx context.Context, msg string) *rpc.Status {
 	return &rpc.Status{
 		Code:    rpc.Code_CODE_INTERNAL,
 		Message: msg,
@@ -79,10 +67,8 @@ func NewInternal(ctx context.Context, err error, msg string) *rpc.Status {
 	}
 }
 
-// NewUnauthenticated returns a Status with CODE_UNAUTHENTICATED and logs the msg.
+// NewUnauthenticated returns a Status with CODE_UNAUTHENTICATED.
 func NewUnauthenticated(ctx context.Context, err error, msg string) *rpc.Status {
-	// log := appctx.GetLogger(ctx).With().CallerWithSkipFrameCount(3).Logger()
-	// log.Warn().Err(err).Msg(msg)
 	return &rpc.Status{
 		Code:    rpc.Code_CODE_UNAUTHENTICATED,
 		Message: msg,
@@ -90,11 +76,8 @@ func NewUnauthenticated(ctx context.Context, err error, msg string) *rpc.Status 
 	}
 }
 
-// NewPermissionDenied returns a Status with PERMISSION_DENIED and logs the msg.
+// NewPermissionDenied returns a Status with PERMISSION_DENIED.
 func NewPermissionDenied(ctx context.Context, err error, msg string) *rpc.Status {
-	// log := appctx.GetLogger(ctx).With().CallerWithSkipFrameCount(3).Logger()
-	// log.Err(err).Msg(msg)
-
 	return &rpc.Status{
 		Code:    rpc.Code_CODE_PERMISSION_DENIED,
 		Message: msg,
@@ -102,11 +85,8 @@ func NewPermissionDenied(ctx context.Context, err error, msg string) *rpc.Status
 	}
 }
 
-// NewInsufficientStorage returns a Status with INSUFFICIENT_STORAGE and logs the msg.
+// NewInsufficientStorage returns a Status with INSUFFICIENT_STORAGE.
 func NewInsufficientStorage(ctx context.Context, err error, msg string) *rpc.Status {
-	// log := appctx.GetLogger(ctx).With().CallerWithSkipFrameCount(3).Logger()
-	// log.Err(err).Msg(msg)
-
 	return &rpc.Status{
 		Code:    rpc.Code_CODE_INSUFFICIENT_STORAGE,
 		Message: msg,
@@ -114,10 +94,8 @@ func NewInsufficientStorage(ctx context.Context, err error, msg string) *rpc.Sta
 	}
 }
 
-// NewUnimplemented returns a Status with CODE_UNIMPLEMENTED and logs the msg.
+// NewUnimplemented returns a Status with CODE_UNIMPLEMENTED.
 func NewUnimplemented(ctx context.Context, err error, msg string) *rpc.Status {
-	// log := appctx.GetLogger(ctx).With().CallerWithSkipFrameCount(3).Logger()
-	// log.Error().Err(err).Msg(msg)
 	return &rpc.Status{
 		Code:    rpc.Code_CODE_UNIMPLEMENTED,
 		Message: msg,
@@ -125,10 +103,8 @@ func NewUnimplemented(ctx context.Context, err error, msg string) *rpc.Status {
 	}
 }
 
-// NewAlreadyExists returns a Status with CODE_ALREADY_EXISTS and logs the msg.
+// NewAlreadyExists returns a Status with CODE_ALREADY_EXISTS.
 func NewAlreadyExists(ctx context.Context, err error, msg string) *rpc.Status {
-	// log := appctx.GetLogger(ctx).With().CallerWithSkipFrameCount(3).Logger()
-	// log.Error().Err(err).Msg(msg)
 	return &rpc.Status{
 		Code:    rpc.Code_CODE_ALREADY_EXISTS,
 		Message: msg,
@@ -144,7 +120,7 @@ func NewInvalidArg(ctx context.Context, msg string) *rpc.Status {
 	}
 }
 
-// NewConflict returns a Status with Code_CODE_ABORTED and logs the msg.
+// NewConflict returns a Status with Code_CODE_ABORTED.
 func NewConflict(ctx context.Context, err error, msg string) *rpc.Status {
 	return &rpc.Status{
 		Code:    rpc.Code_CODE_ABORTED,
@@ -192,7 +168,7 @@ func NewStatusFromErrType(ctx context.Context, msg string, err error) *rpc.Statu
 		}
 	}
 
-	return NewInternal(ctx, err, "gateway: "+msg+":"+err.Error())
+	return NewInternal(ctx, "gateway: "+msg+":"+err.Error())
 }
 
 // NewErrorFromCode returns a standardized Error for a given RPC code.

--- a/pkg/rgrpc/status/status.go
+++ b/pkg/rgrpc/status/status.go
@@ -26,7 +26,6 @@ import (
 	"errors"
 
 	rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
-	"github.com/cs3org/reva/pkg/appctx"
 	"github.com/cs3org/reva/pkg/errtypes"
 	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc/codes"
@@ -43,8 +42,8 @@ func NewOK(ctx context.Context) *rpc.Status {
 
 // NewNotFound returns a Status with CODE_NOT_FOUND and logs the msg.
 func NewNotFound(ctx context.Context, msg string) *rpc.Status {
-	log := appctx.GetLogger(ctx).With().CallerWithSkipFrameCount(3).Logger()
-	log.Warn().Msg(msg)
+	// log := appctx.GetLogger(ctx).With().CallerWithSkipFrameCount(3).Logger()
+	// log.Warn().Msg(msg)
 	return &rpc.Status{
 		Code:    rpc.Code_CODE_NOT_FOUND,
 		Message: msg,
@@ -54,8 +53,8 @@ func NewNotFound(ctx context.Context, msg string) *rpc.Status {
 
 // NewInvalid returns a Status with CODE_INVALID_ARGUMENT and logs the msg.
 func NewInvalid(ctx context.Context, msg string) *rpc.Status {
-	log := appctx.GetLogger(ctx).With().CallerWithSkipFrameCount(3).Logger()
-	log.Warn().Msg(msg)
+	// log := appctx.GetLogger(ctx).With().CallerWithSkipFrameCount(3).Logger()
+	// log.Warn().Msg(msg)
 	return &rpc.Status{
 		Code:    rpc.Code_CODE_INVALID_ARGUMENT,
 		Message: msg,
@@ -70,8 +69,8 @@ func NewInternal(ctx context.Context, err error, msg string) *rpc.Status {
 		panic("Internal error triggered without an error context")
 	}
 
-	log := appctx.GetLogger(ctx).With().CallerWithSkipFrameCount(3).Logger()
-	log.Err(err).Msg(msg)
+	// log := appctx.GetLogger(ctx).With().CallerWithSkipFrameCount(3).Logger()
+	// log.Err(err).Msg(msg)
 
 	return &rpc.Status{
 		Code:    rpc.Code_CODE_INTERNAL,
@@ -82,8 +81,8 @@ func NewInternal(ctx context.Context, err error, msg string) *rpc.Status {
 
 // NewUnauthenticated returns a Status with CODE_UNAUTHENTICATED and logs the msg.
 func NewUnauthenticated(ctx context.Context, err error, msg string) *rpc.Status {
-	log := appctx.GetLogger(ctx).With().CallerWithSkipFrameCount(3).Logger()
-	log.Warn().Err(err).Msg(msg)
+	// log := appctx.GetLogger(ctx).With().CallerWithSkipFrameCount(3).Logger()
+	// log.Warn().Err(err).Msg(msg)
 	return &rpc.Status{
 		Code:    rpc.Code_CODE_UNAUTHENTICATED,
 		Message: msg,
@@ -93,8 +92,8 @@ func NewUnauthenticated(ctx context.Context, err error, msg string) *rpc.Status 
 
 // NewPermissionDenied returns a Status with PERMISSION_DENIED and logs the msg.
 func NewPermissionDenied(ctx context.Context, err error, msg string) *rpc.Status {
-	log := appctx.GetLogger(ctx).With().CallerWithSkipFrameCount(3).Logger()
-	log.Err(err).Msg(msg)
+	// log := appctx.GetLogger(ctx).With().CallerWithSkipFrameCount(3).Logger()
+	// log.Err(err).Msg(msg)
 
 	return &rpc.Status{
 		Code:    rpc.Code_CODE_PERMISSION_DENIED,
@@ -105,8 +104,8 @@ func NewPermissionDenied(ctx context.Context, err error, msg string) *rpc.Status
 
 // NewInsufficientStorage returns a Status with INSUFFICIENT_STORAGE and logs the msg.
 func NewInsufficientStorage(ctx context.Context, err error, msg string) *rpc.Status {
-	log := appctx.GetLogger(ctx).With().CallerWithSkipFrameCount(3).Logger()
-	log.Err(err).Msg(msg)
+	// log := appctx.GetLogger(ctx).With().CallerWithSkipFrameCount(3).Logger()
+	// log.Err(err).Msg(msg)
 
 	return &rpc.Status{
 		Code:    rpc.Code_CODE_INSUFFICIENT_STORAGE,
@@ -117,8 +116,8 @@ func NewInsufficientStorage(ctx context.Context, err error, msg string) *rpc.Sta
 
 // NewUnimplemented returns a Status with CODE_UNIMPLEMENTED and logs the msg.
 func NewUnimplemented(ctx context.Context, err error, msg string) *rpc.Status {
-	log := appctx.GetLogger(ctx).With().CallerWithSkipFrameCount(3).Logger()
-	log.Error().Err(err).Msg(msg)
+	// log := appctx.GetLogger(ctx).With().CallerWithSkipFrameCount(3).Logger()
+	// log.Error().Err(err).Msg(msg)
 	return &rpc.Status{
 		Code:    rpc.Code_CODE_UNIMPLEMENTED,
 		Message: msg,
@@ -128,8 +127,8 @@ func NewUnimplemented(ctx context.Context, err error, msg string) *rpc.Status {
 
 // NewAlreadyExists returns a Status with CODE_ALREADY_EXISTS and logs the msg.
 func NewAlreadyExists(ctx context.Context, err error, msg string) *rpc.Status {
-	log := appctx.GetLogger(ctx).With().CallerWithSkipFrameCount(3).Logger()
-	log.Error().Err(err).Msg(msg)
+	// log := appctx.GetLogger(ctx).With().CallerWithSkipFrameCount(3).Logger()
+	// log.Error().Err(err).Msg(msg)
 	return &rpc.Status{
 		Code:    rpc.Code_CODE_ALREADY_EXISTS,
 		Message: msg,


### PR DESCRIPTION
Reduced log output. Some errors or warnings were logged multiple times or even unnecesarily. 

Now, there are probably a lot of places where logging is missing but these can be added when we touch those spots again.