### PR TITLE
[tests-only] Remove DELETE_USER_DATA_CMD from tests

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -700,7 +700,6 @@ def ocisIntegrationTests(parallelRuns, skipExceptParts = []):
             "environment": {
               "TEST_SERVER_URL": "http://revad-services:20080",
               "OCIS_REVA_DATA_ROOT": "/drone/src/tmp/reva/data/",
-              "DELETE_USER_DATA_CMD": "rm -rf /drone/src/tmp/reva/data/nodes/root/* /drone/src/tmp/reva/data/nodes/*-*-*-* /drone/src/tmp/reva/data/blobs/* /drone/src/tmp/reva/data/spaces/*/*",
               "STORAGE_DRIVER": "OCIS",
               "SKELETON_DIR": "/drone/src/tmp/testing/data/apiSkeleton",
               "TEST_WITH_LDAP": "true",
@@ -776,7 +775,6 @@ def s3ngIntegrationTests(parallelRuns, skipExceptParts = []):
             "environment": {
               "TEST_SERVER_URL": "http://revad-services:20080",
               "OCIS_REVA_DATA_ROOT": "/drone/src/tmp/reva/data/",
-              "DELETE_USER_DATA_CMD": "rm -rf /drone/src/tmp/reva/data/nodes/root/* /drone/src/tmp/reva/data/nodes/*-*-*-* /drone/src/tmp/reva/data/blobs/* /drone/src/tmp/reva/data/spaces/*/*",
               "STORAGE_DRIVER": "S3NG",
               "SKELETON_DIR": "/drone/src/tmp/testing/data/apiSkeleton",
               "TEST_WITH_LDAP": "true",

--- a/README.md
+++ b/README.md
@@ -146,7 +146,6 @@ This will require some PHP-related tools to run, for instance on Ubuntu you will
     cd testrunner
     TEST_SERVER_URL='http://localhost:20080' \
     OCIS_REVA_DATA_ROOT='/var/tmp/reva/' \
-    DELETE_USER_DATA_CMD="rm -rf /var/tmp/reva/data/nodes/root/* /var/tmp/reva/data/nodes/*-*-*-* /var/tmp/reva/data/blobs/*" \
     SKELETON_DIR='./apps/testing/data/apiSkeleton' \
     TEST_WITH_LDAP='true' \
     REVA_LDAP_HOSTNAME='localhost' \
@@ -160,7 +159,7 @@ This will require some PHP-related tools to run, for instance on Ubuntu you will
 
     To run a single test add `BEHAT_FEATURE=<feature file>` and specify the path to the feature file and an optional line number. For example: `BEHAT_FEATURE='tests/acceptance/features/apiWebdavUpload1/uploadFile.feature:12'`
 
-    Make sure to double check the paths if you are changing the `OCIS_REVA_DATA_ROOT`. The `DELETE_USER_DATA_CMD` needs to clean up the correct folders.
+    Make sure to double check the paths if you are changing the `OCIS_REVA_DATA_ROOT`.
 
 ## Daily releases
 On every commit on the master branch (including merged Pull Requests) a new release will be created and 

--- a/changelog/unreleased/test-no-delete-user.md
+++ b/changelog/unreleased/test-no-delete-user.md
@@ -1,0 +1,7 @@
+Enhancement: Removed DELETE_USER_DATA_CMD from tests
+    
+With recent changes in the test configs for user and group providers we
+no longer need to manually remove the user data after each testcase.
+User and groups will get a new unique id with every test run.
+
+https://github.com/cs3org/reva/pull/2367


### PR DESCRIPTION
With recent changes in the test configs for user and group providers we
no longer need to manually remove the user data after each testcase.
User and groups will get a new unique id with every test run.