### PR TITLE
fix webdav copy for zero byte files

### DIFF
--- a/changelog/unreleased/fix-webdav-copy-zero-byte-file.md
+++ b/changelog/unreleased/fix-webdav-copy-zero-byte-file.md
@@ -1,0 +1,9 @@
+Bugfix: Fix webdav copy of zero byte files
+
+We've fixed the webdav copy action of zero byte files, which was not performed
+because the webdav api assumed, that zero byte uploads are created when initiating
+the upload, which was recently removed from all storage drivers. Therefore the 
+webdav api also uploads zero byte files after initiating the upload.
+
+https://github.com/cs3org/reva/pull/2374
+https://github.com/cs3org/reva/pull/2309

--- a/internal/http/services/owncloud/ocdav/copy.go
+++ b/internal/http/services/owncloud/ocdav/copy.go
@@ -237,22 +237,21 @@ func (s *svc) executePathCopy(ctx context.Context, client gateway.GatewayAPIClie
 
 		// 4. do upload
 
-		if cp.sourceInfo.GetSize() > 0 {
-			httpUploadReq, err := rhttp.NewRequest(ctx, "PUT", uploadEP, httpDownloadRes.Body)
-			if err != nil {
-				return err
-			}
-			httpUploadReq.Header.Set(datagateway.TokenTransportHeader, uploadToken)
-
-			httpUploadRes, err := s.client.Do(httpUploadReq)
-			if err != nil {
-				return err
-			}
-			defer httpUploadRes.Body.Close()
-			if httpUploadRes.StatusCode != http.StatusOK {
-				return err
-			}
+		httpUploadReq, err := rhttp.NewRequest(ctx, "PUT", uploadEP, httpDownloadRes.Body)
+		if err != nil {
+			return err
 		}
+		httpUploadReq.Header.Set(datagateway.TokenTransportHeader, uploadToken)
+
+		httpUploadRes, err := s.client.Do(httpUploadReq)
+		if err != nil {
+			return err
+		}
+		defer httpUploadRes.Body.Close()
+		if httpUploadRes.StatusCode != http.StatusOK {
+			return err
+		}
+
 	}
 	return nil
 }
@@ -457,21 +456,19 @@ func (s *svc) executeSpacesCopy(ctx context.Context, w http.ResponseWriter, clie
 
 		// 4. do upload
 
-		if cp.sourceInfo.GetSize() > 0 {
-			httpUploadReq, err := rhttp.NewRequest(ctx, http.MethodPut, uploadEP, httpDownloadRes.Body)
-			if err != nil {
-				return err
-			}
-			httpUploadReq.Header.Set(datagateway.TokenTransportHeader, uploadToken)
+		httpUploadReq, err := rhttp.NewRequest(ctx, http.MethodPut, uploadEP, httpDownloadRes.Body)
+		if err != nil {
+			return err
+		}
+		httpUploadReq.Header.Set(datagateway.TokenTransportHeader, uploadToken)
 
-			httpUploadRes, err := s.client.Do(httpUploadReq)
-			if err != nil {
-				return err
-			}
-			defer httpUploadRes.Body.Close()
-			if httpUploadRes.StatusCode != http.StatusOK {
-				return err
-			}
+		httpUploadRes, err := s.client.Do(httpUploadReq)
+		if err != nil {
+			return err
+		}
+		defer httpUploadRes.Body.Close()
+		if httpUploadRes.StatusCode != http.StatusOK {
+			return err
 		}
 	}
 	return nil


### PR DESCRIPTION
Bugfix: Fix webdav copy of zero byte files

We've fixed the webdav copy action of zero byte files, which was not performed
because the webdav api assumed, that zero byte uploads are created when initiating
the upload, which was recently removed from all storage drivers. Therefore the 
webdav api also uploads zero byte files after initiating the upload.

Fixes https://github.com/owncloud/ocis/issues/2868