### PR TITLE
[tests-only] fix tests by pointing to the right owncloud/core commit id for tests

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The test runner source for API tests
-CORE_COMMITID=5f98837bd95d75660fc9fbc9a8802f7db8793a89
+CORE_COMMITID=2987544bfd6f6823df68f6ea392ba41c1ea4f07c
 CORE_BRANCH=acceptance-test-changes-waiting-2021-11


### PR DESCRIPTION
The owncloud/core commit id for tests changed because we're currently on a branch for the development of the test suite (to not disturb oC 10.9 release) and it was rebased by accident. Therefore the current commit id is no longer existing.

cc @phil-davis 