### PR TITLE
[tests-only] add .drone.env to CODEOWNERS as it is part of the test files

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,5 @@
 *                                     @labkode @ishank011
+.drone.env                            @labkode @ishank011 @glpatcern @cs3org/owncloud-team
 changelog                             @labkode @ishank011 @glpatcern @cs3org/owncloud-team
 examples                              @labkode @ishank011 @glpatcern @cs3org/owncloud-team
 tests                                 @labkode @ishank011 @glpatcern @cs3org/owncloud-team


### PR DESCRIPTION
`.drone.env` contains the branch and commit id pointing to where the API tests are found in `owncloud/core`

It often needs to be modified by the same people/groups who modify tests. This PR makes that addition to CODEOWNERS.