### PR TITLE
add new file url of the app provider to the ocs capabilities

### DIFF
--- a/changelog/unreleased/enhancement-add-new-file-capability.md
+++ b/changelog/unreleased/enhancement-add-new-file-capability.md
@@ -1,0 +1,8 @@
+Enhancement: add new file url of the app provider to the ocs capabilities
+
+We've added the new file capability of the app provider to the ocs capabilities, so that
+clients can discover this url analogous to the app list and file open urls.
+
+https://github.com/cs3org/reva/pull/2379
+https://github.com/owncloud/ocis/pull/2884
+https://github.com/owncloud/web/pull/5890#issuecomment-993905242

--- a/internal/http/services/owncloud/ocs/data/capabilities.go
+++ b/internal/http/services/owncloud/ocs/data/capabilities.go
@@ -117,6 +117,7 @@ type CapabilitiesAppProvider struct {
 	Version string `json:"version" xml:"version" mapstructure:"version"`
 	AppsURL string `json:"apps_url" xml:"apps_url" mapstructure:"apps_url"`
 	OpenURL string `json:"open_url" xml:"open_url" mapstructure:"open_url"`
+	NewURL  string `json:"new_url" xml:"new_url" mapstructure:"new_url"`
 }
 
 // CapabilitiesFiles TODO this is storage specific, not global. What effect do these options have on the clients?


### PR DESCRIPTION
Enhancement: add new file url of the app provider to the ocs capabilities

We've added the new file capability of the app provider to the ocs capabilities, so that
clients can discover this url analogous to the app list and file open urls.

Needed for: https://github.com/owncloud/ocis/pull/2884, https://github.com/owncloud/web/pull/5890#issuecomment-993905242