### PR TITLE
allow new file create with app provider on public links

### DIFF
--- a/changelog/unreleased/enhancement-app-new-public-link.md
+++ b/changelog/unreleased/enhancement-app-new-public-link.md
@@ -1,0 +1,5 @@
+Enhancement: Allow to create new files with the app provider on public links
+
+We've added the option to create files with the app provider on public links.
+
+https://github.com/cs3org/reva/pull/2385

--- a/pkg/auth/scope/resourceinfo.go
+++ b/pkg/auth/scope/resourceinfo.go
@@ -102,6 +102,7 @@ func checkResourcePath(path string) bool {
 		"/dataprovider",
 		"/data",
 		"/app/open",
+		"/app/new",
 		"/archiver",
 		"/ocs/v2.php/cloud/capabilities",
 		"/ocs/v1.php/cloud/capabilities",


### PR DESCRIPTION
We've added the option to create files with the app provider on public links.
