### PR TITLE
Add product to ocs Version struct

### DIFF
--- a/changelog/unreleased/enhancement-product-field-in-ocs-version.md
+++ b/changelog/unreleased/enhancement-product-field-in-ocs-version.md
@@ -1,0 +1,5 @@
+Enhancement: Product field in OCS version
+
+We've added a new field to the OCS Version, which is supposed to announce the product name. The web ui as a client will make use of it to make the backend product and version available (e.g. for easier bug reports).
+
+https://github.com/cs3org/reva/pull/2397

--- a/internal/http/services/owncloud/ocs/data/capabilities.go
+++ b/internal/http/services/owncloud/ocs/data/capabilities.go
@@ -224,4 +224,5 @@ type Version struct {
 	Micro   int    `json:"micro" xml:"micro"` // = patch level
 	String  string `json:"string" xml:"string"`
 	Edition string `json:"edition" xml:"edition"`
+	Product string `json:"product" xml:"product"`
 }


### PR DESCRIPTION
The web ui will announce the backend version in the javascript console
and is supposed to include the product name as well. The version seems
to be a good location for the product field as it already includes the
software edition as well.

There is a pull request in the ownCloud web repo which will already utilize this field (when filled, e.g. via oCIS). https://github.com/owncloud/web/pull/6190