### PR TITLE
[tests-only] [full-ci] Bump core commit id for tests in edge

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The test runner source for API tests
-CORE_COMMITID=fe2504387a9e914e03d6af55c54e34a617e55cf0
+CORE_COMMITID=a37efb60db92923398de7efef1abb173d13a9afb
 CORE_BRANCH=master


### PR DESCRIPTION
## Description
Bump core commit id to the latest for the tests

## Related Issue
- Part of https://github.com/owncloud/QA/issues/711

## How Has This Been Tested?
CI