### PR TITLE
services should never return transport level errors

### DIFF
--- a/changelog/unreleased/services-should-never-return-transport-level-errors.md
+++ b/changelog/unreleased/services-should-never-return-transport-level-errors.md
@@ -1,0 +1,5 @@
+Bugfix: services should never return transport level errors
+
+The CS3 API adopted the grpc error codes from the [google grpc status package](https://github.com/googleapis/googleapis/blob/master/google/rpc/status.proto). It also separates transport level errors from application level errors on purpose. This allows sending CS3 messages over protocols other than GRPC. To keep that seperation, the server side must always return `nil`, even though the code generation for go produces function signatures for rpcs with an `error` return property. That allows clients to clearly distinguish between transport level errors indicated by `err != nil` the error and application level errors by checking the status code.
+
+https://github.com/cs3org/reva/pull/2415

--- a/internal/grpc/services/storageprovider/storageprovider.go
+++ b/internal/grpc/services/storageprovider/storageprovider.go
@@ -1026,15 +1026,7 @@ func (s *service) PurgeRecycle(ctx context.Context, req *provider.PurgeRecycleRe
 	key, itemPath := router.ShiftPath(req.Key)
 	if key != "" {
 		if err := s.storage.PurgeRecycleItem(ctx, req.Ref, key, itemPath); err != nil {
-			var st *rpc.Status
-			switch err.(type) {
-			case errtypes.IsNotFound:
-				st = status.NewNotFound(ctx, "path not found when purging recycle item")
-			case errtypes.PermissionDenied:
-				st = status.NewPermissionDenied(ctx, err, "permission denied")
-			default:
-				st = status.NewInternal(ctx, "error purging recycle item")
-			}
+			st := status.NewStatusFromErrType(ctx, "error purging recycle item", err)
 			appctx.GetLogger(ctx).
 				Error().
 				Err(err).
@@ -1048,15 +1040,7 @@ func (s *service) PurgeRecycle(ctx context.Context, req *provider.PurgeRecycleRe
 		}
 	} else if err := s.storage.EmptyRecycle(ctx, req.Ref); err != nil {
 		// otherwise try emptying the whole recycle bin
-		var st *rpc.Status
-		switch err.(type) {
-		case errtypes.IsNotFound:
-			st = status.NewNotFound(ctx, "path not found when purging recycle bin")
-		case errtypes.PermissionDenied:
-			st = status.NewPermissionDenied(ctx, err, "permission denied")
-		default:
-			st = status.NewInternal(ctx, "error purging recycle bin")
-		}
+		st := status.NewStatusFromErrType(ctx, "error emptying recycle", err)
 		appctx.GetLogger(ctx).
 			Error().
 			Err(err).

--- a/pkg/rgrpc/status/status.go
+++ b/pkg/rgrpc/status/status.go
@@ -135,16 +135,16 @@ func NewStatusFromErrType(ctx context.Context, msg string, err error) *rpc.Statu
 	case nil:
 		NewOK(ctx)
 	case errtypes.IsNotFound:
-		return NewNotFound(ctx, "gateway: "+msg+": "+err.Error())
+		return NewNotFound(ctx, msg+": "+err.Error())
 	case errtypes.IsInvalidCredentials:
 		// TODO this maps badly
-		return NewUnauthenticated(ctx, err, "gateway: "+msg+": "+err.Error())
+		return NewUnauthenticated(ctx, err, msg+": "+err.Error())
 	case errtypes.PermissionDenied:
-		return NewPermissionDenied(ctx, e, "gateway: "+msg+": "+err.Error())
+		return NewPermissionDenied(ctx, e, msg+": "+err.Error())
 	case errtypes.IsNotSupported:
-		return NewUnimplemented(ctx, err, "gateway: "+msg+":"+err.Error())
+		return NewUnimplemented(ctx, err, msg+":"+err.Error())
 	case errtypes.BadRequest:
-		return NewInvalidArg(ctx, "gateway: "+msg+":"+err.Error())
+		return NewInvalidArg(ctx, msg+":"+err.Error())
 	}
 
 	// map GRPC status codes coming from the auth middleware
@@ -154,11 +154,11 @@ func NewStatusFromErrType(ctx context.Context, msg string, err error) *rpc.Statu
 		if ok {
 			switch st.Code() {
 			case codes.NotFound:
-				return NewNotFound(ctx, "gateway: "+msg+": "+err.Error())
+				return NewNotFound(ctx, msg+": "+err.Error())
 			case codes.Unauthenticated:
-				return NewUnauthenticated(ctx, err, "gateway: "+msg+": "+err.Error())
+				return NewUnauthenticated(ctx, err, msg+": "+err.Error())
 			case codes.PermissionDenied:
-				return NewPermissionDenied(ctx, err, "gateway: "+msg+": "+err.Error())
+				return NewPermissionDenied(ctx, err, msg+": "+err.Error())
 			}
 		}
 		// the actual error can be wrapped multiple times
@@ -168,7 +168,7 @@ func NewStatusFromErrType(ctx context.Context, msg string, err error) *rpc.Statu
 		}
 	}
 
-	return NewInternal(ctx, "gateway: "+msg+":"+err.Error())
+	return NewInternal(ctx, msg+":"+err.Error())
 }
 
 // NewErrorFromCode returns a standardized Error for a given RPC code.


### PR DESCRIPTION
The CS3 API adopted the grpc error codes from the [google grpc status package](https://github.com/googleapis/googleapis/blob/master/google/rpc/status.proto). It also separates transport level errors from application level errors on purpose. This allows sending CS3 messages over protocols other than GRPC. To keep that seperation, the server side must always return `nil`, even though the code generation for go produces function signatures for rpcs with an `error` return property. That allows clients to clearly distinguish between transport level errors indicated by `err != nil` the error and application level errors by checking the status code.