### PR TITLE
pass complete spaces as json

### DIFF
--- a/changelog/unreleased/pass-complete-spaces-as-json.md
+++ b/changelog/unreleased/pass-complete-spaces-as-json.md
@@ -1,0 +1,5 @@
+Bugfix: The registry now returns complete space structs 
+
+We now return the complete space info, including name, path, owner, etc. instead of only path and id.
+
+https://github.com/cs3org/reva/pull/2416

--- a/internal/grpc/services/gateway/ocmshareprovider.go
+++ b/internal/grpc/services/gateway/ocmshareprovider.go
@@ -30,7 +30,6 @@ import (
 	"github.com/cs3org/reva/pkg/errtypes"
 	"github.com/cs3org/reva/pkg/rgrpc/status"
 	"github.com/cs3org/reva/pkg/rgrpc/todo/pool"
-	"github.com/cs3org/reva/pkg/utils"
 	"github.com/pkg/errors"
 )
 
@@ -363,16 +362,10 @@ func (s *svc) createOCMReference(ctx context.Context, share *ocm.Share) (*rpc.St
 		root      *provider.ResourceId
 		mountPath string
 	)
-	for spaceID, mp := range decodeSpacePaths(p) {
-		rootSpace, rootNode, err := utils.SplitStorageSpaceID(spaceID)
-		if err != nil {
-			continue
-		}
-		mountPath = mp
-		root = &provider.ResourceId{
-			StorageId: rootSpace,
-			OpaqueId:  rootNode,
-		}
+	for _, space := range decodeSpaces(p) {
+		mountPath = decodePath(space)
+		root = space.Root
+		break // TODO can there be more than one space for a path?
 	}
 
 	pRef := unwrap(&provider.Reference{Path: refPath}, mountPath, root)

--- a/internal/grpc/services/gateway/storageprovider.go
+++ b/internal/grpc/services/gateway/storageprovider.go
@@ -1237,6 +1237,9 @@ func (s *svc) RestoreRecycleItem(ctx context.Context, req *provider.RestoreRecyc
 			srcProvider = providerInfos[i]
 			break
 		}
+		if srcProvider != nil {
+			break
+		}
 	}
 
 	if srcProvider == nil || srcRef == nil {
@@ -1273,6 +1276,9 @@ func (s *svc) RestoreRecycleItem(ctx context.Context, req *provider.RestoreRecyc
 			}
 			dstRef = unwrap(r, mountPath, root)
 			dstProvider = providerInfos[i]
+			break
+		}
+		if dstProvider != nil {
 			break
 		}
 	}

--- a/internal/grpc/services/gateway/storageprovider.go
+++ b/internal/grpc/services/gateway/storageprovider.go
@@ -1539,7 +1539,17 @@ func decodeSpaces(r *registry.ProviderInfo) []*provider.StorageSpace {
 			}
 		}
 	}
-
+	if len(spaces) == 0 {
+		// we need to convert the provider into a space, needed for the static registry
+		spaces = append(spaces, &provider.StorageSpace{
+			Opaque: &typesv1beta1.Opaque{Map: map[string]*typesv1beta1.OpaqueEntry{
+				"path": {
+					Decoder: "plain",
+					Value:   []byte(r.ProviderPath),
+				},
+			}},
+		})
+	}
 	return spaces
 }
 

--- a/internal/grpc/services/gateway/storageprovider.go
+++ b/internal/grpc/services/gateway/storageprovider.go
@@ -1541,6 +1541,8 @@ func decodePath(s *provider.StorageSpace) (path string) {
 	if s.Opaque != nil {
 		if entry, ok := s.Opaque.Map["path"]; ok {
 			switch entry.Decoder {
+			case "plain":
+				path = string(entry.Value)
 			case "json":
 				_ = json.Unmarshal(entry.Value, &path)
 			case "toml":

--- a/internal/grpc/services/gateway/storageprovider.go
+++ b/internal/grpc/services/gateway/storageprovider.go
@@ -240,6 +240,9 @@ func (s *svc) ListStorageSpaces(ctx context.Context, req *provider.ListStorageSp
 	}
 
 	listReq := &registry.ListStorageProvidersRequest{Opaque: req.Opaque}
+	if listReq.Opaque == nil {
+		listReq.Opaque = &typesv1beta1.Opaque{}
+	}
 	if len(filters) > 0 {
 		sdk.EncodeOpaqueMap(listReq.Opaque, filters)
 	}

--- a/internal/grpc/services/gateway/usershareprovider.go
+++ b/internal/grpc/services/gateway/usershareprovider.go
@@ -24,7 +24,6 @@ import (
 
 	ctxpkg "github.com/cs3org/reva/pkg/ctx"
 	rtrace "github.com/cs3org/reva/pkg/trace"
-	"github.com/cs3org/reva/pkg/utils"
 
 	rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
 	collaboration "github.com/cs3org/go-cs3apis/cs3/sharing/collaboration/v1beta1"
@@ -383,16 +382,10 @@ func (s *svc) removeReference(ctx context.Context, resourceID *provider.Resource
 		root      *provider.ResourceId
 		mountPath string
 	)
-	for spaceID, mp := range decodeSpacePaths(providerInfo) {
-		mountPath = mp
-		rootSpace, rootNode, err := utils.SplitStorageSpaceID(spaceID)
-		if err != nil {
-			continue
-		}
-		root = &provider.ResourceId{
-			StorageId: rootSpace,
-			OpaqueId:  rootNode,
-		}
+	for _, space := range decodeSpaces(providerInfo) {
+		mountPath = decodePath(space)
+		root = space.Root
+		break // TODO can there be more than one space for a path?
 	}
 
 	ref := unwrap(sharePathRef, mountPath, root)

--- a/internal/http/services/owncloud/ocdav/report.go
+++ b/internal/http/services/owncloud/ocdav/report.go
@@ -22,7 +22,6 @@ import (
 	"encoding/xml"
 	"io"
 	"net/http"
-	"strings"
 
 	rpcv1beta1 "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
@@ -107,13 +106,14 @@ func (s *svc) doFilterFiles(w http.ResponseWriter, r *http.Request, ff *reportFi
 				continue
 			}
 
+			// TODO: do we need to adjust the path?
 			// The paths we receive have the format /user/<userid>/<filepath>
 			// We only want the `<filepath>` part. Thus we remove the /user/<userid>/ part.
-			parts := strings.SplitN(statRes.Info.Path, "/", 4)
-			if len(parts) != 4 {
-				log.Error().Str("path", statRes.Info.Path).Msg("path doesn't have the expected format")
-				continue
-			}
+			// parts := strings.SplitN(statRes.Info.Path, "/", 4)
+			// if len(parts) != 4 {
+			// log.Error().Str("path", statRes.Info.Path).Msg("path doesn't have the expected format")
+			// continue
+			// }
 
 			infos = append(infos, statRes.Info)
 		}

--- a/pkg/storage/registry/spaces/spaces.go
+++ b/pkg/storage/registry/spaces/spaces.go
@@ -379,7 +379,8 @@ func (r *registry) findProvidersForResource(ctx context.Context, id string, find
 	providerInfos := []*registrypb.ProviderInfo{}
 	for address, provider := range r.c.Providers {
 		p := &registrypb.ProviderInfo{
-			Address: address,
+			Address:    address,
+			ProviderId: id,
 		}
 		filters := []*providerpb.ListStorageSpacesRequest_Filter{{
 			Type: providerpb.ListStorageSpacesRequest_Filter_TYPE_ID,

--- a/pkg/storage/registry/spaces/spaces.go
+++ b/pkg/storage/registry/spaces/spaces.go
@@ -551,7 +551,7 @@ func (r *registry) findProvidersForAbsolutePathReference(ctx context.Context, pa
 
 	if deepestMountPathProvider != nil {
 		if _, ok := providers[deepestMountPathProvider.Address]; !ok {
-			if err := setSpaces(deepestMountPathProvider, []*providerpb.StorageSpace{deepestMountSpace}); err != nil {
+			if err := setSpaces(deepestMountPathProvider, []*providerpb.StorageSpace{deepestMountSpace}); err == nil {
 				providers[deepestMountPathProvider.Address] = deepestMountPathProvider
 			} else {
 				appctx.GetLogger(ctx).Debug().Err(err).Interface("provider", deepestMountPathProvider).Interface("space", deepestMountSpace).Msg("marshaling space failed, continuing")


### PR DESCRIPTION
We now return the complete space info, including name, path, owner, etc. instead of only path and id.
This fixes some spaces related requests that now contain all data.