### PR TITLE
Spaces fixes

### DIFF
--- a/changelog/unreleased/spaces-fixes.md
+++ b/changelog/unreleased/spaces-fixes.md
@@ -1,0 +1,5 @@
+Bugfix: list project spaces for share recipients
+
+The sharing handler now uses the ListProvider call on the registry when sharing by reference. Furthermore, the decomposedfs now checks permissions on the root of a space so that a space is listed for users that have access to a space.
+
+https://github.com/cs3org/reva/pull/2419

--- a/pkg/storage/utils/decomposedfs/grants.go
+++ b/pkg/storage/utils/decomposedfs/grants.go
@@ -146,9 +146,9 @@ func (fs *Decomposedfs) RemoveGrant(ctx context.Context, ref *provider.Reference
 
 	var attr string
 	if g.Grantee.Type == provider.GranteeType_GRANTEE_TYPE_GROUP {
-		attr = xattrs.GrantPrefix + xattrs.GroupAcePrefix + g.Grantee.GetGroupId().OpaqueId
+		attr = xattrs.GrantGroupAcePrefix + g.Grantee.GetGroupId().OpaqueId
 	} else {
-		attr = xattrs.GrantPrefix + xattrs.UserAcePrefix + g.Grantee.GetUserId().OpaqueId
+		attr = xattrs.GrantUserAcePrefix + g.Grantee.GetUserId().OpaqueId
 	}
 
 	np := fs.lu.InternalPath(node.ID)

--- a/pkg/storage/utils/decomposedfs/grants_test.go
+++ b/pkg/storage/utils/decomposedfs/grants_test.go
@@ -116,7 +116,7 @@ var _ = Describe("Grants", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				localPath := path.Join(env.Root, "nodes", n.ID)
-				attr, err := xattr.Get(localPath, xattrs.GrantPrefix+xattrs.UserAcePrefix+grant.Grantee.GetUserId().OpaqueId)
+				attr, err := xattr.Get(localPath, xattrs.GrantUserAcePrefix+grant.Grantee.GetUserId().OpaqueId)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(string(attr)).To(Equal("\x00t=A:f=:p=rw"))
 			})

--- a/pkg/storage/utils/decomposedfs/node/node.go
+++ b/pkg/storage/utils/decomposedfs/node/node.go
@@ -833,15 +833,15 @@ func (n *Node) ReadUserPermissions(ctx context.Context, u *userpb.User) (ap prov
 	// 1. we can start iterating over the acls / grants on the node or
 	// 2. we can iterate over the number of groups
 	// The current implementation tries to be defensive for cases where users have hundreds or thousands of groups, so we iterate over the existing acls.
-	userace := xattrs.GrantPrefix + xattrs.UserAcePrefix + u.Id.OpaqueId
+	userace := xattrs.GrantUserAcePrefix + u.Id.OpaqueId
 	userFound := false
 	for i := range grantees {
 		switch {
 		// we only need to find the user once
 		case !userFound && grantees[i] == userace:
 			g, err = n.ReadGrant(ctx, grantees[i])
-		case strings.HasPrefix(grantees[i], xattrs.GrantPrefix+xattrs.GroupAcePrefix): // only check group grantees
-			gr := strings.TrimPrefix(grantees[i], xattrs.GrantPrefix+xattrs.GroupAcePrefix)
+		case strings.HasPrefix(grantees[i], xattrs.GrantGroupAcePrefix): // only check group grantees
+			gr := strings.TrimPrefix(grantees[i], xattrs.GrantGroupAcePrefix)
 			if groupsMap[gr] {
 				g, err = n.ReadGrant(ctx, grantees[i])
 			} else {
@@ -921,7 +921,7 @@ func (n *Node) hasUserShares(ctx context.Context) bool {
 	}
 
 	for i := range g {
-		if strings.Contains(g[i], xattrs.GrantPrefix+xattrs.UserAcePrefix) {
+		if strings.HasPrefix(g[i], xattrs.GrantUserAcePrefix) {
 			return true
 		}
 	}

--- a/pkg/storage/utils/decomposedfs/node/permissions.go
+++ b/pkg/storage/utils/decomposedfs/node/permissions.go
@@ -225,7 +225,7 @@ func nodeHasPermission(ctx context.Context, cn *Node, groupsMap map[string]bool,
 		return false
 	}
 
-	userace := xattrs.GrantPrefix + xattrs.UserAcePrefix + userid
+	userace := xattrs.GrantUserAcePrefix + userid
 	userFound := false
 	for i := range grantees {
 		// we only need the find the user once per node
@@ -233,8 +233,8 @@ func nodeHasPermission(ctx context.Context, cn *Node, groupsMap map[string]bool,
 		switch {
 		case !userFound && grantees[i] == userace:
 			g, err = cn.ReadGrant(ctx, grantees[i])
-		case strings.HasPrefix(grantees[i], xattrs.GrantPrefix+xattrs.GroupAcePrefix):
-			gr := strings.TrimPrefix(grantees[i], xattrs.GrantPrefix+xattrs.GroupAcePrefix)
+		case strings.HasPrefix(grantees[i], xattrs.GrantGroupAcePrefix):
+			gr := strings.TrimPrefix(grantees[i], xattrs.GrantGroupAcePrefix)
 			if groupsMap[gr] {
 				g, err = cn.ReadGrant(ctx, grantees[i])
 			} else {

--- a/pkg/storage/utils/decomposedfs/node/permissions.go
+++ b/pkg/storage/utils/decomposedfs/node/permissions.go
@@ -200,50 +200,11 @@ func (p *Permissions) HasPermission(ctx context.Context, n *Node, check func(*pr
 		groupsMap[u.Groups[i]] = true
 	}
 
-	var g *provider.Grant
 	// for all segments, starting at the leaf
 	cn := n
 	for cn.ID != n.SpaceRoot.ID {
-
-		var grantees []string
-		if grantees, err = cn.ListGrantees(ctx); err != nil {
-			appctx.GetLogger(ctx).Error().Err(err).Interface("node", cn).Msg("error listing grantees")
-			return false, err
-		}
-
-		userace := xattrs.GrantPrefix + xattrs.UserAcePrefix + u.Id.OpaqueId
-		userFound := false
-		for i := range grantees {
-			// we only need the find the user once per node
-			switch {
-			case !userFound && grantees[i] == userace:
-				g, err = cn.ReadGrant(ctx, grantees[i])
-			case strings.HasPrefix(grantees[i], xattrs.GrantPrefix+xattrs.GroupAcePrefix):
-				gr := strings.TrimPrefix(grantees[i], xattrs.GrantPrefix+xattrs.GroupAcePrefix)
-				if groupsMap[gr] {
-					g, err = cn.ReadGrant(ctx, grantees[i])
-				} else {
-					// no need to check attribute
-					continue
-				}
-			default:
-				// no need to check attribute
-				continue
-			}
-
-			switch {
-			case err == nil:
-				appctx.GetLogger(ctx).Debug().Interface("node", cn).Str("grant", grantees[i]).Interface("permissions", g.GetPermissions()).Msg("checking permissions")
-				if check(g.GetPermissions()) {
-					return true, nil
-				}
-			case isAttrUnset(err):
-				err = nil
-				appctx.GetLogger(ctx).Error().Interface("node", cn).Str("grant", grantees[i]).Interface("grantees", grantees).Msg("grant vanished from node after listing")
-			default:
-				appctx.GetLogger(ctx).Error().Err(err).Interface("node", cn).Str("grant", grantees[i]).Msg("error reading permissions")
-				return false, err
-			}
+		if ok := nodeHasPermission(ctx, cn, groupsMap, u.Id.OpaqueId, check); ok {
+			return true, nil
 		}
 
 		if cn, err = cn.Parent(); err != nil {
@@ -251,9 +212,60 @@ func (p *Permissions) HasPermission(ctx context.Context, n *Node, check func(*pr
 		}
 	}
 
-	// NOTE: this log is being printed 1 million times on a simple test. TODO: Check if this is expected
-	// appctx.GetLogger(ctx).Debug().Interface("permissions", NoPermissions()).Interface("node", n).Interface("user", u).Msg("no grant found, returning default permissions")
+	// also check permissions on root, eg. for for project spaces
+	if ok := nodeHasPermission(ctx, cn, groupsMap, u.Id.OpaqueId, check); ok {
+		return true, nil
+	}
+
 	return false, nil
+}
+
+func nodeHasPermission(ctx context.Context, cn *Node, groupsMap map[string]bool, userid string, check func(*provider.ResourcePermissions) bool) (ok bool) {
+
+	var grantees []string
+	var err error
+	if grantees, err = cn.ListGrantees(ctx); err != nil {
+		appctx.GetLogger(ctx).Error().Err(err).Interface("node", cn).Msg("error listing grantees")
+		return false
+	}
+
+	userace := xattrs.GrantPrefix + xattrs.UserAcePrefix + userid
+	userFound := false
+	for i := range grantees {
+		// we only need the find the user once per node
+		var g *provider.Grant
+		switch {
+		case !userFound && grantees[i] == userace:
+			g, err = cn.ReadGrant(ctx, grantees[i])
+		case strings.HasPrefix(grantees[i], xattrs.GrantPrefix+xattrs.GroupAcePrefix):
+			gr := strings.TrimPrefix(grantees[i], xattrs.GrantPrefix+xattrs.GroupAcePrefix)
+			if groupsMap[gr] {
+				g, err = cn.ReadGrant(ctx, grantees[i])
+			} else {
+				// no need to check attribute
+				continue
+			}
+		default:
+			// no need to check attribute
+			continue
+		}
+
+		switch {
+		case err == nil:
+			appctx.GetLogger(ctx).Debug().Interface("node", cn).Str("grant", grantees[i]).Interface("permissions", g.GetPermissions()).Msg("checking permissions")
+			if check(g.GetPermissions()) {
+				return true
+			}
+		case isAttrUnset(err):
+			err = nil
+			appctx.GetLogger(ctx).Error().Interface("node", cn).Str("grant", grantees[i]).Interface("grantees", grantees).Msg("grant vanished from node after listing")
+		default:
+			appctx.GetLogger(ctx).Error().Err(err).Interface("node", cn).Str("grant", grantees[i]).Msg("error reading permissions")
+			return false
+		}
+	}
+
+	return false
 }
 
 func (p *Permissions) getUserAndPermissions(ctx context.Context, n *Node) (*userv1beta1.User, *provider.ResourcePermissions) {

--- a/pkg/storage/utils/decomposedfs/node/permissions.go
+++ b/pkg/storage/utils/decomposedfs/node/permissions.go
@@ -213,11 +213,7 @@ func (p *Permissions) HasPermission(ctx context.Context, n *Node, check func(*pr
 	}
 
 	// also check permissions on root, eg. for for project spaces
-	if ok := nodeHasPermission(ctx, cn, groupsMap, u.Id.OpaqueId, check); ok {
-		return true, nil
-	}
-
-	return false, nil
+	return nodeHasPermission(ctx, cn, groupsMap, u.Id.OpaqueId, check), nil
 }
 
 func nodeHasPermission(ctx context.Context, cn *Node, groupsMap map[string]bool, userid string, check func(*provider.ResourcePermissions) bool) (ok bool) {

--- a/pkg/storage/utils/decomposedfs/node/permissions.go
+++ b/pkg/storage/utils/decomposedfs/node/permissions.go
@@ -257,7 +257,6 @@ func nodeHasPermission(ctx context.Context, cn *Node, groupsMap map[string]bool,
 				return true
 			}
 		case isAttrUnset(err):
-			err = nil
 			appctx.GetLogger(ctx).Error().Interface("node", cn).Str("grant", grantees[i]).Interface("grantees", grantees).Msg("grant vanished from node after listing")
 		default:
 			appctx.GetLogger(ctx).Error().Err(err).Interface("node", cn).Str("grant", grantees[i]).Msg("error reading permissions")

--- a/pkg/storage/utils/decomposedfs/xattrs/xattrs.go
+++ b/pkg/storage/utils/decomposedfs/xattrs/xattrs.go
@@ -47,8 +47,10 @@ const (
 	BlobsizeAttr string = OcisPrefix + "blobsize"
 
 	// grantPrefix is the prefix for sharing related extended attributes
-	GrantPrefix    string = OcisPrefix + "grant."
-	MetadataPrefix string = OcisPrefix + "md."
+	GrantPrefix         string = OcisPrefix + "grant."
+	GrantUserAcePrefix  string = OcisPrefix + "grant." + UserAcePrefix
+	GrantGroupAcePrefix string = OcisPrefix + "grant." + GroupAcePrefix
+	MetadataPrefix      string = OcisPrefix + "md."
 
 	// favorite flag, per user
 	FavPrefix string = OcisPrefix + "fav."


### PR DESCRIPTION
The decomposedfs now also checks the permissons on the root node of a space. This makes spaces of type 'project' show up for user that have received a share for the space.