### PR TITLE
remove unused home provider from spaces registry config

### DIFF
--- a/changelog/unreleased/remove-unused-home-provider-config.md
+++ b/changelog/unreleased/remove-unused-home-provider-config.md
@@ -1,0 +1,5 @@
+Bugfix: remove unused home provider from config
+
+The spaces registry does not use a home provider config.
+
+https://github.com/cs3org/reva/pull/2428

--- a/pkg/storage/registry/spaces/spaces.go
+++ b/pkg/storage/registry/spaces/spaces.go
@@ -90,15 +90,10 @@ type StorageProviderClient interface {
 }
 
 type config struct {
-	Providers    map[string]*Provider `mapstructure:"providers"`
-	HomeTemplate string               `mapstructure:"home_template"`
+	Providers map[string]*Provider `mapstructure:"providers"`
 }
 
 func (c *config) init() {
-
-	if c.HomeTemplate == "" {
-		c.HomeTemplate = "/"
-	}
 
 	if len(c.Providers) == 0 {
 		c.Providers = map[string]*Provider{
@@ -165,10 +160,6 @@ func New(m map[string]interface{}, getClientFunc GetStorageProviderServiceClient
 		resourceNameCache:               make(map[string]string),
 		getStorageProviderServiceClient: getClientFunc,
 	}
-	r.homeTemplate, err = template.New("home_template").Funcs(sprig.TxtFuncMap()).Parse(c.HomeTemplate)
-	if err != nil {
-		return nil, err
-	}
 	return r, nil
 }
 
@@ -186,8 +177,6 @@ type GetStorageProviderServiceClientFunc func(addr string) (StorageProviderClien
 
 type registry struct {
 	c *config
-	// the template to use when determining the home provider
-	homeTemplate *template.Template
 	// a map of resources to providers
 	resources         map[string][]*registrypb.ProviderInfo
 	resourceNameCache map[string]string


### PR DESCRIPTION
The spaces registry does not use a home provider config.