### PR TITLE
fix aggregated child folder id

### DIFF
--- a/changelog/unreleased/fix-aggregated-child-folder-id.md
+++ b/changelog/unreleased/fix-aggregated-child-folder-id.md
@@ -1,0 +1,5 @@
+Bugfix: fix aggregated child folder id
+
+Propfind now returns the correct id and correctly aggregates the mtime and etag.
+
+https://github.com/cs3org/reva/pull/2430


### PR DESCRIPTION
Propfind now returns the correct id and correctly aggregates the mtime and etag.