### PR TITLE
Purge spaces

### DIFF
--- a/changelog/unreleased/purge-spaces.md
+++ b/changelog/unreleased/purge-spaces.md
@@ -1,0 +1,8 @@
+Enhancement: Delete shares when purging spaces 
+
+Implemented the second step of the two step spaces delete process.
+The first step is marking the space as deleted, the second step is actually purging the space.
+During the second step all shares, including public shares, in the space will be deleted.
+When deleting a space the blobs are currently not yet deleted since the decomposedfs will receive some changes soon.
+
+https://github.com/cs3org/reva/pull/2431

--- a/internal/grpc/services/gateway/storageprovider.go
+++ b/internal/grpc/services/gateway/storageprovider.go
@@ -42,21 +42,16 @@ import (
 	"github.com/cs3org/reva/pkg/appctx"
 	ctxpkg "github.com/cs3org/reva/pkg/ctx"
 	"github.com/cs3org/reva/pkg/errtypes"
+	"github.com/cs3org/reva/pkg/publicshare"
 	"github.com/cs3org/reva/pkg/rgrpc/status"
 	"github.com/cs3org/reva/pkg/rgrpc/todo/pool"
 	"github.com/cs3org/reva/pkg/rhttp/router"
 	sdk "github.com/cs3org/reva/pkg/sdk/common"
+	"github.com/cs3org/reva/pkg/share"
 	"github.com/cs3org/reva/pkg/utils"
 	"github.com/golang-jwt/jwt"
 	"github.com/pkg/errors"
 	gstatus "google.golang.org/grpc/status"
-)
-
-const (
-	// ShareSpaceFilterType represents a share filter type to filter by space ids.
-	ShareSpaceFilterType collaborationv1beta1.Filter_Type = 7
-	// PublicShareSpaceFilterType represents a publicshare filter type to filter by space ids.
-	PublicShareSpaceFilterType linkv1beta1.ListPublicSharesRequest_Filter_Type = 4
 )
 
 /*  About caching
@@ -344,13 +339,7 @@ func (s *svc) DeleteStorageSpace(ctx context.Context, req *provider.DeleteStorag
 	log.Debug().Msg("purging storage space")
 	// List all shares in this storage space
 	lsRes, err := s.ListShares(ctx, &collaborationv1beta1.ListSharesRequest{
-		Filters: []*collaborationv1beta1.Filter{
-			{
-				// TODO: introduce the new fiter type to the CS3 API
-				Type: ShareSpaceFilterType,
-				Term: &collaborationv1beta1.Filter_ResourceId{ResourceId: &provider.ResourceId{StorageId: storageid}},
-			},
-		},
+		Filters: []*collaborationv1beta1.Filter{share.StorageIDFilter(storageid)},
 	})
 	switch {
 	case err != nil:
@@ -375,13 +364,7 @@ func (s *svc) DeleteStorageSpace(ctx context.Context, req *provider.DeleteStorag
 
 	// List all public shares in this storage space
 	lpsRes, err := s.ListPublicShares(ctx, &linkv1beta1.ListPublicSharesRequest{
-		Filters: []*linkv1beta1.ListPublicSharesRequest_Filter{
-			{
-				// TODO: introduce the new fiter type to the CS3 API
-				Type: PublicShareSpaceFilterType,
-				Term: &linkv1beta1.ListPublicSharesRequest_Filter_ResourceId{ResourceId: &provider.ResourceId{StorageId: storageid}},
-			},
-		},
+		Filters: []*linkv1beta1.ListPublicSharesRequest_Filter{publicshare.StorageIDFilter(storageid)},
 	})
 	switch {
 	case err != nil:

--- a/pkg/publicshare/publicshare.go
+++ b/pkg/publicshare/publicshare.go
@@ -33,6 +33,12 @@ import (
 	"github.com/cs3org/reva/pkg/utils"
 )
 
+const (
+	// StorageIDFilterType defines a new filter type for storage id.
+	// TODO: Remove this once the filter type is in the CS3 API.
+	StorageIDFilterType link.ListPublicSharesRequest_Filter_Type = 4
+)
+
 // Manager manipulates public shares.
 type Manager interface {
 	CreatePublicShare(ctx context.Context, u *user.User, md *provider.ResourceInfo, g *link.Grant) (*link.PublicShare, error)
@@ -95,12 +101,24 @@ func ResourceIDFilter(id *provider.ResourceId) *link.ListPublicSharesRequest_Fil
 	}
 }
 
+// StorageIDFilter is an abstraction for creating filter by storage id.
+func StorageIDFilter(id string) *link.ListPublicSharesRequest_Filter {
+	return &link.ListPublicSharesRequest_Filter{
+		Type: StorageIDFilterType,
+		Term: &link.ListPublicSharesRequest_Filter_ResourceId{
+			ResourceId: &provider.ResourceId{
+				StorageId: id,
+			},
+		},
+	}
+}
+
 // MatchesFilter tests if the share passes the filter.
 func MatchesFilter(share *link.PublicShare, filter *link.ListPublicSharesRequest_Filter) bool {
 	switch filter.Type {
 	case link.ListPublicSharesRequest_Filter_TYPE_RESOURCE_ID:
 		return utils.ResourceIDEqual(share.ResourceId, filter.GetResourceId())
-	case link.ListPublicSharesRequest_Filter_Type(4):
+	case StorageIDFilterType:
 		return share.ResourceId.StorageId == filter.GetResourceId().GetStorageId()
 	default:
 		return false

--- a/pkg/publicshare/publicshare.go
+++ b/pkg/publicshare/publicshare.go
@@ -100,6 +100,8 @@ func MatchesFilter(share *link.PublicShare, filter *link.ListPublicSharesRequest
 	switch filter.Type {
 	case link.ListPublicSharesRequest_Filter_TYPE_RESOURCE_ID:
 		return utils.ResourceIDEqual(share.ResourceId, filter.GetResourceId())
+	case link.ListPublicSharesRequest_Filter_Type(4):
+		return share.ResourceId.StorageId == filter.GetResourceId().GetStorageId()
 	default:
 		return false
 	}

--- a/pkg/rgrpc/status/status.go
+++ b/pkg/rgrpc/status/status.go
@@ -159,6 +159,8 @@ func NewStatusFromErrType(ctx context.Context, msg string, err error) *rpc.Statu
 				return NewUnauthenticated(ctx, err, msg+": "+err.Error())
 			case codes.PermissionDenied:
 				return NewPermissionDenied(ctx, err, msg+": "+err.Error())
+			case codes.Unimplemented:
+				return NewUnimplemented(ctx, err, msg+": "+err.Error())
 			}
 		}
 		// the actual error can be wrapped multiple times

--- a/pkg/share/share.go
+++ b/pkg/share/share.go
@@ -121,6 +121,8 @@ func MatchesFilter(share *collaboration.Share, filter *collaboration.Filter) boo
 		// This filter type is used to filter out "denial shares". These are currently implemented by having the permission "0".
 		// I.e. if the permission is 0 we don't want to show it.
 		return int(conversions.RoleFromResourcePermissions(share.Permissions.Permissions).OCSPermissions()) != 0
+	case collaboration.Filter_Type(7):
+		return share.ResourceId.StorageId == filter.GetResourceId().GetStorageId()
 	default:
 		return false
 	}

--- a/pkg/share/share.go
+++ b/pkg/share/share.go
@@ -29,6 +29,12 @@ import (
 	"google.golang.org/genproto/protobuf/field_mask"
 )
 
+const (
+	// StorageIDFilterType defines a new filter type for storage id.
+	// TODO: Remove once this filter type is in the CS3 API.
+	StorageIDFilterType collaboration.Filter_Type = 7
+)
+
 //go:generate mockery -name Manager
 
 // Manager is the interface that manipulates shares.
@@ -89,6 +95,18 @@ func ResourceIDFilter(id *provider.ResourceId) *collaboration.Filter {
 	}
 }
 
+// StorageIDFilter is an abstraction for creating filter by storage id.
+func StorageIDFilter(id string) *collaboration.Filter {
+	return &collaboration.Filter{
+		Type: StorageIDFilterType,
+		Term: &collaboration.Filter_ResourceId{
+			ResourceId: &provider.ResourceId{
+				StorageId: id,
+			},
+		},
+	}
+}
+
 // IsCreatedByUser checks if the user is the owner or creator of the share.
 func IsCreatedByUser(share *collaboration.Share, user *userv1beta1.User) bool {
 	return utils.UserEqual(user.Id, share.Owner) || utils.UserEqual(user.Id, share.Creator)
@@ -121,7 +139,7 @@ func MatchesFilter(share *collaboration.Share, filter *collaboration.Filter) boo
 		// This filter type is used to filter out "denial shares". These are currently implemented by having the permission "0".
 		// I.e. if the permission is 0 we don't want to show it.
 		return int(conversions.RoleFromResourcePermissions(share.Permissions.Permissions).OCSPermissions()) != 0
-	case collaboration.Filter_Type(7):
+	case StorageIDFilterType:
 		return share.ResourceId.StorageId == filter.GetResourceId().GetStorageId()
 	default:
 		return false

--- a/pkg/storage/utils/decomposedfs/node/node.go
+++ b/pkg/storage/utils/decomposedfs/node/node.go
@@ -61,6 +61,9 @@ const (
 	QuotaUncalculated = "-1"
 	QuotaUnknown      = "-2"
 	QuotaUnlimited    = "-3"
+
+	// TrashIDDelimiter represents the characters used to separate the nodeid and the deletion time.
+	TrashIDDelimiter = ".T."
 )
 
 // Node represents a node in the tree and provides methods to get a Parent or Child instance

--- a/pkg/storage/utils/decomposedfs/recycle.go
+++ b/pkg/storage/utils/decomposedfs/recycle.go
@@ -122,7 +122,7 @@ func (fs *Decomposedfs) createTrashItem(ctx context.Context, parentNode, interme
 		log.Error().Err(err).Msg("error reading trash link, skipping")
 		return nil, err
 	}
-	parts := strings.SplitN(filepath.Base(parentNode), ".T.", 2)
+	parts := strings.SplitN(filepath.Base(parentNode), node.TrashIDDelimiter, 2)
 	if len(parts) != 2 {
 		log.Error().Str("trashnode", trashnode).Interface("parts", parts).Msg("malformed trash link, skipping")
 		return nil, errors.New("malformed trash link")
@@ -191,7 +191,7 @@ func (fs *Decomposedfs) listTrashRoot(ctx context.Context, spaceID string) ([]*p
 			log.Error().Err(err).Str("trashRoot", trashRoot).Str("name", names[i]).Msg("error reading trash link, skipping")
 			continue
 		}
-		parts := strings.SplitN(filepath.Base(trashnode), ".T.", 2)
+		parts := strings.SplitN(filepath.Base(trashnode), node.TrashIDDelimiter, 2)
 		if len(parts) != 2 {
 			log.Error().Err(err).Str("trashRoot", trashRoot).Str("name", names[i]).Str("trashnode", trashnode).Interface("parts", parts).Msg("malformed trash link, skipping")
 			continue

--- a/pkg/storage/utils/decomposedfs/spaces.go
+++ b/pkg/storage/utils/decomposedfs/spaces.go
@@ -404,12 +404,12 @@ func (fs *Decomposedfs) DeleteStorageSpace(ctx context.Context, req *provider.De
 		return err
 	}
 
-	trashPathMatches, err := filepath.Glob(n.InternalPath() + node.TrashIDDelimiter)
+	trashPathMatches, err := filepath.Glob(n.InternalPath() + node.TrashIDDelimiter + "*")
 	if err != nil {
 		return err
 	}
 	if len(trashPathMatches) != 1 {
-		return fmt.Errorf("delete space failed: found %d matching trashed spaces", len(matches))
+		return fmt.Errorf("delete space failed: found %d matching trashed spaces", len(trashPathMatches))
 	}
 	trashPath := trashPathMatches[0]
 	return os.Symlink(trashPath, filepath.Join(filepath.Dir(matches[0]), filepath.Base(trashPath)))

--- a/pkg/storage/utils/decomposedfs/spaces.go
+++ b/pkg/storage/utils/decomposedfs/spaces.go
@@ -369,10 +369,8 @@ func (fs *Decomposedfs) DeleteStorageSpace(ctx context.Context, req *provider.De
 		if len(matches) != 1 {
 			return fmt.Errorf("delete space failed: found %d matching spaces", len(matches))
 		}
-		if err := os.RemoveAll(matches[0]); err != nil {
-			return err
-		}
-		return nil
+
+		return os.RemoveAll(matches[0])
 	}
 
 	spaceID := req.Id.OpaqueId

--- a/pkg/storage/utils/decomposedfs/tree/tree.go
+++ b/pkg/storage/utils/decomposedfs/tree/tree.go
@@ -420,7 +420,7 @@ func (t *Tree) Delete(ctx context.Context, n *node.Node) (err error) {
 	// first make node appear in the space trash
 	// parent id and name are stored as extended attributes in the node itself
 	trashLink := filepath.Join(t.root, "trash", n.SpaceRoot.ID, n.ID)
-	err = os.Symlink("../../nodes/"+n.ID+".T."+deletionTime, trashLink)
+	err = os.Symlink("../../nodes/"+n.ID+node.TrashIDDelimiter+deletionTime, trashLink)
 	if err != nil {
 		// To roll back changes
 		// TODO unset trashOriginAttr
@@ -430,7 +430,7 @@ func (t *Tree) Delete(ctx context.Context, n *node.Node) (err error) {
 	// at this point we have a symlink pointing to a non existing destination, which is fine
 
 	// rename the trashed node so it is not picked up when traversing up the tree and matches the symlink
-	trashPath := nodePath + ".T." + deletionTime
+	trashPath := nodePath + node.TrashIDDelimiter + deletionTime
 	err = os.Rename(nodePath, trashPath)
 	if err != nil {
 		// To roll back changes
@@ -840,7 +840,7 @@ func (t *Tree) readRecycleItem(ctx context.Context, spaceid, key, path string) (
 	err = recycleNode.FindStorageSpaceRoot()
 
 	if path == "" || path == "/" {
-		parts := strings.SplitN(filepath.Base(link), ".T.", 2)
+		parts := strings.SplitN(filepath.Base(link), node.TrashIDDelimiter, 2)
 		if len(parts) != 2 {
 			appctx.GetLogger(ctx).Error().Err(err).Str("trashItem", trashItem).Interface("parts", parts).Msg("malformed trash link")
 			return


### PR DESCRIPTION
Implemented the second step of the two step spaces delete process.
The first step is marking the space as deleted, the second step is actually purging the space.
During the second step all shares, including public shares, in the space will be deleted.
When deleting a space the blobs are currently not yet deleted since the decomposedfs will receive some changes soon.

