### PR TITLE
use space reference when listing containers

### DIFF
--- a/changelog/unreleased/use-space-reference.md
+++ b/changelog/unreleased/use-space-reference.md
@@ -1,0 +1,5 @@
+Bugfix: use space reference when listing containers
+
+The propfind handler now uses the reference for a space to make lookups relative.
+
+https://github.com/cs3org/reva/pull/2432


### PR DESCRIPTION
The propfind handler now uses the reference for a space to make lookups relative.
