### PR TITLE
ignore handled errors when creating spaces

### DIFF
--- a/changelog/unreleased/ignore-known-erros.md
+++ b/changelog/unreleased/ignore-known-erros.md
@@ -1,0 +1,5 @@
+Enhancement: ignore handled errors when creating spaces
+
+The CreateStorageSpace no longer logs all error cases with error level logging
+
+https://github.com/cs3org/reva/pull/2439

--- a/internal/grpc/services/storageprovider/storageprovider.go
+++ b/internal/grpc/services/storageprovider/storageprovider.go
@@ -507,13 +507,13 @@ func (s *service) CreateStorageSpace(ctx context.Context, req *provider.CreateSt
 			st = status.NewAlreadyExists(ctx, err, "already exists")
 		default:
 			st = status.NewInternal(ctx, "error listing spaces")
+			appctx.GetLogger(ctx).
+				Error().
+				Err(err).
+				Interface("status", st).
+				Interface("request", req).
+				Msg("failed to create storage space")
 		}
-		appctx.GetLogger(ctx).
-			Error().
-			Err(err).
-			Interface("status", st).
-			Interface("request", req).
-			Msg("failed to create storage space")
 		return &provider.CreateStorageSpaceResponse{
 			Status: st,
 		}, nil


### PR DESCRIPTION
The CreateStorageSpace no longer logs all error cases with error level logging
