### PR TITLE
Fix publiclinks and decomposedfs

### DIFF
--- a/changelog/unreleased/fix-id-checking-in-decomposedfs.md
+++ b/changelog/unreleased/fix-id-checking-in-decomposedfs.md
@@ -1,0 +1,8 @@
+Bugfix: Don't handle ids containing "/" in decomposedfs
+
+The storageprovider previously checked all ids without checking their validity
+this lead to flaky test because it shouldn't check ids that are used from the
+public storage provider
+
+https://github.com/cs3org/reva/pull/2445
+

--- a/pkg/storage/utils/decomposedfs/spaces.go
+++ b/pkg/storage/utils/decomposedfs/spaces.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 
 	userv1beta1 "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	v1beta11 "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
@@ -195,6 +196,9 @@ func (fs *Decomposedfs) ListStorageSpaces(ctx context.Context, filter []*provide
 			}
 		case provider.ListStorageSpacesRequest_Filter_TYPE_ID:
 			spaceID, nodeID, _ = utils.SplitStorageSpaceID(filter[i].GetId().OpaqueId)
+			if strings.Contains(nodeID, "/") {
+				return []*provider.StorageSpace{}, nil
+			}
 		}
 	}
 	if len(spaceTypes) == 0 {


### PR DESCRIPTION
A missing check lead to flaky tests