### PR TITLE
decomposedfs: do not swallow errors when creating nodes

### DIFF
--- a/changelog/unreleased/do-not-swallow-error.md
+++ b/changelog/unreleased/do-not-swallow-error.md
@@ -1,0 +1,5 @@
+Bugfix: do not swallow error
+
+decomposedfs not longer swallows errors when creating a node fails.
+
+https://github.com/cs3org/reva/pull/2457

--- a/pkg/storage/utils/decomposedfs/tree/tree.go
+++ b/pkg/storage/utils/decomposedfs/tree/tree.go
@@ -259,7 +259,7 @@ func (t *Tree) CreateDir(ctx context.Context, n *node.Node) (err error) {
 
 	err = t.createNode(n, owner)
 	if err != nil {
-		return nil
+		return
 	}
 
 	// make child appear in listings


### PR DESCRIPTION
decomposedfs not longer swallows errors when creating a node fails