### PR TITLE
prevent purging of enabled spaces

### DIFF
--- a/changelog/unreleased/purge-spaces.md
+++ b/changelog/unreleased/purge-spaces.md
@@ -6,3 +6,4 @@ During the second step all shares, including public shares, in the space will be
 When deleting a space the blobs are currently not yet deleted since the decomposedfs will receive some changes soon.
 
 https://github.com/cs3org/reva/pull/2431
+https://github.com/cs3org/reva/pull/2458

--- a/internal/grpc/services/storageprovider/storageprovider.go
+++ b/internal/grpc/services/storageprovider/storageprovider.go
@@ -593,6 +593,8 @@ func (s *service) DeleteStorageSpace(ctx context.Context, req *provider.DeleteSt
 			st = status.NewNotFound(ctx, "not found when deleting space")
 		case errtypes.PermissionDenied:
 			st = status.NewPermissionDenied(ctx, err, "permission denied")
+		case errtypes.BadRequest:
+			st = status.NewInvalidArg(ctx, err.Error())
 		default:
 			st = status.NewInternal(ctx, "error deleting space: "+req.Id.String())
 		}

--- a/pkg/storage/utils/decomposedfs/spaces.go
+++ b/pkg/storage/utils/decomposedfs/spaces.go
@@ -35,6 +35,7 @@ import (
 	"github.com/cs3org/reva/pkg/appctx"
 	ctxpkg "github.com/cs3org/reva/pkg/ctx"
 	"github.com/cs3org/reva/pkg/errtypes"
+	"github.com/cs3org/reva/pkg/rgrpc/status"
 	"github.com/cs3org/reva/pkg/storage/utils/decomposedfs/node"
 	"github.com/cs3org/reva/pkg/storage/utils/decomposedfs/xattrs"
 	"github.com/cs3org/reva/pkg/utils"
@@ -351,6 +352,9 @@ func (fs *Decomposedfs) DeleteStorageSpace(ctx context.Context, req *provider.De
 	}
 
 	if purge {
+		if !strings.Contains(req.Id.OpaqueId, node.TrashIDDelimiter) {
+			return errtypes.NewErrtypeFromStatus(status.NewInvalidArg(ctx, "can't purge enabled space"))
+		}
 		ip := fs.lu.InternalPath(req.Id.OpaqueId)
 		matches, err := filepath.Glob(ip)
 		if err != nil {


### PR DESCRIPTION
Without these changes it is possible to purge a space with one request.