### PR TITLE
Do not log nodes

### DIFF
--- a/changelog/unreleased/do-not-log-nodes.md
+++ b/changelog/unreleased/do-not-log-nodes.md
@@ -1,0 +1,6 @@
+Enhancement: do not log whole nodes
+
+It turns out that logging whole node objects is very expensive and also
+spams the logs quite a bit. Instead we just log the node ID now.
+
+https://github.com/cs3org/reva/pull/2463

--- a/pkg/storage/utils/decomposedfs/node/node.go
+++ b/pkg/storage/utils/decomposedfs/node/node.go
@@ -482,7 +482,7 @@ func (n *Node) SetFavorite(uid *userpb.UserId, val string) error {
 
 // AsResourceInfo return the node as CS3 ResourceInfo
 func (n *Node) AsResourceInfo(ctx context.Context, rp *provider.ResourcePermissions, mdKeys []string, returnBasename bool) (ri *provider.ResourceInfo, err error) {
-	sublog := appctx.GetLogger(ctx).With().Interface("node", n).Logger()
+	sublog := appctx.GetLogger(ctx).With().Interface("node", n.ID).Logger()
 
 	var fn string
 	nodePath := n.lu.InternalPath(n.ID)


### PR DESCRIPTION
It turns out that logging whole node objects is very expensive and also spams the logs quite a bit. Instead we just log the node ID now.