### PR TITLE
Space grants

### DIFF
--- a/changelog/unreleased/extract-space-grants.md
+++ b/changelog/unreleased/extract-space-grants.md
@@ -1,0 +1,9 @@
+Bugfix: pass spacegrants when adding member to space
+
+When creating a space grant there should not be created a new space. 
+Unfortunately SpaceGrant didn't work when adding members to a space.
+Now a value is placed in the ctx of the storageprovider on which decomposedfs reacts
+
+
+
+https://github.com/cs3org/reva/pull/2464

--- a/internal/grpc/services/storageprovider/storageprovider.go
+++ b/internal/grpc/services/storageprovider/storageprovider.go
@@ -1128,6 +1128,15 @@ func (s *service) DenyGrant(ctx context.Context, req *provider.DenyGrantRequest)
 }
 
 func (s *service) AddGrant(ctx context.Context, req *provider.AddGrantRequest) (*provider.AddGrantResponse, error) {
+	// TODO: update CS3 APIs
+	if req.Opaque != nil {
+		_, spacegrant := req.Opaque.Map["spacegrant"]
+		if spacegrant {
+			ctx = context.WithValue(ctx, utils.SpaceGrant, struct{}{})
+		}
+
+	}
+
 	// check grantee type is valid
 	if req.Grant.Grantee.Type == provider.GranteeType_GRANTEE_TYPE_INVALID {
 		return &provider.AddGrantResponse{

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/spaces.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/spaces.go
@@ -102,8 +102,16 @@ func (h *Handler) addSpaceMember(w http.ResponseWriter, r *http.Request, info *p
 		return
 	}
 
+	// TODO: change CS3 APIs
+	opaque := &types.Opaque{
+		Map: map[string]*types.OpaqueEntry{
+			"spacegrant": {},
+		},
+	}
+
 	addGrantRes, err := providerClient.AddGrant(ctx, &provider.AddGrantRequest{
-		Ref: ref,
+		Opaque: opaque,
+		Ref:    ref,
 		Grant: &provider.Grant{
 			Grantee:     &grantee,
 			Permissions: role.CS3ResourcePermissions(),

--- a/pkg/storage/utils/decomposedfs/grants.go
+++ b/pkg/storage/utils/decomposedfs/grants.go
@@ -29,11 +29,9 @@ import (
 	"github.com/cs3org/reva/pkg/storage/utils/ace"
 	"github.com/cs3org/reva/pkg/storage/utils/decomposedfs/node"
 	"github.com/cs3org/reva/pkg/storage/utils/decomposedfs/xattrs"
+	"github.com/cs3org/reva/pkg/utils"
 	"github.com/pkg/xattr"
 )
-
-// SpaceGrant is the key used to signal not to create a new space when a grant is assigned to a storage space.
-var SpaceGrant struct{}
 
 // DenyGrant denies access to a resource.
 func (fs *Decomposedfs) DenyGrant(ctx context.Context, ref *provider.Reference, g *provider.Grantee) error {
@@ -72,7 +70,7 @@ func (fs *Decomposedfs) AddGrant(ctx context.Context, ref *provider.Reference, g
 	}
 
 	// when a grant is added to a space, do not add a new space under "shares"
-	if spaceGrant := ctx.Value(SpaceGrant); spaceGrant == nil {
+	if spaceGrant := ctx.Value(utils.SpaceGrant); spaceGrant == nil {
 		err := fs.createStorageSpace(ctx, "share", node.ID)
 		if err != nil {
 			return err

--- a/pkg/storage/utils/decomposedfs/spaces.go
+++ b/pkg/storage/utils/decomposedfs/spaces.go
@@ -143,7 +143,7 @@ func (fs *Decomposedfs) CreateStorageSpace(ctx context.Context, req *provider.Cr
 		},
 	}
 
-	ctx = context.WithValue(ctx, SpaceGrant, struct{}{})
+	ctx = context.WithValue(ctx, utils.SpaceGrant, struct{}{})
 
 	if err := fs.AddGrant(ctx, &provider.Reference{
 		ResourceId: resp.StorageSpace.Root,

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -55,6 +55,9 @@ var (
 
 	// PublicStorageProviderID is the id used by the sharestorageprovider
 	PublicStorageProviderID = "7993447f-687f-490d-875c-ac95e89a62a4"
+
+	// SpaceGrant is used to signal the storageprovider that the grant is on a space
+	SpaceGrant struct{}
 )
 
 // Skip  evaluates whether a source endpoint contains any of the prefixes.


### PR DESCRIPTION
When adding a grant to a space, there should not be a new space created. This passes the info that the grant is on a space to the storageprovider