### PR TITLE
[tests-only] [full-ci] Add end-of-line to expected-failures files

### DIFF
--- a/tests/acceptance/expected-failures-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-on-OCIS-storage.md
@@ -1382,4 +1382,6 @@ _ocs: api compatibility, return correct status code_
 -   [apiWebdavProperties1/createFileFolderWhenSharesExist.feature:32](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/createFileFolderWhenSharesExist.feature#L32)
 -   [apiWebdavProperties1/createFileFolderWhenSharesExist.feature:45](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/createFileFolderWhenSharesExist.feature#L45)
 -   [apiWebdavProperties1/createFileFolderWhenSharesExist.feature:48](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/createFileFolderWhenSharesExist.feature#L48)
--   [apiWebdavProperties1/createFileFolderWhenSharesExist.feature:60](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/createFileFolderWhenSharesExist.feature#L60)
+
+Note: always have an empty line at the end of this file.
+The bash script that processes this file may not process a scenario reference on the last line.

--- a/tests/acceptance/expected-failures-on-S3NG-storage.md
+++ b/tests/acceptance/expected-failures-on-S3NG-storage.md
@@ -1382,4 +1382,6 @@ _ocs: api compatibility, return correct status code_
 -   [apiWebdavProperties1/createFileFolderWhenSharesExist.feature:32](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/createFileFolderWhenSharesExist.feature#L32)
 -   [apiWebdavProperties1/createFileFolderWhenSharesExist.feature:45](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/createFileFolderWhenSharesExist.feature#L45)
 -   [apiWebdavProperties1/createFileFolderWhenSharesExist.feature:48](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/createFileFolderWhenSharesExist.feature#L48)
--   [apiWebdavProperties1/createFileFolderWhenSharesExist.feature:60](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/createFileFolderWhenSharesExist.feature#L60)
+
+Note: always have an empty line at the end of this file.
+The bash script that processes this file may not process a scenario reference on the last line.


### PR DESCRIPTION
`apiWebdavProperties1/createFileFolderWhenSharesExist.feature:60` is actually passing, but is not always reported as an "unexpected pass" because it is at the very end of the expected-failures files, and there is no newline character at the end.

For now, do not put a scenario reference on the last line. Tomorrow, I will think about making the bash script smarter in core.

Various discussion of this "last line" problem: https://stackoverflow.com/questions/12916352/shell-script-read-missing-last-line