### PR TITLE
[tests-only] [full-ci] Add end-of-line to expected-failures files

### DIFF
--- a/tests/acceptance/expected-failures-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-on-OCIS-storage.md
@@ -1303,3 +1303,6 @@ _ocs: api compatibility, return correct status code_
 -   [apiWebdavProperties1/createFileFolderWhenSharesExist.feature:48](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/createFileFolderWhenSharesExist.feature#L48)
 -   [apiWebdavProperties1/createFileFolderWhenSharesExist.feature:59](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/createFileFolderWhenSharesExist.feature#L59)
 -   [apiWebdavProperties1/createFileFolderWhenSharesExist.feature:60](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/createFileFolderWhenSharesExist.feature#L60)
+
+Note: always have an empty line at the end of this file.
+The bash script that processes this file may not process a scenario reference on the last line.

--- a/tests/acceptance/expected-failures-on-S3NG-storage.md
+++ b/tests/acceptance/expected-failures-on-S3NG-storage.md
@@ -1305,3 +1305,6 @@ _ocs: api compatibility, return correct status code_
 -   [apiWebdavProperties1/createFileFolderWhenSharesExist.feature:48](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/createFileFolderWhenSharesExist.feature#L48)
 -   [apiWebdavProperties1/createFileFolderWhenSharesExist.feature:59](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/createFileFolderWhenSharesExist.feature#L59)
 -   [apiWebdavProperties1/createFileFolderWhenSharesExist.feature:60](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/createFileFolderWhenSharesExist.feature#L60)
+
+Note: always have an empty line at the end of this file.
+The bash script that processes this file may not process a scenario reference on the last line.


### PR DESCRIPTION
Same as #2482 - add the explanation about having an empty line at the end of expected-failures.

Note:
`createFileFolderWhenSharesExist.feature:59` and `createFileFolderWhenSharesExist.feature:60` scenarios do actually fail in the `edge` branch. So they do need to stay in expected-failures here. They pass in `master` branch, so they are not in expected-failures there.