### PR TITLE
Cephfs: support keyrings with IDs

### DIFF
--- a/changelog/1.18.0_2022-02-11/cephfs-driver.md
+++ b/changelog/1.18.0_2022-02-11/cephfs-driver.md
@@ -1,3 +1,4 @@
 Enhancement: Reva CephFS module v0.2.1
 
 https://github.com/cs3org/reva/pull/1209
+https://github.com/cs3org/reva/pull/2488

--- a/changelog/1.18.0_2022-02-11/cephfs-driver.md
+++ b/changelog/1.18.0_2022-02-11/cephfs-driver.md
@@ -1,4 +1,3 @@
 Enhancement: Reva CephFS module v0.2.1
 
 https://github.com/cs3org/reva/pull/1209
-https://github.com/cs3org/reva/pull/2488

--- a/changelog/unreleased/support-keyrings-with-ids.md
+++ b/changelog/unreleased/support-keyrings-with-ids.md
@@ -1,0 +1,3 @@
+Enhancement: cephfs support keyrings with IDs
+
+https://github.com/cs3org/reva/pull/2488

--- a/pkg/storage/fs/cephfs/cephfs.go
+++ b/pkg/storage/fs/cephfs/cephfs.go
@@ -77,7 +77,7 @@ func New(m map[string]interface{}) (fs storage.FS, err error) {
 		return nil, errors.New("cephfs: can't create caches")
 	}
 
-	adminConn := newAdminConn(c.IndexPool)
+	adminConn := newAdminConn(c)
 	if adminConn == nil {
 		return nil, errors.Wrap(err, "cephfs: Couldn't create admin connections")
 	}
@@ -562,30 +562,64 @@ func (fs *cephfs) UnsetArbitraryMetadata(ctx context.Context, ref *provider.Refe
 	return getRevaError(err)
 }
 
+func (fs *cephfs) TouchFile(ctx context.Context, ref *provider.Reference) error {
+	user := fs.makeUser(ctx)
+	path, err := user.resolveRef(ref)
+	if err != nil {
+		return getRevaError(err)
+	}
+
+	user.op(func(cv *cacheVal) {
+		if err = cv.mount.Open(path, , 0); err != nil {
+			return
+		}
+
+		//TODO(tmourati): Add entry id logic
+	})
+
+	return getRevaError(err)
+}
+
 func (fs *cephfs) EmptyRecycle(ctx context.Context) error {
-	return errtypes.NotSupported("cephfs: empty recycle not supported")
+	return errtypes.NotSupported("unimplemented")
 }
 
 func (fs *cephfs) CreateStorageSpace(ctx context.Context, req *provider.CreateStorageSpaceRequest) (r *provider.CreateStorageSpaceResponse, err error) {
-	return nil, errors.New("cephfs: createStorageSpace not supported")
+	return nil, errtypes.NotSupported("unimplemented")
 }
 
 func (fs *cephfs) ListRecycle(ctx context.Context, basePath, key, relativePath string) ([]*provider.RecycleItem, error) {
-	panic("implement me")
+	return nil, errtypes.NotSupported("unimplemented")
 }
 
 func (fs *cephfs) RestoreRecycleItem(ctx context.Context, basePath, key, relativePath string, restoreRef *provider.Reference) error {
-	return errors.New("cephfs: restoreRecycleItem not supported")
+	return errtypes.NotSupported("unimplemented")
 }
 
 func (fs *cephfs) PurgeRecycleItem(ctx context.Context, basePath, key, relativePath string) error {
-	return errors.New("cephfs: purgeRecycleItem not supported")
+	return errtypes.NotSupported("unimplemented")
 }
 
 func (fs *cephfs) ListStorageSpaces(ctx context.Context, filter []*provider.ListStorageSpacesRequest_Filter, permissions map[string]struct{}) ([]*provider.StorageSpace, error) {
-	return nil, errors.New("cephfs: listStorageSpaces not supported")
+	return nil, errtypes.NotSupported("unimplemented")
 }
 
 func (fs *cephfs) UpdateStorageSpace(ctx context.Context, req *provider.UpdateStorageSpaceRequest) (*provider.UpdateStorageSpaceResponse, error) {
-	return nil, errors.New("cephfs: updateStorageSpace not supported")
+	return nil, errtypes.NotSupported("unimplemented")
+}
+
+func (fs *cephfs) SetLock(ctx context.Context, ref *provider.Reference, lock *provider.Lock) error {
+	return errtypes.NotSupported("unimplemented")
+}
+
+func (fs *cephfs) GetLock(ctx context.Context, ref *provider.Reference) (*provider.Lock, error) {
+	return nil, errtypes.NotSupported("unimplemented")
+}
+
+func (fs *cephfs) RefreshLock(ctx context.Context, ref *provider.Reference, lock *provider.Lock) error {
+	return errtypes.NotSupported("unimplemented")
+}
+
+func (fs *cephfs) Unlock(ctx context.Context, ref *provider.Reference) error {
+	return errtypes.NotSupported("unimplemented")
 }

--- a/pkg/storage/fs/cephfs/cephfs.go
+++ b/pkg/storage/fs/cephfs/cephfs.go
@@ -602,7 +602,7 @@ func (fs *cephfs) PurgeRecycleItem(ctx context.Context, basePath, key, relativeP
 	return errtypes.NotSupported("unimplemented")
 }
 
-func (fs *cephfs) ListStorageSpaces(ctx context.Context, filter []*provider.ListStorageSpacesRequest_Filter, permissions map[string]struct{}) ([]*provider.StorageSpace, error) {
+func (fs *cephfs) ListStorageSpaces(ctx context.Context, filter []*provider.ListStorageSpacesRequest_Filter) ([]*provider.StorageSpace, error) {
 	return nil, errtypes.NotSupported("unimplemented")
 }
 

--- a/pkg/storage/fs/cephfs/chunking.go
+++ b/pkg/storage/fs/cephfs/chunking.go
@@ -120,7 +120,7 @@ func (c *ChunkHandler) saveChunk(path string, r io.ReadCloser) (finish bool, chu
 	c.user.op(func(cv *cacheVal) {
 		var tmpFile *cephfs2.File
 		target := filepath.Join(c.chunkFolder, chunkTempFilename)
-		tmpFile, err = cv.mount.Open(target, os.O_CREATE|os.O_WRONLY, filePermDefault)
+		tmpFile, err = cv.mount.Open(target, os.O_CREATE|os.O_WRONLY, c.user.fs.conf.FilePerms)
 		defer closeFile(tmpFile)
 		if err != nil {
 			return
@@ -170,7 +170,7 @@ func (c *ChunkHandler) saveChunk(path string, r io.ReadCloser) (finish bool, chu
 		}
 
 		chunk = filepath.Join(c.chunkFolder, c.getChunkTempFileName())
-		assembledFile, err = cv.mount.Open(chunk, os.O_CREATE|os.O_WRONLY, filePermDefault)
+		assembledFile, err = cv.mount.Open(chunk, os.O_CREATE|os.O_WRONLY, c.user.fs.conf.FilePerms)
 		defer closeFile(assembledFile)
 		defer deleteFile(cv.mount, chunk)
 		if err != nil {

--- a/pkg/storage/fs/cephfs/connections.go
+++ b/pkg/storage/fs/cephfs/connections.go
@@ -116,7 +116,7 @@ type adminConn struct {
 }
 
 func newAdminConn(conf *Options) *adminConn {
-	rados, err := rados2.NewConnWithUser(conf.ClientId)
+	rados, err := rados2.NewConnWithUser(conf.ClientID)
 	if err != nil {
 		return nil
 	}
@@ -185,7 +185,7 @@ func newAdminConn(conf *Options) *adminConn {
 
 func newConn(user *User) *cacheVal {
 	var perm *cephfs2.UserPerm
-	mount, err := cephfs2.CreateMountWithId(user.fs.conf.ClientId)
+	mount, err := cephfs2.CreateMountWithId(user.fs.conf.ClientID)
 	if err != nil {
 		return destroyCephConn(mount, perm)
 	}

--- a/pkg/storage/fs/cephfs/connections.go
+++ b/pkg/storage/fs/cephfs/connections.go
@@ -116,11 +116,15 @@ type adminConn struct {
 }
 
 func newAdminConn(conf *Options) *adminConn {
-	rados, err := rados2.NewConn()
+	rados, err := rados2.NewConnWithUser(conf.ClientId)
 	if err != nil {
 		return nil
 	}
 	if err = rados.ReadConfigFile(conf.Config); err != nil {
+		return nil
+	}
+
+	if err = rados.SetConfigOption("keyring", conf.Keyring); err != nil {
 		return nil
 	}
 
@@ -181,7 +185,7 @@ func newAdminConn(conf *Options) *adminConn {
 
 func newConn(user *User) *cacheVal {
 	var perm *cephfs2.UserPerm
-	mount, err := cephfs2.CreateMount()
+	mount, err := cephfs2.CreateMountWithId(user.fs.conf.ClientId)
 	if err != nil {
 		return destroyCephConn(mount, perm)
 	}

--- a/pkg/storage/fs/cephfs/options.go
+++ b/pkg/storage/fs/cephfs/options.go
@@ -29,8 +29,10 @@ import (
 
 // Options for the cephfs module
 type Options struct {
+	Config       string `mapstructure:"config"`
 	GatewaySvc   string `mapstructure:"gatewaysvc"`
 	IndexPool    string `mapstructure:"index_pool"`
+	Keyring      string `mapstructure:"keyring"`
 	Root         string `mapstructure:"root"`
 	ShadowFolder string `mapstructure:"shadow_folder"`
 	ShareFolder  string `mapstructure:"share_folder"`
@@ -49,10 +51,22 @@ func (c *Options) fillDefaults() {
 		c.IndexPool = "path_index"
 	}
 
+	if c.Config == "" {
+		c.Config = "/etc/ceph/ceph.conf"
+	} else {
+		c.Config = addLeadingSlash(c.Config) //force absolute path in case leading "/" is omitted
+	}
+
+	if c.Keyring == "" {
+		c.Keyring = "/etc/ceph/keyring"
+	} else {
+		c.Keyring = addLeadingSlash(c.Keyring)
+	}
+
 	if c.Root == "" {
 		c.Root = "/home"
 	} else {
-		c.Root = addLeadingSlash(c.Root) //force absolute path in case leading "/" is omitted
+		c.Root = addLeadingSlash(c.Root)
 	}
 
 	if c.ShadowFolder == "" {

--- a/pkg/storage/fs/cephfs/options.go
+++ b/pkg/storage/fs/cephfs/options.go
@@ -29,8 +29,8 @@ import (
 
 // Options for the cephfs module
 type Options struct {
-	ClientId     string `mapstructure:"client_id"`
-	Config       string `mapstructure:"config"`
+	ClientID string `mapstructure:"client_id"`
+	Config   string `mapstructure:"config"`
 	GatewaySvc   string `mapstructure:"gatewaysvc"`
 	IndexPool    string `mapstructure:"index_pool"`
 	Keyring      string `mapstructure:"keyring"`
@@ -60,8 +60,8 @@ func (c *Options) fillDefaults() {
 		c.Config = addLeadingSlash(c.Config) //force absolute path in case leading "/" is omitted
 	}
 
-	if c.ClientId == "" {
-		c.ClientId = "admin"
+	if c.ClientID == "" {
+		c.ClientID = "admin"
 	}
 
 	if c.Keyring == "" {

--- a/pkg/storage/fs/cephfs/options.go
+++ b/pkg/storage/fs/cephfs/options.go
@@ -29,6 +29,7 @@ import (
 
 // Options for the cephfs module
 type Options struct {
+	ClientId     string `mapstructure:"client_id"`
 	Config       string `mapstructure:"config"`
 	GatewaySvc   string `mapstructure:"gatewaysvc"`
 	IndexPool    string `mapstructure:"index_pool"`
@@ -40,6 +41,8 @@ type Options struct {
 	UserLayout   string `mapstructure:"user_layout"`
 
 	DisableHome    bool   `mapstructure:"disable_home"`
+	DirPerms       uint32 `mapstructure:"dir_perms"`
+	FilePerms      uint32 `mapstructure:"file_perms"`
 	UserQuotaBytes uint64 `mapstructure:"user_quota_bytes"`
 	HiddenDirs     map[string]bool
 }
@@ -55,6 +58,10 @@ func (c *Options) fillDefaults() {
 		c.Config = "/etc/ceph/ceph.conf"
 	} else {
 		c.Config = addLeadingSlash(c.Config) //force absolute path in case leading "/" is omitted
+	}
+
+	if c.ClientId == "" {
+		c.ClientId = "admin"
 	}
 
 	if c.Keyring == "" {
@@ -96,7 +103,13 @@ func (c *Options) fillDefaults() {
 		removeLeadingSlash(c.ShadowFolder): true,
 	}
 
-	c.DisableHome = false // it is currently only home based
+	if c.DirPerms == 0 {
+		c.DirPerms = dirPermDefault
+	}
+
+	if c.FilePerms == 0 {
+		c.FilePerms = filePermDefault
+	}
 
 	if c.UserQuotaBytes == 0 {
 		c.UserQuotaBytes = 50000000000

--- a/pkg/storage/fs/cephfs/upload.go
+++ b/pkg/storage/fs/cephfs/upload.go
@@ -179,7 +179,7 @@ func (fs *cephfs) NewUpload(ctx context.Context, info tusd.FileInfo) (upload tus
 	user.op(func(cv *cacheVal) {
 		var f *cephfs2.File
 		defer closeFile(f)
-		f, err = cv.mount.Open(binPath, os.O_CREATE|os.O_WRONLY, filePermDefault)
+		f, err = cv.mount.Open(binPath, os.O_CREATE|os.O_WRONLY, fs.conf.FilePerms)
 		if err != nil {
 			return
 		}
@@ -332,7 +332,7 @@ func (upload *fileUpload) writeInfo() error {
 	user := upload.fs.makeUser(upload.ctx)
 	user.op(func(cv *cacheVal) {
 		var file io.WriteCloser
-		if file, err = cv.mount.Open(upload.infoPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, filePermDefault); err != nil {
+		if file, err = cv.mount.Open(upload.infoPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, upload.fs.conf.FilePerms); err != nil {
 			return
 		}
 		defer file.Close()

--- a/pkg/storage/fs/cephfs/user.go
+++ b/pkg/storage/fs/cephfs/user.go
@@ -53,7 +53,11 @@ type User struct {
 
 func (fs *cephfs) makeUser(ctx context.Context) *User {
 	u := ctx2.ContextMustGetUser(ctx)
-	home := filepath.Join(fs.conf.Root, templates.WithUser(u, fs.conf.UserLayout))
+	home := fs.conf.Root
+	if !fs.conf.DisableHome {
+		home = filepath.Join(fs.conf.Root, templates.WithUser(u, fs.conf.UserLayout))
+	}
+
 	return &User{u, fs, ctx, home}
 }
 

--- a/pkg/storage/fs/cephfs/utils.go
+++ b/pkg/storage/fs/cephfs/utils.go
@@ -29,7 +29,6 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
-	"strings"
 
 	cephfs2 "github.com/ceph/go-ceph/cephfs"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
@@ -75,8 +74,10 @@ func isDir(t provider.ResourceType) bool {
 	return t == provider.ResourceType_RESOURCE_TYPE_CONTAINER
 }
 
+// TODO: Use when fileids are available
+/*
 func (fs *cephfs) makeFIDPath(fid string) string {
-	return "" //filepath.Join(fs.conf.EIDFolder, fid)
+	return "" // filepath.Join(fs.conf.EIDFolder, fid) EIDFolder does not exist
 }
 
 func (fs *cephfs) makeFID(absolutePath string, inode string) (rid *provider.ResourceId, err error) {
@@ -99,6 +100,7 @@ func (fs *cephfs) getFIDPath(cv *cacheVal, path string) (fid string, err error) 
 
 	return fs.makeFIDPath(string(buffer)), err
 }
+ */
 
 func calcChecksum(filepath string, mt Mount, stat Statx) (checksum string, err error) {
 	file, err := mt.Open(filepath, os.O_RDONLY, 0)
@@ -195,6 +197,8 @@ func walkPath(path string, f func(string) error, reverse bool) (err error) {
 	return
 }
 
+// TODO: Use when fileids are available
+/*
 func (fs *cephfs) writeIndex(oid string, value string) (err error) {
 	return fs.adminConn.radosIO.WriteFull(oid, []byte(value))
 }
@@ -243,3 +247,4 @@ func (fs *cephfs) resolveIndex(oid string) (fullPath string, err error) {
 		currPath.Reset()
 	}
 }
+ */

--- a/pkg/storage/fs/cephfs/utils.go
+++ b/pkg/storage/fs/cephfs/utils.go
@@ -41,8 +41,8 @@ type Mount = *cephfs2.MountInfo
 type Statx = *cephfs2.CephStatx
 
 var dirPermFull = uint32(0777)
-var dirPermDefault = uint32(0775)
-var filePermDefault = uint32(0660)
+var dirPermDefault = uint32(0700)
+var filePermDefault = uint32(0640)
 
 func closeDir(directory *cephfs2.Directory) {
 	if directory != nil {


### PR DESCRIPTION
Support keyrings with IDs. We can't expose an admin keyring to a webserver, only keyrings that edit a specified subpath in CephFS.