### PR TITLE
invalidate cache when modifying or deleting a space

### DIFF
--- a/changelog/unreleased/invalidate-listproviders-cache.md
+++ b/changelog/unreleased/invalidate-listproviders-cache.md
@@ -1,0 +1,5 @@
+Enhancement: Invalidate listproviders cache
+
+We now invalidate the related listproviders cache entries when updating or deleting a storage space.
+
+https://github.com/cs3org/reva/pull/2500

--- a/internal/grpc/services/gateway/storageprovider.go
+++ b/internal/grpc/services/gateway/storageprovider.go
@@ -285,7 +285,10 @@ func (s *svc) UpdateStorageSpace(ctx context.Context, req *provider.UpdateStorag
 			Status: status.NewStatusFromErrType(ctx, "gateway could not call UpdateStorageSpace", err),
 		}, nil
 	}
-	s.cache.RemoveStat(ctxpkg.ContextMustGetUser(ctx), res.StorageSpace.Root)
+
+	id := res.StorageSpace.Root
+	s.cache.RemoveStat(ctxpkg.ContextMustGetUser(ctx), id)
+	s.cache.RemoveListStorageProviders(id)
 	return res, nil
 }
 
@@ -322,7 +325,9 @@ func (s *svc) DeleteStorageSpace(ctx context.Context, req *provider.DeleteStorag
 		}, nil
 	}
 
-	s.cache.RemoveStat(ctxpkg.ContextMustGetUser(ctx), &provider.ResourceId{OpaqueId: req.Id.OpaqueId})
+	id := &provider.ResourceId{OpaqueId: req.Id.OpaqueId}
+	s.cache.RemoveStat(ctxpkg.ContextMustGetUser(ctx), id)
+	s.cache.RemoveListStorageProviders(id)
 
 	if dsRes.Status.Code != rpc.Code_CODE_OK {
 		return dsRes, nil

--- a/internal/grpc/services/gateway/storageprovidercache.go
+++ b/internal/grpc/services/gateway/storageprovidercache.go
@@ -128,6 +128,22 @@ func (c Caches) RemoveStat(user *userpb.User, res *provider.ResourceId) {
 	}
 }
 
+// RemoveListStorageProviders removes a reference from the listproviders cache
+func (c Caches) RemoveListStorageProviders(res *provider.ResourceId) {
+	if res == nil {
+		return
+	}
+	sid := res.StorageId
+
+	cache := c[listproviders]
+	for _, key := range cache.GetKeys() {
+		if strings.Contains(key, sid) {
+			_ = cache.Remove(key)
+			continue
+		}
+	}
+}
+
 func initCache(ttlSeconds int) *ttlcache.Cache {
 	cache := ttlcache.NewCache()
 	_ = cache.SetTTL(time.Duration(ttlSeconds) * time.Second)


### PR DESCRIPTION
# Description

We now invalidate the related listproviders cache entries when updating or deleting a storage space.

## Related

fixes https://github.com/owncloud/ocis/issues/3104