### PR TITLE
fix spaces stat requests

### DIFF
--- a/changelog/unreleased/spaces-stat.md
+++ b/changelog/unreleased/spaces-stat.md
@@ -1,0 +1,6 @@
+Bugfix: Fix spaces stat
+
+When stating a space e.g. the Share Jail and that space contains another space, in this case a share
+then the stat would sometimes get the sub space instead of the Share Jail itself.
+
+https://github.com/cs3org/reva/pull/2501

--- a/internal/grpc/services/gateway/storageprovider.go
+++ b/internal/grpc/services/gateway/storageprovider.go
@@ -802,7 +802,7 @@ func (s *svc) Unlock(ctx context.Context, req *provider.UnlockRequest) (*provide
 // Stat returns the Resoure info for a given resource by forwarding the request to the responsible provider.
 // TODO cache info
 func (s *svc) Stat(ctx context.Context, req *provider.StatRequest) (*provider.StatResponse, error) {
-	c, _, ref, err := s.findAndUnwrap(ctx, req.Ref)
+	c, _, ref, err := s.findAndUnwrapUnique(ctx, req.Ref)
 	if err != nil {
 		return &provider.StatResponse{
 			Status: status.NewNotFound(ctx, fmt.Sprintf("gateway could not find space for ref=%+v", req.Ref)),
@@ -991,10 +991,41 @@ func (s *svc) find(ctx context.Context, ref *provider.Reference) (provider.Provi
 	return client, p[0], err
 }
 
+func (s *svc) findUnique(ctx context.Context, ref *provider.Reference) (provider.ProviderAPIClient, *registry.ProviderInfo, error) {
+	p, err := s.findSingleSpace(ctx, ref)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	client, err := s.getStorageProviderClient(ctx, p[0])
+	return client, p[0], err
+}
+
 // FIXME findAndUnwrap currently just returns the first provider ... which may not be what is needed.
 // for the ListRecycle call we need an exact match, for Stat and List we need to query all related providers
 func (s *svc) findAndUnwrap(ctx context.Context, ref *provider.Reference) (provider.ProviderAPIClient, *registry.ProviderInfo, *provider.Reference, error) {
 	c, p, err := s.find(ctx, ref)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	var (
+		root      *provider.ResourceId
+		mountPath string
+	)
+	for _, space := range decodeSpaces(p) {
+		mountPath = decodePath(space)
+		root = space.Root
+		break // TODO can there be more than one space for a path?
+	}
+
+	relativeReference := unwrap(ref, mountPath, root)
+
+	return c, p, relativeReference, nil
+}
+
+func (s *svc) findAndUnwrapUnique(ctx context.Context, ref *provider.Reference) (provider.ProviderAPIClient, *registry.ProviderInfo, *provider.Reference, error) {
+	c, p, err := s.findUnique(ctx, ref)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -1046,6 +1077,35 @@ func (s *svc) findSpaces(ctx context.Context, ref *provider.Reference) ([]*regis
 
 	filters := map[string]string{
 		"path": ref.Path,
+	}
+	if ref.ResourceId != nil {
+		filters["storage_id"] = ref.ResourceId.StorageId
+		filters["opaque_id"] = ref.ResourceId.OpaqueId
+	}
+
+	listReq := &registry.ListStorageProvidersRequest{
+		Opaque: &typesv1beta1.Opaque{},
+	}
+	sdk.EncodeOpaqueMap(listReq.Opaque, filters)
+
+	return s.findProvider(ctx, listReq)
+}
+
+func (s *svc) findSingleSpace(ctx context.Context, ref *provider.Reference) ([]*registry.ProviderInfo, error) {
+	switch {
+	case ref == nil:
+		return nil, errtypes.BadRequest("missing reference")
+	case ref.ResourceId != nil:
+		// no action needed in that case
+	case ref.Path != "": //  TODO implement a mount path cache in the registry?
+		// nothing to do here either
+	default:
+		return nil, errtypes.BadRequest("invalid reference, at least path or id must be set")
+	}
+
+	filters := map[string]string{
+		"path":   ref.Path,
+		"unique": "true",
 	}
 	if ref.ResourceId != nil {
 		filters["storage_id"] = ref.ResourceId.StorageId


### PR DESCRIPTION
When stating a space e.g. the Share Jail and that space contains another space, in this case a share
then the stat would sometimes get the sub space instead of the Share Jail itself.

The problem in detail:

Requested path: `/users/<userid>/Shares`

Returned spaces: `[/users/<userid>/Shares, /users/<userid>/Shares/FOLDER]`

Then in https://github.com/cs3org/reva/pull/2501/files#diff-0d2961654453acb28ab32bc57e437cd52492efd9c76e2db3b49864e6322081a6R1016 we take the first spaces from that list.

Sometimes the returned spaces are ordered the other way around: `[/users/<userid>/Shares/FOLDER, /users/<userid>/Shares]`.
In this case we use the wrong space provider and then the CI will fail.

Fixes the flaky CI problem.