### PR TITLE
Consolidate all metadata Get's and Set's to central functions.

### DIFF
--- a/changelog/unreleased/consolidate-xattr.md
+++ b/changelog/unreleased/consolidate-xattr.md
@@ -1,0 +1,7 @@
+Enhancement: Consolidate xattr setter and getter
+
+- Consolidate all metadata Get's and Set's to central functions.
+- Cleaner code by reduction of casts
+- Easier to hook functionality like indexing
+
+https://github.com/cs3org/reva/pull/2512

--- a/pkg/storage/utils/decomposedfs/decomposedfs.go
+++ b/pkg/storage/utils/decomposedfs/decomposedfs.go
@@ -222,7 +222,7 @@ func (fs *Decomposedfs) CreateHome(ctx context.Context) (err error) {
 
 	// update the owner
 	u := ctxpkg.ContextMustGetUser(ctx)
-	if err = h.WriteNodeMetadata(u.Id); err != nil {
+	if err = h.WriteAllNodeMetadata(u.Id); err != nil {
 		return
 	}
 

--- a/pkg/storage/utils/decomposedfs/decomposedfs.go
+++ b/pkg/storage/utils/decomposedfs/decomposedfs.go
@@ -430,11 +430,11 @@ func (fs *Decomposedfs) CreateReference(ctx context.Context, p string, targetURI
 	}
 	childCreated = true
 
-	if err := n.SetMetadata(xattrs.ReferenceAttr, targetURI.String()); err != nil {
+	if err := childNode.SetMetadata(xattrs.ReferenceAttr, targetURI.String()); err != nil {
 		// the reference could not be set - that would result in an lost reference?
 		err := errors.Wrapf(err, "Decomposedfs: error setting the target %s on the reference file %s",
 			targetURI.String(),
-			n.InternalPath(),
+			childNode.InternalPath(),
 		)
 		span.SetStatus(codes.Error, err.Error())
 		return err

--- a/pkg/storage/utils/decomposedfs/lookup.go
+++ b/pkg/storage/utils/decomposedfs/lookup.go
@@ -33,7 +33,6 @@ import (
 	"github.com/cs3org/reva/pkg/storage/utils/decomposedfs/options"
 	"github.com/cs3org/reva/pkg/storage/utils/decomposedfs/xattrs"
 	"github.com/cs3org/reva/pkg/storage/utils/templates"
-	"github.com/pkg/xattr"
 )
 
 // Lookup implements transformations from filepath to node and back
@@ -148,9 +147,9 @@ func (lu *Lookup) WalkPath(ctx context.Context, r *node.Node, p string, followRe
 		}
 
 		if followReferences {
-			if attrBytes, err := xattr.Get(r.InternalPath(), xattrs.ReferenceAttr); err == nil {
+			if attrBytes, err := r.GetMetadata(xattrs.ReferenceAttr); err == nil {
 				realNodeID := attrBytes
-				ref, err := xattrs.ReferenceFromAttr(realNodeID)
+				ref, err := xattrs.ReferenceFromAttr([]byte(realNodeID))
 				if err != nil {
 					return nil, err
 				}

--- a/pkg/storage/utils/decomposedfs/node/node.go
+++ b/pkg/storage/utils/decomposedfs/node/node.go
@@ -148,7 +148,7 @@ func (n *Node) WriteAllNodeMetadata(owner *userpb.UserId) (err error) {
 	attribs[xattrs.ParentidAttr] = n.ParentID
 	attribs[xattrs.NameAttr] = n.Name
 	attribs[xattrs.BlobIDAttr] = n.BlobID
-	attribs[xattrs.BlobsizeAttr] = fmt.Sprintf("%d", n.Blobsize)
+	attribs[xattrs.BlobsizeAttr] = strconv.FormatInt(n.Blobsize, 10)
 
 	nodePath := n.InternalPath()
 	attribs[xattrs.OwnerIDAttr] = ""

--- a/pkg/storage/utils/decomposedfs/node/node.go
+++ b/pkg/storage/utils/decomposedfs/node/node.go
@@ -525,7 +525,7 @@ func (n *Node) AsResourceInfo(ctx context.Context, rp *provider.ResourcePermissi
 		Type:          nodeType,
 		MimeType:      mime.Detect(nodeType == provider.ResourceType_RESOURCE_TYPE_CONTAINER, fn),
 		Size:          uint64(n.Blobsize),
-		Target:        string(target),
+		Target:        target,
 		PermissionSet: rp,
 	}
 

--- a/pkg/storage/utils/decomposedfs/node/node.go
+++ b/pkg/storage/utils/decomposedfs/node/node.go
@@ -286,8 +286,8 @@ func (n *Node) Parent() (p *Node, err error) {
 	}
 	// lookup name in extended attributes
 	if p.Name, err = xattrs.Get(parentPath, xattrs.NameAttr); err != nil {
-		p.Name = string("")
-		p.ParentID = string("")
+		p.Name = ""
+		p.ParentID = ""
 		return
 	}
 

--- a/pkg/storage/utils/decomposedfs/node/node.go
+++ b/pkg/storage/utils/decomposedfs/node/node.go
@@ -281,7 +281,7 @@ func (n *Node) Parent() (p *Node, err error) {
 
 	// lookup parent id in extended attributes
 	if p.ParentID, err = xattrs.Get(parentPath, xattrs.ParentidAttr); err != nil {
-		p.ParentID = string("")
+		p.ParentID = ""
 		return
 	}
 	// lookup name in extended attributes

--- a/pkg/storage/utils/decomposedfs/node/node.go
+++ b/pkg/storage/utils/decomposedfs/node/node.go
@@ -115,7 +115,7 @@ func (n *Node) ChangeOwner(new *userpb.UserId) (err error) {
 		xattrs.OwnerIDPAttr:  new.Idp,
 		xattrs.OwnerTypeAttr: utils.UserTypeToString(new.Type)}
 
-	if err := xattrs.SetMutltiple(nodePath, attribs); err != nil {
+	if err := xattrs.SetMultiple(nodePath, attribs); err != nil {
 		return err
 	}
 
@@ -132,6 +132,7 @@ func (n *Node) SetMetadata(key string, val string) (err error) {
 	return nil
 }
 
+// GetMetadata reads the metadata for the given key
 func (n *Node) GetMetadata(key string) (val string, err error) {
 	nodePath := n.InternalPath()
 	if val, err := xattrs.Get(nodePath, key); err != nil {
@@ -159,7 +160,7 @@ func (n *Node) WriteMetadata(owner *userpb.UserId) (err error) {
 		attribs[xattrs.OwnerIDPAttr] = owner.Idp
 		attribs[xattrs.OwnerTypeAttr] = utils.UserTypeToString(owner.Type)
 	}
-	if err := xattrs.SetMutltiple(nodePath, attribs); err != nil {
+	if err := xattrs.SetMultiple(nodePath, attribs); err != nil {
 		return err
 	}
 	return

--- a/pkg/storage/utils/decomposedfs/node/node.go
+++ b/pkg/storage/utils/decomposedfs/node/node.go
@@ -330,7 +330,7 @@ func (n *Node) Owner() (*userpb.UserId, error) {
 	attr, err = xattrs.Get(nodePath, xattrs.OwnerIDPAttr)
 	switch {
 	case err == nil:
-		owner.Idp = string(attr)
+		owner.Idp = attr
 	case isAttrUnset(err), isNotFound(err):
 		fallthrough
 	default:
@@ -589,7 +589,7 @@ func (n *Node) AsResourceInfo(ctx context.Context, rp *provider.ResourcePermissi
 					sublog.Debug().
 						Str("favorite", fa).
 						Msg("found favorite flag")
-					favorite = string(val)
+					favorite = val
 				}
 			} else {
 				sublog.Error().Err(errtypes.UserRequired("userrequired")).Msg("user has no id")
@@ -937,7 +937,7 @@ func ReadBlobSizeAttr(path string) (int64, error) {
 	if err != nil {
 		return 0, errors.Wrapf(err, "error reading blobsize xattr")
 	}
-	blobSize, err := strconv.ParseInt(string(attr), 10, 64)
+	blobSize, err := strconv.ParseInt(attr, 10, 64)
 	if err != nil {
 		return 0, errors.Wrapf(err, "invalid blobsize xattr format")
 	}

--- a/pkg/storage/utils/decomposedfs/node/node.go
+++ b/pkg/storage/utils/decomposedfs/node/node.go
@@ -652,7 +652,7 @@ func (n *Node) AsResourceInfo(ctx context.Context, rp *provider.ResourcePermissi
 			k := attrs[i][len(xattrs.MetadataPrefix):]
 			if _, ok := mdKeysMap[k]; returnAllKeys || ok {
 				if val, err := xattrs.Get(nodePath, attrs[i]); err == nil {
-					metadata[k] = string(val)
+					metadata[k] = val
 				} else {
 					sublog.Error().Err(err).
 						Str("entry", attrs[i]).
@@ -747,7 +747,7 @@ func readQuotaIntoOpaque(ctx context.Context, nodePath string, ri *provider.Reso
 // HasPropagation checks if the propagation attribute exists and is set to "1"
 func (n *Node) HasPropagation() (propagation bool) {
 	if b, err := xattrs.Get(n.lu.InternalPath(n.ID), xattrs.PropagationAttr); err == nil {
-		return string(b) == "1"
+		return b == "1"
 	}
 	return false
 }
@@ -772,7 +772,7 @@ func (n *Node) GetTreeSize() (treesize uint64, err error) {
 	if b, err = xattrs.Get(n.InternalPath(), xattrs.TreesizeAttr); err != nil {
 		return
 	}
-	return strconv.ParseUint(string(b), 10, 64)
+	return strconv.ParseUint(b, 10, 64)
 }
 
 // SetTreeSize writes the treesize to the extended attributes

--- a/pkg/storage/utils/decomposedfs/node/node.go
+++ b/pkg/storage/utils/decomposedfs/node/node.go
@@ -319,7 +319,7 @@ func (n *Node) Owner() (*userpb.UserId, error) {
 	attr, err = xattrs.Get(nodePath, xattrs.OwnerIDAttr)
 	switch {
 	case err == nil:
-		owner.OpaqueId = string(attr)
+		owner.OpaqueId = attr
 	case isAttrUnset(err), isNotFound(err):
 		fallthrough
 	default:
@@ -722,7 +722,7 @@ func readQuotaIntoOpaque(ctx context.Context, nodePath string, ri *provider.Reso
 		// -1 = uncalculated
 		// -2 = unknown
 		// -3 = unlimited
-		if _, err := strconv.ParseInt(string(v), 10, 64); err == nil {
+		if _, err := strconv.ParseInt(v, 10, 64); err == nil {
 			if ri.Opaque == nil {
 				ri.Opaque = &types.Opaque{
 					Map: map[string]*types.OpaqueEntry{},
@@ -733,7 +733,7 @@ func readQuotaIntoOpaque(ctx context.Context, nodePath string, ri *provider.Reso
 				Value:   []byte(v),
 			}
 		} else {
-			appctx.GetLogger(ctx).Error().Err(err).Str("nodepath", nodePath).Str("quota", string(v)).Msg("malformed quota")
+			appctx.GetLogger(ctx).Error().Err(err).Str("nodepath", nodePath).Str("quota", v).Msg("malformed quota")
 		}
 	case isAttrUnset(err):
 		appctx.GetLogger(ctx).Debug().Err(err).Str("nodepath", nodePath).Msg("quota not set")

--- a/pkg/storage/utils/decomposedfs/node/node.go
+++ b/pkg/storage/utils/decomposedfs/node/node.go
@@ -201,7 +201,7 @@ func ReadNode(ctx context.Context, lu PathLookup, id string) (n *Node, err error
 	}
 	// lookup blobID in extended attributes
 	if attr, err = xattrs.Get(nodePath, xattrs.BlobIDAttr); err == nil {
-		n.BlobID = string(attr)
+		n.BlobID = attr
 	} else {
 		return
 	}
@@ -341,7 +341,7 @@ func (n *Node) Owner() (*userpb.UserId, error) {
 	attr, err = xattrs.Get(nodePath, xattrs.OwnerTypeAttr)
 	switch {
 	case err == nil:
-		owner.Type = utils.UserTypeMap(string(attr))
+		owner.Type = utils.UserTypeMap(attr)
 	case isAttrUnset(err), isNotFound(err):
 		fallthrough
 	default:
@@ -553,7 +553,7 @@ func (n *Node) AsResourceInfo(ctx context.Context, rp *provider.ResourcePermissi
 
 	// use temporary etag if it is set
 	if b, err := xattrs.Get(nodePath, xattrs.TmpEtagAttr); err == nil {
-		ri.Etag = fmt.Sprintf(`"%x"`, string(b)) // TODO why do we convert string(b)? is the temporary etag stored as string? -> should we use bytes? use hex.EncodeToString?
+		ri.Etag = fmt.Sprintf(`"%x"`, b) // TODO why do we convert string(b)? is the temporary etag stored as string? -> should we use bytes? use hex.EncodeToString?
 	} else if ri.Etag, err = calculateEtag(n.ID, tmTime); err != nil {
 		sublog.Debug().Err(err).Msg("could not calculate etag")
 	}
@@ -1012,7 +1012,7 @@ var CheckQuota = func(spaceRoot *Node, fileSize uint64) (quotaSufficient bool, e
 		// if quota is not set, it means unlimited
 		return true, nil
 	}
-	total, _ = strconv.ParseUint(string(quotaByte), 10, 64)
+	total, _ = strconv.ParseUint(quotaByte, 10, 64)
 	// if total is smaller than used, total-used could overflow and be bigger than fileSize
 	if fileSize > total-used || total < used {
 		return false, errtypes.InsufficientStorage("quota exceeded")

--- a/pkg/storage/utils/decomposedfs/node/node_test.go
+++ b/pkg/storage/utils/decomposedfs/node/node_test.go
@@ -97,7 +97,7 @@ var _ = Describe("Node", func() {
 				Type:     userpb.UserType_USER_TYPE_PRIMARY,
 			}
 
-			err = n.WriteMetadata(owner)
+			err = n.WriteAllNodeMetadata(owner)
 			Expect(err).ToNot(HaveOccurred())
 			n2, err := env.Lookup.NodeFromResource(env.Ctx, ref)
 			Expect(err).ToNot(HaveOccurred())

--- a/pkg/storage/utils/decomposedfs/spaces.go
+++ b/pkg/storage/utils/decomposedfs/spaces.go
@@ -542,6 +542,7 @@ func (fs *Decomposedfs) storageSpaceFromNode(ctx context.Context, n *node.Node, 
 	var sname string
 	if sname, err = n.GetMetadata(xattrs.SpaceNameAttr); err != nil {
 		// FIXME: Is that a severe problem?
+		appctx.GetLogger(ctx).Debug().Err(err).Msg("space does not have a name attribute")
 	}
 
 	if err := n.FindStorageSpaceRoot(); err != nil {

--- a/pkg/storage/utils/decomposedfs/testhelpers/helpers.go
+++ b/pkg/storage/utils/decomposedfs/testhelpers/helpers.go
@@ -151,7 +151,7 @@ func (t *TestEnv) CreateTestFile(name, blobID string, blobSize int64, parentID s
 	if err != nil {
 		return nil, err
 	}
-	err = file.WriteMetadata(t.Owner.Id)
+	err = file.WriteAllNodeMetadata(t.Owner.Id)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/storage/utils/decomposedfs/tree/tree.go
+++ b/pkg/storage/utils/decomposedfs/tree/tree.go
@@ -118,9 +118,9 @@ func (t *Tree) Setup(owner *userpb.UserId, propagateToRoot bool) error {
 	}
 
 	// set propagation flag
-	v := []byte("0")
+	v := "0"
 	if propagateToRoot {
-		v = []byte("1")
+		v = "1"
 	}
 	if err = n.SetMetadata(xattrs.PropagationAttr, v); err != nil {
 		return err
@@ -779,7 +779,7 @@ func (t *Tree) createNode(n *node.Node, owner *userpb.UserId) (err error) {
 		return errors.Wrap(err, "Decomposedfs: error creating node")
 	}
 
-	return n.WriteMetadata(owner)
+	return n.WriteAllNodeMetadata(owner)
 }
 
 // TODO refactor the returned params into Node properties? would make all the path transformations go away...

--- a/pkg/storage/utils/decomposedfs/tree/tree.go
+++ b/pkg/storage/utils/decomposedfs/tree/tree.go
@@ -122,7 +122,7 @@ func (t *Tree) Setup(owner *userpb.UserId, propagateToRoot bool) error {
 	if propagateToRoot {
 		v = []byte("1")
 	}
-	if err = xattr.Set(n.InternalPath(), xattrs.PropagationAttr, v); err != nil {
+	if err = n.SetMetadata(xattrs.PropagationAttr, v); err != nil {
 		return err
 	}
 
@@ -206,8 +206,8 @@ func (t *Tree) linkSpace(spaceType, spaceID, nodeID string) {
 }
 
 func isRootNode(nodePath string) bool {
-	attrBytes, err := xattr.Get(nodePath, xattrs.ParentidAttr)
-	return err == nil && string(attrBytes) == "root"
+	attr, err := xattrs.Get(nodePath, xattrs.ParentidAttr)
+	return err == nil && string(attr) == "root"
 }
 func isSharedNode(nodePath string) bool {
 	if attrs, err := xattr.List(nodePath); err == nil {
@@ -310,7 +310,7 @@ func (t *Tree) Move(ctx context.Context, oldNode *node.Node, newNode *node.Node)
 		}
 
 		// update name attribute
-		if err := xattr.Set(tgtPath, xattrs.NameAttr, []byte(newNode.Name)); err != nil {
+		if err := xattrs.Set(tgtPath, xattrs.NameAttr, newNode.Name); err != nil {
 			return errors.Wrap(err, "Decomposedfs: could not set name attribute")
 		}
 
@@ -330,10 +330,10 @@ func (t *Tree) Move(ctx context.Context, oldNode *node.Node, newNode *node.Node)
 	}
 
 	// update target parentid and name
-	if err := xattr.Set(tgtPath, xattrs.ParentidAttr, []byte(newNode.ParentID)); err != nil {
+	if err := xattrs.Set(tgtPath, xattrs.ParentidAttr, newNode.ParentID); err != nil {
 		return errors.Wrap(err, "Decomposedfs: could not set parentid attribute")
 	}
-	if err := xattr.Set(tgtPath, xattrs.NameAttr, []byte(newNode.Name)); err != nil {
+	if err := xattrs.Set(tgtPath, xattrs.NameAttr, newNode.Name); err != nil {
 		return errors.Wrap(err, "Decomposedfs: could not set name attribute")
 	}
 
@@ -411,7 +411,7 @@ func (t *Tree) Delete(ctx context.Context, n *node.Node) (err error) {
 
 	// set origin location in metadata
 	nodePath := n.InternalPath()
-	if err := xattr.Set(nodePath, xattrs.TrashOriginAttr, []byte(origin)); err != nil {
+	if err := n.SetMetadata(xattrs.TrashOriginAttr, origin); err != nil {
 		return err
 	}
 
@@ -523,13 +523,13 @@ func (t *Tree) RestoreRecycleItemFunc(ctx context.Context, spaceid, key, trashPa
 
 		targetNode.Exists = true
 		// update name attribute
-		if err := xattr.Set(nodePath, xattrs.NameAttr, []byte(targetNode.Name)); err != nil {
+		if err := recycleNode.SetMetadata(xattrs.NameAttr, targetNode.Name); err != nil {
 			return errors.Wrap(err, "Decomposedfs: could not set name attribute")
 		}
 
 		// set ParentidAttr to restorePath's node parent id
 		if trashPath != "" {
-			if err := xattr.Set(nodePath, xattrs.ParentidAttr, []byte(targetNode.ParentID)); err != nil {
+			if err := recycleNode.SetMetadata(xattrs.ParentidAttr, targetNode.ParentID); err != nil {
 				return errors.Wrap(err, "Decomposedfs: could not set name attribute")
 			}
 		}
@@ -734,13 +734,13 @@ func calculateTreeSize(ctx context.Context, nodePath string) (uint64, error) {
 			size += uint64(blobSize)
 		} else {
 			// read from attr
-			var b []byte
-			// xattr.Get will follow the symlink
-			if b, err = xattr.Get(cPath, xattrs.TreesizeAttr); err != nil {
+			var b string
+			// xattrs.Get will follow the symlink
+			if b, err = xattrs.Get(cPath, xattrs.TreesizeAttr); err != nil {
 				// TODO recursively descend and recalculate treesize
 				continue // continue after an error
 			}
-			csize, err := strconv.ParseUint(string(b), 10, 64)
+			csize, err := strconv.ParseUint(b, 10, 64)
 			if err != nil {
 				// TODO recursively descend and recalculate treesize
 				continue // continue after an error
@@ -797,48 +797,48 @@ func (t *Tree) readRecycleItem(ctx context.Context, spaceid, key, path string) (
 		return
 	}
 
-	var attrBytes []byte
+	var attrStr string
 	trashNodeID := filepath.Base(link)
 	deletedNodePath = t.lookup.InternalPath(trashNodeID)
 
 	owner := &userpb.UserId{}
 	// lookup ownerId in extended attributes
-	if attrBytes, err = xattr.Get(deletedNodePath, xattrs.OwnerIDAttr); err == nil {
-		owner.OpaqueId = string(attrBytes)
+	if attrStr, err = xattrs.Get(deletedNodePath, xattrs.OwnerIDAttr); err == nil {
+		owner.OpaqueId = attrStr
 	} else {
 		return
 	}
 	// lookup ownerIdp in extended attributes
-	if attrBytes, err = xattr.Get(deletedNodePath, xattrs.OwnerIDPAttr); err == nil {
-		owner.Idp = string(attrBytes)
+	if attrStr, err = xattrs.Get(deletedNodePath, xattrs.OwnerIDPAttr); err == nil {
+		owner.Idp = attrStr
 	} else {
 		return
 	}
 	// lookup ownerType in extended attributes
-	if attrBytes, err = xattr.Get(deletedNodePath, xattrs.OwnerTypeAttr); err == nil {
-		owner.Type = utils.UserTypeMap(string(attrBytes))
+	if attrStr, err = xattrs.Get(deletedNodePath, xattrs.OwnerTypeAttr); err == nil {
+		owner.Type = utils.UserTypeMap(string(attrStr))
 	} else {
 		return
 	}
 
 	recycleNode = node.New(trashNodeID, "", "", 0, "", owner, t.lookup)
 	// lookup blobID in extended attributes
-	if attrBytes, err = xattr.Get(deletedNodePath, xattrs.BlobIDAttr); err == nil {
-		recycleNode.BlobID = string(attrBytes)
+	if attrStr, err = xattrs.Get(deletedNodePath, xattrs.BlobIDAttr); err == nil {
+		recycleNode.BlobID = attrStr
 	} else {
 		return
 	}
 
 	// lookup parent id in extended attributes
-	if attrBytes, err = xattr.Get(deletedNodePath, xattrs.ParentidAttr); err == nil {
-		recycleNode.ParentID = string(attrBytes)
+	if attrStr, err = xattrs.Get(deletedNodePath, xattrs.ParentidAttr); err == nil {
+		recycleNode.ParentID = attrStr
 	} else {
 		return
 	}
 
 	// lookup name in extended attributes
-	if attrBytes, err = xattr.Get(deletedNodePath, xattrs.NameAttr); err == nil {
-		recycleNode.Name = string(attrBytes)
+	if attrStr, err = xattrs.Get(deletedNodePath, xattrs.NameAttr); err == nil {
+		recycleNode.Name = attrStr
 	} else {
 		return
 	}
@@ -871,8 +871,8 @@ func (t *Tree) readRecycleItem(ctx context.Context, spaceid, key, path string) (
 		deletedNodeRootPath = t.lookup.InternalPath(filepath.Base(rootLink))
 	}
 	// lookup origin path in extended attributes
-	if attrBytes, err = xattr.Get(deletedNodeRootPath, xattrs.TrashOriginAttr); err == nil {
-		origin = filepath.Join(string(attrBytes), path)
+	if attrStr, err = xattrs.Get(deletedNodeRootPath, xattrs.TrashOriginAttr); err == nil {
+		origin = filepath.Join(string(attrStr), path)
 	} else {
 		log.Error().Err(err).Str("trashItem", trashItem).Str("link", link).Str("deletedNodePath", deletedNodePath).Msg("could not read origin path, restoring to /")
 	}

--- a/pkg/storage/utils/decomposedfs/tree/tree.go
+++ b/pkg/storage/utils/decomposedfs/tree/tree.go
@@ -207,7 +207,7 @@ func (t *Tree) linkSpace(spaceType, spaceID, nodeID string) {
 
 func isRootNode(nodePath string) bool {
 	attr, err := xattrs.Get(nodePath, xattrs.ParentidAttr)
-	return err == nil && string(attr) == "root"
+	return err == nil && attr == "root"
 }
 func isSharedNode(nodePath string) bool {
 	if attrs, err := xattr.List(nodePath); err == nil {
@@ -816,7 +816,7 @@ func (t *Tree) readRecycleItem(ctx context.Context, spaceid, key, path string) (
 	}
 	// lookup ownerType in extended attributes
 	if attrStr, err = xattrs.Get(deletedNodePath, xattrs.OwnerTypeAttr); err == nil {
-		owner.Type = utils.UserTypeMap(string(attrStr))
+		owner.Type = utils.UserTypeMap(attrStr)
 	} else {
 		return
 	}
@@ -872,7 +872,7 @@ func (t *Tree) readRecycleItem(ctx context.Context, spaceid, key, path string) (
 	}
 	// lookup origin path in extended attributes
 	if attrStr, err = xattrs.Get(deletedNodeRootPath, xattrs.TrashOriginAttr); err == nil {
-		origin = filepath.Join(string(attrStr), path)
+		origin = filepath.Join(attrStr, path)
 	} else {
 		log.Error().Err(err).Str("trashItem", trashItem).Str("link", link).Str("deletedNodePath", deletedNodePath).Msg("could not read origin path, restoring to /")
 	}

--- a/pkg/storage/utils/decomposedfs/upload.go
+++ b/pkg/storage/utils/decomposedfs/upload.go
@@ -602,7 +602,7 @@ func (upload *fileUpload) FinishUpload(ctx context.Context) (err error) {
 	tryWritingChecksum(&sublog, n, "adler32", adler32h)
 
 	// who will become the owner?  the owner of the parent actually ... not the currently logged in user
-	err = n.WriteMetadata(&userpb.UserId{
+	err = n.WriteAllNodeMetadata(&userpb.UserId{
 		Idp:      upload.info.Storage["OwnerIdp"],
 		OpaqueId: upload.info.Storage["OwnerId"],
 	})

--- a/pkg/storage/utils/decomposedfs/xattrs/xattrs.go
+++ b/pkg/storage/utils/decomposedfs/xattrs/xattrs.go
@@ -169,7 +169,7 @@ func All(filePath string) (map[string]string, error) {
 		return nil, errors.Wrap(err, "xattrs: Can not list extended attributes")
 	}
 
-       attribs := make(map[string]string, len(attrNames))
+	attribs := make(map[string]string, len(attrNames))
 	for _, name := range attrNames {
 		val, err := xattr.Get(filePath, name)
 		if err != nil {

--- a/pkg/storage/utils/decomposedfs/xattrs/xattrs.go
+++ b/pkg/storage/utils/decomposedfs/xattrs/xattrs.go
@@ -156,7 +156,7 @@ func Get(filePath, key string) (string, error) {
 
 	v, err := xattr.Get(filePath, key)
 	if err != nil {
-		return "", errors.Wrap(err, "xattrs: Can not read value")
+		return "", errors.Wrap(err, "xattrs: Can not read xattr")
 	}
 	val := string(v)
 	return val, nil

--- a/pkg/storage/utils/decomposedfs/xattrs/xattrs.go
+++ b/pkg/storage/utils/decomposedfs/xattrs/xattrs.go
@@ -164,15 +164,13 @@ func Get(filePath, key string) (string, error) {
 
 // All reads all extended attributes for a node
 func All(filePath string) (map[string]string, error) {
-	var attribs = make(map[string]string)
-	var attrNames []string
-	var err error
-	if attrNames, err = xattr.List(filePath); err != nil {
-		return attribs, errors.Wrap(err, "xattrs: Can not list extended attributes")
+	attrNames, err := xattr.List(filePath)
+	if err != nil {
+		return nil, errors.Wrap(err, "xattrs: Can not list extended attributes")
 	}
 
-	for i := range attrNames {
-		name := attrNames[i]
+       attribs := make(map[string]string, len(attrNames))
+	for _, name := range attrNames {
 		val, err := xattr.Get(filePath, name)
 		if err != nil {
 			return nil, errors.Wrap(err, "Failed to read extended attrib")

--- a/pkg/storage/utils/decomposedfs/xattrs/xattrs.go
+++ b/pkg/storage/utils/decomposedfs/xattrs/xattrs.go
@@ -129,7 +129,7 @@ func CopyMetadata(s, t string, filter func(attributeName string) bool) error {
 	return nil
 }
 
-// The primitive function to set the extended attribute
+// Set an extended attribute key to the given value
 func Set(filePath string, key string, val string) error {
 
 	if err := xattr.Set(filePath, key, []byte(val)); err != nil {
@@ -138,7 +138,9 @@ func Set(filePath string, key string, val string) error {
 	return nil
 }
 
-func SetMutltiple(filePath string, attribs map[string]string) error {
+// SetMultiple allows setting multiple key value pairs at once
+// TODO the changes are protected with an flock
+func SetMultiple(filePath string, attribs map[string]string) error {
 
 	// FIXME: Lock here
 	for key, val := range attribs {
@@ -149,7 +151,7 @@ func SetMutltiple(filePath string, attribs map[string]string) error {
 	return nil
 }
 
-// Primitive function to get a value of extended attribs
+// Get an extended attribute value for the given key
 func Get(filePath, key string) (string, error) {
 
 	v, err := xattr.Get(filePath, key)
@@ -160,7 +162,7 @@ func Get(filePath, key string) (string, error) {
 	return val, nil
 }
 
-// Primitive function to get all extended attributes back
+// All reads all extended attributes for a node
 func All(filePath string) (map[string]string, error) {
 	var attribs = make(map[string]string)
 	var attrNames []string


### PR DESCRIPTION
In the decomposed FS, access to xattr was spread all over. This
patch consolidates that to use either the Node.SetMetadata() or
xattrs.Set(). This allows us to hook in indexing for example.

This does not yet handle Remove, List and others. Subject of another patch.