### PR TITLE
Remove space members

### DIFF
--- a/changelog/unreleased/remove-space-members.md
+++ b/changelog/unreleased/remove-space-members.md
@@ -1,0 +1,10 @@
+Enhancement: Fix behavior for foobar (in present tense)
+
+We've fixed the behavior for foobar, a long-standing annoyance for Reva
+users.
+
+The text in the paragraphs is written in past tense. The last section is a list
+of issue URLs, PR URLs and other URLs. The first issue ID (or the first PR ID,
+in case there aren't any issue links) is used as the primary ID.
+
+https://github.com/cs3org/reva/pull/2524

--- a/changelog/unreleased/remove-space-members.md
+++ b/changelog/unreleased/remove-space-members.md
@@ -1,10 +1,8 @@
-Enhancement: Fix behavior for foobar (in present tense)
+Enhancement: add checks when removing space members
 
-We've fixed the behavior for foobar, a long-standing annoyance for Reva
-users.
-
-The text in the paragraphs is written in past tense. The last section is a list
-of issue URLs, PR URLs and other URLs. The first issue ID (or the first PR ID,
-in case there aren't any issue links) is used as the primary ID.
+- Removed owners from project spaces
+- Prevent deletion of last space manager
+- Viewers and editors can always be deleted
+- Managers can only be deleted when there will be at least one remaining
 
 https://github.com/cs3org/reva/pull/2524

--- a/internal/http/services/owncloud/ocs/conversions/role.go
+++ b/internal/http/services/owncloud/ocs/conversions/role.go
@@ -40,8 +40,6 @@ const (
 	RoleEditor = "editor"
 	// RoleFileEditor grants editor permission on a single file.
 	RoleFileEditor = "file-editor"
-	// RoleCoowner grants co-owner permissions on a resource.
-	RoleCoowner = "coowner"
 	// RoleUploader grants uploader permission to upload onto a resource.
 	RoleUploader = "uploader"
 	// RoleManager grants manager permissions on a resource. Semantically equivalent to co-owner.
@@ -127,8 +125,6 @@ func RoleFromName(name string) *Role {
 		return NewEditorRole()
 	case RoleFileEditor:
 		return NewFileEditorRole()
-	case RoleCoowner:
-		return NewCoownerRole()
 	case RoleUploader:
 		return NewUploaderRole()
 	case RoleManager:
@@ -211,34 +207,6 @@ func NewFileEditorRole() *Role {
 	}
 }
 
-// NewCoownerRole creates a coowner role
-func NewCoownerRole() *Role {
-	return &Role{
-		Name: RoleCoowner,
-		cS3ResourcePermissions: &provider.ResourcePermissions{
-			GetPath:              true,
-			GetQuota:             true,
-			InitiateFileDownload: true,
-			ListGrants:           true,
-			ListContainer:        true,
-			ListFileVersions:     true,
-			ListRecycle:          true,
-			Stat:                 true,
-			InitiateFileUpload:   true,
-			RestoreFileVersion:   true,
-			RestoreRecycleItem:   true,
-			CreateContainer:      true,
-			Delete:               true,
-			Move:                 true,
-			PurgeRecycle:         true,
-			AddGrant:             true,
-			UpdateGrant:          true,
-			RemoveGrant:          true,
-		},
-		ocsPermissions: PermissionAll,
-	}
-}
-
 // NewUploaderRole creates an uploader role
 func NewUploaderRole() *Role {
 	return &Role{
@@ -254,7 +222,7 @@ func NewUploaderRole() *Role {
 	}
 }
 
-// NewManagerRole creates an editor role
+// NewManagerRole creates an manager role
 func NewManagerRole() *Role {
 	return &Role{
 		Name: RoleManager,
@@ -394,9 +362,9 @@ func RoleFromResourcePermissions(rp *provider.ResourcePermissions) *Role {
 		if r.ocsPermissions.Contain(PermissionWrite) && r.ocsPermissions.Contain(PermissionCreate) && r.ocsPermissions.Contain(PermissionDelete) {
 			r.Name = RoleEditor
 			if r.ocsPermissions.Contain(PermissionShare) {
-				r.Name = RoleCoowner
+				r.Name = RoleManager
 			}
-			return r // editor or coowner
+			return r // editor or manager
 		}
 		if r.ocsPermissions == PermissionRead {
 			r.Name = RoleViewer

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/shares.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/shares.go
@@ -247,8 +247,8 @@ func (h *Handler) CreateShare(w http.ResponseWriter, r *http.Request) {
 
 	switch shareType {
 	case int(conversions.ShareTypeUser), int(conversions.ShareTypeGroup):
-		// user collaborations default to coowner
-		role, val, ocsErr := h.extractPermissions(w, r, statRes.Info, conversions.NewCoownerRole())
+		// user collaborations default to Manager (=all permissions)
+		role, val, ocsErr := h.extractPermissions(w, r, statRes.Info, conversions.NewManagerRole())
 		if ocsErr != nil {
 			response.WriteOCSError(w, r, ocsErr.Code, ocsErr.Message, ocsErr.Error)
 			return

--- a/pkg/storage/registry/spaces/spaces.go
+++ b/pkg/storage/registry/spaces/spaces.go
@@ -194,7 +194,8 @@ func (r *registry) GetProvider(ctx context.Context, space *providerpb.StorageSpa
 				continue
 			}
 			if space.Owner != nil {
-				spacePath, err = sc.SpacePath(nil, space)
+				user := ctxpkg.ContextMustGetUser(ctx)
+				spacePath, err = sc.SpacePath(user, space)
 				if err != nil {
 					continue
 				}

--- a/pkg/storage/utils/decomposedfs/decomposedfs.go
+++ b/pkg/storage/utils/decomposedfs/decomposedfs.go
@@ -250,7 +250,7 @@ func (fs *Decomposedfs) CreateHome(ctx context.Context) (err error) {
 	}
 
 	// add storage space
-	if err := fs.createStorageSpace(ctx, "personal", h.ID); err != nil {
+	if err := fs.createStorageSpace(ctx, spaceTypePersonal, h.ID); err != nil {
 		return err
 	}
 

--- a/pkg/storage/utils/decomposedfs/grants.go
+++ b/pkg/storage/utils/decomposedfs/grants.go
@@ -91,7 +91,7 @@ func (fs *Decomposedfs) AddGrant(ctx context.Context, ref *provider.Reference, g
 
 	// when a grant is added to a space, do not add a new space under "shares"
 	if spaceGrant := ctx.Value(utils.SpaceGrant); spaceGrant == nil {
-		err := fs.createStorageSpace(ctx, "share", node.ID)
+		err := fs.createStorageSpace(ctx, spaceTypeShare, node.ID)
 		if err != nil {
 			return err
 		}

--- a/pkg/storage/utils/decomposedfs/lookup.go
+++ b/pkg/storage/utils/decomposedfs/lookup.go
@@ -130,7 +130,7 @@ func (lu *Lookup) Path(ctx context.Context, n *node.Node) (p string, err error) 
 
 // RootNode returns the root node of the storage
 func (lu *Lookup) RootNode(ctx context.Context) (*node.Node, error) {
-	n := node.New("root", "", "", 0, "", nil, lu)
+	n := node.New(node.RootID, "", "", 0, "", nil, lu)
 	n.Exists = true
 	return n, nil
 }

--- a/pkg/storage/utils/decomposedfs/node/node.go
+++ b/pkg/storage/utils/decomposedfs/node/node.go
@@ -807,9 +807,11 @@ func (n *Node) ReadUserPermissions(ctx context.Context, u *userpb.User) (ap prov
 		return NoPermissions(), err
 	}
 	if o.OpaqueId == "" {
-		// this happens for root nodes in the storage. the extended attributes are set to emptystring to indicate: no owner
-		// TODO what if no owner is set but grants are present?
-		return NoOwnerPermissions(), nil
+		// this happens for root nodes and project spaces in the storage. the extended attributes are set to emptystring to indicate: no owner
+		// for project spaces we need to go over the grants and check the granted permissions
+		if n.ID == "root" {
+			return NoOwnerPermissions(), nil
+		}
 	}
 	if utils.UserEqual(u.Id, o) {
 		appctx.GetLogger(ctx).Debug().Str("node", n.ID).Msg("user is owner, returning owner permissions")

--- a/pkg/storage/utils/decomposedfs/node/node.go
+++ b/pkg/storage/utils/decomposedfs/node/node.go
@@ -64,6 +64,9 @@ const (
 
 	// TrashIDDelimiter represents the characters used to separate the nodeid and the deletion time.
 	TrashIDDelimiter = ".T."
+
+	// RootID defines the root node's ID
+	RootID = "root"
 )
 
 // Node represents a node in the tree and provides methods to get a Parent or Child instance
@@ -809,7 +812,7 @@ func (n *Node) ReadUserPermissions(ctx context.Context, u *userpb.User) (ap prov
 	if o.OpaqueId == "" {
 		// this happens for root nodes and project spaces in the storage. the extended attributes are set to emptystring to indicate: no owner
 		// for project spaces we need to go over the grants and check the granted permissions
-		if n.ID == "root" {
+		if n.ID == RootID {
 			return NoOwnerPermissions(), nil
 		}
 	}

--- a/pkg/storage/utils/decomposedfs/node/node.go
+++ b/pkg/storage/utils/decomposedfs/node/node.go
@@ -803,7 +803,7 @@ func (n *Node) ReadUserPermissions(ctx context.Context, u *userpb.User) (ap prov
 	o, err := n.Owner()
 	if err != nil {
 		// TODO check if a parent folder has the owner set?
-		appctx.GetLogger(ctx).Error().Err(err).Interface("node", n).Msg("could not determine owner, returning default permissions")
+		appctx.GetLogger(ctx).Error().Err(err).Str("node", n.ID).Msg("could not determine owner, returning default permissions")
 		return NoPermissions(), err
 	}
 	if o.OpaqueId == "" {
@@ -812,7 +812,7 @@ func (n *Node) ReadUserPermissions(ctx context.Context, u *userpb.User) (ap prov
 		return NoOwnerPermissions(), nil
 	}
 	if utils.UserEqual(u.Id, o) {
-		appctx.GetLogger(ctx).Debug().Interface("node", n).Msg("user is owner, returning owner permissions")
+		appctx.GetLogger(ctx).Debug().Str("node", n.ID).Msg("user is owner, returning owner permissions")
 		return OwnerPermissions(), nil
 	}
 

--- a/pkg/storage/utils/decomposedfs/node/permissions.go
+++ b/pkg/storage/utils/decomposedfs/node/permissions.go
@@ -117,7 +117,7 @@ func (p *Permissions) AssemblePermissions(ctx context.Context, n *Node) (ap prov
 		if err == nil && lp == n.lu.ShareFolder() {
 			return ShareFolderPermissions(), nil
 		}
-		appctx.GetLogger(ctx).Debug().Interface("node", n.ID).Msg("user is owner, returning owner permissions")
+		appctx.GetLogger(ctx).Debug().Str("node", n.ID).Msg("user is owner, returning owner permissions")
 		return OwnerPermissions(), nil
 	}
 	// determine root
@@ -282,7 +282,7 @@ func (p *Permissions) getUserAndPermissions(ctx context.Context, n *Node) (*user
 		return nil, &perms
 	}
 	if utils.UserEqual(u.Id, o) {
-		appctx.GetLogger(ctx).Debug().Interface("node", n.ID).Msg("user is owner, returning owner permissions")
+		appctx.GetLogger(ctx).Debug().Str("node", n.ID).Msg("user is owner, returning owner permissions")
 		perms := OwnerPermissions()
 		return u, &perms
 	}

--- a/pkg/storage/utils/decomposedfs/node/permissions.go
+++ b/pkg/storage/utils/decomposedfs/node/permissions.go
@@ -110,7 +110,7 @@ func (p *Permissions) AssemblePermissions(ctx context.Context, n *Node) (ap prov
 	if o.OpaqueId == "" {
 		// this happens for root nodes and project spaces in the storage. the extended attributes are set to emptystring to indicate: no owner
 		// for project spaces we need to go over the grants and check the granted permissions
-		if n.ID == "root" {
+		if n.ID == RootID {
 			return NoOwnerPermissions(), nil
 		}
 	}
@@ -280,7 +280,7 @@ func (p *Permissions) getUserAndPermissions(ctx context.Context, n *Node) (*user
 	if o.OpaqueId == "" {
 		// this happens for root nodes and project spaces in the storage. the extended attributes are set to emptystring to indicate: no owner
 		// for project spaces we need to go over the grants and check the granted permissions
-		if n.ID != "root" {
+		if n.ID != RootID {
 			return u, nil
 		}
 		perms := NoOwnerPermissions()

--- a/pkg/storage/utils/decomposedfs/node/permissions.go
+++ b/pkg/storage/utils/decomposedfs/node/permissions.go
@@ -108,9 +108,11 @@ func (p *Permissions) AssemblePermissions(ctx context.Context, n *Node) (ap prov
 		return NoPermissions(), err
 	}
 	if o.OpaqueId == "" {
-		// this happens for root nodes in the storage. the extended attributes are set to emptystring to indicate: no owner
-		// TODO what if no owner is set but grants are present?
-		return NoOwnerPermissions(), nil
+		// this happens for root nodes and project spaces in the storage. the extended attributes are set to emptystring to indicate: no owner
+		// for project spaces we need to go over the grants and check the granted permissions
+		if n.ID == "root" {
+			return NoOwnerPermissions(), nil
+		}
 	}
 	if utils.UserEqual(u.Id, o) {
 		lp, err := n.lu.Path(ctx, n)
@@ -276,8 +278,11 @@ func (p *Permissions) getUserAndPermissions(ctx context.Context, n *Node) (*user
 		return nil, &perms
 	}
 	if o.OpaqueId == "" {
-		// this happens for root nodes in the storage. the extended attributes are set to emptystring to indicate: no owner
-		// TODO what if no owner is set but grants are present?
+		// this happens for root nodes and project spaces in the storage. the extended attributes are set to emptystring to indicate: no owner
+		// for project spaces we need to go over the grants and check the granted permissions
+		if n.ID != "root" {
+			return u, nil
+		}
 		perms := NoOwnerPermissions()
 		return nil, &perms
 	}

--- a/pkg/storage/utils/decomposedfs/spaces.go
+++ b/pkg/storage/utils/decomposedfs/spaces.go
@@ -47,8 +47,11 @@ import (
 )
 
 const (
-	spaceTypeAny = "*"
-	spaceIDAny   = "*"
+	spaceTypePersonal = "personal"
+	spaceTypeProject  = "project"
+	spaceTypeShare    = "share"
+	spaceTypeAny      = "*"
+	spaceIDAny        = "*"
 )
 
 // CreateStorageSpace creates a storage space
@@ -76,7 +79,7 @@ func (fs *Decomposedfs) CreateStorageSpace(ctx context.Context, req *provider.Cr
 	}
 	// TODO enforce a uuid?
 	// TODO clarify if we want to enforce a single personal storage space or if we want to allow sending the spaceid
-	if req.Type == "personal" {
+	if req.Type == spaceTypePersonal {
 		spaceID = req.Owner.Id.OpaqueId
 	}
 
@@ -110,7 +113,7 @@ func (fs *Decomposedfs) CreateStorageSpace(ctx context.Context, req *provider.Cr
 	}
 
 	ownerID := u.Id
-	if req.Type == "project" {
+	if req.Type == spaceTypeProject {
 		ownerID = &userv1beta1.UserId{}
 	}
 
@@ -283,7 +286,7 @@ func (fs *Decomposedfs) ListStorageSpaces(ctx context.Context, filter []*provide
 		spaceType := filepath.Base(filepath.Dir(matches[i]))
 
 		// FIXME type share evolved to grant on the edge branch ... make it configurable if the driver should support them or not for now ... ignore type share
-		if spaceType == "share" {
+		if spaceType == spaceTypeShare {
 			numShares++
 			// do not list shares as spaces for the owner
 			continue
@@ -512,7 +515,7 @@ func (fs *Decomposedfs) DeleteStorageSpace(ctx context.Context, req *provider.De
 			return err
 		}
 
-		matches, err = filepath.Glob(filepath.Join(fs.o.Root, "nodes", "root", req.Id.OpaqueId+node.TrashIDDelimiter+"*"))
+		matches, err = filepath.Glob(filepath.Join(fs.o.Root, "nodes", node.RootID, req.Id.OpaqueId+node.TrashIDDelimiter+"*"))
 		if err != nil {
 			return err
 		}
@@ -664,7 +667,7 @@ func (fs *Decomposedfs) storageSpaceFromNode(ctx context.Context, n *node.Node, 
 		}
 	}
 
-	if spaceType != "project" && owner.OpaqueId != "" {
+	if spaceType != spaceTypeProject && owner.OpaqueId != "" {
 		space.Owner = &userv1beta1.User{ // FIXME only return a UserID, not a full blown user object
 			Id: owner,
 		}

--- a/pkg/storage/utils/decomposedfs/spaces.go
+++ b/pkg/storage/utils/decomposedfs/spaces.go
@@ -109,7 +109,12 @@ func (fs *Decomposedfs) CreateStorageSpace(ctx context.Context, req *provider.Cr
 		return nil, fmt.Errorf("decomposedfs: spaces: contextual user not found")
 	}
 
-	if err := n.ChangeOwner(u.Id); err != nil {
+	ownerID := u.Id
+	if req.Type == "project" {
+		ownerID = &userv1beta1.UserId{}
+	}
+
+	if err := n.ChangeOwner(ownerID); err != nil {
 		return nil, err
 	}
 
@@ -659,8 +664,10 @@ func (fs *Decomposedfs) storageSpaceFromNode(ctx context.Context, n *node.Node, 
 		}
 	}
 
-	space.Owner = &userv1beta1.User{ // FIXME only return a UserID, not a full blown user object
-		Id: owner,
+	if spaceType != "project" && owner.OpaqueId != "" {
+		space.Owner = &userv1beta1.User{ // FIXME only return a UserID, not a full blown user object
+			Id: owner,
+		}
 	}
 
 	// we set the space mtime to the root item mtime

--- a/pkg/storage/utils/decomposedfs/tree/tree.go
+++ b/pkg/storage/utils/decomposedfs/tree/tree.go
@@ -111,7 +111,7 @@ func (t *Tree) Setup(owner *userpb.UserId, propagateToRoot bool) error {
 
 	// the root node has an empty name
 	// the root node has no parent
-	n := node.New("root", "", "", 0, "", nil, t.lookup)
+	n := node.New(node.RootID, "", "", 0, "", nil, t.lookup)
 	err := t.createNode(n, owner)
 	if err != nil {
 		return err
@@ -207,7 +207,7 @@ func (t *Tree) linkSpace(spaceType, spaceID, nodeID string) {
 
 func isRootNode(nodePath string) bool {
 	attr, err := xattrs.Get(nodePath, xattrs.ParentidAttr)
-	return err == nil && attr == "root"
+	return err == nil && attr == node.RootID
 }
 func isSharedNode(nodePath string) bool {
 	if attrs, err := xattr.List(nodePath); err == nil {

--- a/tests/integration/grpc/fixtures/gateway.toml
+++ b/tests/integration/grpc/fixtures/gateway.toml
@@ -27,7 +27,7 @@ home_template = "/users/{{.Id.OpaqueId}}"
 "personal" = { "mount_point" = "/users", "path_template" = "/users/{{.Space.Owner.Id.OpaqueId}}" }
 
 [grpc.services.storageregistry.drivers.spaces.providers."{{storage2_address}}".spaces]
-"project" = { "mount_point" = "/users/[^/]+/Projects", "path_template" = "/users/{{.Space.Owner.Id.OpaqueId}}/Projects/{{.Space.Name}}" }
+"project" = { "mount_point" = "/users/[^/]+/Projects", "path_template" = "/users/{{.CurrentUser.Id.OpaqueId}}/Projects/{{.Space.Name}}" }
 
 [http]
 address = "{{grpc_address+1}}"

--- a/tests/integration/grpc/gateway_storageprovider_test.go
+++ b/tests/integration/grpc/gateway_storageprovider_test.go
@@ -495,7 +495,6 @@ var _ = Describe("gateway", func() {
 				info := statRes.Info
 				Expect(info.Type).To(Equal(storagep.ResourceType_RESOURCE_TYPE_CONTAINER))
 				Expect(info.Path).To(Equal(embeddedSpaceID))
-				Expect(info.Owner.OpaqueId).To(Equal(user.Id.OpaqueId))
 				Expect(info.Size).To(Equal(uint64(2)))
 			})
 


### PR DESCRIPTION
- Removed owners from project spaces
- Prevent deletion of last space manager
- Viewers and editors can always be deleted
- Managers can only be deleted when there will be at least one remaining
- Fixed a bug that prevented adding new space managers

The delete request looks like this:
```
curl -k -s -u admin:admin -X DELETE 'https://localhost:9200/ocs/v2.php/apps/files_sharing/api/v1/shares/24387715-32d0
-4a91-8fe9-e4950c2e6c3f?shareWith=richard'
```