### PR TITLE
Allow using AD UUID as userId values

### DIFF
--- a/changelog/unreleased/ldap-guid.md
+++ b/changelog/unreleased/ldap-guid.md
@@ -1,0 +1,7 @@
+Enhancement: Allow using AD UUID as userId values
+
+Active Directory UUID attributes (like e.g. objectGUID) use the LDAP octectString
+Syntax. In order to be able to use them as userids in reva, they need to be converted
+to their string representation.
+
+https://github.com/cs3org/reva/pull/2525


### PR DESCRIPTION
Active Directory treats UUID attributes like 'objectGUID' as octet
string. This means they need some special treatment:
- When storing them into UserId Object we need to convert the Raw Value
  to a string
- When using them in LDAP filter they need to be correctly escaped as backslash
  escaped hex values.

Partial Fix for #2523