### PR TITLE
xattrs: use unix flocks when writing multiple xattrs

### DIFF
--- a/changelog/unreleased/flock-xattr-set-multiple.md
+++ b/changelog/unreleased/flock-xattr-set-multiple.md
@@ -1,0 +1,5 @@
+Enhancement: use an exclcusive write lock when writing multiple attributes
+
+The xattr package can use an exclusive write lock when writing multiple extended attributes
+
+https://github.com/cs3org/reva/pull/2528

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/go-openapi/errors v0.20.1 // indirect
 	github.com/go-openapi/strfmt v0.20.2 // indirect
 	github.com/go-sql-driver/mysql v1.6.0
-	github.com/gofrs/flock v0.8.1 // indirect
+	github.com/gofrs/flock v0.8.1
 	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/golang/protobuf v1.5.2
 	github.com/gomodule/redigo v1.8.8

--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/go-openapi/errors v0.20.1 // indirect
 	github.com/go-openapi/strfmt v0.20.2 // indirect
 	github.com/go-sql-driver/mysql v1.6.0
+	github.com/gofrs/flock v0.8.1 // indirect
 	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/golang/protobuf v1.5.2
 	github.com/gomodule/redigo v1.8.8

--- a/go.sum
+++ b/go.sum
@@ -419,6 +419,8 @@ github.com/gobwas/pool v0.2.1/go.mod h1:q8bcK0KcYlCgd9e7WYLm9LpyS+YeLd8JVDW6Wezm
 github.com/gobwas/ws v1.0.4/go.mod h1:szmBTxLgaFppYjEmNtny/v3w89xOydFnnZMcgRRu/EM=
 github.com/godbus/dbus/v5 v5.0.3/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
+github.com/gofrs/flock v0.8.1 h1:+gYjHKf32LDeiEEFhQaotPbLuUXjY5ZqxKgXy7n59aw=
+github.com/gofrs/flock v0.8.1/go.mod h1:F1TvTiK9OcQqauNUHlbJvyl9Qa1QvF/gOUDKA14jxHU=
 github.com/gofrs/uuid v3.2.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gofrs/uuid v4.0.0+incompatible h1:1SD/1F5pU8p29ybwgQSwpQk+mwdRrXCYuPhW6m+TnJw=
 github.com/gofrs/uuid v4.0.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=

--- a/pkg/storage/utils/decomposedfs/xattrs/xattrs.go
+++ b/pkg/storage/utils/decomposedfs/xattrs/xattrs.go
@@ -294,5 +294,5 @@ func All(filePath string) (attribs map[string]string, err error) {
 		err = errors.New("Failed to read all xattrs")
 	}
 
-	return attribs, nil
+	return attribs, err
 }

--- a/pkg/storage/utils/decomposedfs/xattrs/xattrs.go
+++ b/pkg/storage/utils/decomposedfs/xattrs/xattrs.go
@@ -226,7 +226,7 @@ func SetMultiple(filePath string, attribs map[string]string) (err error) {
 	if xerrs > 0 {
 		err = errors.Wrap(xerr, "Failed to set all xattrs")
 	}
-	return nil
+	return err
 }
 
 // Get an extended attribute value for the given key

--- a/pkg/storage/utils/filelocks/filelocks.go
+++ b/pkg/storage/utils/filelocks/filelocks.go
@@ -1,0 +1,85 @@
+// Copyright 2018-2021 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package filelocks
+
+import (
+	"errors"
+	"os"
+
+	"github.com/gofrs/flock"
+)
+
+// flockFile returns the flock filename for a given file name
+// it returns an empty string if the input is empty
+func FlockFile(file string) string {
+	var n string
+	if len(file) > 0 {
+		n = file + ".flock"
+	}
+	return n
+}
+
+// acquireWriteLog acquires a lock on a file or directory.
+// if the parameter write is true, it gets an exclusive write lock, otherwise a shared read lock.
+// The function returns a Flock object, unlocking has to be done in the calling function.
+func acquireLock(file string, write bool) (*flock.Flock, error) {
+	var err error
+
+	// Create the a file to carry the log
+	n := FlockFile(file)
+	if len(n) == 0 {
+		return nil, errors.New("lock path is empty")
+	}
+	// Acquire the write log on the target node first.
+	lock := flock.New(n)
+
+	if write {
+		_, err = lock.TryLock()
+	} else {
+		_, err = lock.TryRLock()
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	return lock, nil
+}
+
+// AcquireReadLock tries to acquire a shared lock to read from the
+// file and returns a lock object or an error accordingly.
+func AcquireReadLock(file string) (*flock.Flock, error) {
+	return acquireLock(file, false)
+}
+
+// AcquireWriteLock tries to acquire a shared lock to write from the
+// file and returns a lock object or an error accordingly.
+func AcquireWriteLock(file string) (*flock.Flock, error) {
+	return acquireLock(file, true)
+}
+
+func ReleaseLock(lock *flock.Flock) error {
+	// there is a probability that if the file can not be unlocked,
+	// we also can not remove the file. We will only try to remove if it
+	// was successfully unlocked.
+	err := lock.Unlock()
+	if err == nil {
+		err = os.Remove(lock.Path())
+	}
+	return err
+}

--- a/pkg/storage/utils/filelocks/filelocks.go
+++ b/pkg/storage/utils/filelocks/filelocks.go
@@ -25,7 +25,7 @@ import (
 	"github.com/gofrs/flock"
 )
 
-// flockFile returns the flock filename for a given file name
+// FlockFile returns the flock filename for a given file name
 // it returns an empty string if the input is empty
 func FlockFile(file string) string {
 	var n string
@@ -73,6 +73,8 @@ func AcquireWriteLock(file string) (*flock.Flock, error) {
 	return acquireLock(file, true)
 }
 
+// ReleaseLock releases a lock from a file that was previously created
+// by AcquireReadLock or AcquireWriteLock.
 func ReleaseLock(lock *flock.Flock) error {
 	// there is a probability that if the file can not be unlocked,
 	// we also can not remove the file. We will only try to remove if it

--- a/pkg/storage/utils/filelocks/filelocks.go
+++ b/pkg/storage/utils/filelocks/filelocks.go
@@ -51,7 +51,7 @@ func acquireLock(file string, write bool) (*flock.Flock, error) {
 	lock := flock.New(n)
 
 	var ok bool
-	for i := 0; i < 10; i++ {
+	for i := 1; i <= 10; i++ {
 		if write {
 			ok, err = lock.TryLock()
 		} else {


### PR DESCRIPTION
checking the flock implementation options...

- [x] x/sys/unix ... current state of this PR ... ties us to unix
- [x] https://github.com/gofrs/flock ... uses a dedicated file ... I still like this ... but it seems unmaintaind
- [ ] wait for official lockfile: [Proposal: make the internal lockedfile package public](https://go.googlesource.com/proposal/+/master/design/33974-add-public-lockedfile-pkg.md)
- [ ] use https://github.com/rogpeppe/go-internal/blob/master/lockedfile/lockedfile.go until then? because it seems maintained.