### PR TITLE
Use space description on creation

### DIFF
--- a/changelog/unreleased/change-use-description-during-space-creation.md
+++ b/changelog/unreleased/change-use-description-during-space-creation.md
@@ -1,0 +1,5 @@
+Change: Use description during space creation
+
+We can now use a space description during space creation. We also fixed a bug in the spaces roles. Co-owners are now maintainers.
+
+https://github.com/cs3org/reva/pull/2524

--- a/internal/http/services/owncloud/ocs/conversions/permissions_test.go
+++ b/internal/http/services/owncloud/ocs/conversions/permissions_test.go
@@ -145,7 +145,7 @@ func TestPermissions2Role(t *testing.T) {
 	table := map[Permissions]string{
 		PermissionRead: RoleViewer,
 		PermissionRead | PermissionWrite | PermissionCreate | PermissionDelete: RoleEditor,
-		PermissionAll:                     RoleCoowner,
+		PermissionAll:                     RoleManager,
 		PermissionWrite:                   RoleLegacy,
 		PermissionShare:                   RoleLegacy,
 		PermissionWrite | PermissionShare: RoleLegacy,

--- a/internal/http/services/owncloud/ocs/conversions/role.go
+++ b/internal/http/services/owncloud/ocs/conversions/role.go
@@ -284,12 +284,12 @@ func NewManagerRole() *Role {
 	}
 }
 
-// RoleFromOCSPermissions tries to map ocs permissions to a role
+// RoleFromOCSPermissions  tries to map ocs permissions to a role
 func RoleFromOCSPermissions(p Permissions) *Role {
 	if p.Contain(PermissionRead) {
 		if p.Contain(PermissionWrite) && p.Contain(PermissionCreate) && p.Contain(PermissionDelete) {
 			if p.Contain(PermissionShare) {
-				return NewCoownerRole()
+				return NewManagerRole()
 			}
 			return NewEditorRole()
 		}

--- a/internal/http/services/owncloud/ocs/conversions/role.go
+++ b/internal/http/services/owncloud/ocs/conversions/role.go
@@ -284,7 +284,7 @@ func NewManagerRole() *Role {
 	}
 }
 
-// RoleFromOCSPermissions  tries to map ocs permissions to a role
+// RoleFromOCSPermissions tries to map ocs permissions to a role
 func RoleFromOCSPermissions(p Permissions) *Role {
 	if p.Contain(PermissionRead) {
 		if p.Contain(PermissionWrite) && p.Contain(PermissionCreate) && p.Contain(PermissionDelete) {


### PR DESCRIPTION
# Description

1) Make it possible to send an opaque "description" value in the CreateStorageSpaces Request.

2) Fixed a bug in the sharing roles. CoOnwners are now Managers.