### PR TITLE
remove base64 encoding of ids

### DIFF
--- a/changelog/unreleased/remove-base64-encoding-of-ids.md
+++ b/changelog/unreleased/remove-base64-encoding-of-ids.md
@@ -1,5 +1,5 @@
 Change: Do not encode webDAV ids to base64
 
-We removed the encoding of the IDs and use the format <storageID>!<opaqueID> with a delimiter. The used delimiter is url safe anc belongs to the reserved keys.
+We removed the base64 encoding of the IDs and use the format <storageID>!<opaqueID> with a `!` delimiter. As a reserved delimiter it is URL safe. The IDs will be XML and JSON encoded as necessary.
 
 https://github.com/cs3org/reva/pull/2542

--- a/changelog/unreleased/remove-base64-encoding-of-ids.md
+++ b/changelog/unreleased/remove-base64-encoding-of-ids.md
@@ -1,0 +1,5 @@
+Change: Do not encode webDAV ids to base64
+
+We removed the encoding of the IDs and use the format <storageID>!<opaqueID> with a delimiter. The used delimiter is url safe anc belongs to the reserved keys.
+
+https://github.com/cs3org/reva/pull/2542

--- a/internal/http/services/owncloud/ocdav/ocdav_test.go
+++ b/internal/http/services/owncloud/ocdav/ocdav_test.go
@@ -30,7 +30,7 @@ import (
 )
 
 func TestWrapResourceID(t *testing.T) {
-	expected := "c3RvcmFnZWlkOm9wYXF1ZWlk"
+	expected := "storageid" + "!" + "opaqueid"
 	wrapped := resourceid.OwnCloudResourceIDWrap(&providerv1beta1.ResourceId{StorageId: "storageid", OpaqueId: "opaqueid"})
 
 	if wrapped != expected {

--- a/pkg/storage/utils/decomposedfs/spaces.go
+++ b/pkg/storage/utils/decomposedfs/spaces.go
@@ -43,6 +43,7 @@ import (
 	"github.com/cs3org/reva/pkg/storage/utils/decomposedfs/node"
 	"github.com/cs3org/reva/pkg/storage/utils/decomposedfs/xattrs"
 	"github.com/cs3org/reva/pkg/utils"
+	"github.com/cs3org/reva/pkg/utils/resourceid"
 	"github.com/google/uuid"
 )
 
@@ -417,10 +418,12 @@ func (fs *Decomposedfs) UpdateStorageSpace(ctx context.Context, req *provider.Up
 			hasDescription = true
 		}
 		if image, ok := space.Opaque.Map["image"]; ok {
-			metadata[xattrs.SpaceImageAttr] = string(image.Value)
+			imageID := resourceid.OwnCloudResourceIDUnwrap(string(image.Value))
+			metadata[xattrs.SpaceImageAttr] = imageID.OpaqueId
 		}
 		if readme, ok := space.Opaque.Map["readme"]; ok {
-			metadata[xattrs.SpaceReadmeAttr] = string(readme.Value)
+			readmeID := resourceid.OwnCloudResourceIDUnwrap(string(readme.Value))
+			metadata[xattrs.SpaceReadmeAttr] = readmeID.OpaqueId
 		}
 	}
 
@@ -716,7 +719,7 @@ func (fs *Decomposedfs) storageSpaceFromNode(ctx context.Context, n *node.Node, 
 	if ok {
 		space.Opaque.Map["image"] = &types.OpaqueEntry{
 			Decoder: "plain",
-			Value:   []byte(spaceImage),
+			Value:   []byte(resourceid.OwnCloudResourceIDWrap(&provider.ResourceId{StorageId: space.Root.StorageId, OpaqueId: spaceImage})),
 		}
 	}
 	spaceDescription, ok := spaceAttributes[xattrs.SpaceDescriptionAttr]
@@ -730,7 +733,7 @@ func (fs *Decomposedfs) storageSpaceFromNode(ctx context.Context, n *node.Node, 
 	if ok {
 		space.Opaque.Map["readme"] = &types.OpaqueEntry{
 			Decoder: "plain",
-			Value:   []byte(spaceReadme),
+			Value:   []byte(resourceid.OwnCloudResourceIDWrap(&provider.ResourceId{StorageId: space.Root.StorageId, OpaqueId: spaceReadme})),
 		}
 	}
 	return space, nil

--- a/pkg/utils/resourceid/owncloud.go
+++ b/pkg/utils/resourceid/owncloud.go
@@ -19,7 +19,6 @@
 package resourceid
 
 import (
-	"encoding/base64"
 	"errors"
 	"strings"
 	"unicode/utf8"
@@ -28,7 +27,7 @@ import (
 )
 
 const (
-	idDelimiter string = ":"
+	idDelimiter string = "!"
 )
 
 // OwnCloudResourceIDUnwrap returns the wrapped resource id
@@ -42,12 +41,7 @@ func OwnCloudResourceIDUnwrap(rid string) *provider.ResourceId {
 }
 
 func unwrap(rid string) (*provider.ResourceId, error) {
-	decodedID, err := base64.URLEncoding.DecodeString(rid)
-	if err != nil {
-		return nil, err
-	}
-
-	parts := strings.SplitN(string(decodedID), idDelimiter, 2)
+	parts := strings.SplitN(rid, idDelimiter, 2)
 	if len(parts) != 2 {
 		return nil, errors.New("could not find two parts with given delimiter")
 	}
@@ -68,10 +62,9 @@ func OwnCloudResourceIDWrap(r *provider.ResourceId) string {
 	return wrap(r.StorageId, r.OpaqueId)
 }
 
-// The fileID must be encoded
-// - XML safe, because it is going to be used in the propfind result
-// - url safe, because the id might be used in a url, eg. the /dav/meta nodes
-// which is why we base64 encode it
+// The storageID and OpaqueID need to be separated by a delimiter
+// this delimiter should be Url safe
+// we use a reserved character
 func wrap(sid string, oid string) string {
-	return base64.URLEncoding.EncodeToString([]byte(sid + idDelimiter + oid))
+	return sid + idDelimiter + oid
 }

--- a/pkg/utils/resourceid/owncloud_test.go
+++ b/pkg/utils/resourceid/owncloud_test.go
@@ -31,7 +31,7 @@ func BenchmarkWrap(b *testing.B) {
 }
 
 func TestWrap(t *testing.T) {
-	expected := "c3RvcmFnZWlkOm9wYXF1ZWlk"
+	expected := "storageid" + idDelimiter + "opaqueid"
 	wrapped := wrap("storageid", "opaqueid")
 
 	if wrapped != expected {
@@ -40,7 +40,7 @@ func TestWrap(t *testing.T) {
 }
 
 func TestWrapResourceID(t *testing.T) {
-	expected := "c3RvcmFnZWlkOm9wYXF1ZWlk"
+	expected := "storageid" + idDelimiter + "opaqueid"
 	wrapped := OwnCloudResourceIDWrap(&providerv1beta1.ResourceId{StorageId: "storageid", OpaqueId: "opaqueid"})
 
 	if wrapped != expected {
@@ -50,7 +50,7 @@ func TestWrapResourceID(t *testing.T) {
 
 func BenchmarkUnwrap(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		_, _ = unwrap("c3RvcmFnZWlkOm9wYXF1ZWlk")
+		_, _ = unwrap("storageid" + idDelimiter + "opaqueid")
 	}
 }
 
@@ -60,7 +60,7 @@ func TestUnwrap(t *testing.T) {
 		expected *providerv1beta1.ResourceId
 	}{
 		{
-			"c3RvcmFnZWlkOm9wYXF1ZWlk",
+			"storageid" + idDelimiter + "opaqueid",
 			&providerv1beta1.ResourceId{StorageId: "storageid", OpaqueId: "opaqueid"},
 		},
 		{


### PR DESCRIPTION
## Change: Unify file IDs

We changed the file IDs to be consistent across all our APIs (WebDAV, LibreGraph, OCS). We removed the base64 encoding. Now they are formatted like `<storageID>!<opaqueID>`. They are using a reserved character ``!`` as a URL safe separator.

## Related Issue

ocis PR https://github.com/owncloud/ocis/pull/3185

## Examples

```bash
curl -L -X PROPFIND 'https://localhost:9200/dav/spaces/6afcb97a-e632-447d-b832-1334a8a9634f' \
-H 'Depth: infinity' \
-H 'Authorization: Basic YWRtaW46YWRtaW4='
```

```xml
<d:multistatus xmlns:s="http://sabredav.org/ns" xmlns:d="DAV:" xmlns:oc="http://owncloud.org/ns">
    <d:response>
        <d:href>/dav/spaces/6afcb97a-e632-447d-b832-1334a8a9634f/</d:href>
        <d:propstat>
            <d:prop>
                <oc:id>6afcb97a-e632-447d-b832-1334a8a9634f!6afcb97a-e632-447d-b832-1334a8a9634f</oc:id>
                <oc:fileid>6afcb97a-e632-447d-b832-1334a8a9634f!6afcb97a-e632-447d-b832-1334a8a9634f</oc:fileid>
                <d:getetag>&#34;55e95f454e48c0047d901686f4f7027c&#34;</d:getetag>
                <oc:permissions>RDNVCK</oc:permissions>
                <d:resourcetype>
                    <d:collection/>
                </d:resourcetype>
                <oc:size>2019472</oc:size>
                <d:getlastmodified>Tue, 15 Feb 2022 11:42:10 GMT</d:getlastmodified>
                <oc:favorite>0</oc:favorite>
            </d:prop>
            <d:status>HTTP/1.1 200 OK</d:status>
        </d:propstat>
    </d:response>
    <d:response>
        <d:href>/dav/spaces/6afcb97a-e632-447d-b832-1334a8a9634f/Space_Image.jpg</d:href>
        <d:propstat>
            <d:prop>
                <oc:id>6afcb97a-e632-447d-b832-1334a8a9634f!83a2c6ab-19f2-4f51-b3cb-41aef54ee5ab</oc:id>
                <oc:fileid>6afcb97a-e632-447d-b832-1334a8a9634f!83a2c6ab-19f2-4f51-b3cb-41aef54ee5ab</oc:fileid>
                <d:getetag>&#34;0440204b65664c18fa73a40cfe625815&#34;</d:getetag>
                <oc:permissions>RDNVW</oc:permissions>
                <d:resourcetype></d:resourcetype>
                <d:getcontentlength>2019367</d:getcontentlength>
                <d:getcontenttype>image/jpeg</d:getcontenttype>
                <d:getlastmodified>Tue, 15 Feb 2022 11:42:10 GMT</d:getlastmodified>
                <oc:checksums>
                    <oc:checksum>SHA1:439c4a6de0489288bb88914913fd1e5ece7d1764 MD5:2540f4e8f934296b617973f1a5cd5ae3 ADLER32:1c056526</oc:checksum>
                </oc:checksums>
                <oc:favorite>0</oc:favorite>
            </d:prop>
            <d:status>HTTP/1.1 200 OK</d:status>
        </d:propstat>
    </d:response>
    <d:response>
        <d:href>/dav/spaces/6afcb97a-e632-447d-b832-1334a8a9634f/NewFile5.md</d:href>
        <d:propstat>
            <d:prop>
                <oc:id>6afcb97a-e632-447d-b832-1334a8a9634f!44b8c8ba-8f57-452f-9b28-85b2058bdac8</oc:id>
                <oc:fileid>6afcb97a-e632-447d-b832-1334a8a9634f!44b8c8ba-8f57-452f-9b28-85b2058bdac8</oc:fileid>
                <d:getetag>&#34;6f35041017b213007453cd8d74ccb331&#34;</d:getetag>
                <oc:permissions>RDNVW</oc:permissions>
                <d:resourcetype></d:resourcetype>
                <d:getcontentlength>105</d:getcontentlength>
                <d:getcontenttype>text/markdown</d:getcontenttype>
                <d:getlastmodified>Tue, 15 Feb 2022 11:41:34 GMT</d:getlastmodified>
                <oc:checksums>
                    <oc:checksum>SHA1:081272bd25665a1a884fd50f3143220411c6e8a3 MD5:9bdb7fc99749fb9b2207358aec781742 ADLER32:dd6928f0</oc:checksum>
                </oc:checksums>
                <oc:favorite>0</oc:favorite>
            </d:prop>
            <d:status>HTTP/1.1 200 OK</d:status>
        </d:propstat>
    </d:response>
    <d:response>
        <d:href>/dav/spaces/6afcb97a-e632-447d-b832-1334a8a9634f/NewFolder/</d:href>
        <d:propstat>
            <d:prop>
                <oc:id>6afcb97a-e632-447d-b832-1334a8a9634f!dc4399c7-1fed-46e1-b81d-36c3db1c74ba</oc:id>
                <oc:fileid>6afcb97a-e632-447d-b832-1334a8a9634f!dc4399c7-1fed-46e1-b81d-36c3db1c74ba</oc:fileid>
                <d:getetag>&#34;0e0ec707e062c806e5e48faefcdca725&#34;</d:getetag>
                <oc:permissions>RDNVCK</oc:permissions>
                <d:resourcetype>
                    <d:collection/>
                </d:resourcetype>
                <oc:size>0</oc:size>
                <d:getlastmodified>Tue, 15 Feb 2022 11:40:51 GMT</d:getlastmodified>
                <oc:favorite>0</oc:favorite>
            </d:prop>
            <d:status>HTTP/1.1 200 OK</d:status>
        </d:propstat>
    </d:response>
</d:multistatus>
```