### PR TITLE
[tests-only] test update-getPersonalSpaceIdForUser

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The test runner source for API tests
-CORE_COMMITID=534c180aa714f97cb195bbf5cdb03f21680f94a0
-CORE_BRANCH=master
+CORE_COMMITID=ee827fd3affbcf52f24a3109a26f5db57af3e3bc
+CORE_BRANCH=update-getPersonalSpaceIdForUser


### PR DESCRIPTION
core PR https://github.com/owncloud/core/pull/39793 changes test method `getPersonalSpaceIdForUser` so that it can work with 2 different space id formats.

This PR is to test that the core code does correctly process the current base64-encoded space-id.

Running with edge branch.