### PR TITLE
 [tests-only] Test update-getPersonalSpaceIdForUser

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The test runner source for API tests
-CORE_COMMITID=534c180aa714f97cb195bbf5cdb03f21680f94a0
-CORE_BRANCH=master
+CORE_COMMITID=ee827fd3affbcf52f24a3109a26f5db57af3e3bc
+CORE_BRANCH=update-getPersonalSpaceIdForUser

--- a/changelog/unreleased/remove-base64-encoding-of-ids.md
+++ b/changelog/unreleased/remove-base64-encoding-of-ids.md
@@ -1,0 +1,5 @@
+Change: Do not encode webDAV ids to base64
+
+We removed the encoding of the IDs and use the format <storageID>!<opaqueID> with a delimiter. The used delimiter is url safe anc belongs to the reserved keys.
+
+https://github.com/cs3org/reva/pull/2542

--- a/internal/http/services/owncloud/ocdav/ocdav_test.go
+++ b/internal/http/services/owncloud/ocdav/ocdav_test.go
@@ -30,7 +30,7 @@ import (
 )
 
 func TestWrapResourceID(t *testing.T) {
-	expected := "c3RvcmFnZWlkOm9wYXF1ZWlk"
+	expected := "storageid" + "!" + "opaqueid"
 	wrapped := resourceid.OwnCloudResourceIDWrap(&providerv1beta1.ResourceId{StorageId: "storageid", OpaqueId: "opaqueid"})
 
 	if wrapped != expected {

--- a/pkg/utils/resourceid/owncloud.go
+++ b/pkg/utils/resourceid/owncloud.go
@@ -19,7 +19,6 @@
 package resourceid
 
 import (
-	"encoding/base64"
 	"errors"
 	"strings"
 	"unicode/utf8"
@@ -28,7 +27,7 @@ import (
 )
 
 const (
-	idDelimiter string = ":"
+	idDelimiter string = "!"
 )
 
 // OwnCloudResourceIDUnwrap returns the wrapped resource id
@@ -42,12 +41,7 @@ func OwnCloudResourceIDUnwrap(rid string) *provider.ResourceId {
 }
 
 func unwrap(rid string) (*provider.ResourceId, error) {
-	decodedID, err := base64.URLEncoding.DecodeString(rid)
-	if err != nil {
-		return nil, err
-	}
-
-	parts := strings.SplitN(string(decodedID), idDelimiter, 2)
+	parts := strings.SplitN(rid, idDelimiter, 2)
 	if len(parts) != 2 {
 		return nil, errors.New("could not find two parts with given delimiter")
 	}
@@ -68,10 +62,9 @@ func OwnCloudResourceIDWrap(r *provider.ResourceId) string {
 	return wrap(r.StorageId, r.OpaqueId)
 }
 
-// The fileID must be encoded
-// - XML safe, because it is going to be used in the propfind result
-// - url safe, because the id might be used in a url, eg. the /dav/meta nodes
-// which is why we base64 encode it
+// The storageID and OpaqueID need to be separated by a delimiter
+// this delimiter should be Url safe
+// we use a reserved character
 func wrap(sid string, oid string) string {
-	return base64.URLEncoding.EncodeToString([]byte(sid + idDelimiter + oid))
+	return sid + idDelimiter + oid
 }

--- a/pkg/utils/resourceid/owncloud_test.go
+++ b/pkg/utils/resourceid/owncloud_test.go
@@ -31,7 +31,7 @@ func BenchmarkWrap(b *testing.B) {
 }
 
 func TestWrap(t *testing.T) {
-	expected := "c3RvcmFnZWlkOm9wYXF1ZWlk"
+	expected := "storageid" + idDelimiter + "opaqueid"
 	wrapped := wrap("storageid", "opaqueid")
 
 	if wrapped != expected {
@@ -40,7 +40,7 @@ func TestWrap(t *testing.T) {
 }
 
 func TestWrapResourceID(t *testing.T) {
-	expected := "c3RvcmFnZWlkOm9wYXF1ZWlk"
+	expected := "storageid" + idDelimiter + "opaqueid"
 	wrapped := OwnCloudResourceIDWrap(&providerv1beta1.ResourceId{StorageId: "storageid", OpaqueId: "opaqueid"})
 
 	if wrapped != expected {
@@ -50,7 +50,7 @@ func TestWrapResourceID(t *testing.T) {
 
 func BenchmarkUnwrap(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		_, _ = unwrap("c3RvcmFnZWlkOm9wYXF1ZWlk")
+		_, _ = unwrap("storageid" + idDelimiter + "opaqueid")
 	}
 }
 
@@ -60,7 +60,7 @@ func TestUnwrap(t *testing.T) {
 		expected *providerv1beta1.ResourceId
 	}{
 		{
-			"c3RvcmFnZWlkOm9wYXF1ZWlk",
+			"storageid" + idDelimiter + "opaqueid",
 			&providerv1beta1.ResourceId{StorageId: "storageid", OpaqueId: "opaqueid"},
 		},
 		{


### PR DESCRIPTION
This is code from PR #2542 "remove base64 encoding of ids" and running the `getPersonalSpaceIdForUser` test code from core PR https://github.com/owncloud/core/pull/39793 that is core branch `update-getPersonalSpaceIdForUser`

This PR is just to confirm that the changed test code works.