### PR TITLE
[tests-only] Bump core commit id to include PR 39793 getPersonalSpaceIdForUser changes

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The test runner source for API tests
-CORE_COMMITID=534c180aa714f97cb195bbf5cdb03f21680f94a0
+CORE_COMMITID=93d081488afcba12abb709765dd0baa3aa3eb56d
 CORE_BRANCH=master


### PR DESCRIPTION
Bumps the core commit id for tests in master branch. Gets the code from https://github.com/owncloud/core/pull/39793 running in CI for the edge branch.