### PR TITLE
[tests-only] Silence some linter errors

### DIFF
--- a/pkg/storage/fs/owncloudsql/owncloudsql.go
+++ b/pkg/storage/fs/owncloudsql/owncloudsql.go
@@ -1893,12 +1893,12 @@ func (fs *owncloudsqlfs) propagate(ctx context.Context, leafPath string) error {
 			Str("leafPath", leafPath).
 			Str("currentPath", currentPath).
 			Msg("propagating change")
-		parentFi, err := os.Stat(filepath.Join(currentPath))
+		parentFi, err := os.Stat(currentPath)
 		if err != nil {
 			return err
 		}
 		if fi.ModTime().UnixNano() > parentFi.ModTime().UnixNano() {
-			if err := os.Chtimes(filepath.Join(currentPath), fi.ModTime(), fi.ModTime()); err != nil {
+			if err := os.Chtimes(currentPath, fi.ModTime(), fi.ModTime()); err != nil {
 				appctx.GetLogger(ctx).Error().
 					Err(err).
 					Str("leafPath", leafPath).
@@ -1907,7 +1907,7 @@ func (fs *owncloudsqlfs) propagate(ctx context.Context, leafPath string) error {
 				return err
 			}
 		}
-		fi, err = os.Stat(filepath.Join(currentPath))
+		fi, err = os.Stat(currentPath)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This fixes a couple of "badCall: suspicious Join on 1 argument" warning from golangci-lint.