### PR TITLE
set status values to match what is currently in oCIS frontend.go

### DIFF
--- a/changelog/unreleased/change-status-values.md
+++ b/changelog/unreleased/change-status-values.md
@@ -1,0 +1,5 @@
+Change: Update hard-coded status values
+
+The hard-coded version and product values have been updated to be consistent in all places in the code.
+
+https://github.com/cs3org/reva/pull/2581

--- a/internal/http/services/owncloud/ocdav/status.go
+++ b/internal/http/services/owncloud/ocdav/status.go
@@ -32,10 +32,10 @@ func (s *svc) doStatus(w http.ResponseWriter, r *http.Request) {
 		Installed:      true,
 		Maintenance:    false,
 		NeedsDBUpgrade: false,
-		Version:        "10.0.9.5", // TODO(jfd) make build/config determined
-		VersionString:  "10.0.9",
+		Version:        "10.0.11.5", // TODO(jfd) make build/config determined
+		VersionString:  "10.0.11",
 		Edition:        "community",
-		ProductName:    "ownCloud",
+		ProductName:    "reva",
 	}
 
 	statusJSON, err := json.MarshalIndent(status, "", "    ")

--- a/internal/http/services/owncloud/ocs/handlers/cloud/capabilities/capabilities.go
+++ b/internal/http/services/owncloud/ocs/handlers/cloud/capabilities/capabilities.go
@@ -64,10 +64,10 @@ func (h *Handler) Init(c *config.Config) {
 	// h.c.Capabilities.Core.Status.Maintenance is boolean
 	// h.c.Capabilities.Core.Status.NeedsDBUpgrade is boolean
 	if h.c.Capabilities.Core.Status.Version == "" {
-		h.c.Capabilities.Core.Status.Version = "10.0.9.5" // TODO make build determined
+		h.c.Capabilities.Core.Status.Version = "10.0.11.5" // TODO make build determined
 	}
 	if h.c.Capabilities.Core.Status.VersionString == "" {
-		h.c.Capabilities.Core.Status.VersionString = "10.0.9" // TODO make build determined
+		h.c.Capabilities.Core.Status.VersionString = "10.0.11" // TODO make build determined
 	}
 	if h.c.Capabilities.Core.Status.Edition == "" {
 		h.c.Capabilities.Core.Status.Edition = "community" // TODO make build determined
@@ -213,8 +213,8 @@ func (h *Handler) Init(c *config.Config) {
 			// TODO get from build env
 			Major:   10,
 			Minor:   0,
-			Micro:   9,
-			String:  "10.0.9",
+			Micro:   11,
+			String:  "10.0.11",
 			Edition: "community",
 		}
 	}


### PR DESCRIPTION
https://github.com/owncloud/ocis/blob/master/storage/pkg/command/frontend.go currently has hard-coded values in capabilities core status that get returned in a capabilities response.

reva has 10.0.9.5 still in some places, but other places have 10.0.11.5

Make the hardcoded values for version, product name etc. the same - then at least they will be consistent for now.

There has been other mention of implementing some proper advertising of a product name and version of reva and oCIS using semver etc. That is a different issue, and can be sorted out after this PR gets the hard-coded values consistent.