### PR TITLE
Locks mutexed

### DIFF
--- a/changelog/unreleased/locksMutexed.md
+++ b/changelog/unreleased/locksMutexed.md
@@ -1,0 +1,6 @@
+Bugfix: keep lock structs in a local map protected by a mutex
+
+Make sure that only one go routine or process can get the 
+lock.
+
+https://github.com/cs3org/reva/pull/2582

--- a/pkg/storage/utils/filelocks/filelocks.go
+++ b/pkg/storage/utils/filelocks/filelocks.go
@@ -29,10 +29,6 @@ import (
 
 var _localLocks sync.Map
 
-func init() {
-
-}
-
 // getMutexedFlock returns a new Flock struct for the given file.
 // If there is already one in the local store, it returns nil.
 // The caller has to wait until it can get a new one out of this


### PR DESCRIPTION
There must be only one Flock struct per lock file. If that
is existing, no other routine or process may get a lock.