### PR TITLE
cephfs: fix Dockerfile.revad-ceph to use the right base image

### DIFF
--- a/Dockerfile.revad-ceph
+++ b/Dockerfile.revad-ceph
@@ -16,7 +16,7 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
-FROM ceph/daemon-base
+FROM quay.ceph.io/ceph-ci/ceph:pacific
 
 RUN dnf update -y && dnf install -y \
   git \

--- a/changelog/unreleased/cephfs-fix-base.md
+++ b/changelog/unreleased/cephfs-fix-base.md
@@ -1,0 +1,6 @@
+Bugfix: Dockerfile.revad-ceph to use the right base image
+
+In Aug2021 https://hub.docker.com/r/ceph/daemon-base was moved to quay.ceph.io
+and the builds for this image were failing for some weeks after January.
+
+https://github.com/cs3org/reva/pull/2588


### PR DESCRIPTION
- In Aug2021 https://hub.docker.com/r/ceph/daemon-base was moved
  to quay.ceph.io and the builds for this image were failing for
  some weeks after January.