### PR TITLE
[tests-only] Increase lint timeout to 3 minutes

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -29,7 +29,7 @@ def lintStep():
         "name": "lint",
         "image": "registry.cern.ch/docker.io/golangci/golangci-lint:v1.42.1",
         "commands": [
-            "golangci-lint run --timeout 2m0s",
+            "golangci-lint run --timeout 3m0s",
         ],
     }
 

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ litmus-test-new: build
 	pkill revad
 lint:
 	go run tools/check-license/check-license.go
-	`go env GOPATH`/bin/golangci-lint run --timeout 2m0s
+	`go env GOPATH`/bin/golangci-lint run --timeout 3m0s
 
 contrib:
 	git shortlog -se | cut -c8- | sort -u | awk '{print "-", $$0}' | grep -v 'users.noreply.github.com' > CONTRIBUTORS.md


### PR DESCRIPTION
This was done in edge branch in PRs #2576 and #2583 

Do it here in master also, to prevent CI fails like:
https://drone.cernbox.cern.ch/cs3org/reva/5884/4/5
```
level=error msg="Timeout exceeded: try increasing it by passing --timeout option"
```
