### PR TITLE
use shares api for space members

### DIFF
--- a/changelog/unreleased/use-share-api-spaces.md
+++ b/changelog/unreleased/use-share-api-spaces.md
@@ -1,0 +1,5 @@
+Change: Use the cs3 share api to manage spaces
+
+We now use the cs3 share Api to manage the space roles. We do not send the request to the share manager, the permissions are stored in the storage provider
+
+https://github.com/cs3org/reva/pull/2600

--- a/internal/grpc/services/gateway/ocmshareprovider.go
+++ b/internal/grpc/services/gateway/ocmshareprovider.go
@@ -54,7 +54,7 @@ func (s *svc) CreateOCMShare(ctx context.Context, req *ocm.CreateOCMShareRequest
 
 	// TODO(labkode): if both commits are enabled they could be done concurrently.
 	if s.c.CommitShareToStorageGrant {
-		addGrantStatus, err := s.addGrant(ctx, req.ResourceId, req.Grant.Grantee, req.Grant.Permissions.Permissions)
+		addGrantStatus, err := s.addGrant(ctx, req.ResourceId, req.Grant.Grantee, req.Grant.Permissions.Permissions, nil)
 		if err != nil {
 			return nil, errors.Wrap(err, "gateway: error adding OCM grant to storage")
 		}


### PR DESCRIPTION
# Description

- Use the CS3 Shares API to manage space permissions
- This replaces the implementation which was using the Grants Methods directly
- The grants methods are considered internal to the storage Providers https://github.com/cs3org/cs3apis/pull/165#issuecomment-1054054568