### PR TITLE
[Build-deps]: Fix archiver test mocks

### DIFF
--- a/internal/http/services/archiver/manager/archiver_test.go
+++ b/internal/http/services/archiver/manager/archiver_test.go
@@ -417,7 +417,7 @@ func TestCreateTar(t *testing.T) {
 				resources = append(resources, &provider.ResourceId{OpaqueId: path.Join(tmpdir, f)})
 			}
 
-			w := walkerMock.NewWalker()
+			w := walkerMock.NewWalker(tmpdir)
 			d := downMock.NewDownloader()
 
 			arch, err := NewArchiver(resources, w, d, tt.config)
@@ -865,7 +865,7 @@ func TestCreateZip(t *testing.T) {
 				resources = append(resources, &provider.ResourceId{OpaqueId: path.Join(tmpdir, f)})
 			}
 
-			w := walkerMock.NewWalker()
+			w := walkerMock.NewWalker(tmpdir)
 			d := downMock.NewDownloader()
 
 			arch, err := NewArchiver(resources, w, d, tt.config)


### PR DESCRIPTION
fixes the archiver tests on mac (they don't have `/tmp` but `/var/files/...`, which doesn't work with the current static shift path approach) 