### PR TITLE
trace: honour tracing_service_name config directive

### DIFF
--- a/changelog/unreleased/honour-tracing-service-name.md
+++ b/changelog/unreleased/honour-tracing-service-name.md
@@ -1,0 +1,3 @@
+Bugfix: respect the tracing_service_name config variable
+
+https://github.com/cs3org/reva/pull/2608

--- a/cmd/revad/runtime/runtime.go
+++ b/cmd/revad/runtime/runtime.go
@@ -149,7 +149,7 @@ func initServers(mainConf map[string]interface{}, log *zerolog.Logger) map[strin
 }
 
 func initTracing(conf *coreConf) {
-	rtrace.SetTraceProvider(conf.TracingCollector, conf.TracingEndpoint)
+	rtrace.SetTraceProvider(conf.TracingCollector, conf.TracingEndpoint, conf.TracingServiceName)
 }
 
 func initCPUCount(conf *coreConf, log *zerolog.Logger) {

--- a/docs/content/en/docs/config/packages/auth/manager/oidcmapping/_index.md
+++ b/docs/content/en/docs/config/packages/auth/manager/oidcmapping/_index.md
@@ -56,16 +56,8 @@ gatewaysvc = ""
 {{< /highlight >}}
 {{% /dir %}}
 
-{{% dir name="userprovidersvc" type="string" default="" %}}
-The endpoint at which the GRPC userprovider is exposed. [[Ref]](https://github.com/cs3org/reva/tree/master/pkg/auth/manager/oidcmapping/oidcmapping.go#L65)
-{{< highlight toml >}}
-[auth.manager.oidcmapping]
-userprovidersvc = ""
-{{< /highlight >}}
-{{% /dir %}}
-
 {{% dir name="users_mapping" type="string" default="" %}}
- The optional OIDC users mapping file path [[Ref]](https://github.com/cs3org/reva/tree/master/pkg/auth/manager/oidcmapping/oidcmapping.go#L66)
+ The optional OIDC users mapping file path [[Ref]](https://github.com/cs3org/reva/tree/master/pkg/auth/manager/oidcmapping/oidcmapping.go#L65)
 {{< highlight toml >}}
 [auth.manager.oidcmapping]
 users_mapping = ""
@@ -73,7 +65,7 @@ users_mapping = ""
 {{% /dir %}}
 
 {{% dir name="group_claim" type="string" default="" %}}
- The group claim to be looked up to map the user (default to 'groups'). [[Ref]](https://github.com/cs3org/reva/tree/master/pkg/auth/manager/oidcmapping/oidcmapping.go#L67)
+ The group claim to be looked up to map the user (default to 'groups'). [[Ref]](https://github.com/cs3org/reva/tree/master/pkg/auth/manager/oidcmapping/oidcmapping.go#L66)
 {{< highlight toml >}}
 [auth.manager.oidcmapping]
 group_claim = ""

--- a/pkg/trace/trace.go
+++ b/pkg/trace/trace.go
@@ -40,7 +40,12 @@ var (
 )
 
 // SetTraceProvider sets the TracerProvider at a package level.
-func SetTraceProvider(collectorEndpoint string, agentEndpoint string) {
+func SetTraceProvider(collectorEndpoint string, agentEndpoint, serviceName string) {
+	// default to 'reva' as service name if not set
+	if serviceName == "" {
+		serviceName = "reva"
+	}
+
 	var exp *jaeger.Exporter
 	var err error
 
@@ -75,7 +80,7 @@ func SetTraceProvider(collectorEndpoint string, agentEndpoint string) {
 		sdktrace.WithBatcher(exp),
 		sdktrace.WithResource(resource.NewWithAttributes(
 			semconv.SchemaURL,
-			semconv.ServiceNameKey.String("reva"),
+			semconv.ServiceNameKey.String(serviceName),
 		)),
 	)
 }


### PR DESCRIPTION
The already available `tracing_service_name` directive was not been honoured as the `reva` value was hardcoded.