### PR TITLE
fix token scope authentication

### DIFF
--- a/changelog/unreleased/scope-handling-spaces.md
+++ b/changelog/unreleased/scope-handling-spaces.md
@@ -1,0 +1,5 @@
+Bugfix: Adjust the scope handling to support the spaces architecture
+
+The scope authentication interceptors weren't updated to the spaces architecture and couldn't authenticate some requests.
+
+https://github.com/cs3org/reva/pull/2612

--- a/internal/grpc/interceptors/auth/scope.go
+++ b/internal/grpc/interceptors/auth/scope.go
@@ -182,7 +182,7 @@ func checkIfNestedResource(ctx context.Context, ref *provider.Reference, parent 
 	parentPath := statResponse.Info.Path
 
 	childPath := ref.GetPath()
-	if childPath == "" {
+	if childPath == "" || childPath == "." {
 		// We mint a token as the owner of the public share and try to stat the reference
 		// TODO(ishank011): We need to find a better alternative to this
 
@@ -201,14 +201,14 @@ func checkIfNestedResource(ctx context.Context, ref *provider.Reference, parent 
 		}
 		ctx = metadata.AppendToOutgoingContext(context.Background(), ctxpkg.TokenHeader, token)
 
-		childStat, err := client.Stat(ctx, &provider.StatRequest{Ref: ref})
+		gpRes, err := client.GetPath(ctx, &provider.GetPathRequest{ResourceId: ref.ResourceId})
 		if err != nil {
 			return false, err
 		}
-		if childStat.Status.Code != rpc.Code_CODE_OK {
-			return false, statuspkg.NewErrorFromCode(childStat.Status.Code, "auth interceptor")
+		if gpRes.Status.Code != rpc.Code_CODE_OK {
+			return false, statuspkg.NewErrorFromCode(gpRes.Status.Code, "auth interceptor")
 		}
-		childPath = statResponse.Info.Path
+		childPath = gpRes.Path
 	}
 
 	return strings.HasPrefix(childPath, parentPath), nil
@@ -219,6 +219,25 @@ func extractRef(req interface{}, hasEditorRole bool) (*provider.Reference, bool)
 	// Read requests
 	case *registry.GetStorageProvidersRequest:
 		return v.GetRef(), true
+	case *registry.ListStorageProvidersRequest:
+		ref := &provider.Reference{}
+		if v.Opaque != nil && v.Opaque.Map != nil {
+			if e, ok := v.Opaque.Map["storage_id"]; ok {
+				ref.ResourceId = &provider.ResourceId{
+					StorageId: string(e.Value),
+				}
+			}
+			if e, ok := v.Opaque.Map["opaque_id"]; ok {
+				if ref.ResourceId == nil {
+					ref.ResourceId = &provider.ResourceId{}
+				}
+				ref.ResourceId.OpaqueId = string(e.Value)
+			}
+			if e, ok := v.Opaque.Map["path"]; ok {
+				ref.Path = string(e.Value)
+			}
+		}
+		return ref, true
 	case *provider.StatRequest:
 		return v.GetRef(), true
 	case *provider.ListContainerRequest:

--- a/pkg/auth/scope/publicshare.go
+++ b/pkg/auth/scope/publicshare.go
@@ -108,6 +108,8 @@ func publicshareScope(ctx context.Context, scope *authpb.Scope, resource interfa
 
 	case *userv1beta1.GetUserByClaimRequest:
 		return true, nil
+	case *userv1beta1.GetUserRequest:
+		return true, nil
 
 	case *provider.ListStorageSpacesRequest:
 		return checkPublicListStorageSpacesFilter(v.Filters), nil


### PR DESCRIPTION
The scope authentication interceptors weren't updated to the spaces architecture and couldn't authenticate some requests.
E.g. this fixes the archive downloads in public links.