### PR TITLE
add etag to spaces response

### DIFF
--- a/changelog/unreleased/spaces-etags.md
+++ b/changelog/unreleased/spaces-etags.md
@@ -1,0 +1,5 @@
+Enhancement: add etag to spaces response
+
+Added the spaces etag to the response when listing spaces.
+
+https://github.com/cs3org/reva/pull/2616


### PR DESCRIPTION
Added the spaces etag to the response when listing spaces.
The clients need the etag in the list drives response. This is the preparation on the reva side for this.