### PR TITLE
Send events only if StatusCode is `OK`

### DIFF
--- a/changelog/unreleased/send-events-only-if-ok.md
+++ b/changelog/unreleased/send-events-only-if-ok.md
@@ -1,0 +1,5 @@
+Bugfix: send events only if response code is `OK`
+
+Before events middleware was sending events also when the resulting status code was not `OK`. This is clearly a bug.
+
+https://github.com/cs3org/reva/pull/2621

--- a/internal/grpc/interceptors/eventsmiddleware/events.go
+++ b/internal/grpc/interceptors/eventsmiddleware/events.go
@@ -26,6 +26,7 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/asim/go-micro/plugins/events/nats/v4"
+	rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
 	collaboration "github.com/cs3org/go-cs3apis/cs3/sharing/collaboration/v1beta1"
 	"github.com/cs3org/reva/v2/pkg/events"
 	"github.com/cs3org/reva/v2/pkg/events/server"
@@ -58,7 +59,9 @@ func NewUnary(m map[string]interface{}) (grpc.UnaryServerInterceptor, int, error
 		var ev interface{}
 		switch v := res.(type) {
 		case *collaboration.CreateShareResponse:
-			ev = ShareCreated(v)
+			if v.Status.Code == rpc.Code_CODE_OK {
+				ev = ShareCreated(v)
+			}
 		}
 
 		if ev != nil {

--- a/pkg/events/example/example.go
+++ b/pkg/events/example/example.go
@@ -61,7 +61,7 @@ func Server() {
 
 // Client builds a nats client
 func Client() events.Stream {
-	c, err := server.NewNatsStream(nats.Address("127.0.0.1:4222"), nats.ClusterID("test-cluster"))
+	c, err := server.NewNatsStream(nats.Address("127.0.0.1:9233"), nats.ClusterID("test-cluster"))
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
Until now it was sending events regardless of response status. This is clearly a bug