### PR TITLE
implement listing shares in spaces

### DIFF
--- a/changelog/unreleased/sharing-in-spaces.md
+++ b/changelog/unreleased/sharing-in-spaces.md
@@ -1,0 +1,5 @@
+Enhancement: Allow listing shares in spaces via the OCS API
+
+Added a `space_ref` parameter to the list shares endpoints so that one can list shares inside of spaces.
+
+https://github.com/cs3org/reva/pull/2622

--- a/internal/http/services/owncloud/ocs/response/response.go
+++ b/internal/http/services/owncloud/ocs/response/response.go
@@ -150,7 +150,11 @@ func WriteOCSData(w http.ResponseWriter, r *http.Request, m Meta, d interface{},
 // WriteOCSResponse handles writing ocs responses in json and xml
 func WriteOCSResponse(w http.ResponseWriter, r *http.Request, res Response, err error) {
 	if err != nil {
-		appctx.GetLogger(r.Context()).Error().Err(err).Msg(res.OCS.Meta.Message)
+		appctx.GetLogger(r.Context()).
+			Debug().
+			Err(err).
+			Str("ocs_msg", res.OCS.Meta.Message).
+			Msg("writing ocs error response")
 	}
 
 	version := APIVersion(r.Context())

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -42,6 +42,10 @@ import (
 	"google.golang.org/protobuf/encoding/protojson"
 )
 
+const (
+	spaceIDDelimiter = "!"
+)
+
 var (
 	matchFirstCap = regexp.MustCompile("(.)([A-Z][a-z]+)")
 	matchAllCap   = regexp.MustCompile("([a-z0-9])([A-Z])")
@@ -58,6 +62,8 @@ var (
 
 	// SpaceGrant is used to signal the storageprovider that the grant is on a space
 	SpaceGrant struct{}
+
+	errInvalidSpaceReference = errors.New("invalid storage space reference")
 )
 
 // Skip  evaluates whether a source endpoint contains any of the prefixes.
@@ -326,7 +332,7 @@ func SplitStorageSpaceID(ssid string) (storageid, nodeid string, err error) {
 	if ssid == "" {
 		return "", "", errors.New("can't split empty StorageSpaceID")
 	}
-	parts := strings.SplitN(ssid, "!", 2)
+	parts := strings.SplitN(ssid, spaceIDDelimiter, 2)
 	if len(parts) == 1 {
 		return parts[0], parts[0], nil
 	}
@@ -355,6 +361,35 @@ func ParseStorageSpaceReference(sRef string) (provider.Reference, error) {
 		},
 		Path: MakeRelativePath(relPath),
 	}, nil
+}
+
+// FormatStorageSpaceReference will format a storage space reference into a string representation.
+// If ref or ref.ResourceId are nil an empty string will be returned.
+// The function doesn't check if all values are set.
+// The resulting format can be:
+//
+// "storage_id!opaque_id"
+// "storage_id!opaque_id/path"
+// "storage_id/path"
+// "storage_id"
+func FormatStorageSpaceReference(ref *provider.Reference) (string, error) {
+	if ref == nil || ref.ResourceId == nil || ref.ResourceId.StorageId == "" {
+		return "", errInvalidSpaceReference
+	}
+	var ssid string
+	if ref.ResourceId.OpaqueId == "" {
+
+		ssid = ref.ResourceId.StorageId
+	} else {
+		var sb strings.Builder
+		// ssid == storage_id!opaque_id
+		sb.Grow(len(ref.ResourceId.StorageId) + len(ref.ResourceId.OpaqueId) + 1)
+		sb.WriteString(ref.ResourceId.StorageId)
+		sb.WriteString(spaceIDDelimiter)
+		sb.WriteString(ref.ResourceId.OpaqueId)
+		ssid = sb.String()
+	}
+	return path.Join(ssid, ref.Path), nil
 }
 
 // GetViewMode converts a human-readable string to a view mode for opening a resource in an app.

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -364,7 +364,7 @@ func ParseStorageSpaceReference(sRef string) (provider.Reference, error) {
 }
 
 // FormatStorageSpaceReference will format a storage space reference into a string representation.
-// If ref or ref.ResourceId are nil an empty string will be returned.
+// If ref or ref.ResourceId are nil an error will be returned.
 // The function doesn't check if all values are set.
 // The resulting format can be:
 //

--- a/tests/oc-integration-tests/local/ldap-users.toml
+++ b/tests/oc-integration-tests/local/ldap-users.toml
@@ -16,7 +16,7 @@ address = "0.0.0.0:18000"
 auth_manager = "ldap"
 
 [grpc.services.authprovider.auth_managers.ldap]
-hostname="ldap"
+hostname="localhost"
 port=636
 insecure=true
 base_dn="dc=owncloud,dc=com"
@@ -34,7 +34,7 @@ cn="cn"
 driver = "ldap"
 
 [grpc.services.userprovider.drivers.ldap]
-hostname="ldap"
+hostname="localhost"
 port=636
 insecure=true
 base_dn="dc=owncloud,dc=com"
@@ -57,7 +57,7 @@ gid="entryuuid"
 driver = "ldap"
 
 [grpc.services.groupprovider.drivers.ldap]
-hostname="ldap"
+hostname="localhost"
 port=636
 insecure=true
 base_dn="dc=owncloud,dc=com"


### PR DESCRIPTION
Instead of the query parameter `path` one can now send `space_ref` to
list shares in spaces. The URL would look like this:
`https://localhost:9200/ocs/v1.php/apps/files_sharing/api/v1/shares?reshares=true&space_ref=ae96eb17-1b37-4bfc-8ed6-9c044723a43f/elmo.gif`
The difference to the 'old' URL is the parameter `space_ref` instead of the `path` parameter.
`path` is always assumed to be relative to the users home and `space_ref` is the combined spaceid and the path relative to the space root.