### PR TITLE
Locking fixes

### DIFF
--- a/changelog/unreleased/fix-locking.md
+++ b/changelog/unreleased/fix-locking.md
@@ -1,0 +1,12 @@
+Bugfix: Fix locking on publik links and the decomposed filesystem
+
+We've fixed the behavior of locking on the decomposed filesystem, so that now
+users can remove a lock which was initially created by another user (needed for WOPI integration).
+Also we added a check, if a lock is already expired and if so, we lazily delete the lock.
+The InitiateUploadRequest now adds the Lock to the upload metadata so that an upload to an
+locked file is possible.
+
+We'v added the locking api requests to the public link scope checks, so that locking
+also can be used on public links (needed for WOPI integration).
+
+https://github.com/cs3org/reva/pull/2625

--- a/changelog/unreleased/fix-locking.md
+++ b/changelog/unreleased/fix-locking.md
@@ -1,7 +1,7 @@
 Bugfix: Fix locking on publik links and the decomposed filesystem
 
 We've fixed the behavior of locking on the decomposed filesystem, so that now
-users can remove a lock which was initially created by another user (needed for WOPI integration).
+app based locks can be modified user independently (needed for WOPI integration).
 Also we added a check, if a lock is already expired and if so, we lazily delete the lock.
 The InitiateUploadRequest now adds the Lock to the upload metadata so that an upload to an
 locked file is possible.

--- a/internal/grpc/interceptors/auth/scope.go
+++ b/internal/grpc/interceptors/auth/scope.go
@@ -164,8 +164,6 @@ func expandAndVerifyScope(ctx context.Context, req interface{}, tokenScope map[s
 				}
 			}
 		}
-	} else if _, ok := listStorageSpaces(req); ok {
-		return nil
 	}
 
 	return errtypes.PermissionDenied("access to resource not allowed within the assigned scope")
@@ -289,17 +287,4 @@ func extractShareRef(req interface{}) (*collaboration.ShareReference, bool) {
 		return &collaboration.ShareReference{Spec: &collaboration.ShareReference_Id{Id: v.GetShare().GetShare().GetId()}}, true
 	}
 	return nil, false
-}
-
-func listStorageSpaces(req interface{}) (*provider.ListStorageSpacesRequest, bool) {
-	switch req.(type) {
-	case *provider.ListStorageSpacesRequest:
-		// TODO: checks
-		return nil, true
-	case *registry.ListStorageProvidersRequest:
-		// TODO: checks
-		return nil, true
-	default:
-		return nil, false
-	}
 }

--- a/internal/grpc/interceptors/auth/scope.go
+++ b/internal/grpc/interceptors/auth/scope.go
@@ -244,14 +244,14 @@ func extractRef(req interface{}, hasEditorRole bool) (*provider.Reference, bool)
 		return v.GetRef(), true
 	case *provider.InitiateFileDownloadRequest:
 		return v.GetRef(), true
+
+	// App provider requests
+	case *appregistry.GetAppProvidersRequest:
+		return &provider.Reference{ResourceId: v.ResourceInfo.Id, Path: v.ResourceInfo.Path}, true
 	case *appprovider.OpenInAppRequest:
-		return &provider.Reference{ResourceId: v.ResourceInfo.Id, Path: "."}, true
+		return &provider.Reference{ResourceId: v.ResourceInfo.Id, Path: v.ResourceInfo.Path}, true
 	case *gateway.OpenInAppRequest:
 		return v.GetRef(), true
-
-		// App provider requests
-	case *appregistry.GetAppProvidersRequest:
-		return &provider.Reference{ResourceId: v.ResourceInfo.Id, Path: "."}, true
 	}
 
 	if !hasEditorRole {

--- a/internal/grpc/interceptors/auth/scope.go
+++ b/internal/grpc/interceptors/auth/scope.go
@@ -245,6 +245,16 @@ func extractRef(req interface{}, hasEditorRole bool) (*provider.Reference, bool)
 	case *provider.InitiateFileDownloadRequest:
 		return v.GetRef(), true
 
+	// Locking
+	case *provider.GetLockRequest:
+		return v.GetRef(), true
+	case *provider.SetLockRequest:
+		return v.GetRef(), true
+	case *provider.RefreshLockRequest:
+		return v.GetRef(), true
+	case *provider.UnlockRequest:
+		return v.GetRef(), true
+
 	// App provider requests
 	case *appregistry.GetAppProvidersRequest:
 		return &provider.Reference{ResourceId: v.ResourceInfo.Id, Path: v.ResourceInfo.Path}, true

--- a/internal/grpc/interceptors/auth/scope.go
+++ b/internal/grpc/interceptors/auth/scope.go
@@ -164,6 +164,8 @@ func expandAndVerifyScope(ctx context.Context, req interface{}, tokenScope map[s
 				}
 			}
 		}
+	} else if _, ok := listStorageSpaces(req); ok {
+		return nil
 	}
 
 	return errtypes.PermissionDenied("access to resource not allowed within the assigned scope")
@@ -245,13 +247,13 @@ func extractRef(req interface{}, hasEditorRole bool) (*provider.Reference, bool)
 	case *provider.InitiateFileDownloadRequest:
 		return v.GetRef(), true
 	case *appprovider.OpenInAppRequest:
-		return &provider.Reference{ResourceId: v.ResourceInfo.Id}, true
+		return &provider.Reference{ResourceId: v.ResourceInfo.Id, Path: "."}, true
 	case *gateway.OpenInAppRequest:
 		return v.GetRef(), true
 
 		// App provider requests
 	case *appregistry.GetAppProvidersRequest:
-		return &provider.Reference{ResourceId: v.ResourceInfo.Id}, true
+		return &provider.Reference{ResourceId: v.ResourceInfo.Id, Path: "."}, true
 	}
 
 	if !hasEditorRole {
@@ -287,4 +289,17 @@ func extractShareRef(req interface{}) (*collaboration.ShareReference, bool) {
 		return &collaboration.ShareReference{Spec: &collaboration.ShareReference_Id{Id: v.GetShare().GetShare().GetId()}}, true
 	}
 	return nil, false
+}
+
+func listStorageSpaces(req interface{}) (*provider.ListStorageSpacesRequest, bool) {
+	switch req.(type) {
+	case *provider.ListStorageSpacesRequest:
+		// TODO: checks
+		return nil, true
+	case *registry.ListStorageProvidersRequest:
+		// TODO: checks
+		return nil, true
+	default:
+		return nil, false
+	}
 }

--- a/internal/grpc/services/publicstorageprovider/publicstorageprovider.go
+++ b/internal/grpc/services/publicstorageprovider/publicstorageprovider.go
@@ -120,22 +120,58 @@ func (s *service) UnsetArbitraryMetadata(ctx context.Context, req *provider.Unse
 
 // SetLock puts a lock on the given reference
 func (s *service) SetLock(ctx context.Context, req *provider.SetLockRequest) (*provider.SetLockResponse, error) {
-	return nil, gstatus.Errorf(codes.Unimplemented, "method not implemented")
+	ref, _, _, st, err := s.translatePublicRefToCS3Ref(ctx, req.Ref)
+	switch {
+	case err != nil:
+		return nil, err
+	case st != nil:
+		return &provider.SetLockResponse{
+			Status: st,
+		}, nil
+	}
+	return s.gateway.SetLock(ctx, &provider.SetLockRequest{Opaque: req.Opaque, Ref: ref, Lock: req.Lock})
 }
 
 // GetLock returns an existing lock on the given reference
 func (s *service) GetLock(ctx context.Context, req *provider.GetLockRequest) (*provider.GetLockResponse, error) {
-	return nil, gstatus.Errorf(codes.Unimplemented, "method not implemented")
+	ref, _, _, st, err := s.translatePublicRefToCS3Ref(ctx, req.Ref)
+	switch {
+	case err != nil:
+		return nil, err
+	case st != nil:
+		return &provider.GetLockResponse{
+			Status: st,
+		}, nil
+	}
+	return s.gateway.GetLock(ctx, &provider.GetLockRequest{Opaque: req.Opaque, Ref: ref})
 }
 
 // RefreshLock refreshes an existing lock on the given reference
 func (s *service) RefreshLock(ctx context.Context, req *provider.RefreshLockRequest) (*provider.RefreshLockResponse, error) {
-	return nil, gstatus.Errorf(codes.Unimplemented, "method not implemented")
+	ref, _, _, st, err := s.translatePublicRefToCS3Ref(ctx, req.Ref)
+	switch {
+	case err != nil:
+		return nil, err
+	case st != nil:
+		return &provider.RefreshLockResponse{
+			Status: st,
+		}, nil
+	}
+	return s.gateway.RefreshLock(ctx, &provider.RefreshLockRequest{Opaque: req.Opaque, Ref: ref, Lock: req.Lock})
 }
 
 // Unlock removes an existing lock from the given reference
 func (s *service) Unlock(ctx context.Context, req *provider.UnlockRequest) (*provider.UnlockResponse, error) {
-	return nil, gstatus.Errorf(codes.Unimplemented, "method not implemented")
+	ref, _, _, st, err := s.translatePublicRefToCS3Ref(ctx, req.Ref)
+	switch {
+	case err != nil:
+		return nil, err
+	case st != nil:
+		return &provider.UnlockResponse{
+			Status: st,
+		}, nil
+	}
+	return s.gateway.Unlock(ctx, &provider.UnlockRequest{Opaque: req.Opaque, Ref: ref, Lock: req.Lock})
 }
 
 func (s *service) InitiateFileDownload(ctx context.Context, req *provider.InitiateFileDownloadRequest) (*provider.InitiateFileDownloadResponse, error) {

--- a/internal/http/services/appprovider/appprovider.go
+++ b/internal/http/services/appprovider/appprovider.go
@@ -349,6 +349,7 @@ func (s *svc) handleOpen(w http.ResponseWriter, r *http.Request) {
 
 	fileRef := &provider.Reference{
 		ResourceId: resourceID,
+		Path:       ".",
 	}
 
 	statRes, err := client.Stat(ctx, &provider.StatRequest{Ref: fileRef})

--- a/internal/http/services/owncloud/ocdav/locks.go
+++ b/internal/http/services/owncloud/ocdav/locks.go
@@ -220,10 +220,13 @@ func (cls *cs3LS) Refresh(ctx context.Context, now time.Time, token string, dura
 	return LockDetails{}, errors.ErrNotImplemented
 }
 func (cls *cs3LS) Unlock(ctx context.Context, now time.Time, ref *provider.Reference, token string) error {
+	u := ctxpkg.ContextMustGetUser(ctx)
+
 	r := &provider.UnlockRequest{
 		Ref: ref,
 		Lock: &provider.Lock{
 			LockId: token, // can be a token or a Coded-URL
+			User:   u.Id,
 		},
 	}
 	res, err := cls.client.Unlock(ctx, r)

--- a/pkg/auth/scope/publicshare.go
+++ b/pkg/auth/scope/publicshare.go
@@ -77,6 +77,18 @@ func publicshareScope(ctx context.Context, scope *authpb.Scope, resource interfa
 		return checkStorageRef(ctx, &share, &provider.Reference{ResourceId: v.GetResourceId()}), nil
 	case *provider.StatRequest:
 		return checkStorageRef(ctx, &share, v.GetRef()), nil
+	case *provider.GetLockRequest:
+		return true, nil
+		//return checkStorageRef(ctx, &share, v.GetRef()), nil
+	case *provider.UnlockRequest:
+		return true, nil
+		//return checkStorageRef(ctx, &share, v.GetRef()), nil
+	case *provider.RefreshLockRequest:
+		return true, nil
+		//return checkStorageRef(ctx, &share, v.GetRef()), nil
+	case *provider.SetLockRequest:
+		return true, nil
+		//return checkStorageRef(ctx, &share, v.GetRef()), nil
 	case *provider.ListContainerRequest:
 		return checkStorageRef(ctx, &share, v.GetRef()), nil
 	case *provider.InitiateFileDownloadRequest:
@@ -109,6 +121,8 @@ func publicshareScope(ctx context.Context, scope *authpb.Scope, resource interfa
 	case *appregistry.GetDefaultAppProviderForMimeTypeRequest:
 		return true, nil
 
+	case *appregistry.GetAppProvidersRequest:
+		return true, nil
 	case *userv1beta1.GetUserByClaimRequest:
 		return true, nil
 	case *userv1beta1.GetUserRequest:

--- a/pkg/auth/scope/publicshare.go
+++ b/pkg/auth/scope/publicshare.go
@@ -78,17 +78,13 @@ func publicshareScope(ctx context.Context, scope *authpb.Scope, resource interfa
 	case *provider.StatRequest:
 		return checkStorageRef(ctx, &share, v.GetRef()), nil
 	case *provider.GetLockRequest:
-		return true, nil
-		//return checkStorageRef(ctx, &share, v.GetRef()), nil
+		return checkStorageRef(ctx, &share, v.GetRef()), nil
 	case *provider.UnlockRequest:
-		return true, nil
-		//return checkStorageRef(ctx, &share, v.GetRef()), nil
+		return checkStorageRef(ctx, &share, v.GetRef()), nil
 	case *provider.RefreshLockRequest:
-		return true, nil
-		//return checkStorageRef(ctx, &share, v.GetRef()), nil
+		return checkStorageRef(ctx, &share, v.GetRef()), nil
 	case *provider.SetLockRequest:
-		return true, nil
-		//return checkStorageRef(ctx, &share, v.GetRef()), nil
+		return checkStorageRef(ctx, &share, v.GetRef()), nil
 	case *provider.ListContainerRequest:
 		return checkStorageRef(ctx, &share, v.GetRef()), nil
 	case *provider.InitiateFileDownloadRequest:

--- a/pkg/rhttp/datatx/manager/simple/simple.go
+++ b/pkg/rhttp/datatx/manager/simple/simple.go
@@ -23,6 +23,7 @@ import (
 
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	"github.com/cs3org/reva/v2/pkg/appctx"
+	ctxpkg "github.com/cs3org/reva/v2/pkg/ctx"
 	"github.com/cs3org/reva/v2/pkg/errtypes"
 	"github.com/cs3org/reva/v2/pkg/rhttp/datatx"
 	"github.com/cs3org/reva/v2/pkg/rhttp/datatx/manager/registry"
@@ -64,6 +65,11 @@ func New(m map[string]interface{}) (datatx.DataTX, error) {
 func (m *manager) Handler(fs storage.FS) (http.Handler, error) {
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
+
+		if lockID := r.Header.Get("X-Lock-Id"); lockID != "" {
+			ctx = ctxpkg.ContextSetLockID(ctx, lockID)
+		}
+
 		sublog := appctx.GetLogger(ctx).With().Str("datatx", "simple").Logger()
 
 		switch r.Method {

--- a/pkg/rhttp/datatx/manager/simple/simple.go
+++ b/pkg/rhttp/datatx/manager/simple/simple.go
@@ -23,7 +23,6 @@ import (
 
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	"github.com/cs3org/reva/v2/pkg/appctx"
-	ctxpkg "github.com/cs3org/reva/v2/pkg/ctx"
 	"github.com/cs3org/reva/v2/pkg/errtypes"
 	"github.com/cs3org/reva/v2/pkg/rhttp/datatx"
 	"github.com/cs3org/reva/v2/pkg/rhttp/datatx/manager/registry"
@@ -65,11 +64,6 @@ func New(m map[string]interface{}) (datatx.DataTX, error) {
 func (m *manager) Handler(fs storage.FS) (http.Handler, error) {
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
-
-		if lockID := r.Header.Get("X-Lock-Id"); lockID != "" {
-			ctx = ctxpkg.ContextSetLockID(ctx, lockID)
-		}
-
 		sublog := appctx.GetLogger(ctx).With().Str("datatx", "simple").Logger()
 
 		switch r.Method {

--- a/pkg/rhttp/datatx/manager/spaces/spaces.go
+++ b/pkg/rhttp/datatx/manager/spaces/spaces.go
@@ -25,7 +25,6 @@ import (
 
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	"github.com/cs3org/reva/v2/pkg/appctx"
-	ctxpkg "github.com/cs3org/reva/v2/pkg/ctx"
 	"github.com/cs3org/reva/v2/pkg/errtypes"
 	"github.com/cs3org/reva/v2/pkg/rhttp/datatx"
 	"github.com/cs3org/reva/v2/pkg/rhttp/datatx/manager/registry"
@@ -69,11 +68,6 @@ func New(m map[string]interface{}) (datatx.DataTX, error) {
 func (m *manager) Handler(fs storage.FS) (http.Handler, error) {
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
-
-		if lockID := r.Header.Get("X-Lock-Id"); lockID != "" {
-			ctx = ctxpkg.ContextSetLockID(ctx, lockID)
-		}
-
 		var spaceID string
 		spaceID, r.URL.Path = router.ShiftPath(r.URL.Path)
 

--- a/pkg/rhttp/datatx/manager/spaces/spaces.go
+++ b/pkg/rhttp/datatx/manager/spaces/spaces.go
@@ -25,6 +25,7 @@ import (
 
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	"github.com/cs3org/reva/v2/pkg/appctx"
+	ctxpkg "github.com/cs3org/reva/v2/pkg/ctx"
 	"github.com/cs3org/reva/v2/pkg/errtypes"
 	"github.com/cs3org/reva/v2/pkg/rhttp/datatx"
 	"github.com/cs3org/reva/v2/pkg/rhttp/datatx/manager/registry"
@@ -68,6 +69,10 @@ func New(m map[string]interface{}) (datatx.DataTX, error) {
 func (m *manager) Handler(fs storage.FS) (http.Handler, error) {
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
+
+		if lockID := r.Header.Get("X-Lock-Id"); lockID != "" {
+			ctx = ctxpkg.ContextSetLockID(ctx, lockID)
+		}
 
 		var spaceID string
 		spaceID, r.URL.Path = router.ShiftPath(r.URL.Path)

--- a/pkg/storage/utils/decomposedfs/node/locks.go
+++ b/pkg/storage/utils/decomposedfs/node/locks.go
@@ -129,7 +129,7 @@ func (n Node) ReadLock(ctx context.Context) (*provider.Lock, error) {
 			return nil, errors.Wrap(err, "Decomposedfs: could not remove expired lock file")
 		}
 		// we successfully deleted the expired lock
-		return nil, nil
+		return nil, errtypes.NotFound("no lock found")
 	}
 
 	return lock, nil

--- a/pkg/storage/utils/decomposedfs/node/locks.go
+++ b/pkg/storage/utils/decomposedfs/node/locks.go
@@ -123,14 +123,15 @@ func (n Node) ReadLock(ctx context.Context) (*provider.Lock, error) {
 	}
 
 	// lock already expired
-	if time.Now().After(time.Unix(int64(lock.Expiration.Seconds), int64(lock.Expiration.Nanos))) {
+	if lock.Expiration != nil && time.Now().After(time.Unix(int64(lock.Expiration.Seconds), int64(lock.Expiration.Nanos))) {
 		if err = os.Remove(f.Name()); err != nil {
 			return nil, errors.Wrap(err, "Decomposedfs: could not remove expired lock file")
 		}
+		// we successfully deleted the expired lock
 		return nil, nil
 	}
 
-	return lock, err
+	return lock, nil
 }
 
 // RefreshLock refreshes the node's lock

--- a/pkg/storage/utils/decomposedfs/node/locks.go
+++ b/pkg/storage/utils/decomposedfs/node/locks.go
@@ -329,7 +329,6 @@ func isLockModificationAllowed(ctx context.Context, oldLock *provider.Lock, newL
 
 	if oldLock.User != nil || newLock.GetUser() != nil {
 		lockUserEquals = utils.UserEqual(oldLock.User, newLock.GetUser())
-		//err = errtypes.PermissionDenied("cannot change holder (user) when refreshing a lock")
 
 		u := ctxpkg.ContextMustGetUser(ctx)
 		contextUserEquals = utils.UserEqual(oldLock.User, u.Id)
@@ -359,9 +358,9 @@ func isLockModificationAllowed(ctx context.Context, oldLock *provider.Lock, newL
 
 	for i, reason := range denialReasons {
 		if i != 0 && i != len(denialReasons)-1 {
-			errMsg = errMsg + ", "
+			errMsg += ", "
 		}
-		errMsg = errMsg + reason
+		errMsg += reason
 	}
 
 	return false, errtypes.PermissionDenied(errMsg)

--- a/pkg/storage/utils/decomposedfs/node/locks_test.go
+++ b/pkg/storage/utils/decomposedfs/node/locks_test.go
@@ -158,20 +158,18 @@ var _ = Describe("Node locks", func() {
 				Expect(err.Error()).To(ContainSubstring("mismatching"))
 			})
 
-			It("refuses to refresh the lock for other users than the lock holder", func() {
+			It("refreshes the lock for other users than the lock holder", func() {
 				err := n.RefreshLock(otherCtx, newLock)
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("permission denied"))
+				Expect(err).NotTo(HaveOccurred())
 			})
 
-			It("refuses to change the lock holder", func() {
+			It("changes the lock holder", func() {
 				newLock.User = otherUser.Id
 				err := n.RefreshLock(env.Ctx, newLock)
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("permission denied"))
+				Expect(err).NotTo(HaveOccurred())
 			})
 
-			It("refreshes the lock", func() {
+			It("refreshes the lock for the original user", func() {
 				err := n.RefreshLock(env.Ctx, newLock)
 				Expect(err).ToNot(HaveOccurred())
 			})
@@ -191,10 +189,9 @@ var _ = Describe("Node locks", func() {
 				Expect(err.Error()).To(ContainSubstring(lock.LockId))
 			})
 
-			It("refuses to unlock for others even if they have the lock", func() {
+			It("unlocks when other another user uses the lock", func() {
 				err := n.Unlock(otherCtx, lock)
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("mismatching"))
+				Expect(err).NotTo(HaveOccurred())
 			})
 
 			It("unlocks when the owner uses the lock", func() {

--- a/pkg/storage/utils/decomposedfs/node/locks_test.go
+++ b/pkg/storage/utils/decomposedfs/node/locks_test.go
@@ -37,10 +37,12 @@ var _ = Describe("Node locks", func() {
 	var (
 		env *helpers.TestEnv
 
-		lock      *provider.Lock
-		wrongLock *provider.Lock
-		n         *node.Node
-		n2        *node.Node
+		lockByUser      *provider.Lock
+		wrongLockByUser *provider.Lock
+		lockByApp       *provider.Lock
+		wrongLockByApp  *provider.Lock
+		n               *node.Node
+		n2              *node.Node
 
 		otherUser = &userpb.User{
 			Id: &userpb.UserId{
@@ -58,15 +60,25 @@ var _ = Describe("Node locks", func() {
 		env, err = helpers.NewTestEnv(nil)
 		Expect(err).ToNot(HaveOccurred())
 
-		lock = &provider.Lock{
+		lockByUser = &provider.Lock{
 			Type:   provider.LockType_LOCK_TYPE_EXCL,
 			User:   env.Owner.Id,
 			LockId: uuid.New().String(),
 		}
-		wrongLock = &provider.Lock{
+		wrongLockByUser = &provider.Lock{
 			Type:   provider.LockType_LOCK_TYPE_EXCL,
 			User:   env.Owner.Id,
 			LockId: uuid.New().String(),
+		}
+		lockByApp = &provider.Lock{
+			Type:    provider.LockType_LOCK_TYPE_WRITE,
+			AppName: "app1",
+			LockId:  uuid.New().String(),
+		}
+		wrongLockByApp = &provider.Lock{
+			Type:    provider.LockType_LOCK_TYPE_WRITE,
+			AppName: "app2",
+			LockId:  uuid.New().String(),
 		}
 		n = node.New("u-s-e-r-id", "tobelockedid", "", "tobelocked", 10, "", env.Owner.Id, env.Lookup)
 		n2 = node.New("u-s-e-r-id", "neverlockedid", "", "neverlocked", 10, "", env.Owner.Id, env.Lookup)
@@ -78,12 +90,12 @@ var _ = Describe("Node locks", func() {
 		}
 	})
 
-	Describe("SetLock", func() {
+	Describe("SetLock for a user", func() {
 		It("sets the lock", func() {
 			_, err := os.Stat(n.LockFilePath())
 			Expect(err).To(HaveOccurred())
 
-			err = n.SetLock(env.Ctx, lock)
+			err = n.SetLock(env.Ctx, lockByUser)
 			Expect(err).ToNot(HaveOccurred())
 
 			_, err = os.Stat(n.LockFilePath())
@@ -91,30 +103,64 @@ var _ = Describe("Node locks", func() {
 		})
 
 		It("refuses to lock if already locked an existing lock was not provided", func() {
-			err := n.SetLock(env.Ctx, lock)
+			err := n.SetLock(env.Ctx, lockByUser)
 			Expect(err).ToNot(HaveOccurred())
 
-			err = n.SetLock(env.Ctx, lock)
+			err = n.SetLock(env.Ctx, lockByUser)
 			Expect(err).To(HaveOccurred())
 
-			env.Ctx = ctxpkg.ContextSetLockID(env.Ctx, wrongLock.LockId)
-			err = n.SetLock(env.Ctx, lock)
+			env.Ctx = ctxpkg.ContextSetLockID(env.Ctx, wrongLockByUser.LockId)
+			err = n.SetLock(env.Ctx, lockByUser)
 			Expect(err).To(HaveOccurred())
 		})
 
 		It("relocks if the existing lock was provided", func() {
-			err := n.SetLock(env.Ctx, lock)
+			err := n.SetLock(env.Ctx, lockByUser)
 			Expect(err).ToNot(HaveOccurred())
 
-			env.Ctx = ctxpkg.ContextSetLockID(env.Ctx, lock.LockId)
-			err = n.SetLock(env.Ctx, lock)
+			env.Ctx = ctxpkg.ContextSetLockID(env.Ctx, lockByUser.LockId)
+			err = n.SetLock(env.Ctx, lockByUser)
 			Expect(err).ToNot(HaveOccurred())
 		})
 	})
 
-	Context("with an existing lock", func() {
+	Describe("SetLock for an app", func() {
+		It("sets the lock", func() {
+			_, err := os.Stat(n.LockFilePath())
+			Expect(err).To(HaveOccurred())
+
+			err = n.SetLock(env.Ctx, lockByApp)
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = os.Stat(n.LockFilePath())
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("refuses to lock if already locked an existing lock was not provided", func() {
+			err := n.SetLock(env.Ctx, lockByApp)
+			Expect(err).ToNot(HaveOccurred())
+
+			err = n.SetLock(env.Ctx, lockByApp)
+			Expect(err).To(HaveOccurred())
+
+			env.Ctx = ctxpkg.ContextSetLockID(env.Ctx, wrongLockByApp.LockId)
+			err = n.SetLock(env.Ctx, lockByApp)
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("relocks if the existing lock was provided", func() {
+			err := n.SetLock(env.Ctx, lockByApp)
+			Expect(err).ToNot(HaveOccurred())
+
+			env.Ctx = ctxpkg.ContextSetLockID(env.Ctx, lockByApp.LockId)
+			err = n.SetLock(env.Ctx, lockByApp)
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	Context("with an existing lock for a user", func() {
 		BeforeEach(func() {
-			err := n.SetLock(env.Ctx, lock)
+			err := n.SetLock(env.Ctx, lockByUser)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -122,10 +168,10 @@ var _ = Describe("Node locks", func() {
 			It("returns the lock", func() {
 				l, err := n.ReadLock(env.Ctx)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(l).To(Equal(lock))
+				Expect(l).To(Equal(lockByUser))
 			})
 
-			It("reporst an error when the node wasn't locked", func() {
+			It("reports an error when the node wasn't locked", func() {
 				_, err := n2.ReadLock(env.Ctx)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("no lock found"))
@@ -141,12 +187,12 @@ var _ = Describe("Node locks", func() {
 				newLock = &provider.Lock{
 					Type:   provider.LockType_LOCK_TYPE_EXCL,
 					User:   env.Owner.Id,
-					LockId: lock.LockId,
+					LockId: lockByUser.LockId,
 				}
 			})
 
 			It("fails when the node is unlocked", func() {
-				err := n2.RefreshLock(env.Ctx, lock)
+				err := n2.RefreshLock(env.Ctx, lockByUser)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("precondition failed"))
 			})
@@ -158,18 +204,20 @@ var _ = Describe("Node locks", func() {
 				Expect(err.Error()).To(ContainSubstring("mismatching"))
 			})
 
-			It("refreshes the lock for other users than the lock holder", func() {
+			It("refuses to refresh the lock for other users than the lock holder", func() {
 				err := n.RefreshLock(otherCtx, newLock)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("permission denied"))
 			})
 
-			It("changes the lock holder", func() {
+			It("refuses to change the lock holder", func() {
 				newLock.User = otherUser.Id
 				err := n.RefreshLock(env.Ctx, newLock)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("permission denied"))
 			})
 
-			It("refreshes the lock for the original user", func() {
+			It("refreshes the lock", func() {
 				err := n.RefreshLock(env.Ctx, newLock)
 				Expect(err).ToNot(HaveOccurred())
 			})
@@ -178,24 +226,25 @@ var _ = Describe("Node locks", func() {
 		Describe("Unlock", func() {
 			It("refuses to unlock without having a lock", func() {
 				err := n.Unlock(env.Ctx, nil)
-				Expect(err.Error()).To(ContainSubstring(lock.LockId))
+				Expect(err.Error()).To(ContainSubstring(lockByUser.LockId))
 			})
 
 			It("refuses to unlock without having the proper lock", func() {
 				err := n.Unlock(env.Ctx, nil)
-				Expect(err.Error()).To(ContainSubstring(lock.LockId))
+				Expect(err.Error()).To(ContainSubstring(lockByUser.LockId))
 
-				err = n.Unlock(env.Ctx, wrongLock)
-				Expect(err.Error()).To(ContainSubstring(lock.LockId))
+				err = n.Unlock(env.Ctx, wrongLockByUser)
+				Expect(err.Error()).To(ContainSubstring(lockByUser.LockId))
 			})
 
-			It("unlocks when other another user uses the lock", func() {
-				err := n.Unlock(otherCtx, lock)
-				Expect(err).NotTo(HaveOccurred())
+			It("refuses to unlock for others even if they have the lock", func() {
+				err := n.Unlock(otherCtx, lockByUser)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("mismatching"))
 			})
 
 			It("unlocks when the owner uses the lock", func() {
-				err := n.Unlock(env.Ctx, lock)
+				err := n.Unlock(env.Ctx, lockByUser)
 				Expect(err).ToNot(HaveOccurred())
 
 				_, err = os.Stat(n.LockFilePath())
@@ -203,10 +252,112 @@ var _ = Describe("Node locks", func() {
 			})
 
 			It("fails to unlock an unlocked node", func() {
-				err := n.Unlock(env.Ctx, lock)
+				err := n.Unlock(env.Ctx, lockByUser)
 				Expect(err).ToNot(HaveOccurred())
 
-				err = n.Unlock(env.Ctx, lock)
+				err = n.Unlock(env.Ctx, lockByUser)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("lock does not exist"))
+			})
+		})
+	})
+
+	Context("with an existing lock for an app", func() {
+		BeforeEach(func() {
+			err := n.SetLock(env.Ctx, lockByApp)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		Describe("ReadLock", func() {
+			It("returns the lock", func() {
+				l, err := n.ReadLock(env.Ctx)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(l).To(Equal(lockByApp))
+			})
+
+			It("reports an error when the node wasn't locked", func() {
+				_, err := n2.ReadLock(env.Ctx)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("no lock found"))
+			})
+		})
+
+		Describe("RefreshLock", func() {
+			var (
+				newLock *provider.Lock
+			)
+
+			JustBeforeEach(func() {
+				newLock = &provider.Lock{
+					Type:    provider.LockType_LOCK_TYPE_EXCL,
+					AppName: lockByApp.AppName,
+					LockId:  lockByApp.LockId,
+				}
+			})
+
+			It("fails when the node is unlocked", func() {
+				err := n2.RefreshLock(env.Ctx, lockByApp)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("precondition failed"))
+			})
+
+			It("refuses to refresh the lock without holding the lock", func() {
+				newLock.LockId = "somethingsomething"
+				err := n.RefreshLock(env.Ctx, newLock)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("mismatching"))
+			})
+
+			It("refreshes the lock for other users", func() {
+				err := n.RefreshLock(otherCtx, lockByApp)
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("refuses to change the lock holder", func() {
+				newLock.AppName = wrongLockByApp.AppName
+				err := n.RefreshLock(env.Ctx, newLock)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("permission denied"))
+			})
+
+			It("refreshes the lock", func() {
+				err := n.RefreshLock(env.Ctx, newLock)
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Describe("Unlock", func() {
+			It("refuses to unlock without having a lock", func() {
+				err := n.Unlock(env.Ctx, nil)
+				Expect(err.Error()).To(ContainSubstring(lockByApp.LockId))
+			})
+
+			It("refuses to unlock without having the proper lock", func() {
+				err := n.Unlock(env.Ctx, nil)
+				Expect(err.Error()).To(ContainSubstring(lockByApp.LockId))
+
+				err = n.Unlock(env.Ctx, wrongLockByUser)
+				Expect(err.Error()).To(ContainSubstring(lockByApp.LockId))
+			})
+
+			It("accepts to unlock for others if they have the lock", func() {
+				err := n.Unlock(otherCtx, lockByApp)
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("unlocks when the owner uses the lock", func() {
+				err := n.Unlock(env.Ctx, lockByApp)
+				Expect(err).ToNot(HaveOccurred())
+
+				_, err = os.Stat(n.LockFilePath())
+				Expect(err).To(HaveOccurred())
+			})
+
+			It("fails to unlock an unlocked node", func() {
+				err := n.Unlock(env.Ctx, lockByApp)
+				Expect(err).ToNot(HaveOccurred())
+
+				err = n.Unlock(env.Ctx, lockByApp)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("lock does not exist"))
 			})


### PR DESCRIPTION
- expire locks
- pass lockid from the InitiateUploadRequest via metadata to the FinishUpload, so that we don't need to provide that info the the datagateway
- enable lock modification for app based locks independently of the user
- implement locking for public storage provider