### PR TITLE
Share events for audit logging

### DIFF
--- a/changelog/unreleased/sharing-events.md
+++ b/changelog/unreleased/sharing-events.md
@@ -1,0 +1,6 @@
+Enhancement: Add events for sharing action
+
+Includes lifecycle events for shares and public links doesn't include federated sharing events for now
+see full list of events in `pkg/events/types.go`
+
+https://github.com/cs3org/reva/pull/2627

--- a/internal/grpc/interceptors/eventsmiddleware/conversion.go
+++ b/internal/grpc/interceptors/eventsmiddleware/conversion.go
@@ -32,6 +32,7 @@ func ShareCreated(r *collaboration.CreateShareResponse) events.ShareCreated {
 		GranteeGroupID: r.Share.GetGrantee().GetGroupId(),
 		ItemID:         r.Share.ResourceId,
 		CTime:          r.Share.Ctime,
+		Permissions:    r.Share.Permissions,
 	}
 }
 

--- a/internal/grpc/interceptors/eventsmiddleware/conversion.go
+++ b/internal/grpc/interceptors/eventsmiddleware/conversion.go
@@ -20,6 +20,7 @@ package eventsmiddleware
 
 import (
 	collaboration "github.com/cs3org/go-cs3apis/cs3/sharing/collaboration/v1beta1"
+	link "github.com/cs3org/go-cs3apis/cs3/sharing/link/v1beta1"
 	"github.com/cs3org/reva/v2/pkg/events"
 )
 
@@ -63,6 +64,23 @@ func ShareUpdated(r *collaboration.UpdateShareResponse, req *collaboration.Updat
 		Sharer:         r.Share.Creator,
 		MTime:          r.Share.Mtime,
 		Updated:        updated,
+	}
+
+	return e
+}
+
+// LinkCreated converts the response to an event
+func LinkCreated(r *link.CreatePublicShareResponse) events.LinkCreated {
+	e := events.LinkCreated{
+		ShareID:           r.Share.Id,
+		Sharer:            r.Share.Creator,
+		ItemID:            r.Share.ResourceId,
+		Permissions:       r.Share.Permissions,
+		DisplayName:       r.Share.DisplayName,
+		Expiration:        r.Share.Expiration,
+		PasswordProtected: r.Share.PasswordProtected,
+		CTime:             r.Share.Ctime,
+		Token:             r.Share.Token,
 	}
 
 	return e

--- a/internal/grpc/interceptors/eventsmiddleware/conversion.go
+++ b/internal/grpc/interceptors/eventsmiddleware/conversion.go
@@ -63,6 +63,20 @@ func ShareUpdated(r *collaboration.UpdateShareResponse, req *collaboration.Updat
 	}
 }
 
+// ReceivedShareUpdated converts the response to an event
+func ReceivedShareUpdated(r *collaboration.UpdateReceivedShareResponse) events.ReceivedShareUpdated {
+	return events.ReceivedShareUpdated{
+		ShareID:        r.Share.Share.Id,
+		ItemID:         r.Share.Share.ResourceId,
+		Permissions:    r.Share.Share.Permissions,
+		GranteeUserID:  r.Share.Share.GetGrantee().GetUserId(),
+		GranteeGroupID: r.Share.Share.GetGrantee().GetGroupId(),
+		Sharer:         r.Share.Share.Creator,
+		MTime:          r.Share.Share.Mtime,
+		State:          collaboration.ShareState_name[int32(r.Share.State)],
+	}
+}
+
 // LinkCreated converts the response to an event
 func LinkCreated(r *link.CreatePublicShareResponse) events.LinkCreated {
 	return events.LinkCreated{

--- a/internal/grpc/interceptors/eventsmiddleware/conversion.go
+++ b/internal/grpc/interceptors/eventsmiddleware/conversion.go
@@ -108,6 +108,31 @@ func LinkUpdated(r *link.UpdatePublicShareResponse, req *link.UpdatePublicShareR
 	}
 }
 
+// LinkAccessed converts the response to an event
+func LinkAccessed(r *link.GetPublicShareByTokenResponse) events.LinkAccessed {
+	return events.LinkAccessed{
+		ShareID:           r.Share.Id,
+		Sharer:            r.Share.Creator,
+		ItemID:            r.Share.ResourceId,
+		Permissions:       r.Share.Permissions,
+		DisplayName:       r.Share.DisplayName,
+		Expiration:        r.Share.Expiration,
+		PasswordProtected: r.Share.PasswordProtected,
+		CTime:             r.Share.Ctime,
+		Token:             r.Share.Token,
+	}
+}
+
+// LinkAccessFailed converts the response to an event
+func LinkAccessFailed(r *link.GetPublicShareByTokenResponse, req *link.GetPublicShareByTokenRequest) events.LinkAccessFailed {
+	return events.LinkAccessFailed{
+		ShareID: r.Share.Id,
+		Token:   r.Share.Token,
+		Status:  r.Status.Code,
+		Message: r.Status.Message,
+	}
+}
+
 // LinkRemoved converts the response to an event
 func LinkRemoved(r *link.RemovePublicShareResponse, req *link.RemovePublicShareRequest) events.LinkRemoved {
 	return events.LinkRemoved{

--- a/internal/grpc/interceptors/eventsmiddleware/conversion.go
+++ b/internal/grpc/interceptors/eventsmiddleware/conversion.go
@@ -23,7 +23,7 @@ import (
 	"github.com/cs3org/reva/v2/pkg/events"
 )
 
-// ShareCreated converts response to event
+// ShareCreated converts the response to an event
 func ShareCreated(r *collaboration.CreateShareResponse) events.ShareCreated {
 	e := events.ShareCreated{
 		Sharer:         r.Share.Creator,
@@ -31,6 +31,16 @@ func ShareCreated(r *collaboration.CreateShareResponse) events.ShareCreated {
 		GranteeGroupID: r.Share.GetGrantee().GetGroupId(),
 		ItemID:         r.Share.ResourceId,
 		CTime:          r.Share.Ctime,
+	}
+
+	return e
+}
+
+// ShareRemoved converts the response to an event
+func ShareRemoved(r *collaboration.RemoveShareResponse, req *collaboration.RemoveShareRequest) events.ShareRemoved {
+	e := events.ShareRemoved{
+		ShareID:  req.Ref.GetId(),
+		ShareKey: req.Ref.GetKey(),
 	}
 
 	return e

--- a/internal/grpc/interceptors/eventsmiddleware/conversion.go
+++ b/internal/grpc/interceptors/eventsmiddleware/conversion.go
@@ -26,25 +26,21 @@ import (
 
 // ShareCreated converts the response to an event
 func ShareCreated(r *collaboration.CreateShareResponse) events.ShareCreated {
-	e := events.ShareCreated{
+	return events.ShareCreated{
 		Sharer:         r.Share.Creator,
 		GranteeUserID:  r.Share.GetGrantee().GetUserId(),
 		GranteeGroupID: r.Share.GetGrantee().GetGroupId(),
 		ItemID:         r.Share.ResourceId,
 		CTime:          r.Share.Ctime,
 	}
-
-	return e
 }
 
 // ShareRemoved converts the response to an event
 func ShareRemoved(r *collaboration.RemoveShareResponse, req *collaboration.RemoveShareRequest) events.ShareRemoved {
-	e := events.ShareRemoved{
+	return events.ShareRemoved{
 		ShareID:  req.Ref.GetId(),
 		ShareKey: req.Ref.GetKey(),
 	}
-
-	return e
 }
 
 // ShareUpdated converts the response to an event
@@ -55,7 +51,7 @@ func ShareUpdated(r *collaboration.UpdateShareResponse, req *collaboration.Updat
 	} else if req.Field.GetDisplayName() != "" {
 		updated = "displayname"
 	}
-	e := events.ShareUpdated{
+	return events.ShareUpdated{
 		ShareID:        r.Share.Id,
 		ItemID:         r.Share.ResourceId,
 		Permissions:    r.Share.Permissions,
@@ -65,13 +61,11 @@ func ShareUpdated(r *collaboration.UpdateShareResponse, req *collaboration.Updat
 		MTime:          r.Share.Mtime,
 		Updated:        updated,
 	}
-
-	return e
 }
 
 // LinkCreated converts the response to an event
 func LinkCreated(r *link.CreatePublicShareResponse) events.LinkCreated {
-	e := events.LinkCreated{
+	return events.LinkCreated{
 		ShareID:           r.Share.Id,
 		Sharer:            r.Share.Creator,
 		ItemID:            r.Share.ResourceId,
@@ -82,6 +76,20 @@ func LinkCreated(r *link.CreatePublicShareResponse) events.LinkCreated {
 		CTime:             r.Share.Ctime,
 		Token:             r.Share.Token,
 	}
+}
 
-	return e
+// LinkUpdated converts the response to an event
+func LinkUpdated(r *link.UpdatePublicShareResponse, req *link.UpdatePublicShareRequest) events.LinkUpdated {
+	return events.LinkUpdated{
+		ShareID:           r.Share.Id,
+		Sharer:            r.Share.Creator,
+		ItemID:            r.Share.ResourceId,
+		Permissions:       r.Share.Permissions,
+		DisplayName:       r.Share.DisplayName,
+		Expiration:        r.Share.Expiration,
+		PasswordProtected: r.Share.PasswordProtected,
+		CTime:             r.Share.Ctime,
+		Token:             r.Share.Token,
+		FieldUpdated:      link.UpdatePublicShareRequest_Update_Type_name[int32(req.Update.GetType())],
+	}
 }

--- a/internal/grpc/interceptors/eventsmiddleware/conversion.go
+++ b/internal/grpc/interceptors/eventsmiddleware/conversion.go
@@ -93,3 +93,11 @@ func LinkUpdated(r *link.UpdatePublicShareResponse, req *link.UpdatePublicShareR
 		FieldUpdated:      link.UpdatePublicShareRequest_Update_Type_name[int32(req.Update.GetType())],
 	}
 }
+
+// LinkRemoved converts the response to an event
+func LinkRemoved(r *link.RemovePublicShareResponse, req *link.RemovePublicShareRequest) events.LinkRemoved {
+	return events.LinkRemoved{
+		ShareID:    req.Ref.GetId(),
+		ShareToken: req.Ref.GetToken(),
+	}
+}

--- a/internal/grpc/interceptors/eventsmiddleware/conversion.go
+++ b/internal/grpc/interceptors/eventsmiddleware/conversion.go
@@ -45,3 +45,25 @@ func ShareRemoved(r *collaboration.RemoveShareResponse, req *collaboration.Remov
 
 	return e
 }
+
+// ShareUpdated converts the response to an event
+func ShareUpdated(r *collaboration.UpdateShareResponse, req *collaboration.UpdateShareRequest) events.ShareUpdated {
+	updated := ""
+	if req.Field.GetPermissions() != nil {
+		updated = "permissions"
+	} else if req.Field.GetDisplayName() != "" {
+		updated = "displayname"
+	}
+	e := events.ShareUpdated{
+		ShareID:        r.Share.Id,
+		ItemID:         r.Share.ResourceId,
+		Permissions:    r.Share.Permissions,
+		GranteeUserID:  r.Share.GetGrantee().GetUserId(),
+		GranteeGroupID: r.Share.GetGrantee().GetGroupId(),
+		Sharer:         r.Share.Creator,
+		MTime:          r.Share.Mtime,
+		Updated:        updated,
+	}
+
+	return e
+}

--- a/internal/grpc/interceptors/eventsmiddleware/events.go
+++ b/internal/grpc/interceptors/eventsmiddleware/events.go
@@ -67,6 +67,10 @@ func NewUnary(m map[string]interface{}) (grpc.UnaryServerInterceptor, int, error
 			if isSuccess(v) {
 				ev = ShareRemoved(v, req.(*collaboration.RemoveShareRequest))
 			}
+		case *collaboration.UpdateShareResponse:
+			if isSuccess(v) {
+				ev = ShareUpdated(v, req.(*collaboration.UpdateShareRequest))
+			}
 		}
 
 		if ev != nil {

--- a/internal/grpc/interceptors/eventsmiddleware/events.go
+++ b/internal/grpc/interceptors/eventsmiddleware/events.go
@@ -76,6 +76,10 @@ func NewUnary(m map[string]interface{}) (grpc.UnaryServerInterceptor, int, error
 			if isSuccess(v) {
 				ev = LinkCreated(v)
 			}
+		case *link.UpdatePublicShareResponse:
+			if isSuccess(v) {
+				ev = LinkUpdated(v, req.(*link.UpdatePublicShareRequest))
+			}
 		}
 
 		if ev != nil {

--- a/internal/grpc/interceptors/eventsmiddleware/events.go
+++ b/internal/grpc/interceptors/eventsmiddleware/events.go
@@ -117,7 +117,7 @@ func NewStream() grpc.StreamServerInterceptor {
 	return interceptor
 }
 
-// common interface to all respones
+// common interface to all responses
 type su interface {
 	GetStatus() *v1beta12.Status
 }

--- a/internal/grpc/interceptors/eventsmiddleware/events.go
+++ b/internal/grpc/interceptors/eventsmiddleware/events.go
@@ -80,6 +80,10 @@ func NewUnary(m map[string]interface{}) (grpc.UnaryServerInterceptor, int, error
 			if isSuccess(v) {
 				ev = LinkUpdated(v, req.(*link.UpdatePublicShareRequest))
 			}
+		case *link.RemovePublicShareResponse:
+			if isSuccess(v) {
+				ev = LinkRemoved(v, req.(*link.RemovePublicShareRequest))
+			}
 		}
 
 		if ev != nil {

--- a/internal/grpc/interceptors/eventsmiddleware/events.go
+++ b/internal/grpc/interceptors/eventsmiddleware/events.go
@@ -72,6 +72,10 @@ func NewUnary(m map[string]interface{}) (grpc.UnaryServerInterceptor, int, error
 			if isSuccess(v) {
 				ev = ShareUpdated(v, req.(*collaboration.UpdateShareRequest))
 			}
+		case *collaboration.UpdateReceivedShareResponse:
+			if isSuccess(v) {
+				ev = ReceivedShareUpdated(v)
+			}
 		case *link.CreatePublicShareResponse:
 			if isSuccess(v) {
 				ev = LinkCreated(v)

--- a/internal/grpc/interceptors/eventsmiddleware/events.go
+++ b/internal/grpc/interceptors/eventsmiddleware/events.go
@@ -88,6 +88,12 @@ func NewUnary(m map[string]interface{}) (grpc.UnaryServerInterceptor, int, error
 			if isSuccess(v) {
 				ev = LinkRemoved(v, req.(*link.RemovePublicShareRequest))
 			}
+		case *link.GetPublicShareByTokenResponse:
+			if isSuccess(v) {
+				ev = LinkAccessed(v)
+			} else {
+				ev = LinkAccessFailed(v, req.(*link.GetPublicShareByTokenRequest))
+			}
 		}
 
 		if ev != nil {

--- a/internal/grpc/interceptors/eventsmiddleware/events.go
+++ b/internal/grpc/interceptors/eventsmiddleware/events.go
@@ -29,6 +29,7 @@ import (
 	rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
 	v1beta12 "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
 	collaboration "github.com/cs3org/go-cs3apis/cs3/sharing/collaboration/v1beta1"
+	link "github.com/cs3org/go-cs3apis/cs3/sharing/link/v1beta1"
 	"github.com/cs3org/reva/v2/pkg/events"
 	"github.com/cs3org/reva/v2/pkg/events/server"
 	"github.com/cs3org/reva/v2/pkg/rgrpc"
@@ -70,6 +71,10 @@ func NewUnary(m map[string]interface{}) (grpc.UnaryServerInterceptor, int, error
 		case *collaboration.UpdateShareResponse:
 			if isSuccess(v) {
 				ev = ShareUpdated(v, req.(*collaboration.UpdateShareRequest))
+			}
+		case *link.CreatePublicShareResponse:
+			if isSuccess(v) {
+				ev = LinkCreated(v)
 			}
 		}
 

--- a/pkg/events/example/consumer/consumer.go
+++ b/pkg/events/example/consumer/consumer.go
@@ -34,8 +34,9 @@ func Example(c events.Consumer) {
 
 	// Step 2 - which events does the consumer listen too?
 	evs := []events.Unmarshaller{
-		// for example created shares
 		events.ShareCreated{},
+		events.ShareUpdated{},
+		events.ShareRemoved{},
 	}
 
 	// Step 3 - create event channel

--- a/pkg/events/example/consumer/consumer.go
+++ b/pkg/events/example/consumer/consumer.go
@@ -42,6 +42,7 @@ func Example(c events.Consumer) {
 		events.LinkUpdated{},
 		events.LinkRemoved{},
 		events.LinkAccessed{},
+		events.LinkAccessFailed{},
 	}
 
 	// Step 3 - create event channel

--- a/pkg/events/example/consumer/consumer.go
+++ b/pkg/events/example/consumer/consumer.go
@@ -37,6 +37,7 @@ func Example(c events.Consumer) {
 		events.ShareCreated{},
 		events.ShareUpdated{},
 		events.ShareRemoved{},
+		events.ReceivedShareUpdated{},
 		events.LinkCreated{},
 		events.LinkUpdated{},
 		events.LinkRemoved{},

--- a/pkg/events/example/consumer/consumer.go
+++ b/pkg/events/example/consumer/consumer.go
@@ -38,6 +38,7 @@ func Example(c events.Consumer) {
 		events.ShareUpdated{},
 		events.ShareRemoved{},
 		events.LinkCreated{},
+		events.LinkUpdated{},
 	}
 
 	// Step 3 - create event channel

--- a/pkg/events/example/consumer/consumer.go
+++ b/pkg/events/example/consumer/consumer.go
@@ -41,6 +41,7 @@ func Example(c events.Consumer) {
 		events.LinkCreated{},
 		events.LinkUpdated{},
 		events.LinkRemoved{},
+		events.LinkAccessed{},
 	}
 
 	// Step 3 - create event channel

--- a/pkg/events/example/consumer/consumer.go
+++ b/pkg/events/example/consumer/consumer.go
@@ -39,6 +39,7 @@ func Example(c events.Consumer) {
 		events.ShareRemoved{},
 		events.LinkCreated{},
 		events.LinkUpdated{},
+		events.LinkRemoved{},
 	}
 
 	// Step 3 - create event channel
@@ -56,7 +57,7 @@ func Example(c events.Consumer) {
 		case events.ShareCreated:
 			fmt.Printf("%s) Share created: %+v\n", group, v)
 		default:
-			fmt.Printf("%s) Unregistered event: %+v\n", group, v)
+			fmt.Printf("%s) %T: %+v\n", group, v, v)
 		}
 	}
 

--- a/pkg/events/example/consumer/consumer.go
+++ b/pkg/events/example/consumer/consumer.go
@@ -37,6 +37,7 @@ func Example(c events.Consumer) {
 		events.ShareCreated{},
 		events.ShareUpdated{},
 		events.ShareRemoved{},
+		events.LinkCreated{},
 	}
 
 	// Step 3 - create event channel

--- a/pkg/events/types.go
+++ b/pkg/events/types.go
@@ -23,12 +23,13 @@ import (
 
 	group "github.com/cs3org/go-cs3apis/cs3/identity/group/v1beta1"
 	user "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
+	collaboration "github.com/cs3org/go-cs3apis/cs3/sharing/collaboration/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	types "github.com/cs3org/go-cs3apis/cs3/types/v1beta1"
 )
 
 // ShareCreated is emitted when a share is created
-type ShareCreated struct { // TODO: Rename to ShareCreatedEvent?
+type ShareCreated struct {
 	Sharer *user.UserId
 	// split the protobuf Grantee oneof so we can use stdlib encoding/json
 	GranteeUserID  *user.UserId
@@ -41,6 +42,20 @@ type ShareCreated struct { // TODO: Rename to ShareCreatedEvent?
 // Unmarshal to fulfill umarshaller interface
 func (ShareCreated) Unmarshal(v []byte) (interface{}, error) {
 	e := ShareCreated{}
+	err := json.Unmarshal(v, &e)
+	return e, err
+}
+
+// ShareRemoved is emitted when a share is removed
+type ShareRemoved struct {
+	// split protobuf Spec
+	ShareID  *collaboration.ShareId
+	ShareKey *collaboration.ShareKey
+}
+
+// Unmarshal to fulfill umarshaller interface
+func (ShareRemoved) Unmarshal(v []byte) (interface{}, error) {
+	e := ShareRemoved{}
 	err := json.Unmarshal(v, &e)
 	return e, err
 }

--- a/pkg/events/types.go
+++ b/pkg/events/types.go
@@ -104,3 +104,25 @@ func (LinkCreated) Unmarshal(v []byte) (interface{}, error) {
 	err := json.Unmarshal(v, &e)
 	return e, err
 }
+
+// LinkUpdated is emitted when a public link is updated
+type LinkUpdated struct {
+	ShareID           *link.PublicShareId
+	Sharer            *user.UserId
+	ItemID            *provider.ResourceId
+	Permissions       *link.PublicSharePermissions
+	DisplayName       string
+	Expiration        *types.Timestamp
+	PasswordProtected bool
+	CTime             *types.Timestamp
+	Token             string
+
+	FieldUpdated string
+}
+
+// Unmarshal to fulfill umarshaller interface
+func (LinkUpdated) Unmarshal(v []byte) (interface{}, error) {
+	e := LinkUpdated{}
+	err := json.Unmarshal(v, &e)
+	return e, err
+}

--- a/pkg/events/types.go
+++ b/pkg/events/types.go
@@ -38,6 +38,7 @@ type ShareCreated struct {
 	GranteeGroupID *group.GroupId
 	Sharee         *provider.Grantee
 	ItemID         *provider.ResourceId
+	Permissions    *collaboration.SharePermissions
 	CTime          *types.Timestamp
 }
 

--- a/pkg/events/types.go
+++ b/pkg/events/types.go
@@ -126,3 +126,17 @@ func (LinkUpdated) Unmarshal(v []byte) (interface{}, error) {
 	err := json.Unmarshal(v, &e)
 	return e, err
 }
+
+// LinkRemoved is emitted when a share is removed
+type LinkRemoved struct {
+	// split protobuf Ref
+	ShareID    *link.PublicShareId
+	ShareToken string
+}
+
+// Unmarshal to fulfill umarshaller interface
+func (LinkRemoved) Unmarshal(v []byte) (interface{}, error) {
+	e := LinkRemoved{}
+	err := json.Unmarshal(v, &e)
+	return e, err
+}

--- a/pkg/events/types.go
+++ b/pkg/events/types.go
@@ -24,6 +24,7 @@ import (
 	group "github.com/cs3org/go-cs3apis/cs3/identity/group/v1beta1"
 	user "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	collaboration "github.com/cs3org/go-cs3apis/cs3/sharing/collaboration/v1beta1"
+	link "github.com/cs3org/go-cs3apis/cs3/sharing/link/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	types "github.com/cs3org/go-cs3apis/cs3/types/v1beta1"
 )
@@ -77,6 +78,29 @@ type ShareUpdated struct {
 // Unmarshal to fulfill umarshaller interface
 func (ShareUpdated) Unmarshal(v []byte) (interface{}, error) {
 	e := ShareUpdated{}
+	err := json.Unmarshal(v, &e)
+	return e, err
+}
+
+// LinkCreated is emitted when a public link is created
+type LinkCreated struct {
+	ShareID           *link.PublicShareId
+	Sharer            *user.UserId
+	ItemID            *provider.ResourceId
+	Permissions       *link.PublicSharePermissions
+	DisplayName       string
+	Expiration        *types.Timestamp
+	PasswordProtected bool
+	CTime             *types.Timestamp
+
+	// TODO: are we sure we want to send the token via event-bus? Imho this is a major security issue:
+	// Eveybody who has access to the event bus can access the file
+	Token string
+}
+
+// Unmarshal to fulfill umarshaller interface
+func (LinkCreated) Unmarshal(v []byte) (interface{}, error) {
+	e := LinkCreated{}
 	err := json.Unmarshal(v, &e)
 	return e, err
 }

--- a/pkg/events/types.go
+++ b/pkg/events/types.go
@@ -59,3 +59,24 @@ func (ShareRemoved) Unmarshal(v []byte) (interface{}, error) {
 	err := json.Unmarshal(v, &e)
 	return e, err
 }
+
+// ShareUpdated is emitted when a share is updated
+type ShareUpdated struct {
+	ShareID        *collaboration.ShareId
+	ItemID         *provider.ResourceId
+	Permissions    *collaboration.SharePermissions
+	GranteeUserID  *user.UserId
+	GranteeGroupID *group.GroupId
+	Sharer         *user.UserId
+	MTime          *types.Timestamp
+
+	// indicates what was updated - one of "displayname", "permissions"
+	Updated string
+}
+
+// Unmarshal to fulfill umarshaller interface
+func (ShareUpdated) Unmarshal(v []byte) (interface{}, error) {
+	e := ShareUpdated{}
+	err := json.Unmarshal(v, &e)
+	return e, err
+}

--- a/pkg/events/types.go
+++ b/pkg/events/types.go
@@ -23,6 +23,7 @@ import (
 
 	group "github.com/cs3org/go-cs3apis/cs3/identity/group/v1beta1"
 	user "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
+	rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
 	collaboration "github.com/cs3org/go-cs3apis/cs3/sharing/collaboration/v1beta1"
 	link "github.com/cs3org/go-cs3apis/cs3/sharing/link/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
@@ -112,10 +113,7 @@ type LinkCreated struct {
 	Expiration        *types.Timestamp
 	PasswordProtected bool
 	CTime             *types.Timestamp
-
-	// TODO: are we sure we want to send the token via event-bus? Imho this is a major security issue:
-	// Eveybody who has access to the event bus can access the file
-	Token string
+	Token             string
 }
 
 // Unmarshal to fulfill umarshaller interface
@@ -143,6 +141,41 @@ type LinkUpdated struct {
 // Unmarshal to fulfill umarshaller interface
 func (LinkUpdated) Unmarshal(v []byte) (interface{}, error) {
 	e := LinkUpdated{}
+	err := json.Unmarshal(v, &e)
+	return e, err
+}
+
+// LinkAccessed is emitted when a public link is accessed successfully (by token)
+type LinkAccessed struct {
+	ShareID           *link.PublicShareId
+	Sharer            *user.UserId
+	ItemID            *provider.ResourceId
+	Permissions       *link.PublicSharePermissions
+	DisplayName       string
+	Expiration        *types.Timestamp
+	PasswordProtected bool
+	CTime             *types.Timestamp
+	Token             string
+}
+
+// Unmarshal to fulfill umarshaller interface
+func (LinkAccessed) Unmarshal(v []byte) (interface{}, error) {
+	e := LinkAccessed{}
+	err := json.Unmarshal(v, &e)
+	return e, err
+}
+
+// LinkAccessFailed is emitted when an access to a public link has resulted in an error (by token)
+type LinkAccessFailed struct {
+	ShareID *link.PublicShareId
+	Token   string
+	Status  rpc.Code
+	Message string
+}
+
+// Unmarshal to fulfill umarshaller interface
+func (LinkAccessFailed) Unmarshal(v []byte) (interface{}, error) {
+	e := LinkAccessFailed{}
 	err := json.Unmarshal(v, &e)
 	return e, err
 }

--- a/pkg/events/types.go
+++ b/pkg/events/types.go
@@ -82,6 +82,26 @@ func (ShareUpdated) Unmarshal(v []byte) (interface{}, error) {
 	return e, err
 }
 
+// ReceivedShareUpdated is emitted when a received share is accepted or declined
+type ReceivedShareUpdated struct {
+	ShareID        *collaboration.ShareId
+	ItemID         *provider.ResourceId
+	Permissions    *collaboration.SharePermissions
+	GranteeUserID  *user.UserId
+	GranteeGroupID *group.GroupId
+	Sharer         *user.UserId
+	MTime          *types.Timestamp
+
+	State string
+}
+
+// Unmarshal to fulfill umarshaller interface
+func (ReceivedShareUpdated) Unmarshal(v []byte) (interface{}, error) {
+	e := ReceivedShareUpdated{}
+	err := json.Unmarshal(v, &e)
+	return e, err
+}
+
 // LinkCreated is emitted when a public link is created
 type LinkCreated struct {
 	ShareID           *link.PublicShareId


### PR DESCRIPTION
Contains lifecyle events for shares and links for now.

List of sharing events:
```golang
		events.ShareCreated{},
		events.ShareUpdated{},
		events.ShareRemoved{},
		events.ReceivedShareUpdated{},
		events.LinkCreated{},
		events.LinkUpdated{},
		events.LinkRemoved{},
		events.LinkAccessed{},
		events.LinkAccessFailed{},
```
see details in `pkg/events/types.go`

Does not include federated shares in this PR