### PR TITLE
Webdav trash-bin API for spaces

### DIFF
--- a/changelog/unreleased/spaces-trashbin.md
+++ b/changelog/unreleased/spaces-trashbin.md
@@ -1,0 +1,5 @@
+Enhancement: Add spaces aware trash-bin API
+
+Added the webdav trash-bin endpoint for spaces.
+
+https://github.com/cs3org/reva/pull/2628

--- a/internal/http/services/owncloud/ocdav/copy.go
+++ b/internal/http/services/owncloud/ocdav/copy.go
@@ -55,7 +55,10 @@ func (s *svc) handlePathCopy(w http.ResponseWriter, r *http.Request, ns string) 
 	defer span.End()
 
 	src := path.Join(ns, r.URL.Path)
-	dst, err := extractDestination(r)
+
+	dh := r.Header.Get(net.HeaderDestination)
+	baseURI := r.Context().Value(net.CtxKeyBaseURI).(string)
+	dst, err := net.ParseDestination(baseURI, dh)
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		return
@@ -274,7 +277,9 @@ func (s *svc) handleSpacesCopy(w http.ResponseWriter, r *http.Request, spaceID s
 	ctx, span := rtrace.Provider.Tracer("reva").Start(r.Context(), "spaces_copy")
 	defer span.End()
 
-	dst, err := extractDestination(r)
+	dh := r.Header.Get(net.HeaderDestination)
+	baseURI := r.Context().Value(net.CtxKeyBaseURI).(string)
+	dst, err := net.ParseDestination(baseURI, dh)
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		return

--- a/internal/http/services/owncloud/ocdav/move.go
+++ b/internal/http/services/owncloud/ocdav/move.go
@@ -42,7 +42,9 @@ func (s *svc) handlePathMove(w http.ResponseWriter, r *http.Request, ns string) 
 	defer span.End()
 
 	srcPath := path.Join(ns, r.URL.Path)
-	dstPath, err := extractDestination(r)
+	dh := r.Header.Get(net.HeaderDestination)
+	baseURI := r.Context().Value(net.CtxKeyBaseURI).(string)
+	dstPath, err := net.ParseDestination(baseURI, dh)
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		return
@@ -98,7 +100,9 @@ func (s *svc) handleSpacesMove(w http.ResponseWriter, r *http.Request, srcSpaceI
 	ctx, span := rtrace.Provider.Tracer("ocdav").Start(r.Context(), "spaces_move")
 	defer span.End()
 
-	dst, err := extractDestination(r)
+	dh := r.Header.Get(net.HeaderDestination)
+	baseURI := r.Context().Value(net.CtxKeyBaseURI).(string)
+	dst, err := net.ParseDestination(baseURI, dh)
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		return

--- a/internal/http/services/owncloud/ocdav/move.go
+++ b/internal/http/services/owncloud/ocdav/move.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"net/http"
 	"path"
-	"strings"
 
 	rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
@@ -145,15 +144,11 @@ func (s *svc) handleSpacesMove(w http.ResponseWriter, r *http.Request, srcSpaceI
 }
 
 func (s *svc) handleMove(ctx context.Context, w http.ResponseWriter, r *http.Request, src, dst *provider.Reference, log zerolog.Logger) {
-	overwrite := r.Header.Get(net.HeaderOverwrite)
-	log.Debug().Str("overwrite", overwrite).Msg("move")
+	oh := r.Header.Get(net.HeaderOverwrite)
+	log.Debug().Str("overwrite", oh).Msg("move")
 
-	overwrite = strings.ToUpper(overwrite)
-	if overwrite == "" {
-		overwrite = "T"
-	}
-
-	if overwrite != "T" && overwrite != "F" {
+	overwrite, err := net.ParseOverwrite(oh)
+	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
@@ -201,8 +196,8 @@ func (s *svc) handleMove(ctx context.Context, w http.ResponseWriter, r *http.Req
 	if dstStatRes.Status.Code == rpc.Code_CODE_OK {
 		successCode = http.StatusNoContent // 204 if target already existed, see https://tools.ietf.org/html/rfc4918#section-9.9.4
 
-		if overwrite == "F" {
-			log.Warn().Str("overwrite", overwrite).Msg("dst already exists")
+		if !overwrite {
+			log.Warn().Bool("overwrite", overwrite).Msg("dst already exists")
 			w.WriteHeader(http.StatusPreconditionFailed) // 412, see https://tools.ietf.org/html/rfc4918#section-9.9.4
 			return
 		}

--- a/internal/http/services/owncloud/ocdav/net/net.go
+++ b/internal/http/services/owncloud/ocdav/net/net.go
@@ -125,7 +125,6 @@ func ParseDepth(s string) (Depth, error) {
 // ParseOverwrite parses the overwrite header value defined in https://datatracker.ietf.org/doc/html/rfc4918#section-10.6
 // Valid values are "T" and "F". An empty string will be parse to true.
 func ParseOverwrite(s string) (bool, error) {
-	s = strings.ToUpper(s)
 	if s == "" {
 		s = "T"
 	}

--- a/internal/http/services/owncloud/ocdav/net/net.go
+++ b/internal/http/services/owncloud/ocdav/net/net.go
@@ -113,3 +113,16 @@ func ParseDepth(s string) (Depth, error) {
 		return "", fmt.Errorf("invalid depth: %s", s)
 	}
 }
+
+// ParseOverwrite parses the overwrite header value defined in https://datatracker.ietf.org/doc/html/rfc4918#section-10.6
+// Valid values are "T" and "F". An empty string will be parse to true.
+func ParseOverwrite(s string) (bool, error) {
+	s = strings.ToUpper(s)
+	if s == "" {
+		s = "T"
+	}
+	if s != "T" && s != "F" {
+		return false, fmt.Errorf("invalid overwrite: %s", s)
+	}
+	return s == "T", nil
+}

--- a/internal/http/services/owncloud/ocdav/net/net.go
+++ b/internal/http/services/owncloud/ocdav/net/net.go
@@ -20,8 +20,16 @@ package net
 
 import (
 	"fmt"
+	"net/url"
 	"regexp"
 	"strings"
+
+	"github.com/pkg/errors"
+)
+
+var (
+	// ErrInvalidHeaderValue defines an error which can occure when trying to parse a header value.
+	ErrInvalidHeaderValue = errors.New("invalid value")
 )
 
 type ctxKey int
@@ -110,7 +118,7 @@ func ParseDepth(s string) (Depth, error) {
 	case DepthInfinity.String():
 		return DepthInfinity, nil
 	default:
-		return "", fmt.Errorf("invalid depth: %s", s)
+		return "", errors.Wrapf(ErrInvalidHeaderValue, "invalid depth: %s", s)
 	}
 }
 
@@ -122,7 +130,29 @@ func ParseOverwrite(s string) (bool, error) {
 		s = "T"
 	}
 	if s != "T" && s != "F" {
-		return false, fmt.Errorf("invalid overwrite: %s", s)
+		return false, errors.Wrapf(ErrInvalidHeaderValue, "invalid overwrite: %s", s)
 	}
 	return s == "T", nil
+}
+
+// ParseDestination parses the destination header value defined in https://datatracker.ietf.org/doc/html/rfc4918#section-10.3
+// The returned path will be relative to the given baseURI.
+func ParseDestination(baseURI, s string) (string, error) {
+	if s == "" {
+		return "", errors.Wrap(ErrInvalidHeaderValue, "destination header is empty")
+	}
+	dstURL, err := url.ParseRequestURI(s)
+	if err != nil {
+		return "", errors.Wrap(ErrInvalidHeaderValue, err.Error())
+	}
+
+	// TODO check if path is on same storage, return 502 on problems, see https://tools.ietf.org/html/rfc4918#section-9.9.4
+	// TODO make request.php optional in destination header
+	// Strip the base URI from the destination. The destination might contain redirection prefixes which need to be handled
+	urlSplit := strings.Split(dstURL.Path, baseURI)
+	if len(urlSplit) != 2 {
+		return "", errors.Wrap(ErrInvalidHeaderValue, "destination path does not contain base URI")
+	}
+
+	return urlSplit[1], nil
 }

--- a/internal/http/services/owncloud/ocdav/net/net_test.go
+++ b/internal/http/services/owncloud/ocdav/net/net_test.go
@@ -103,4 +103,16 @@ var _ = Describe("Net", func() {
 		Entry("F", "F", true, false),
 		Entry("f", "f", true, false),
 		Entry("invalid", "invalid", false, false))
+
+	DescribeTable("TestParseDestination",
+		func(baseURI, v string, expectSuccess bool, expectedValue string) {
+			parsed, err := net.ParseDestination(baseURI, v)
+			Expect(err == nil).To(Equal(expectSuccess))
+			Expect(parsed).To(Equal(expectedValue))
+		},
+		Entry("invalid1", "", "", false, ""),
+		Entry("invalid2", "baseURI", "", false, ""),
+		Entry("invalid3", "", "/dest/path", false, ""),
+		Entry("invalid4", "/foo", "/dest/path", false, ""),
+		Entry("valid", "/foo", "https://example.com/foo/dest/path", true, "/dest/path"))
 })

--- a/internal/http/services/owncloud/ocdav/net/net_test.go
+++ b/internal/http/services/owncloud/ocdav/net/net_test.go
@@ -90,4 +90,17 @@ var _ = Describe("Net", func() {
 			Expect(medianDuration).To(BeNumerically("<", 10*time.Millisecond))
 		})
 	})
+
+	DescribeTable("TestParseOverwrite",
+		func(v string, expectSuccess bool, expectedValue bool) {
+			parsed, err := net.ParseOverwrite(v)
+			Expect(err == nil).To(Equal(expectSuccess))
+			Expect(parsed).To(Equal(expectedValue))
+		},
+		Entry("default", "", true, true),
+		Entry("T", "T", true, true),
+		Entry("t", "t", true, true),
+		Entry("F", "F", true, false),
+		Entry("f", "f", true, false),
+		Entry("invalid", "invalid", false, false))
 })

--- a/internal/http/services/owncloud/ocdav/net/net_test.go
+++ b/internal/http/services/owncloud/ocdav/net/net_test.go
@@ -99,9 +99,7 @@ var _ = Describe("Net", func() {
 		},
 		Entry("default", "", true, true),
 		Entry("T", "T", true, true),
-		Entry("t", "t", true, true),
 		Entry("F", "F", true, false),
-		Entry("f", "f", true, false),
 		Entry("invalid", "invalid", false, false))
 
 	DescribeTable("TestParseDestination",

--- a/internal/http/services/owncloud/ocdav/ocdav_test.go
+++ b/internal/http/services/owncloud/ocdav/ocdav_test.go
@@ -18,14 +18,9 @@
 package ocdav
 
 import (
-	"context"
-	"errors"
-	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	providerv1beta1 "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
-	"github.com/cs3org/reva/v2/internal/http/services/owncloud/ocdav/net"
 	"github.com/cs3org/reva/v2/pkg/utils/resourceid"
 )
 
@@ -35,63 +30,6 @@ func TestWrapResourceID(t *testing.T) {
 
 	if wrapped != expected {
 		t.Errorf("wrapped id doesn't have the expected format: got %s expected %s", wrapped, expected)
-	}
-}
-
-func TestExtractDestination(t *testing.T) {
-	expected := "/dst"
-	request := httptest.NewRequest(http.MethodGet, "https://example.org/remote.php/dav/src", nil)
-	request.Header.Set(net.HeaderDestination, "https://example.org/remote.php/dav/dst")
-
-	ctx := context.WithValue(context.Background(), net.CtxKeyBaseURI, "remote.php/dav")
-	destination, err := extractDestination(request.WithContext(ctx))
-	if err != nil {
-		t.Errorf("Expected err to be nil got %s", err)
-	}
-
-	if destination != expected {
-		t.Errorf("Extracted destination is not expected, got %s want %s", destination, expected)
-	}
-}
-
-func TestExtractDestinationWithoutHeader(t *testing.T) {
-	request := httptest.NewRequest(http.MethodGet, "https://example.org/remote.php/dav/src", nil)
-
-	_, err := extractDestination(request)
-	if err == nil {
-		t.Errorf("Expected err to be nil got %s", err)
-	}
-
-	if !errors.Is(err, errInvalidValue) {
-		t.Errorf("Expected error invalid value, got %s", err)
-	}
-}
-
-func TestExtractDestinationWithInvalidDestination(t *testing.T) {
-	request := httptest.NewRequest(http.MethodGet, "https://example.org/remote.php/dav/src", nil)
-	request.Header.Set(net.HeaderDestination, "://example.org/remote.php/dav/dst")
-	_, err := extractDestination(request)
-	if err == nil {
-		t.Errorf("Expected err to be nil got %s", err)
-	}
-
-	if !errors.Is(err, errInvalidValue) {
-		t.Errorf("Expected error invalid value, got %s", err)
-	}
-}
-
-func TestExtractDestinationWithDestinationWrongBaseURI(t *testing.T) {
-	request := httptest.NewRequest(http.MethodGet, "https://example.org/remote.php/dav/src", nil)
-	request.Header.Set(net.HeaderDestination, "https://example.org/remote.php/dav/dst")
-
-	ctx := context.WithValue(context.Background(), net.CtxKeyBaseURI, "remote.php/webdav")
-	_, err := extractDestination(request.WithContext(ctx))
-	if err == nil {
-		t.Errorf("Expected err to be nil got %s", err)
-	}
-
-	if !errors.Is(err, errInvalidValue) {
-		t.Errorf("Expected error invalid value, got %s", err)
 	}
 }
 

--- a/internal/http/services/owncloud/ocdav/spaces.go
+++ b/internal/http/services/owncloud/ocdav/spaces.go
@@ -62,6 +62,7 @@ func (h *SpacesHandler) Handler(s *svc, trashbinHandler *TrashbinHandler) http.H
 		var spaceID string
 		if p == _trashbinPath {
 			h.handleSpacesTrashbin(w, r, s, trashbinHandler)
+			return
 		} else {
 			spaceID = p
 		}
@@ -167,7 +168,6 @@ func (h *SpacesHandler) handleSpacesTrashbin(w http.ResponseWriter, r *http.Requ
 	case MethodPropfind:
 		trashbinHandler.listTrashbin(w, r, s, ref, path.Join(_trashbinPath, spaceID), key, r.URL.Path)
 	case http.MethodDelete:
-		// trashbinHandler.delete(w, r, s, )
+		trashbinHandler.delete(w, r, s, ref, key, r.URL.Path)
 	}
-
 }

--- a/internal/http/services/owncloud/ocdav/spaces.go
+++ b/internal/http/services/owncloud/ocdav/spaces.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cs3org/reva/v2/pkg/appctx"
 	"github.com/cs3org/reva/v2/pkg/rgrpc/todo/pool"
 	"github.com/cs3org/reva/v2/pkg/rhttp/router"
+	"github.com/cs3org/reva/v2/pkg/utils"
 )
 
 // SpacesHandler handles trashbin requests
@@ -184,9 +185,12 @@ func (h *SpacesHandler) handleSpacesTrashbin(w http.ResponseWriter, r *http.Requ
 			w.WriteHeader(http.StatusBadRequest)
 			return
 		}
-
 		log.Debug().Str("key", key).Str("path", r.URL.Path).Str("dst", dst).Msg("spaces restore")
-		trashbinHandler.restore(w, r, s, ref, dst, key, r.URL.Path)
+
+		dstRef := ref
+		dstRef.Path = utils.MakeRelativePath(dst)
+
+		trashbinHandler.restore(w, r, s, ref, dstRef, key, r.URL.Path)
 	case http.MethodDelete:
 		trashbinHandler.delete(w, r, s, ref, key, r.URL.Path)
 	default:

--- a/pkg/storage/utils/decomposedfs/recycle.go
+++ b/pkg/storage/utils/decomposedfs/recycle.go
@@ -295,6 +295,9 @@ func (fs *Decomposedfs) PurgeRecycleItem(ctx context.Context, ref *provider.Refe
 	}
 	rn, purgeFunc, err := fs.tp.PurgeRecycleItemFunc(ctx, ref.ResourceId.OpaqueId, key, relativePath)
 	if err != nil {
+		if errors.Is(err, iofs.ErrNotExist) {
+			return errtypes.NotFound(key)
+		}
 		return err
 	}
 


### PR DESCRIPTION
Added the webdav trash-bin API for spaces. It works the same way as the 'normal' API.
The spaces trashbin is reachable at '/remote.php/dav/spaces/trash-bin/{spaceid}`.
