### PR TITLE
Delay reconnect log

### DIFF
--- a/changelog/unreleased/delay-reconnect-log.md
+++ b/changelog/unreleased/delay-reconnect-log.md
@@ -1,0 +1,5 @@
+Bugfix: delay reconnect log for events
+
+Print reconnect information log only when reconnect time is bigger than a second
+
+https://github.com/cs3org/reva/pull/2636

--- a/pkg/events/server/nats.go
+++ b/pkg/events/server/nats.go
@@ -19,11 +19,11 @@
 package server
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/asim/go-micro/plugins/events/nats/v4"
 	"github.com/cenkalti/backoff"
+	"github.com/cs3org/reva/v2/pkg/logger"
 	"go-micro.dev/v4/events"
 
 	stanServer "github.com/nats-io/nats-streaming-server/server"
@@ -50,8 +50,7 @@ func NewNatsStream(opts ...nats.Option) (events.Stream, error) {
 		n := b.NextBackOff()
 		s, err := nats.NewStream(opts...)
 		if err != nil && n > time.Second {
-			// TODO: should we get the standard logger here? if yes: How?
-			fmt.Printf("can't connect to nats (stan) server, retrying in %s\n", n)
+			logger.New().Error().Err(err).Msgf("can't connect to nats (stan) server, retrying in %s", n)
 		}
 		stream = s
 		return err

--- a/pkg/events/server/nats.go
+++ b/pkg/events/server/nats.go
@@ -20,6 +20,7 @@ package server
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/asim/go-micro/plugins/events/nats/v4"
 	"github.com/cenkalti/backoff"
@@ -46,10 +47,11 @@ func NewNatsStream(opts ...nats.Option) (events.Stream, error) {
 	b := backoff.NewExponentialBackOff()
 	var stream events.Stream
 	o := func() error {
+		n := b.NextBackOff()
 		s, err := nats.NewStream(opts...)
-		if err != nil {
+		if err != nil && n > time.Second {
 			// TODO: should we get the standard logger here? if yes: How?
-			fmt.Printf("can't connect to nats (stan) server, retrying in %s\n", b.NextBackOff())
+			fmt.Printf("can't connect to nats (stan) server, retrying in %s\n", n)
 		}
 		stream = s
 		return err


### PR DESCRIPTION
When services are connecting to nats server but don't succeed they print a message like 
```
can't connect to nats (stan) server, retrying in 676.400829ms
```

This is confusing for the end user as it is not an error if this message only appears once. For avoiding the confusion we will only log this when the reconnect is bigger than a second already