### PR TITLE
emit linkaccessfailed event when share is nil

### DIFF
--- a/changelog/unreleased/make-linkaccessfailed-more-robust.md
+++ b/changelog/unreleased/make-linkaccessfailed-more-robust.md
@@ -1,0 +1,5 @@
+Bugfix: emit linkaccessfailed event when share is nil
+
+The code no longer panics when a link access failed event has no share.
+
+https://github.com/cs3org/reva/pull/2643

--- a/internal/grpc/interceptors/eventsmiddleware/conversion.go
+++ b/internal/grpc/interceptors/eventsmiddleware/conversion.go
@@ -126,12 +126,15 @@ func LinkAccessed(r *link.GetPublicShareByTokenResponse) events.LinkAccessed {
 
 // LinkAccessFailed converts the response to an event
 func LinkAccessFailed(r *link.GetPublicShareByTokenResponse, req *link.GetPublicShareByTokenRequest) events.LinkAccessFailed {
-	return events.LinkAccessFailed{
-		ShareID: r.Share.Id,
-		Token:   r.Share.Token,
+	e := events.LinkAccessFailed{
 		Status:  r.Status.Code,
 		Message: r.Status.Message,
 	}
+	if r.Share != nil {
+		e.ShareID = r.Share.Id
+		e.Token = r.Share.Token
+	}
+	return e
 }
 
 // LinkRemoved converts the response to an event


### PR DESCRIPTION
The code no longer panics when a link access failed event has no share.
