### PR TITLE
Publicstorageprovider rewrite

### DIFF
--- a/changelog/unreleased/publicstorageprovider-rewrite.md
+++ b/changelog/unreleased/publicstorageprovider-rewrite.md
@@ -1,0 +1,6 @@
+Bugfix: Make public link access use same fileids as authenticated access
+
+A resource now always hase the same fileid, regardless of how it is accessed.
+
+https://github.com/cs3org/reva/pull/2646
+https://github.com/cs3org/reva/issues/2635

--- a/changelog/unreleased/publicstorageprovider-rewrite.md
+++ b/changelog/unreleased/publicstorageprovider-rewrite.md
@@ -1,6 +1,6 @@
-Bugfix: Make public link access use same fileids as authenticated access
+Bugfix: replace public mountpoint fileid with grant fileid in ocdav
 
-A resource now always hase the same fileid, regardless of how it is accessed.
+We now show the same resoucre id for resources when accessing them via a public links as when using a logged in user. This allows the web ui to start a WOPI session with the correct resource id.
 
 https://github.com/cs3org/reva/pull/2646
 https://github.com/cs3org/reva/issues/2635

--- a/internal/grpc/interceptors/auth/auth.go
+++ b/internal/grpc/interceptors/auth/auth.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/bluele/gcache"
+	authpb "github.com/cs3org/go-cs3apis/cs3/auth/provider/v1beta1"
 	gatewayv1beta1 "github.com/cs3org/go-cs3apis/cs3/gateway/v1beta1"
 	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	"github.com/cs3org/reva/v2/pkg/appctx"
@@ -96,9 +97,11 @@ func NewUnary(m map[string]interface{}, unprotected []string) (grpc.UnaryServerI
 			// to decide the storage provider.
 			tkn, ok := ctxpkg.ContextGetToken(ctx)
 			if ok {
-				u, err := dismantleToken(ctx, tkn, req, tokenManager, conf.GatewayAddr, false)
+				u, tokenScope, err := dismantleToken(ctx, tkn, req, tokenManager, conf.GatewayAddr, false)
 				if err == nil {
+					// store user and scopes in context
 					ctx = ctxpkg.ContextSetUser(ctx, u)
+					ctx = ctxpkg.ContextSetScopes(ctx, tokenScope)
 				}
 			}
 			return handler(ctx, req)
@@ -112,13 +115,15 @@ func NewUnary(m map[string]interface{}, unprotected []string) (grpc.UnaryServerI
 		}
 
 		// validate the token and ensure access to the resource is allowed
-		u, err := dismantleToken(ctx, tkn, req, tokenManager, conf.GatewayAddr, true)
+		u, tokenScope, err := dismantleToken(ctx, tkn, req, tokenManager, conf.GatewayAddr, true)
 		if err != nil {
 			log.Warn().Err(err).Msg("access token is invalid")
 			return nil, status.Errorf(codes.PermissionDenied, "auth: core access token is invalid")
 		}
 
+		// store user and scopes in context
 		ctx = ctxpkg.ContextSetUser(ctx, u)
+		ctx = ctxpkg.ContextSetScopes(ctx, tokenScope)
 		return handler(ctx, req)
 	}
 	return interceptor, nil
@@ -159,9 +164,11 @@ func NewStream(m map[string]interface{}, unprotected []string) (grpc.StreamServe
 			// to decide the storage provider.
 			tkn, ok := ctxpkg.ContextGetToken(ctx)
 			if ok {
-				u, err := dismantleToken(ctx, tkn, ss, tokenManager, conf.GatewayAddr, false)
+				u, tokenScope, err := dismantleToken(ctx, tkn, ss, tokenManager, conf.GatewayAddr, false)
 				if err == nil {
+					// store user and scopes in context
 					ctx = ctxpkg.ContextSetUser(ctx, u)
+					ctx = ctxpkg.ContextSetScopes(ctx, tokenScope)
 					ss = newWrappedServerStream(ctx, ss)
 				}
 			}
@@ -177,14 +184,15 @@ func NewStream(m map[string]interface{}, unprotected []string) (grpc.StreamServe
 		}
 
 		// validate the token and ensure access to the resource is allowed
-		u, err := dismantleToken(ctx, tkn, ss, tokenManager, conf.GatewayAddr, true)
+		u, tokenScope, err := dismantleToken(ctx, tkn, ss, tokenManager, conf.GatewayAddr, true)
 		if err != nil {
 			log.Warn().Err(err).Msg("access token is invalid")
 			return status.Errorf(codes.PermissionDenied, "auth: core access token is invalid")
 		}
 
-		// store user and core access token in context.
+		// store user and scopes in context
 		ctx = ctxpkg.ContextSetUser(ctx, u)
+		ctx = ctxpkg.ContextSetScopes(ctx, tokenScope)
 		wrapped := newWrappedServerStream(ctx, ss)
 		return handler(srv, wrapped)
 	}
@@ -204,21 +212,22 @@ func (ss *wrappedServerStream) Context() context.Context {
 	return ss.newCtx
 }
 
-func dismantleToken(ctx context.Context, tkn string, req interface{}, mgr token.Manager, gatewayAddr string, fetchUserGroups bool) (*userpb.User, error) {
+// dismantleToken extraclts the user and scopes from the reva access token
+func dismantleToken(ctx context.Context, tkn string, req interface{}, mgr token.Manager, gatewayAddr string, fetchUserGroups bool) (*userpb.User, map[string]*authpb.Scope, error) {
 	u, tokenScope, err := mgr.DismantleToken(ctx, tkn)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	client, err := pool.GetGatewayServiceClient(gatewayAddr)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	if sharedconf.SkipUserGroupsInToken() && fetchUserGroups {
 		groups, err := getUserGroups(ctx, u, client)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		u.Groups = groups
 	}
@@ -226,17 +235,17 @@ func dismantleToken(ctx context.Context, tkn string, req interface{}, mgr token.
 	// Check if access to the resource is in the scope of the token
 	ok, err := scope.VerifyScope(ctx, tokenScope, req)
 	if err != nil {
-		return nil, errtypes.InternalError("error verifying scope of access token")
+		return nil, nil, errtypes.InternalError("error verifying scope of access token")
 	}
 	if ok {
-		return u, nil
+		return u, tokenScope, nil
 	}
 
 	if err = expandAndVerifyScope(ctx, req, tokenScope, gatewayAddr, mgr); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	return u, nil
+	return u, tokenScope, nil
 }
 
 func getUserGroups(ctx context.Context, u *userpb.User, client gatewayv1beta1.GatewayAPIClient) ([]string, error) {

--- a/internal/grpc/interceptors/auth/auth.go
+++ b/internal/grpc/interceptors/auth/auth.go
@@ -212,7 +212,7 @@ func (ss *wrappedServerStream) Context() context.Context {
 	return ss.newCtx
 }
 
-// dismantleToken extraclts the user and scopes from the reva access token
+// dismantleToken extracts the user and scopes from the reva access token
 func dismantleToken(ctx context.Context, tkn string, req interface{}, mgr token.Manager, gatewayAddr string, fetchUserGroups bool) (*userpb.User, map[string]*authpb.Scope, error) {
 	u, tokenScope, err := mgr.DismantleToken(ctx, tkn)
 	if err != nil {

--- a/internal/grpc/services/publicstorageprovider/publicstorageprovider.go
+++ b/internal/grpc/services/publicstorageprovider/publicstorageprovider.go
@@ -819,7 +819,7 @@ func (s *service) ListContainer(ctx context.Context, req *provider.ListContainer
 	for i := range listContainerR.Infos {
 		// FIXME how do we reduce permissions to what is granted by the public link?
 		filterPermissions(listContainerR.Infos[i].PermissionSet, share.GetPermissions().Permissions)
-		//s.setPublicStorageID(listContainerR.Infos[i], tkn)
+		// s.setPublicStorageID(listContainerR.Infos[i], tkn)
 		if err := addShare(listContainerR.Infos[i], share); err != nil {
 			appctx.GetLogger(ctx).Error().Err(err).Interface("share", share).Interface("info", listContainerR.Infos[i]).Msg("error when adding share")
 		}

--- a/internal/http/interceptors/auth/auth.go
+++ b/internal/http/interceptors/auth/auth.go
@@ -284,6 +284,9 @@ func New(m map[string]interface{}, unprotected []string) (global.Middleware, err
 
 			ctx = metadata.AppendToOutgoingContext(ctx, ctxpkg.UserAgentHeader, r.UserAgent())
 
+			// store scopes in context
+			ctx = ctxpkg.ContextSetScopes(ctx, tokenScope)
+
 			r = r.WithContext(ctx)
 			h.ServeHTTP(w, r)
 		})

--- a/internal/http/services/owncloud/ocdav/dav.go
+++ b/internal/http/services/owncloud/ocdav/dav.go
@@ -276,9 +276,8 @@ func getTokenStatInfo(ctx context.Context, client gatewayv1beta1.GatewayAPIClien
 	return client.Stat(ctx, &provider.StatRequest{Ref: &provider.Reference{
 		ResourceId: &provider.ResourceId{
 			StorageId: utils.PublicStorageProviderID,
-			OpaqueId:  utils.PublicStorageProviderID,
+			OpaqueId:  token,
 		},
-		Path: utils.MakeRelativePath(token),
 	}})
 }
 

--- a/internal/http/services/owncloud/ocdav/propfind/propfind.go
+++ b/internal/http/services/owncloud/ocdav/propfind/propfind.go
@@ -721,6 +721,11 @@ func mdToPropResponse(ctx context.Context, pf *XML, md *provider.ResourceInfo, p
 		sublog.Debug().Interface("role", role).Str("dav-permissions", wdp).Msg("converted PermissionSet")
 	}
 
+	// replace fileid of /public/{token} mountpoint with grant fileid
+	if ls != nil && md.Id != nil && md.Id.StorageId == utils.PublicStorageProviderID && md.Id.OpaqueId == ls.Token {
+		md.Id = ls.ResourceId
+	}
+
 	propstatOK := PropstatXML{
 		Status: "HTTP/1.1 200 OK",
 		Prop:   []*props.PropertyXML{},

--- a/pkg/auth/scope/publicshare.go
+++ b/pkg/auth/scope/publicshare.go
@@ -113,7 +113,7 @@ func publicshareScope(ctx context.Context, scope *authpb.Scope, resource interfa
 		return true, nil
 
 	case *provider.ListStorageSpacesRequest:
-		//return checkPublicListStorageSpacesFilter(v.Filters), nil
+		// return checkPublicListStorageSpacesFilter(v.Filters), nil
 		return true, nil
 	case *link.GetPublicShareRequest:
 		return checkPublicShareRef(&share, v.GetRef()), nil

--- a/pkg/auth/scope/publicshare.go
+++ b/pkg/auth/scope/publicshare.go
@@ -158,29 +158,6 @@ func checkStorageRef(ctx context.Context, s *link.PublicShare, r *provider.Refer
 	return false
 }
 
-// public link access must send a filter with id or type
-/*
-func checkPublicListStorageSpacesFilter(filters []*provider.ListStorageSpacesRequest_Filter) bool {
-	// return true
-	for _, f := range filters {
-		switch f.Type {
-		case provider.ListStorageSpacesRequest_Filter_TYPE_SPACE_TYPE:
-			switch f.GetSpaceType() {
-			case "mountpoint", "+mountpoint":
-				return true
-			case "grant", "+grant":
-				return true
-			}
-		case provider.ListStorageSpacesRequest_Filter_TYPE_ID:
-			if f.GetId().OpaqueId != "" {
-				return true
-			}
-		}
-	}
-	return false
-}
-*/
-
 func checkPublicShareRef(s *link.PublicShare, ref *link.PublicShareReference) bool {
 	// ref: <token:$token >
 	return ref.GetToken() == s.Token

--- a/pkg/auth/scope/publicshare.go
+++ b/pkg/auth/scope/publicshare.go
@@ -71,6 +71,8 @@ func publicshareScope(ctx context.Context, scope *authpb.Scope, resource interfa
 			}
 		}
 		return checkStorageRef(ctx, &share, ref), nil
+	case *provider.CreateHomeRequest:
+		return false, nil
 	case *provider.GetPathRequest:
 		return checkStorageRef(ctx, &share, &provider.Reference{ResourceId: v.GetResourceId()}), nil
 	case *provider.StatRequest:
@@ -127,7 +129,7 @@ func publicshareScope(ctx context.Context, scope *authpb.Scope, resource interfa
 		return checkResourcePath(v), nil
 	}
 
-	msg := "resource type assertion failed"
+	msg := "public resource type assertion failed"
 	logger.Debug().Str("scope", "publicshareScope").Interface("resource", resource).Msg(msg)
 	return false, errtypes.InternalError(msg)
 }

--- a/pkg/auth/scope/publicshare.go
+++ b/pkg/auth/scope/publicshare.go
@@ -113,7 +113,6 @@ func publicshareScope(ctx context.Context, scope *authpb.Scope, resource interfa
 		return true, nil
 
 	case *provider.ListStorageSpacesRequest:
-		// return checkPublicListStorageSpacesFilter(v.Filters), nil
 		return true, nil
 	case *link.GetPublicShareRequest:
 		return checkPublicShareRef(&share, v.GetRef()), nil

--- a/pkg/ctx/scopectx.go
+++ b/pkg/ctx/scopectx.go
@@ -1,0 +1,36 @@
+// Copyright 2018-2021 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package ctx
+
+import (
+	"context"
+
+	auth "github.com/cs3org/go-cs3apis/cs3/auth/provider/v1beta1"
+)
+
+// ContextGetScopes returns the scopes if set in the given context.
+func ContextGetScopes(ctx context.Context) (map[string]*auth.Scope, bool) {
+	s, ok := ctx.Value(scopeKey).(map[string]*auth.Scope)
+	return s, ok
+}
+
+// ContextSetScopes stores the scopes in the context.
+func ContextSetScopes(ctx context.Context, s map[string]*auth.Scope) context.Context {
+	return context.WithValue(ctx, scopeKey, s)
+}

--- a/pkg/ctx/userctx.go
+++ b/pkg/ctx/userctx.go
@@ -31,6 +31,7 @@ const (
 	tokenKey
 	idKey
 	lockIDKey
+	scopeKey
 )
 
 // ContextGetUser returns the user if set in the given context.

--- a/tests/oc-integration-tests/drone/gateway.toml
+++ b/tests/oc-integration-tests/drone/gateway.toml
@@ -78,7 +78,8 @@ home_template = "/users/{{.Id.OpaqueId}}"
 ## While public shares are mounted at /public logged in end will should never see that path because it is only created by the spaces registry when
 ## a public link is accessed.
 [grpc.services.storageregistry.drivers.spaces.providers."localhost:13000".spaces]
-"public" = { "mount_point" = "/public", "path_template" = "/public" }
+"grant" = { "mount_point" = "." }
+"mountpoint" = { "mount_point" = "/public", "path_template" = "/public/{{.Space.Name}}" }
 
 [http]
 address = "0.0.0.0:19001"

--- a/tests/oc-integration-tests/drone/gateway.toml
+++ b/tests/oc-integration-tests/drone/gateway.toml
@@ -79,7 +79,7 @@ home_template = "/users/{{.Id.OpaqueId}}"
 ## a public link is accessed.
 [grpc.services.storageregistry.drivers.spaces.providers."localhost:13000".spaces]
 "grant" = { "mount_point" = "." }
-"mountpoint" = { "mount_point" = "/public", "path_template" = "/public/{{.Space.Name}}" }
+"mountpoint" = { "mount_point" = "/public", "path_template" = "/public/{{.Space.Root.OpaqueId}}" }
 
 [http]
 address = "0.0.0.0:19001"

--- a/tests/oc-integration-tests/local/gateway.toml
+++ b/tests/oc-integration-tests/local/gateway.toml
@@ -84,7 +84,8 @@ home_template = "/users/{{.Id.OpaqueId}}"
 ## While public shares are mounted at /public logged in end will should never see that path because it is only created by the spaces registry when
 ## a public link is accessed.
 [grpc.services.storageregistry.drivers.spaces.providers."localhost:13000".spaces]
-"public" = { "mount_point" = "/public" }
+"grant" = { "mount_point" = "." }
+"mountpoint" = { "mount_point" = "/public", "path_template" = "/public/{{.Space.Name}}" }
 
 [http]
 address = "0.0.0.0:19001"

--- a/tests/oc-integration-tests/local/gateway.toml
+++ b/tests/oc-integration-tests/local/gateway.toml
@@ -85,7 +85,7 @@ home_template = "/users/{{.Id.OpaqueId}}"
 ## a public link is accessed.
 [grpc.services.storageregistry.drivers.spaces.providers."localhost:13000".spaces]
 "grant" = { "mount_point" = "." }
-"mountpoint" = { "mount_point" = "/public", "path_template" = "/public/{{.Space.Name}}" }
+"mountpoint" = { "mount_point" = "/public", "path_template" = "/public/{{.Space.Root.OpaqueId}}" }
 
 [http]
 address = "0.0.0.0:19001"


### PR DESCRIPTION
We cannot use the current publicstorageprovider implementation as it changes the fileid when accessing a file via a public link. This causes problems with the WOPI server when users enter and leave the session. see https://github.com/cs3org/reva/issues/2635

This PR uses two types of spaces: `grant` and `mountpoint` similar to the sharesstorageprovider. The `mountpoint` space is however only listed when the scope indicates a public link.

The `grant` space is used to forward requests to the actual storage provider.

Note that the mountpoint has a different resourceid than the grant.
- The `mountpoint` space uses the publicstorageproviderid as the `storageid`/`spaceid` and the `token` as the `opaqueid`/`nodeid`.
- The `grant` space uses the `storageid`/`spaceid` and `opaqueid`/`nodeid` of the shared resource. This causes requests to be routed directly to the original storage provider.

This is now in alignment to how the sharesstorageprovider works.

While relative access using the `/public/{token}` mountpoint works, a fileid based access, eg via `/dav/spaces/{spaceid}!{nodeid}` would need an additional publicstorage middleware that reduces the permissions to what is granted by the link. Currently, the authentication impersonates the owner of the shared resource, which would report the wrong permissions.

- [x] double check the public scope does prevent escaping the shared tree
- [ ] ~~add public scope / link middleware (must be a middleware, manipulating permissions in ocdav would not affect CS3 api calls, eg by the WCOPI server)~~ tracked in https://github.com/cs3org/reva/issues/2656
- [x] fix test config
- [x] test ocis update in https://github.com/owncloud/ocis/pull/3349