### PR TITLE
add a spaceid to the propfind response

### DIFF
--- a/changelog/unreleased/spaceid-propfind.md
+++ b/changelog/unreleased/spaceid-propfind.md
@@ -1,0 +1,6 @@
+Enhancement: Add the spaceid to propfind responses
+
+Added the spaceid to propfind responses so that clients have the necessary data to send subsequent requests.
+
+https://github.com/owncloud/ocis/issues/3345
+https://github.com/cs3org/reva/pull/2657

--- a/internal/http/services/owncloud/ocdav/propfind/propfind.go
+++ b/internal/http/services/owncloud/ocdav/propfind/propfind.go
@@ -734,6 +734,7 @@ func mdToPropResponse(ctx context.Context, pf *XML, md *provider.ResourceInfo, p
 			propstatOK.Prop = append(propstatOK.Prop,
 				props.NewProp("oc:id", id),
 				props.NewProp("oc:fileid", id),
+				props.NewProp("oc:spaceid", md.Id.StorageId),
 			)
 		}
 
@@ -842,6 +843,12 @@ func mdToPropResponse(ctx context.Context, pf *XML, md *provider.ResourceInfo, p
 						propstatOK.Prop = append(propstatOK.Prop, props.NewProp("oc:id", resourceid.OwnCloudResourceIDWrap(md.Id)))
 					} else {
 						propstatNotFound.Prop = append(propstatNotFound.Prop, props.NewProp("oc:id", ""))
+					}
+				case "spaceid":
+					if md.Id != nil {
+						propstatOK.Prop = append(propstatOK.Prop, props.NewProp("oc:spaceid", md.Id.StorageId))
+					} else {
+						propstatNotFound.Prop = append(propstatNotFound.Prop, props.NewProp("oc:spaceid", ""))
 					}
 				case "permissions": // both
 					// oc:permissions take several char flags to indicate the permissions the user has on this node:


### PR DESCRIPTION
Added the spaceid to propfind responses so that clients have the necessary data to send subsequent requests.
See: https://github.com/owncloud/ocis/issues/3345