### PR TITLE
ldap: Allow groups to have no gidNumber

### DIFF
--- a/changelog/unreleased/group-without-gidnumber.md
+++ b/changelog/unreleased/group-without-gidnumber.md
@@ -1,0 +1,6 @@
+Change: Allow LDAP groups to have no gidNumber
+
+Similar to the user-provider allow a group to have no gidNumber. Assign
+a default in that case.
+
+https://github.com/cs3org/reva/pull/2667

--- a/pkg/group/manager/ldap/ldap.go
+++ b/pkg/group/manager/ldap/ldap.go
@@ -239,9 +239,14 @@ func (m *manager) GetGroupByClaim(ctx context.Context, claim, value string) (*gr
 	if err != nil {
 		return nil, err
 	}
-	gidNumber, err := strconv.ParseInt(sr.Entries[0].GetEqualFoldAttributeValue(m.c.Schema.GIDNumber), 10, 64)
-	if err != nil {
-		return nil, err
+
+	gidNumber := m.c.Nobody
+	gidValue := sr.Entries[0].GetEqualFoldAttributeValue(m.c.Schema.GIDNumber)
+	if gidValue != "" {
+		gidNumber, err = strconv.ParseInt(gidValue, 10, 64)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	g := &grouppb.Group{


### PR DESCRIPTION
Similar to the user-provider allow a group to have no gidNumber. Assign
a default in that case.