### PR TITLE
Shares improvements

### DIFF
--- a/changelog/unreleased/spaces-shares.md
+++ b/changelog/unreleased/spaces-shares.md
@@ -1,0 +1,7 @@
+Enhancement: Enable space members to list shares inside the space
+
+If there are shared resources in a space then all members are allowed to see those shares.
+The json share manager was enhanced to check if the user is allowed to see a share by checking the grants on a resource.
+
+https://github.com/owncloud/ocis/issues/3370
+https://github.com/cs3org/reva/pull/2674

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/spaces.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/spaces.go
@@ -95,11 +95,16 @@ func (h *Handler) addSpaceMember(w http.ResponseWriter, r *http.Request, info *p
 		return
 	}
 
+	permissions := role.CS3ResourcePermissions()
+	// All members of a space should be able to list shares inside that space.
+	// The viewer role doesn't have the ListGrants permission so we set it here.
+	permissions.ListGrants = true
+
 	createShareRes, err := client.CreateShare(ctx, &collaborationv1beta1.CreateShareRequest{
 		ResourceInfo: info,
 		Grant: &collaborationv1beta1.ShareGrant{
 			Permissions: &collaborationv1beta1.SharePermissions{
-				Permissions: role.CS3ResourcePermissions(),
+				Permissions: permissions,
 			},
 			Grantee: &grantee,
 		},

--- a/pkg/publicshare/manager/cs3/cs3.go
+++ b/pkg/publicshare/manager/cs3/cs3.go
@@ -267,7 +267,9 @@ func (m *Manager) getWithPassword(ctx context.Context, ref *link.PublicShareRefe
 }
 
 func (m *Manager) getByID(ctx context.Context, id string) (*PublicShareWithPassword, error) {
-	tokens, err := m.indexer.FindBy(&link.PublicShare{}, "Id.OpaqueId", id)
+	tokens, err := m.indexer.FindBy(&link.PublicShare{},
+		indexer.NewField("Id.OpaqueId", id),
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -298,7 +300,9 @@ func (m *Manager) ListPublicShares(ctx context.Context, u *user.User, filters []
 		return nil, err
 	}
 
-	tokens, err := m.indexer.FindBy(&link.PublicShare{}, "Owner", userIDToIndex(u.Id))
+	tokens, err := m.indexer.FindBy(&link.PublicShare{},
+		indexer.NewField("Owner", userIDToIndex(u.Id)),
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/share/manager/cs3/cs3.go
+++ b/pkg/share/manager/cs3/cs3.go
@@ -128,6 +128,13 @@ func (m *Manager) initialize() error {
 		return err
 	}
 	err = m.indexer.AddIndex(&collaboration.Share{}, option.IndexByFunc{
+		Name: "CreatorId",
+		Func: indexCreatorFunc,
+	}, "Id.OpaqueId", "shares", "non_unique", nil, true)
+	if err != nil {
+		return err
+	}
+	err = m.indexer.AddIndex(&collaboration.Share{}, option.IndexByFunc{
 		Name: "GranteeId",
 		Func: indexGranteeFunc,
 	}, "Id.OpaqueId", "shares", "non_unique", nil, true)
@@ -499,6 +506,14 @@ func indexOwnerFunc(v interface{}) (string, error) {
 		return "", fmt.Errorf("given entity is not a share")
 	}
 	return userIDToIndex(share.Owner), nil
+}
+
+func indexCreatorFunc(v interface{}) (string, error) {
+	share, ok := v.(*collaboration.Share)
+	if !ok {
+		return "", fmt.Errorf("given entity is not a share")
+	}
+	return userIDToIndex(share.Creator), nil
 }
 
 func userIDToIndex(id *userpb.UserId) string {

--- a/pkg/share/share.go
+++ b/pkg/share/share.go
@@ -161,6 +161,9 @@ func MatchesAnyFilter(share *collaboration.Share, filters []*collaboration.Filte
 // Here is an example:
 // (resource_id=1 OR resource_id=2) AND (grantee_type=USER OR grantee_type=GROUP)
 func MatchesFilters(share *collaboration.Share, filters []*collaboration.Filter) bool {
+	if len(filters) == 0 {
+		return true
+	}
 	grouped := GroupFiltersByType(filters)
 	for _, f := range grouped {
 		if !MatchesAnyFilter(share, f) {

--- a/pkg/storage/utils/indexer/indexer_test.go
+++ b/pkg/storage/utils/indexer/indexer_test.go
@@ -43,7 +43,7 @@ func TestIndexer_Disk_FindByWithUniqueIndex(t *testing.T) {
 	_, err = indexer.Add(u)
 	assert.NoError(t, err)
 
-	res, err := indexer.FindBy(User{}, "UserName", "mikey")
+	res, err := indexer.FindBy(User{}, NewField("UserName", "mikey"))
 	assert.NoError(t, err)
 	t.Log(res)
 
@@ -82,7 +82,7 @@ func TestIndexer_Disk_AddWithNonUniqueIndex(t *testing.T) {
 	_, err = indexer.Add(pet2)
 	assert.NoError(t, err)
 
-	res, err := indexer.FindBy(Pet{}, "Kind", "Hog")
+	res, err := indexer.FindBy(Pet{}, NewField("Kind", "Hog"))
 	assert.NoError(t, err)
 
 	t.Log(res)
@@ -108,7 +108,7 @@ func TestIndexer_Disk_AddWithAutoincrementIndex(t *testing.T) {
 	assert.Equal(t, "UID", res2[0].Field)
 	assert.Equal(t, "6", path.Base(res2[0].Value))
 
-	resFindBy, err := indexer.FindBy(User{}, "UID", "6")
+	resFindBy, err := indexer.FindBy(User{}, NewField("UID", "6"))
 	assert.NoError(t, err)
 	assert.Equal(t, "hijklmn-456", resFindBy[0])
 	t.Log(resFindBy)
@@ -189,10 +189,10 @@ func TestIndexer_Disk_UpdateWithUniqueIndex(t *testing.T) {
 		Email:    "mikey@example.com",
 	})
 	assert.NoError(t, err)
-	v, err1 := indexer.FindBy(&User{}, "UserName", "mikey-new")
+	v, err1 := indexer.FindBy(&User{}, NewField("UserName", "mikey-new"))
 	assert.NoError(t, err1)
 	assert.Len(t, v, 1)
-	v, err2 := indexer.FindBy(&User{}, "UserName", "mikey")
+	v, err2 := indexer.FindBy(&User{}, NewField("UserName", "mikey"))
 	assert.NoError(t, err2)
 	assert.Len(t, v, 0)
 
@@ -206,10 +206,10 @@ func TestIndexer_Disk_UpdateWithUniqueIndex(t *testing.T) {
 		Email:    "mikey-new@example.com",
 	})
 	assert.NoError(t, err1)
-	fbUserName, err2 := indexer.FindBy(&User{}, "UserName", "mikey-newest")
+	fbUserName, err2 := indexer.FindBy(&User{}, NewField("UserName", "mikey-newest"))
 	assert.NoError(t, err2)
 	assert.Len(t, fbUserName, 1)
-	fbEmail, err3 := indexer.FindBy(&User{}, "Email", "mikey-new@example.com")
+	fbEmail, err3 := indexer.FindBy(&User{}, NewField("Email", "mikey-new@example.com"))
 	assert.NoError(t, err3)
 	assert.Len(t, fbEmail, 1)
 

--- a/pkg/storage/utils/indexer/mocks/Indexer.go
+++ b/pkg/storage/utils/indexer/mocks/Indexer.go
@@ -83,13 +83,20 @@ func (_m *Indexer) Delete(t interface{}) error {
 	return r0
 }
 
-// FindBy provides a mock function with given fields: t, field, val
-func (_m *Indexer) FindBy(t interface{}, field string, val string) ([]string, error) {
-	ret := _m.Called(t, field, val)
+// FindBy provides a mock function with given fields: t, fields
+func (_m *Indexer) FindBy(t interface{}, fields ...indexer.Field) ([]string, error) {
+	_va := make([]interface{}, len(fields))
+	for _i := range fields {
+		_va[_i] = fields[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, t)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 []string
-	if rf, ok := ret.Get(0).(func(interface{}, string, string) []string); ok {
-		r0 = rf(t, field, val)
+	if rf, ok := ret.Get(0).(func(interface{}, ...indexer.Field) []string); ok {
+		r0 = rf(t, fields...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]string)
@@ -97,8 +104,8 @@ func (_m *Indexer) FindBy(t interface{}, field string, val string) ([]string, er
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(interface{}, string, string) error); ok {
-		r1 = rf(t, field, val)
+	if rf, ok := ret.Get(1).(func(interface{}, ...indexer.Field) error); ok {
+		r1 = rf(t, fields...)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/tests/oc-integration-tests/drone/shares.toml
+++ b/tests/oc-integration-tests/drone/shares.toml
@@ -18,3 +18,4 @@ gateway_addr = "localhost:19000"
 
 [grpc.services.publicshareprovider.drivers.json]
 file = "/drone/src/tmp/reva/publicshares.json"
+gateway_addr = "localhost:19000"

--- a/tests/oc-integration-tests/local/shares.toml
+++ b/tests/oc-integration-tests/local/shares.toml
@@ -22,3 +22,4 @@ gateway_addr = "0.0.0.0:19000"
 
 [grpc.services.publicshareprovider.drivers.json]
 file = "/var/tmp/reva/publicshares.json"
+gateway_addr = "0.0.0.0:19000"


### PR DESCRIPTION
If there are shared resources in a space then all members are allowed to see those shares.
The json share manager was enhanced to check if the user is allowed to see a share by checking the grants on a resource.

I also cleaned up the code in the json share manager and reduced the runtime complexity of `ListReceivedShares`.

The new grants check actually needs to be added to the CS3 share manager too, I need to talk to @aduffeck though because I don't know if I somehow can get all shares.