### PR TITLE
remove ioutil and use io or os appropriately

### DIFF
--- a/cmd/reva/common.go
+++ b/cmd/reva/common.go
@@ -21,7 +21,7 @@ package main
 import (
 	"bufio"
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	gouser "os/user"
 	"path"
 	"strings"
@@ -50,7 +50,7 @@ func getConfigFile() string {
 }
 
 func readConfig() (*config, error) {
-	data, err := ioutil.ReadFile(getConfigFile())
+	data, err := os.ReadFile(getConfigFile())
 	if err != nil {
 		return nil, err
 	}
@@ -68,7 +68,7 @@ func writeConfig(c *config) error {
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(getConfigFile(), data, 0600)
+	return os.WriteFile(getConfigFile(), data, 0600)
 }
 
 func getTokenFile() string {
@@ -81,7 +81,7 @@ func getTokenFile() string {
 }
 
 func readToken() (string, error) {
-	data, err := ioutil.ReadFile(getTokenFile())
+	data, err := os.ReadFile(getTokenFile())
 	if err != nil {
 		return "", err
 	}
@@ -89,7 +89,7 @@ func readToken() (string, error) {
 }
 
 func writeToken(token string) {
-	err := ioutil.WriteFile(getTokenFile(), []byte(token), 0600)
+	err := os.WriteFile(getTokenFile(), []byte(token), 0600)
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/revad/internal/config/config.go
+++ b/cmd/revad/internal/config/config.go
@@ -20,7 +20,6 @@ package config
 
 import (
 	"io"
-	"io/ioutil"
 
 	"github.com/BurntSushi/toml"
 	"github.com/pkg/errors"
@@ -28,7 +27,7 @@ import (
 
 // Read reads the configuration from the reader.
 func Read(r io.Reader) (map[string]interface{}, error) {
-	data, err := ioutil.ReadAll(r)
+	data, err := io.ReadAll(r)
 	if err != nil {
 		err = errors.Wrap(err, "config: error reading from reader")
 		return nil, err

--- a/cmd/revad/internal/grace/grace.go
+++ b/cmd/revad/internal/grace/grace.go
@@ -20,7 +20,6 @@ package grace
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"os/signal"
@@ -108,7 +107,7 @@ func (w *Watcher) clean() error {
 }
 
 func (w *Watcher) readPID() (int, error) {
-	piddata, err := ioutil.ReadFile(w.pidFile)
+	piddata, err := os.ReadFile(w.pidFile)
 	if err != nil {
 		return 0, err
 	}
@@ -123,7 +122,7 @@ func (w *Watcher) readPID() (int, error) {
 // GetProcessFromFile reads the pidfile and returns the running process or error if the process or file
 // are not available.
 func GetProcessFromFile(pfile string) (*os.Process, error) {
-	data, err := ioutil.ReadFile(pfile)
+	data, err := os.ReadFile(pfile)
 	if err != nil {
 		return nil, err
 	}
@@ -144,7 +143,7 @@ func GetProcessFromFile(pfile string) (*os.Process, error) {
 // WritePID writes the pid to the configured pid file.
 func (w *Watcher) WritePID() error {
 	// Read in the pid file as a slice of bytes.
-	if piddata, err := ioutil.ReadFile(w.pidFile); err == nil {
+	if piddata, err := os.ReadFile(w.pidFile); err == nil {
 		// Convert the file contents to an integer.
 		if pid, err := strconv.Atoi(string(piddata)); err == nil {
 			// Look for the pid in the process list.
@@ -174,7 +173,7 @@ func (w *Watcher) WritePID() error {
 
 	// If we get here, then the pidfile didn't exist or we are are in graceful reload and thus we overwrite
 	// or the pid in it doesn't belong to the user running this app.
-	err := ioutil.WriteFile(w.pidFile, []byte(fmt.Sprintf("%d", os.Getpid())), 0664)
+	err := os.WriteFile(w.pidFile, []byte(fmt.Sprintf("%d", os.Getpid())), 0664)
 	if err != nil {
 		return err
 	}

--- a/cmd/revad/main.go
+++ b/cmd/revad/main.go
@@ -21,7 +21,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"regexp"
@@ -163,7 +162,7 @@ func getConfigs() ([]map[string]interface{}, error) {
 }
 
 func getConfigsFromDir(dir string) (confs []string, err error) {
-	files, err := ioutil.ReadDir(*dirFlag)
+	files, err := os.ReadDir(*dirFlag)
 	if err != nil {
 		return nil, err
 	}

--- a/docs/content/en/docs/config/packages/storage/utils/decomposedfs/atomicity.md
+++ b/docs/content/en/docs/config/packages/storage/utils/decomposedfs/atomicity.md
@@ -167,16 +167,15 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 )
 
 func main() {
-	err := ioutil.WriteFile("file1", []byte(""), 0600)
+	err := os.WriteFile("file1", []byte(""), 0600)
 	if err != nil {
 		os.Exit(1)
 	}
-	err = ioutil.WriteFile("file2", []byte(""), 0600)
+	err = os.WriteFile("file2", []byte(""), 0600)
 	if err != nil {
 		os.Exit(1)
 	}
@@ -208,16 +207,15 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 )
 
 func main() {
-	err := ioutil.WriteFile("file1", []byte(""), 0600)
+	err := os.WriteFile("file1", []byte(""), 0600)
 	if err != nil {
 		os.Exit(1)
 	}
-	err = ioutil.WriteFile("file2", []byte(""), 0600)
+	err = os.WriteFile("file2", []byte(""), 0600)
 	if err != nil {
 		os.Exit(1)
 	}

--- a/examples/plugin/json/json.go
+++ b/examples/plugin/json/json.go
@@ -22,7 +22,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
@@ -63,7 +63,7 @@ func (m *Manager) Configure(ml map[string]interface{}) error {
 		return err
 	}
 
-	f, err := ioutil.ReadFile(c.Users)
+	f, err := os.ReadFile(c.Users)
 	if err != nil {
 		return err
 	}

--- a/internal/grpc/services/datatx/datatx.go
+++ b/internal/grpc/services/datatx/datatx.go
@@ -22,7 +22,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/url"
 	"os"
 	"sync"
@@ -334,7 +334,7 @@ func (s *service) extractEndpointInfo(ctx context.Context, targetURL string) (*w
 func loadOrCreate(file string) (*txShareModel, error) {
 	_, err := os.Stat(file)
 	if os.IsNotExist(err) {
-		if err := ioutil.WriteFile(file, []byte("{}"), 0700); err != nil {
+		if err := os.WriteFile(file, []byte("{}"), 0700); err != nil {
 			err = errors.Wrap(err, "datatx service: error creating the transfer shares storage file: "+file)
 			return nil, err
 		}
@@ -347,7 +347,7 @@ func loadOrCreate(file string) (*txShareModel, error) {
 	}
 	defer fd.Close()
 
-	data, err := ioutil.ReadAll(fd)
+	data, err := io.ReadAll(fd)
 	if err != nil {
 		err = errors.Wrap(err, "datatx service: error reading the data")
 		return nil, err
@@ -374,7 +374,7 @@ func (m *txShareModel) saveTxShare() error {
 		return err
 	}
 
-	if err := ioutil.WriteFile(m.File, data, 0644); err != nil {
+	if err := os.WriteFile(m.File, data, 0644); err != nil {
 		err = errors.Wrap(err, "datatx service: error writing transfer share data to file: "+m.File)
 		return err
 	}

--- a/internal/grpc/services/storageprovider/storageprovider.go
+++ b/internal/grpc/services/storageprovider/storageprovider.go
@@ -22,7 +22,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"path"
@@ -144,7 +143,7 @@ func parseConfig(m map[string]interface{}) (*config, error) {
 
 func registerMimeTypes(mappingFile string) error {
 	if mappingFile != "" {
-		f, err := ioutil.ReadFile(mappingFile)
+		f, err := os.ReadFile(mappingFile)
 		if err != nil {
 			return fmt.Errorf("storageprovider: error reading the custom mime types file: +%v", err)
 		}

--- a/internal/http/services/reverseproxy/reverseproxy.go
+++ b/internal/http/services/reverseproxy/reverseproxy.go
@@ -20,10 +20,10 @@ package reverseproxy
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"os"
 
 	ctxpkg "github.com/cs3org/reva/pkg/ctx"
 	"github.com/cs3org/reva/pkg/rhttp/global"
@@ -63,7 +63,7 @@ func New(m map[string]interface{}, log *zerolog.Logger) (global.Service, error) 
 	}
 	conf.init()
 
-	f, err := ioutil.ReadFile(conf.ProxyRulesJSON)
+	f, err := os.ReadFile(conf.ProxyRulesJSON)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/app/provider/wopi/wopi.go
+++ b/pkg/app/provider/wopi/wopi.go
@@ -24,7 +24,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -201,7 +200,7 @@ func (p *wopiProvider) GetAppURL(ctx context.Context, resource *provider.Resourc
 	}
 	defer openRes.Body.Close()
 
-	body, err := ioutil.ReadAll(openRes.Body)
+	body, err := io.ReadAll(openRes.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/appauth/manager/json/json.go
+++ b/pkg/appauth/manager/json/json.go
@@ -21,7 +21,7 @@ package json
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"os"
 	"sync"
 	"time"
@@ -100,7 +100,7 @@ func parseConfig(m map[string]interface{}) (*config, error) {
 func loadOrCreate(file string) (*jsonManager, error) {
 	stat, err := os.Stat(file)
 	if os.IsNotExist(err) || stat.Size() == 0 {
-		if err = ioutil.WriteFile(file, []byte("{}"), 0644); err != nil {
+		if err = os.WriteFile(file, []byte("{}"), 0644); err != nil {
 			return nil, errors.Wrapf(err, "error creating the file %s", file)
 		}
 	}
@@ -111,7 +111,7 @@ func loadOrCreate(file string) (*jsonManager, error) {
 	}
 	defer fd.Close()
 
-	data, err := ioutil.ReadAll(fd)
+	data, err := io.ReadAll(fd)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error reading the file %s", file)
 	}
@@ -246,7 +246,7 @@ func (mgr *jsonManager) save() error {
 		return errors.Wrap(err, "error encoding json file")
 	}
 
-	if err = ioutil.WriteFile(mgr.config.File, data, 0644); err != nil {
+	if err = os.WriteFile(mgr.config.File, data, 0644); err != nil {
 		return errors.Wrapf(err, "error writing to file %s", mgr.config.File)
 	}
 

--- a/pkg/appauth/manager/json/json_test.go
+++ b/pkg/appauth/manager/json/json_test.go
@@ -22,7 +22,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"os"
 	"reflect"
 	"testing"
@@ -270,7 +270,7 @@ func TestGenerateAppPassword(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			data, err := ioutil.ReadAll(tmpFile)
+			data, err := io.ReadAll(tmpFile)
 			if err != nil {
 				t.Fatalf("error reading file %s: %v", tmpFile.Name(), err)
 			}
@@ -701,7 +701,7 @@ func TestGetAppPassword(t *testing.T) {
 }
 
 func createTempDir(t *testing.T, name string) string {
-	tempDir, err := ioutil.TempDir("", name)
+	tempDir, err := os.MkdirTemp("", name)
 	if err != nil {
 		t.Fatalf("error while creating temp dir: %v", err)
 	}
@@ -709,7 +709,7 @@ func createTempDir(t *testing.T, name string) string {
 }
 
 func createTempFile(t *testing.T, tempDir string, name string) *os.File {
-	tempFile, err := ioutil.TempFile(tempDir, name)
+	tempFile, err := os.CreateTemp(tempDir, name)
 	if err != nil {
 		t.Fatalf("error while creating temp file: %v", err)
 	}

--- a/pkg/auth/manager/json/json.go
+++ b/pkg/auth/manager/json/json.go
@@ -21,7 +21,7 @@ package json
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"os"
 
 	authpb "github.com/cs3org/go-cs3apis/cs3/auth/provider/v1beta1"
 	user "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
@@ -94,7 +94,7 @@ func (m *manager) Configure(ml map[string]interface{}) error {
 	}
 
 	m.credentials = map[string]*Credentials{}
-	f, err := ioutil.ReadFile(c.Users)
+	f, err := os.ReadFile(c.Users)
 	if err != nil {
 		return err
 	}

--- a/pkg/auth/manager/json/json_test.go
+++ b/pkg/auth/manager/json/json_test.go
@@ -20,7 +20,6 @@ package json
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -93,7 +92,7 @@ func TestGetManagerWithJSONObject(t *testing.T) {
 	var tmpFile *os.File
 
 	// add tempdir
-	tmpDir, err := ioutil.TempDir("", "json_test")
+	tmpDir, err := os.MkdirTemp("", "json_test")
 	if err != nil {
 		t.Fatalf("Error while creating temp dir: %v", err)
 	}
@@ -101,7 +100,7 @@ func TestGetManagerWithJSONObject(t *testing.T) {
 
 	for _, tt := range tests {
 		// get file handler for temporary file
-		tmpFile, err = ioutil.TempFile(tmpDir, "json_test")
+		tmpFile, err = os.CreateTemp(tmpDir, "json_test")
 		if err != nil {
 			t.Fatalf("Error while opening temp file: %v", err)
 		}
@@ -159,14 +158,14 @@ func TestGetAuthenticatedManager(t *testing.T) {
 	}
 
 	// add tempdir
-	tempdir, err := ioutil.TempDir("", "json_test")
+	tempdir, err := os.MkdirTemp("", "json_test")
 	if err != nil {
 		t.Fatalf("Error while creating temp dir: %v", err)
 	}
 	defer os.RemoveAll(tempdir)
 
 	// get file handler for temporary file
-	tempFile, err := ioutil.TempFile(tempdir, "json_test")
+	tempFile, err := os.CreateTemp(tempdir, "json_test")
 	if err != nil {
 		t.Fatalf("Error while opening temp file: %v", err)
 	}

--- a/pkg/auth/manager/oidcmapping/oidcmapping.go
+++ b/pkg/auth/manager/oidcmapping/oidcmapping.go
@@ -22,7 +22,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 	"time"
 
@@ -117,7 +117,7 @@ func (am *mgr) Configure(m map[string]interface{}) error {
 		return nil
 	}
 
-	f, err := ioutil.ReadFile(c.UsersMapping)
+	f, err := os.ReadFile(c.UsersMapping)
 	if err != nil {
 		return fmt.Errorf("oidc: error reading the users mapping file: +%v", err)
 	}

--- a/pkg/auth/manager/owncloudsql/accounts/accounts_test.go
+++ b/pkg/auth/manager/owncloudsql/accounts/accounts_test.go
@@ -21,7 +21,6 @@ package accounts_test
 import (
 	"context"
 	"database/sql"
-	"io/ioutil"
 	"os"
 
 	_ "github.com/mattn/go-sqlite3"
@@ -41,10 +40,10 @@ var _ = Describe("Accounts", func() {
 
 	BeforeEach(func() {
 		var err error
-		testDbFile, err = ioutil.TempFile("", "example")
+		testDbFile, err = os.CreateTemp("", "example")
 		Expect(err).ToNot(HaveOccurred())
 
-		dbData, err := ioutil.ReadFile("test.sqlite")
+		dbData, err := os.ReadFile("test.sqlite")
 		Expect(err).ToNot(HaveOccurred())
 
 		_, err = testDbFile.Write(dbData)

--- a/pkg/cbox/utils/tokenmanagement.go
+++ b/pkg/cbox/utils/tokenmanagement.go
@@ -22,7 +22,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -107,7 +107,7 @@ func (a *APITokenManager) getAPIToken(ctx context.Context) (string, time.Time, e
 	}
 	defer httpRes.Body.Close()
 
-	body, err := ioutil.ReadAll(httpRes.Body)
+	body, err := io.ReadAll(httpRes.Body)
 	if err != nil {
 		return "", time.Time{}, err
 	}
@@ -157,7 +157,7 @@ func (a *APITokenManager) SendAPIGetRequest(ctx context.Context, url string, for
 		return nil, errors.New("rest: API request returned " + httpRes.Status)
 	}
 
-	body, err := ioutil.ReadAll(httpRes.Body)
+	body, err := io.ReadAll(httpRes.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/datatx/manager/rclone/rclone.go
+++ b/pkg/datatx/manager/rclone/rclone.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -158,7 +158,7 @@ func parseConfig(m map[string]interface{}) (*config, error) {
 func loadOrCreate(file string) (*transferModel, error) {
 	_, err := os.Stat(file)
 	if os.IsNotExist(err) {
-		if err := ioutil.WriteFile(file, []byte("{}"), 0700); err != nil {
+		if err := os.WriteFile(file, []byte("{}"), 0700); err != nil {
 			err = errors.Wrap(err, "error creating the transfers storage file: "+file)
 			return nil, err
 		}
@@ -171,7 +171,7 @@ func loadOrCreate(file string) (*transferModel, error) {
 	}
 	defer fd.Close()
 
-	data, err := ioutil.ReadAll(fd)
+	data, err := io.ReadAll(fd)
 	if err != nil {
 		err = errors.Wrap(err, "error reading the data")
 		return nil, err
@@ -199,7 +199,7 @@ func (m *transferModel) saveTransfer(e error) error {
 		return e
 	}
 
-	if err := ioutil.WriteFile(m.File, data, 0644); err != nil {
+	if err := os.WriteFile(m.File, data, 0644); err != nil {
 		e = errors.Wrap(err, "error writing transfer data to file: "+m.File)
 		return e
 	}

--- a/pkg/eosclient/eosbinary/eosbinary.go
+++ b/pkg/eosclient/eosbinary/eosbinary.go
@@ -23,7 +23,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -673,7 +672,7 @@ func (c *Client) Read(ctx context.Context, auth eosclient.Authorization, path st
 
 // Write writes a stream to the mgm
 func (c *Client) Write(ctx context.Context, auth eosclient.Authorization, path string, stream io.ReadCloser) error {
-	fd, err := ioutil.TempFile(c.opt.CacheDirectory, "eoswrite-")
+	fd, err := os.CreateTemp(c.opt.CacheDirectory, "eoswrite-")
 	if err != nil {
 		return err
 	}

--- a/pkg/eosclient/eosgrpc/eosgrpc.go
+++ b/pkg/eosclient/eosgrpc/eosgrpc.go
@@ -24,7 +24,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -1236,7 +1235,7 @@ func (c *Client) Write(ctx context.Context, auth eosclient.Authorization, path s
 	length = -1
 
 	if c.opt.WriteUsesLocalTemp {
-		fd, err := ioutil.TempFile(c.opt.CacheDirectory, "eoswrite-")
+		fd, err := os.CreateTemp(c.opt.CacheDirectory, "eoswrite-")
 		if err != nil {
 			return err
 		}

--- a/pkg/eosclient/eosgrpc/eoshttp.go
+++ b/pkg/eosclient/eosgrpc/eoshttp.go
@@ -289,7 +289,7 @@ func (c *EOSHTTPClient) GETFile(ctx context.Context, remoteuser string, auth eos
 		// Let's support redirections... and if we retry we have to retry at the same FST, avoid going back to the MGM
 		if resp != nil && (resp.StatusCode == http.StatusFound || resp.StatusCode == http.StatusTemporaryRedirect) {
 
-			// io.Copy(ioutil.Discard, resp.Body)
+			// io.Copy(io.Discard, resp.Body)
 			// resp.Body.Close()
 
 			loc, err := resp.Location()
@@ -383,7 +383,7 @@ func (c *EOSHTTPClient) PUTFile(ctx context.Context, remoteuser string, auth eos
 		// Let's support redirections... and if we retry we retry at the same FST
 		if resp != nil && resp.StatusCode == 307 {
 
-			// io.Copy(ioutil.Discard, resp.Body)
+			// io.Copy(io.Discard, resp.Body)
 			// resp.Body.Close()
 
 			loc, err := resp.Location()

--- a/pkg/group/manager/json/json.go
+++ b/pkg/group/manager/json/json.go
@@ -21,7 +21,7 @@ package json
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"strconv"
 	"strings"
 
@@ -70,7 +70,7 @@ func New(m map[string]interface{}) (group.Manager, error) {
 		return nil, err
 	}
 
-	f, err := ioutil.ReadFile(c.Groups)
+	f, err := os.ReadFile(c.Groups)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/group/manager/json/json_test.go
+++ b/pkg/group/manager/json/json_test.go
@@ -20,7 +20,6 @@ package json
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"testing"
@@ -34,7 +33,7 @@ var ctx = context.Background()
 
 func TestUserManager(t *testing.T) {
 	// add tempdir
-	tempdir, err := ioutil.TempDir("", "json_test")
+	tempdir, err := os.MkdirTemp("", "json_test")
 	if err != nil {
 		t.Fatalf("error while create temp dir: %v", err)
 	}
@@ -44,7 +43,7 @@ func TestUserManager(t *testing.T) {
 	userJSON := `[{`
 
 	// get file handler for temporary file
-	file, err := ioutil.TempFile(tempdir, "json_test")
+	file, err := os.CreateTemp(tempdir, "json_test")
 	if err != nil {
 		t.Fatalf("error while open temp file: %v", err)
 	}
@@ -71,7 +70,7 @@ func TestUserManager(t *testing.T) {
 	userJSON = `[{"id":{"opaque_id":"sailing-lovers"},"group_name":"sailing-lovers","mail":"sailing-lovers@example.org","display_name":"Sailing Lovers","gid_number":1234,"members":[{"idp":"localhost","opaque_id":"einstein","type":1},{"idp":"localhost","opaque_id":"marie","type":1}]}]`
 
 	// get file handler for temporary file
-	file, err = ioutil.TempFile(tempdir, "json_test")
+	file, err = os.CreateTemp(tempdir, "json_test")
 	if err != nil {
 		t.Fatalf("error while open temp file: %v", err)
 	}

--- a/pkg/mentix/exchangers/exporters/promsd.go
+++ b/pkg/mentix/exchangers/exporters/promsd.go
@@ -21,7 +21,6 @@ package exporters
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"path"
@@ -219,7 +218,7 @@ func (exporter *PrometheusSDExporter) exportScrapeConfig(outputFilename string, 
 	}
 
 	// Write the data to disk
-	if err := ioutil.WriteFile(outputFilename, data, 0755); err != nil {
+	if err := os.WriteFile(outputFilename, data, 0755); err != nil {
 		return fmt.Errorf("unable to write scrape config '%v': %v", outputFilename, err)
 	}
 

--- a/pkg/mentix/exchangers/exporters/reqexporter.go
+++ b/pkg/mentix/exchangers/exporters/reqexporter.go
@@ -19,7 +19,7 @@
 package exporters
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 
@@ -37,7 +37,7 @@ type BaseRequestExporter struct {
 
 // HandleRequest handles the actual HTTP request.
 func (exporter *BaseRequestExporter) HandleRequest(resp http.ResponseWriter, req *http.Request, conf *config.Configuration, log *zerolog.Logger) {
-	body, _ := ioutil.ReadAll(req.Body)
+	body, _ := io.ReadAll(req.Body)
 	status, respData, err := exporter.handleQuery(body, req.URL.Query(), conf, log)
 	if err != nil {
 		respData = []byte(err.Error())

--- a/pkg/mentix/exchangers/importers/reqimporter.go
+++ b/pkg/mentix/exchangers/importers/reqimporter.go
@@ -19,7 +19,7 @@
 package importers
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 
@@ -38,7 +38,7 @@ type BaseRequestImporter struct {
 
 // HandleRequest handles the actual HTTP request.
 func (importer *BaseRequestImporter) HandleRequest(resp http.ResponseWriter, req *http.Request, conf *config.Configuration, log *zerolog.Logger) {
-	body, _ := ioutil.ReadAll(req.Body)
+	body, _ := io.ReadAll(req.Body)
 	meshDataSet, status, respData, err := importer.handleQuery(body, req.URL.Query(), conf, log)
 	if err == nil {
 		if len(meshDataSet) > 0 {

--- a/pkg/mentix/utils/network/network.go
+++ b/pkg/mentix/utils/network/network.go
@@ -21,7 +21,7 @@ package network
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -87,7 +87,7 @@ func queryEndpoint(method string, endpointURL *url.URL, auth *BasicAuth, checkSt
 		return nil, fmt.Errorf("invalid response received: %v", resp.Status)
 	}
 
-	body, _ := ioutil.ReadAll(resp.Body)
+	body, _ := io.ReadAll(resp.Body)
 	return body, nil
 }
 

--- a/pkg/metrics/driver/json/json.go
+++ b/pkg/metrics/driver/json/json.go
@@ -21,7 +21,6 @@ package json
 import (
 	"encoding/json"
 	"errors"
-	"io/ioutil"
 	"os"
 
 	"github.com/cs3org/reva/pkg/metrics/driver/registry"
@@ -47,7 +46,7 @@ func driverName() string {
 func readJSON(driver *MetricsJSONDriver) *data {
 	data := &data{}
 
-	file, err := ioutil.ReadFile(driver.metricsDataLocation)
+	file, err := os.ReadFile(driver.metricsDataLocation)
 	if err != nil {
 		log.Error().Err(err).Str("location", driver.metricsDataLocation).Msg("Unable to read json file from location.")
 	}

--- a/pkg/metrics/driver/xcloud/xcloud.go
+++ b/pkg/metrics/driver/xcloud/xcloud.go
@@ -23,7 +23,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"sync"
@@ -82,7 +82,7 @@ func (d *CloudDriver) refresh() error {
 	defer resp.Body.Close()
 
 	// read response body
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		log.Err(err).Msgf("xcloud: error reading resp body from internal metrics from %s", d.instance)
 		return err

--- a/pkg/ocm/invite/manager/json/json.go
+++ b/pkg/ocm/invite/manager/json/json.go
@@ -22,7 +22,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -125,7 +125,7 @@ func loadOrCreate(file string) (*inviteModel, error) {
 
 	_, err := os.Stat(file)
 	if os.IsNotExist(err) {
-		if err := ioutil.WriteFile(file, []byte("{}"), 0700); err != nil {
+		if err := os.WriteFile(file, []byte("{}"), 0700); err != nil {
 			err = errors.Wrap(err, "error creating the invite storage file: "+file)
 			return nil, err
 		}
@@ -138,7 +138,7 @@ func loadOrCreate(file string) (*inviteModel, error) {
 	}
 	defer fd.Close()
 
-	data, err := ioutil.ReadAll(fd)
+	data, err := io.ReadAll(fd)
 	if err != nil {
 		err = errors.Wrap(err, "error reading the data")
 		return nil, err
@@ -168,7 +168,7 @@ func (model *inviteModel) Save() error {
 		return err
 	}
 
-	if err := ioutil.WriteFile(model.File, data, 0644); err != nil {
+	if err := os.WriteFile(model.File, data, 0644); err != nil {
 		err = errors.Wrap(err, "error writing invite data to file: "+model.File)
 		return err
 	}
@@ -242,7 +242,7 @@ func (m *manager) ForwardInvite(ctx context.Context, invite *invitepb.InviteToke
 
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		respBody, e := ioutil.ReadAll(resp.Body)
+		respBody, e := io.ReadAll(resp.Body)
 		if e != nil {
 			return errors.Wrap(e, "json: error reading request body")
 		}

--- a/pkg/ocm/provider/authorizer/json/json.go
+++ b/pkg/ocm/provider/authorizer/json/json.go
@@ -21,9 +21,9 @@ package json
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
 	"net"
 	"net/url"
+	"os"
 	"strings"
 	"sync"
 
@@ -48,7 +48,7 @@ func New(m map[string]interface{}) (provider.Authorizer, error) {
 	}
 	c.init()
 
-	f, err := ioutil.ReadFile(c.Providers)
+	f, err := os.ReadFile(c.Providers)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ocm/provider/authorizer/open/open.go
+++ b/pkg/ocm/provider/authorizer/open/open.go
@@ -21,8 +21,8 @@ package open
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
 	"net/url"
+	"os"
 	"strings"
 
 	ocmprovider "github.com/cs3org/go-cs3apis/cs3/ocm/provider/v1beta1"
@@ -46,7 +46,7 @@ func New(m map[string]interface{}) (provider.Authorizer, error) {
 	}
 	c.init()
 
-	f, err := ioutil.ReadFile(c.Providers)
+	f, err := os.ReadFile(c.Providers)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ocm/share/manager/json/json.go
+++ b/pkg/ocm/share/manager/json/json.go
@@ -22,7 +22,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"sync"
 	"time"
@@ -76,7 +76,7 @@ func New(m map[string]interface{}) (share.Manager, error) {
 func loadOrCreate(file string) (*shareModel, error) {
 	_, err := os.Stat(file)
 	if os.IsNotExist(err) {
-		if err := ioutil.WriteFile(file, []byte("{}"), 0700); err != nil {
+		if err := os.WriteFile(file, []byte("{}"), 0700); err != nil {
 			err = errors.Wrap(err, "error creating the file: "+file)
 			return nil, err
 		}
@@ -89,7 +89,7 @@ func loadOrCreate(file string) (*shareModel, error) {
 	}
 	defer fd.Close()
 
-	data, err := ioutil.ReadAll(fd)
+	data, err := io.ReadAll(fd)
 	if err != nil {
 		err = errors.Wrap(err, "error reading the data")
 		return nil, err
@@ -142,7 +142,7 @@ func (m *shareModel) Save() error {
 		return err
 	}
 
-	if err := ioutil.WriteFile(m.file, data, 0644); err != nil {
+	if err := os.WriteFile(m.file, data, 0644); err != nil {
 		err = errors.Wrap(err, "error writing to file: "+m.file)
 		return err
 	}
@@ -151,7 +151,7 @@ func (m *shareModel) Save() error {
 }
 
 func (m *shareModel) ReadFile() error {
-	data, err := ioutil.ReadFile(m.file)
+	data, err := os.ReadFile(m.file)
 	if err != nil {
 		err = errors.Wrap(err, "error reading the data")
 		return err

--- a/pkg/ocm/share/sender/sender.go
+++ b/pkg/ocm/share/sender/sender.go
@@ -21,7 +21,7 @@ package sender
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"path"
@@ -81,7 +81,7 @@ func Send(requestBodyMap map[string]interface{}, pi *ocmprovider.ProviderInfo) e
 
 	defer resp.Body.Close()
 	if (resp.StatusCode != http.StatusCreated) && (resp.StatusCode != http.StatusOK) {
-		respBody, e := ioutil.ReadAll(resp.Body)
+		respBody, e := io.ReadAll(resp.Body)
 		if e != nil {
 			e = errors.Wrap(e, "sender: error reading request body")
 			return e

--- a/pkg/publicshare/manager/json/json.go
+++ b/pkg/publicshare/manager/json/json.go
@@ -22,7 +22,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -81,7 +80,7 @@ func New(c map[string]interface{}) (publicshare.Manager, error) {
 	}
 
 	if fi == nil || fi.Size() == 0 {
-		err := ioutil.WriteFile(m.file, []byte("{}"), 0644)
+		err := os.WriteFile(m.file, []byte("{}"), 0644)
 		if err != nil {
 			return nil, err
 		}
@@ -542,7 +541,7 @@ func (m *manager) GetPublicShareByToken(ctx context.Context, token string, auth 
 
 func (m *manager) readDb() (map[string]interface{}, error) {
 	db := map[string]interface{}{}
-	readBytes, err := ioutil.ReadFile(m.file)
+	readBytes, err := os.ReadFile(m.file)
 	if err != nil {
 		return nil, err
 	}
@@ -558,7 +557,7 @@ func (m *manager) writeDb(db map[string]interface{}) error {
 		return err
 	}
 
-	if err := ioutil.WriteFile(m.file, dbAsJSON, 0644); err != nil {
+	if err := os.WriteFile(m.file, dbAsJSON, 0644); err != nil {
 		return err
 	}
 

--- a/pkg/sdk/common/net/httpreq.go
+++ b/pkg/sdk/common/net/httpreq.go
@@ -22,7 +22,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"time"
 )
@@ -93,7 +92,7 @@ func (request *HTTPRequest) Do(checkStatus bool) ([]byte, error) {
 		return nil, fmt.Errorf("received invalid response from '%v': %s", request.endpoint, httpRes.Status)
 	}
 
-	data, err := ioutil.ReadAll(httpRes.Body)
+	data, err := io.ReadAll(httpRes.Body)
 	if err != nil {
 		return nil, fmt.Errorf("reading response data from '%v' failed: %v", request.endpoint, err)
 	}

--- a/pkg/sdk/common/net/webdav.go
+++ b/pkg/sdk/common/net/webdav.go
@@ -21,7 +21,6 @@ package net
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"strconv"
 
 	types "github.com/cs3org/go-cs3apis/cs3/types/v1beta1"
@@ -61,7 +60,7 @@ func (webdav *WebDAVClient) Read(file string) ([]byte, error) {
 	}
 	defer reader.Close()
 
-	data, err := ioutil.ReadAll(reader)
+	data, err := io.ReadAll(reader)
 	if err != nil {
 		return nil, fmt.Errorf("unable to read the data: %v", err)
 	}

--- a/pkg/share/manager/json/json.go
+++ b/pkg/share/manager/json/json.go
@@ -21,7 +21,7 @@ package json
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"os"
 	"sync"
 	"time"
@@ -71,7 +71,7 @@ func New(m map[string]interface{}) (share.Manager, error) {
 func loadOrCreate(file string) (*shareModel, error) {
 	info, err := os.Stat(file)
 	if os.IsNotExist(err) || info.Size() == 0 {
-		if err := ioutil.WriteFile(file, []byte("{}"), 0700); err != nil {
+		if err := os.WriteFile(file, []byte("{}"), 0700); err != nil {
 			err = errors.Wrap(err, "error opening/creating the file: "+file)
 			return nil, err
 		}
@@ -84,7 +84,7 @@ func loadOrCreate(file string) (*shareModel, error) {
 	}
 	defer fd.Close()
 
-	data, err := ioutil.ReadAll(fd)
+	data, err := io.ReadAll(fd)
 	if err != nil {
 		err = errors.Wrap(err, "error reading the data")
 		return nil, err
@@ -140,7 +140,7 @@ func (m *shareModel) Save() error {
 		return err
 	}
 
-	if err := ioutil.WriteFile(m.file, data, 0644); err != nil {
+	if err := os.WriteFile(m.file, data, 0644); err != nil {
 		err = errors.Wrap(err, "error writing to file: "+m.file)
 		return err
 	}

--- a/pkg/share/manager/sql/sql_test.go
+++ b/pkg/share/manager/sql/sql_test.go
@@ -21,7 +21,6 @@ package sql_test
 import (
 	"context"
 	"database/sql"
-	"io/ioutil"
 	"os"
 
 	user "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
@@ -80,10 +79,10 @@ var _ = Describe("SQL manager", func() {
 
 	BeforeEach(func() {
 		var err error
-		testDbFile, err = ioutil.TempFile("", "example")
+		testDbFile, err = os.CreateTemp("", "example")
 		Expect(err).ToNot(HaveOccurred())
 
-		dbData, err := ioutil.ReadFile("test.db")
+		dbData, err := os.ReadFile("test.db")
 		Expect(err).ToNot(HaveOccurred())
 
 		_, err = testDbFile.Write(dbData)

--- a/pkg/siteacc/data/filestorage.go
+++ b/pkg/siteacc/data/filestorage.go
@@ -20,7 +20,6 @@ package data
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -67,7 +66,7 @@ func (storage *FileStorage) ReadAll() (*Accounts, error) {
 	accounts := &Accounts{}
 
 	// Read the data from the configured file
-	jsonData, err := ioutil.ReadFile(storage.filePath)
+	jsonData, err := os.ReadFile(storage.filePath)
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to read file %v", storage.filePath)
 	}
@@ -83,7 +82,7 @@ func (storage *FileStorage) ReadAll() (*Accounts, error) {
 func (storage *FileStorage) WriteAll(accounts *Accounts) error {
 	// Write the data to the configured file
 	jsonData, _ := json.MarshalIndent(accounts, "", "\t")
-	if err := ioutil.WriteFile(storage.filePath, jsonData, 0755); err != nil {
+	if err := os.WriteFile(storage.filePath, jsonData, 0755); err != nil {
 		return errors.Wrapf(err, "unable to write file %v", storage.filePath)
 	}
 

--- a/pkg/siteacc/endpoints.go
+++ b/pkg/siteacc/endpoints.go
@@ -21,7 +21,7 @@ package siteacc
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -133,7 +133,7 @@ func callMethodEndpoint(siteacc *SiteAccounts, ep endpoint, w http.ResponseWrite
 		// Search for a matching method in the list of callbacks
 		for method, cb := range ep.MethodCallbacks {
 			if method == r.Method {
-				body, _ := ioutil.ReadAll(r.Body)
+				body, _ := io.ReadAll(r.Body)
 
 				if respData, err := cb(siteacc, r.URL.Query(), body, session); err == nil {
 					resp.Success = true

--- a/pkg/siteacc/manager/gocdb/account.go
+++ b/pkg/siteacc/manager/gocdb/account.go
@@ -21,7 +21,7 @@ package gocdb
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/cs3org/reva/pkg/mentix/utils/network"
@@ -78,7 +78,7 @@ func writeAccount(account *data.Account, operation string, address string, apiKe
 	defer resp.Body.Close()
 
 	if resp.StatusCode >= 400 {
-		msg, _ := ioutil.ReadAll(resp.Body)
+		msg, _ := io.ReadAll(resp.Body)
 		return errors.Errorf("unable to perform request: %v", string(msg))
 	}
 

--- a/pkg/storage/fs/ocis/blobstore/blobstore_test.go
+++ b/pkg/storage/fs/ocis/blobstore/blobstore_test.go
@@ -20,7 +20,7 @@ package blobstore_test
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"os"
 	"path"
 
@@ -70,7 +70,7 @@ var _ = Describe("Blobstore", func() {
 			err := bs.Upload(key, bytes.NewReader(data))
 			Expect(err).ToNot(HaveOccurred())
 
-			writtenBytes, err := ioutil.ReadFile(blobPath)
+			writtenBytes, err := os.ReadFile(blobPath)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(writtenBytes).To(Equal(data))
 		})
@@ -78,7 +78,7 @@ var _ = Describe("Blobstore", func() {
 
 	Context("with an existing blob", func() {
 		BeforeEach(func() {
-			Expect(ioutil.WriteFile(blobPath, data, 0700)).To(Succeed())
+			Expect(os.WriteFile(blobPath, data, 0700)).To(Succeed())
 		})
 
 		Describe("Download", func() {
@@ -86,7 +86,7 @@ var _ = Describe("Blobstore", func() {
 				reader, err := bs.Download("../" + key)
 				Expect(err).ToNot(HaveOccurred())
 
-				readData, err := ioutil.ReadAll(reader)
+				readData, err := io.ReadAll(reader)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(readData).To(Equal(data))
 			})
@@ -95,7 +95,7 @@ var _ = Describe("Blobstore", func() {
 				reader, err := bs.Download(key)
 				Expect(err).ToNot(HaveOccurred())
 
-				readData, err := ioutil.ReadAll(reader)
+				readData, err := io.ReadAll(reader)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(readData).To(Equal(data))
 			})

--- a/pkg/storage/fs/owncloud/owncloud.go
+++ b/pkg/storage/fs/owncloud/owncloud.go
@@ -23,7 +23,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -1789,7 +1788,7 @@ func (fs *ocfs) listWithNominalHome(ctx context.Context, ip string, mdKeys []str
 		return nil, errors.Wrap(err, "ocfs: error reading permissions")
 	}
 
-	mds, err := ioutil.ReadDir(ip)
+	mds, err := os.ReadDir(ip)
 	if err != nil {
 		return nil, errors.Wrapf(err, "ocfs: error listing %s", ip)
 	}
@@ -1840,7 +1839,7 @@ func (fs *ocfs) listHome(ctx context.Context, home string, mdKeys []string) ([]*
 		return nil, errors.Wrap(err, "ocfs: error reading permissions")
 	}
 
-	mds, err := ioutil.ReadDir(ip)
+	mds, err := os.ReadDir(ip)
 	if err != nil {
 		return nil, errors.Wrap(err, "ocfs: error listing files")
 	}
@@ -1857,7 +1856,7 @@ func (fs *ocfs) listHome(ctx context.Context, home string, mdKeys []string) ([]*
 
 	// list shadow_files
 	ip = fs.toInternalShadowPath(ctx, home)
-	mds, err = ioutil.ReadDir(ip)
+	mds, err = os.ReadDir(ip)
 	if err != nil {
 		return nil, errors.Wrap(err, "ocfs: error listing shadow_files")
 	}
@@ -1884,7 +1883,7 @@ func (fs *ocfs) listShareFolderRoot(ctx context.Context, sp string, mdKeys []str
 		return nil, errors.Wrap(err, "ocfs: error reading permissions")
 	}
 
-	mds, err := ioutil.ReadDir(ip)
+	mds, err := os.ReadDir(ip)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, errtypes.NotFound(fs.toStoragePath(ctx, filepath.Dir(ip)))
@@ -1996,7 +1995,7 @@ func (fs *ocfs) ListRevisions(ctx context.Context, ref *provider.Reference) ([]*
 	bn := filepath.Base(ip)
 
 	revisions := []*provider.FileVersion{}
-	mds, err := ioutil.ReadDir(filepath.Dir(vp))
+	mds, err := os.ReadDir(filepath.Dir(vp))
 	if err != nil {
 		return nil, errors.Wrap(err, "ocfs: error reading"+filepath.Dir(vp))
 	}
@@ -2195,7 +2194,7 @@ func (fs *ocfs) ListRecycle(ctx context.Context, basePath, key, relativePath str
 	}
 
 	// list files folder
-	mds, err := ioutil.ReadDir(filepath.Join(rp, key))
+	mds, err := os.ReadDir(filepath.Join(rp, key))
 	if err != nil {
 		log := appctx.GetLogger(ctx)
 		log.Debug().Err(err).Str("path", rp).Msg("trash not readable")

--- a/pkg/storage/fs/owncloud/upload.go
+++ b/pkg/storage/fs/owncloud/upload.go
@@ -27,7 +27,6 @@ import (
 	"fmt"
 	"hash/adler32"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -247,7 +246,7 @@ func (fs *ocfs) GetUpload(ctx context.Context, id string) (tusd.Upload, error) {
 	infoPath := filepath.Join(fs.c.UploadInfoDir, filepath.Join("/", id+".info"))
 
 	info := tusd.FileInfo{}
-	data, err := ioutil.ReadFile(infoPath)
+	data, err := os.ReadFile(infoPath)
 	if err != nil {
 		return nil, err
 	}
@@ -348,7 +347,7 @@ func (upload *fileUpload) writeInfo() error {
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(upload.infoPath, data, defaultFilePerm)
+	return os.WriteFile(upload.infoPath, data, defaultFilePerm)
 }
 
 // FinishUpload finishes an upload and moves the file to the internal destination

--- a/pkg/storage/fs/owncloudsql/filecache/filecache_test.go
+++ b/pkg/storage/fs/owncloudsql/filecache/filecache_test.go
@@ -20,7 +20,6 @@ package filecache_test
 
 import (
 	"database/sql"
-	"io/ioutil"
 	"os"
 	"strconv"
 
@@ -41,10 +40,10 @@ var _ = Describe("Filecache", func() {
 
 	BeforeEach(func() {
 		var err error
-		testDbFile, err = ioutil.TempFile("", "example")
+		testDbFile, err = os.CreateTemp("", "example")
 		Expect(err).ToNot(HaveOccurred())
 
-		dbData, err := ioutil.ReadFile("test.db")
+		dbData, err := os.ReadFile("test.db")
 		Expect(err).ToNot(HaveOccurred())
 
 		_, err = testDbFile.Write(dbData)

--- a/pkg/storage/fs/owncloudsql/owncloudsql.go
+++ b/pkg/storage/fs/owncloudsql/owncloudsql.go
@@ -26,7 +26,6 @@ import (
 	"fmt"
 	"hash/adler32"
 	"io"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -1744,7 +1743,7 @@ func (fs *owncloudsqlfs) ListRecycle(ctx context.Context, basePath, key, relativ
 	}
 
 	// list files folder
-	mds, err := ioutil.ReadDir(rp)
+	mds, err := os.ReadDir(rp)
 	if err != nil {
 		log := appctx.GetLogger(ctx)
 		log.Debug().Err(err).Str("path", rp).Msg("trash not readable")

--- a/pkg/storage/fs/owncloudsql/upload.go
+++ b/pkg/storage/fs/owncloudsql/upload.go
@@ -23,7 +23,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -249,7 +248,7 @@ func (fs *owncloudsqlfs) GetUpload(ctx context.Context, id string) (tusd.Upload,
 	infoPath := filepath.Join(fs.c.UploadInfoDir, id+".info")
 
 	info := tusd.FileInfo{}
-	data, err := ioutil.ReadFile(infoPath)
+	data, err := os.ReadFile(infoPath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			// Interpret os.ErrNotExist as 404 Not Found
@@ -354,7 +353,7 @@ func (upload *fileUpload) writeInfo() error {
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(upload.infoPath, data, defaultFilePerm)
+	return os.WriteFile(upload.infoPath, data, defaultFilePerm)
 }
 
 // FinishUpload finishes an upload and moves the file to the internal destination

--- a/pkg/storage/utils/chunking/chunking.go
+++ b/pkg/storage/utils/chunking/chunking.go
@@ -21,7 +21,6 @@ package chunking
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -87,7 +86,7 @@ func NewChunkHandler(chunkFolder string) *ChunkHandler {
 }
 
 func (c *ChunkHandler) createChunkTempFile() (string, *os.File, error) {
-	file, err := ioutil.TempFile(fmt.Sprintf("/%s", c.ChunkFolder), "")
+	file, err := os.CreateTemp(fmt.Sprintf("/%s", c.ChunkFolder), "")
 	if err != nil {
 		return "", nil, err
 	}

--- a/pkg/storage/utils/decomposedfs/decomposedfs_concurrency_test.go
+++ b/pkg/storage/utils/decomposedfs/decomposedfs_concurrency_test.go
@@ -20,7 +20,6 @@ package decomposedfs_test
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path"
 	"sync"
@@ -116,7 +115,7 @@ var _ = Describe("Decomposed", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(len(revisions)).To(Equal(1))
 
-				_, err = ioutil.ReadFile(path.Join(tmpRoot, "nodes", "root", "uploaded.txt"))
+				_, err = os.ReadFile(path.Join(tmpRoot, "nodes", "root", "uploaded.txt"))
 				Expect(err).ToNot(HaveOccurred())
 			})
 		})

--- a/pkg/storage/utils/decomposedfs/upload.go
+++ b/pkg/storage/utils/decomposedfs/upload.go
@@ -28,7 +28,6 @@ import (
 	"hash"
 	"hash/adler32"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -304,7 +303,7 @@ func (fs *Decomposedfs) GetUpload(ctx context.Context, id string) (tusd.Upload, 
 	infoPath := filepath.Join(fs.o.Root, "uploads", id+".info")
 
 	info := tusd.FileInfo{}
-	data, err := ioutil.ReadFile(infoPath)
+	data, err := os.ReadFile(infoPath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			// Interpret os.ErrNotExist as 404 Not Found
@@ -440,7 +439,7 @@ func (upload *fileUpload) writeInfo() error {
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(upload.infoPath, data, defaultFilePerm)
+	return os.WriteFile(upload.infoPath, data, defaultFilePerm)
 }
 
 // FinishUpload finishes an upload and moves the file to the internal destination

--- a/pkg/storage/utils/decomposedfs/upload_test.go
+++ b/pkg/storage/utils/decomposedfs/upload_test.go
@@ -23,7 +23,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 
 	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
@@ -215,13 +214,13 @@ var _ = Describe("File uploads", func() {
 					Return(nil).
 					Run(func(args mock.Arguments) {
 						reader := args.Get(1).(io.Reader)
-						data, err := ioutil.ReadAll(reader)
+						data, err := io.ReadAll(reader)
 
 						Expect(err).ToNot(HaveOccurred())
 						Expect(data).To(Equal([]byte("0123456789")))
 					})
 
-				err = fs.Upload(ctx, uploadRef, ioutil.NopCloser(bytes.NewReader(fileContent)))
+				err = fs.Upload(ctx, uploadRef, io.NopCloser(bytes.NewReader(fileContent)))
 
 				Expect(err).ToNot(HaveOccurred())
 				bs.AssertCalled(GinkgoT(), "Upload", mock.Anything, mock.Anything)
@@ -254,13 +253,13 @@ var _ = Describe("File uploads", func() {
 					Return(nil).
 					Run(func(args mock.Arguments) {
 						reader := args.Get(1).(io.Reader)
-						data, err := ioutil.ReadAll(reader)
+						data, err := io.ReadAll(reader)
 
 						Expect(err).ToNot(HaveOccurred())
 						Expect(data).To(Equal([]byte("")))
 					})
 
-				err = fs.Upload(ctx, uploadRef, ioutil.NopCloser(bytes.NewReader(fileContent)))
+				err = fs.Upload(ctx, uploadRef, io.NopCloser(bytes.NewReader(fileContent)))
 
 				Expect(err).ToNot(HaveOccurred())
 				bs.AssertCalled(GinkgoT(), "Upload", mock.Anything, mock.Anything)
@@ -281,7 +280,7 @@ var _ = Describe("File uploads", func() {
 				)
 
 				uploadRef := &provider.Reference{Path: "/some-non-existent-upload-reference"}
-				err := fs.Upload(ctx, uploadRef, ioutil.NopCloser(bytes.NewReader(fileContent)))
+				err := fs.Upload(ctx, uploadRef, io.NopCloser(bytes.NewReader(fileContent)))
 
 				Expect(err).To(HaveOccurred())
 

--- a/pkg/storage/utils/localfs/localfs.go
+++ b/pkg/storage/utils/localfs/localfs.go
@@ -23,7 +23,6 @@ import (
 	"database/sql"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"path"
@@ -993,7 +992,7 @@ func (fs *localfs) listFolder(ctx context.Context, fn string, mdKeys []string) (
 
 	fn = fs.wrap(ctx, fn)
 
-	mds, err := ioutil.ReadDir(fn)
+	mds, err := os.ReadDir(fn)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, errtypes.NotFound(fn)
@@ -1015,7 +1014,7 @@ func (fs *localfs) listShareFolderRoot(ctx context.Context, home string, mdKeys 
 
 	fn := fs.wrapReferences(ctx, home)
 
-	mds, err := ioutil.ReadDir(fn)
+	mds, err := os.ReadDir(fn)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, errtypes.NotFound(fn)
@@ -1087,7 +1086,7 @@ func (fs *localfs) ListRevisions(ctx context.Context, ref *provider.Reference) (
 
 	versionsDir := fs.wrapVersions(ctx, np)
 	revisions := []*provider.FileVersion{}
-	mds, err := ioutil.ReadDir(versionsDir)
+	mds, err := os.ReadDir(versionsDir)
 	if err != nil {
 		return nil, errors.Wrap(err, "localfs: error reading"+versionsDir)
 	}
@@ -1226,7 +1225,7 @@ func (fs *localfs) ListRecycle(ctx context.Context, basePath, key, relativePath 
 
 	rp := fs.wrapRecycleBin(ctx, "/")
 
-	mds, err := ioutil.ReadDir(rp)
+	mds, err := os.ReadDir(rp)
 	if err != nil {
 		return nil, errors.Wrap(err, "localfs: error listing deleted files")
 	}

--- a/pkg/storage/utils/localfs/upload.go
+++ b/pkg/storage/utils/localfs/upload.go
@@ -22,7 +22,6 @@ import (
 	"context"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -211,7 +210,7 @@ func (fs *localfs) GetUpload(ctx context.Context, id string) (tusd.Upload, error
 	}
 	infoPath := binPath + ".info"
 	info := tusd.FileInfo{}
-	data, err := ioutil.ReadFile(infoPath)
+	data, err := os.ReadFile(infoPath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			// Interpret os.ErrNotExist as 404 Not Found
@@ -305,7 +304,7 @@ func (upload *fileUpload) writeInfo() error {
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(upload.infoPath, data, defaultFilePerm)
+	return os.WriteFile(upload.infoPath, data, defaultFilePerm)
 }
 
 // FinishUpload finishes an upload and moves the file to the internal destination

--- a/pkg/test/vars.go
+++ b/pkg/test/vars.go
@@ -21,7 +21,6 @@ package test
 import (
 	"bytes"
 	"errors"
-	"io/ioutil"
 	"os"
 	"path"
 )
@@ -47,7 +46,7 @@ type CleanerFunc func()
 // TmpDir creates a dir in the system temp folder that has
 // TmpDirPattern as prefix
 func TmpDir() (string, CleanerFunc, error) {
-	name, err := ioutil.TempDir("", TmpDirPattern)
+	name, err := os.MkdirTemp("", TmpDirPattern)
 	if err != nil {
 		return "", nil, err
 	}

--- a/pkg/user/manager/json/json.go
+++ b/pkg/user/manager/json/json.go
@@ -21,7 +21,7 @@ package json
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"strconv"
 	"strings"
 
@@ -79,7 +79,7 @@ func (m *manager) Configure(ml map[string]interface{}) error {
 		return err
 	}
 
-	f, err := ioutil.ReadFile(c.Users)
+	f, err := os.ReadFile(c.Users)
 	if err != nil {
 		return err
 	}

--- a/pkg/user/manager/json/json_test.go
+++ b/pkg/user/manager/json/json_test.go
@@ -20,7 +20,6 @@ package json
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"testing"
@@ -33,7 +32,7 @@ var ctx = context.Background()
 
 func TestUserManager(t *testing.T) {
 	// add tempdir
-	tempdir, err := ioutil.TempDir("", "json_test")
+	tempdir, err := os.MkdirTemp("", "json_test")
 	if err != nil {
 		t.Fatalf("error while create temp dir: %v", err)
 	}
@@ -43,7 +42,7 @@ func TestUserManager(t *testing.T) {
 	userJSON := `[{`
 
 	// get file handler for temporary file
-	file, err := ioutil.TempFile(tempdir, "json_test")
+	file, err := os.CreateTemp(tempdir, "json_test")
 	if err != nil {
 		t.Fatalf("error while open temp file: %v", err)
 	}
@@ -70,7 +69,7 @@ func TestUserManager(t *testing.T) {
 	userJSON = `[{"id":{"idp":"localhost","opaque_id":"einstein","type":1},"username":"einstein","mail":"einstein@example.org","display_name":"Albert Einstein","groups":["sailing-lovers","violin-haters","physics-lovers"]}]`
 
 	// get file handler for temporary file
-	file, err = ioutil.TempFile(tempdir, "json_test")
+	file, err = os.CreateTemp(tempdir, "json_test")
 	if err != nil {
 		t.Fatalf("error while open temp file: %v", err)
 	}

--- a/pkg/user/manager/owncloudsql/accounts/accounts_test.go
+++ b/pkg/user/manager/owncloudsql/accounts/accounts_test.go
@@ -21,7 +21,6 @@ package accounts_test
 import (
 	"context"
 	"database/sql"
-	"io/ioutil"
 	"os"
 
 	_ "github.com/mattn/go-sqlite3"
@@ -41,10 +40,10 @@ var _ = Describe("Accounts", func() {
 
 	BeforeEach(func() {
 		var err error
-		testDbFile, err = ioutil.TempFile("", "example")
+		testDbFile, err = os.CreateTemp("", "example")
 		Expect(err).ToNot(HaveOccurred())
 
-		dbData, err := ioutil.ReadFile("test.sqlite")
+		dbData, err := os.ReadFile("test.sqlite")
 		Expect(err).ToNot(HaveOccurred())
 
 		_, err = testDbFile.Write(dbData)

--- a/pkg/utils/ldap.go
+++ b/pkg/utils/ldap.go
@@ -22,7 +22,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/go-ldap/ldap/v3"
 	"github.com/pkg/errors"
@@ -46,7 +46,7 @@ func GetLDAPConnection(c *LDAPConn) (*ldap.Conn, error) {
 	tlsconfig := &tls.Config{InsecureSkipVerify: c.Insecure}
 
 	if !c.Insecure && c.CACert != "" {
-		if pemBytes, err := ioutil.ReadFile(c.CACert); err == nil {
+		if pemBytes, err := os.ReadFile(c.CACert); err == nil {
 			rpool, _ := x509.SystemCertPool()
 			rpool.AppendCertsFromPEM(pemBytes)
 			tlsconfig.RootCAs = rpool

--- a/tests/helpers/helpers.go
+++ b/tests/helpers/helpers.go
@@ -22,7 +22,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -43,7 +43,7 @@ func TempDir(name string) (string, error) {
 	if err != nil {
 		return "nil", err
 	}
-	tmpRoot, err := ioutil.TempDir(tmpDir, "reva-unit-tests-*-root")
+	tmpRoot, err := os.MkdirTemp(tmpDir, "reva-unit-tests-*-root")
 	if err != nil {
 		return "nil", err
 	}
@@ -62,6 +62,6 @@ func Upload(ctx context.Context, fs storage.FS, ref *provider.Reference, content
 		return errors.New("simple upload method not available")
 	}
 	uploadRef := &provider.Reference{Path: "/" + uploadID}
-	err = fs.Upload(ctx, uploadRef, ioutil.NopCloser(bytes.NewReader(content)))
+	err = fs.Upload(ctx, uploadRef, io.NopCloser(bytes.NewReader(content)))
 	return err
 }

--- a/tests/integration/grpc/grpc_suite_test.go
+++ b/tests/integration/grpc/grpc_suite_test.go
@@ -20,7 +20,6 @@ package grpc_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"os/exec"
@@ -91,12 +90,12 @@ func startRevads(configs map[string]string, variables map[string]string) (map[st
 		ownAddress := addresses[name]
 
 		// Create a temporary root for this revad
-		tmpRoot, err := ioutil.TempDir("", "reva-grpc-integration-tests-*-root")
+		tmpRoot, err := os.MkdirTemp("", "reva-grpc-integration-tests-*-root")
 		if err != nil {
 			return nil, errors.Wrapf(err, "Could not create tmpdir")
 		}
 		newCfgPath := path.Join(tmpRoot, "config.toml")
-		rawCfg, err := ioutil.ReadFile(path.Join("fixtures", config))
+		rawCfg, err := os.ReadFile(path.Join("fixtures", config))
 		if err != nil {
 			return nil, errors.Wrapf(err, "Could not read config file")
 		}
@@ -109,7 +108,7 @@ func startRevads(configs map[string]string, variables map[string]string) (map[st
 		for name, address := range addresses {
 			cfg = strings.ReplaceAll(cfg, "{{"+name+"_address}}", address)
 		}
-		err = ioutil.WriteFile(newCfgPath, []byte(cfg), 0600)
+		err = os.WriteFile(newCfgPath, []byte(cfg), 0600)
 		if err != nil {
 			return nil, errors.Wrapf(err, "Could not write config file")
 		}

--- a/tools/check-license/check-license.go
+++ b/tools/check-license/check-license.go
@@ -22,7 +22,6 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -78,7 +77,7 @@ func main() {
 			return nil
 		}
 
-		src, err := ioutil.ReadFile(path)
+		src, err := os.ReadFile(path)
 		if err != nil {
 			return nil
 		}
@@ -88,7 +87,7 @@ func main() {
 			err := fmt.Errorf("%v: license header not present or not at the top, to fix run: go run tools/check-license/check-license.go -fix", path)
 			if *fix {
 				newSrc := licenseText + string(src)
-				if err := ioutil.WriteFile(path, []byte(newSrc), 0644); err != nil {
+				if err := os.WriteFile(path, []byte(newSrc), 0644); err != nil {
 					fmt.Println(err)
 					os.Exit(1)
 				}

--- a/tools/create-artifacts/main.go
+++ b/tools/create-artifacts/main.go
@@ -25,7 +25,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -122,7 +121,7 @@ func hashFile(file string) {
 	}
 	f.Close()
 	val := hex.EncodeToString(hasher.Sum(nil))
-	if err := ioutil.WriteFile(file+".sha256", []byte(val), 0644); err != nil {
+	if err := os.WriteFile(file+".sha256", []byte(val), 0644); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/tools/prepare-release/main.go
+++ b/tools/prepare-release/main.go
@@ -23,7 +23,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -81,18 +80,18 @@ func main() {
 	run(cmd)
 
 	// add new VERSION and BUILD_DATE
-	if err := ioutil.WriteFile("VERSION", []byte(*version), 0644); err != nil {
+	if err := os.WriteFile("VERSION", []byte(*version), 0644); err != nil {
 		fmt.Fprintf(os.Stderr, "error writing to VERSION file: %s", err)
 		os.Exit(1)
 	}
 
 	// add new VERSION and RELEASE_DATE
-	if err := ioutil.WriteFile("RELEASE_DATE", []byte(date), 0644); err != nil {
+	if err := os.WriteFile("RELEASE_DATE", []byte(date), 0644); err != nil {
 		fmt.Fprintf(os.Stderr, "error writing to RELEASE_DATE file: %s", err)
 		os.Exit(1)
 	}
 
-	tmp, err := ioutil.TempDir("", "reva-changelog")
+	tmp, err := os.MkdirTemp("", "reva-changelog")
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error creating tmp directory to store changelog: %s", err)
 		os.Exit(1)
@@ -120,7 +119,7 @@ func main() {
 	}
 	os.RemoveAll(tmp)
 
-	data, err := ioutil.ReadFile("changelog/NOTE.md")
+	data, err := os.ReadFile("changelog/NOTE.md")
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error reading NOTE.md: %s", err)
 		os.Exit(1)
@@ -138,7 +137,7 @@ description: >
 `, *version, *version, *version, date)
 
 	releaseDocs += string(data)
-	if err := ioutil.WriteFile(fmt.Sprintf("docs/content/en/docs/changelog/%s/_index.md", *version), []byte(releaseDocs), 0644); err != nil {
+	if err := os.WriteFile(fmt.Sprintf("docs/content/en/docs/changelog/%s/_index.md", *version), []byte(releaseDocs), 0644); err != nil {
 		fmt.Fprintf(os.Stderr, "error writing docs release file _index.md: %s", err)
 		os.Exit(1)
 	}


### PR DESCRIPTION
package `ioutil` is deprecated from `1.16` and same functionality is implemented in across packages `os` and `io`.

This commit replaces `ioutil` with `io` and `os` packages.
Simple find and replace.