### PR TITLE
decomposed fs: return reference to parent

### DIFF
--- a/changelog/unreleased/decomposed-fs-parent.md
+++ b/changelog/unreleased/decomposed-fs-parent.md
@@ -1,0 +1,5 @@
+Enhancement: Decomposed FS: return a reference to the parent
+
+We've implemented the changes from cs3org/cs3apis#167 in the DecomposedFS, so that a stat on a resource always includes a reference to the parent of the resource.
+
+https://github.com/cs3org/reva/pull/2691

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/cheggaaa/pb v1.0.29
 	github.com/coreos/go-oidc v2.2.1+incompatible
 	github.com/cs3org/cato v0.0.0-20200828125504-e418fc54dd5e
-	github.com/cs3org/go-cs3apis v0.0.0-20220126114148-64c025ccdd19
+	github.com/cs3org/go-cs3apis v0.0.0-20220328105952-297bef33e13f
 	github.com/cubewise-code/go-mime v0.0.0-20200519001935-8c5762b177d8
 	github.com/dgraph-io/ristretto v0.1.0
 	github.com/eventials/go-tus v0.0.0-20200718001131-45c7ec8f5d59

--- a/go.sum
+++ b/go.sum
@@ -209,6 +209,8 @@ github.com/cs3org/cato v0.0.0-20200828125504-e418fc54dd5e h1:tqSPWQeueWTKnJVMJff
 github.com/cs3org/cato v0.0.0-20200828125504-e418fc54dd5e/go.mod h1:XJEZ3/EQuI3BXTp/6DUzFr850vlxq11I6satRtz0YQ4=
 github.com/cs3org/go-cs3apis v0.0.0-20220126114148-64c025ccdd19 h1:1jqPH58jCxvbaJ9WLIJ7W2/m622bWS6ChptzljSG6IQ=
 github.com/cs3org/go-cs3apis v0.0.0-20220126114148-64c025ccdd19/go.mod h1:UXha4TguuB52H14EMoSsCqDj7k8a/t7g4gVP+bgY5LY=
+github.com/cs3org/go-cs3apis v0.0.0-20220328105952-297bef33e13f h1:emnlOWc1s2gx77MViLnZH9yh5TRHKsykRu6rJjx3lkM=
+github.com/cs3org/go-cs3apis v0.0.0-20220328105952-297bef33e13f/go.mod h1:UXha4TguuB52H14EMoSsCqDj7k8a/t7g4gVP+bgY5LY=
 github.com/cubewise-code/go-mime v0.0.0-20200519001935-8c5762b177d8 h1:Z9lwXumT5ACSmJ7WGnFl+OMLLjpz5uR2fyz7dC255FI=
 github.com/cubewise-code/go-mime v0.0.0-20200519001935-8c5762b177d8/go.mod h1:4abs/jPXcmJzYoYGF91JF9Uq9s/KL5n1jvFDix8KcqY=
 github.com/cyberdelia/templates v0.0.0-20141128023046-ca7fffd4298c/go.mod h1:GyV+0YP4qX0UQ7r2MoYZ+AvYDp12OF5yg4q8rGnyNh4=

--- a/internal/grpc/services/authregistry/authregistry.go
+++ b/internal/grpc/services/authregistry/authregistry.go
@@ -116,17 +116,19 @@ func (s *service) ListAuthProviders(ctx context.Context, req *registrypb.ListAut
 	return res, nil
 }
 
-func (s *service) GetAuthProvider(ctx context.Context, req *registrypb.GetAuthProviderRequest) (*registrypb.GetAuthProviderResponse, error) {
+func (s *service) GetAuthProviders(ctx context.Context, req *registrypb.GetAuthProvidersRequest) (*registrypb.GetAuthProvidersResponse, error) {
 	pinfo, err := s.reg.GetProvider(ctx, req.Type)
 	if err != nil {
-		return &registrypb.GetAuthProviderResponse{
+		return &registrypb.GetAuthProvidersResponse{
 			Status: status.NewInternal(ctx, "error getting auth provider for type: "+req.Type),
 		}, nil
 	}
 
-	res := &registrypb.GetAuthProviderResponse{
-		Status:   status.NewOK(ctx),
-		Provider: pinfo,
+	res := &registrypb.GetAuthProvidersResponse{
+		Status: status.NewOK(ctx),
+		Providers: []*registrypb.ProviderInfo{
+			pinfo,
+		},
 	}
 	return res, nil
 }

--- a/internal/grpc/services/datatx/datatx.go
+++ b/internal/grpc/services/datatx/datatx.go
@@ -81,15 +81,27 @@ func (s *service) UnprotectedEndpoints() []string {
 	return []string{}
 }
 
-func (s *service) CreateTransfer(ctx context.Context, req *datatx.CreateTransferRequest) (*datatx.CreateTransferResponse, error) {
-	return &datatx.CreateTransferResponse{
-		Status: status.NewUnimplemented(ctx, errtypes.NotSupported("CreateTransfer not implemented"), "CreateTransfer not implemented"),
+func (s *service) PullTransfer(ctx context.Context, req *datatx.PullTransferRequest) (*datatx.PullTransferResponse, error) {
+	return &datatx.PullTransferResponse{
+		Status: status.NewUnimplemented(ctx, errtypes.NotSupported("PullTransfer not implemented"), "PullTransfer not implemented"),
 	}, nil
 }
 
 func (s *service) GetTransferStatus(ctx context.Context, in *datatx.GetTransferStatusRequest) (*datatx.GetTransferStatusResponse, error) {
 	return &datatx.GetTransferStatusResponse{
 		Status: status.NewUnimplemented(ctx, errtypes.NotSupported("GetTransferStatus not implemented"), "GetTransferStatus not implemented"),
+	}, nil
+}
+
+func (s *service) ListTransfers(ctx context.Context, in *datatx.ListTransfersRequest) (*datatx.ListTransfersResponse, error) {
+	return &datatx.ListTransfersResponse{
+		Status: status.NewUnimplemented(ctx, errtypes.NotSupported("ListTransfers not implemented"), "ListTransfers not implemented"),
+	}, nil
+}
+
+func (s *service) RetryTransfer(ctx context.Context, in *datatx.RetryTransferRequest) (*datatx.RetryTransferResponse, error) {
+	return &datatx.RetryTransferResponse{
+		Status: status.NewUnimplemented(ctx, errtypes.NotSupported("RetryTransfer not implemented"), "RetryTransfer not implemented"),
 	}, nil
 }
 

--- a/internal/grpc/services/gateway/authprovider.go
+++ b/internal/grpc/services/gateway/authprovider.go
@@ -210,7 +210,7 @@ func (s *svc) findAuthProvider(ctx context.Context, authType string) (authpb.Pro
 		return nil, err
 	}
 
-	res, err := c.GetAuthProvider(ctx, &registry.GetAuthProviderRequest{
+	res, err := c.GetAuthProviders(ctx, &registry.GetAuthProvidersRequest{
 		Type: authType,
 	})
 
@@ -219,9 +219,9 @@ func (s *svc) findAuthProvider(ctx context.Context, authType string) (authpb.Pro
 		return nil, err
 	}
 
-	if res.Status.Code == rpc.Code_CODE_OK && res.Provider != nil {
+	if res.Status.Code == rpc.Code_CODE_OK && res.Providers != nil && len(res.Providers) > 0 {
 		// TODO(labkode): check for capabilities here
-		c, err := pool.GetAuthProviderServiceClient(res.Provider.Address)
+		c, err := pool.GetAuthProviderServiceClient(res.Providers[0].Address)
 		if err != nil {
 			err = errors.Wrap(err, "gateway: error getting an auth provider client")
 			return nil, err

--- a/internal/grpc/services/gateway/datatx.go
+++ b/internal/grpc/services/gateway/datatx.go
@@ -27,17 +27,49 @@ import (
 	"github.com/pkg/errors"
 )
 
-func (s *svc) CreateTransfer(ctx context.Context, req *datatx.CreateTransferRequest) (*datatx.CreateTransferResponse, error) {
+func (s *svc) PullTransfer(ctx context.Context, req *datatx.PullTransferRequest) (*datatx.PullTransferResponse, error) {
 	c, err := pool.GetDataTxClient(s.c.DataTxEndpoint)
 	if err != nil {
-		return &datatx.CreateTransferResponse{
+		return &datatx.PullTransferResponse{
 			Status: status.NewInternal(ctx, "error getting data transfer client"),
 		}, nil
 	}
 
-	res, err := c.CreateTransfer(ctx, req)
+	res, err := c.PullTransfer(ctx, req)
 	if err != nil {
-		return nil, errors.Wrap(err, "gateway: error calling CreateTransfer")
+		return nil, errors.Wrap(err, "gateway: error calling PullTransfer")
+	}
+
+	return res, nil
+}
+
+func (s *svc) ListTransfers(ctx context.Context, req *datatx.ListTransfersRequest) (*datatx.ListTransfersResponse, error) {
+	c, err := pool.GetDataTxClient(s.c.DataTxEndpoint)
+	if err != nil {
+		return &datatx.ListTransfersResponse{
+			Status: status.NewInternal(ctx, "error getting data transfer client"),
+		}, nil
+	}
+
+	res, err := c.ListTransfers(ctx, req)
+	if err != nil {
+		return nil, errors.Wrap(err, "gateway: error calling ListTransfers")
+	}
+
+	return res, nil
+}
+
+func (s *svc) RetryTransfer(ctx context.Context, req *datatx.RetryTransferRequest) (*datatx.RetryTransferResponse, error) {
+	c, err := pool.GetDataTxClient(s.c.DataTxEndpoint)
+	if err != nil {
+		return &datatx.RetryTransferResponse{
+			Status: status.NewInternal(ctx, "error getting data transfer client"),
+		}, nil
+	}
+
+	res, err := c.RetryTransfer(ctx, req)
+	if err != nil {
+		return nil, errors.Wrap(err, "gateway: error calling RetryTransfer")
 	}
 
 	return res, nil

--- a/internal/http/services/owncloud/ocdav/propfind/mocks/GatewayClient.go
+++ b/internal/http/services/owncloud/ocdav/propfind/mocks/GatewayClient.go
@@ -456,36 +456,6 @@ func (_m *GatewayClient) CreateSymlink(ctx context.Context, in *providerv1beta1.
 	return r0, r1
 }
 
-// CreateTransfer provides a mock function with given fields: ctx, in, opts
-func (_m *GatewayClient) CreateTransfer(ctx context.Context, in *txv1beta1.CreateTransferRequest, opts ...grpc.CallOption) (*txv1beta1.CreateTransferResponse, error) {
-	_va := make([]interface{}, len(opts))
-	for _i := range opts {
-		_va[_i] = opts[_i]
-	}
-	var _ca []interface{}
-	_ca = append(_ca, ctx, in)
-	_ca = append(_ca, _va...)
-	ret := _m.Called(_ca...)
-
-	var r0 *txv1beta1.CreateTransferResponse
-	if rf, ok := ret.Get(0).(func(context.Context, *txv1beta1.CreateTransferRequest, ...grpc.CallOption) *txv1beta1.CreateTransferResponse); ok {
-		r0 = rf(ctx, in, opts...)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*txv1beta1.CreateTransferResponse)
-		}
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, *txv1beta1.CreateTransferRequest, ...grpc.CallOption) error); ok {
-		r1 = rf(ctx, in, opts...)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
 // Delete provides a mock function with given fields: ctx, in, opts
 func (_m *GatewayClient) Delete(ctx context.Context, in *providerv1beta1.DeleteRequest, opts ...grpc.CallOption) (*providerv1beta1.DeleteResponse, error) {
 	_va := make([]interface{}, len(opts))
@@ -2046,6 +2016,36 @@ func (_m *GatewayClient) ListSupportedMimeTypes(ctx context.Context, in *registr
 	return r0, r1
 }
 
+// ListTransfers provides a mock function with given fields: ctx, in, opts
+func (_m *GatewayClient) ListTransfers(ctx context.Context, in *txv1beta1.ListTransfersRequest, opts ...grpc.CallOption) (*txv1beta1.ListTransfersResponse, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx, in)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	var r0 *txv1beta1.ListTransfersResponse
+	if rf, ok := ret.Get(0).(func(context.Context, *txv1beta1.ListTransfersRequest, ...grpc.CallOption) *txv1beta1.ListTransfersResponse); ok {
+		r0 = rf(ctx, in, opts...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*txv1beta1.ListTransfersResponse)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, *txv1beta1.ListTransfersRequest, ...grpc.CallOption) error); ok {
+		r1 = rf(ctx, in, opts...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // Move provides a mock function with given fields: ctx, in, opts
 func (_m *GatewayClient) Move(ctx context.Context, in *providerv1beta1.MoveRequest, opts ...grpc.CallOption) (*providerv1beta1.MoveResponse, error) {
 	_va := make([]interface{}, len(opts))
@@ -2098,6 +2098,36 @@ func (_m *GatewayClient) OpenInApp(ctx context.Context, in *gatewayv1beta1.OpenI
 
 	var r1 error
 	if rf, ok := ret.Get(1).(func(context.Context, *gatewayv1beta1.OpenInAppRequest, ...grpc.CallOption) error); ok {
+		r1 = rf(ctx, in, opts...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// PullTransfer provides a mock function with given fields: ctx, in, opts
+func (_m *GatewayClient) PullTransfer(ctx context.Context, in *txv1beta1.PullTransferRequest, opts ...grpc.CallOption) (*txv1beta1.PullTransferResponse, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx, in)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	var r0 *txv1beta1.PullTransferResponse
+	if rf, ok := ret.Get(0).(func(context.Context, *txv1beta1.PullTransferRequest, ...grpc.CallOption) *txv1beta1.PullTransferResponse); ok {
+		r0 = rf(ctx, in, opts...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*txv1beta1.PullTransferResponse)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, *txv1beta1.PullTransferRequest, ...grpc.CallOption) error); ok {
 		r1 = rf(ctx, in, opts...)
 	} else {
 		r1 = ret.Error(1)
@@ -2308,6 +2338,36 @@ func (_m *GatewayClient) RestoreRecycleItem(ctx context.Context, in *providerv1b
 
 	var r1 error
 	if rf, ok := ret.Get(1).(func(context.Context, *providerv1beta1.RestoreRecycleItemRequest, ...grpc.CallOption) error); ok {
+		r1 = rf(ctx, in, opts...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// RetryTransfer provides a mock function with given fields: ctx, in, opts
+func (_m *GatewayClient) RetryTransfer(ctx context.Context, in *txv1beta1.RetryTransferRequest, opts ...grpc.CallOption) (*txv1beta1.RetryTransferResponse, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx, in)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	var r0 *txv1beta1.RetryTransferResponse
+	if rf, ok := ret.Get(0).(func(context.Context, *txv1beta1.RetryTransferRequest, ...grpc.CallOption) *txv1beta1.RetryTransferResponse); ok {
+		r0 = rf(ctx, in, opts...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*txv1beta1.RetryTransferResponse)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, *txv1beta1.RetryTransferRequest, ...grpc.CallOption) error); ok {
 		r1 = rf(ctx, in, opts...)
 	} else {
 		r1 = ret.Error(1)

--- a/pkg/storage/utils/decomposedfs/node/node.go
+++ b/pkg/storage/utils/decomposedfs/node/node.go
@@ -604,6 +604,14 @@ func (n *Node) AsResourceInfo(ctx context.Context, rp *provider.ResourcePermissi
 		}
 	}
 
+	var parentID *provider.ResourceId = nil
+	if p, err := n.Parent(); err == nil {
+		parentID = &provider.ResourceId{
+			StorageId: p.SpaceID,
+			OpaqueId:  p.ID,
+		}
+	}
+
 	ri = &provider.ResourceInfo{
 		Id:            id,
 		Path:          fn,
@@ -613,6 +621,7 @@ func (n *Node) AsResourceInfo(ctx context.Context, rp *provider.ResourcePermissi
 		Target:        target,
 		PermissionSet: rp,
 		Owner:         n.Owner(),
+		ParentId:      parentID,
 	}
 
 	if nodeType == provider.ResourceType_RESOURCE_TYPE_CONTAINER {

--- a/pkg/storage/utils/decomposedfs/node/node.go
+++ b/pkg/storage/utils/decomposedfs/node/node.go
@@ -604,7 +604,7 @@ func (n *Node) AsResourceInfo(ctx context.Context, rp *provider.ResourcePermissi
 		}
 	}
 
-	var parentID *provider.ResourceId = nil
+	var parentID *provider.ResourceId
 	if p, err := n.Parent(); err == nil {
 		parentID = &provider.ResourceId{
 			StorageId: p.SpaceID,


### PR DESCRIPTION
# Description
We've implemented the changes from cs3org/cs3apis#167 in the DecomposedFS, so that a stat on a resource always includes a reference to the parent of the resource.


# Related issues
fixes https://github.com/owncloud/ocis/issues/3409
related to:
- https://github.com/cs3org/reva/issues/1804#issuecomment-1076471437
- https://github.com/cs3org/wopiserver/pull/67#issuecomment-1080509185
- https://github.com/cs3org/cs3apis/pull/167