### PR TITLE
Support editnew actions from MS Office

### DIFF
--- a/changelog/unreleased/app-editnew.md
+++ b/changelog/unreleased/app-editnew.md
@@ -1,0 +1,5 @@
+Bugfix: Support editnew actions from MS Office
+
+This fixes the incorrect behavior when creating new xlsx and pptx files, as MS Office supports the editnew action and it must be used for newly created files instead of the normal edit action.
+
+https://github.com/cs3org/reva/pull/2693

--- a/pkg/app/provider/wopi/wopi.go
+++ b/pkg/app/provider/wopi/wopi.go
@@ -165,13 +165,19 @@ func (p *wopiProvider) GetAppURL(ctx context.Context, resource *provider.Resourc
 			q.Add("appviewurl", viewAppURL)
 		}
 	}
-	if editAppURLs, ok := p.appURLs["edit"]; ok {
+	var access string = "edit"
+	if resource.GetSize() == 0 {
+		if _, ok := p.appURLs["editnew"]; ok {
+			access = "editnew"
+		}
+	}
+	if editAppURLs, ok := p.appURLs[access]; ok {
 		if editAppURL, ok := editAppURLs[ext]; ok {
 			q.Add("appurl", editAppURL)
 		}
 	}
 	if q.Get("appurl") == "" {
-		// assuming that an view action is always available in the /hosting/discovery manifest
+		// assuming that a view action is always available in the /hosting/discovery manifest
 		// eg. Collabora does support viewing jpgs but no editing
 		// eg. OnlyOffice does support viewing pdfs but no editing
 		// there is no known case of supporting edit only without view
@@ -371,7 +377,7 @@ func parseWopiDiscovery(body io.Reader) (map[string]map[string]string, error) {
 			for _, app := range netzone.SelectElements("app") {
 				for _, action := range app.SelectElements("action") {
 					access := action.SelectAttrValue("name", "")
-					if access == "view" || access == "edit" {
+					if access == "view" || access == "edit" || access == "editnew" {
 						ext := action.SelectAttrValue("ext", "")
 						urlString := action.SelectAttrValue("urlsrc", "")
 


### PR DESCRIPTION
This fixes the incorrect behavior when creating new xlsx and pptx files, as MS Office supports the `editnew` action and it must be used for newly created files instead of the normal `edit` action.