### PR TITLE
fix ListReceivedShares in json share manager

### DIFF
--- a/changelog/unreleased/spaces-shares.md
+++ b/changelog/unreleased/spaces-shares.md
@@ -5,3 +5,4 @@ The json share manager was enhanced to check if the user is allowed to see a sha
 
 https://github.com/owncloud/ocis/issues/3370
 https://github.com/cs3org/reva/pull/2674
+https://github.com/cs3org/reva/pull/2710

--- a/pkg/share/manager/json/json.go
+++ b/pkg/share/manager/json/json.go
@@ -414,6 +414,8 @@ func (m *mgr) ListReceivedShares(ctx context.Context, filters []*collaboration.F
 			if other.Share.Grantee.Type == provider.GranteeType_GRANTEE_TYPE_GROUP && s.Grantee.Type == provider.GranteeType_GRANTEE_TYPE_USER {
 				if other.State == rs.State {
 					rss[idx] = rs
+				} else {
+					rss = append(rss, rs)
 				}
 			}
 		}


### PR DESCRIPTION
When refactoring the code in ListReceivedShares this crucial behavior got lost.