### PR TITLE
fix: update eos-revad dockerfile

### DIFF
--- a/Dockerfile.revad-eos
+++ b/Dockerfile.revad-eos
@@ -35,9 +35,6 @@ RUN make build-revad-docker && cp /go/src/github/cs3org/reva/cmd/revad/revad /us
 RUN mkdir -p /etc/revad/ && echo "" > /etc/revad/revad.toml
 RUN mkdir -p /usr/local/bin
 
-# COPY --from=builder /go/bin/revad /usr/bin/revad
-# COPY --from=builder /etc/revad /etc/revad
-
 RUN chmod +x /usr/bin/revad
 
 ENTRYPOINT [ "/usr/bin/revad" ]

--- a/Dockerfile.revad-eos
+++ b/Dockerfile.revad-eos
@@ -16,32 +16,27 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
-FROM golang:alpine3.13 as builder
+FROM gitlab-registry.cern.ch/dss/eos/eos-slim:4.8.54
 
-RUN apk --no-cache add \
-  ca-certificates \
-  bash \
-  git \
-  gcc \
-  libc-dev \
-  make
+RUN yum -y update && yum clean all
+
+RUN yum -y install https://packages.endpointdev.com/rhel/7/os/x86_64/endpoint-repo.x86_64.rpm
+RUN yum install -y make git gcc libc-dev bash
+
+RUN yum install -y epel-release && yum install -y golang
 
 ENV PATH /go/bin:/usr/local/go/bin:$PATH
 ENV GOPATH /go
 
 WORKDIR /go/src/github/cs3org/reva
 COPY . .
-RUN make build-revad-docker && \
-    cp /go/src/github/cs3org/reva/cmd/revad/revad /go/bin/revad
+RUN make build-revad-docker && cp /go/src/github/cs3org/reva/cmd/revad/revad /usr/bin/revad
 
 RUN mkdir -p /etc/revad/ && echo "" > /etc/revad/revad.toml
-
-FROM gitlab-registry.cern.ch/dss/eos/eos-all:4.8.57
-
 RUN mkdir -p /usr/local/bin
 
-COPY --from=builder /go/bin/revad /usr/bin/revad
-COPY --from=builder /etc/revad /etc/revad
+# COPY --from=builder /go/bin/revad /usr/bin/revad
+# COPY --from=builder /etc/revad /etc/revad
 
 RUN chmod +x /usr/bin/revad
 

--- a/Dockerfile.revad-eos
+++ b/Dockerfile.revad-eos
@@ -21,9 +21,9 @@ FROM gitlab-registry.cern.ch/dss/eos/eos-slim:4.8.54
 RUN yum -y update && yum clean all
 
 RUN yum -y install https://packages.endpointdev.com/rhel/7/os/x86_64/endpoint-repo.x86_64.rpm
-RUN yum install -y make git gcc libc-dev bash
-
-RUN yum install -y epel-release && yum install -y golang
+RUN yum install -y make git gcc libc-dev bash epel-release golang && \
+  yum clean all && \
+  rm -rf /var/cache/yum
 
 ENV PATH /go/bin:/usr/local/go/bin:$PATH
 ENV GOPATH /go

--- a/changelog/unreleased/eos-revad-dockerfile.md
+++ b/changelog/unreleased/eos-revad-dockerfile.md
@@ -1,0 +1,3 @@
+Bugfix: Update Dockerfile.revad.eos to not break the image
+
+https://github.com/cs3org/reva/pull/2712


### PR DESCRIPTION
Updates the dockerfile for `revad-eos` to not break.

The compressed size of the image is 2.76GB. 

/cc @SamuAlfageme 

Signed-off-by: Jimil Desai <jimildesai42@gmail.com>