### PR TITLE
Quicklinks

### DIFF
--- a/changelog/unreleased/quicklinks.md
+++ b/changelog/unreleased/quicklinks.md
@@ -1,0 +1,9 @@
+Enhancement: introduced quicklinks
+
+We now support Quicklinks. When creating a link with flag "quicklink=true", no new link will be created when a link
+already exists.
+
+Downside: since we can't update cs3api at the moment, we reserve the name `Quicklink` for the quicklink. Trying to create
+a link named `Quicklink` without the "quicklink=true" flag will result in a `Bad Request`
+
+https://github.com/cs3org/reva/pull/2715

--- a/changelog/unreleased/quicklinks.md
+++ b/changelog/unreleased/quicklinks.md
@@ -3,7 +3,4 @@ Enhancement: introduced quicklinks
 We now support Quicklinks. When creating a link with flag "quicklink=true", no new link will be created when a link
 already exists.
 
-Downside: since we can't update cs3api at the moment, we reserve the name `Quicklink` for the quicklink. Trying to create
-a link named `Quicklink` without the "quicklink=true" flag will result in a `Bad Request`
-
 https://github.com/cs3org/reva/pull/2715

--- a/cmd/reva/preferences.go
+++ b/cmd/reva/preferences.go
@@ -55,7 +55,7 @@ var preferencesCommand = func() *command {
 			}
 			value := cmd.Args()[2]
 			req := &preferences.SetKeyRequest{
-				Key: key,
+				Key: &preferences.PreferenceKey{Key: key},
 				Val: value,
 			}
 
@@ -70,7 +70,7 @@ var preferencesCommand = func() *command {
 
 		case "get":
 			req := &preferences.GetKeyRequest{
-				Key: key,
+				Key: &preferences.PreferenceKey{Key: key},
 			}
 
 			res, err := client.GetKey(ctx, req)

--- a/go.mod
+++ b/go.mod
@@ -93,6 +93,7 @@ require (
 go 1.16
 
 replace (
+	github.com/cs3org/go-cs3apis => github.com/kobergj/go-cs3apis v0.0.0-20220406134716-65f04386eb09 // temporary fork
 	github.com/eventials/go-tus => github.com/andrewmostello/go-tus v0.0.0-20200314041820-904a9904af9a
 	github.com/oleiade/reflections => github.com/oleiade/reflections v1.0.1
 	google.golang.org/grpc => google.golang.org/grpc v1.26.0 // temporary downgrade

--- a/go.sum
+++ b/go.sum
@@ -207,10 +207,6 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/cs3org/cato v0.0.0-20200828125504-e418fc54dd5e h1:tqSPWQeueWTKnJVMJffz4pz0o1WuQxJ28+5x5JgaHD8=
 github.com/cs3org/cato v0.0.0-20200828125504-e418fc54dd5e/go.mod h1:XJEZ3/EQuI3BXTp/6DUzFr850vlxq11I6satRtz0YQ4=
-github.com/cs3org/go-cs3apis v0.0.0-20220126114148-64c025ccdd19 h1:1jqPH58jCxvbaJ9WLIJ7W2/m622bWS6ChptzljSG6IQ=
-github.com/cs3org/go-cs3apis v0.0.0-20220126114148-64c025ccdd19/go.mod h1:UXha4TguuB52H14EMoSsCqDj7k8a/t7g4gVP+bgY5LY=
-github.com/cs3org/go-cs3apis v0.0.0-20220328105952-297bef33e13f h1:emnlOWc1s2gx77MViLnZH9yh5TRHKsykRu6rJjx3lkM=
-github.com/cs3org/go-cs3apis v0.0.0-20220328105952-297bef33e13f/go.mod h1:UXha4TguuB52H14EMoSsCqDj7k8a/t7g4gVP+bgY5LY=
 github.com/cubewise-code/go-mime v0.0.0-20200519001935-8c5762b177d8 h1:Z9lwXumT5ACSmJ7WGnFl+OMLLjpz5uR2fyz7dC255FI=
 github.com/cubewise-code/go-mime v0.0.0-20200519001935-8c5762b177d8/go.mod h1:4abs/jPXcmJzYoYGF91JF9Uq9s/KL5n1jvFDix8KcqY=
 github.com/cyberdelia/templates v0.0.0-20141128023046-ca7fffd4298c/go.mod h1:GyV+0YP4qX0UQ7r2MoYZ+AvYDp12OF5yg4q8rGnyNh4=
@@ -639,6 +635,8 @@ github.com/klauspost/compress v1.14.3/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47e
 github.com/klauspost/cpuid v1.2.3/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
 github.com/klauspost/cpuid v1.3.1 h1:5JNjFYYQrZeKRJ0734q51WCEEn2huer72Dc7K+R/b6s=
 github.com/klauspost/cpuid v1.3.1/go.mod h1:bYW4mA6ZgKPob1/Dlai2LviZJO7KGI3uoWLd42rAQw4=
+github.com/kobergj/go-cs3apis v0.0.0-20220406134716-65f04386eb09 h1:i1caLRatgEscEdtcplmwjxHSVve13rQTuRDxo42FZI8=
+github.com/kobergj/go-cs3apis v0.0.0-20220406134716-65f04386eb09/go.mod h1:UXha4TguuB52H14EMoSsCqDj7k8a/t7g4gVP+bgY5LY=
 github.com/kolo/xmlrpc v0.0.0-20200310150728-e0350524596b/go.mod h1:o03bZfuBwAXHetKXuInt4S7omeXUu62/A845kiycsSQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=

--- a/internal/grpc/services/preferences/preferences.go
+++ b/internal/grpc/services/preferences/preferences.go
@@ -92,10 +92,10 @@ func (s *service) SetKey(ctx context.Context, req *preferences.SetKeyRequest) (*
 	mutex.Lock()
 	defer mutex.Unlock()
 	if len(m[name]) == 0 {
-		m[name] = map[string]string{key: value}
+		m[name] = map[string]string{key.Key: value}
 	} else {
 		usersettings := m[name]
-		usersettings[key] = value
+		usersettings[key.Key] = value
 	}
 
 	return &preferences.SetKeyResponse{
@@ -118,7 +118,7 @@ func (s *service) GetKey(ctx context.Context, req *preferences.GetKeyRequest) (*
 	mutex.Lock()
 	defer mutex.Unlock()
 	if len(m[name]) != 0 {
-		if value, ok := m[name][key]; ok {
+		if value, ok := m[name][key.Key]; ok {
 			return &preferences.GetKeyResponse{
 				Status: status.NewOK(ctx),
 				Val:    value,

--- a/internal/http/services/owncloud/ocs/conversions/main.go
+++ b/internal/http/services/owncloud/ocs/conversions/main.go
@@ -142,6 +142,8 @@ type ShareData struct {
 	URL string `json:"url,omitempty" xml:"url,omitempty"`
 	// Attributes associated
 	Attributes string `json:"attributes,omitempty" xml:"attributes,omitempty"`
+	// Quicklink indicates if the link is the quicklink
+	Quicklink bool `json:"quicklink,omitempty" xml:"quicklink,omitempty"`
 	// PasswordProtected represents a public share is password protected
 	// PasswordProtected bool `json:"password_protected,omitempty" xml:"password_protected,omitempty"`
 }
@@ -233,6 +235,7 @@ func PublicShare2ShareData(share *link.PublicShare, r *http.Request, publicURL s
 		URL:          publicURL + path.Join("/", "s/"+share.Token),
 		UIDOwner:     LocalUserIDToString(share.Creator),
 		UIDFileOwner: LocalUserIDToString(share.Owner),
+		Quicklink:    share.Quicklink,
 	}
 	if share.Id != nil {
 		sd.ID = share.Id.OpaqueId

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/public.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/public.go
@@ -33,13 +33,14 @@ import (
 	"github.com/cs3org/reva/v2/internal/http/services/owncloud/ocs/conversions"
 	"github.com/cs3org/reva/v2/internal/http/services/owncloud/ocs/response"
 	"github.com/cs3org/reva/v2/pkg/appctx"
+	"github.com/cs3org/reva/v2/pkg/publicshare"
 	"github.com/cs3org/reva/v2/pkg/rgrpc/todo/pool"
 	"github.com/pkg/errors"
 )
 
 // QuicklinkName is the reserved name for a quicklink.
 // Creating (or updating) a link with (to) the same name will be blocked by the server
-var QuicklinkName = "Quicklink"
+const QuicklinkName = "Quicklink"
 
 func (h *Handler) createPublicLinkShare(w http.ResponseWriter, r *http.Request, statInfo *provider.ResourceInfo) (*link.PublicShare, *ocsError) {
 	ctx := r.Context()
@@ -76,16 +77,7 @@ func (h *Handler) createPublicLinkShare(w http.ResponseWriter, r *http.Request, 
 
 	// check if a quicklink should be created
 	if quick {
-		_, f, err := h.addFilters(w, r, &provider.Reference{ResourceId: statInfo.Id})
-		if err != nil {
-			log.Error().Err(err).Msg("could not add filters")
-			return nil, &ocsError{
-				Code:    response.MetaServerError.StatusCode,
-				Message: "could not add filters",
-				Error:   err,
-			}
-		}
-
+		f := []*link.ListPublicSharesRequest_Filter{publicshare.ResourceIDFilter(statInfo.Id)}
 		req := link.ListPublicSharesRequest{Filters: f}
 		res, err := c.ListPublicShares(ctx, &req)
 		if err != nil {

--- a/pkg/publicshare/manager/cs3/cs3.go
+++ b/pkg/publicshare/manager/cs3/cs3.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"net/url"
 	"path"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -173,12 +174,14 @@ func (m *Manager) CreatePublicShare(ctx context.Context, u *user.User, ri *provi
 	tkn := utils.RandString(15)
 	now := time.Now().UnixNano()
 
-	displayName := tkn
+	displayName, quicklink := tkn, false
 	if ri.ArbitraryMetadata != nil {
 		metadataName, ok := ri.ArbitraryMetadata.Metadata["name"]
 		if ok {
 			displayName = metadataName
 		}
+
+		quicklink, _ = strconv.ParseBool(ri.ArbitraryMetadata.Metadata["quicklink"])
 	}
 
 	var passwordProtected bool
@@ -210,6 +213,7 @@ func (m *Manager) CreatePublicShare(ctx context.Context, u *user.User, ri *provi
 			PasswordProtected: passwordProtected,
 			Expiration:        g.Expiration,
 			DisplayName:       displayName,
+			Quicklink:         quicklink,
 		},
 		HashedPassword: password,
 	}

--- a/pkg/publicshare/manager/json/json.go
+++ b/pkg/publicshare/manager/json/json.go
@@ -26,6 +26,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"syscall"
@@ -159,6 +160,8 @@ func (m *manager) CreatePublicShare(ctx context.Context, u *user.User, rInfo *pr
 		displayName = tkn
 	}
 
+	quicklink, _ := strconv.ParseBool(rInfo.ArbitraryMetadata.Metadata["quicklink"])
+
 	var passwordProtected bool
 	password := g.Password
 	if len(password) > 0 {
@@ -187,6 +190,7 @@ func (m *manager) CreatePublicShare(ctx context.Context, u *user.User, rInfo *pr
 		PasswordProtected: passwordProtected,
 		Expiration:        g.Expiration,
 		DisplayName:       displayName,
+		Quicklink:         quicklink,
 	}
 
 	ps := &publicShare{


### PR DESCRIPTION
Introduces quicklinks.

Creating a Link with the flag `"quicklink=true"` will create a Quicklink. If another create link request with "quicklink=true" comes in, the server will return the existing link instead of creating a new one.

- Since that functionality is not part of the cs3api we needed to update it.
- Besides `"true"` usual go convertible string values are supported for the quicklink flag: ` 1, t, T, TRUE, true, True` see https://golang.google.cn/pkg/strconv/#ParseBool

Curl example:
```bash
curl --insecure -X POST "https://localhost:9200/ocs/v1.php/apps/files_sharing/api/v1/shares" -u admin:admin -d 'shareType=3&path=/rhino.png&permissions=15&name=BLUBB&quicklink=true'

<?xml version="1.0" encoding="UTF-8"?>
<ocs>
  <meta>
    <status>ok</status>
    <statuscode>100</statuscode>
    <message>OK</message>
  </meta>
  <data>
    <id>exmHTRXGQCwSOyL</id>
    <share_type>3</share_type>
    <uid_owner>admin</uid_owner>
    <displayname_owner>Admin</displayname_owner>
    <additional_info_owner>admin@example.org</additional_info_owner>
    <permissions>3</permissions>
    <stime>1649167505</stime>
    <parent/>
    <expiration/>
    <token>avEAzCCwPcfNuer</token>
    <uid_file_owner>admin</uid_file_owner>
    <displayname_file_owner>Admin</displayname_file_owner>
    <additional_info_file_owner>admin@example.org</additional_info_file_owner>
    <state>0</state>
    <path>/rhino.png</path>
    <item_type>file</item_type>
    <mimetype>image/png</mimetype>
    <storage_id>shared::/rhino.png</storage_id>
    <storage>0</storage>
    <item_source>ddc2004c-0977-11eb-9d3f-a793888cd0f8!db6f0bc2-dc85-4b5e-9834-621dd76d1e68</item_source>
    <file_source>ddc2004c-0977-11eb-9d3f-a793888cd0f8!db6f0bc2-dc85-4b5e-9834-621dd76d1e68</file_source>
    <file_parent/>
    <file_target>/rhino.png</file_target>
    <share_with_additional_info/>
    <mail_send>0</mail_send>
    <name>BLUBB</name>
    <url>https://localhost:9200/s/avEAzCCwPcfNuer</url>
    <quicklink>true</quicklink>
  </data>
</ocs>

```