### PR TITLE
Avoid user enumeration

### DIFF
--- a/changelog/unreleased/avoid-user-enumeration.md
+++ b/changelog/unreleased/avoid-user-enumeration.md
@@ -1,0 +1,7 @@
+Change: avoid user enumeration
+
+sending PROPFIND requests to `../files/admin` did return a different response than sending the
+same request to `../files/notexists`. This allowed enumerating users.
+This response was changed to be the same always
+
+https://github.com/cs3org/reva/pull/2735

--- a/internal/http/services/owncloud/ocdav/propfind/propfind.go
+++ b/internal/http/services/owncloud/ocdav/propfind/propfind.go
@@ -423,7 +423,7 @@ func (p *Handler) getResourceInfos(ctx context.Context, w http.ResponseWriter, r
 	if len(spaceInfos) == 0 || rootInfo == nil {
 		// TODO if we have children invent node on the fly
 		w.WriteHeader(http.StatusNotFound)
-		m := fmt.Sprintf("Resource %v not found", requestPath)
+		m := "Resource not found"
 		b, err := errors.Marshal(http.StatusNotFound, m, "")
 		errors.HandleWebdavError(&log, w, b, err)
 		return nil, false, false

--- a/tests/acceptance/expected-failures-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-on-OCIS-storage.md
@@ -1573,5 +1573,10 @@ _ocs: api compatibility, return correct status code_
 - [apiShareCreateSpecialToShares2/createShareWithInvalidPermissions.feature:28](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareCreateSpecialToShares2/createShareWithInvalidPermissions.feature#L28)
 - [apiShareCreateSpecialToShares2/createShareWithInvalidPermissions.feature:29](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareCreateSpecialToShares2/createShareWithInvalidPermissions.feature#L29)
 
+#### resource path is no longer included in the returned error message
+- [apiWebdavProperties2/getFileProperties.feature:324](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties2/getFileProperties.feature#L324)
+- [apiWebdavProperties2/getFileProperties.feature:336](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties2/getFileProperties.feature#L336)
+- [apiWebdavProperties2/getFileProperties.feature:337](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties2/getFileProperties.feature#L337)
+
 Note: always have an empty line at the end of this file.
 The bash script that processes this file may not process a scenario reference on the last line.

--- a/tests/acceptance/expected-failures-on-S3NG-storage.md
+++ b/tests/acceptance/expected-failures-on-S3NG-storage.md
@@ -1573,5 +1573,10 @@ _ocs: api compatibility, return correct status code_
 - [apiShareCreateSpecialToShares2/createShareWithInvalidPermissions.feature:28](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareCreateSpecialToShares2/createShareWithInvalidPermissions.feature#L28)
 - [apiShareCreateSpecialToShares2/createShareWithInvalidPermissions.feature:29](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareCreateSpecialToShares2/createShareWithInvalidPermissions.feature#L29)
 
+#### resource path is no longer included in the returned error message
+- [apiWebdavProperties2/getFileProperties.feature:324](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties2/getFileProperties.feature#L324)
+- [apiWebdavProperties2/getFileProperties.feature:336](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties2/getFileProperties.feature#L336)
+- [apiWebdavProperties2/getFileProperties.feature:337](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties2/getFileProperties.feature#L337)
+
  Note: always have an empty line at the end of this file.
 The bash script that processes this file may not process a scenario reference on the last line.


### PR DESCRIPTION
Don't expose the altered `requestPath` to avoid user enumeration through PROPFIND requests.

Github-Issue: https://github.com/owncloud/ocis/issues/3344
See also jira-ticket: https://jira.owncloud.com/browse/OCIS-2414