### PR TITLE
Add support for meta-path-for-user propfind

### DIFF
--- a/changelog/unreleased/meta-path-for-user.md
+++ b/changelog/unreleased/meta-path-for-user.md
@@ -1,0 +1,6 @@
+Enhancement: Meta path for user
+
+We've added support for requesting the `meta-path-for-user` via a propfind to the `dav/meta/<id>` endpoint. 
+
+https://github.com/cs3org/reva/pull/2741
+https://doc.owncloud.com/server/next/developer_manual/webdav_api/meta.html

--- a/internal/http/services/owncloud/ocdav/meta.go
+++ b/internal/http/services/owncloud/ocdav/meta.go
@@ -58,6 +58,15 @@ func (h *MetaHandler) Handler(s *svc) http.Handler {
 		}
 
 		did := resourceid.OwnCloudResourceIDUnwrap(id)
+		if did == nil {
+			logger := appctx.GetLogger(r.Context())
+			logger.Debug().Str("prop", net.PropOcMetaPathForUser).Msg("invalid resource id")
+			w.WriteHeader(http.StatusBadRequest)
+			m := fmt.Sprintf("Invalid resource id %v", id)
+			b, err := errors.Marshal(http.StatusBadRequest, m, "")
+			errors.HandleWebdavError(logger, w, b, err)
+			return
+		}
 
 		var head string
 		head, r.URL.Path = router.ShiftPath(r.URL.Path)

--- a/internal/http/services/owncloud/ocdav/net/net.go
+++ b/internal/http/services/owncloud/ocdav/net/net.go
@@ -50,6 +50,8 @@ const (
 	PropQuotaUnknown = "-2"
 	// PropOcFavorite is the favorite ns property
 	PropOcFavorite = "http://owncloud.org/ns/favorite"
+	// PropOcMetaPathForUser is the meta-path-for-user ns property
+	PropOcMetaPathForUser = "http://owncloud.org/ns/meta-path-for-user"
 
 	// DepthZero represents the webdav zero depth value
 	DepthZero Depth = "0"


### PR DESCRIPTION
This PR adds support for the `meta-path-for-user` prop in propfinds to the `/dav/meta` endpoint. This is needed oC Web for two situations:
a) when a resource path but only the id is not given in the browser URL, fetch path to make a propfind afterwards
b) when a resource path is given in the browser URL but resolves to an outdated location (e.g. resource has been moved), fetch new path to make another propfind afterwards

Based on outdated/closed https://github.com/cs3org/reva/pull/2321 and https://github.com/cs3org/reva/pull/1604

Spec can be found here: https://doc.owncloud.com/server/next/developer_manual/webdav_api/meta.html

An example request:
`curl -u einstein:relativity --insecure -X PROPFIND -H "Depth: 0" -H "Content-Type: text/xml" --data "@meta-files.xml" 'https://localhost:9200/remote.php/dav/meta/ddc2004c-0977-11eb-9d3f-a793888cd0f8!aa07d86a-f564-4e26-9e36-632ef63df9f0' | xmllint --format -`

with content of `meta-files.xml` being:
```xml
<?xml version="1.0"?>
<a:propfind xmlns:a="DAV:" xmlns:oc="http://owncloud.org/ns">
    <a:prop>
        <oc:meta-path-for-user/>
    </a:prop>
</a:propfind>
```