### PR TITLE
auth-provider: Fix LDAP login filter

### DIFF
--- a/changelog/unreleased/ldap-login-filter.md
+++ b/changelog/unreleased/ldap-login-filter.md
@@ -1,0 +1,6 @@
+Bugfix: Use exact match in login filter
+
+After the recent config changes the auth-provider was accidently using a
+substring match for the login filter. It's no fixed to use an exact match.
+
+https://github.com/cs3org/reva/pull/2742

--- a/pkg/auth/manager/ldap/ldap.go
+++ b/pkg/auth/manager/ldap/ldap.go
@@ -203,7 +203,7 @@ func (am *mgr) Authenticate(ctx context.Context, clientID, clientSecret string) 
 func (am *mgr) getLoginFilter(login string) string {
 	var filter string
 	for _, attr := range am.c.LoginAttributes {
-		filter = fmt.Sprintf("%s(%s=%s*)", filter, attr, ldap.EscapeFilter(login))
+		filter = fmt.Sprintf("%s(%s=%s)", filter, attr, ldap.EscapeFilter(login))
 	}
 
 	return fmt.Sprintf("(&%s(objectclass=%s)(|%s))",


### PR DESCRIPTION
Using a substring filter is certainly wrong here. We need an exact match.