### PR TITLE
`RFC3339` as layout for parsing time 

### DIFF
--- a/changelog/unreleased/rfc3339-fix.md
+++ b/changelog/unreleased/rfc3339-fix.md
@@ -1,0 +1,6 @@
+Bugfix: Use RFC3339 for parsing dates
+
+We have used the RFC3339 format for parsing dates to be consistent with oC Web.
+
+https://github.com/cs3org/reva/issues/2322
+https://github.com/cs3org/reva/pull/2744

--- a/internal/http/services/owncloud/ocs/conversions/main.go
+++ b/internal/http/services/owncloud/ocs/conversions/main.go
@@ -281,7 +281,7 @@ func timestampToExpiration(t *types.Timestamp) string {
 
 // ParseTimestamp tries to parses the ocs expiry into a CS3 Timestamp
 func ParseTimestamp(timestampString string) (*types.Timestamp, error) {
-	parsedTime, err := time.Parse("2006-01-02T15:04:05Z0700", timestampString)
+	parsedTime, err := time.Parse(time.RFC3339, timestampString)
 	if err != nil {
 		parsedTime, err = time.Parse("2006-01-02", timestampString)
 	}


### PR DESCRIPTION
The `time.Parse()` method currently uses `2006-01-02T15:04:05Z0700` as layout for parsing dates. This is somewhat inconsistent with oC Web. This PR changes `time.Parse()` to use the `RFC3339` layout for parsing dates.

Fixes #2322 