### PR TITLE
fix share jail caching

### DIFF
--- a/changelog/unreleased/share-jail-cache.md
+++ b/changelog/unreleased/share-jail-cache.md
@@ -1,0 +1,5 @@
+Bugfix: Disable storageprovider cache for the share jail
+
+The share jail should not be cached in the provider cache because it is a virtual collection of resources from different storage providers.
+
+https://github.com/cs3org/reva/pull/2784

--- a/internal/grpc/services/gateway/storageprovidercache.go
+++ b/internal/grpc/services/gateway/storageprovidercache.go
@@ -184,8 +184,8 @@ func (c *cachedRegistryClient) ListStorageProviders(ctx context.Context, in *reg
 
 	storageID := sdk.DecodeOpaqueMap(in.Opaque)["storage_id"]
 
-	key := user.GetId().GetOpaqueId() + storageID
-	if key != "" {
+	key := user.GetId().GetOpaqueId() + "!" + storageID
+	if key != "!" {
 		s := &registry.ListStorageProvidersResponse{}
 		if err := pullFromCache(cache, key, s); err == nil {
 			return s, nil
@@ -199,6 +199,8 @@ func (c *cachedRegistryClient) ListStorageProviders(ctx context.Context, in *reg
 	case resp.Status.Code != rpc.Code_CODE_OK:
 		return resp, nil
 	case storageID == "":
+		return resp, nil
+	case storageID == utils.ShareStorageProviderID:
 		return resp, nil
 	default:
 		return resp, pushToCache(cache, key, resp)


### PR DESCRIPTION
# Description

Bugfix: Disable storageprovider cache for the share jail

The share jail should not be cached in the provider cache because it is a virtual collection of resources from different storage providers.

Needed for https://github.com/owncloud/web/pull/6593