### PR TITLE
implement workaround for chi.RegisterMethod

### DIFF
--- a/changelog/unreleased/chi-method-workaround.md
+++ b/changelog/unreleased/chi-method-workaround.md
@@ -1,0 +1,6 @@
+Change: Implement workaround for chi.RegisterMethod
+
+Implemented a workaround for `chi.RegisterMethod` because of a concurrent map read write issue.
+This needs to be fixed upstream in go-chi.
+
+https://github.com/cs3org/reva/pull/2785

--- a/pkg/micro/ocdav/service.go
+++ b/pkg/micro/ocdav/service.go
@@ -66,15 +66,17 @@ func Service(opts ...Option) (micro.Service, error) {
 		return nil, err
 	}
 
+	// Comment back in after resolving the issue in go-chi.
+	// See comment in line 87.
 	// register additional webdav verbs
-	chi.RegisterMethod(ocdav.MethodPropfind)
-	chi.RegisterMethod(ocdav.MethodProppatch)
-	chi.RegisterMethod(ocdav.MethodLock)
-	chi.RegisterMethod(ocdav.MethodUnlock)
-	chi.RegisterMethod(ocdav.MethodCopy)
-	chi.RegisterMethod(ocdav.MethodMove)
-	chi.RegisterMethod(ocdav.MethodMkcol)
-	chi.RegisterMethod(ocdav.MethodReport)
+	// chi.RegisterMethod(ocdav.MethodPropfind)
+	// chi.RegisterMethod(ocdav.MethodProppatch)
+	// chi.RegisterMethod(ocdav.MethodLock)
+	// chi.RegisterMethod(ocdav.MethodUnlock)
+	// chi.RegisterMethod(ocdav.MethodCopy)
+	// chi.RegisterMethod(ocdav.MethodMove)
+	// chi.RegisterMethod(ocdav.MethodMkcol)
+	// chi.RegisterMethod(ocdav.MethodReport)
 	r := chi.NewRouter()
 
 	if err := useMiddlewares(r, &sopts, revaService); err != nil {
@@ -82,6 +84,10 @@ func Service(opts ...Option) (micro.Service, error) {
 	}
 
 	r.Handle("/*", revaService.Handler())
+	// This is a workaround for the go-chi concurrent map read write issue.
+	// After the issue has been solved upstream in go-chi we should switch
+	// back to using `chi.RegisterMethod`.
+	r.MethodNotAllowed(http.HandlerFunc(revaService.Handler().ServeHTTP))
 
 	hd := srv.NewHandler(r)
 	if err := srv.Handle(hd); err != nil {


### PR DESCRIPTION
Implemented a workaround for `chi.RegisterMethod` because of a concurrent map read write issue.
This needs to be fixed upstream in go-chi. Basically this map needs to support concurrent access: https://github.com/go-chi/chi/blob/c97bc988430d623a14f50b7019fb40529036a35a/tree.go#L34