### PR TITLE
add flag to unrestrict spaces listing

### DIFF
--- a/changelog/unreleased/list-spaces-unrestricted.md
+++ b/changelog/unreleased/list-spaces-unrestricted.md
@@ -1,0 +1,6 @@
+Enhancement: Add flag to enable unrestriced listing of spaces
+
+Listing spaces now only returns all spaces when the user has the permissions and it was explicitly requested.
+The default will only return the spaces the current user has access to.
+
+https://github.com/cs3org/reva/pull/2799

--- a/internal/grpc/services/storageprovider/storageprovider.go
+++ b/internal/grpc/services/storageprovider/storageprovider.go
@@ -520,7 +520,15 @@ func (s *service) ListStorageSpaces(ctx context.Context, req *provider.ListStora
 
 	log := appctx.GetLogger(ctx)
 
-	spaces, err := s.storage.ListStorageSpaces(ctx, req.Filters)
+	// TODO this is just temporary. Update the API to include this flag.
+	unrestricted := false
+	if req.Opaque != nil {
+		if entry, ok := req.Opaque.Map["unrestricted"]; ok {
+			unrestricted, _ = strconv.ParseBool(string(entry.Value))
+		}
+	}
+
+	spaces, err := s.storage.ListStorageSpaces(ctx, req.Filters, unrestricted)
 	if err != nil {
 		var st *rpc.Status
 		switch err.(type) {

--- a/pkg/storage/fs/nextcloud/nextcloud.go
+++ b/pkg/storage/fs/nextcloud/nextcloud.go
@@ -795,7 +795,7 @@ func (nc *StorageDriver) Unlock(ctx context.Context, ref *provider.Reference, lo
 }
 
 // ListStorageSpaces as defined in the storage.FS interface
-func (nc *StorageDriver) ListStorageSpaces(ctx context.Context, f []*provider.ListStorageSpacesRequest_Filter) ([]*provider.StorageSpace, error) {
+func (nc *StorageDriver) ListStorageSpaces(ctx context.Context, f []*provider.ListStorageSpacesRequest_Filter, unrestricted bool) ([]*provider.StorageSpace, error) {
 	bodyStr, _ := json.Marshal(f)
 	_, respBody, err := nc.do(ctx, Action{"ListStorageSpaces", string(bodyStr)})
 	if err != nil {

--- a/pkg/storage/fs/nextcloud/nextcloud_test.go
+++ b/pkg/storage/fs/nextcloud/nextcloud_test.go
@@ -982,7 +982,7 @@ var _ = Describe("Nextcloud", func() {
 				},
 			}
 			filters := []*provider.ListStorageSpacesRequest_Filter{filter1, filter2, filter3}
-			spaces, err := nc.ListStorageSpaces(ctx, filters)
+			spaces, err := nc.ListStorageSpaces(ctx, filters, false)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(len(spaces)).To(Equal(1))
 			// https://github.com/cs3org/go-cs3apis/blob/970eec3/cs3/storage/provider/v1beta1/resources.pb.go#L1341-L1366

--- a/pkg/storage/fs/owncloudsql/spaces.go
+++ b/pkg/storage/fs/owncloudsql/spaces.go
@@ -34,7 +34,7 @@ import (
 )
 
 // ListStorageSpaces lists storage spaces according to the provided filters
-func (fs *owncloudsqlfs) ListStorageSpaces(ctx context.Context, filter []*provider.ListStorageSpacesRequest_Filter) ([]*provider.StorageSpace, error) {
+func (fs *owncloudsqlfs) ListStorageSpaces(ctx context.Context, filter []*provider.ListStorageSpacesRequest_Filter, unrestricted bool) ([]*provider.StorageSpace, error) {
 	var (
 		spaceID = "*"
 	)

--- a/pkg/storage/fs/s3/s3.go
+++ b/pkg/storage/fs/s3/s3.go
@@ -702,7 +702,7 @@ func (fs *s3FS) RestoreRecycleItem(ctx context.Context, ref *provider.Reference,
 	return errtypes.NotSupported("restore recycle")
 }
 
-func (fs *s3FS) ListStorageSpaces(ctx context.Context, filter []*provider.ListStorageSpacesRequest_Filter) ([]*provider.StorageSpace, error) {
+func (fs *s3FS) ListStorageSpaces(ctx context.Context, filter []*provider.ListStorageSpacesRequest_Filter, unrestricted bool) ([]*provider.StorageSpace, error) {
 	return nil, errtypes.NotSupported("list storage spaces")
 }
 

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -62,7 +62,10 @@ type FS interface {
 	GetLock(ctx context.Context, ref *provider.Reference) (*provider.Lock, error)
 	RefreshLock(ctx context.Context, ref *provider.Reference, lock *provider.Lock) error
 	Unlock(ctx context.Context, ref *provider.Reference, lock *provider.Lock) error
-	ListStorageSpaces(ctx context.Context, filter []*provider.ListStorageSpacesRequest_Filter) ([]*provider.StorageSpace, error)
+	// ListStorageSpaces lists the spaces in the storage.
+	// The unrestricted parameter can be used to list other user's spaces when
+	// the user has the necessary permissions.
+	ListStorageSpaces(ctx context.Context, filter []*provider.ListStorageSpacesRequest_Filter, unrestricted bool) ([]*provider.StorageSpace, error)
 	CreateStorageSpace(ctx context.Context, req *provider.CreateStorageSpaceRequest) (*provider.CreateStorageSpaceResponse, error)
 	UpdateStorageSpace(ctx context.Context, req *provider.UpdateStorageSpaceRequest) (*provider.UpdateStorageSpaceResponse, error)
 	DeleteStorageSpace(ctx context.Context, req *provider.DeleteStorageSpaceRequest) error

--- a/pkg/storage/utils/decomposedfs/spaces_test.go
+++ b/pkg/storage/utils/decomposedfs/spaces_test.go
@@ -48,7 +48,7 @@ var _ = Describe("Create Spaces", func() {
 
 	Context("during login", func() {
 		It("space is created", func() {
-			resp, err := env.Fs.ListStorageSpaces(env.Ctx, nil)
+			resp, err := env.Fs.ListStorageSpaces(env.Ctx, nil, false)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(len(resp)).To(Equal(1))
 			Expect(string(resp[0].Opaque.GetMap()["spaceAlias"].Value)).To(Equal("personal/username"))
@@ -89,7 +89,7 @@ var _ = Describe("Create Spaces", func() {
 		})
 		Context("during login", func() {
 			It("personal space is created with custom alias", func() {
-				resp, err := env.Fs.ListStorageSpaces(env.Ctx, nil)
+				resp, err := env.Fs.ListStorageSpaces(env.Ctx, nil, false)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(len(resp)).To(Equal(1))
 				Expect(string(resp[0].Opaque.GetMap()["spaceAlias"].Value)).To(Equal("personal/username@_unknown"))

--- a/pkg/storage/utils/eosfs/eosfs.go
+++ b/pkg/storage/utils/eosfs/eosfs.go
@@ -1603,7 +1603,7 @@ func (fs *eosfs) RestoreRecycleItem(ctx context.Context, ref *provider.Reference
 	return fs.c.RestoreDeletedEntry(ctx, auth, key)
 }
 
-func (fs *eosfs) ListStorageSpaces(ctx context.Context, filter []*provider.ListStorageSpacesRequest_Filter) ([]*provider.StorageSpace, error) {
+func (fs *eosfs) ListStorageSpaces(ctx context.Context, filter []*provider.ListStorageSpacesRequest_Filter, unrestricted bool) ([]*provider.StorageSpace, error) {
 	return nil, errtypes.NotSupported("list storage spaces")
 }
 

--- a/pkg/storage/utils/localfs/localfs.go
+++ b/pkg/storage/utils/localfs/localfs.go
@@ -1290,7 +1290,7 @@ func (fs *localfs) RestoreRecycleItem(ctx context.Context, ref *provider.Referen
 	return fs.propagate(ctx, localRestorePath)
 }
 
-func (fs *localfs) ListStorageSpaces(ctx context.Context, filter []*provider.ListStorageSpacesRequest_Filter) ([]*provider.StorageSpace, error) {
+func (fs *localfs) ListStorageSpaces(ctx context.Context, filter []*provider.ListStorageSpacesRequest_Filter, unrestricted bool) ([]*provider.StorageSpace, error) {
 	return nil, errtypes.NotSupported("list storage spaces")
 }
 

--- a/tests/integration/grpc/gateway_storageprovider_test.go
+++ b/tests/integration/grpc/gateway_storageprovider_test.go
@@ -373,7 +373,7 @@ var _ = Describe("gateway", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(r.Status.Code).To(Equal(rpcv1beta1.Code_CODE_OK))
 
-			spaces, err := fs.ListStorageSpaces(ctx, []*storagep.ListStorageSpacesRequest_Filter{})
+			spaces, err := fs.ListStorageSpaces(ctx, []*storagep.ListStorageSpacesRequest_Filter{}, false)
 			Expect(err).ToNot(HaveOccurred())
 			homeSpace = spaces[0]
 


### PR DESCRIPTION
Listing spaces now only returns all spaces when the user has the permissions and it was explicitly requested.
The default will only return the spaces the current user has access to.

This is necessary to be able to limit the list in the graph `/me/drives` API.