### PR TITLE
properly parse space id in spaces trashbin api

### DIFF
--- a/changelog/unreleased/fix-spaces-trashbin.md
+++ b/changelog/unreleased/fix-spaces-trashbin.md
@@ -1,0 +1,5 @@
+Bugfix: Fix spaceid parsing in spaces trashbin API
+
+Added proper space id parsing to the spaces trashbin API endpoint.
+
+https://github.com/cs3org/reva/pull/2800


### PR DESCRIPTION
Added proper space id parsing to the spaces trashbin API endpoint.
This is also needed to fix the localAPI tests in oCIS.
