### PR TITLE
ench: use functional options for client gRPC connections

### DIFF
--- a/changelog/unreleased/func-opts-pool.md
+++ b/changelog/unreleased/func-opts-pool.md
@@ -1,0 +1,5 @@
+Enhancement: Use functional options for client gRPC connections
+
+This will add more ability to configure the client side gRPC connections.
+
+https://github.com/cs3org/reva/pull/2801

--- a/internal/grpc/interceptors/auth/auth.go
+++ b/internal/grpc/interceptors/auth/auth.go
@@ -218,7 +218,7 @@ func dismantleToken(ctx context.Context, tkn string, req interface{}, mgr token.
 	}
 
 	if sharedconf.SkipUserGroupsInToken() {
-		client, err := pool.GetGatewayServiceClient(gatewayAddr)
+		client, err := pool.GetGatewayServiceClient(pool.Endpoint(gatewayAddr))
 		if err != nil {
 			return nil, err
 		}

--- a/internal/grpc/interceptors/auth/scope.go
+++ b/internal/grpc/interceptors/auth/scope.go
@@ -52,7 +52,7 @@ const (
 
 func expandAndVerifyScope(ctx context.Context, req interface{}, tokenScope map[string]*authpb.Scope, user *userpb.User, gatewayAddr string, mgr token.Manager) error {
 	log := appctx.GetLogger(ctx)
-	client, err := pool.GetGatewayServiceClient(gatewayAddr)
+	client, err := pool.GetGatewayServiceClient(pool.Endpoint(gatewayAddr))
 	if err != nil {
 		return err
 	}

--- a/internal/grpc/services/appprovider/appprovider.go
+++ b/internal/grpc/services/appprovider/appprovider.go
@@ -120,7 +120,7 @@ func (s *service) registerProvider() {
 		pInfo.MimeTypes = mimeTypes
 	}
 
-	client, err := pool.GetGatewayServiceClient(s.conf.GatewaySvc)
+	client, err := pool.GetGatewayServiceClient(pool.Endpoint(s.conf.GatewaySvc))
 	if err != nil {
 		log.Error().Err(err).Msgf("error registering app provider: could not get gateway client")
 		return

--- a/internal/grpc/services/gateway/applicationauth.go
+++ b/internal/grpc/services/gateway/applicationauth.go
@@ -28,7 +28,7 @@ import (
 )
 
 func (s *svc) GenerateAppPassword(ctx context.Context, req *appauthpb.GenerateAppPasswordRequest) (*appauthpb.GenerateAppPasswordResponse, error) {
-	c, err := pool.GetAppAuthProviderServiceClient(s.c.ApplicationAuthEndpoint)
+	c, err := pool.GetAppAuthProviderServiceClient(pool.Endpoint(s.c.ApplicationAuthEndpoint))
 	if err != nil {
 		err = errors.Wrap(err, "gateway: error calling GetAppAuthProviderServiceClient")
 		return &appauthpb.GenerateAppPasswordResponse{
@@ -45,7 +45,7 @@ func (s *svc) GenerateAppPassword(ctx context.Context, req *appauthpb.GenerateAp
 }
 
 func (s *svc) ListAppPasswords(ctx context.Context, req *appauthpb.ListAppPasswordsRequest) (*appauthpb.ListAppPasswordsResponse, error) {
-	c, err := pool.GetAppAuthProviderServiceClient(s.c.ApplicationAuthEndpoint)
+	c, err := pool.GetAppAuthProviderServiceClient(pool.Endpoint(s.c.ApplicationAuthEndpoint))
 	if err != nil {
 		err = errors.Wrap(err, "gateway: error calling GetAppAuthProviderServiceClient")
 		return &appauthpb.ListAppPasswordsResponse{
@@ -62,7 +62,7 @@ func (s *svc) ListAppPasswords(ctx context.Context, req *appauthpb.ListAppPasswo
 }
 
 func (s *svc) InvalidateAppPassword(ctx context.Context, req *appauthpb.InvalidateAppPasswordRequest) (*appauthpb.InvalidateAppPasswordResponse, error) {
-	c, err := pool.GetAppAuthProviderServiceClient(s.c.ApplicationAuthEndpoint)
+	c, err := pool.GetAppAuthProviderServiceClient(pool.Endpoint(s.c.ApplicationAuthEndpoint))
 	if err != nil {
 		err = errors.Wrap(err, "gateway: error calling GetAppAuthProviderServiceClient")
 		return &appauthpb.InvalidateAppPasswordResponse{
@@ -79,7 +79,7 @@ func (s *svc) InvalidateAppPassword(ctx context.Context, req *appauthpb.Invalida
 }
 
 func (s *svc) GetAppPassword(ctx context.Context, req *appauthpb.GetAppPasswordRequest) (*appauthpb.GetAppPasswordResponse, error) {
-	c, err := pool.GetAppAuthProviderServiceClient(s.c.ApplicationAuthEndpoint)
+	c, err := pool.GetAppAuthProviderServiceClient(pool.Endpoint(s.c.ApplicationAuthEndpoint))
 	if err != nil {
 		err = errors.Wrap(err, "gateway: error calling GetAppAuthProviderServiceClient")
 		return &appauthpb.GetAppPasswordResponse{

--- a/internal/grpc/services/gateway/appprovider.go
+++ b/internal/grpc/services/gateway/appprovider.go
@@ -189,7 +189,7 @@ func (s *svc) openLocalResources(ctx context.Context, ri *storageprovider.Resour
 		return nil, err
 	}
 
-	appProviderClient, err := pool.GetAppProviderClient(provider.Address)
+	appProviderClient, err := pool.GetAppProviderClient(pool.Endpoint(provider.Address))
 	if err != nil {
 		return nil, errors.Wrap(err, "gateway: error calling GetAppProviderClient")
 	}

--- a/internal/grpc/services/gateway/appprovider.go
+++ b/internal/grpc/services/gateway/appprovider.go
@@ -209,7 +209,7 @@ func (s *svc) openLocalResources(ctx context.Context, ri *storageprovider.Resour
 }
 
 func (s *svc) findAppProvider(ctx context.Context, ri *storageprovider.ResourceInfo, app string) (*registry.ProviderInfo, error) {
-	c, err := pool.GetAppRegistryClient(s.c.AppRegistryEndpoint)
+	c, err := pool.GetAppRegistryClient(pool.Endpoint(s.c.AppRegistryEndpoint))
 	if err != nil {
 		err = errors.Wrap(err, "gateway: error getting appregistry client")
 		return nil, err

--- a/internal/grpc/services/gateway/appregistry.go
+++ b/internal/grpc/services/gateway/appregistry.go
@@ -28,7 +28,7 @@ import (
 )
 
 func (s *svc) GetAppProviders(ctx context.Context, req *registry.GetAppProvidersRequest) (*registry.GetAppProvidersResponse, error) {
-	c, err := pool.GetAppRegistryClient(s.c.AppRegistryEndpoint)
+	c, err := pool.GetAppRegistryClient(pool.Endpoint(s.c.AppRegistryEndpoint))
 	if err != nil {
 		err = errors.Wrap(err, "gateway: error calling GetAppRegistryClient")
 		return &registry.GetAppProvidersResponse{
@@ -45,7 +45,7 @@ func (s *svc) GetAppProviders(ctx context.Context, req *registry.GetAppProviders
 }
 
 func (s *svc) AddAppProvider(ctx context.Context, req *registry.AddAppProviderRequest) (*registry.AddAppProviderResponse, error) {
-	c, err := pool.GetAppRegistryClient(s.c.AppRegistryEndpoint)
+	c, err := pool.GetAppRegistryClient(pool.Endpoint(s.c.AppRegistryEndpoint))
 	if err != nil {
 		err = errors.Wrap(err, "gateway: error calling GetAppRegistryClient")
 		return &registry.AddAppProviderResponse{
@@ -62,7 +62,7 @@ func (s *svc) AddAppProvider(ctx context.Context, req *registry.AddAppProviderRe
 }
 
 func (s *svc) ListAppProviders(ctx context.Context, req *registry.ListAppProvidersRequest) (*registry.ListAppProvidersResponse, error) {
-	c, err := pool.GetAppRegistryClient(s.c.AppRegistryEndpoint)
+	c, err := pool.GetAppRegistryClient(pool.Endpoint(s.c.AppRegistryEndpoint))
 	if err != nil {
 		err = errors.Wrap(err, "gateway: error calling GetAppRegistryClient")
 		return &registry.ListAppProvidersResponse{
@@ -79,7 +79,7 @@ func (s *svc) ListAppProviders(ctx context.Context, req *registry.ListAppProvide
 }
 
 func (s *svc) ListSupportedMimeTypes(ctx context.Context, req *registry.ListSupportedMimeTypesRequest) (*registry.ListSupportedMimeTypesResponse, error) {
-	c, err := pool.GetAppRegistryClient(s.c.AppRegistryEndpoint)
+	c, err := pool.GetAppRegistryClient(pool.Endpoint(s.c.AppRegistryEndpoint))
 	if err != nil {
 		err = errors.Wrap(err, "gateway: error calling GetAppRegistryClient")
 		return &registry.ListSupportedMimeTypesResponse{
@@ -96,7 +96,7 @@ func (s *svc) ListSupportedMimeTypes(ctx context.Context, req *registry.ListSupp
 }
 
 func (s *svc) GetDefaultAppProviderForMimeType(ctx context.Context, req *registry.GetDefaultAppProviderForMimeTypeRequest) (*registry.GetDefaultAppProviderForMimeTypeResponse, error) {
-	c, err := pool.GetAppRegistryClient(s.c.AppRegistryEndpoint)
+	c, err := pool.GetAppRegistryClient(pool.Endpoint(s.c.AppRegistryEndpoint))
 	if err != nil {
 		err = errors.Wrap(err, "gateway: error calling GetAppRegistryClient")
 		return &registry.GetDefaultAppProviderForMimeTypeResponse{
@@ -113,7 +113,7 @@ func (s *svc) GetDefaultAppProviderForMimeType(ctx context.Context, req *registr
 }
 
 func (s *svc) SetDefaultAppProviderForMimeType(ctx context.Context, req *registry.SetDefaultAppProviderForMimeTypeRequest) (*registry.SetDefaultAppProviderForMimeTypeResponse, error) {
-	c, err := pool.GetAppRegistryClient(s.c.AppRegistryEndpoint)
+	c, err := pool.GetAppRegistryClient(pool.Endpoint(s.c.AppRegistryEndpoint))
 	if err != nil {
 		err = errors.Wrap(err, "gateway: error calling GetAppRegistryClient")
 		return &registry.SetDefaultAppProviderForMimeTypeResponse{

--- a/internal/grpc/services/gateway/authprovider.go
+++ b/internal/grpc/services/gateway/authprovider.go
@@ -207,7 +207,7 @@ func (s *svc) WhoAmI(ctx context.Context, req *gateway.WhoAmIRequest) (*gateway.
 }
 
 func (s *svc) findAuthProvider(ctx context.Context, authType string) (authpb.ProviderAPIClient, error) {
-	c, err := pool.GetAuthRegistryServiceClient(s.c.AuthRegistryEndpoint)
+	c, err := pool.GetAuthRegistryServiceClient(pool.Endpoint(s.c.AuthRegistryEndpoint))
 	if err != nil {
 		err = errors.Wrap(err, "gateway: error getting auth registry client")
 		return nil, err
@@ -224,7 +224,7 @@ func (s *svc) findAuthProvider(ctx context.Context, authType string) (authpb.Pro
 
 	if res.Status.Code == rpc.Code_CODE_OK && res.Providers != nil && len(res.Providers) > 0 {
 		// TODO(labkode): check for capabilities here
-		c, err := pool.GetAuthProviderServiceClient(res.Providers[0].Address)
+		c, err := pool.GetAuthProviderServiceClient(pool.Endpoint(res.Providers[0].Address))
 		if err != nil {
 			err = errors.Wrap(err, "gateway: error getting an auth provider client")
 			return nil, err

--- a/internal/grpc/services/gateway/authregistry.go
+++ b/internal/grpc/services/gateway/authregistry.go
@@ -30,7 +30,7 @@ import (
 )
 
 func (s *svc) ListAuthProviders(ctx context.Context, req *registry.ListAuthProvidersRequest) (*gateway.ListAuthProvidersResponse, error) {
-	c, err := pool.GetAuthRegistryServiceClient(s.c.AuthRegistryEndpoint)
+	c, err := pool.GetAuthRegistryServiceClient(pool.Endpoint(s.c.AuthRegistryEndpoint))
 	if err != nil {
 		err = errors.Wrap(err, "gateway: error getting auth registry client")
 		return &gateway.ListAuthProvidersResponse{

--- a/internal/grpc/services/gateway/datatx.go
+++ b/internal/grpc/services/gateway/datatx.go
@@ -28,7 +28,7 @@ import (
 )
 
 func (s *svc) PullTransfer(ctx context.Context, req *datatx.PullTransferRequest) (*datatx.PullTransferResponse, error) {
-	c, err := pool.GetDataTxClient(s.c.DataTxEndpoint)
+	c, err := pool.GetDataTxClient(pool.Endpoint(s.c.DataTxEndpoint))
 	if err != nil {
 		err = errors.Wrap(err, "gateway: error calling GetDataTxClient")
 		return &datatx.PullTransferResponse{
@@ -45,7 +45,7 @@ func (s *svc) PullTransfer(ctx context.Context, req *datatx.PullTransferRequest)
 }
 
 func (s *svc) GetTransferStatus(ctx context.Context, req *datatx.GetTransferStatusRequest) (*datatx.GetTransferStatusResponse, error) {
-	c, err := pool.GetDataTxClient(s.c.DataTxEndpoint)
+	c, err := pool.GetDataTxClient(pool.Endpoint(s.c.DataTxEndpoint))
 	if err != nil {
 		err = errors.Wrap(err, "gateway: error calling GetDataTxClient")
 		return &datatx.GetTransferStatusResponse{
@@ -62,7 +62,7 @@ func (s *svc) GetTransferStatus(ctx context.Context, req *datatx.GetTransferStat
 }
 
 func (s *svc) CancelTransfer(ctx context.Context, req *datatx.CancelTransferRequest) (*datatx.CancelTransferResponse, error) {
-	c, err := pool.GetDataTxClient(s.c.DataTxEndpoint)
+	c, err := pool.GetDataTxClient(pool.Endpoint(s.c.DataTxEndpoint))
 	if err != nil {
 		err = errors.Wrap(err, "gateway: error calling GetDataTxClient")
 		return &datatx.CancelTransferResponse{
@@ -79,7 +79,7 @@ func (s *svc) CancelTransfer(ctx context.Context, req *datatx.CancelTransferRequ
 }
 
 func (s *svc) ListTransfers(ctx context.Context, req *datatx.ListTransfersRequest) (*datatx.ListTransfersResponse, error) {
-	c, err := pool.GetDataTxClient(s.c.DataTxEndpoint)
+	c, err := pool.GetDataTxClient(pool.Endpoint(s.c.DataTxEndpoint))
 	if err != nil {
 		err = errors.Wrap(err, "gateway: error calling GetDataTxClient")
 		return &datatx.ListTransfersResponse{
@@ -96,7 +96,7 @@ func (s *svc) ListTransfers(ctx context.Context, req *datatx.ListTransfersReques
 }
 
 func (s *svc) RetryTransfer(ctx context.Context, req *datatx.RetryTransferRequest) (*datatx.RetryTransferResponse, error) {
-	c, err := pool.GetDataTxClient(s.c.DataTxEndpoint)
+	c, err := pool.GetDataTxClient(pool.Endpoint(s.c.DataTxEndpoint))
 	if err != nil {
 		err = errors.Wrap(err, "gateway: error calling GetDataTxClient")
 		return &datatx.RetryTransferResponse{

--- a/internal/grpc/services/gateway/groupprovider.go
+++ b/internal/grpc/services/gateway/groupprovider.go
@@ -28,7 +28,7 @@ import (
 )
 
 func (s *svc) GetGroup(ctx context.Context, req *group.GetGroupRequest) (*group.GetGroupResponse, error) {
-	c, err := pool.GetGroupProviderServiceClient(s.c.GroupProviderEndpoint)
+	c, err := pool.GetGroupProviderServiceClient(pool.Endpoint(s.c.GroupProviderEndpoint))
 	if err != nil {
 		return &group.GetGroupResponse{
 			Status: status.NewInternal(ctx, err, "error getting auth client"),
@@ -44,7 +44,7 @@ func (s *svc) GetGroup(ctx context.Context, req *group.GetGroupRequest) (*group.
 }
 
 func (s *svc) GetGroupByClaim(ctx context.Context, req *group.GetGroupByClaimRequest) (*group.GetGroupByClaimResponse, error) {
-	c, err := pool.GetGroupProviderServiceClient(s.c.GroupProviderEndpoint)
+	c, err := pool.GetGroupProviderServiceClient(pool.Endpoint(s.c.GroupProviderEndpoint))
 	if err != nil {
 		return &group.GetGroupByClaimResponse{
 			Status: status.NewInternal(ctx, err, "error getting auth client"),
@@ -60,7 +60,7 @@ func (s *svc) GetGroupByClaim(ctx context.Context, req *group.GetGroupByClaimReq
 }
 
 func (s *svc) FindGroups(ctx context.Context, req *group.FindGroupsRequest) (*group.FindGroupsResponse, error) {
-	c, err := pool.GetGroupProviderServiceClient(s.c.GroupProviderEndpoint)
+	c, err := pool.GetGroupProviderServiceClient(pool.Endpoint(s.c.GroupProviderEndpoint))
 	if err != nil {
 		return &group.FindGroupsResponse{
 			Status: status.NewInternal(ctx, err, "error getting auth client"),
@@ -76,7 +76,7 @@ func (s *svc) FindGroups(ctx context.Context, req *group.FindGroupsRequest) (*gr
 }
 
 func (s *svc) GetMembers(ctx context.Context, req *group.GetMembersRequest) (*group.GetMembersResponse, error) {
-	c, err := pool.GetGroupProviderServiceClient(s.c.GroupProviderEndpoint)
+	c, err := pool.GetGroupProviderServiceClient(pool.Endpoint(s.c.GroupProviderEndpoint))
 	if err != nil {
 		return &group.GetMembersResponse{
 			Status: status.NewInternal(ctx, err, "error getting auth client"),
@@ -92,7 +92,7 @@ func (s *svc) GetMembers(ctx context.Context, req *group.GetMembersRequest) (*gr
 }
 
 func (s *svc) HasMember(ctx context.Context, req *group.HasMemberRequest) (*group.HasMemberResponse, error) {
-	c, err := pool.GetGroupProviderServiceClient(s.c.GroupProviderEndpoint)
+	c, err := pool.GetGroupProviderServiceClient(pool.Endpoint(s.c.GroupProviderEndpoint))
 	if err != nil {
 		return &group.HasMemberResponse{
 			Status: status.NewInternal(ctx, err, "error getting auth client"),

--- a/internal/grpc/services/gateway/ocmcore.go
+++ b/internal/grpc/services/gateway/ocmcore.go
@@ -28,7 +28,7 @@ import (
 )
 
 func (s *svc) CreateOCMCoreShare(ctx context.Context, req *ocmcore.CreateOCMCoreShareRequest) (*ocmcore.CreateOCMCoreShareResponse, error) {
-	c, err := pool.GetOCMCoreClient(s.c.OCMCoreEndpoint)
+	c, err := pool.GetOCMCoreClient(pool.Endpoint(s.c.OCMCoreEndpoint))
 	if err != nil {
 		return &ocmcore.CreateOCMCoreShareResponse{
 			Status: status.NewInternal(ctx, err, "error getting ocm core client"),

--- a/internal/grpc/services/gateway/ocminvitemanager.go
+++ b/internal/grpc/services/gateway/ocminvitemanager.go
@@ -28,7 +28,7 @@ import (
 )
 
 func (s *svc) GenerateInviteToken(ctx context.Context, req *invitepb.GenerateInviteTokenRequest) (*invitepb.GenerateInviteTokenResponse, error) {
-	c, err := pool.GetOCMInviteManagerClient(s.c.OCMInviteManagerEndpoint)
+	c, err := pool.GetOCMInviteManagerClient(pool.Endpoint(s.c.OCMInviteManagerEndpoint))
 	if err != nil {
 		return &invitepb.GenerateInviteTokenResponse{
 			Status: status.NewInternal(ctx, err, "error getting user invite provider client"),
@@ -44,7 +44,7 @@ func (s *svc) GenerateInviteToken(ctx context.Context, req *invitepb.GenerateInv
 }
 
 func (s *svc) ForwardInvite(ctx context.Context, req *invitepb.ForwardInviteRequest) (*invitepb.ForwardInviteResponse, error) {
-	c, err := pool.GetOCMInviteManagerClient(s.c.OCMInviteManagerEndpoint)
+	c, err := pool.GetOCMInviteManagerClient(pool.Endpoint(s.c.OCMInviteManagerEndpoint))
 	if err != nil {
 		return &invitepb.ForwardInviteResponse{
 			Status: status.NewInternal(ctx, err, "error getting user invite provider client"),
@@ -60,7 +60,7 @@ func (s *svc) ForwardInvite(ctx context.Context, req *invitepb.ForwardInviteRequ
 }
 
 func (s *svc) AcceptInvite(ctx context.Context, req *invitepb.AcceptInviteRequest) (*invitepb.AcceptInviteResponse, error) {
-	c, err := pool.GetOCMInviteManagerClient(s.c.OCMInviteManagerEndpoint)
+	c, err := pool.GetOCMInviteManagerClient(pool.Endpoint(s.c.OCMInviteManagerEndpoint))
 	if err != nil {
 		return &invitepb.AcceptInviteResponse{
 			Status: status.NewInternal(ctx, err, "error getting user invite provider client"),
@@ -76,7 +76,7 @@ func (s *svc) AcceptInvite(ctx context.Context, req *invitepb.AcceptInviteReques
 }
 
 func (s *svc) GetAcceptedUser(ctx context.Context, req *invitepb.GetAcceptedUserRequest) (*invitepb.GetAcceptedUserResponse, error) {
-	c, err := pool.GetOCMInviteManagerClient(s.c.OCMInviteManagerEndpoint)
+	c, err := pool.GetOCMInviteManagerClient(pool.Endpoint(s.c.OCMInviteManagerEndpoint))
 	if err != nil {
 		return &invitepb.GetAcceptedUserResponse{
 			Status: status.NewInternal(ctx, err, "error getting user invite provider client"),
@@ -92,7 +92,7 @@ func (s *svc) GetAcceptedUser(ctx context.Context, req *invitepb.GetAcceptedUser
 }
 
 func (s *svc) FindAcceptedUsers(ctx context.Context, req *invitepb.FindAcceptedUsersRequest) (*invitepb.FindAcceptedUsersResponse, error) {
-	c, err := pool.GetOCMInviteManagerClient(s.c.OCMInviteManagerEndpoint)
+	c, err := pool.GetOCMInviteManagerClient(pool.Endpoint(s.c.OCMInviteManagerEndpoint))
 	if err != nil {
 		return &invitepb.FindAcceptedUsersResponse{
 			Status: status.NewInternal(ctx, err, "error getting user invite provider client"),

--- a/internal/grpc/services/gateway/ocmproviderauthorizer.go
+++ b/internal/grpc/services/gateway/ocmproviderauthorizer.go
@@ -28,7 +28,7 @@ import (
 )
 
 func (s *svc) IsProviderAllowed(ctx context.Context, req *ocmprovider.IsProviderAllowedRequest) (*ocmprovider.IsProviderAllowedResponse, error) {
-	c, err := pool.GetOCMProviderAuthorizerClient(s.c.OCMProviderAuthorizerEndpoint)
+	c, err := pool.GetOCMProviderAuthorizerClient(pool.Endpoint(s.c.OCMProviderAuthorizerEndpoint))
 	if err != nil {
 		return &ocmprovider.IsProviderAllowedResponse{
 			Status: status.NewInternal(ctx, err, "error getting ocm authorizer provider client"),
@@ -44,7 +44,7 @@ func (s *svc) IsProviderAllowed(ctx context.Context, req *ocmprovider.IsProvider
 }
 
 func (s *svc) GetInfoByDomain(ctx context.Context, req *ocmprovider.GetInfoByDomainRequest) (*ocmprovider.GetInfoByDomainResponse, error) {
-	c, err := pool.GetOCMProviderAuthorizerClient(s.c.OCMProviderAuthorizerEndpoint)
+	c, err := pool.GetOCMProviderAuthorizerClient(pool.Endpoint(s.c.OCMProviderAuthorizerEndpoint))
 	if err != nil {
 		return &ocmprovider.GetInfoByDomainResponse{
 			Status: status.NewInternal(ctx, err, "error getting ocm authorizer provider client"),
@@ -60,7 +60,7 @@ func (s *svc) GetInfoByDomain(ctx context.Context, req *ocmprovider.GetInfoByDom
 }
 
 func (s *svc) ListAllProviders(ctx context.Context, req *ocmprovider.ListAllProvidersRequest) (*ocmprovider.ListAllProvidersResponse, error) {
-	c, err := pool.GetOCMProviderAuthorizerClient(s.c.OCMProviderAuthorizerEndpoint)
+	c, err := pool.GetOCMProviderAuthorizerClient(pool.Endpoint(s.c.OCMProviderAuthorizerEndpoint))
 	if err != nil {
 		return &ocmprovider.ListAllProvidersResponse{
 			Status: status.NewInternal(ctx, err, "error getting ocm authorizer provider client"),

--- a/internal/grpc/services/gateway/ocmshareprovider.go
+++ b/internal/grpc/services/gateway/ocmshareprovider.go
@@ -41,7 +41,7 @@ import (
 
 // TODO(labkode): add multi-phase commit logic when commit share or commit ref is enabled.
 func (s *svc) CreateOCMShare(ctx context.Context, req *ocm.CreateOCMShareRequest) (*ocm.CreateOCMShareResponse, error) {
-	c, err := pool.GetOCMShareProviderClient(s.c.OCMShareProviderEndpoint)
+	c, err := pool.GetOCMShareProviderClient(pool.Endpoint(s.c.OCMShareProviderEndpoint))
 	if err != nil {
 		return &ocm.CreateOCMShareResponse{
 			Status: status.NewInternal(ctx, err, "error getting user share provider client"),
@@ -75,7 +75,7 @@ func (s *svc) CreateOCMShare(ctx context.Context, req *ocm.CreateOCMShareRequest
 }
 
 func (s *svc) RemoveOCMShare(ctx context.Context, req *ocm.RemoveOCMShareRequest) (*ocm.RemoveOCMShareResponse, error) {
-	c, err := pool.GetOCMShareProviderClient(s.c.OCMShareProviderEndpoint)
+	c, err := pool.GetOCMShareProviderClient(pool.Endpoint(s.c.OCMShareProviderEndpoint))
 	if err != nil {
 		return &ocm.RemoveOCMShareResponse{
 			Status: status.NewInternal(ctx, err, "error getting user share provider client"),
@@ -137,7 +137,7 @@ func (s *svc) GetOCMShare(ctx context.Context, req *ocm.GetOCMShareRequest) (*oc
 }
 
 func (s *svc) getOCMShare(ctx context.Context, req *ocm.GetOCMShareRequest) (*ocm.GetOCMShareResponse, error) {
-	c, err := pool.GetOCMShareProviderClient(s.c.OCMShareProviderEndpoint)
+	c, err := pool.GetOCMShareProviderClient(pool.Endpoint(s.c.OCMShareProviderEndpoint))
 	if err != nil {
 		err = errors.Wrap(err, "gateway: error calling GetOCMShareProviderClient")
 		return &ocm.GetOCMShareResponse{
@@ -155,7 +155,7 @@ func (s *svc) getOCMShare(ctx context.Context, req *ocm.GetOCMShareRequest) (*oc
 
 // TODO(labkode): read GetShare comment.
 func (s *svc) ListOCMShares(ctx context.Context, req *ocm.ListOCMSharesRequest) (*ocm.ListOCMSharesResponse, error) {
-	c, err := pool.GetOCMShareProviderClient(s.c.OCMShareProviderEndpoint)
+	c, err := pool.GetOCMShareProviderClient(pool.Endpoint(s.c.OCMShareProviderEndpoint))
 	if err != nil {
 		err = errors.Wrap(err, "gateway: error calling GetOCMShareProviderClient")
 		return &ocm.ListOCMSharesResponse{
@@ -172,7 +172,7 @@ func (s *svc) ListOCMShares(ctx context.Context, req *ocm.ListOCMSharesRequest) 
 }
 
 func (s *svc) UpdateOCMShare(ctx context.Context, req *ocm.UpdateOCMShareRequest) (*ocm.UpdateOCMShareResponse, error) {
-	c, err := pool.GetOCMShareProviderClient(s.c.OCMShareProviderEndpoint)
+	c, err := pool.GetOCMShareProviderClient(pool.Endpoint(s.c.OCMShareProviderEndpoint))
 	if err != nil {
 		err = errors.Wrap(err, "gateway: error calling GetOCMShareProviderClient")
 		return &ocm.UpdateOCMShareResponse{
@@ -189,7 +189,7 @@ func (s *svc) UpdateOCMShare(ctx context.Context, req *ocm.UpdateOCMShareRequest
 }
 
 func (s *svc) ListReceivedOCMShares(ctx context.Context, req *ocm.ListReceivedOCMSharesRequest) (*ocm.ListReceivedOCMSharesResponse, error) {
-	c, err := pool.GetOCMShareProviderClient(s.c.OCMShareProviderEndpoint)
+	c, err := pool.GetOCMShareProviderClient(pool.Endpoint(s.c.OCMShareProviderEndpoint))
 	if err != nil {
 		err = errors.Wrap(err, "gateway: error calling GetOCMShareProviderClient")
 		return &ocm.ListReceivedOCMSharesResponse{
@@ -207,7 +207,7 @@ func (s *svc) ListReceivedOCMShares(ctx context.Context, req *ocm.ListReceivedOC
 
 func (s *svc) UpdateReceivedOCMShare(ctx context.Context, req *ocm.UpdateReceivedOCMShareRequest) (*ocm.UpdateReceivedOCMShareResponse, error) {
 	log := appctx.GetLogger(ctx)
-	c, err := pool.GetOCMShareProviderClient(s.c.OCMShareProviderEndpoint)
+	c, err := pool.GetOCMShareProviderClient(pool.Endpoint(s.c.OCMShareProviderEndpoint))
 	if err != nil {
 		err = errors.Wrap(err, "gateway: error calling GetOCMShareProviderClient")
 		return &ocm.UpdateReceivedOCMShareResponse{
@@ -409,7 +409,7 @@ func (s *svc) UpdateReceivedOCMShare(ctx context.Context, req *ocm.UpdateReceive
 }
 
 func (s *svc) GetReceivedOCMShare(ctx context.Context, req *ocm.GetReceivedOCMShareRequest) (*ocm.GetReceivedOCMShareResponse, error) {
-	c, err := pool.GetOCMShareProviderClient(s.c.OCMShareProviderEndpoint)
+	c, err := pool.GetOCMShareProviderClient(pool.Endpoint(s.c.OCMShareProviderEndpoint))
 	if err != nil {
 		err = errors.Wrap(err, "gateway: error calling GetOCMShareProviderClient")
 		return &ocm.GetReceivedOCMShareResponse{

--- a/internal/grpc/services/gateway/permissions.go
+++ b/internal/grpc/services/gateway/permissions.go
@@ -28,7 +28,7 @@ import (
 )
 
 func (s *svc) CheckPermission(ctx context.Context, req *permissions.CheckPermissionRequest) (*permissions.CheckPermissionResponse, error) {
-	c, err := pool.GetPermissionsClient(s.c.PermissionsEndpoint)
+	c, err := pool.GetPermissionsClient(pool.Endpoint(s.c.PermissionsEndpoint))
 	if err != nil {
 		err = errors.Wrap(err, "gateway: error calling GetPermissionssClient")
 		return &permissions.CheckPermissionResponse{

--- a/internal/grpc/services/gateway/preferences.go
+++ b/internal/grpc/services/gateway/preferences.go
@@ -28,7 +28,7 @@ import (
 )
 
 func (s *svc) SetKey(ctx context.Context, req *preferences.SetKeyRequest) (*preferences.SetKeyResponse, error) {
-	c, err := pool.GetPreferencesClient(s.c.PreferencesEndpoint)
+	c, err := pool.GetPreferencesClient(pool.Endpoint(s.c.PreferencesEndpoint))
 	if err != nil {
 		err = errors.Wrap(err, "gateway: error calling GetPreferencesClient")
 		return &preferences.SetKeyResponse{
@@ -45,7 +45,7 @@ func (s *svc) SetKey(ctx context.Context, req *preferences.SetKeyRequest) (*pref
 }
 
 func (s *svc) GetKey(ctx context.Context, req *preferences.GetKeyRequest) (*preferences.GetKeyResponse, error) {
-	c, err := pool.GetPreferencesClient(s.c.PreferencesEndpoint)
+	c, err := pool.GetPreferencesClient(pool.Endpoint(s.c.PreferencesEndpoint))
 	if err != nil {
 		err = errors.Wrap(err, "gateway: error calling GetPreferencesClient")
 		return &preferences.GetKeyResponse{

--- a/internal/grpc/services/gateway/publicshareprovider.go
+++ b/internal/grpc/services/gateway/publicshareprovider.go
@@ -37,7 +37,7 @@ func (s *svc) CreatePublicShare(ctx context.Context, req *link.CreatePublicShare
 	log := appctx.GetLogger(ctx)
 	log.Info().Msg("create public share")
 
-	c, err := pool.GetPublicShareProviderClient(s.c.PublicShareProviderEndpoint)
+	c, err := pool.GetPublicShareProviderClient(pool.Endpoint(s.c.PublicShareProviderEndpoint))
 	if err != nil {
 		return nil, err
 	}
@@ -54,7 +54,7 @@ func (s *svc) RemovePublicShare(ctx context.Context, req *link.RemovePublicShare
 	log := appctx.GetLogger(ctx)
 	log.Info().Msg("remove public share")
 
-	driver, err := pool.GetPublicShareProviderClient(s.c.PublicShareProviderEndpoint)
+	driver, err := pool.GetPublicShareProviderClient(pool.Endpoint(s.c.PublicShareProviderEndpoint))
 	if err != nil {
 		return nil, err
 	}
@@ -69,7 +69,7 @@ func (s *svc) GetPublicShareByToken(ctx context.Context, req *link.GetPublicShar
 	log := appctx.GetLogger(ctx)
 	log.Info().Msg("get public share by token")
 
-	driver, err := pool.GetPublicShareProviderClient(s.c.PublicShareProviderEndpoint)
+	driver, err := pool.GetPublicShareProviderClient(pool.Endpoint(s.c.PublicShareProviderEndpoint))
 	if err != nil {
 		return nil, err
 	}
@@ -86,7 +86,7 @@ func (s *svc) GetPublicShare(ctx context.Context, req *link.GetPublicShareReques
 	log := appctx.GetLogger(ctx)
 	log.Info().Msg("get public share")
 
-	pClient, err := pool.GetPublicShareProviderClient(s.c.PublicShareProviderEndpoint)
+	pClient, err := pool.GetPublicShareProviderClient(pool.Endpoint(s.c.PublicShareProviderEndpoint))
 	if err != nil {
 		log.Err(err).Msg("error connecting to a public share provider")
 		return &link.GetPublicShareResponse{
@@ -103,7 +103,7 @@ func (s *svc) ListPublicShares(ctx context.Context, req *link.ListPublicSharesRe
 	log := appctx.GetLogger(ctx)
 	log.Info().Msg("listing public shares")
 
-	pClient, err := pool.GetPublicShareProviderClient(s.c.PublicShareProviderEndpoint)
+	pClient, err := pool.GetPublicShareProviderClient(pool.Endpoint(s.c.PublicShareProviderEndpoint))
 	if err != nil {
 		log.Err(err).Msg("error connecting to a public share provider")
 		return &link.ListPublicSharesResponse{
@@ -125,7 +125,7 @@ func (s *svc) UpdatePublicShare(ctx context.Context, req *link.UpdatePublicShare
 	log := appctx.GetLogger(ctx)
 	log.Info().Msg("update public share")
 
-	pClient, err := pool.GetPublicShareProviderClient(s.c.PublicShareProviderEndpoint)
+	pClient, err := pool.GetPublicShareProviderClient(pool.Endpoint(s.c.PublicShareProviderEndpoint))
 	if err != nil {
 		log.Err(err).Msg("error connecting to a public share provider")
 		return &link.UpdatePublicShareResponse{

--- a/internal/grpc/services/gateway/storageprovider.go
+++ b/internal/grpc/services/gateway/storageprovider.go
@@ -135,7 +135,7 @@ func (s *svc) ListStorageSpaces(ctx context.Context, req *provider.ListStorageSp
 		providers []*registry.ProviderInfo
 		err       error
 	)
-	c, err := pool.GetStorageRegistryClient(s.c.StorageRegistryEndpoint)
+	c, err := pool.GetStorageRegistryClient(pool.Endpoint(s.c.StorageRegistryEndpoint))
 	if err != nil {
 		return nil, errors.Wrap(err, "gateway: error getting storage registry client")
 	}
@@ -2286,7 +2286,7 @@ func (s *svc) find(ctx context.Context, ref *provider.Reference) (provider.Provi
 }
 
 func (s *svc) getStorageProviderClient(_ context.Context, p *registry.ProviderInfo) (provider.ProviderAPIClient, error) {
-	c, err := pool.GetStorageProviderServiceClient(p.Address)
+	c, err := pool.GetStorageProviderServiceClient(pool.Endpoint(p.Address))
 	if err != nil {
 		err = errors.Wrap(err, "gateway: error getting a storage provider client")
 		return nil, err
@@ -2296,7 +2296,7 @@ func (s *svc) getStorageProviderClient(_ context.Context, p *registry.ProviderIn
 }
 
 func (s *svc) findProviders(ctx context.Context, ref *provider.Reference) ([]*registry.ProviderInfo, error) {
-	c, err := pool.GetStorageRegistryClient(s.c.StorageRegistryEndpoint)
+	c, err := pool.GetStorageRegistryClient(pool.Endpoint(s.c.StorageRegistryEndpoint))
 	if err != nil {
 		return nil, errors.Wrap(err, "gateway: error getting storage registry client")
 	}

--- a/internal/grpc/services/gateway/userprovider.go
+++ b/internal/grpc/services/gateway/userprovider.go
@@ -28,7 +28,7 @@ import (
 )
 
 func (s *svc) GetUser(ctx context.Context, req *user.GetUserRequest) (*user.GetUserResponse, error) {
-	c, err := pool.GetUserProviderServiceClient(s.c.UserProviderEndpoint)
+	c, err := pool.GetUserProviderServiceClient(pool.Endpoint(s.c.UserProviderEndpoint))
 	if err != nil {
 		return &user.GetUserResponse{
 			Status: status.NewInternal(ctx, err, "error getting auth client"),
@@ -44,7 +44,7 @@ func (s *svc) GetUser(ctx context.Context, req *user.GetUserRequest) (*user.GetU
 }
 
 func (s *svc) GetUserByClaim(ctx context.Context, req *user.GetUserByClaimRequest) (*user.GetUserByClaimResponse, error) {
-	c, err := pool.GetUserProviderServiceClient(s.c.UserProviderEndpoint)
+	c, err := pool.GetUserProviderServiceClient(pool.Endpoint(s.c.UserProviderEndpoint))
 	if err != nil {
 		return &user.GetUserByClaimResponse{
 			Status: status.NewInternal(ctx, err, "error getting auth client"),
@@ -60,7 +60,7 @@ func (s *svc) GetUserByClaim(ctx context.Context, req *user.GetUserByClaimReques
 }
 
 func (s *svc) FindUsers(ctx context.Context, req *user.FindUsersRequest) (*user.FindUsersResponse, error) {
-	c, err := pool.GetUserProviderServiceClient(s.c.UserProviderEndpoint)
+	c, err := pool.GetUserProviderServiceClient(pool.Endpoint(s.c.UserProviderEndpoint))
 	if err != nil {
 		return &user.FindUsersResponse{
 			Status: status.NewInternal(ctx, err, "error getting auth client"),
@@ -76,7 +76,7 @@ func (s *svc) FindUsers(ctx context.Context, req *user.FindUsersRequest) (*user.
 }
 
 func (s *svc) GetUserGroups(ctx context.Context, req *user.GetUserGroupsRequest) (*user.GetUserGroupsResponse, error) {
-	c, err := pool.GetUserProviderServiceClient(s.c.UserProviderEndpoint)
+	c, err := pool.GetUserProviderServiceClient(pool.Endpoint(s.c.UserProviderEndpoint))
 	if err != nil {
 		return &user.GetUserGroupsResponse{
 			Status: status.NewInternal(ctx, err, "error getting auth client"),

--- a/internal/grpc/services/gateway/usershareprovider.go
+++ b/internal/grpc/services/gateway/usershareprovider.go
@@ -44,7 +44,7 @@ func (s *svc) CreateShare(ctx context.Context, req *collaboration.CreateShareReq
 		return nil, errtypes.AlreadyExists("gateway: can't share the share folder itself")
 	}
 
-	c, err := pool.GetUserShareProviderClient(s.c.UserShareProviderEndpoint)
+	c, err := pool.GetUserShareProviderClient(pool.Endpoint(s.c.UserShareProviderEndpoint))
 	if err != nil {
 		return &collaboration.CreateShareResponse{
 			Status: status.NewInternal(ctx, err, "error getting user share provider client"),
@@ -97,7 +97,7 @@ func (s *svc) CreateShare(ctx context.Context, req *collaboration.CreateShareReq
 }
 
 func (s *svc) RemoveShare(ctx context.Context, req *collaboration.RemoveShareRequest) (*collaboration.RemoveShareResponse, error) {
-	c, err := pool.GetUserShareProviderClient(s.c.UserShareProviderEndpoint)
+	c, err := pool.GetUserShareProviderClient(pool.Endpoint(s.c.UserShareProviderEndpoint))
 	if err != nil {
 		return &collaboration.RemoveShareResponse{
 			Status: status.NewInternal(ctx, err, "error getting user share provider client"),
@@ -161,7 +161,7 @@ func (s *svc) GetShare(ctx context.Context, req *collaboration.GetShareRequest) 
 }
 
 func (s *svc) getShare(ctx context.Context, req *collaboration.GetShareRequest) (*collaboration.GetShareResponse, error) {
-	c, err := pool.GetUserShareProviderClient(s.c.UserShareProviderEndpoint)
+	c, err := pool.GetUserShareProviderClient(pool.Endpoint(s.c.UserShareProviderEndpoint))
 	if err != nil {
 		err = errors.Wrap(err, "gateway: error calling GetUserShareProviderClient")
 		return &collaboration.GetShareResponse{
@@ -179,7 +179,7 @@ func (s *svc) getShare(ctx context.Context, req *collaboration.GetShareRequest) 
 
 // TODO(labkode): read GetShare comment.
 func (s *svc) ListShares(ctx context.Context, req *collaboration.ListSharesRequest) (*collaboration.ListSharesResponse, error) {
-	c, err := pool.GetUserShareProviderClient(s.c.UserShareProviderEndpoint)
+	c, err := pool.GetUserShareProviderClient(pool.Endpoint(s.c.UserShareProviderEndpoint))
 	if err != nil {
 		err = errors.Wrap(err, "gateway: error calling GetUserShareProviderClient")
 		return &collaboration.ListSharesResponse{
@@ -196,7 +196,7 @@ func (s *svc) ListShares(ctx context.Context, req *collaboration.ListSharesReque
 }
 
 func (s *svc) UpdateShare(ctx context.Context, req *collaboration.UpdateShareRequest) (*collaboration.UpdateShareResponse, error) {
-	c, err := pool.GetUserShareProviderClient(s.c.UserShareProviderEndpoint)
+	c, err := pool.GetUserShareProviderClient(pool.Endpoint(s.c.UserShareProviderEndpoint))
 	if err != nil {
 		err = errors.Wrap(err, "gateway: error calling GetUserShareProviderClient")
 		return &collaboration.UpdateShareResponse{
@@ -240,7 +240,7 @@ func (s *svc) UpdateShare(ctx context.Context, req *collaboration.UpdateShareReq
 // received shares. The display name of the shares should be the a friendly name, like the basename
 // of the original file.
 func (s *svc) ListReceivedShares(ctx context.Context, req *collaboration.ListReceivedSharesRequest) (*collaboration.ListReceivedSharesResponse, error) {
-	c, err := pool.GetUserShareProviderClient(s.c.UserShareProviderEndpoint)
+	c, err := pool.GetUserShareProviderClient(pool.Endpoint(s.c.UserShareProviderEndpoint))
 	if err != nil {
 		err = errors.Wrap(err, "gateway: error calling GetUserShareProviderClient")
 		return &collaboration.ListReceivedSharesResponse{
@@ -256,7 +256,7 @@ func (s *svc) ListReceivedShares(ctx context.Context, req *collaboration.ListRec
 }
 
 func (s *svc) GetReceivedShare(ctx context.Context, req *collaboration.GetReceivedShareRequest) (*collaboration.GetReceivedShareResponse, error) {
-	c, err := pool.GetUserShareProviderClient(s.c.UserShareProviderEndpoint)
+	c, err := pool.GetUserShareProviderClient(pool.Endpoint(s.c.UserShareProviderEndpoint))
 	if err != nil {
 		err := errors.Wrap(err, "gateway: error getting user share provider client")
 		return &collaboration.GetReceivedShareResponse{
@@ -299,7 +299,7 @@ func (s *svc) UpdateReceivedShare(ctx context.Context, req *collaboration.Update
 		}, nil
 	}
 
-	c, err := pool.GetUserShareProviderClient(s.c.UserShareProviderEndpoint)
+	c, err := pool.GetUserShareProviderClient(pool.Endpoint(s.c.UserShareProviderEndpoint))
 	if err != nil {
 		err = errors.Wrap(err, "gateway: error calling GetUserShareProviderClient")
 		return &collaboration.UpdateReceivedShareResponse{

--- a/internal/grpc/services/publicstorageprovider/publicstorageprovider.go
+++ b/internal/grpc/services/publicstorageprovider/publicstorageprovider.go
@@ -92,7 +92,7 @@ func New(m map[string]interface{}, ss *grpc.Server) (rgrpc.Service, error) {
 	mountPath := c.MountPath
 	mountID := c.MountID
 
-	gateway, err := pool.GetGatewayServiceClient(c.GatewayAddr)
+	gateway, err := pool.GetGatewayServiceClient(pool.Endpoint(c.GatewayAddr))
 	if err != nil {
 		return nil, err
 	}
@@ -777,7 +777,7 @@ func (s *service) trimMountPrefix(fn string) (string, error) {
 
 // resolveToken returns the path and share for the publicly shared resource.
 func (s *service) resolveToken(ctx context.Context, token string) (*link.PublicShare, *provider.ResourceInfo, *rpc.Status, error) {
-	driver, err := pool.GetGatewayServiceClient(s.conf.GatewayAddr)
+	driver, err := pool.GetGatewayServiceClient(pool.Endpoint(s.conf.GatewayAddr))
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/internal/http/interceptors/auth/auth.go
+++ b/internal/http/interceptors/auth/auth.go
@@ -194,7 +194,7 @@ func authenticateUser(w http.ResponseWriter, r *http.Request, conf *config, toke
 	// Add the request user-agent to the ctx
 	ctx = metadata.NewIncomingContext(ctx, metadata.New(map[string]string{ctxpkg.UserAgentHeader: r.UserAgent()}))
 
-	client, err := pool.GetGatewayServiceClient(conf.GatewaySvc)
+	client, err := pool.GetGatewayServiceClient(pool.Endpoint(conf.GatewaySvc))
 	if err != nil {
 		logError(isUnprotectedEndpoint, log, err, "error getting the authsvc client", http.StatusUnauthorized, w)
 		return nil, err

--- a/internal/http/services/appprovider/appprovider.go
+++ b/internal/http/services/appprovider/appprovider.go
@@ -117,7 +117,7 @@ func (s *svc) Handler() http.Handler {
 func (s *svc) handleNew(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	client, err := pool.GetGatewayServiceClient(s.conf.GatewaySvc)
+	client, err := pool.GetGatewayServiceClient(pool.Endpoint(s.conf.GatewaySvc))
 	if err != nil {
 		writeError(w, r, appErrorServerError, "error getting grpc gateway client", err)
 		return
@@ -288,7 +288,7 @@ func (s *svc) handleNew(w http.ResponseWriter, r *http.Request) {
 
 func (s *svc) handleList(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	client, err := pool.GetGatewayServiceClient(s.conf.GatewaySvc)
+	client, err := pool.GetGatewayServiceClient(pool.Endpoint(s.conf.GatewaySvc))
 	if err != nil {
 		writeError(w, r, appErrorServerError, "error getting grpc gateway client", err)
 		return
@@ -321,7 +321,7 @@ func (s *svc) handleList(w http.ResponseWriter, r *http.Request) {
 func (s *svc) handleOpen(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	client, err := pool.GetGatewayServiceClient(s.conf.GatewaySvc)
+	client, err := pool.GetGatewayServiceClient(pool.Endpoint(s.conf.GatewaySvc))
 	if err != nil {
 		writeError(w, r, appErrorServerError, "Internal error with the gateway, please try again later", err)
 		return

--- a/internal/http/services/archiver/handler.go
+++ b/internal/http/services/archiver/handler.go
@@ -82,7 +82,7 @@ func New(conf map[string]interface{}, log *zerolog.Logger) (global.Service, erro
 
 	c.init()
 
-	gtw, err := pool.GetGatewayServiceClient(c.GatewaySvc)
+	gtw, err := pool.GetGatewayServiceClient(pool.Endpoint(c.GatewaySvc))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/http/services/meshdirectory/meshdirectory.go
+++ b/internal/http/services/meshdirectory/meshdirectory.go
@@ -100,7 +100,7 @@ func (s *svc) Close() error {
 }
 
 func (s *svc) getClient() (gateway.GatewayAPIClient, error) {
-	return pool.GetGatewayServiceClient(s.conf.GatewaySvc)
+	return pool.GetGatewayServiceClient(pool.Endpoint(s.conf.GatewaySvc))
 }
 
 func (s *svc) serveJSON(w http.ResponseWriter, r *http.Request) {

--- a/internal/http/services/ocmd/invites.go
+++ b/internal/http/services/ocmd/invites.go
@@ -81,7 +81,7 @@ func (h *invitesHandler) generateInviteToken(w http.ResponseWriter, r *http.Requ
 
 	ctx := r.Context()
 
-	gatewayClient, err := pool.GetGatewayServiceClient(h.gatewayAddr)
+	gatewayClient, err := pool.GetGatewayServiceClient(pool.Endpoint(h.gatewayAddr))
 	if err != nil {
 		WriteError(w, r, APIErrorServerError, "error getting gateway grpc client", err)
 		return
@@ -155,7 +155,7 @@ func (h *invitesHandler) forwardInvite(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	gatewayClient, err := pool.GetGatewayServiceClient(h.gatewayAddr)
+	gatewayClient, err := pool.GetGatewayServiceClient(pool.Endpoint(h.gatewayAddr))
 	if err != nil {
 		WriteError(w, r, APIErrorServerError, "error getting gateway grpc client", err)
 		return
@@ -226,7 +226,7 @@ func (h *invitesHandler) acceptInvite(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	gatewayClient, err := pool.GetGatewayServiceClient(h.gatewayAddr)
+	gatewayClient, err := pool.GetGatewayServiceClient(pool.Endpoint(h.gatewayAddr))
 	if err != nil {
 		WriteError(w, r, APIErrorServerError, "error getting gateway grpc client", err)
 		return
@@ -297,7 +297,7 @@ func (h *invitesHandler) findAcceptedUsers(w http.ResponseWriter, r *http.Reques
 	log := appctx.GetLogger(r.Context())
 
 	ctx := r.Context()
-	gatewayClient, err := pool.GetGatewayServiceClient(h.gatewayAddr)
+	gatewayClient, err := pool.GetGatewayServiceClient(pool.Endpoint(h.gatewayAddr))
 	if err != nil {
 		WriteError(w, r, APIErrorServerError, "error getting gateway grpc client", err)
 		return
@@ -323,7 +323,7 @@ func (h *invitesHandler) generate(w http.ResponseWriter, r *http.Request) {
 	log := appctx.GetLogger(r.Context())
 
 	ctx := r.Context()
-	gatewayClient, err := pool.GetGatewayServiceClient(h.gatewayAddr)
+	gatewayClient, err := pool.GetGatewayServiceClient(pool.Endpoint(h.gatewayAddr))
 	if err != nil {
 		WriteError(w, r, APIErrorServerError, "error getting gateway grpc client", err)
 		return

--- a/internal/http/services/ocmd/send.go
+++ b/internal/http/services/ocmd/send.go
@@ -80,7 +80,7 @@ func (h *sendHandler) Handler() http.Handler {
 		// "loginPassword": "Ny4Nv6WLoC1o70kVgrVOZLZ2vRgPjuej"
 
 		gatewayAddr := h.GatewaySvc
-		gatewayClient, err := pool.GetGatewayServiceClient(gatewayAddr)
+		gatewayClient, err := pool.GetGatewayServiceClient(pool.Endpoint(gatewayAddr))
 		if err != nil {
 			log.Error().Msg("cannot get grpc client!")
 			w.WriteHeader(http.StatusInternalServerError)

--- a/internal/http/services/ocmd/shares.go
+++ b/internal/http/services/ocmd/shares.go
@@ -109,7 +109,7 @@ func (h *sharesHandler) createShare(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	gatewayClient, err := pool.GetGatewayServiceClient(h.gatewayAddr)
+	gatewayClient, err := pool.GetGatewayServiceClient(pool.Endpoint(h.gatewayAddr))
 	if err != nil {
 		WriteError(w, r, APIErrorServerError, "error getting storage grpc client", err)
 		return

--- a/internal/http/services/owncloud/ocdav/dav.go
+++ b/internal/http/services/owncloud/ocdav/dav.go
@@ -175,7 +175,7 @@ func (h *DavHandler) Handler(s *svc) http.Handler {
 		case "public-files":
 			base := path.Join(ctx.Value(ctxKeyBaseURI).(string), "public-files")
 			ctx = context.WithValue(ctx, ctxKeyBaseURI, base)
-			c, err := pool.GetGatewayServiceClient(s.c.GatewaySvc)
+			c, err := pool.GetGatewayServiceClient(pool.Endpoint(s.c.GatewaySvc))
 			if err != nil {
 				w.WriteHeader(http.StatusNotFound)
 			}

--- a/internal/http/services/owncloud/ocdav/ocdav.go
+++ b/internal/http/services/owncloud/ocdav/ocdav.go
@@ -255,7 +255,7 @@ func (s *svc) Handler() http.Handler {
 }
 
 func (s *svc) getClient() (gateway.GatewayAPIClient, error) {
-	return pool.GetGatewayServiceClient(s.c.GatewaySvc)
+	return pool.GetGatewayServiceClient(pool.Endpoint(s.c.GatewaySvc))
 }
 
 func applyLayout(ctx context.Context, ns string, useLoggedInUserNS bool, requestPath string) string {

--- a/internal/http/services/owncloud/ocdav/trashbin.go
+++ b/internal/http/services/owncloud/ocdav/trashbin.go
@@ -106,7 +106,7 @@ func (h *TrashbinHandler) Handler(s *svc) http.Handler {
 		// If not, we user the user home to route the request
 		basePath := r.URL.Query().Get("base_path")
 		if basePath == "" {
-			gc, err := pool.GetGatewayServiceClient(s.c.GatewaySvc)
+			gc, err := pool.GetGatewayServiceClient(pool.Endpoint(s.c.GatewaySvc))
 			if err != nil {
 				// TODO(jfd) how do we make the user aware that some storages are not available?
 				// opaque response property? Or a list of errors?
@@ -206,7 +206,7 @@ func (h *TrashbinHandler) listTrashbin(w http.ResponseWriter, r *http.Request, s
 		return
 	}
 
-	gc, err := pool.GetGatewayServiceClient(s.c.GatewaySvc)
+	gc, err := pool.GetGatewayServiceClient(pool.Endpoint(s.c.GatewaySvc))
 	if err != nil {
 		// TODO(jfd) how do we make the user aware that some storages are not available?
 		// opaque response property? Or a list of errors?

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/sharees/sharees.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/sharees/sharees.go
@@ -54,7 +54,7 @@ func (h *Handler) FindSharees(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	gwc, err := pool.GetGatewayServiceClient(h.gatewayAddr)
+	gwc, err := pool.GetGatewayServiceClient(pool.Endpoint(h.gatewayAddr))
 	if err != nil {
 		response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "error getting gateway grpc client", err)
 		return

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/group.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/group.go
@@ -34,7 +34,7 @@ import (
 
 func (h *Handler) createGroupShare(w http.ResponseWriter, r *http.Request, statInfo *provider.ResourceInfo, role *conversions.Role, roleVal []byte) {
 	ctx := r.Context()
-	c, err := pool.GetGatewayServiceClient(h.gatewayAddr)
+	c, err := pool.GetGatewayServiceClient(pool.Endpoint(h.gatewayAddr))
 	if err != nil {
 		response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "error getting grpc gateway client", err)
 		return

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/pending.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/pending.go
@@ -49,7 +49,7 @@ func (h *Handler) updateReceivedShare(w http.ResponseWriter, r *http.Request, sh
 	ctx := r.Context()
 	logger := appctx.GetLogger(ctx)
 
-	client, err := pool.GetGatewayServiceClient(h.gatewayAddr)
+	client, err := pool.GetGatewayServiceClient(pool.Endpoint(h.gatewayAddr))
 	if err != nil {
 		response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "error getting grpc gateway client", err)
 		return

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/public.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/public.go
@@ -41,7 +41,7 @@ func (h *Handler) createPublicLinkShare(w http.ResponseWriter, r *http.Request, 
 	ctx := r.Context()
 	log := appctx.GetLogger(ctx)
 
-	c, err := pool.GetGatewayServiceClient(h.gatewayAddr)
+	c, err := pool.GetGatewayServiceClient(pool.Endpoint(h.gatewayAddr))
 	if err != nil {
 		response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "error getting grpc gateway client", err)
 		return
@@ -141,7 +141,7 @@ func (h *Handler) listPublicShares(r *http.Request, filters []*link.ListPublicSh
 	ocsDataPayload := make([]*conversions.ShareData, 0)
 	// TODO(refs) why is this guard needed? Are we moving towards a gateway only for service discovery? without a gateway this is dead code.
 	if h.gatewayAddr != "" {
-		client, err := pool.GetGatewayServiceClient(h.gatewayAddr)
+		client, err := pool.GetGatewayServiceClient(pool.Endpoint(h.gatewayAddr))
 		if err != nil {
 			return ocsDataPayload, nil, err
 		}
@@ -189,7 +189,7 @@ func (h *Handler) listPublicShares(r *http.Request, filters []*link.ListPublicSh
 
 func (h *Handler) isPublicShare(r *http.Request, oid string) bool {
 	logger := appctx.GetLogger(r.Context())
-	client, err := pool.GetGatewayServiceClient(h.gatewayAddr)
+	client, err := pool.GetGatewayServiceClient(pool.Endpoint(h.gatewayAddr))
 	if err != nil {
 		logger.Err(err)
 	}
@@ -215,7 +215,7 @@ func (h *Handler) updatePublicShare(w http.ResponseWriter, r *http.Request, shar
 	updates := []*link.UpdatePublicShareRequest_Update{}
 	logger := appctx.GetLogger(r.Context())
 
-	gwC, err := pool.GetGatewayServiceClient(h.gatewayAddr)
+	gwC, err := pool.GetGatewayServiceClient(pool.Endpoint(h.gatewayAddr))
 	if err != nil {
 		log.Err(err).Str("shareID", shareID).Msg("updatePublicShare")
 		response.WriteOCSError(w, r, response.MetaBadRequest.StatusCode, "error getting a connection to the gateway service", nil)
@@ -377,7 +377,7 @@ func (h *Handler) updatePublicShare(w http.ResponseWriter, r *http.Request, shar
 func (h *Handler) removePublicShare(w http.ResponseWriter, r *http.Request, shareID string) {
 	ctx := r.Context()
 
-	c, err := pool.GetGatewayServiceClient(h.gatewayAddr)
+	c, err := pool.GetGatewayServiceClient(pool.Endpoint(h.gatewayAddr))
 	if err != nil {
 		response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "error getting grpc gateway client", err)
 		return

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/remote.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/remote.go
@@ -39,7 +39,7 @@ import (
 func (h *Handler) createFederatedCloudShare(w http.ResponseWriter, r *http.Request, statInfo *provider.ResourceInfo, role *conversions.Role, roleVal []byte) {
 	ctx := r.Context()
 
-	c, err := pool.GetGatewayServiceClient(h.gatewayAddr)
+	c, err := pool.GetGatewayServiceClient(pool.Endpoint(h.gatewayAddr))
 	if err != nil {
 		response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "error getting grpc gateway client", err)
 		return
@@ -127,7 +127,7 @@ func (h *Handler) GetFederatedShare(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
 	shareID := chi.URLParam(r, "shareid")
-	gatewayClient, err := pool.GetGatewayServiceClient(h.gatewayAddr)
+	gatewayClient, err := pool.GetGatewayServiceClient(pool.Endpoint(h.gatewayAddr))
 	if err != nil {
 		response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "error getting grpc gateway client", err)
 		return
@@ -163,7 +163,7 @@ func (h *Handler) ListFederatedShares(w http.ResponseWriter, r *http.Request) {
 	// TODO Implement response with HAL schemating
 	ctx := r.Context()
 
-	gatewayClient, err := pool.GetGatewayServiceClient(h.gatewayAddr)
+	gatewayClient, err := pool.GetGatewayServiceClient(pool.Endpoint(h.gatewayAddr))
 	if err != nil {
 		response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "error getting grpc gateway client", err)
 		return

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/shares.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/shares.go
@@ -159,7 +159,7 @@ func (h *Handler) CreateShare(w http.ResponseWriter, r *http.Request) {
 	}
 	// get user permissions on the shared file
 
-	client, err := pool.GetGatewayServiceClient(h.gatewayAddr)
+	client, err := pool.GetGatewayServiceClient(pool.Endpoint(h.gatewayAddr))
 	if err != nil {
 		response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "error getting grpc gateway client", err)
 		return
@@ -301,7 +301,7 @@ func (h *Handler) GetShare(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	logger := appctx.GetLogger(r.Context())
 	logger.Debug().Str("shareID", shareID).Msg("get share by id")
-	client, err := pool.GetGatewayServiceClient(h.gatewayAddr)
+	client, err := pool.GetGatewayServiceClient(pool.Endpoint(h.gatewayAddr))
 	if err != nil {
 		response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "error getting grpc gateway client", err)
 		return
@@ -440,7 +440,7 @@ func (h *Handler) updateShare(w http.ResponseWriter, r *http.Request, shareID st
 		return
 	}
 
-	client, err := pool.GetGatewayServiceClient(h.gatewayAddr)
+	client, err := pool.GetGatewayServiceClient(pool.Endpoint(h.gatewayAddr))
 	if err != nil {
 		response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "error getting grpc gateway client", err)
 		return
@@ -557,7 +557,7 @@ func (h *Handler) listSharesWithMe(w http.ResponseWriter, r *http.Request) {
 	stateFilter := getStateFilter(r.FormValue("state"))
 
 	log := appctx.GetLogger(r.Context())
-	client, err := pool.GetGatewayServiceClient(h.gatewayAddr)
+	client, err := pool.GetGatewayServiceClient(pool.Endpoint(h.gatewayAddr))
 	if err != nil {
 		response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "error getting grpc gateway client", err)
 		return
@@ -837,7 +837,7 @@ func (h *Handler) addFilters(w http.ResponseWriter, r *http.Request, prefix stri
 	ctx := r.Context()
 
 	// first check if the file exists
-	client, err := pool.GetGatewayServiceClient(h.gatewayAddr)
+	client, err := pool.GetGatewayServiceClient(pool.Endpoint(h.gatewayAddr))
 	if err != nil {
 		response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "error getting grpc gateway client", err)
 		return nil, nil, err

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/spaces.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/spaces.go
@@ -167,7 +167,7 @@ func (h *Handler) removeSpaceMember(w http.ResponseWriter, r *http.Request, spac
 }
 
 func (h *Handler) getStorageProviderClient(p *registry.ProviderInfo) (provider.ProviderAPIClient, error) {
-	c, err := pool.GetStorageProviderServiceClient(p.Address)
+	c, err := pool.GetStorageProviderServiceClient(pool.Endpoint(p.Address))
 	if err != nil {
 		err = errors.Wrap(err, "gateway: error getting a storage provider client")
 		return nil, err
@@ -177,7 +177,7 @@ func (h *Handler) getStorageProviderClient(p *registry.ProviderInfo) (provider.P
 }
 
 func (h *Handler) findProviders(ctx context.Context, ref *provider.Reference) ([]*registry.ProviderInfo, error) {
-	c, err := pool.GetStorageRegistryClient(h.storageRegistryAddr)
+	c, err := pool.GetStorageRegistryClient(pool.Endpoint(h.storageRegistryAddr))
 	if err != nil {
 		return nil, errors.Wrap(err, "gateway: error getting storage registry client")
 	}

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/spaces.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/spaces.go
@@ -40,7 +40,7 @@ import (
 
 func (h *Handler) getGrantee(ctx context.Context, name string) (provider.Grantee, error) {
 	log := appctx.GetLogger(ctx)
-	client, err := pool.GetGatewayServiceClient(h.gatewayAddr)
+	client, err := pool.GetGatewayServiceClient(pool.Endpoint(h.gatewayAddr))
 	if err != nil {
 		return provider.Grantee{}, err
 	}

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/user.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/user.go
@@ -35,7 +35,7 @@ import (
 
 func (h *Handler) createUserShare(w http.ResponseWriter, r *http.Request, statInfo *provider.ResourceInfo, role *conversions.Role, roleVal []byte) {
 	ctx := r.Context()
-	c, err := pool.GetGatewayServiceClient(h.gatewayAddr)
+	c, err := pool.GetGatewayServiceClient(pool.Endpoint(h.gatewayAddr))
 	if err != nil {
 		response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "error getting grpc gateway client", err)
 		return
@@ -88,7 +88,7 @@ func (h *Handler) createUserShare(w http.ResponseWriter, r *http.Request, statIn
 
 func (h *Handler) isUserShare(r *http.Request, oid string) bool {
 	logger := appctx.GetLogger(r.Context())
-	client, err := pool.GetGatewayServiceClient(h.gatewayAddr)
+	client, err := pool.GetGatewayServiceClient(pool.Endpoint(h.gatewayAddr))
 	if err != nil {
 		logger.Err(err)
 	}
@@ -113,7 +113,7 @@ func (h *Handler) isUserShare(r *http.Request, oid string) bool {
 func (h *Handler) removeUserShare(w http.ResponseWriter, r *http.Request, shareID string) {
 	ctx := r.Context()
 
-	uClient, err := pool.GetGatewayServiceClient(h.gatewayAddr)
+	uClient, err := pool.GetGatewayServiceClient(pool.Endpoint(h.gatewayAddr))
 	if err != nil {
 		response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "error getting grpc gateway client", err)
 		return
@@ -177,7 +177,7 @@ func (h *Handler) listUserShares(r *http.Request, filters []*collaboration.Filte
 	ocsDataPayload := make([]*conversions.ShareData, 0)
 	if h.gatewayAddr != "" {
 		// get a connection to the users share provider
-		client, err := pool.GetGatewayServiceClient(h.gatewayAddr)
+		client, err := pool.GetGatewayServiceClient(pool.Endpoint(h.gatewayAddr))
 		if err != nil {
 			return ocsDataPayload, nil, err
 		}

--- a/internal/http/services/owncloud/ocs/handlers/cloud/users/users.go
+++ b/internal/http/services/owncloud/ocs/handlers/cloud/users/users.go
@@ -112,7 +112,7 @@ func (h *Handler) GetUsers(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	gc, err := pool.GetGatewayServiceClient(h.gatewayAddr)
+	gc, err := pool.GetGatewayServiceClient(pool.Endpoint(h.gatewayAddr))
 	if err != nil {
 		sublog.Error().Err(err).Msg("error getting gateway client")
 		w.WriteHeader(http.StatusInternalServerError)

--- a/internal/http/services/preferences/preferences.go
+++ b/internal/http/services/preferences/preferences.go
@@ -119,7 +119,7 @@ func (s *svc) handleGet(w http.ResponseWriter, r *http.Request) {
 
 	}
 
-	client, err := pool.GetGatewayServiceClient(s.conf.GatewaySvc)
+	client, err := pool.GetGatewayServiceClient(pool.Endpoint(s.conf.GatewaySvc))
 	if err != nil {
 		log.Error().Err(err).Msg("error getting grpc gateway client")
 		w.WriteHeader(http.StatusInternalServerError)
@@ -185,7 +185,7 @@ func (s *svc) handlePost(w http.ResponseWriter, r *http.Request) {
 
 	}
 
-	client, err := pool.GetGatewayServiceClient(s.conf.GatewaySvc)
+	client, err := pool.GetGatewayServiceClient(pool.Endpoint(s.conf.GatewaySvc))
 	if err != nil {
 		log.Error().Err(err).Msg("error getting grpc gateway client")
 		w.WriteHeader(http.StatusInternalServerError)

--- a/pkg/auth/manager/appauth/appauth.go
+++ b/pkg/auth/manager/appauth/appauth.go
@@ -60,7 +60,7 @@ func (m *manager) Configure(ml map[string]interface{}) error {
 }
 
 func (m *manager) Authenticate(ctx context.Context, username, password string) (*user.User, map[string]*authpb.Scope, error) {
-	gtw, err := pool.GetGatewayServiceClient(m.GatewayAddr)
+	gtw, err := pool.GetGatewayServiceClient(pool.Endpoint(m.GatewayAddr))
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/auth/manager/ldap/ldap.go
+++ b/pkg/auth/manager/ldap/ldap.go
@@ -171,7 +171,7 @@ func (am *mgr) Authenticate(ctx context.Context, clientID, clientSecret string) 
 		OpaqueId: sr.Entries[0].GetEqualFoldAttributeValue(am.c.Schema.UID),
 		Type:     user.UserType_USER_TYPE_PRIMARY, // TODO: assign the appropriate user type
 	}
-	gwc, err := pool.GetGatewayServiceClient(am.c.GatewaySvc)
+	gwc, err := pool.GetGatewayServiceClient(pool.Endpoint(am.c.GatewaySvc))
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "ldap: error getting gateway grpc client")
 	}

--- a/pkg/auth/manager/machine/machine.go
+++ b/pkg/auth/manager/machine/machine.go
@@ -75,7 +75,7 @@ func (m *manager) Authenticate(ctx context.Context, user, secret string) (*userp
 		return nil, nil, errtypes.InvalidCredentials("")
 	}
 
-	gtw, err := pool.GetGatewayServiceClient(m.GatewayAddr)
+	gtw, err := pool.GetGatewayServiceClient(pool.Endpoint(m.GatewayAddr))
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/auth/manager/oidc/oidc.go
+++ b/pkg/auth/manager/oidc/oidc.go
@@ -323,7 +323,7 @@ func (am *mgr) resolveUser(ctx context.Context, claims map[string]interface{}) e
 			username = am.oidcUsersMapping[m.(string)].Username
 		}
 
-		upsc, err := pool.GetUserProviderServiceClient(am.c.GatewaySvc)
+		upsc, err := pool.GetUserProviderServiceClient(pool.Endpoint(am.c.GatewaySvc))
 		if err != nil {
 			return errors.Wrap(err, "error getting user provider grpc client")
 		}

--- a/pkg/auth/manager/oidc/oidc.go
+++ b/pkg/auth/manager/oidc/oidc.go
@@ -216,7 +216,7 @@ func (am *mgr) Authenticate(ctx context.Context, clientID, clientSecret string) 
 		Type:     getUserType(claims[am.c.IDClaim].(string)),
 	}
 
-	gwc, err := pool.GetGatewayServiceClient(am.c.GatewaySvc)
+	gwc, err := pool.GetGatewayServiceClient(pool.Endpoint(am.c.GatewaySvc))
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "oidc: error getting gateway grpc client")
 	}

--- a/pkg/auth/manager/publicshares/publicshares.go
+++ b/pkg/auth/manager/publicshares/publicshares.go
@@ -79,7 +79,7 @@ func (m *manager) Configure(ml map[string]interface{}) error {
 }
 
 func (m *manager) Authenticate(ctx context.Context, token, secret string) (*user.User, map[string]*authpb.Scope, error) {
-	gwConn, err := pool.GetGatewayServiceClient(m.c.GatewayAddr)
+	gwConn, err := pool.GetGatewayServiceClient(pool.Endpoint(m.c.GatewayAddr))
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/rgrpc/todo/pool/option.go
+++ b/pkg/rgrpc/todo/pool/option.go
@@ -19,7 +19,7 @@
 package pool
 
 const (
-	DefaultMaxCallRecvMsgSize = 10240000
+	defaultMaxCallRecvMsgSize = 10240000
 )
 
 // Option defines a single option function.
@@ -34,7 +34,7 @@ type Options struct {
 // newOptions initializes the available default options.
 func newOptions(opts ...Option) Options {
 	opt := Options{
-		MaxCallRecvMsgSize: DefaultMaxCallRecvMsgSize,
+		MaxCallRecvMsgSize: defaultMaxCallRecvMsgSize,
 	}
 
 	for _, o := range opts {
@@ -51,7 +51,7 @@ func Endpoint(val string) Option {
 	}
 }
 
-//  MaxCallMsgRecvSizeprovides a function to set the MaxCallRecvMsgSize option.
+// MaxCallRecvMsgSize provides a function to set the MaxCallRecvMsgSize option.
 func MaxCallRecvMsgSize(size int) Option {
 	return func(o *Options) {
 		o.MaxCallRecvMsgSize = size

--- a/pkg/rgrpc/todo/pool/option.go
+++ b/pkg/rgrpc/todo/pool/option.go
@@ -1,0 +1,69 @@
+// Copyright 2018-2022 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package pool
+
+// Option defines a single option function.
+type Option func(o *Options)
+
+// Options defines the available options for this package.
+type Options struct {
+	Endpoint           string
+	Insecure           bool
+	SkipVerify         bool
+	MaxCallRecvMsgSize int
+}
+
+// newOptions initializes the available default options.
+func newOptions(opts ...Option) Options {
+	opt := Options{}
+
+	for _, o := range opts {
+		o(&opt)
+	}
+
+	return opt
+}
+
+// Endpoint provides a function to set the endpoint option.
+func Endpoint(val string) Option {
+	return func(o *Options) {
+		o.Endpoint = val
+	}
+}
+
+// Insecure provides a function to set the insecure option.
+func Insecure(insecure bool) Option {
+	return func(o *Options) {
+		o.Insecure = insecure
+	}
+}
+
+// SkipVerify provides a function to set the skip verify option.
+func SkipVerify(skipVerify bool) Option {
+	return func(o *Options) {
+		o.SkipVerify = skipVerify
+	}
+}
+
+//  MaxCallMsgRecvSizeprovides a function to set the MaxCallRecvMsgSize option.
+func MaxCallRecvMsgSize(size int) Option {
+	return func(o *Options) {
+		o.MaxCallRecvMsgSize = size
+	}
+}

--- a/pkg/rgrpc/todo/pool/option.go
+++ b/pkg/rgrpc/todo/pool/option.go
@@ -18,20 +18,24 @@
 
 package pool
 
+const (
+	DefaultMaxCallRecvMsgSize = 10240000
+)
+
 // Option defines a single option function.
 type Option func(o *Options)
 
 // Options defines the available options for this package.
 type Options struct {
 	Endpoint           string
-	Insecure           bool
-	SkipVerify         bool
 	MaxCallRecvMsgSize int
 }
 
 // newOptions initializes the available default options.
 func newOptions(opts ...Option) Options {
-	opt := Options{}
+	opt := Options{
+		MaxCallRecvMsgSize: DefaultMaxCallRecvMsgSize,
+	}
 
 	for _, o := range opts {
 		o(&opt)
@@ -44,20 +48,6 @@ func newOptions(opts ...Option) Options {
 func Endpoint(val string) Option {
 	return func(o *Options) {
 		o.Endpoint = val
-	}
-}
-
-// Insecure provides a function to set the insecure option.
-func Insecure(insecure bool) Option {
-	return func(o *Options) {
-		o.Insecure = insecure
-	}
-}
-
-// SkipVerify provides a function to set the skip verify option.
-func SkipVerify(skipVerify bool) Option {
-	return func(o *Options) {
-		o.SkipVerify = skipVerify
 	}
 }
 

--- a/pkg/rgrpc/todo/pool/pool.go
+++ b/pkg/rgrpc/todo/pool/pool.go
@@ -80,7 +80,6 @@ var (
 	userProviders          = newProvider()
 	groupProviders         = newProvider()
 	dataTxs                = newProvider()
-	maxCallRecvMsgSize     = 10240000
 )
 
 // NewConn creates a new connection to a grpc server
@@ -129,7 +128,7 @@ func GetGatewayServiceClient(endpoint string) (gateway.GatewayAPIClient, error) 
 		return val.(gateway.GatewayAPIClient), nil
 	}
 
-	conn, err := NewConn(endpoint)
+	conn, err := NewConn(Endpoint(endpoint))
 	if err != nil {
 		return nil, err
 	}
@@ -149,7 +148,7 @@ func GetUserProviderServiceClient(endpoint string) (user.UserAPIClient, error) {
 		return val.(user.UserAPIClient), nil
 	}
 
-	conn, err := NewConn(endpoint)
+	conn, err := NewConn(Endpoint(endpoint))
 	if err != nil {
 		return nil, err
 	}
@@ -168,7 +167,7 @@ func GetGroupProviderServiceClient(endpoint string) (group.GroupAPIClient, error
 		return val.(group.GroupAPIClient), nil
 	}
 
-	conn, err := NewConn(endpoint)
+	conn, err := NewConn(Endpoint(endpoint))
 	if err != nil {
 		return nil, err
 	}
@@ -187,7 +186,7 @@ func GetStorageProviderServiceClient(endpoint string) (storageprovider.ProviderA
 		return c.(storageprovider.ProviderAPIClient), nil
 	}
 
-	conn, err := NewConn(endpoint)
+	conn, err := NewConn(Endpoint(endpoint))
 	if err != nil {
 		return nil, err
 	}
@@ -208,7 +207,7 @@ func GetAuthRegistryServiceClient(endpoint string) (authregistry.RegistryAPIClie
 	}
 
 	// if not, create a new connection
-	conn, err := NewConn(endpoint)
+	conn, err := NewConn(Endpoint(endpoint))
 	if err != nil {
 		return nil, err
 	}
@@ -228,7 +227,7 @@ func GetAuthProviderServiceClient(endpoint string) (authprovider.ProviderAPIClie
 		return c.(authprovider.ProviderAPIClient), nil
 	}
 
-	conn, err := NewConn(endpoint)
+	conn, err := NewConn(Endpoint(endpoint))
 	if err != nil {
 		return nil, err
 	}
@@ -247,7 +246,7 @@ func GetAppAuthProviderServiceClient(endpoint string) (applicationauth.Applicati
 		return c.(applicationauth.ApplicationsAPIClient), nil
 	}
 
-	conn, err := NewConn(endpoint)
+	conn, err := NewConn(Endpoint(endpoint))
 	if err != nil {
 		return nil, err
 	}
@@ -266,7 +265,7 @@ func GetUserShareProviderClient(endpoint string) (collaboration.CollaborationAPI
 		return c.(collaboration.CollaborationAPIClient), nil
 	}
 
-	conn, err := NewConn(endpoint)
+	conn, err := NewConn(Endpoint(endpoint))
 	if err != nil {
 		return nil, err
 	}
@@ -285,7 +284,7 @@ func GetOCMShareProviderClient(endpoint string) (ocm.OcmAPIClient, error) {
 		return c.(ocm.OcmAPIClient), nil
 	}
 
-	conn, err := NewConn(endpoint)
+	conn, err := NewConn(Endpoint(endpoint))
 	if err != nil {
 		return nil, err
 	}
@@ -304,7 +303,7 @@ func GetOCMInviteManagerClient(endpoint string) (invitepb.InviteAPIClient, error
 		return c.(invitepb.InviteAPIClient), nil
 	}
 
-	conn, err := NewConn(endpoint)
+	conn, err := NewConn(Endpoint(endpoint))
 	if err != nil {
 		return nil, err
 	}
@@ -323,7 +322,7 @@ func GetPublicShareProviderClient(endpoint string) (link.LinkAPIClient, error) {
 		return c.(link.LinkAPIClient), nil
 	}
 
-	conn, err := NewConn(endpoint)
+	conn, err := NewConn(Endpoint(endpoint))
 	if err != nil {
 		return nil, err
 	}
@@ -342,7 +341,7 @@ func GetPreferencesClient(endpoint string) (preferences.PreferencesAPIClient, er
 		return c.(preferences.PreferencesAPIClient), nil
 	}
 
-	conn, err := NewConn(endpoint)
+	conn, err := NewConn(Endpoint(endpoint))
 	if err != nil {
 		return nil, err
 	}
@@ -361,7 +360,7 @@ func GetPermissionsClient(endpoint string) (permissions.PermissionsAPIClient, er
 		return c.(permissions.PermissionsAPIClient), nil
 	}
 
-	conn, err := NewConn(endpoint)
+	conn, err := NewConn(Endpoint(endpoint))
 	if err != nil {
 		return nil, err
 	}
@@ -380,7 +379,7 @@ func GetAppRegistryClient(endpoint string) (appregistry.RegistryAPIClient, error
 		return c.(appregistry.RegistryAPIClient), nil
 	}
 
-	conn, err := NewConn(endpoint)
+	conn, err := NewConn(Endpoint(endpoint))
 	if err != nil {
 		return nil, err
 	}
@@ -399,7 +398,7 @@ func GetAppProviderClient(endpoint string) (appprovider.ProviderAPIClient, error
 		return c.(appprovider.ProviderAPIClient), nil
 	}
 
-	conn, err := NewConn(endpoint)
+	conn, err := NewConn(Endpoint(endpoint))
 	if err != nil {
 		return nil, err
 	}
@@ -418,7 +417,7 @@ func GetStorageRegistryClient(endpoint string) (storageregistry.RegistryAPIClien
 		return c.(storageregistry.RegistryAPIClient), nil
 	}
 
-	conn, err := NewConn(endpoint)
+	conn, err := NewConn(Endpoint(endpoint))
 	if err != nil {
 		return nil, err
 	}
@@ -437,7 +436,7 @@ func GetOCMProviderAuthorizerClient(endpoint string) (ocmprovider.ProviderAPICli
 		return c.(ocmprovider.ProviderAPIClient), nil
 	}
 
-	conn, err := NewConn(endpoint)
+	conn, err := NewConn(Endpoint(endpoint))
 	if err != nil {
 		return nil, err
 	}
@@ -456,7 +455,7 @@ func GetOCMCoreClient(endpoint string) (ocmcore.OcmCoreAPIClient, error) {
 		return c.(ocmcore.OcmCoreAPIClient), nil
 	}
 
-	conn, err := NewConn(endpoint)
+	conn, err := NewConn(Endpoint(endpoint))
 	if err != nil {
 		return nil, err
 	}
@@ -475,7 +474,7 @@ func GetDataTxClient(endpoint string) (datatx.TxAPIClient, error) {
 		return c.(datatx.TxAPIClient), nil
 	}
 
-	conn, err := NewConn(endpoint)
+	conn, err := NewConn(Endpoint(endpoint))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/rgrpc/todo/pool/pool.go
+++ b/pkg/rgrpc/todo/pool/pool.go
@@ -1,4 +1,4 @@
-// Copyright 2018-2021 CERN
+// Copyright 2018-2022 CERN
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -86,13 +86,13 @@ var (
 // NewConn creates a new connection to a grpc server
 // with open census tracing support.
 // TODO(labkode): make grpc tls configurable.
-// TODO make maxCallRecvMsgSize configurable, raised from the default 4MB to be able to list 10k files
-func NewConn(endpoint string) (*grpc.ClientConn, error) {
+func NewConn(opts ...Option) (*grpc.ClientConn, error) {
+	options := newOptions(opts...)
 	conn, err := grpc.Dial(
-		endpoint,
+		options.Endpoint,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithDefaultCallOptions(
-			grpc.MaxCallRecvMsgSize(maxCallRecvMsgSize),
+			grpc.MaxCallRecvMsgSize(options.MaxCallRecvMsgSize),
 		),
 		grpc.WithStreamInterceptor(otelgrpc.StreamClientInterceptor(
 			otelgrpc.WithTracerProvider(

--- a/pkg/rgrpc/todo/pool/pool.go
+++ b/pkg/rgrpc/todo/pool/pool.go
@@ -140,347 +140,365 @@ func GetGatewayServiceClient(opts ...Option) (gateway.GatewayAPIClient, error) {
 }
 
 // GetUserProviderServiceClient returns a UserProviderServiceClient.
-func GetUserProviderServiceClient(endpoint string) (user.UserAPIClient, error) {
+func GetUserProviderServiceClient(opts ...Option) (user.UserAPIClient, error) {
 	userProviders.m.Lock()
 	defer userProviders.m.Unlock()
 
-	if val, ok := userProviders.conn[endpoint]; ok {
+	options := newOptions(opts...)
+	if val, ok := userProviders.conn[options.Endpoint]; ok {
 		return val.(user.UserAPIClient), nil
 	}
 
-	conn, err := NewConn(Endpoint(endpoint))
+	conn, err := NewConn(options)
 	if err != nil {
 		return nil, err
 	}
 
 	v := user.NewUserAPIClient(conn)
-	userProviders.conn[endpoint] = v
+	userProviders.conn[options.Endpoint] = v
 	return v, nil
 }
 
 // GetGroupProviderServiceClient returns a GroupProviderServiceClient.
-func GetGroupProviderServiceClient(endpoint string) (group.GroupAPIClient, error) {
+func GetGroupProviderServiceClient(opts ...Option) (group.GroupAPIClient, error) {
 	groupProviders.m.Lock()
 	defer groupProviders.m.Unlock()
 
-	if val, ok := groupProviders.conn[endpoint]; ok {
+	options := newOptions(opts...)
+	if val, ok := groupProviders.conn[options.Endpoint]; ok {
 		return val.(group.GroupAPIClient), nil
 	}
 
-	conn, err := NewConn(Endpoint(endpoint))
+	conn, err := NewConn(options)
 	if err != nil {
 		return nil, err
 	}
 
 	v := group.NewGroupAPIClient(conn)
-	groupProviders.conn[endpoint] = v
+	groupProviders.conn[options.Endpoint] = v
 	return v, nil
 }
 
 // GetStorageProviderServiceClient returns a StorageProviderServiceClient.
-func GetStorageProviderServiceClient(endpoint string) (storageprovider.ProviderAPIClient, error) {
+func GetStorageProviderServiceClient(opts ...Option) (storageprovider.ProviderAPIClient, error) {
 	storageProviders.m.Lock()
 	defer storageProviders.m.Unlock()
 
-	if c, ok := storageProviders.conn[endpoint]; ok {
+	options := newOptions(opts...)
+	if c, ok := storageProviders.conn[options.Endpoint]; ok {
 		return c.(storageprovider.ProviderAPIClient), nil
 	}
 
-	conn, err := NewConn(Endpoint(endpoint))
+	conn, err := NewConn(options)
 	if err != nil {
 		return nil, err
 	}
 
 	v := storageprovider.NewProviderAPIClient(conn)
-	storageProviders.conn[endpoint] = v
+	storageProviders.conn[options.Endpoint] = v
 	return v, nil
 }
 
 // GetAuthRegistryServiceClient returns a new AuthRegistryServiceClient.
-func GetAuthRegistryServiceClient(endpoint string) (authregistry.RegistryAPIClient, error) {
+func GetAuthRegistryServiceClient(opts ...Option) (authregistry.RegistryAPIClient, error) {
 	authRegistries.m.Lock()
 	defer authRegistries.m.Unlock()
 
 	// if there is already a connection to this node, use it.
-	if c, ok := authRegistries.conn[endpoint]; ok {
+	options := newOptions(opts...)
+	if c, ok := authRegistries.conn[options.Endpoint]; ok {
 		return c.(authregistry.RegistryAPIClient), nil
 	}
 
 	// if not, create a new connection
-	conn, err := NewConn(Endpoint(endpoint))
+	conn, err := NewConn(options)
 	if err != nil {
 		return nil, err
 	}
 
 	// and memoize it
 	v := authregistry.NewRegistryAPIClient(conn)
-	authRegistries.conn[endpoint] = v
+	authRegistries.conn[options.Endpoint] = v
 	return v, nil
 }
 
 // GetAuthProviderServiceClient returns a new AuthProviderServiceClient.
-func GetAuthProviderServiceClient(endpoint string) (authprovider.ProviderAPIClient, error) {
+func GetAuthProviderServiceClient(opts ...Option) (authprovider.ProviderAPIClient, error) {
 	authProviders.m.Lock()
 	defer authProviders.m.Unlock()
 
-	if c, ok := authProviders.conn[endpoint]; ok {
+	options := newOptions(opts...)
+	if c, ok := authProviders.conn[options.Endpoint]; ok {
 		return c.(authprovider.ProviderAPIClient), nil
 	}
 
-	conn, err := NewConn(Endpoint(endpoint))
+	conn, err := NewConn(options)
 	if err != nil {
 		return nil, err
 	}
 
 	v := authprovider.NewProviderAPIClient(conn)
-	authProviders.conn[endpoint] = v
+	authProviders.conn[options.Endpoint] = v
 	return v, nil
 }
 
 // GetAppAuthProviderServiceClient returns a new AppAuthProviderServiceClient.
-func GetAppAuthProviderServiceClient(endpoint string) (applicationauth.ApplicationsAPIClient, error) {
+func GetAppAuthProviderServiceClient(opts ...Option) (applicationauth.ApplicationsAPIClient, error) {
 	appAuthProviders.m.Lock()
 	defer appAuthProviders.m.Unlock()
 
-	if c, ok := appAuthProviders.conn[endpoint]; ok {
+	options := newOptions(opts...)
+	if c, ok := appAuthProviders.conn[options.Endpoint]; ok {
 		return c.(applicationauth.ApplicationsAPIClient), nil
 	}
 
-	conn, err := NewConn(Endpoint(endpoint))
+	conn, err := NewConn(options)
 	if err != nil {
 		return nil, err
 	}
 
 	v := applicationauth.NewApplicationsAPIClient(conn)
-	appAuthProviders.conn[endpoint] = v
+	appAuthProviders.conn[options.Endpoint] = v
 	return v, nil
 }
 
 // GetUserShareProviderClient returns a new UserShareProviderClient.
-func GetUserShareProviderClient(endpoint string) (collaboration.CollaborationAPIClient, error) {
+func GetUserShareProviderClient(opts ...Option) (collaboration.CollaborationAPIClient, error) {
 	userShareProviders.m.Lock()
 	defer userShareProviders.m.Unlock()
 
-	if c, ok := userShareProviders.conn[endpoint]; ok {
+	options := newOptions(opts...)
+	if c, ok := userShareProviders.conn[options.Endpoint]; ok {
 		return c.(collaboration.CollaborationAPIClient), nil
 	}
 
-	conn, err := NewConn(Endpoint(endpoint))
+	conn, err := NewConn(options)
 	if err != nil {
 		return nil, err
 	}
 
 	v := collaboration.NewCollaborationAPIClient(conn)
-	userShareProviders.conn[endpoint] = v
+	userShareProviders.conn[options.Endpoint] = v
 	return v, nil
 }
 
 // GetOCMShareProviderClient returns a new OCMShareProviderClient.
-func GetOCMShareProviderClient(endpoint string) (ocm.OcmAPIClient, error) {
+func GetOCMShareProviderClient(opts ...Option) (ocm.OcmAPIClient, error) {
 	ocmShareProviders.m.Lock()
 	defer ocmShareProviders.m.Unlock()
 
-	if c, ok := ocmShareProviders.conn[endpoint]; ok {
+	options := newOptions(opts...)
+	if c, ok := ocmShareProviders.conn[options.Endpoint]; ok {
 		return c.(ocm.OcmAPIClient), nil
 	}
 
-	conn, err := NewConn(Endpoint(endpoint))
+	conn, err := NewConn(options)
 	if err != nil {
 		return nil, err
 	}
 
 	v := ocm.NewOcmAPIClient(conn)
-	ocmShareProviders.conn[endpoint] = v
+	ocmShareProviders.conn[options.Endpoint] = v
 	return v, nil
 }
 
 // GetOCMInviteManagerClient returns a new OCMInviteManagerClient.
-func GetOCMInviteManagerClient(endpoint string) (invitepb.InviteAPIClient, error) {
+func GetOCMInviteManagerClient(opts ...Option) (invitepb.InviteAPIClient, error) {
 	ocmInviteManagers.m.Lock()
 	defer ocmInviteManagers.m.Unlock()
 
-	if c, ok := ocmInviteManagers.conn[endpoint]; ok {
+	options := newOptions(opts...)
+	if c, ok := ocmInviteManagers.conn[options.Endpoint]; ok {
 		return c.(invitepb.InviteAPIClient), nil
 	}
 
-	conn, err := NewConn(Endpoint(endpoint))
+	conn, err := NewConn(options)
 	if err != nil {
 		return nil, err
 	}
 
 	v := invitepb.NewInviteAPIClient(conn)
-	ocmInviteManagers.conn[endpoint] = v
+	ocmInviteManagers.conn[options.Endpoint] = v
 	return v, nil
 }
 
 // GetPublicShareProviderClient returns a new PublicShareProviderClient.
-func GetPublicShareProviderClient(endpoint string) (link.LinkAPIClient, error) {
+func GetPublicShareProviderClient(opts ...Option) (link.LinkAPIClient, error) {
 	publicShareProviders.m.Lock()
 	defer publicShareProviders.m.Unlock()
 
-	if c, ok := publicShareProviders.conn[endpoint]; ok {
+	options := newOptions(opts...)
+	if c, ok := publicShareProviders.conn[options.Endpoint]; ok {
 		return c.(link.LinkAPIClient), nil
 	}
 
-	conn, err := NewConn(Endpoint(endpoint))
+	conn, err := NewConn(options)
 	if err != nil {
 		return nil, err
 	}
 
 	v := link.NewLinkAPIClient(conn)
-	publicShareProviders.conn[endpoint] = v
+	publicShareProviders.conn[options.Endpoint] = v
 	return v, nil
 }
 
 // GetPreferencesClient returns a new PreferencesClient.
-func GetPreferencesClient(endpoint string) (preferences.PreferencesAPIClient, error) {
+func GetPreferencesClient(opts ...Option) (preferences.PreferencesAPIClient, error) {
 	preferencesProviders.m.Lock()
 	defer preferencesProviders.m.Unlock()
 
-	if c, ok := preferencesProviders.conn[endpoint]; ok {
+	options := newOptions(opts...)
+	if c, ok := preferencesProviders.conn[options.Endpoint]; ok {
 		return c.(preferences.PreferencesAPIClient), nil
 	}
 
-	conn, err := NewConn(Endpoint(endpoint))
+	conn, err := NewConn(options)
 	if err != nil {
 		return nil, err
 	}
 
 	v := preferences.NewPreferencesAPIClient(conn)
-	preferencesProviders.conn[endpoint] = v
+	preferencesProviders.conn[options.Endpoint] = v
 	return v, nil
 }
 
 // GetPermissionsClient returns a new PermissionsClient.
-func GetPermissionsClient(endpoint string) (permissions.PermissionsAPIClient, error) {
+func GetPermissionsClient(opts ...Option) (permissions.PermissionsAPIClient, error) {
 	permissionsProviders.m.Lock()
 	defer permissionsProviders.m.Unlock()
 
-	if c, ok := permissionsProviders.conn[endpoint]; ok {
+	options := newOptions(opts...)
+	if c, ok := permissionsProviders.conn[options.Endpoint]; ok {
 		return c.(permissions.PermissionsAPIClient), nil
 	}
 
-	conn, err := NewConn(Endpoint(endpoint))
+	conn, err := NewConn(options)
 	if err != nil {
 		return nil, err
 	}
 
 	v := permissions.NewPermissionsAPIClient(conn)
-	permissionsProviders.conn[endpoint] = v
+	permissionsProviders.conn[options.Endpoint] = v
 	return v, nil
 }
 
 // GetAppRegistryClient returns a new AppRegistryClient.
-func GetAppRegistryClient(endpoint string) (appregistry.RegistryAPIClient, error) {
+func GetAppRegistryClient(opts ...Option) (appregistry.RegistryAPIClient, error) {
 	appRegistries.m.Lock()
 	defer appRegistries.m.Unlock()
 
-	if c, ok := appRegistries.conn[endpoint]; ok {
+	options := newOptions(opts...)
+	if c, ok := appRegistries.conn[options.Endpoint]; ok {
 		return c.(appregistry.RegistryAPIClient), nil
 	}
 
-	conn, err := NewConn(Endpoint(endpoint))
+	conn, err := NewConn(options)
 	if err != nil {
 		return nil, err
 	}
 
 	v := appregistry.NewRegistryAPIClient(conn)
-	appRegistries.conn[endpoint] = v
+	appRegistries.conn[options.Endpoint] = v
 	return v, nil
 }
 
 // GetAppProviderClient returns a new AppRegistryClient.
-func GetAppProviderClient(endpoint string) (appprovider.ProviderAPIClient, error) {
+func GetAppProviderClient(opts ...Option) (appprovider.ProviderAPIClient, error) {
 	appProviders.m.Lock()
 	defer appProviders.m.Unlock()
 
-	if c, ok := appProviders.conn[endpoint]; ok {
+	options := newOptions(opts...)
+	if c, ok := appProviders.conn[options.Endpoint]; ok {
 		return c.(appprovider.ProviderAPIClient), nil
 	}
 
-	conn, err := NewConn(Endpoint(endpoint))
+	conn, err := NewConn(options)
 	if err != nil {
 		return nil, err
 	}
 
 	v := appprovider.NewProviderAPIClient(conn)
-	appProviders.conn[endpoint] = v
+	appProviders.conn[options.Endpoint] = v
 	return v, nil
 }
 
 // GetStorageRegistryClient returns a new StorageRegistryClient.
-func GetStorageRegistryClient(endpoint string) (storageregistry.RegistryAPIClient, error) {
+func GetStorageRegistryClient(opts ...Option) (storageregistry.RegistryAPIClient, error) {
 	storageRegistries.m.Lock()
 	defer storageRegistries.m.Unlock()
 
-	if c, ok := storageRegistries.conn[endpoint]; ok {
+	options := newOptions(opts...)
+	if c, ok := storageRegistries.conn[options.Endpoint]; ok {
 		return c.(storageregistry.RegistryAPIClient), nil
 	}
 
-	conn, err := NewConn(Endpoint(endpoint))
+	conn, err := NewConn(options)
 	if err != nil {
 		return nil, err
 	}
 
 	v := storageregistry.NewRegistryAPIClient(conn)
-	storageRegistries.conn[endpoint] = v
+	storageRegistries.conn[options.Endpoint] = v
 	return v, nil
 }
 
 // GetOCMProviderAuthorizerClient returns a new OCMProviderAuthorizerClient.
-func GetOCMProviderAuthorizerClient(endpoint string) (ocmprovider.ProviderAPIClient, error) {
+func GetOCMProviderAuthorizerClient(opts ...Option) (ocmprovider.ProviderAPIClient, error) {
 	ocmProviderAuthorizers.m.Lock()
 	defer ocmProviderAuthorizers.m.Unlock()
 
-	if c, ok := ocmProviderAuthorizers.conn[endpoint]; ok {
+	options := newOptions(opts...)
+	if c, ok := ocmProviderAuthorizers.conn[options.Endpoint]; ok {
 		return c.(ocmprovider.ProviderAPIClient), nil
 	}
 
-	conn, err := NewConn(Endpoint(endpoint))
+	conn, err := NewConn(options)
 	if err != nil {
 		return nil, err
 	}
 
 	v := ocmprovider.NewProviderAPIClient(conn)
-	ocmProviderAuthorizers.conn[endpoint] = v
+	ocmProviderAuthorizers.conn[options.Endpoint] = v
 	return v, nil
 }
 
 // GetOCMCoreClient returns a new OCMCoreClient.
-func GetOCMCoreClient(endpoint string) (ocmcore.OcmCoreAPIClient, error) {
+func GetOCMCoreClient(opts ...Option) (ocmcore.OcmCoreAPIClient, error) {
 	ocmCores.m.Lock()
 	defer ocmCores.m.Unlock()
 
-	if c, ok := ocmCores.conn[endpoint]; ok {
+	options := newOptions(opts...)
+	if c, ok := ocmCores.conn[options.Endpoint]; ok {
 		return c.(ocmcore.OcmCoreAPIClient), nil
 	}
 
-	conn, err := NewConn(Endpoint(endpoint))
+	conn, err := NewConn(options)
 	if err != nil {
 		return nil, err
 	}
 
 	v := ocmcore.NewOcmCoreAPIClient(conn)
-	ocmCores.conn[endpoint] = v
+	ocmCores.conn[options.Endpoint] = v
 	return v, nil
 }
 
 // GetDataTxClient returns a new DataTxClient.
-func GetDataTxClient(endpoint string) (datatx.TxAPIClient, error) {
+func GetDataTxClient(opts ...Option) (datatx.TxAPIClient, error) {
 	dataTxs.m.Lock()
 	defer dataTxs.m.Unlock()
 
-	if c, ok := dataTxs.conn[endpoint]; ok {
+	options := newOptions(opts...)
+	if c, ok := dataTxs.conn[options.Endpoint]; ok {
 		return c.(datatx.TxAPIClient), nil
 	}
 
-	conn, err := NewConn(Endpoint(endpoint))
+	conn, err := NewConn(options)
 	if err != nil {
 		return nil, err
 	}
 
 	v := datatx.NewTxAPIClient(conn)
-	dataTxs.conn[endpoint] = v
+	dataTxs.conn[options.Endpoint] = v
 	return v, nil
 }
 

--- a/pkg/share/cache/warmup/cbox/cbox.go
+++ b/pkg/share/cache/warmup/cbox/cbox.go
@@ -119,7 +119,7 @@ func (m *manager) GetResourceInfos() ([]*provider.ResourceInfo, error) {
 	}
 	ctx := metadata.AppendToOutgoingContext(context.Background(), ctxpkg.TokenHeader, tkn)
 
-	client, err := pool.GetGatewayServiceClient(m.conf.GatewaySvc)
+	client, err := pool.GetGatewayServiceClient(pool.Endpoint(m.conf.GatewaySvc))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/share/manager/sql/conversions.go
+++ b/pkg/share/manager/sql/conversions.go
@@ -74,7 +74,7 @@ func NewGatewayUserConverter(gwAddr string) *GatewayUserConverter {
 
 // UserIDToUserName converts a user ID to an username
 func (c *GatewayUserConverter) UserIDToUserName(ctx context.Context, userid *userpb.UserId) (string, error) {
-	gwConn, err := pool.GetGatewayServiceClient(c.gwAddr)
+	gwConn, err := pool.GetGatewayServiceClient(pool.Endpoint(c.gwAddr))
 	if err != nil {
 		return "", err
 	}
@@ -93,7 +93,7 @@ func (c *GatewayUserConverter) UserIDToUserName(ctx context.Context, userid *use
 
 // UserNameToUserID converts a username to an user ID
 func (c *GatewayUserConverter) UserNameToUserID(ctx context.Context, username string) (*userpb.UserId, error) {
-	gwConn, err := pool.GetGatewayServiceClient(c.gwAddr)
+	gwConn, err := pool.GetGatewayServiceClient(pool.Endpoint(c.gwAddr))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/storage/fs/owncloud/owncloud.go
+++ b/pkg/storage/fs/owncloud/owncloud.go
@@ -485,7 +485,7 @@ func (fs *ocfs) getUser(ctx context.Context, usernameOrID string) (id *userpb.Us
 	// look up at the userprovider
 
 	// parts[0] contains the username or userid. use  user service to look up id
-	c, err := pool.GetUserProviderServiceClient(fs.c.UserProviderEndpoint)
+	c, err := pool.GetUserProviderServiceClient(pool.Endpoint(fs.c.UserProviderEndpoint))
 	if err != nil {
 		appctx.GetLogger(ctx).
 			Error().Err(err).

--- a/pkg/storage/fs/owncloudsql/owncloudsql.go
+++ b/pkg/storage/fs/owncloudsql/owncloudsql.go
@@ -370,7 +370,7 @@ func (fs *owncloudsqlfs) getUser(ctx context.Context, usernameOrID string) (id *
 	// look up at the userprovider
 
 	// parts[0] contains the username or userid. use  user service to look up id
-	c, err := pool.GetUserProviderServiceClient(fs.c.UserProviderEndpoint)
+	c, err := pool.GetUserProviderServiceClient(pool.Endpoint(fs.c.UserProviderEndpoint))
 	if err != nil {
 		appctx.GetLogger(ctx).
 			Error().Err(err).

--- a/pkg/storage/utils/decomposedfs/spaces.go
+++ b/pkg/storage/utils/decomposedfs/spaces.go
@@ -202,7 +202,7 @@ func (fs *Decomposedfs) ListStorageSpaces(ctx context.Context, filter []*provide
 		return spaces, nil
 	}
 
-	client, err := pool.GetGatewayServiceClient(fs.o.GatewayAddr)
+	client, err := pool.GetGatewayServiceClient(pool.Endpoint(fs.o.GatewayAddr))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/storage/utils/eosfs/eosfs.go
+++ b/pkg/storage/utils/eosfs/eosfs.go
@@ -817,7 +817,7 @@ func (fs *eosfs) SetLock(ctx context.Context, ref *provider.Reference, l *provid
 }
 
 func (fs *eosfs) getUserFromID(ctx context.Context, userID *userpb.UserId) (*userpb.User, error) {
-	client, err := pool.GetGatewayServiceClient(fs.conf.GatewaySvc)
+	client, err := pool.GetGatewayServiceClient(pool.Endpoint(fs.conf.GatewaySvc))
 	if err != nil {
 		return nil, err
 	}
@@ -2211,7 +2211,7 @@ func (fs *eosfs) getUIDGateway(ctx context.Context, u *userpb.UserId) (eosclient
 		return fs.extractUIDAndGID(userIDInterface.(*userpb.User))
 	}
 
-	client, err := pool.GetGatewayServiceClient(fs.conf.GatewaySvc)
+	client, err := pool.GetGatewayServiceClient(pool.Endpoint(fs.conf.GatewaySvc))
 	if err != nil {
 		return eosclient.Authorization{}, errors.Wrap(err, "eosfs: error getting gateway grpc client")
 	}
@@ -2245,7 +2245,7 @@ func (fs *eosfs) getUserIDGateway(ctx context.Context, uid string) (*userpb.User
 	}
 
 	log.Debug().Msg("eosfs: retrieving user from gateway for uid " + uid)
-	client, err := pool.GetGatewayServiceClient(fs.conf.GatewaySvc)
+	client, err := pool.GetGatewayServiceClient(pool.Endpoint(fs.conf.GatewaySvc))
 	if err != nil {
 		return nil, errors.Wrap(err, "eosfs: error getting gateway grpc client")
 	}

--- a/tests/integration/grpc/storageprovider_test.go
+++ b/tests/integration/grpc/storageprovider_test.go
@@ -91,7 +91,7 @@ var _ = Describe("storage providers", func() {
 
 		revads, err = startRevads(dependencies, variables)
 		Expect(err).ToNot(HaveOccurred())
-		serviceClient, err = pool.GetStorageProviderServiceClient(revads["storage"].GrpcAddress)
+		serviceClient, err = pool.GetStorageProviderServiceClient(pool.Endpoint(revads["storage"].GrpcAddress))
 		Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/tests/integration/grpc/userprovider_test.go
+++ b/tests/integration/grpc/userprovider_test.go
@@ -68,7 +68,7 @@ var _ = Describe("user providers", func() {
 
 		revads, err = startRevads(dependencies, map[string]string{})
 		Expect(err).ToNot(HaveOccurred())
-		serviceClient, err = pool.GetUserProviderServiceClient(revads["users"].GrpcAddress)
+		serviceClient, err = pool.GetUserProviderServiceClient(pool.Endpoint(revads["users"].GrpcAddress))
 		Expect(err).ToNot(HaveOccurred())
 	})
 


### PR DESCRIPTION
Refactored and introduced functional options to `pkg/pool`. This will aid more flexible configuration for the client side gRPC connections. 