### PR TITLE
Add custom mimetypes config to the app provider

### DIFF
--- a/changelog/unreleased/custom-mime-appprovider.md
+++ b/changelog/unreleased/custom-mime-appprovider.md
@@ -1,0 +1,6 @@
+Enhancement: support custom mimetypes in the WOPI appprovider driver
+
+Similarly to the storage provider, also the WOPI appprovider driver
+now supports custom mime types. Also fixed a small typo.
+
+https://github.com/cs3org/reva/pull/2813

--- a/examples/nextcloud-integration/revad.toml
+++ b/examples/nextcloud-integration/revad.toml
@@ -73,6 +73,7 @@ iop_secret = "hello"
 wopi_url = "http://0.0.0.0:8880/"
 app_name = "Collabora"
 app_url = "https://your-collabora-server.org:9980"
+custom_mime_types_json = "custom-mime-types-demo.json"
 
 [grpc.services.appregistry]
 driver = "static"

--- a/internal/grpc/services/storageprovider/storageprovider.go
+++ b/internal/grpc/services/storageprovider/storageprovider.go
@@ -63,7 +63,7 @@ type config struct {
 	DataServerURL       string                            `mapstructure:"data_server_url" docs:"http://localhost/data;The URL for the data server."`
 	ExposeDataServer    bool                              `mapstructure:"expose_data_server" docs:"false;Whether to expose data server."` // if true the client will be able to upload/download directly to it
 	AvailableXS         map[string]uint32                 `mapstructure:"available_checksums" docs:"nil;List of available checksums."`
-	CustomMimeTypesJSON string                            `mapstructure:"custom_mimetypes_json" docs:"nil;An optional mapping file with the list of supported custom file extensions and corresponding mime types."`
+	CustomMimeTypesJSON string                            `mapstructure:"custom_mime_types_json" docs:"nil;An optional mapping file with the list of supported custom file extensions and corresponding mime types."`
 }
 
 func (c *config) init() {


### PR DESCRIPTION
Same as for the storage provider, this adds the ability to configure custom mimetypes to ext mappings for the WOPI app provider.

If it needs to be moved "up" at the appprovider level, it can be done at a later stage. For now this only affects the WOPI driver as it is extension-based, whereas the appprovider is mimetype-based in general.