### PR TITLE
[tests-only] Only delete flock if file is no longer locked

### DIFF
--- a/pkg/storage/utils/filelocks/filelocks.go
+++ b/pkg/storage/utils/filelocks/filelocks.go
@@ -140,7 +140,9 @@ func ReleaseLock(lock *flock.Flock) error {
 
 	err = lock.Unlock()
 	if err == nil {
-		err = os.Remove(n)
+		if !lock.Locked() {
+			err = os.Remove(n)
+		}
 	}
 	releaseMutexedFlock(n)
 


### PR DESCRIPTION
Running multiple uploads of small files would sometimes result in random `404` errors. The reason for that is that the file lock removes the `flock` file after it is released. Having multiple threads `ReadLocking` the file would make the first routine that is done removing the file, but concurrent ones would fail the remove with "File not found" (because it was already deleted)

Simple solution is to only delete the file if the file is no longer locked. this solution holds some uncertainty as we don't know how fast `lock.Locked()` reacts after `lock.Lock()` or `lock.Unlock()` is called