### PR TITLE
Instrument with HTTP and GRPC requests with Otel

### DIFF
--- a/changelog/unreleased/instrument-with-otel.md
+++ b/changelog/unreleased/instrument-with-otel.md
@@ -1,0 +1,7 @@
+Enhancement: Instrument GRPC and HTTP requests with OTel
+
+We've added the enduser.id tag to the HTTP and GRPC requests.
+We've fixed the tracer names.
+We've decorated the traces with the hostname.
+
+https://github.com/cs3org/reva/pull/2820

--- a/internal/grpc/interceptors/appctx/appctx.go
+++ b/internal/grpc/interceptors/appctx/appctx.go
@@ -28,13 +28,16 @@ import (
 	"google.golang.org/grpc"
 )
 
+// name is the Tracer name used to identify this instrumentation library.
+const tracerName = "appctx"
+
 // NewUnary returns a new unary interceptor that creates the application context.
 func NewUnary(log zerolog.Logger) grpc.UnaryServerInterceptor {
 	interceptor := func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
 		span := trace.SpanFromContext(ctx)
 		defer span.End()
 		if !span.SpanContext().HasTraceID() {
-			ctx, span = rtrace.Provider.Tracer("grpc").Start(ctx, "grpc unary")
+			ctx, span = rtrace.Provider.Tracer(tracerName).Start(ctx, "grpc unary")
 		}
 
 		sub := log.With().Str("traceid", span.SpanContext().TraceID().String()).Logger()
@@ -54,7 +57,7 @@ func NewStream(log zerolog.Logger) grpc.StreamServerInterceptor {
 		defer span.End()
 
 		if !span.SpanContext().HasTraceID() {
-			ctx, span = rtrace.Provider.Tracer("grpc").Start(ctx, "grpc stream")
+			ctx, span = rtrace.Provider.Tracer(tracerName).Start(ctx, "grpc stream")
 		}
 
 		sub := log.With().Str("traceid", span.SpanContext().TraceID().String()).Logger()

--- a/internal/grpc/interceptors/appctx/appctx.go
+++ b/internal/grpc/interceptors/appctx/appctx.go
@@ -20,10 +20,12 @@ package appctx
 
 import (
 	"context"
+	"runtime"
 
 	"github.com/cs3org/reva/pkg/appctx"
 	rtrace "github.com/cs3org/reva/pkg/trace"
 	"github.com/rs/zerolog"
+	semconv "go.opentelemetry.io/otel/semconv/v1.10.0"
 	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc"
 )
@@ -38,6 +40,10 @@ func NewUnary(log zerolog.Logger) grpc.UnaryServerInterceptor {
 		defer span.End()
 		if !span.SpanContext().HasTraceID() {
 			ctx, span = rtrace.Provider.Tracer(tracerName).Start(ctx, "grpc unary")
+		}
+		_, file, _, ok := runtime.Caller(1)
+		if ok {
+			span.SetAttributes(semconv.CodeFilepathKey.String(file))
 		}
 
 		sub := log.With().Str("traceid", span.SpanContext().TraceID().String()).Logger()
@@ -58,6 +64,10 @@ func NewStream(log zerolog.Logger) grpc.StreamServerInterceptor {
 
 		if !span.SpanContext().HasTraceID() {
 			ctx, span = rtrace.Provider.Tracer(tracerName).Start(ctx, "grpc stream")
+		}
+		_, file, _, ok := runtime.Caller(1)
+		if ok {
+			span.SetAttributes(semconv.CodeFilepathKey.String(file))
 		}
 
 		sub := log.With().Str("traceid", span.SpanContext().TraceID().String()).Logger()

--- a/internal/grpc/interceptors/auth/auth.go
+++ b/internal/grpc/interceptors/auth/auth.go
@@ -33,13 +33,19 @@ import (
 	"github.com/cs3org/reva/pkg/sharedconf"
 	"github.com/cs3org/reva/pkg/token"
 	tokenmgr "github.com/cs3org/reva/pkg/token/manager/registry"
+	rtrace "github.com/cs3org/reva/pkg/trace"
 	"github.com/cs3org/reva/pkg/utils"
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
+	semconv "go.opentelemetry.io/otel/semconv/v1.10.0"
+	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
+
+// name is the Tracer name used to identify this instrumentation library.
+const tracerName = "auth"
 
 var userGroupsCache gcache.Cache
 var scopeExpansionCache gcache.Cache
@@ -91,6 +97,12 @@ func NewUnary(m map[string]interface{}, unprotected []string) (grpc.UnaryServerI
 	interceptor := func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
 		log := appctx.GetLogger(ctx)
 
+		span := trace.SpanFromContext(ctx)
+		defer span.End()
+		if !span.SpanContext().HasTraceID() {
+			ctx, span = rtrace.Provider.Tracer(tracerName).Start(ctx, "grpc auth unary")
+		}
+
 		if utils.Skip(info.FullMethod, unprotected) {
 			log.Debug().Str("method", info.FullMethod).Msg("skipping auth")
 
@@ -101,6 +113,7 @@ func NewUnary(m map[string]interface{}, unprotected []string) (grpc.UnaryServerI
 				u, err := dismantleToken(ctx, tkn, req, tokenManager, conf.GatewayAddr, true)
 				if err == nil {
 					ctx = ctxpkg.ContextSetUser(ctx, u)
+					span.SetAttributes(semconv.EnduserIDKey.String(u.Id.OpaqueId))
 				}
 			}
 			return handler(ctx, req)
@@ -121,6 +134,9 @@ func NewUnary(m map[string]interface{}, unprotected []string) (grpc.UnaryServerI
 		}
 
 		ctx = ctxpkg.ContextSetUser(ctx, u)
+
+		span.SetAttributes(semconv.EnduserIDKey.String(u.Id.OpaqueId))
+
 		return handler(ctx, req)
 	}
 	return interceptor, nil
@@ -155,6 +171,12 @@ func NewStream(m map[string]interface{}, unprotected []string) (grpc.StreamServe
 		ctx := ss.Context()
 		log := appctx.GetLogger(ctx)
 
+		span := trace.SpanFromContext(ctx)
+		defer span.End()
+		if !span.SpanContext().HasTraceID() {
+			ctx, span = rtrace.Provider.Tracer(tracerName).Start(ctx, "grpc auth new stream")
+		}
+
 		if utils.Skip(info.FullMethod, unprotected) {
 			log.Debug().Str("method", info.FullMethod).Msg("skipping auth")
 
@@ -166,6 +188,8 @@ func NewStream(m map[string]interface{}, unprotected []string) (grpc.StreamServe
 				if err == nil {
 					ctx = ctxpkg.ContextSetUser(ctx, u)
 					ss = newWrappedServerStream(ctx, ss)
+
+					span.SetAttributes(semconv.EnduserIDKey.String(u.Id.OpaqueId))
 				}
 			}
 
@@ -189,6 +213,9 @@ func NewStream(m map[string]interface{}, unprotected []string) (grpc.StreamServe
 		// store user and core access token in context.
 		ctx = ctxpkg.ContextSetUser(ctx, u)
 		wrapped := newWrappedServerStream(ctx, ss)
+
+		span.SetAttributes(semconv.EnduserIDKey.String(u.Id.OpaqueId))
+
 		return handler(srv, wrapped)
 	}
 	return interceptor, nil

--- a/internal/grpc/services/gateway/storageprovider.go
+++ b/internal/grpc/services/gateway/storageprovider.go
@@ -52,6 +52,9 @@ import (
 	gstatus "google.golang.org/grpc/status"
 )
 
+// name is the Tracer name used to identify this instrumentation library.
+const tracerName = "gateway"
+
 // transferClaims are custom claims for a JWT token to be used between the metadata and data gateways.
 type transferClaims struct {
 	jwt.StandardClaims
@@ -883,7 +886,7 @@ func (s *svc) Delete(ctx context.Context, req *provider.DeleteRequest) (*provide
 		}, nil
 	}
 
-	ctx, span := rtrace.Provider.Tracer("reva").Start(ctx, "Delete")
+	ctx, span := rtrace.Provider.Tracer(tracerName).Start(ctx, "Delete")
 	defer span.End()
 
 	if !s.inSharedFolder(ctx, p) {

--- a/internal/grpc/services/publicstorageprovider/publicstorageprovider.go
+++ b/internal/grpc/services/publicstorageprovider/publicstorageprovider.go
@@ -44,6 +44,9 @@ import (
 	gstatus "google.golang.org/grpc/status"
 )
 
+// name is the Tracer name used to identify this instrumentation library.
+const tracerName = "publicstorageprovider"
+
 func init() {
 	rgrpc.Register("publicstorageprovider", New)
 }
@@ -344,7 +347,7 @@ func (s *service) DeleteStorageSpace(ctx context.Context, req *provider.DeleteSt
 }
 
 func (s *service) CreateContainer(ctx context.Context, req *provider.CreateContainerRequest) (*provider.CreateContainerResponse, error) {
-	ctx, span := rtrace.Provider.Tracer("publicstorageprovider").Start(ctx, "CreateContainer")
+	ctx, span := rtrace.Provider.Tracer(tracerName).Start(ctx, "CreateContainer")
 	defer span.End()
 
 	span.SetAttributes(attribute.KeyValue{
@@ -397,7 +400,7 @@ func (s *service) TouchFile(ctx context.Context, req *provider.TouchFileRequest)
 }
 
 func (s *service) Delete(ctx context.Context, req *provider.DeleteRequest) (*provider.DeleteResponse, error) {
-	ctx, span := rtrace.Provider.Tracer("publicstorageprovider").Start(ctx, "Delete")
+	ctx, span := rtrace.Provider.Tracer(tracerName).Start(ctx, "Delete")
 	defer span.End()
 
 	span.SetAttributes(attribute.KeyValue{
@@ -437,7 +440,7 @@ func (s *service) Delete(ctx context.Context, req *provider.DeleteRequest) (*pro
 }
 
 func (s *service) Move(ctx context.Context, req *provider.MoveRequest) (*provider.MoveResponse, error) {
-	ctx, span := rtrace.Provider.Tracer("publicstorageprovider").Start(ctx, "Move")
+	ctx, span := rtrace.Provider.Tracer(tracerName).Start(ctx, "Move")
 	defer span.End()
 
 	span.SetAttributes(
@@ -500,7 +503,7 @@ func (s *service) Move(ctx context.Context, req *provider.MoveRequest) (*provide
 }
 
 func (s *service) Stat(ctx context.Context, req *provider.StatRequest) (*provider.StatResponse, error) {
-	ctx, span := rtrace.Provider.Tracer("publicstorageprovider").Start(ctx, "Stat")
+	ctx, span := rtrace.Provider.Tracer(tracerName).Start(ctx, "Stat")
 	defer span.End()
 
 	span.SetAttributes(

--- a/internal/grpc/services/storageprovider/storageprovider.go
+++ b/internal/grpc/services/storageprovider/storageprovider.go
@@ -50,6 +50,9 @@ import (
 	"google.golang.org/grpc"
 )
 
+// name is the Tracer name used to identify this instrumentation library.
+const tracerName = "storageprovider"
+
 func init() {
 	rgrpc.Register("storageprovider", New)
 }
@@ -787,7 +790,7 @@ func (s *service) Move(ctx context.Context, req *provider.MoveRequest) (*provide
 }
 
 func (s *service) Stat(ctx context.Context, req *provider.StatRequest) (*provider.StatResponse, error) {
-	ctx, span := rtrace.Provider.Tracer("reva").Start(ctx, "stat")
+	ctx, span := rtrace.Provider.Tracer(tracerName).Start(ctx, "stat")
 	defer span.End()
 
 	span.SetAttributes(attribute.KeyValue{

--- a/internal/http/interceptors/appctx/appctx.go
+++ b/internal/http/interceptors/appctx/appctx.go
@@ -30,6 +30,9 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
+// name is the Tracer name used to identify this instrumentation library.
+const tracerName = "appctx"
+
 // New returns a new HTTP middleware that stores the log
 // in the context with request ID information.
 func New(log zerolog.Logger) func(http.Handler) http.Handler {
@@ -46,7 +49,7 @@ func handler(log zerolog.Logger, h http.Handler) http.Handler {
 		span := trace.SpanFromContext(ctx)
 		defer span.End()
 		if !span.SpanContext().HasTraceID() {
-			ctx, span = rtrace.Provider.Tracer("http").Start(ctx, "http interceptor")
+			ctx, span = rtrace.Provider.Tracer(tracerName).Start(ctx, "http interceptor")
 		}
 
 		sub := log.With().Str("traceid", span.SpanContext().TraceID().String()).Logger()

--- a/internal/http/interceptors/auth/auth.go
+++ b/internal/http/interceptors/auth/auth.go
@@ -43,12 +43,18 @@ import (
 	"github.com/cs3org/reva/pkg/sharedconf"
 	"github.com/cs3org/reva/pkg/token"
 	tokenmgr "github.com/cs3org/reva/pkg/token/manager/registry"
+	rtrace "github.com/cs3org/reva/pkg/trace"
 	"github.com/cs3org/reva/pkg/utils"
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
+	semconv "go.opentelemetry.io/otel/semconv/v1.10.0"
+	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc/metadata"
 )
+
+// name is the Tracer name used to identify this instrumentation library.
+const tracerName = "auth"
 
 var userGroupsCache gcache.Cache
 
@@ -158,6 +164,13 @@ func New(m map[string]interface{}, unprotected []string) (global.Middleware, err
 			// OPTION requests need to pass for preflight requests
 			// TODO(labkode): this will break options for auth protected routes.
 			// Maybe running the CORS middleware before auth kicks in is enough.
+			ctx := r.Context()
+			span := trace.SpanFromContext(ctx)
+			defer span.End()
+			if !span.SpanContext().HasTraceID() {
+				_, span = rtrace.Provider.Tracer(tracerName).Start(ctx, "http auth interceptor")
+			}
+
 			if r.Method == "OPTIONS" {
 				h.ServeHTTP(w, r)
 				return
@@ -182,6 +195,11 @@ func New(m map[string]interface{}, unprotected []string) (global.Middleware, err
 				r = r.WithContext(ctx)
 			}
 			h.ServeHTTP(w, r)
+
+			u, ok := ctxpkg.ContextGetUser(ctx)
+			if ok {
+				span.SetAttributes(semconv.EnduserIDKey.String(u.Id.OpaqueId))
+			}
 		})
 	}
 	return chain, nil

--- a/internal/http/services/owncloud/ocdav/copy.go
+++ b/internal/http/services/owncloud/ocdav/copy.go
@@ -49,7 +49,7 @@ type copy struct {
 type intermediateDirRefFunc func() (*provider.Reference, *rpc.Status, error)
 
 func (s *svc) handlePathCopy(w http.ResponseWriter, r *http.Request, ns string) {
-	ctx, span := rtrace.Provider.Tracer("reva").Start(r.Context(), "copy")
+	ctx, span := rtrace.Provider.Tracer(tracerName).Start(r.Context(), "copy")
 	defer span.End()
 
 	if s.c.EnableHTTPTpc {
@@ -274,7 +274,7 @@ func (s *svc) executePathCopy(ctx context.Context, client gateway.GatewayAPIClie
 }
 
 func (s *svc) handleSpacesCopy(w http.ResponseWriter, r *http.Request, spaceID string) {
-	ctx, span := rtrace.Provider.Tracer("reva").Start(r.Context(), "spaces_copy")
+	ctx, span := rtrace.Provider.Tracer(tracerName).Start(r.Context(), "spaces_copy")
 	defer span.End()
 
 	dst, err := extractDestination(r)

--- a/internal/http/services/owncloud/ocdav/delete.go
+++ b/internal/http/services/owncloud/ocdav/delete.go
@@ -47,7 +47,7 @@ func (s *svc) handleDelete(ctx context.Context, w http.ResponseWriter, r *http.R
 		return
 	}
 
-	ctx, span := rtrace.Provider.Tracer("reva").Start(ctx, "delete")
+	ctx, span := rtrace.Provider.Tracer(tracerName).Start(ctx, "delete")
 	defer span.End()
 
 	req := &provider.DeleteRequest{Ref: ref}
@@ -96,7 +96,7 @@ func (s *svc) handleDelete(ctx context.Context, w http.ResponseWriter, r *http.R
 
 func (s *svc) handleSpacesDelete(w http.ResponseWriter, r *http.Request, spaceID string) {
 	ctx := r.Context()
-	ctx, span := rtrace.Provider.Tracer("reva").Start(ctx, "spaces_delete")
+	ctx, span := rtrace.Provider.Tracer(tracerName).Start(ctx, "spaces_delete")
 	defer span.End()
 
 	sublog := appctx.GetLogger(ctx).With().Logger()

--- a/internal/http/services/owncloud/ocdav/get.go
+++ b/internal/http/services/owncloud/ocdav/get.go
@@ -41,7 +41,7 @@ import (
 )
 
 func (s *svc) handlePathGet(w http.ResponseWriter, r *http.Request, ns string) {
-	ctx, span := rtrace.Provider.Tracer("reva").Start(r.Context(), "get")
+	ctx, span := rtrace.Provider.Tracer(tracerName).Start(r.Context(), "get")
 	defer span.End()
 
 	fn := path.Join(ns, r.URL.Path)
@@ -160,7 +160,7 @@ func (s *svc) handleGet(ctx context.Context, w http.ResponseWriter, r *http.Requ
 }
 
 func (s *svc) handleSpacesGet(w http.ResponseWriter, r *http.Request, spaceID string) {
-	ctx, span := rtrace.Provider.Tracer("reva").Start(r.Context(), "spaces_get")
+	ctx, span := rtrace.Provider.Tracer(tracerName).Start(r.Context(), "spaces_get")
 	defer span.End()
 
 	sublog := appctx.GetLogger(ctx).With().Str("path", r.URL.Path).Str("spaceid", spaceID).Str("handler", "get").Logger()

--- a/internal/http/services/owncloud/ocdav/head.go
+++ b/internal/http/services/owncloud/ocdav/head.go
@@ -39,7 +39,7 @@ import (
 )
 
 func (s *svc) handlePathHead(w http.ResponseWriter, r *http.Request, ns string) {
-	ctx, span := rtrace.Provider.Tracer("reva").Start(r.Context(), "head")
+	ctx, span := rtrace.Provider.Tracer(tracerName).Start(r.Context(), "head")
 	defer span.End()
 
 	fn := path.Join(ns, r.URL.Path)
@@ -90,7 +90,7 @@ func (s *svc) handleHead(ctx context.Context, w http.ResponseWriter, r *http.Req
 }
 
 func (s *svc) handleSpacesHead(w http.ResponseWriter, r *http.Request, spaceID string) {
-	ctx, span := rtrace.Provider.Tracer("reva").Start(r.Context(), "spaces_head")
+	ctx, span := rtrace.Provider.Tracer(tracerName).Start(r.Context(), "spaces_head")
 	defer span.End()
 
 	sublog := appctx.GetLogger(ctx).With().Str("spaceid", spaceID).Str("path", r.URL.Path).Logger()

--- a/internal/http/services/owncloud/ocdav/mkcol.go
+++ b/internal/http/services/owncloud/ocdav/mkcol.go
@@ -32,7 +32,7 @@ import (
 )
 
 func (s *svc) handlePathMkcol(w http.ResponseWriter, r *http.Request, ns string) {
-	ctx, span := rtrace.Provider.Tracer("reva").Start(r.Context(), "mkcol")
+	ctx, span := rtrace.Provider.Tracer(tracerName).Start(r.Context(), "mkcol")
 	defer span.End()
 
 	fn := path.Join(ns, r.URL.Path)
@@ -51,7 +51,7 @@ func (s *svc) handlePathMkcol(w http.ResponseWriter, r *http.Request, ns string)
 }
 
 func (s *svc) handleSpacesMkCol(w http.ResponseWriter, r *http.Request, spaceID string) {
-	ctx, span := rtrace.Provider.Tracer("reva").Start(r.Context(), "spaces_mkcol")
+	ctx, span := rtrace.Provider.Tracer(tracerName).Start(r.Context(), "spaces_mkcol")
 	defer span.End()
 
 	sublog := appctx.GetLogger(ctx).With().Str("path", r.URL.Path).Str("spaceid", spaceID).Str("handler", "mkcol").Logger()

--- a/internal/http/services/owncloud/ocdav/move.go
+++ b/internal/http/services/owncloud/ocdav/move.go
@@ -35,7 +35,7 @@ import (
 )
 
 func (s *svc) handlePathMove(w http.ResponseWriter, r *http.Request, ns string) {
-	ctx, span := rtrace.Provider.Tracer("ocdav").Start(r.Context(), "move")
+	ctx, span := rtrace.Provider.Tracer(tracerName).Start(r.Context(), "move")
 	defer span.End()
 
 	srcPath := path.Join(ns, r.URL.Path)
@@ -67,7 +67,7 @@ func (s *svc) handlePathMove(w http.ResponseWriter, r *http.Request, ns string) 
 }
 
 func (s *svc) handleSpacesMove(w http.ResponseWriter, r *http.Request, srcSpaceID string) {
-	ctx, span := rtrace.Provider.Tracer("ocdav").Start(r.Context(), "spaces_move")
+	ctx, span := rtrace.Provider.Tracer(tracerName).Start(r.Context(), "spaces_move")
 	defer span.End()
 
 	dst, err := extractDestination(r)

--- a/internal/http/services/owncloud/ocdav/ocdav.go
+++ b/internal/http/services/owncloud/ocdav/ocdav.go
@@ -51,6 +51,9 @@ type ctxKey int
 
 const (
 	ctxKeyBaseURI ctxKey = iota
+
+	// name is the Tracer name used to identify this instrumentation library.
+	tracerName = "ocdav"
 )
 
 var (

--- a/internal/http/services/owncloud/ocdav/propfind.go
+++ b/internal/http/services/owncloud/ocdav/propfind.go
@@ -68,10 +68,11 @@ const (
 
 // ns is the namespace that is prefixed to the path in the cs3 namespace
 func (s *svc) handlePathPropfind(w http.ResponseWriter, r *http.Request, ns string) {
-	ctx, span := rtrace.Provider.Tracer("reva").Start(r.Context(), fmt.Sprintf("%s %v", r.Method, r.URL.Path))
+	ctx, span := rtrace.Provider.Tracer(tracerName).Start(r.Context(), "path_propfind")
 	defer span.End()
 
-	span.SetAttributes(attribute.String("component", "ocdav"))
+	span.SetAttributes(attribute.String("http_request_method", r.Method))
+	span.SetAttributes(attribute.String("http_request_url_method", r.URL.Path))
 
 	fn := path.Join(ns, r.URL.Path)
 
@@ -95,7 +96,7 @@ func (s *svc) handlePathPropfind(w http.ResponseWriter, r *http.Request, ns stri
 }
 
 func (s *svc) handleSpacesPropfind(w http.ResponseWriter, r *http.Request, spaceID string) {
-	ctx, span := rtrace.Provider.Tracer("ocdav").Start(r.Context(), "spaces_propfind")
+	ctx, span := rtrace.Provider.Tracer(tracerName).Start(r.Context(), "spaces_propfind")
 	defer span.End()
 
 	sublog := appctx.GetLogger(ctx).With().Str("path", r.URL.Path).Str("spaceid", spaceID).Logger()
@@ -143,7 +144,7 @@ func (s *svc) handleSpacesPropfind(w http.ResponseWriter, r *http.Request, space
 }
 
 func (s *svc) propfindResponse(ctx context.Context, w http.ResponseWriter, r *http.Request, namespace string, pf propfindXML, parentInfo *provider.ResourceInfo, resourceInfos []*provider.ResourceInfo, log zerolog.Logger) {
-	ctx, span := rtrace.Provider.Tracer("ocdav").Start(ctx, "propfind_response")
+	ctx, span := rtrace.Provider.Tracer(tracerName).Start(ctx, "propfind_response")
 	defer span.End()
 
 	filters := make([]*link.ListPublicSharesRequest_Filter, 0, len(resourceInfos))

--- a/internal/http/services/owncloud/ocdav/proppatch.go
+++ b/internal/http/services/owncloud/ocdav/proppatch.go
@@ -37,7 +37,7 @@ import (
 )
 
 func (s *svc) handlePathProppatch(w http.ResponseWriter, r *http.Request, ns string) {
-	ctx, span := rtrace.Provider.Tracer("ocdav").Start(r.Context(), "proppatch")
+	ctx, span := rtrace.Provider.Tracer(tracerName).Start(r.Context(), "proppatch")
 	defer span.End()
 
 	fn := path.Join(ns, r.URL.Path)
@@ -104,7 +104,7 @@ func (s *svc) handlePathProppatch(w http.ResponseWriter, r *http.Request, ns str
 }
 
 func (s *svc) handleSpacesProppatch(w http.ResponseWriter, r *http.Request, spaceID string) {
-	ctx, span := rtrace.Provider.Tracer("ocdav").Start(r.Context(), "spaces_proppatch")
+	ctx, span := rtrace.Provider.Tracer(tracerName).Start(r.Context(), "spaces_proppatch")
 	defer span.End()
 
 	sublog := appctx.GetLogger(ctx).With().Str("path", r.URL.Path).Str("spaceid", spaceID).Logger()

--- a/internal/http/services/owncloud/ocdav/publicfile.go
+++ b/internal/http/services/owncloud/ocdav/publicfile.go
@@ -86,7 +86,7 @@ func (h *PublicFileHandler) Handler(s *svc) http.Handler {
 }
 
 func (s *svc) adjustResourcePathInURL(w http.ResponseWriter, r *http.Request) bool {
-	ctx, span := rtrace.Provider.Tracer("ocdav").Start(r.Context(), "adjustResourcePathInURL")
+	ctx, span := rtrace.Provider.Tracer(tracerName).Start(r.Context(), "adjustResourcePathInURL")
 	defer span.End()
 
 	// find actual file name
@@ -125,7 +125,7 @@ func (s *svc) adjustResourcePathInURL(w http.ResponseWriter, r *http.Request) bo
 
 // ns is the namespace that is prefixed to the path in the cs3 namespace
 func (s *svc) handlePropfindOnToken(w http.ResponseWriter, r *http.Request, ns string, onContainer bool) {
-	ctx, span := rtrace.Provider.Tracer("ocdav").Start(r.Context(), "token_propfind")
+	ctx, span := rtrace.Provider.Tracer(tracerName).Start(r.Context(), "token_propfind")
 	defer span.End()
 
 	tokenStatInfo := ctx.Value(tokenStatInfoKey{}).(*provider.ResourceInfo)

--- a/internal/http/services/owncloud/ocdav/put.go
+++ b/internal/http/services/owncloud/ocdav/put.go
@@ -106,7 +106,7 @@ func isContentRange(r *http.Request) bool {
 }
 
 func (s *svc) handlePathPut(w http.ResponseWriter, r *http.Request, ns string) {
-	ctx, span := rtrace.Provider.Tracer("ocdav").Start(r.Context(), "put")
+	ctx, span := rtrace.Provider.Tracer(tracerName).Start(r.Context(), "put")
 	defer span.End()
 
 	fn := path.Join(ns, r.URL.Path)
@@ -332,7 +332,7 @@ func (s *svc) handlePut(ctx context.Context, w http.ResponseWriter, r *http.Requ
 }
 
 func (s *svc) handleSpacesPut(w http.ResponseWriter, r *http.Request, spaceID string) {
-	ctx, span := rtrace.Provider.Tracer("ocdav").Start(r.Context(), "spaces_put")
+	ctx, span := rtrace.Provider.Tracer(tracerName).Start(r.Context(), "spaces_put")
 	defer span.End()
 
 	sublog := appctx.GetLogger(ctx).With().Str("spaceid", spaceID).Str("path", r.URL.Path).Logger()

--- a/internal/http/services/owncloud/ocdav/trashbin.go
+++ b/internal/http/services/owncloud/ocdav/trashbin.go
@@ -164,7 +164,7 @@ func (h *TrashbinHandler) Handler(s *svc) http.Handler {
 }
 
 func (h *TrashbinHandler) listTrashbin(w http.ResponseWriter, r *http.Request, s *svc, u *userpb.User, basePath, key, itemPath string) {
-	ctx, span := rtrace.Provider.Tracer("trash-bin").Start(r.Context(), "list_trashbin")
+	ctx, span := rtrace.Provider.Tracer(tracerName).Start(r.Context(), "list_trashbin")
 	defer span.End()
 
 	depth := r.Header.Get(HeaderDepth)
@@ -442,7 +442,7 @@ func (h *TrashbinHandler) itemToPropResponse(ctx context.Context, s *svc, u *use
 }
 
 func (h *TrashbinHandler) restore(w http.ResponseWriter, r *http.Request, s *svc, u *userpb.User, basePath, dst, key, itemPath string) {
-	ctx, span := rtrace.Provider.Tracer("trash-bin").Start(r.Context(), "restore")
+	ctx, span := rtrace.Provider.Tracer(tracerName).Start(r.Context(), "restore")
 	defer span.End()
 
 	sublog := appctx.GetLogger(ctx).With().Logger()
@@ -590,7 +590,7 @@ func (h *TrashbinHandler) restore(w http.ResponseWriter, r *http.Request, s *svc
 
 // delete has only a key
 func (h *TrashbinHandler) delete(w http.ResponseWriter, r *http.Request, s *svc, u *userpb.User, basePath, key, itemPath string) {
-	ctx, span := rtrace.Provider.Tracer("trash-bin").Start(r.Context(), "erase")
+	ctx, span := rtrace.Provider.Tracer(tracerName).Start(r.Context(), "erase")
 	defer span.End()
 
 	sublog := appctx.GetLogger(ctx).With().Str("key", key).Logger()

--- a/internal/http/services/owncloud/ocdav/tus.go
+++ b/internal/http/services/owncloud/ocdav/tus.go
@@ -42,7 +42,7 @@ import (
 )
 
 func (s *svc) handlePathTusPost(w http.ResponseWriter, r *http.Request, ns string) {
-	ctx, span := rtrace.Provider.Tracer("ocdav").Start(r.Context(), "tus-post")
+	ctx, span := rtrace.Provider.Tracer(tracerName).Start(r.Context(), "tus-post")
 	defer span.End()
 
 	// read filename from metadata
@@ -65,7 +65,7 @@ func (s *svc) handlePathTusPost(w http.ResponseWriter, r *http.Request, ns strin
 }
 
 func (s *svc) handleSpacesTusPost(w http.ResponseWriter, r *http.Request, spaceID string) {
-	ctx, span := rtrace.Provider.Tracer("ocdav").Start(r.Context(), "spaces-tus-post")
+	ctx, span := rtrace.Provider.Tracer(tracerName).Start(r.Context(), "spaces-tus-post")
 	defer span.End()
 
 	// read filename from metadata

--- a/internal/http/services/owncloud/ocdav/versions.go
+++ b/internal/http/services/owncloud/ocdav/versions.go
@@ -81,7 +81,7 @@ func (h *VersionsHandler) Handler(s *svc, rid *provider.ResourceId) http.Handler
 }
 
 func (h *VersionsHandler) doListVersions(w http.ResponseWriter, r *http.Request, s *svc, rid *provider.ResourceId) {
-	ctx, span := rtrace.Provider.Tracer("ocdav").Start(r.Context(), "listVersions")
+	ctx, span := rtrace.Provider.Tracer(tracerName).Start(r.Context(), "listVersions")
 	defer span.End()
 
 	sublog := appctx.GetLogger(ctx).With().Interface("resourceid", rid).Logger()
@@ -183,7 +183,7 @@ func (h *VersionsHandler) doListVersions(w http.ResponseWriter, r *http.Request,
 }
 
 func (h *VersionsHandler) doRestore(w http.ResponseWriter, r *http.Request, s *svc, rid *provider.ResourceId, key string) {
-	ctx, span := rtrace.Provider.Tracer("ocdav").Start(r.Context(), "restore")
+	ctx, span := rtrace.Provider.Tracer(tracerName).Start(r.Context(), "restore")
 	defer span.End()
 
 	sublog := appctx.GetLogger(ctx).With().Interface("resourceid", rid).Str("key", key).Logger()

--- a/pkg/rhttp/rhttp.go
+++ b/pkg/rhttp/rhttp.go
@@ -40,6 +40,9 @@ import (
 	"go.opentelemetry.io/otel/propagation"
 )
 
+// name is the Tracer name used to identify this instrumentation library.
+const tracerName = "rhttp"
+
 // New returns a new server
 func New(m interface{}, l zerolog.Logger) (*Server, error) {
 	conf := &config{}
@@ -302,7 +305,7 @@ func (s *Server) getHandler() (http.Handler, error) {
 func traceHandler(name string, h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := rtrace.Propagator.Extract(r.Context(), propagation.HeaderCarrier(r.Header))
-		t := rtrace.Provider.Tracer("reva")
+		t := rtrace.Provider.Tracer(tracerName)
 		ctx, span := t.Start(ctx, name)
 		defer span.End()
 

--- a/pkg/storage/utils/decomposedfs/decomposedfs.go
+++ b/pkg/storage/utils/decomposedfs/decomposedfs.go
@@ -53,6 +53,9 @@ import (
 	"github.com/pkg/xattr"
 )
 
+// name is the Tracer name used to identify this instrumentation library.
+const tracerName = "decomposedfs"
+
 // PermissionsChecker defines an interface for checking permissions on a Node
 type PermissionsChecker interface {
 	AssemblePermissions(ctx context.Context, n *node.Node) (ap provider.ResourcePermissions, err error)
@@ -440,7 +443,7 @@ func (fs *Decomposedfs) ListFolder(ctx context.Context, ref *provider.Reference,
 		return
 	}
 
-	ctx, span := rtrace.Provider.Tracer("decomposedfs").Start(ctx, "ListFolder")
+	ctx, span := rtrace.Provider.Tracer(tracerName).Start(ctx, "ListFolder")
 	defer span.End()
 
 	if !n.Exists {

--- a/pkg/trace/trace.go
+++ b/pkg/trace/trace.go
@@ -21,6 +21,7 @@ package trace
 import (
 	"fmt"
 	"net/url"
+	"os"
 	"strings"
 
 	"go.opentelemetry.io/otel/exporters/jaeger"
@@ -76,11 +77,17 @@ func SetTraceProvider(collectorEndpoint string, agentEndpoint, serviceName strin
 		}
 	}
 
+	hostname, err := os.Hostname()
+	if err != nil {
+		panic(err)
+	}
+
 	Provider = sdktrace.NewTracerProvider(
 		sdktrace.WithBatcher(exp),
 		sdktrace.WithResource(resource.NewWithAttributes(
 			semconv.SchemaURL,
 			semconv.ServiceNameKey.String(serviceName),
+			semconv.HostNameKey.String(hostname),
 		)),
 	)
 }


### PR DESCRIPTION
Add the enduser.id tag to HTTP and GRPC requests.
Fix the tracer names.
Decorate traces with hostname.