### PR TITLE
fix trash-bin propfind responses

### DIFF
--- a/changelog/unreleased/fix-trashbin-propfind.md
+++ b/changelog/unreleased/fix-trashbin-propfind.md
@@ -1,0 +1,6 @@
+Bugfix: Fix trash-bin propfind responses
+
+Fixed the href of the root element in trash-bin propfind responses.
+
+https://github.com/owncloud/ocis/issues/1846
+https://github.com/cs3org/reva/pull/2821

--- a/internal/http/services/owncloud/ocdav/trashbin.go
+++ b/internal/http/services/owncloud/ocdav/trashbin.go
@@ -295,7 +295,7 @@ func (h *TrashbinHandler) formatTrashPropfind(ctx context.Context, s *svc, space
 	responses := make([]*propfind.ResponseXML, 0, len(items)+1)
 	// add trashbin dir . entry
 	responses = append(responses, &propfind.ResponseXML{
-		Href: net.EncodePath(ctx.Value(net.CtxKeyBaseURI).(string) + "/"), // url encode response.Href TODO
+		Href: net.EncodePath(path.Join(ctx.Value(net.CtxKeyBaseURI).(string), refBase)), // url encode response.Href TODO
 		Propstat: []propfind.PropstatXML{
 			{
 				Status: "HTTP/1.1 200 OK",


### PR DESCRIPTION
Fixed the href of the root element in trash-bin propfind responses.
Fixes: https://github.com/owncloud/ocis/issues/1846