### PR TITLE
make status values configurable

### DIFF
--- a/changelog/unreleased/make-status-values-configurable.md
+++ b/changelog/unreleased/make-status-values-configurable.md
@@ -1,0 +1,5 @@
+Enhancement: Make status.php values configurable
+
+We've added an option to set the status values for `product`, `productname`, `version`, `versionstring` and `edition`.
+
+https://github.com/cs3org/reva/pull/2833

--- a/internal/http/services/owncloud/ocdav/ocdav.go
+++ b/internal/http/services/owncloud/ocdav/ocdav.go
@@ -96,6 +96,11 @@ type Config struct {
 	PublicURL              string                            `mapstructure:"public_url"`
 	FavoriteStorageDriver  string                            `mapstructure:"favorite_storage_driver"`
 	FavoriteStorageDrivers map[string]map[string]interface{} `mapstructure:"favorite_storage_drivers"`
+	Version                string                            `mapstructure:"version"`
+	VersionString          string                            `mapstructure:"version_string"`
+	Edition                string                            `mapstructure:"edition"`
+	Product                string                            `mapstructure:"product"`
+	ProductName            string                            `mapstructure:"product_name"`
 }
 
 func (c *Config) init() {
@@ -104,6 +109,26 @@ func (c *Config) init() {
 
 	if c.FavoriteStorageDriver == "" {
 		c.FavoriteStorageDriver = "memory"
+	}
+
+	if c.Version == "" {
+		c.Version = "10.0.11.5"
+	}
+
+	if c.VersionString == "" {
+		c.VersionString = "10.0.11"
+	}
+
+	if c.Product == "" {
+		c.Product = "reva"
+	}
+
+	if c.ProductName == "" {
+		c.ProductName = "reva"
+	}
+
+	if c.Edition == "" {
+		c.Edition = "community"
 	}
 }
 

--- a/internal/http/services/owncloud/ocdav/status.go
+++ b/internal/http/services/owncloud/ocdav/status.go
@@ -32,11 +32,11 @@ func (s *svc) doStatus(w http.ResponseWriter, r *http.Request) {
 		Installed:      true,
 		Maintenance:    false,
 		NeedsDBUpgrade: false,
-		Version:        "10.0.11.5", // TODO(jfd) make build/config determined
-		VersionString:  "10.0.11",
-		Edition:        "community",
-		ProductName:    "reva",
-		Product:        "reva",
+		Version:        s.c.Version,
+		VersionString:  s.c.VersionString,
+		Edition:        s.c.Edition,
+		ProductName:    s.c.ProductName,
+		Product:        s.c.Product,
 	}
 
 	statusJSON, err := json.MarshalIndent(status, "", "    ")

--- a/pkg/micro/ocdav/option.go
+++ b/pkg/micro/ocdav/option.go
@@ -39,7 +39,6 @@ type Options struct {
 	// Metrics   *metrics.Metrics
 	// Flags     []cli.Flag
 	Name      string
-	Version   string
 	JWTSecret string
 
 	FavoriteManager favorite.Manager
@@ -185,9 +184,37 @@ func Tracing(trEndpoint string, trCollector string) Option {
 	}
 }
 
-// Version provides a function to set the Version option.
-func Version(version string) Option {
+// Version provides a function to set the Version config option.
+func Version(val string) Option {
 	return func(o *Options) {
-		o.Version = version
+		o.config.Version = val
+	}
+}
+
+// VersionString provides a function to set the VersionString config option.
+func VersionString(val string) Option {
+	return func(o *Options) {
+		o.config.VersionString = val
+	}
+}
+
+// Edition provides a function to set the Edition config option.
+func Edition(val string) Option {
+	return func(o *Options) {
+		o.config.Edition = val
+	}
+}
+
+// Product provides a function to set the Product config option.
+func Product(val string) Option {
+	return func(o *Options) {
+		o.config.Product = val
+	}
+}
+
+// ProductName provides a function to set the ProductName config option.
+func ProductName(val string) Option {
+	return func(o *Options) {
+		o.config.ProductName = val
 	}
 }

--- a/pkg/micro/ocdav/service.go
+++ b/pkg/micro/ocdav/service.go
@@ -59,7 +59,7 @@ func Service(opts ...Option) (micro.Service, error) {
 		server.TLSConfig(sopts.TLSConfig),
 		server.Name(sopts.Name),
 		server.Address(sopts.Address), // Address defaults to ":0" and will pick any free port
-		server.Version(sopts.Version),
+		server.Version(sopts.config.VersionString),
 	)
 
 	revaService, err := ocdav.NewWith(&sopts.config, sopts.FavoriteManager, sopts.lockSystem, &sopts.Logger)
@@ -126,8 +126,8 @@ func setDefaults(sopts *Options) error {
 	if !strings.HasPrefix(sopts.config.Prefix, "/") {
 		sopts.config.Prefix = "/" + sopts.config.Prefix
 	}
-	if sopts.Version == "" {
-		sopts.Version = "0.0.0"
+	if sopts.config.VersionString == "" {
+		sopts.config.VersionString = "0.0.0"
 	}
 	return nil
 }


### PR DESCRIPTION
# Enhancement: Make status.php values configurable

We've added an option to set the status values for `product`, `productname`, `version`, `versionstring` and `edition`.
