### PR TITLE
SDK: Fix download action

### DIFF
--- a/changelog/unreleased/sdk-download-fix.md
+++ b/changelog/unreleased/sdk-download-fix.md
@@ -1,0 +1,5 @@
+Bugfix: SDK - Fix download action
+
+The download action was no longer working in the SDK (used by our testing probes); this PR fixes the underlying issue.
+
+https://github.com/cs3org/reva/pull/2842

--- a/changelog/unreleased/sdk-download-fix.md
+++ b/changelog/unreleased/sdk-download-fix.md
@@ -1,4 +1,4 @@
-Bugfix: SDK - Fix download action
+Bugfix: Fix download action in SDK
 
 The download action was no longer working in the SDK (used by our testing probes); this PR fixes the underlying issue.
 

--- a/pkg/sdk/action/download.go
+++ b/pkg/sdk/action/download.go
@@ -89,7 +89,7 @@ func (action *DownloadAction) Download(fileInfo *storage.ResourceInfo) ([]byte, 
 
 func (action *DownloadAction) initiateDownload(fileInfo *storage.ResourceInfo) (*gateway.InitiateFileDownloadResponse, error) {
 	// Initiating a download request gets us the download endpoint for the specified resource
-	req := &provider.InitiateFileDownloadRequest{Ref: &provider.Reference{ResourceId: fileInfo.Id}}
+	req := &provider.InitiateFileDownloadRequest{Ref: &provider.Reference{Path: fileInfo.Path}}
 	res, err := action.session.Client().InitiateFileDownload(action.session.Context(), req)
 	if err := net.CheckRPCInvocation("initiating download", res, err); err != nil {
 		return nil, err


### PR DESCRIPTION
The download action was no longer working in the SDK (used by our testing probes); this PR fixes the underlying issue.