### PR TITLE
Fix cs3 share manager filter

### DIFF
--- a/changelog/unreleased/filter-cs3-share-manager-listing.md
+++ b/changelog/unreleased/filter-cs3-share-manager-listing.md
@@ -1,0 +1,5 @@
+Bugfix: Filter CS3 share manager listing
+
+The cs3 share manager driver now correctly filters user and group queries
+
+https://github.com/cs3org/reva/pull/2853

--- a/pkg/share/manager/cs3/cs3.go
+++ b/pkg/share/manager/cs3/cs3.go
@@ -404,11 +404,14 @@ func (m *Manager) ListReceivedShares(ctx context.Context, filters []*collaborati
 	}
 
 	for _, id := range receivedIds {
-		share, err := m.getShareByID(ctx, id)
+		s, err := m.getShareByID(ctx, id)
 		if err != nil {
 			return nil, err
 		}
-		metadata, err := m.downloadMetadata(ctx, share)
+		if !share.MatchesFilters(s, filters) {
+			continue
+		}
+		metadata, err := m.downloadMetadata(ctx, s)
 		if err != nil {
 			if _, ok := err.(errtypes.NotFound); !ok {
 				return nil, err
@@ -419,7 +422,7 @@ func (m *Manager) ListReceivedShares(ctx context.Context, filters []*collaborati
 			}
 		}
 		result = append(result, &collaboration.ReceivedShare{
-			Share:      share,
+			Share:      s,
 			State:      metadata.State,
 			MountPoint: metadata.MountPoint,
 		})


### PR DESCRIPTION
The cs3 share manager driver now correctly filters user and group queries
