### PR TITLE
Decomposedfs allow arbitrary length spaceid

### DIFF
--- a/changelog/unreleased/decomposedfs-allow-arbitrary-length-spaceid.md
+++ b/changelog/unreleased/decomposedfs-allow-arbitrary-length-spaceid.md
@@ -1,0 +1,5 @@
+Bugfix: Handle non uuid space and nodeid in decomposedfs
+
+The decomposedfs no longer panics when trying to look up spaces with a non uuid length id.
+
+https://github.com/cs3org/reva/pull/2854

--- a/go.mod
+++ b/go.mod
@@ -81,6 +81,7 @@ require (
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/sys v0.0.0-20220307203707-22a9840ba4d7
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211
+	golang.org/x/text v0.3.7
 	google.golang.org/genproto v0.0.0-20211021150943-2b146023228c
 	google.golang.org/grpc v1.45.0
 	google.golang.org/protobuf v1.28.0

--- a/go.mod
+++ b/go.mod
@@ -81,7 +81,6 @@ require (
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/sys v0.0.0-20220307203707-22a9840ba4d7
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211
-	golang.org/x/text v0.3.7
 	google.golang.org/genproto v0.0.0-20211021150943-2b146023228c
 	google.golang.org/grpc v1.45.0
 	google.golang.org/protobuf v1.28.0

--- a/pkg/storage/utils/decomposedfs/spaces.go
+++ b/pkg/storage/utils/decomposedfs/spaces.go
@@ -215,7 +215,7 @@ func (fs *Decomposedfs) canCreateSpace(ctx context.Context, spaceID string) bool
 	return checkRes.Status.Code == v1beta11.Code_CODE_OK
 }
 
-func readSpaceAndNodeFromSpaceTypeLink(path string) (string, string, error) {
+func ReadSpaceAndNodeFromSpaceTypeLink(path string) (string, string, error) {
 	link, err := os.Readlink(path)
 	if err != nil {
 		return "", "", err
@@ -338,7 +338,7 @@ func (fs *Decomposedfs) ListStorageSpaces(ctx context.Context, filter []*provide
 			continue
 		}
 		// always read link in case storage space id != node id
-		spaceID, nodeID, err = readSpaceAndNodeFromSpaceTypeLink(matches[i])
+		spaceID, nodeID, err = ReadSpaceAndNodeFromSpaceTypeLink(matches[i])
 		if err != nil {
 			appctx.GetLogger(ctx).Error().Err(err).Str("match", matches[i]).Msg("could not read link, skipping")
 			continue

--- a/pkg/storage/utils/decomposedfs/spaces.go
+++ b/pkg/storage/utils/decomposedfs/spaces.go
@@ -229,7 +229,7 @@ func ReadSpaceAndNodeFromSpaceTypeLink(path string) (string, string, error) {
 	if len(parts) != 11 || parts[0] != ".." || parts[1] != ".." || parts[2] != "spaces" || parts[5] != "nodes" {
 		return "", "", errtypes.InternalError("malformed link")
 	}
-	return parts[3] + parts[4], parts[6] + parts[7] + parts[8] + parts[9] + parts[10], nil
+	return strings.Join(parts[3:5], ""), strings.Join(parts[6:11], ""), nil
 }
 
 // ListStorageSpaces returns a list of StorageSpaces.

--- a/pkg/storage/utils/decomposedfs/spaces.go
+++ b/pkg/storage/utils/decomposedfs/spaces.go
@@ -215,13 +215,14 @@ func (fs *Decomposedfs) canCreateSpace(ctx context.Context, spaceID string) bool
 	return checkRes.Status.Code == v1beta11.Code_CODE_OK
 }
 
+// ReadSpaceAndNodeFromSpaceTypeLink reads a symlink and parses space and node id if the link has the correct format, eg:
+// ../../spaces/4c/510ada-c86b-4815-8820-42cdf82c3d51/nodes/4c/51/0a/da/-c86b-4815-8820-42cdf82c3d51
+// ../../spaces/4c/510ada-c86b-4815-8820-42cdf82c3d51/nodes/4c/51/0a/da/-c86b-4815-8820-42cdf82c3d51.T.2022-02-24T12:35:18.196484592Z
 func ReadSpaceAndNodeFromSpaceTypeLink(path string) (string, string, error) {
 	link, err := os.Readlink(path)
 	if err != nil {
 		return "", "", err
 	}
-	// ../../spaces/4c/510ada-c86b-4815-8820-42cdf82c3d51/nodes/4c/51/0a/da/-c86b-4815-8820-42cdf82c3d51
-	// ../../spaces/4c/510ada-c86b-4815-8820-42cdf82c3d51/nodes/4c/51/0a/da/-c86b-4815-8820-42cdf82c3d51.T.2022-02-24T12:35:18.196484592Z
 	// ../../spaces/sp/ace-id/nodes/sh/or/tn/od/eid
 	// 0  1  2      3  4      5     6  7  8  9  10
 	parts := strings.Split(link, string(filepath.Separator))

--- a/pkg/storage/utils/decomposedfs/spaces.go
+++ b/pkg/storage/utils/decomposedfs/spaces.go
@@ -222,13 +222,13 @@ func ReadSpaceAndNodeFromSpaceTypeLink(path string) (string, string, error) {
 	}
 	// ../../spaces/4c/510ada-c86b-4815-8820-42cdf82c3d51/nodes/4c/51/0a/da/-c86b-4815-8820-42cdf82c3d51
 	// ../../spaces/4c/510ada-c86b-4815-8820-42cdf82c3d51/nodes/4c/51/0a/da/-c86b-4815-8820-42cdf82c3d51.T.2022-02-24T12:35:18.196484592Z
-	// TODO use filepath.Separator to support windows
-	link = strings.ReplaceAll(link, "/", "")
-	// ....spaces4c510ada-c86b-4815-8820-42cdf82c3d51nodes4c510ada-c86b-4815-8820-42cdf82c3d51
-	if link[0:10] != "....spaces" || link[46:51] != "nodes" {
+	// ../../spaces/sp/ace-id/nodes/sh/or/tn/od/eid
+	// 0  1  2      3  4      5     6  7  8  9  10
+	parts := strings.Split(link, string(filepath.Separator))
+	if len(parts) != 11 || parts[0] != ".." || parts[1] != ".." || parts[2] != "spaces" || parts[5] != "nodes" {
 		return "", "", errtypes.InternalError("malformed link")
 	}
-	return link[10:46], link[51:], nil
+	return parts[3] + parts[4], parts[6] + parts[7] + parts[8] + parts[9] + parts[10], nil
 }
 
 // ListStorageSpaces returns a list of StorageSpaces.

--- a/pkg/storage/utils/decomposedfs/spaces_test.go
+++ b/pkg/storage/utils/decomposedfs/spaces_test.go
@@ -119,7 +119,7 @@ var _ = Describe("Spaces", func() {
 		)
 
 		BeforeEach(func() {
-			tmpdir = os.TempDir()
+			tmpdir, _ = os.MkdirTemp(os.TempDir(), "ReadSpaceAndNodeFromSpaceTypeLink-")
 		})
 
 		AfterEach(func() {

--- a/pkg/storage/utils/decomposedfs/spaces_test.go
+++ b/pkg/storage/utils/decomposedfs/spaces_test.go
@@ -128,14 +128,14 @@ var _ = Describe("Spaces", func() {
 			}
 		})
 
-		FIt("correctly splits the link target", func() {
+		It("correctly splits the link target", func() {
 			err := os.Symlink("../../spaces/sp/ace-id/nodes/sh/or/tn/od/eid", link)
 			Expect(err).ToNot(HaveOccurred())
 
 			space, node, err := decomposedfs.ReadSpaceAndNodeFromSpaceTypeLink(link)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(space).To(Equal("space-id"))
-			Expect(node).To(Equal("node-id"))
+			Expect(node).To(Equal("shortnodeid"))
 		})
 	})
 })

--- a/pkg/storage/utils/decomposedfs/spaces_test.go
+++ b/pkg/storage/utils/decomposedfs/spaces_test.go
@@ -113,7 +113,7 @@ var _ = Describe("Spaces", func() {
 		})
 	})
 
-	FDescribe("ReadSpaceAndNodeFromSpaceTypeLink", func() {
+	Describe("ReadSpaceAndNodeFromSpaceTypeLink", func() {
 		var (
 			tmpdir string
 		)


### PR DESCRIPTION
The decomposedfs no longer panics when trying to look up spaces with a non uuid length id.
