### PR TITLE
don't include versions in quota check

### DIFF
--- a/changelog/unreleased/versions-quota.md
+++ b/changelog/unreleased/versions-quota.md
@@ -1,0 +1,6 @@
+Bugfix: Don't include versions in quota
+
+Fixed the quota check to not count the quota of previous versions.
+
+https://github.com/owncloud/ocis/issues/2829
+https://github.com/cs3org/reva/pull/2863

--- a/pkg/storage/utils/decomposedfs/upload.go
+++ b/pkg/storage/utils/decomposedfs/upload.go
@@ -154,7 +154,7 @@ func (fs *Decomposedfs) InitiateUpload(ctx context.Context, ref *provider.Refere
 
 	log.Debug().Interface("info", info).Interface("node", n).Interface("metadata", metadata).Msg("Decomposedfs: resolved filename")
 
-	_, err = node.CheckQuota(n.SpaceRoot, uint64(info.Size))
+	_, err = node.CheckQuota(n.SpaceRoot, n.Exists, uint64(n.Blobsize), uint64(info.Size))
 	if err != nil {
 		return nil, err
 	}
@@ -481,7 +481,13 @@ func (upload *fileUpload) FinishUpload(ctx context.Context) (err error) {
 		return err
 	}
 
-	_, err = node.CheckQuota(n.SpaceRoot, uint64(fi.Size()))
+	var oldSize uint64
+	if n.ID != "" {
+		old, _ := node.ReadNode(ctx, upload.fs.lu, spaceID, n.ID)
+		oldSize = uint64(old.Blobsize)
+	}
+	_, err = node.CheckQuota(n.SpaceRoot, n.ID != "", oldSize, uint64(fi.Size()))
+
 	if err != nil {
 		return err
 	}

--- a/pkg/storage/utils/decomposedfs/upload_test.go
+++ b/pkg/storage/utils/decomposedfs/upload_test.go
@@ -130,7 +130,7 @@ var _ = Describe("File uploads", func() {
 		When("the user wants to initiate a file upload", func() {
 			It("fails", func() {
 				var originalFunc = node.CheckQuota
-				node.CheckQuota = func(spaceRoot *node.Node, fileSize uint64) (quotaSufficient bool, err error) {
+				node.CheckQuota = func(spaceRoot *node.Node, overwrite bool, oldSize, newSize uint64) (quotaSufficient bool, err error) {
 					return false, errtypes.InsufficientStorage("quota exceeded")
 				}
 				_, err := fs.InitiateUpload(ctx, ref, 10, map[string]string{})


### PR DESCRIPTION
Fixed the quota check to not count the quota of previous versions.

This will fix the situation where the quota is exceeded and the user wants to create a new version of an existing file.
See this issue for more information: https://github.com/owncloud/ocis/issues/2829