### PR TITLE
Share jail fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,11 @@ test: off
 test-integration: build-ci
 	cd tests/integration && go test -race ./...
 
+# This is needed for osx because this os does not support static linking
+# Use the build target without the static flag
+test-integration-osx: build
+	cd tests/integration && go test -race ./...
+
 litmus-test-old: build
 	cd tests/oc-integration-tests/local && ../../../cmd/revad/revad -c frontend.toml &
 	cd tests/oc-integration-tests/local && ../../../cmd/revad/revad -c gateway.toml &

--- a/changelog/unreleased/share-jail-fixes.md
+++ b/changelog/unreleased/share-jail-fixes.md
@@ -1,0 +1,5 @@
+Bugfix: Fix Grant Space IDs and webDAV GET Headers
+
+The opaqueID for a grant space was incorrectly overwritten with the root space id. We fixed that and now use the Filename from the fileinfo in GET WebDAV requests instead of using the value from the url.
+
+https://github.com/cs3org/reva/pull/2864

--- a/changelog/unreleased/share-jail-fixes.md
+++ b/changelog/unreleased/share-jail-fixes.md
@@ -1,5 +1,5 @@
-Bugfix: Fix Grant Space IDs and webDAV GET Headers
+Bugfix: Fix Grant Space IDs
 
-The opaqueID for a grant space was incorrectly overwritten with the root space id. We fixed that and now use the Filename from the fileinfo in GET WebDAV requests instead of using the value from the url.
+The opaqueID for a grant space was incorrectly overwritten with the root space id. 
 
 https://github.com/cs3org/reva/pull/2864

--- a/pkg/storage/utils/decomposedfs/spaces.go
+++ b/pkg/storage/utils/decomposedfs/spaces.go
@@ -627,7 +627,16 @@ func (fs *Decomposedfs) storageSpaceFromNode(ctx context.Context, n *node.Node, 
 	if err != nil {
 		return nil, err
 	}
-
+	ssID, err := storagespace.FormatReference(
+		&provider.Reference{
+			ResourceId: &provider.ResourceId{
+				StorageId: n.SpaceRoot.SpaceID,
+				OpaqueId:  n.ID},
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
 	space := &provider.StorageSpace{
 		Opaque: &types.Opaque{
 			Map: map[string]*types.OpaqueEntry{
@@ -637,10 +646,10 @@ func (fs *Decomposedfs) storageSpaceFromNode(ctx context.Context, n *node.Node, 
 				},
 			},
 		},
-		Id: &provider.StorageSpaceId{OpaqueId: n.SpaceRoot.SpaceID},
+		Id: &provider.StorageSpaceId{OpaqueId: ssID},
 		Root: &provider.ResourceId{
 			StorageId: n.SpaceRoot.SpaceID,
-			OpaqueId:  n.SpaceRoot.ID,
+			OpaqueId:  n.ID,
 		},
 		Name: sname,
 		// SpaceType is read from xattr below

--- a/pkg/storage/utils/decomposedfs/testhelpers/helpers.go
+++ b/pkg/storage/utils/decomposedfs/testhelpers/helpers.go
@@ -210,7 +210,7 @@ func (t *TestEnv) CreateTestStorageSpace(typ string, quota *providerv1beta1.Quot
 	if err != nil {
 		return nil, err
 	}
-	h, err := node.ReadNode(t.Ctx, t.Lookup, sid.StorageId, sid.OpaqueId, false))
+	h, err := node.ReadNode(t.Ctx, t.Lookup, sid.StorageId, sid.OpaqueId, false)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/storage/utils/decomposedfs/testhelpers/helpers.go
+++ b/pkg/storage/utils/decomposedfs/testhelpers/helpers.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/lookup"
 	"github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/xattrs"
+	"github.com/cs3org/reva/v2/pkg/storagespace"
 	"github.com/google/uuid"
 	"github.com/pkg/xattr"
 	"github.com/stretchr/testify/mock"
@@ -205,7 +206,11 @@ func (t *TestEnv) CreateTestStorageSpace(typ string, quota *providerv1beta1.Quot
 	ref := buildRef(space.StorageSpace.Id.OpaqueId, "")
 
 	// the space name attribute is the stop condition in the lookup
-	h, err := node.ReadNode(t.Ctx, t.Lookup, space.StorageSpace.Id.OpaqueId, space.StorageSpace.Id.OpaqueId, false)
+	sid, err := storagespace.ParseID(space.StorageSpace.Id.OpaqueId)
+	if err != nil {
+		return nil, err
+	}
+	h, err := node.ReadNode(t.Ctx, t.Lookup, sid.StorageId, sid.OpaqueId, false))
 	if err != nil {
 		return nil, err
 	}
@@ -252,10 +257,14 @@ func (t *TestEnv) CreateTestStorageSpace(typ string, quota *providerv1beta1.Quot
 
 // shortcut to get a ref
 func buildRef(id, path string) *providerv1beta1.Reference {
+	res, err := storagespace.ParseID(id)
+	if err != nil {
+		return nil
+	}
 	return &providerv1beta1.Reference{
 		ResourceId: &providerv1beta1.ResourceId{
-			StorageId: id,
-			OpaqueId:  id,
+			StorageId: res.StorageId,
+			OpaqueId:  res.OpaqueId,
 		},
 		Path: path,
 	}

--- a/pkg/storage/utils/decomposedfs/upload_test.go
+++ b/pkg/storage/utils/decomposedfs/upload_test.go
@@ -124,7 +124,7 @@ var _ = Describe("File uploads", func() {
 		Expect(resp.Status.Code).To(Equal(v1beta11.Code_CODE_OK))
 		resID, err := storagespace.ParseID(resp.StorageSpace.Id.OpaqueId)
 		Expect(err).ToNot(HaveOccurred())
-		ref.ResourceId = &provider.ResourceId{StorageId: resID.StorageId, OpaqueId: resID.StorageId}
+		ref.ResourceId = &provider.ResourceId{StorageId: resID.StorageId, OpaqueId: resID.OpaqueId}
 	})
 
 	Context("the user's quota is exceeded", func() {

--- a/pkg/storage/utils/decomposedfs/upload_test.go
+++ b/pkg/storage/utils/decomposedfs/upload_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/tree"
 	treemocks "github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/tree/mocks"
 	"github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/xattrs"
+	"github.com/cs3org/reva/v2/pkg/storagespace"
 	"github.com/cs3org/reva/v2/tests/helpers"
 	"github.com/pkg/xattr"
 	"github.com/stretchr/testify/mock"
@@ -55,7 +56,6 @@ var _ = Describe("File uploads", func() {
 		fs      storage.FS
 		user    *userpb.User
 		ctx     context.Context
-		spaceID string
 
 		o                    *options.Options
 		lu                   *lookup.Lookup
@@ -122,8 +122,9 @@ var _ = Describe("File uploads", func() {
 		resp, err := fs.CreateStorageSpace(ctx, &provider.CreateStorageSpaceRequest{Owner: user, Type: "personal"})
 		Expect(err).ToNot(HaveOccurred())
 		Expect(resp.Status.Code).To(Equal(v1beta11.Code_CODE_OK))
-		spaceID = resp.StorageSpace.Id.OpaqueId
-		ref.ResourceId = &provider.ResourceId{StorageId: spaceID}
+		resID, err := storagespace.ParseID(resp.StorageSpace.Id.OpaqueId)
+		Expect(err).ToNot(HaveOccurred())
+		ref.ResourceId = &provider.ResourceId{StorageId: resID.StorageId, OpaqueId: resID.StorageId}
 	})
 
 	Context("the user's quota is exceeded", func() {


### PR DESCRIPTION
# Bugfix: Fix Grant Space IDs 

The opaqueID for a grant space was incorrectly overwritten with the root space id.
