### PR TITLE
Update quota calculation

### DIFF
--- a/changelog/unreleased/update-quota-calculation.md
+++ b/changelog/unreleased/update-quota-calculation.md
@@ -1,0 +1,5 @@
+Bugfix: Update quota calculation
+
+We now render the `free` and `definition` quota properties, taking into account the remaining bytes reported from the storage space and calculating `relative` only when possible.
+
+https://github.com/cs3org/reva/pull/2870


### PR DESCRIPTION
We now render the `free` and `definition` quota properties, taking into account the remaining bytes reported from the storage space and calculating `relative` only when possible.
