### PR TITLE
ench: make `grpc.MaxCallRecvMsgSize` call option configurable

### DIFF
--- a/changelog/unreleased/clientmsgsize-config.md
+++ b/changelog/unreleased/clientmsgsize-config.md
@@ -1,0 +1,3 @@
+Enhancement: Make `grpc.MaxCallRecvMsgSize` call option configurable 
+
+https://github.com/cs3org/reva/pull/2872

--- a/internal/grpc/interceptors/auth/auth.go
+++ b/internal/grpc/interceptors/auth/auth.go
@@ -47,9 +47,10 @@ var scopeExpansionCache gcache.Cache
 type config struct {
 	// TODO(labkode): access a map is more performant as uri as fixed in length
 	// for SkipMethods.
-	TokenManager  string                            `mapstructure:"token_manager"`
-	TokenManagers map[string]map[string]interface{} `mapstructure:"token_managers"`
-	GatewayAddr   string                            `mapstructure:"gateway_addr"`
+	TokenManager       string                            `mapstructure:"token_manager"`
+	TokenManagers      map[string]map[string]interface{} `mapstructure:"token_managers"`
+	GatewayAddr        string                            `mapstructure:"gateway_addr"`
+	MaxCallRecvMsgSize int                               `mapstructure:"client_recv_msg_size"`
 }
 
 func parseConfig(m map[string]interface{}) (*config, error) {

--- a/internal/grpc/interceptors/auth/auth.go
+++ b/internal/grpc/interceptors/auth/auth.go
@@ -98,7 +98,7 @@ func NewUnary(m map[string]interface{}, unprotected []string) (grpc.UnaryServerI
 			// to decide the storage provider.
 			tkn, ok := ctxpkg.ContextGetToken(ctx)
 			if ok {
-				u, err := dismantleToken(ctx, tkn, req, tokenManager, conf.GatewayAddr, true)
+				u, err := dismantleToken(ctx, tkn, req, tokenManager, conf, true)
 				if err == nil {
 					ctx = ctxpkg.ContextSetUser(ctx, u)
 				}
@@ -114,7 +114,7 @@ func NewUnary(m map[string]interface{}, unprotected []string) (grpc.UnaryServerI
 		}
 
 		// validate the token and ensure access to the resource is allowed
-		u, err := dismantleToken(ctx, tkn, req, tokenManager, conf.GatewayAddr, false)
+		u, err := dismantleToken(ctx, tkn, req, tokenManager, conf, false)
 		if err != nil {
 			log.Warn().Err(err).Msg("access token is invalid")
 			return nil, status.Errorf(codes.PermissionDenied, "auth: core access token is invalid")
@@ -162,7 +162,7 @@ func NewStream(m map[string]interface{}, unprotected []string) (grpc.StreamServe
 			// to decide the storage provider.
 			tkn, ok := ctxpkg.ContextGetToken(ctx)
 			if ok {
-				u, err := dismantleToken(ctx, tkn, ss, tokenManager, conf.GatewayAddr, true)
+				u, err := dismantleToken(ctx, tkn, ss, tokenManager, conf, true)
 				if err == nil {
 					ctx = ctxpkg.ContextSetUser(ctx, u)
 					ss = newWrappedServerStream(ctx, ss)
@@ -180,7 +180,7 @@ func NewStream(m map[string]interface{}, unprotected []string) (grpc.StreamServe
 		}
 
 		// validate the token and ensure access to the resource is allowed
-		u, err := dismantleToken(ctx, tkn, ss, tokenManager, conf.GatewayAddr, false)
+		u, err := dismantleToken(ctx, tkn, ss, tokenManager, conf, false)
 		if err != nil {
 			log.Warn().Err(err).Msg("access token is invalid")
 			return status.Errorf(codes.PermissionDenied, "auth: core access token is invalid")
@@ -207,7 +207,7 @@ func (ss *wrappedServerStream) Context() context.Context {
 	return ss.newCtx
 }
 
-func dismantleToken(ctx context.Context, tkn string, req interface{}, mgr token.Manager, gatewayAddr string, unprotected bool) (*userpb.User, error) {
+func dismantleToken(ctx context.Context, tkn string, req interface{}, mgr token.Manager, conf *config, unprotected bool) (*userpb.User, error) {
 	u, tokenScope, err := mgr.DismantleToken(ctx, tkn)
 	if err != nil {
 		return nil, err
@@ -218,7 +218,7 @@ func dismantleToken(ctx context.Context, tkn string, req interface{}, mgr token.
 	}
 
 	if sharedconf.SkipUserGroupsInToken() {
-		client, err := pool.GetGatewayServiceClient(pool.Endpoint(gatewayAddr))
+		client, err := pool.GetGatewayServiceClient(conf, pool.Endpoint(conf.GatewayAddr))
 		if err != nil {
 			return nil, err
 		}
@@ -238,7 +238,7 @@ func dismantleToken(ctx context.Context, tkn string, req interface{}, mgr token.
 		return u, nil
 	}
 
-	if err = expandAndVerifyScope(ctx, req, tokenScope, u, gatewayAddr, mgr); err != nil {
+	if err = expandAndVerifyScope(ctx, req, tokenScope, u, conf, mgr); err != nil {
 		return nil, err
 	}
 

--- a/internal/grpc/interceptors/auth/scope.go
+++ b/internal/grpc/interceptors/auth/scope.go
@@ -50,9 +50,9 @@ const (
 	scopeCacheExpiration = 3600
 )
 
-func expandAndVerifyScope(ctx context.Context, req interface{}, tokenScope map[string]*authpb.Scope, user *userpb.User, gatewayAddr string, mgr token.Manager) error {
+func expandAndVerifyScope(ctx context.Context, req interface{}, tokenScope map[string]*authpb.Scope, user *userpb.User, conf *config, mgr token.Manager) error {
 	log := appctx.GetLogger(ctx)
-	client, err := pool.GetGatewayServiceClient(pool.Endpoint(gatewayAddr))
+	client, err := pool.GetGatewayServiceClient(conf, pool.Endpoint(conf.GatewayAddr))
 	if err != nil {
 		return err
 	}

--- a/internal/grpc/services/appprovider/appprovider.go
+++ b/internal/grpc/services/appprovider/appprovider.go
@@ -120,7 +120,7 @@ func (s *service) registerProvider() {
 		pInfo.MimeTypes = mimeTypes
 	}
 
-	client, err := pool.GetGatewayServiceClient(pool.Endpoint(s.conf.GatewaySvc))
+	client, err := pool.GetGatewayServiceClient(s.conf, pool.Endpoint(s.conf.GatewaySvc))
 	if err != nil {
 		log.Error().Err(err).Msgf("error registering app provider: could not get gateway client")
 		return

--- a/internal/grpc/services/appprovider/appprovider.go
+++ b/internal/grpc/services/appprovider/appprovider.go
@@ -52,12 +52,13 @@ type service struct {
 }
 
 type config struct {
-	Driver         string                            `mapstructure:"driver"`
-	Drivers        map[string]map[string]interface{} `mapstructure:"drivers"`
-	AppProviderURL string                            `mapstructure:"app_provider_url"`
-	GatewaySvc     string                            `mapstructure:"gatewaysvc"`
-	MimeTypes      []string                          `mapstructure:"mime_types"`
-	Priority       uint64                            `mapstructure:"priority"`
+	Driver             string                            `mapstructure:"driver"`
+	Drivers            map[string]map[string]interface{} `mapstructure:"drivers"`
+	AppProviderURL     string                            `mapstructure:"app_provider_url"`
+	GatewaySvc         string                            `mapstructure:"gatewaysvc"`
+	MimeTypes          []string                          `mapstructure:"mime_types"`
+	Priority           uint64                            `mapstructure:"priority"`
+	MaxCallRecvMsgSize int                               `mapstructure:"client_recv_msg_size"`
 }
 
 func (c *config) init() {

--- a/internal/grpc/services/gateway/applicationauth.go
+++ b/internal/grpc/services/gateway/applicationauth.go
@@ -28,7 +28,7 @@ import (
 )
 
 func (s *svc) GenerateAppPassword(ctx context.Context, req *appauthpb.GenerateAppPasswordRequest) (*appauthpb.GenerateAppPasswordResponse, error) {
-	c, err := pool.GetAppAuthProviderServiceClient(pool.Endpoint(s.c.ApplicationAuthEndpoint))
+	c, err := pool.GetAppAuthProviderServiceClient(s.c, pool.Endpoint(s.c.ApplicationAuthEndpoint))
 	if err != nil {
 		err = errors.Wrap(err, "gateway: error calling GetAppAuthProviderServiceClient")
 		return &appauthpb.GenerateAppPasswordResponse{
@@ -45,7 +45,7 @@ func (s *svc) GenerateAppPassword(ctx context.Context, req *appauthpb.GenerateAp
 }
 
 func (s *svc) ListAppPasswords(ctx context.Context, req *appauthpb.ListAppPasswordsRequest) (*appauthpb.ListAppPasswordsResponse, error) {
-	c, err := pool.GetAppAuthProviderServiceClient(pool.Endpoint(s.c.ApplicationAuthEndpoint))
+	c, err := pool.GetAppAuthProviderServiceClient(s.c, pool.Endpoint(s.c.ApplicationAuthEndpoint))
 	if err != nil {
 		err = errors.Wrap(err, "gateway: error calling GetAppAuthProviderServiceClient")
 		return &appauthpb.ListAppPasswordsResponse{
@@ -62,7 +62,7 @@ func (s *svc) ListAppPasswords(ctx context.Context, req *appauthpb.ListAppPasswo
 }
 
 func (s *svc) InvalidateAppPassword(ctx context.Context, req *appauthpb.InvalidateAppPasswordRequest) (*appauthpb.InvalidateAppPasswordResponse, error) {
-	c, err := pool.GetAppAuthProviderServiceClient(pool.Endpoint(s.c.ApplicationAuthEndpoint))
+	c, err := pool.GetAppAuthProviderServiceClient(s.c, pool.Endpoint(s.c.ApplicationAuthEndpoint))
 	if err != nil {
 		err = errors.Wrap(err, "gateway: error calling GetAppAuthProviderServiceClient")
 		return &appauthpb.InvalidateAppPasswordResponse{
@@ -79,7 +79,7 @@ func (s *svc) InvalidateAppPassword(ctx context.Context, req *appauthpb.Invalida
 }
 
 func (s *svc) GetAppPassword(ctx context.Context, req *appauthpb.GetAppPasswordRequest) (*appauthpb.GetAppPasswordResponse, error) {
-	c, err := pool.GetAppAuthProviderServiceClient(pool.Endpoint(s.c.ApplicationAuthEndpoint))
+	c, err := pool.GetAppAuthProviderServiceClient(s.c, pool.Endpoint(s.c.ApplicationAuthEndpoint))
 	if err != nil {
 		err = errors.Wrap(err, "gateway: error calling GetAppAuthProviderServiceClient")
 		return &appauthpb.GetAppPasswordResponse{

--- a/internal/grpc/services/gateway/appprovider.go
+++ b/internal/grpc/services/gateway/appprovider.go
@@ -189,7 +189,7 @@ func (s *svc) openLocalResources(ctx context.Context, ri *storageprovider.Resour
 		return nil, err
 	}
 
-	appProviderClient, err := pool.GetAppProviderClient(pool.Endpoint(provider.Address))
+	appProviderClient, err := pool.GetAppProviderClient(s.c, pool.Endpoint(provider.Address))
 	if err != nil {
 		return nil, errors.Wrap(err, "gateway: error calling GetAppProviderClient")
 	}
@@ -209,7 +209,7 @@ func (s *svc) openLocalResources(ctx context.Context, ri *storageprovider.Resour
 }
 
 func (s *svc) findAppProvider(ctx context.Context, ri *storageprovider.ResourceInfo, app string) (*registry.ProviderInfo, error) {
-	c, err := pool.GetAppRegistryClient(pool.Endpoint(s.c.AppRegistryEndpoint))
+	c, err := pool.GetAppRegistryClient(s.c, pool.Endpoint(s.c.AppRegistryEndpoint))
 	if err != nil {
 		err = errors.Wrap(err, "gateway: error getting appregistry client")
 		return nil, err

--- a/internal/grpc/services/gateway/appregistry.go
+++ b/internal/grpc/services/gateway/appregistry.go
@@ -28,7 +28,7 @@ import (
 )
 
 func (s *svc) GetAppProviders(ctx context.Context, req *registry.GetAppProvidersRequest) (*registry.GetAppProvidersResponse, error) {
-	c, err := pool.GetAppRegistryClient(pool.Endpoint(s.c.AppRegistryEndpoint))
+	c, err := pool.GetAppRegistryClient(s.c, pool.Endpoint(s.c.AppRegistryEndpoint))
 	if err != nil {
 		err = errors.Wrap(err, "gateway: error calling GetAppRegistryClient")
 		return &registry.GetAppProvidersResponse{
@@ -45,7 +45,7 @@ func (s *svc) GetAppProviders(ctx context.Context, req *registry.GetAppProviders
 }
 
 func (s *svc) AddAppProvider(ctx context.Context, req *registry.AddAppProviderRequest) (*registry.AddAppProviderResponse, error) {
-	c, err := pool.GetAppRegistryClient(pool.Endpoint(s.c.AppRegistryEndpoint))
+	c, err := pool.GetAppRegistryClient(s.c, pool.Endpoint(s.c.AppRegistryEndpoint))
 	if err != nil {
 		err = errors.Wrap(err, "gateway: error calling GetAppRegistryClient")
 		return &registry.AddAppProviderResponse{
@@ -62,7 +62,7 @@ func (s *svc) AddAppProvider(ctx context.Context, req *registry.AddAppProviderRe
 }
 
 func (s *svc) ListAppProviders(ctx context.Context, req *registry.ListAppProvidersRequest) (*registry.ListAppProvidersResponse, error) {
-	c, err := pool.GetAppRegistryClient(pool.Endpoint(s.c.AppRegistryEndpoint))
+	c, err := pool.GetAppRegistryClient(s.c, pool.Endpoint(s.c.AppRegistryEndpoint))
 	if err != nil {
 		err = errors.Wrap(err, "gateway: error calling GetAppRegistryClient")
 		return &registry.ListAppProvidersResponse{
@@ -79,7 +79,7 @@ func (s *svc) ListAppProviders(ctx context.Context, req *registry.ListAppProvide
 }
 
 func (s *svc) ListSupportedMimeTypes(ctx context.Context, req *registry.ListSupportedMimeTypesRequest) (*registry.ListSupportedMimeTypesResponse, error) {
-	c, err := pool.GetAppRegistryClient(pool.Endpoint(s.c.AppRegistryEndpoint))
+	c, err := pool.GetAppRegistryClient(s.c, pool.Endpoint(s.c.AppRegistryEndpoint))
 	if err != nil {
 		err = errors.Wrap(err, "gateway: error calling GetAppRegistryClient")
 		return &registry.ListSupportedMimeTypesResponse{
@@ -96,7 +96,7 @@ func (s *svc) ListSupportedMimeTypes(ctx context.Context, req *registry.ListSupp
 }
 
 func (s *svc) GetDefaultAppProviderForMimeType(ctx context.Context, req *registry.GetDefaultAppProviderForMimeTypeRequest) (*registry.GetDefaultAppProviderForMimeTypeResponse, error) {
-	c, err := pool.GetAppRegistryClient(pool.Endpoint(s.c.AppRegistryEndpoint))
+	c, err := pool.GetAppRegistryClient(s.c, pool.Endpoint(s.c.AppRegistryEndpoint))
 	if err != nil {
 		err = errors.Wrap(err, "gateway: error calling GetAppRegistryClient")
 		return &registry.GetDefaultAppProviderForMimeTypeResponse{
@@ -113,7 +113,7 @@ func (s *svc) GetDefaultAppProviderForMimeType(ctx context.Context, req *registr
 }
 
 func (s *svc) SetDefaultAppProviderForMimeType(ctx context.Context, req *registry.SetDefaultAppProviderForMimeTypeRequest) (*registry.SetDefaultAppProviderForMimeTypeResponse, error) {
-	c, err := pool.GetAppRegistryClient(pool.Endpoint(s.c.AppRegistryEndpoint))
+	c, err := pool.GetAppRegistryClient(s.c, pool.Endpoint(s.c.AppRegistryEndpoint))
 	if err != nil {
 		err = errors.Wrap(err, "gateway: error calling GetAppRegistryClient")
 		return &registry.SetDefaultAppProviderForMimeTypeResponse{

--- a/internal/grpc/services/gateway/authprovider.go
+++ b/internal/grpc/services/gateway/authprovider.go
@@ -207,7 +207,7 @@ func (s *svc) WhoAmI(ctx context.Context, req *gateway.WhoAmIRequest) (*gateway.
 }
 
 func (s *svc) findAuthProvider(ctx context.Context, authType string) (authpb.ProviderAPIClient, error) {
-	c, err := pool.GetAuthRegistryServiceClient(pool.Endpoint(s.c.AuthRegistryEndpoint))
+	c, err := pool.GetAuthRegistryServiceClient(s.c, pool.Endpoint(s.c.AuthRegistryEndpoint))
 	if err != nil {
 		err = errors.Wrap(err, "gateway: error getting auth registry client")
 		return nil, err
@@ -224,7 +224,7 @@ func (s *svc) findAuthProvider(ctx context.Context, authType string) (authpb.Pro
 
 	if res.Status.Code == rpc.Code_CODE_OK && res.Providers != nil && len(res.Providers) > 0 {
 		// TODO(labkode): check for capabilities here
-		c, err := pool.GetAuthProviderServiceClient(pool.Endpoint(res.Providers[0].Address))
+		c, err := pool.GetAuthProviderServiceClient(s.c, pool.Endpoint(res.Providers[0].Address))
 		if err != nil {
 			err = errors.Wrap(err, "gateway: error getting an auth provider client")
 			return nil, err

--- a/internal/grpc/services/gateway/authregistry.go
+++ b/internal/grpc/services/gateway/authregistry.go
@@ -30,7 +30,7 @@ import (
 )
 
 func (s *svc) ListAuthProviders(ctx context.Context, req *registry.ListAuthProvidersRequest) (*gateway.ListAuthProvidersResponse, error) {
-	c, err := pool.GetAuthRegistryServiceClient(pool.Endpoint(s.c.AuthRegistryEndpoint))
+	c, err := pool.GetAuthRegistryServiceClient(s.c, pool.Endpoint(s.c.AuthRegistryEndpoint))
 	if err != nil {
 		err = errors.Wrap(err, "gateway: error getting auth registry client")
 		return &gateway.ListAuthProvidersResponse{

--- a/internal/grpc/services/gateway/datatx.go
+++ b/internal/grpc/services/gateway/datatx.go
@@ -28,7 +28,7 @@ import (
 )
 
 func (s *svc) PullTransfer(ctx context.Context, req *datatx.PullTransferRequest) (*datatx.PullTransferResponse, error) {
-	c, err := pool.GetDataTxClient(pool.Endpoint(s.c.DataTxEndpoint))
+	c, err := pool.GetDataTxClient(s.c, pool.Endpoint(s.c.DataTxEndpoint))
 	if err != nil {
 		err = errors.Wrap(err, "gateway: error calling GetDataTxClient")
 		return &datatx.PullTransferResponse{
@@ -45,7 +45,7 @@ func (s *svc) PullTransfer(ctx context.Context, req *datatx.PullTransferRequest)
 }
 
 func (s *svc) GetTransferStatus(ctx context.Context, req *datatx.GetTransferStatusRequest) (*datatx.GetTransferStatusResponse, error) {
-	c, err := pool.GetDataTxClient(pool.Endpoint(s.c.DataTxEndpoint))
+	c, err := pool.GetDataTxClient(s.c, pool.Endpoint(s.c.DataTxEndpoint))
 	if err != nil {
 		err = errors.Wrap(err, "gateway: error calling GetDataTxClient")
 		return &datatx.GetTransferStatusResponse{
@@ -62,7 +62,7 @@ func (s *svc) GetTransferStatus(ctx context.Context, req *datatx.GetTransferStat
 }
 
 func (s *svc) CancelTransfer(ctx context.Context, req *datatx.CancelTransferRequest) (*datatx.CancelTransferResponse, error) {
-	c, err := pool.GetDataTxClient(pool.Endpoint(s.c.DataTxEndpoint))
+	c, err := pool.GetDataTxClient(s.c, pool.Endpoint(s.c.DataTxEndpoint))
 	if err != nil {
 		err = errors.Wrap(err, "gateway: error calling GetDataTxClient")
 		return &datatx.CancelTransferResponse{
@@ -79,7 +79,7 @@ func (s *svc) CancelTransfer(ctx context.Context, req *datatx.CancelTransferRequ
 }
 
 func (s *svc) ListTransfers(ctx context.Context, req *datatx.ListTransfersRequest) (*datatx.ListTransfersResponse, error) {
-	c, err := pool.GetDataTxClient(pool.Endpoint(s.c.DataTxEndpoint))
+	c, err := pool.GetDataTxClient(s.c, pool.Endpoint(s.c.DataTxEndpoint))
 	if err != nil {
 		err = errors.Wrap(err, "gateway: error calling GetDataTxClient")
 		return &datatx.ListTransfersResponse{
@@ -96,7 +96,7 @@ func (s *svc) ListTransfers(ctx context.Context, req *datatx.ListTransfersReques
 }
 
 func (s *svc) RetryTransfer(ctx context.Context, req *datatx.RetryTransferRequest) (*datatx.RetryTransferResponse, error) {
-	c, err := pool.GetDataTxClient(pool.Endpoint(s.c.DataTxEndpoint))
+	c, err := pool.GetDataTxClient(s.c, pool.Endpoint(s.c.DataTxEndpoint))
 	if err != nil {
 		err = errors.Wrap(err, "gateway: error calling GetDataTxClient")
 		return &datatx.RetryTransferResponse{

--- a/internal/grpc/services/gateway/gateway.go
+++ b/internal/grpc/services/gateway/gateway.go
@@ -72,6 +72,7 @@ type config struct {
 	EtagCacheTTL        int                               `mapstructure:"etag_cache_ttl"`
 	AllowedUserAgents   map[string][]string               `mapstructure:"allowed_user_agents"` // map[path][]user-agent
 	CreateHomeCacheTTL  int                               `mapstructure:"create_home_cache_ttl"`
+	MaxCallRecvMsgSize  int                               `mapstructure:"client_recv_msg_size"`
 }
 
 // sets defaults

--- a/internal/grpc/services/gateway/groupprovider.go
+++ b/internal/grpc/services/gateway/groupprovider.go
@@ -28,7 +28,7 @@ import (
 )
 
 func (s *svc) GetGroup(ctx context.Context, req *group.GetGroupRequest) (*group.GetGroupResponse, error) {
-	c, err := pool.GetGroupProviderServiceClient(pool.Endpoint(s.c.GroupProviderEndpoint))
+	c, err := pool.GetGroupProviderServiceClient(s.c, pool.Endpoint(s.c.GroupProviderEndpoint))
 	if err != nil {
 		return &group.GetGroupResponse{
 			Status: status.NewInternal(ctx, err, "error getting auth client"),
@@ -44,7 +44,7 @@ func (s *svc) GetGroup(ctx context.Context, req *group.GetGroupRequest) (*group.
 }
 
 func (s *svc) GetGroupByClaim(ctx context.Context, req *group.GetGroupByClaimRequest) (*group.GetGroupByClaimResponse, error) {
-	c, err := pool.GetGroupProviderServiceClient(pool.Endpoint(s.c.GroupProviderEndpoint))
+	c, err := pool.GetGroupProviderServiceClient(s.c, pool.Endpoint(s.c.GroupProviderEndpoint))
 	if err != nil {
 		return &group.GetGroupByClaimResponse{
 			Status: status.NewInternal(ctx, err, "error getting auth client"),
@@ -60,7 +60,7 @@ func (s *svc) GetGroupByClaim(ctx context.Context, req *group.GetGroupByClaimReq
 }
 
 func (s *svc) FindGroups(ctx context.Context, req *group.FindGroupsRequest) (*group.FindGroupsResponse, error) {
-	c, err := pool.GetGroupProviderServiceClient(pool.Endpoint(s.c.GroupProviderEndpoint))
+	c, err := pool.GetGroupProviderServiceClient(s.c, pool.Endpoint(s.c.GroupProviderEndpoint))
 	if err != nil {
 		return &group.FindGroupsResponse{
 			Status: status.NewInternal(ctx, err, "error getting auth client"),
@@ -76,7 +76,7 @@ func (s *svc) FindGroups(ctx context.Context, req *group.FindGroupsRequest) (*gr
 }
 
 func (s *svc) GetMembers(ctx context.Context, req *group.GetMembersRequest) (*group.GetMembersResponse, error) {
-	c, err := pool.GetGroupProviderServiceClient(pool.Endpoint(s.c.GroupProviderEndpoint))
+	c, err := pool.GetGroupProviderServiceClient(s.c, pool.Endpoint(s.c.GroupProviderEndpoint))
 	if err != nil {
 		return &group.GetMembersResponse{
 			Status: status.NewInternal(ctx, err, "error getting auth client"),
@@ -92,7 +92,7 @@ func (s *svc) GetMembers(ctx context.Context, req *group.GetMembersRequest) (*gr
 }
 
 func (s *svc) HasMember(ctx context.Context, req *group.HasMemberRequest) (*group.HasMemberResponse, error) {
-	c, err := pool.GetGroupProviderServiceClient(pool.Endpoint(s.c.GroupProviderEndpoint))
+	c, err := pool.GetGroupProviderServiceClient(s.c, pool.Endpoint(s.c.GroupProviderEndpoint))
 	if err != nil {
 		return &group.HasMemberResponse{
 			Status: status.NewInternal(ctx, err, "error getting auth client"),

--- a/internal/grpc/services/gateway/ocmcore.go
+++ b/internal/grpc/services/gateway/ocmcore.go
@@ -28,7 +28,7 @@ import (
 )
 
 func (s *svc) CreateOCMCoreShare(ctx context.Context, req *ocmcore.CreateOCMCoreShareRequest) (*ocmcore.CreateOCMCoreShareResponse, error) {
-	c, err := pool.GetOCMCoreClient(pool.Endpoint(s.c.OCMCoreEndpoint))
+	c, err := pool.GetOCMCoreClient(s.c, pool.Endpoint(s.c.OCMCoreEndpoint))
 	if err != nil {
 		return &ocmcore.CreateOCMCoreShareResponse{
 			Status: status.NewInternal(ctx, err, "error getting ocm core client"),

--- a/internal/grpc/services/gateway/ocminvitemanager.go
+++ b/internal/grpc/services/gateway/ocminvitemanager.go
@@ -28,7 +28,7 @@ import (
 )
 
 func (s *svc) GenerateInviteToken(ctx context.Context, req *invitepb.GenerateInviteTokenRequest) (*invitepb.GenerateInviteTokenResponse, error) {
-	c, err := pool.GetOCMInviteManagerClient(pool.Endpoint(s.c.OCMInviteManagerEndpoint))
+	c, err := pool.GetOCMInviteManagerClient(s.c, pool.Endpoint(s.c.OCMInviteManagerEndpoint))
 	if err != nil {
 		return &invitepb.GenerateInviteTokenResponse{
 			Status: status.NewInternal(ctx, err, "error getting user invite provider client"),
@@ -44,7 +44,7 @@ func (s *svc) GenerateInviteToken(ctx context.Context, req *invitepb.GenerateInv
 }
 
 func (s *svc) ForwardInvite(ctx context.Context, req *invitepb.ForwardInviteRequest) (*invitepb.ForwardInviteResponse, error) {
-	c, err := pool.GetOCMInviteManagerClient(pool.Endpoint(s.c.OCMInviteManagerEndpoint))
+	c, err := pool.GetOCMInviteManagerClient(s.c, pool.Endpoint(s.c.OCMInviteManagerEndpoint))
 	if err != nil {
 		return &invitepb.ForwardInviteResponse{
 			Status: status.NewInternal(ctx, err, "error getting user invite provider client"),
@@ -60,7 +60,7 @@ func (s *svc) ForwardInvite(ctx context.Context, req *invitepb.ForwardInviteRequ
 }
 
 func (s *svc) AcceptInvite(ctx context.Context, req *invitepb.AcceptInviteRequest) (*invitepb.AcceptInviteResponse, error) {
-	c, err := pool.GetOCMInviteManagerClient(pool.Endpoint(s.c.OCMInviteManagerEndpoint))
+	c, err := pool.GetOCMInviteManagerClient(s.c, pool.Endpoint(s.c.OCMInviteManagerEndpoint))
 	if err != nil {
 		return &invitepb.AcceptInviteResponse{
 			Status: status.NewInternal(ctx, err, "error getting user invite provider client"),
@@ -76,7 +76,7 @@ func (s *svc) AcceptInvite(ctx context.Context, req *invitepb.AcceptInviteReques
 }
 
 func (s *svc) GetAcceptedUser(ctx context.Context, req *invitepb.GetAcceptedUserRequest) (*invitepb.GetAcceptedUserResponse, error) {
-	c, err := pool.GetOCMInviteManagerClient(pool.Endpoint(s.c.OCMInviteManagerEndpoint))
+	c, err := pool.GetOCMInviteManagerClient(s.c, pool.Endpoint(s.c.OCMInviteManagerEndpoint))
 	if err != nil {
 		return &invitepb.GetAcceptedUserResponse{
 			Status: status.NewInternal(ctx, err, "error getting user invite provider client"),
@@ -92,7 +92,7 @@ func (s *svc) GetAcceptedUser(ctx context.Context, req *invitepb.GetAcceptedUser
 }
 
 func (s *svc) FindAcceptedUsers(ctx context.Context, req *invitepb.FindAcceptedUsersRequest) (*invitepb.FindAcceptedUsersResponse, error) {
-	c, err := pool.GetOCMInviteManagerClient(pool.Endpoint(s.c.OCMInviteManagerEndpoint))
+	c, err := pool.GetOCMInviteManagerClient(s.c, pool.Endpoint(s.c.OCMInviteManagerEndpoint))
 	if err != nil {
 		return &invitepb.FindAcceptedUsersResponse{
 			Status: status.NewInternal(ctx, err, "error getting user invite provider client"),

--- a/internal/grpc/services/gateway/ocmproviderauthorizer.go
+++ b/internal/grpc/services/gateway/ocmproviderauthorizer.go
@@ -28,7 +28,7 @@ import (
 )
 
 func (s *svc) IsProviderAllowed(ctx context.Context, req *ocmprovider.IsProviderAllowedRequest) (*ocmprovider.IsProviderAllowedResponse, error) {
-	c, err := pool.GetOCMProviderAuthorizerClient(pool.Endpoint(s.c.OCMProviderAuthorizerEndpoint))
+	c, err := pool.GetOCMProviderAuthorizerClient(s.c, pool.Endpoint(s.c.OCMProviderAuthorizerEndpoint))
 	if err != nil {
 		return &ocmprovider.IsProviderAllowedResponse{
 			Status: status.NewInternal(ctx, err, "error getting ocm authorizer provider client"),
@@ -44,7 +44,7 @@ func (s *svc) IsProviderAllowed(ctx context.Context, req *ocmprovider.IsProvider
 }
 
 func (s *svc) GetInfoByDomain(ctx context.Context, req *ocmprovider.GetInfoByDomainRequest) (*ocmprovider.GetInfoByDomainResponse, error) {
-	c, err := pool.GetOCMProviderAuthorizerClient(pool.Endpoint(s.c.OCMProviderAuthorizerEndpoint))
+	c, err := pool.GetOCMProviderAuthorizerClient(s.c, pool.Endpoint(s.c.OCMProviderAuthorizerEndpoint))
 	if err != nil {
 		return &ocmprovider.GetInfoByDomainResponse{
 			Status: status.NewInternal(ctx, err, "error getting ocm authorizer provider client"),
@@ -60,7 +60,7 @@ func (s *svc) GetInfoByDomain(ctx context.Context, req *ocmprovider.GetInfoByDom
 }
 
 func (s *svc) ListAllProviders(ctx context.Context, req *ocmprovider.ListAllProvidersRequest) (*ocmprovider.ListAllProvidersResponse, error) {
-	c, err := pool.GetOCMProviderAuthorizerClient(pool.Endpoint(s.c.OCMProviderAuthorizerEndpoint))
+	c, err := pool.GetOCMProviderAuthorizerClient(s.c, pool.Endpoint(s.c.OCMProviderAuthorizerEndpoint))
 	if err != nil {
 		return &ocmprovider.ListAllProvidersResponse{
 			Status: status.NewInternal(ctx, err, "error getting ocm authorizer provider client"),

--- a/internal/grpc/services/gateway/ocmshareprovider.go
+++ b/internal/grpc/services/gateway/ocmshareprovider.go
@@ -41,7 +41,7 @@ import (
 
 // TODO(labkode): add multi-phase commit logic when commit share or commit ref is enabled.
 func (s *svc) CreateOCMShare(ctx context.Context, req *ocm.CreateOCMShareRequest) (*ocm.CreateOCMShareResponse, error) {
-	c, err := pool.GetOCMShareProviderClient(pool.Endpoint(s.c.OCMShareProviderEndpoint))
+	c, err := pool.GetOCMShareProviderClient(s.c, pool.Endpoint(s.c.OCMShareProviderEndpoint))
 	if err != nil {
 		return &ocm.CreateOCMShareResponse{
 			Status: status.NewInternal(ctx, err, "error getting user share provider client"),
@@ -75,7 +75,7 @@ func (s *svc) CreateOCMShare(ctx context.Context, req *ocm.CreateOCMShareRequest
 }
 
 func (s *svc) RemoveOCMShare(ctx context.Context, req *ocm.RemoveOCMShareRequest) (*ocm.RemoveOCMShareResponse, error) {
-	c, err := pool.GetOCMShareProviderClient(pool.Endpoint(s.c.OCMShareProviderEndpoint))
+	c, err := pool.GetOCMShareProviderClient(s.c, pool.Endpoint(s.c.OCMShareProviderEndpoint))
 	if err != nil {
 		return &ocm.RemoveOCMShareResponse{
 			Status: status.NewInternal(ctx, err, "error getting user share provider client"),
@@ -137,7 +137,7 @@ func (s *svc) GetOCMShare(ctx context.Context, req *ocm.GetOCMShareRequest) (*oc
 }
 
 func (s *svc) getOCMShare(ctx context.Context, req *ocm.GetOCMShareRequest) (*ocm.GetOCMShareResponse, error) {
-	c, err := pool.GetOCMShareProviderClient(pool.Endpoint(s.c.OCMShareProviderEndpoint))
+	c, err := pool.GetOCMShareProviderClient(s.c, pool.Endpoint(s.c.OCMShareProviderEndpoint))
 	if err != nil {
 		err = errors.Wrap(err, "gateway: error calling GetOCMShareProviderClient")
 		return &ocm.GetOCMShareResponse{
@@ -155,7 +155,7 @@ func (s *svc) getOCMShare(ctx context.Context, req *ocm.GetOCMShareRequest) (*oc
 
 // TODO(labkode): read GetShare comment.
 func (s *svc) ListOCMShares(ctx context.Context, req *ocm.ListOCMSharesRequest) (*ocm.ListOCMSharesResponse, error) {
-	c, err := pool.GetOCMShareProviderClient(pool.Endpoint(s.c.OCMShareProviderEndpoint))
+	c, err := pool.GetOCMShareProviderClient(s.c, pool.Endpoint(s.c.OCMShareProviderEndpoint))
 	if err != nil {
 		err = errors.Wrap(err, "gateway: error calling GetOCMShareProviderClient")
 		return &ocm.ListOCMSharesResponse{
@@ -172,7 +172,7 @@ func (s *svc) ListOCMShares(ctx context.Context, req *ocm.ListOCMSharesRequest) 
 }
 
 func (s *svc) UpdateOCMShare(ctx context.Context, req *ocm.UpdateOCMShareRequest) (*ocm.UpdateOCMShareResponse, error) {
-	c, err := pool.GetOCMShareProviderClient(pool.Endpoint(s.c.OCMShareProviderEndpoint))
+	c, err := pool.GetOCMShareProviderClient(s.c, pool.Endpoint(s.c.OCMShareProviderEndpoint))
 	if err != nil {
 		err = errors.Wrap(err, "gateway: error calling GetOCMShareProviderClient")
 		return &ocm.UpdateOCMShareResponse{
@@ -189,7 +189,7 @@ func (s *svc) UpdateOCMShare(ctx context.Context, req *ocm.UpdateOCMShareRequest
 }
 
 func (s *svc) ListReceivedOCMShares(ctx context.Context, req *ocm.ListReceivedOCMSharesRequest) (*ocm.ListReceivedOCMSharesResponse, error) {
-	c, err := pool.GetOCMShareProviderClient(pool.Endpoint(s.c.OCMShareProviderEndpoint))
+	c, err := pool.GetOCMShareProviderClient(s.c, pool.Endpoint(s.c.OCMShareProviderEndpoint))
 	if err != nil {
 		err = errors.Wrap(err, "gateway: error calling GetOCMShareProviderClient")
 		return &ocm.ListReceivedOCMSharesResponse{
@@ -207,7 +207,7 @@ func (s *svc) ListReceivedOCMShares(ctx context.Context, req *ocm.ListReceivedOC
 
 func (s *svc) UpdateReceivedOCMShare(ctx context.Context, req *ocm.UpdateReceivedOCMShareRequest) (*ocm.UpdateReceivedOCMShareResponse, error) {
 	log := appctx.GetLogger(ctx)
-	c, err := pool.GetOCMShareProviderClient(pool.Endpoint(s.c.OCMShareProviderEndpoint))
+	c, err := pool.GetOCMShareProviderClient(s.c, pool.Endpoint(s.c.OCMShareProviderEndpoint))
 	if err != nil {
 		err = errors.Wrap(err, "gateway: error calling GetOCMShareProviderClient")
 		return &ocm.UpdateReceivedOCMShareResponse{
@@ -409,7 +409,7 @@ func (s *svc) UpdateReceivedOCMShare(ctx context.Context, req *ocm.UpdateReceive
 }
 
 func (s *svc) GetReceivedOCMShare(ctx context.Context, req *ocm.GetReceivedOCMShareRequest) (*ocm.GetReceivedOCMShareResponse, error) {
-	c, err := pool.GetOCMShareProviderClient(pool.Endpoint(s.c.OCMShareProviderEndpoint))
+	c, err := pool.GetOCMShareProviderClient(s.c, pool.Endpoint(s.c.OCMShareProviderEndpoint))
 	if err != nil {
 		err = errors.Wrap(err, "gateway: error calling GetOCMShareProviderClient")
 		return &ocm.GetReceivedOCMShareResponse{

--- a/internal/grpc/services/gateway/permissions.go
+++ b/internal/grpc/services/gateway/permissions.go
@@ -28,7 +28,7 @@ import (
 )
 
 func (s *svc) CheckPermission(ctx context.Context, req *permissions.CheckPermissionRequest) (*permissions.CheckPermissionResponse, error) {
-	c, err := pool.GetPermissionsClient(pool.Endpoint(s.c.PermissionsEndpoint))
+	c, err := pool.GetPermissionsClient(s.c, pool.Endpoint(s.c.PermissionsEndpoint))
 	if err != nil {
 		err = errors.Wrap(err, "gateway: error calling GetPermissionssClient")
 		return &permissions.CheckPermissionResponse{

--- a/internal/grpc/services/gateway/preferences.go
+++ b/internal/grpc/services/gateway/preferences.go
@@ -28,7 +28,7 @@ import (
 )
 
 func (s *svc) SetKey(ctx context.Context, req *preferences.SetKeyRequest) (*preferences.SetKeyResponse, error) {
-	c, err := pool.GetPreferencesClient(pool.Endpoint(s.c.PreferencesEndpoint))
+	c, err := pool.GetPreferencesClient(s.c, pool.Endpoint(s.c.PreferencesEndpoint))
 	if err != nil {
 		err = errors.Wrap(err, "gateway: error calling GetPreferencesClient")
 		return &preferences.SetKeyResponse{
@@ -45,7 +45,7 @@ func (s *svc) SetKey(ctx context.Context, req *preferences.SetKeyRequest) (*pref
 }
 
 func (s *svc) GetKey(ctx context.Context, req *preferences.GetKeyRequest) (*preferences.GetKeyResponse, error) {
-	c, err := pool.GetPreferencesClient(pool.Endpoint(s.c.PreferencesEndpoint))
+	c, err := pool.GetPreferencesClient(s.c, pool.Endpoint(s.c.PreferencesEndpoint))
 	if err != nil {
 		err = errors.Wrap(err, "gateway: error calling GetPreferencesClient")
 		return &preferences.GetKeyResponse{

--- a/internal/grpc/services/gateway/publicshareprovider.go
+++ b/internal/grpc/services/gateway/publicshareprovider.go
@@ -37,7 +37,7 @@ func (s *svc) CreatePublicShare(ctx context.Context, req *link.CreatePublicShare
 	log := appctx.GetLogger(ctx)
 	log.Info().Msg("create public share")
 
-	c, err := pool.GetPublicShareProviderClient(pool.Endpoint(s.c.PublicShareProviderEndpoint))
+	c, err := pool.GetPublicShareProviderClient(s.c, pool.Endpoint(s.c.PublicShareProviderEndpoint))
 	if err != nil {
 		return nil, err
 	}
@@ -54,7 +54,7 @@ func (s *svc) RemovePublicShare(ctx context.Context, req *link.RemovePublicShare
 	log := appctx.GetLogger(ctx)
 	log.Info().Msg("remove public share")
 
-	driver, err := pool.GetPublicShareProviderClient(pool.Endpoint(s.c.PublicShareProviderEndpoint))
+	driver, err := pool.GetPublicShareProviderClient(s.c, pool.Endpoint(s.c.PublicShareProviderEndpoint))
 	if err != nil {
 		return nil, err
 	}
@@ -69,7 +69,7 @@ func (s *svc) GetPublicShareByToken(ctx context.Context, req *link.GetPublicShar
 	log := appctx.GetLogger(ctx)
 	log.Info().Msg("get public share by token")
 
-	driver, err := pool.GetPublicShareProviderClient(pool.Endpoint(s.c.PublicShareProviderEndpoint))
+	driver, err := pool.GetPublicShareProviderClient(s.c, pool.Endpoint(s.c.PublicShareProviderEndpoint))
 	if err != nil {
 		return nil, err
 	}
@@ -86,7 +86,7 @@ func (s *svc) GetPublicShare(ctx context.Context, req *link.GetPublicShareReques
 	log := appctx.GetLogger(ctx)
 	log.Info().Msg("get public share")
 
-	pClient, err := pool.GetPublicShareProviderClient(pool.Endpoint(s.c.PublicShareProviderEndpoint))
+	pClient, err := pool.GetPublicShareProviderClient(s.c, pool.Endpoint(s.c.PublicShareProviderEndpoint))
 	if err != nil {
 		log.Err(err).Msg("error connecting to a public share provider")
 		return &link.GetPublicShareResponse{
@@ -103,7 +103,7 @@ func (s *svc) ListPublicShares(ctx context.Context, req *link.ListPublicSharesRe
 	log := appctx.GetLogger(ctx)
 	log.Info().Msg("listing public shares")
 
-	pClient, err := pool.GetPublicShareProviderClient(pool.Endpoint(s.c.PublicShareProviderEndpoint))
+	pClient, err := pool.GetPublicShareProviderClient(s.c, pool.Endpoint(s.c.PublicShareProviderEndpoint))
 	if err != nil {
 		log.Err(err).Msg("error connecting to a public share provider")
 		return &link.ListPublicSharesResponse{
@@ -125,7 +125,7 @@ func (s *svc) UpdatePublicShare(ctx context.Context, req *link.UpdatePublicShare
 	log := appctx.GetLogger(ctx)
 	log.Info().Msg("update public share")
 
-	pClient, err := pool.GetPublicShareProviderClient(pool.Endpoint(s.c.PublicShareProviderEndpoint))
+	pClient, err := pool.GetPublicShareProviderClient(s.c, pool.Endpoint(s.c.PublicShareProviderEndpoint))
 	if err != nil {
 		log.Err(err).Msg("error connecting to a public share provider")
 		return &link.UpdatePublicShareResponse{

--- a/internal/grpc/services/gateway/storageprovider.go
+++ b/internal/grpc/services/gateway/storageprovider.go
@@ -135,7 +135,7 @@ func (s *svc) ListStorageSpaces(ctx context.Context, req *provider.ListStorageSp
 		providers []*registry.ProviderInfo
 		err       error
 	)
-	c, err := pool.GetStorageRegistryClient(pool.Endpoint(s.c.StorageRegistryEndpoint))
+	c, err := pool.GetStorageRegistryClient(s.c, pool.Endpoint(s.c.StorageRegistryEndpoint))
 	if err != nil {
 		return nil, errors.Wrap(err, "gateway: error getting storage registry client")
 	}
@@ -2286,7 +2286,7 @@ func (s *svc) find(ctx context.Context, ref *provider.Reference) (provider.Provi
 }
 
 func (s *svc) getStorageProviderClient(_ context.Context, p *registry.ProviderInfo) (provider.ProviderAPIClient, error) {
-	c, err := pool.GetStorageProviderServiceClient(pool.Endpoint(p.Address))
+	c, err := pool.GetStorageProviderServiceClient(s.c, pool.Endpoint(p.Address))
 	if err != nil {
 		err = errors.Wrap(err, "gateway: error getting a storage provider client")
 		return nil, err
@@ -2296,7 +2296,7 @@ func (s *svc) getStorageProviderClient(_ context.Context, p *registry.ProviderIn
 }
 
 func (s *svc) findProviders(ctx context.Context, ref *provider.Reference) ([]*registry.ProviderInfo, error) {
-	c, err := pool.GetStorageRegistryClient(pool.Endpoint(s.c.StorageRegistryEndpoint))
+	c, err := pool.GetStorageRegistryClient(s.c, pool.Endpoint(s.c.StorageRegistryEndpoint))
 	if err != nil {
 		return nil, errors.Wrap(err, "gateway: error getting storage registry client")
 	}

--- a/internal/grpc/services/gateway/userprovider.go
+++ b/internal/grpc/services/gateway/userprovider.go
@@ -28,7 +28,7 @@ import (
 )
 
 func (s *svc) GetUser(ctx context.Context, req *user.GetUserRequest) (*user.GetUserResponse, error) {
-	c, err := pool.GetUserProviderServiceClient(pool.Endpoint(s.c.UserProviderEndpoint))
+	c, err := pool.GetUserProviderServiceClient(s.c, pool.Endpoint(s.c.UserProviderEndpoint))
 	if err != nil {
 		return &user.GetUserResponse{
 			Status: status.NewInternal(ctx, err, "error getting auth client"),
@@ -44,7 +44,7 @@ func (s *svc) GetUser(ctx context.Context, req *user.GetUserRequest) (*user.GetU
 }
 
 func (s *svc) GetUserByClaim(ctx context.Context, req *user.GetUserByClaimRequest) (*user.GetUserByClaimResponse, error) {
-	c, err := pool.GetUserProviderServiceClient(pool.Endpoint(s.c.UserProviderEndpoint))
+	c, err := pool.GetUserProviderServiceClient(s.c, pool.Endpoint(s.c.UserProviderEndpoint))
 	if err != nil {
 		return &user.GetUserByClaimResponse{
 			Status: status.NewInternal(ctx, err, "error getting auth client"),
@@ -60,7 +60,7 @@ func (s *svc) GetUserByClaim(ctx context.Context, req *user.GetUserByClaimReques
 }
 
 func (s *svc) FindUsers(ctx context.Context, req *user.FindUsersRequest) (*user.FindUsersResponse, error) {
-	c, err := pool.GetUserProviderServiceClient(pool.Endpoint(s.c.UserProviderEndpoint))
+	c, err := pool.GetUserProviderServiceClient(s.c, pool.Endpoint(s.c.UserProviderEndpoint))
 	if err != nil {
 		return &user.FindUsersResponse{
 			Status: status.NewInternal(ctx, err, "error getting auth client"),
@@ -76,7 +76,7 @@ func (s *svc) FindUsers(ctx context.Context, req *user.FindUsersRequest) (*user.
 }
 
 func (s *svc) GetUserGroups(ctx context.Context, req *user.GetUserGroupsRequest) (*user.GetUserGroupsResponse, error) {
-	c, err := pool.GetUserProviderServiceClient(pool.Endpoint(s.c.UserProviderEndpoint))
+	c, err := pool.GetUserProviderServiceClient(&struct{}{}, pool.Endpoint(s.c.UserProviderEndpoint))
 	if err != nil {
 		return &user.GetUserGroupsResponse{
 			Status: status.NewInternal(ctx, err, "error getting auth client"),

--- a/internal/grpc/services/gateway/usershareprovider.go
+++ b/internal/grpc/services/gateway/usershareprovider.go
@@ -44,7 +44,7 @@ func (s *svc) CreateShare(ctx context.Context, req *collaboration.CreateShareReq
 		return nil, errtypes.AlreadyExists("gateway: can't share the share folder itself")
 	}
 
-	c, err := pool.GetUserShareProviderClient(pool.Endpoint(s.c.UserShareProviderEndpoint))
+	c, err := pool.GetUserShareProviderClient(s.c, pool.Endpoint(s.c.UserShareProviderEndpoint))
 	if err != nil {
 		return &collaboration.CreateShareResponse{
 			Status: status.NewInternal(ctx, err, "error getting user share provider client"),
@@ -97,7 +97,7 @@ func (s *svc) CreateShare(ctx context.Context, req *collaboration.CreateShareReq
 }
 
 func (s *svc) RemoveShare(ctx context.Context, req *collaboration.RemoveShareRequest) (*collaboration.RemoveShareResponse, error) {
-	c, err := pool.GetUserShareProviderClient(pool.Endpoint(s.c.UserShareProviderEndpoint))
+	c, err := pool.GetUserShareProviderClient(s.c, pool.Endpoint(s.c.UserShareProviderEndpoint))
 	if err != nil {
 		return &collaboration.RemoveShareResponse{
 			Status: status.NewInternal(ctx, err, "error getting user share provider client"),
@@ -161,7 +161,7 @@ func (s *svc) GetShare(ctx context.Context, req *collaboration.GetShareRequest) 
 }
 
 func (s *svc) getShare(ctx context.Context, req *collaboration.GetShareRequest) (*collaboration.GetShareResponse, error) {
-	c, err := pool.GetUserShareProviderClient(pool.Endpoint(s.c.UserShareProviderEndpoint))
+	c, err := pool.GetUserShareProviderClient(s.c, pool.Endpoint(s.c.UserShareProviderEndpoint))
 	if err != nil {
 		err = errors.Wrap(err, "gateway: error calling GetUserShareProviderClient")
 		return &collaboration.GetShareResponse{
@@ -179,7 +179,7 @@ func (s *svc) getShare(ctx context.Context, req *collaboration.GetShareRequest) 
 
 // TODO(labkode): read GetShare comment.
 func (s *svc) ListShares(ctx context.Context, req *collaboration.ListSharesRequest) (*collaboration.ListSharesResponse, error) {
-	c, err := pool.GetUserShareProviderClient(pool.Endpoint(s.c.UserShareProviderEndpoint))
+	c, err := pool.GetUserShareProviderClient(s.c, pool.Endpoint(s.c.UserShareProviderEndpoint))
 	if err != nil {
 		err = errors.Wrap(err, "gateway: error calling GetUserShareProviderClient")
 		return &collaboration.ListSharesResponse{
@@ -196,7 +196,7 @@ func (s *svc) ListShares(ctx context.Context, req *collaboration.ListSharesReque
 }
 
 func (s *svc) UpdateShare(ctx context.Context, req *collaboration.UpdateShareRequest) (*collaboration.UpdateShareResponse, error) {
-	c, err := pool.GetUserShareProviderClient(pool.Endpoint(s.c.UserShareProviderEndpoint))
+	c, err := pool.GetUserShareProviderClient(s.c, pool.Endpoint(s.c.UserShareProviderEndpoint))
 	if err != nil {
 		err = errors.Wrap(err, "gateway: error calling GetUserShareProviderClient")
 		return &collaboration.UpdateShareResponse{
@@ -240,7 +240,7 @@ func (s *svc) UpdateShare(ctx context.Context, req *collaboration.UpdateShareReq
 // received shares. The display name of the shares should be the a friendly name, like the basename
 // of the original file.
 func (s *svc) ListReceivedShares(ctx context.Context, req *collaboration.ListReceivedSharesRequest) (*collaboration.ListReceivedSharesResponse, error) {
-	c, err := pool.GetUserShareProviderClient(pool.Endpoint(s.c.UserShareProviderEndpoint))
+	c, err := pool.GetUserShareProviderClient(s.c, pool.Endpoint(s.c.UserShareProviderEndpoint))
 	if err != nil {
 		err = errors.Wrap(err, "gateway: error calling GetUserShareProviderClient")
 		return &collaboration.ListReceivedSharesResponse{
@@ -256,7 +256,7 @@ func (s *svc) ListReceivedShares(ctx context.Context, req *collaboration.ListRec
 }
 
 func (s *svc) GetReceivedShare(ctx context.Context, req *collaboration.GetReceivedShareRequest) (*collaboration.GetReceivedShareResponse, error) {
-	c, err := pool.GetUserShareProviderClient(pool.Endpoint(s.c.UserShareProviderEndpoint))
+	c, err := pool.GetUserShareProviderClient(s.c, pool.Endpoint(s.c.UserShareProviderEndpoint))
 	if err != nil {
 		err := errors.Wrap(err, "gateway: error getting user share provider client")
 		return &collaboration.GetReceivedShareResponse{
@@ -299,7 +299,7 @@ func (s *svc) UpdateReceivedShare(ctx context.Context, req *collaboration.Update
 		}, nil
 	}
 
-	c, err := pool.GetUserShareProviderClient(pool.Endpoint(s.c.UserShareProviderEndpoint))
+	c, err := pool.GetUserShareProviderClient(s.c, pool.Endpoint(s.c.UserShareProviderEndpoint))
 	if err != nil {
 		err = errors.Wrap(err, "gateway: error calling GetUserShareProviderClient")
 		return &collaboration.UpdateReceivedShareResponse{

--- a/internal/grpc/services/publicstorageprovider/publicstorageprovider.go
+++ b/internal/grpc/services/publicstorageprovider/publicstorageprovider.go
@@ -49,9 +49,10 @@ func init() {
 }
 
 type config struct {
-	MountPath   string `mapstructure:"mount_path"`
-	MountID     string `mapstructure:"mount_id"`
-	GatewayAddr string `mapstructure:"gateway_addr"`
+	MountPath          string `mapstructure:"mount_path"`
+	MountID            string `mapstructure:"mount_id"`
+	GatewayAddr        string `mapstructure:"gateway_addr"`
+	MaxCallRecvMsgSize int    `mapstructure:"client_recv_msg_size"`
 }
 
 type service struct {

--- a/internal/grpc/services/publicstorageprovider/publicstorageprovider.go
+++ b/internal/grpc/services/publicstorageprovider/publicstorageprovider.go
@@ -92,7 +92,7 @@ func New(m map[string]interface{}, ss *grpc.Server) (rgrpc.Service, error) {
 	mountPath := c.MountPath
 	mountID := c.MountID
 
-	gateway, err := pool.GetGatewayServiceClient(pool.Endpoint(c.GatewayAddr))
+	gateway, err := pool.GetGatewayServiceClient(c, pool.Endpoint(c.GatewayAddr))
 	if err != nil {
 		return nil, err
 	}
@@ -777,7 +777,7 @@ func (s *service) trimMountPrefix(fn string) (string, error) {
 
 // resolveToken returns the path and share for the publicly shared resource.
 func (s *service) resolveToken(ctx context.Context, token string) (*link.PublicShare, *provider.ResourceInfo, *rpc.Status, error) {
-	driver, err := pool.GetGatewayServiceClient(pool.Endpoint(s.conf.GatewayAddr))
+	driver, err := pool.GetGatewayServiceClient(s.conf, pool.Endpoint(s.conf.GatewayAddr))
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/internal/http/interceptors/auth/auth.go
+++ b/internal/http/interceptors/auth/auth.go
@@ -66,6 +66,7 @@ type config struct {
 	TokenManagers          map[string]map[string]interface{} `mapstructure:"token_managers"`
 	TokenWriter            string                            `mapstructure:"token_writer"`
 	TokenWriters           map[string]map[string]interface{} `mapstructure:"token_writers"`
+	MaxCallRecvMsgSize     int                               `mapstructure:"client_recv_msg_size"`
 }
 
 func parseConfig(m map[string]interface{}) (*config, error) {

--- a/internal/http/interceptors/auth/auth.go
+++ b/internal/http/interceptors/auth/auth.go
@@ -194,7 +194,7 @@ func authenticateUser(w http.ResponseWriter, r *http.Request, conf *config, toke
 	// Add the request user-agent to the ctx
 	ctx = metadata.NewIncomingContext(ctx, metadata.New(map[string]string{ctxpkg.UserAgentHeader: r.UserAgent()}))
 
-	client, err := pool.GetGatewayServiceClient(pool.Endpoint(conf.GatewaySvc))
+	client, err := pool.GetGatewayServiceClient(conf, pool.Endpoint(conf.GatewaySvc))
 	if err != nil {
 		logError(isUnprotectedEndpoint, log, err, "error getting the authsvc client", http.StatusUnauthorized, w)
 		return nil, err

--- a/internal/http/services/appprovider/appprovider.go
+++ b/internal/http/services/appprovider/appprovider.go
@@ -49,9 +49,10 @@ func init() {
 
 // Config holds the config options for the HTTP appprovider service
 type Config struct {
-	Prefix     string `mapstructure:"prefix"`
-	GatewaySvc string `mapstructure:"gatewaysvc"`
-	Insecure   bool   `mapstructure:"insecure"`
+	Prefix             string `mapstructure:"prefix"`
+	GatewaySvc         string `mapstructure:"gatewaysvc"`
+	Insecure           bool   `mapstructure:"insecure"`
+	MaxCallRecvMsgSize int    `mapstructure:"client_recv_msg_size"`
 }
 
 func (c *Config) init() {

--- a/internal/http/services/appprovider/appprovider.go
+++ b/internal/http/services/appprovider/appprovider.go
@@ -117,7 +117,7 @@ func (s *svc) Handler() http.Handler {
 func (s *svc) handleNew(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	client, err := pool.GetGatewayServiceClient(pool.Endpoint(s.conf.GatewaySvc))
+	client, err := pool.GetGatewayServiceClient(s.conf, pool.Endpoint(s.conf.GatewaySvc))
 	if err != nil {
 		writeError(w, r, appErrorServerError, "error getting grpc gateway client", err)
 		return
@@ -288,7 +288,7 @@ func (s *svc) handleNew(w http.ResponseWriter, r *http.Request) {
 
 func (s *svc) handleList(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	client, err := pool.GetGatewayServiceClient(pool.Endpoint(s.conf.GatewaySvc))
+	client, err := pool.GetGatewayServiceClient(s.conf, pool.Endpoint(s.conf.GatewaySvc))
 	if err != nil {
 		writeError(w, r, appErrorServerError, "error getting grpc gateway client", err)
 		return
@@ -321,7 +321,7 @@ func (s *svc) handleList(w http.ResponseWriter, r *http.Request) {
 func (s *svc) handleOpen(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	client, err := pool.GetGatewayServiceClient(pool.Endpoint(s.conf.GatewaySvc))
+	client, err := pool.GetGatewayServiceClient(s.conf, pool.Endpoint(s.conf.GatewaySvc))
 	if err != nil {
 		writeError(w, r, appErrorServerError, "Internal error with the gateway, please try again later", err)
 		return

--- a/internal/http/services/archiver/handler.go
+++ b/internal/http/services/archiver/handler.go
@@ -59,14 +59,15 @@ type svc struct {
 
 // Config holds the config options that need to be passed down to all ocdav handlers
 type Config struct {
-	Prefix         string   `mapstructure:"prefix"`
-	GatewaySvc     string   `mapstructure:"gatewaysvc"`
-	Timeout        int64    `mapstructure:"timeout"`
-	Insecure       bool     `mapstructure:"insecure"`
-	Name           string   `mapstructure:"name"`
-	MaxNumFiles    int64    `mapstructure:"max_num_files"`
-	MaxSize        int64    `mapstructure:"max_size"`
-	AllowedFolders []string `mapstructure:"allowed_folders"`
+	Prefix             string   `mapstructure:"prefix"`
+	GatewaySvc         string   `mapstructure:"gatewaysvc"`
+	Timeout            int64    `mapstructure:"timeout"`
+	Insecure           bool     `mapstructure:"insecure"`
+	Name               string   `mapstructure:"name"`
+	MaxNumFiles        int64    `mapstructure:"max_num_files"`
+	MaxSize            int64    `mapstructure:"max_size"`
+	AllowedFolders     []string `mapstructure:"allowed_folders"`
+	MaxCallRecvMsgSize int      `mapstructure:"client_recv_msg_size"`
 }
 
 func init() {

--- a/internal/http/services/archiver/handler.go
+++ b/internal/http/services/archiver/handler.go
@@ -83,7 +83,7 @@ func New(conf map[string]interface{}, log *zerolog.Logger) (global.Service, erro
 
 	c.init()
 
-	gtw, err := pool.GetGatewayServiceClient(pool.Endpoint(c.GatewaySvc))
+	gtw, err := pool.GetGatewayServiceClient(c, pool.Endpoint(c.GatewaySvc))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/http/services/meshdirectory/meshdirectory.go
+++ b/internal/http/services/meshdirectory/meshdirectory.go
@@ -44,8 +44,9 @@ func init() {
 }
 
 type config struct {
-	Prefix     string `mapstructure:"prefix"`
-	GatewaySvc string `mapstructure:"gatewaysvc"`
+	Prefix             string `mapstructure:"prefix"`
+	GatewaySvc         string `mapstructure:"gatewaysvc"`
+	MaxCallRecvMsgSize int    `mapstructure:"client_recv_msg_size"`
 }
 
 func (c *config) init() {

--- a/internal/http/services/meshdirectory/meshdirectory.go
+++ b/internal/http/services/meshdirectory/meshdirectory.go
@@ -100,7 +100,7 @@ func (s *svc) Close() error {
 }
 
 func (s *svc) getClient() (gateway.GatewayAPIClient, error) {
-	return pool.GetGatewayServiceClient(pool.Endpoint(s.conf.GatewaySvc))
+	return pool.GetGatewayServiceClient(s.conf, pool.Endpoint(s.conf.GatewaySvc))
 }
 
 func (s *svc) serveJSON(w http.ResponseWriter, r *http.Request) {

--- a/internal/http/services/ocmd/invites.go
+++ b/internal/http/services/ocmd/invites.go
@@ -81,7 +81,7 @@ func (h *invitesHandler) generateInviteToken(w http.ResponseWriter, r *http.Requ
 
 	ctx := r.Context()
 
-	gatewayClient, err := pool.GetGatewayServiceClient(pool.Endpoint(h.gatewayAddr))
+	gatewayClient, err := pool.GetGatewayServiceClient(h, pool.Endpoint(h.gatewayAddr))
 	if err != nil {
 		WriteError(w, r, APIErrorServerError, "error getting gateway grpc client", err)
 		return
@@ -155,7 +155,7 @@ func (h *invitesHandler) forwardInvite(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	gatewayClient, err := pool.GetGatewayServiceClient(pool.Endpoint(h.gatewayAddr))
+	gatewayClient, err := pool.GetGatewayServiceClient(h, pool.Endpoint(h.gatewayAddr))
 	if err != nil {
 		WriteError(w, r, APIErrorServerError, "error getting gateway grpc client", err)
 		return
@@ -226,7 +226,7 @@ func (h *invitesHandler) acceptInvite(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	gatewayClient, err := pool.GetGatewayServiceClient(pool.Endpoint(h.gatewayAddr))
+	gatewayClient, err := pool.GetGatewayServiceClient(h, pool.Endpoint(h.gatewayAddr))
 	if err != nil {
 		WriteError(w, r, APIErrorServerError, "error getting gateway grpc client", err)
 		return
@@ -297,7 +297,7 @@ func (h *invitesHandler) findAcceptedUsers(w http.ResponseWriter, r *http.Reques
 	log := appctx.GetLogger(r.Context())
 
 	ctx := r.Context()
-	gatewayClient, err := pool.GetGatewayServiceClient(pool.Endpoint(h.gatewayAddr))
+	gatewayClient, err := pool.GetGatewayServiceClient(h, pool.Endpoint(h.gatewayAddr))
 	if err != nil {
 		WriteError(w, r, APIErrorServerError, "error getting gateway grpc client", err)
 		return
@@ -323,7 +323,7 @@ func (h *invitesHandler) generate(w http.ResponseWriter, r *http.Request) {
 	log := appctx.GetLogger(r.Context())
 
 	ctx := r.Context()
-	gatewayClient, err := pool.GetGatewayServiceClient(pool.Endpoint(h.gatewayAddr))
+	gatewayClient, err := pool.GetGatewayServiceClient(h, pool.Endpoint(h.gatewayAddr))
 	if err != nil {
 		WriteError(w, r, APIErrorServerError, "error getting gateway grpc client", err)
 		return

--- a/internal/http/services/ocmd/invites.go
+++ b/internal/http/services/ocmd/invites.go
@@ -40,13 +40,15 @@ import (
 )
 
 type invitesHandler struct {
-	smtpCredentials  *smtpclient.SMTPCredentials
-	gatewayAddr      string
-	meshDirectoryURL string
+	smtpCredentials    *smtpclient.SMTPCredentials
+	gatewayAddr        string
+	meshDirectoryURL   string
+	maxCallRecvMsgSize int `mapstructure:"client_recv_msg_size"`
 }
 
 func (h *invitesHandler) init(c *Config) {
 	h.gatewayAddr = c.GatewaySvc
+	h.maxCallRecvMsgSize = c.MaxCallRecvMsgSize
 	if c.SMTPCredentials != nil {
 		h.smtpCredentials = smtpclient.NewSMTPCredentials(c.SMTPCredentials)
 	}

--- a/internal/http/services/ocmd/ocmd.go
+++ b/internal/http/services/ocmd/ocmd.go
@@ -36,12 +36,13 @@ func init() {
 
 // Config holds the config options that need to be passed down to all ocdav handlers
 type Config struct {
-	SMTPCredentials  *smtpclient.SMTPCredentials `mapstructure:"smtp_credentials"`
-	Prefix           string                      `mapstructure:"prefix"`
-	Host             string                      `mapstructure:"host"`
-	GatewaySvc       string                      `mapstructure:"gatewaysvc"`
-	MeshDirectoryURL string                      `mapstructure:"mesh_directory_url"`
-	Config           configData                  `mapstructure:"config"`
+	SMTPCredentials    *smtpclient.SMTPCredentials `mapstructure:"smtp_credentials"`
+	Prefix             string                      `mapstructure:"prefix"`
+	Host               string                      `mapstructure:"host"`
+	GatewaySvc         string                      `mapstructure:"gatewaysvc"`
+	MeshDirectoryURL   string                      `mapstructure:"mesh_directory_url"`
+	Config             configData                  `mapstructure:"config"`
+	MaxCallRecvMsgSize int                         `mapstructure:"client_recv_msg_size"`
 }
 
 func (c *Config) init() {

--- a/internal/http/services/ocmd/send.go
+++ b/internal/http/services/ocmd/send.go
@@ -41,11 +41,13 @@ import (
 )
 
 type sendHandler struct {
-	GatewaySvc string
+	GatewaySvc         string
+	MaxCallRecvMsgSize int `mapstructure:"client_recv_msg_size"`
 }
 
 func (h *sendHandler) init(c *Config) {
 	h.GatewaySvc = c.GatewaySvc
+	h.MaxCallRecvMsgSize = c.MaxCallRecvMsgSize
 }
 
 func (h *sendHandler) Handler() http.Handler {

--- a/internal/http/services/ocmd/send.go
+++ b/internal/http/services/ocmd/send.go
@@ -80,7 +80,7 @@ func (h *sendHandler) Handler() http.Handler {
 		// "loginPassword": "Ny4Nv6WLoC1o70kVgrVOZLZ2vRgPjuej"
 
 		gatewayAddr := h.GatewaySvc
-		gatewayClient, err := pool.GetGatewayServiceClient(pool.Endpoint(gatewayAddr))
+		gatewayClient, err := pool.GetGatewayServiceClient(h, pool.Endpoint(gatewayAddr))
 		if err != nil {
 			log.Error().Msg("cannot get grpc client!")
 			w.WriteHeader(http.StatusInternalServerError)

--- a/internal/http/services/ocmd/shares.go
+++ b/internal/http/services/ocmd/shares.go
@@ -42,11 +42,13 @@ import (
 )
 
 type sharesHandler struct {
-	gatewayAddr string
+	gatewayAddr        string
+	maxCallRecvMsgSize int `mapstructure:"client_recv_msg_size"`
 }
 
 func (h *sharesHandler) init(c *Config) {
 	h.gatewayAddr = c.GatewaySvc
+	h.maxCallRecvMsgSize = c.MaxCallRecvMsgSize
 }
 
 func (h *sharesHandler) Handler() http.Handler {

--- a/internal/http/services/ocmd/shares.go
+++ b/internal/http/services/ocmd/shares.go
@@ -109,7 +109,7 @@ func (h *sharesHandler) createShare(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	gatewayClient, err := pool.GetGatewayServiceClient(pool.Endpoint(h.gatewayAddr))
+	gatewayClient, err := pool.GetGatewayServiceClient(h, pool.Endpoint(h.gatewayAddr))
 	if err != nil {
 		WriteError(w, r, APIErrorServerError, "error getting storage grpc client", err)
 		return

--- a/internal/http/services/owncloud/ocdav/dav.go
+++ b/internal/http/services/owncloud/ocdav/dav.go
@@ -175,7 +175,7 @@ func (h *DavHandler) Handler(s *svc) http.Handler {
 		case "public-files":
 			base := path.Join(ctx.Value(ctxKeyBaseURI).(string), "public-files")
 			ctx = context.WithValue(ctx, ctxKeyBaseURI, base)
-			c, err := pool.GetGatewayServiceClient(pool.Endpoint(s.c.GatewaySvc))
+			c, err := pool.GetGatewayServiceClient(s.c, pool.Endpoint(s.c.GatewaySvc))
 			if err != nil {
 				w.WriteHeader(http.StatusNotFound)
 			}

--- a/internal/http/services/owncloud/ocdav/ocdav.go
+++ b/internal/http/services/owncloud/ocdav/ocdav.go
@@ -255,7 +255,7 @@ func (s *svc) Handler() http.Handler {
 }
 
 func (s *svc) getClient() (gateway.GatewayAPIClient, error) {
-	return pool.GetGatewayServiceClient(pool.Endpoint(s.c.GatewaySvc))
+	return pool.GetGatewayServiceClient(s.c, pool.Endpoint(s.c.GatewaySvc))
 }
 
 func applyLayout(ctx context.Context, ns string, useLoggedInUserNS bool, requestPath string) string {

--- a/internal/http/services/owncloud/ocdav/ocdav.go
+++ b/internal/http/services/owncloud/ocdav/ocdav.go
@@ -105,6 +105,7 @@ type Config struct {
 	PublicURL              string                            `mapstructure:"public_url"`
 	FavoriteStorageDriver  string                            `mapstructure:"favorite_storage_driver"`
 	FavoriteStorageDrivers map[string]map[string]interface{} `mapstructure:"favorite_storage_drivers"`
+	MaxCallRecvMsgSize     int                               `mapstructure:"client_recv_msg_size"`
 }
 
 func (c *Config) init() {

--- a/internal/http/services/owncloud/ocdav/trashbin.go
+++ b/internal/http/services/owncloud/ocdav/trashbin.go
@@ -106,7 +106,7 @@ func (h *TrashbinHandler) Handler(s *svc) http.Handler {
 		// If not, we user the user home to route the request
 		basePath := r.URL.Query().Get("base_path")
 		if basePath == "" {
-			gc, err := pool.GetGatewayServiceClient(pool.Endpoint(s.c.GatewaySvc))
+			gc, err := pool.GetGatewayServiceClient(s.c, pool.Endpoint(s.c.GatewaySvc))
 			if err != nil {
 				// TODO(jfd) how do we make the user aware that some storages are not available?
 				// opaque response property? Or a list of errors?
@@ -206,7 +206,7 @@ func (h *TrashbinHandler) listTrashbin(w http.ResponseWriter, r *http.Request, s
 		return
 	}
 
-	gc, err := pool.GetGatewayServiceClient(pool.Endpoint(s.c.GatewaySvc))
+	gc, err := pool.GetGatewayServiceClient(s.c, pool.Endpoint(s.c.GatewaySvc))
 	if err != nil {
 		// TODO(jfd) how do we make the user aware that some storages are not available?
 		// opaque response property? Or a list of errors?

--- a/internal/http/services/owncloud/ocs/config/config.go
+++ b/internal/http/services/owncloud/ocs/config/config.go
@@ -41,6 +41,7 @@ type Config struct {
 	ResourceInfoCacheTTL     int                               `mapstructure:"resource_info_cache_ttl"`
 	ResourceInfoCacheDrivers map[string]map[string]interface{} `mapstructure:"resource_info_caches"`
 	UserIdentifierCacheTTL   int                               `mapstructure:"user_identifier_cache_ttl"`
+	MaxCallRecvMsgSize       int                               `mapstructure:"client_recv_msg_size"`
 }
 
 // Init sets sane defaults

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/sharees/sharees.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/sharees/sharees.go
@@ -54,7 +54,7 @@ func (h *Handler) FindSharees(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	gwc, err := pool.GetGatewayServiceClient(pool.Endpoint(h.gatewayAddr))
+	gwc, err := pool.GetGatewayServiceClient(h, pool.Endpoint(h.gatewayAddr))
 	if err != nil {
 		response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "error getting gateway grpc client", err)
 		return

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/group.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/group.go
@@ -34,7 +34,7 @@ import (
 
 func (h *Handler) createGroupShare(w http.ResponseWriter, r *http.Request, statInfo *provider.ResourceInfo, role *conversions.Role, roleVal []byte) {
 	ctx := r.Context()
-	c, err := pool.GetGatewayServiceClient(pool.Endpoint(h.gatewayAddr))
+	c, err := pool.GetGatewayServiceClient(h, pool.Endpoint(h.gatewayAddr))
 	if err != nil {
 		response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "error getting grpc gateway client", err)
 		return

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/pending.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/pending.go
@@ -49,7 +49,7 @@ func (h *Handler) updateReceivedShare(w http.ResponseWriter, r *http.Request, sh
 	ctx := r.Context()
 	logger := appctx.GetLogger(ctx)
 
-	client, err := pool.GetGatewayServiceClient(pool.Endpoint(h.gatewayAddr))
+	client, err := pool.GetGatewayServiceClient(h, pool.Endpoint(h.gatewayAddr))
 	if err != nil {
 		response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "error getting grpc gateway client", err)
 		return

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/public.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/public.go
@@ -41,7 +41,7 @@ func (h *Handler) createPublicLinkShare(w http.ResponseWriter, r *http.Request, 
 	ctx := r.Context()
 	log := appctx.GetLogger(ctx)
 
-	c, err := pool.GetGatewayServiceClient(pool.Endpoint(h.gatewayAddr))
+	c, err := pool.GetGatewayServiceClient(h, pool.Endpoint(h.gatewayAddr))
 	if err != nil {
 		response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "error getting grpc gateway client", err)
 		return
@@ -141,7 +141,7 @@ func (h *Handler) listPublicShares(r *http.Request, filters []*link.ListPublicSh
 	ocsDataPayload := make([]*conversions.ShareData, 0)
 	// TODO(refs) why is this guard needed? Are we moving towards a gateway only for service discovery? without a gateway this is dead code.
 	if h.gatewayAddr != "" {
-		client, err := pool.GetGatewayServiceClient(pool.Endpoint(h.gatewayAddr))
+		client, err := pool.GetGatewayServiceClient(h, pool.Endpoint(h.gatewayAddr))
 		if err != nil {
 			return ocsDataPayload, nil, err
 		}
@@ -189,7 +189,7 @@ func (h *Handler) listPublicShares(r *http.Request, filters []*link.ListPublicSh
 
 func (h *Handler) isPublicShare(r *http.Request, oid string) bool {
 	logger := appctx.GetLogger(r.Context())
-	client, err := pool.GetGatewayServiceClient(pool.Endpoint(h.gatewayAddr))
+	client, err := pool.GetGatewayServiceClient(h, pool.Endpoint(h.gatewayAddr))
 	if err != nil {
 		logger.Err(err)
 	}
@@ -215,7 +215,7 @@ func (h *Handler) updatePublicShare(w http.ResponseWriter, r *http.Request, shar
 	updates := []*link.UpdatePublicShareRequest_Update{}
 	logger := appctx.GetLogger(r.Context())
 
-	gwC, err := pool.GetGatewayServiceClient(pool.Endpoint(h.gatewayAddr))
+	gwC, err := pool.GetGatewayServiceClient(h, pool.Endpoint(h.gatewayAddr))
 	if err != nil {
 		log.Err(err).Str("shareID", shareID).Msg("updatePublicShare")
 		response.WriteOCSError(w, r, response.MetaBadRequest.StatusCode, "error getting a connection to the gateway service", nil)
@@ -377,7 +377,7 @@ func (h *Handler) updatePublicShare(w http.ResponseWriter, r *http.Request, shar
 func (h *Handler) removePublicShare(w http.ResponseWriter, r *http.Request, shareID string) {
 	ctx := r.Context()
 
-	c, err := pool.GetGatewayServiceClient(pool.Endpoint(h.gatewayAddr))
+	c, err := pool.GetGatewayServiceClient(h, pool.Endpoint(h.gatewayAddr))
 	if err != nil {
 		response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "error getting grpc gateway client", err)
 		return

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/remote.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/remote.go
@@ -39,7 +39,7 @@ import (
 func (h *Handler) createFederatedCloudShare(w http.ResponseWriter, r *http.Request, statInfo *provider.ResourceInfo, role *conversions.Role, roleVal []byte) {
 	ctx := r.Context()
 
-	c, err := pool.GetGatewayServiceClient(pool.Endpoint(h.gatewayAddr))
+	c, err := pool.GetGatewayServiceClient(h, pool.Endpoint(h.gatewayAddr))
 	if err != nil {
 		response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "error getting grpc gateway client", err)
 		return
@@ -127,7 +127,7 @@ func (h *Handler) GetFederatedShare(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
 	shareID := chi.URLParam(r, "shareid")
-	gatewayClient, err := pool.GetGatewayServiceClient(pool.Endpoint(h.gatewayAddr))
+	gatewayClient, err := pool.GetGatewayServiceClient(h, pool.Endpoint(h.gatewayAddr))
 	if err != nil {
 		response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "error getting grpc gateway client", err)
 		return
@@ -163,7 +163,7 @@ func (h *Handler) ListFederatedShares(w http.ResponseWriter, r *http.Request) {
 	// TODO Implement response with HAL schemating
 	ctx := r.Context()
 
-	gatewayClient, err := pool.GetGatewayServiceClient(pool.Endpoint(h.gatewayAddr))
+	gatewayClient, err := pool.GetGatewayServiceClient(h, pool.Endpoint(h.gatewayAddr))
 	if err != nil {
 		response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "error getting grpc gateway client", err)
 		return

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/shares.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/shares.go
@@ -73,6 +73,7 @@ type Handler struct {
 	userIdentifierCache    *ttlcache.Cache
 	resourceInfoCache      cache.ResourceInfoCache
 	resourceInfoCacheTTL   time.Duration
+	maxCallRecvMsgSize     int `mapstructure:"client_recv_msg_size"`
 }
 
 // we only cache the minimal set of data instead of the full user metadata
@@ -106,6 +107,7 @@ func (h *Handler) Init(c *config.Config) {
 
 	h.additionalInfoTemplate, _ = template.New("additionalInfo").Parse(c.AdditionalInfoAttribute)
 	h.resourceInfoCacheTTL = time.Second * time.Duration(c.ResourceInfoCacheTTL)
+	h.maxCallRecvMsgSize = c.MaxCallRecvMsgSize
 
 	h.userIdentifierCache = ttlcache.NewCache()
 	_ = h.userIdentifierCache.SetTTL(time.Second * time.Duration(c.UserIdentifierCacheTTL))

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/shares.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/shares.go
@@ -159,7 +159,7 @@ func (h *Handler) CreateShare(w http.ResponseWriter, r *http.Request) {
 	}
 	// get user permissions on the shared file
 
-	client, err := pool.GetGatewayServiceClient(pool.Endpoint(h.gatewayAddr))
+	client, err := pool.GetGatewayServiceClient(h, pool.Endpoint(h.gatewayAddr))
 	if err != nil {
 		response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "error getting grpc gateway client", err)
 		return
@@ -301,7 +301,7 @@ func (h *Handler) GetShare(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	logger := appctx.GetLogger(r.Context())
 	logger.Debug().Str("shareID", shareID).Msg("get share by id")
-	client, err := pool.GetGatewayServiceClient(pool.Endpoint(h.gatewayAddr))
+	client, err := pool.GetGatewayServiceClient(h, pool.Endpoint(h.gatewayAddr))
 	if err != nil {
 		response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "error getting grpc gateway client", err)
 		return
@@ -440,7 +440,7 @@ func (h *Handler) updateShare(w http.ResponseWriter, r *http.Request, shareID st
 		return
 	}
 
-	client, err := pool.GetGatewayServiceClient(pool.Endpoint(h.gatewayAddr))
+	client, err := pool.GetGatewayServiceClient(h, pool.Endpoint(h.gatewayAddr))
 	if err != nil {
 		response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "error getting grpc gateway client", err)
 		return
@@ -557,7 +557,7 @@ func (h *Handler) listSharesWithMe(w http.ResponseWriter, r *http.Request) {
 	stateFilter := getStateFilter(r.FormValue("state"))
 
 	log := appctx.GetLogger(r.Context())
-	client, err := pool.GetGatewayServiceClient(pool.Endpoint(h.gatewayAddr))
+	client, err := pool.GetGatewayServiceClient(h, pool.Endpoint(h.gatewayAddr))
 	if err != nil {
 		response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "error getting grpc gateway client", err)
 		return
@@ -837,7 +837,7 @@ func (h *Handler) addFilters(w http.ResponseWriter, r *http.Request, prefix stri
 	ctx := r.Context()
 
 	// first check if the file exists
-	client, err := pool.GetGatewayServiceClient(pool.Endpoint(h.gatewayAddr))
+	client, err := pool.GetGatewayServiceClient(h, pool.Endpoint(h.gatewayAddr))
 	if err != nil {
 		response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "error getting grpc gateway client", err)
 		return nil, nil, err

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/spaces.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/spaces.go
@@ -40,7 +40,7 @@ import (
 
 func (h *Handler) getGrantee(ctx context.Context, name string) (provider.Grantee, error) {
 	log := appctx.GetLogger(ctx)
-	client, err := pool.GetGatewayServiceClient(pool.Endpoint(h.gatewayAddr))
+	client, err := pool.GetGatewayServiceClient(h, pool.Endpoint(h.gatewayAddr))
 	if err != nil {
 		return provider.Grantee{}, err
 	}
@@ -167,7 +167,7 @@ func (h *Handler) removeSpaceMember(w http.ResponseWriter, r *http.Request, spac
 }
 
 func (h *Handler) getStorageProviderClient(p *registry.ProviderInfo) (provider.ProviderAPIClient, error) {
-	c, err := pool.GetStorageProviderServiceClient(pool.Endpoint(p.Address))
+	c, err := pool.GetStorageProviderServiceClient(h, pool.Endpoint(p.Address))
 	if err != nil {
 		err = errors.Wrap(err, "gateway: error getting a storage provider client")
 		return nil, err
@@ -177,7 +177,7 @@ func (h *Handler) getStorageProviderClient(p *registry.ProviderInfo) (provider.P
 }
 
 func (h *Handler) findProviders(ctx context.Context, ref *provider.Reference) ([]*registry.ProviderInfo, error) {
-	c, err := pool.GetStorageRegistryClient(pool.Endpoint(h.storageRegistryAddr))
+	c, err := pool.GetStorageRegistryClient(h, pool.Endpoint(h.storageRegistryAddr))
 	if err != nil {
 		return nil, errors.Wrap(err, "gateway: error getting storage registry client")
 	}

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/user.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/user.go
@@ -35,7 +35,7 @@ import (
 
 func (h *Handler) createUserShare(w http.ResponseWriter, r *http.Request, statInfo *provider.ResourceInfo, role *conversions.Role, roleVal []byte) {
 	ctx := r.Context()
-	c, err := pool.GetGatewayServiceClient(pool.Endpoint(h.gatewayAddr))
+	c, err := pool.GetGatewayServiceClient(h, pool.Endpoint(h.gatewayAddr))
 	if err != nil {
 		response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "error getting grpc gateway client", err)
 		return
@@ -88,7 +88,7 @@ func (h *Handler) createUserShare(w http.ResponseWriter, r *http.Request, statIn
 
 func (h *Handler) isUserShare(r *http.Request, oid string) bool {
 	logger := appctx.GetLogger(r.Context())
-	client, err := pool.GetGatewayServiceClient(pool.Endpoint(h.gatewayAddr))
+	client, err := pool.GetGatewayServiceClient(h, pool.Endpoint(h.gatewayAddr))
 	if err != nil {
 		logger.Err(err)
 	}
@@ -113,7 +113,7 @@ func (h *Handler) isUserShare(r *http.Request, oid string) bool {
 func (h *Handler) removeUserShare(w http.ResponseWriter, r *http.Request, shareID string) {
 	ctx := r.Context()
 
-	uClient, err := pool.GetGatewayServiceClient(pool.Endpoint(h.gatewayAddr))
+	uClient, err := pool.GetGatewayServiceClient(h, pool.Endpoint(h.gatewayAddr))
 	if err != nil {
 		response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "error getting grpc gateway client", err)
 		return
@@ -177,7 +177,7 @@ func (h *Handler) listUserShares(r *http.Request, filters []*collaboration.Filte
 	ocsDataPayload := make([]*conversions.ShareData, 0)
 	if h.gatewayAddr != "" {
 		// get a connection to the users share provider
-		client, err := pool.GetGatewayServiceClient(pool.Endpoint(h.gatewayAddr))
+		client, err := pool.GetGatewayServiceClient(h, pool.Endpoint(h.gatewayAddr))
 		if err != nil {
 			return ocsDataPayload, nil, err
 		}

--- a/internal/http/services/owncloud/ocs/handlers/cloud/users/users.go
+++ b/internal/http/services/owncloud/ocs/handlers/cloud/users/users.go
@@ -38,12 +38,14 @@ import (
 
 // Handler renders user data for the user id given in the url path
 type Handler struct {
-	gatewayAddr string
+	gatewayAddr        string
+	maxCallRecvMsgSize int `mapstructure:"client_recv_msg_size"`
 }
 
 // Init initializes this and any contained handlers
 func (h *Handler) Init(c *config.Config) {
 	h.gatewayAddr = c.GatewaySvc
+	h.maxCallRecvMsgSize = c.MaxCallRecvMsgSize
 }
 
 // GetGroups handles GET requests on /cloud/users/groups

--- a/internal/http/services/owncloud/ocs/handlers/cloud/users/users.go
+++ b/internal/http/services/owncloud/ocs/handlers/cloud/users/users.go
@@ -112,7 +112,7 @@ func (h *Handler) GetUsers(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	gc, err := pool.GetGatewayServiceClient(pool.Endpoint(h.gatewayAddr))
+	gc, err := pool.GetGatewayServiceClient(h, pool.Endpoint(h.gatewayAddr))
 	if err != nil {
 		sublog.Error().Err(err).Msg("error getting gateway client")
 		w.WriteHeader(http.StatusInternalServerError)

--- a/internal/http/services/preferences/preferences.go
+++ b/internal/http/services/preferences/preferences.go
@@ -39,8 +39,9 @@ func init() {
 
 // Config holds the config options that for the preferences HTTP service
 type Config struct {
-	Prefix     string `mapstructure:"prefix"`
-	GatewaySvc string `mapstructure:"gatewaysvc"`
+	Prefix             string `mapstructure:"prefix"`
+	GatewaySvc         string `mapstructure:"gatewaysvc"`
+	MaxCallRecvMsgSize int    `mapstructure:"client_recv_msg_size"`
 }
 
 func (c *Config) init() {

--- a/internal/http/services/preferences/preferences.go
+++ b/internal/http/services/preferences/preferences.go
@@ -119,7 +119,7 @@ func (s *svc) handleGet(w http.ResponseWriter, r *http.Request) {
 
 	}
 
-	client, err := pool.GetGatewayServiceClient(pool.Endpoint(s.conf.GatewaySvc))
+	client, err := pool.GetGatewayServiceClient(s.conf, pool.Endpoint(s.conf.GatewaySvc))
 	if err != nil {
 		log.Error().Err(err).Msg("error getting grpc gateway client")
 		w.WriteHeader(http.StatusInternalServerError)
@@ -185,7 +185,7 @@ func (s *svc) handlePost(w http.ResponseWriter, r *http.Request) {
 
 	}
 
-	client, err := pool.GetGatewayServiceClient(pool.Endpoint(s.conf.GatewaySvc))
+	client, err := pool.GetGatewayServiceClient(s.conf, pool.Endpoint(s.conf.GatewaySvc))
 	if err != nil {
 		log.Error().Err(err).Msg("error getting grpc gateway client")
 		w.WriteHeader(http.StatusInternalServerError)

--- a/pkg/auth/manager/appauth/appauth.go
+++ b/pkg/auth/manager/appauth/appauth.go
@@ -38,7 +38,8 @@ func init() {
 }
 
 type manager struct {
-	GatewayAddr string `mapstructure:"gateway_addr"`
+	GatewayAddr        string `mapstructure:"gateway_addr"`
+	MaxCallRecvMsgSize int    `mapstructure:"client_recv_msg_size"`
 }
 
 // New returns a new auth Manager.

--- a/pkg/auth/manager/appauth/appauth.go
+++ b/pkg/auth/manager/appauth/appauth.go
@@ -60,7 +60,7 @@ func (m *manager) Configure(ml map[string]interface{}) error {
 }
 
 func (m *manager) Authenticate(ctx context.Context, username, password string) (*user.User, map[string]*authpb.Scope, error) {
-	gtw, err := pool.GetGatewayServiceClient(pool.Endpoint(m.GatewayAddr))
+	gtw, err := pool.GetGatewayServiceClient(m, pool.Endpoint(m.GatewayAddr))
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/auth/manager/ldap/ldap.go
+++ b/pkg/auth/manager/ldap/ldap.go
@@ -49,14 +49,15 @@ type mgr struct {
 }
 
 type config struct {
-	utils.LDAPConn `mapstructure:",squash"`
-	BaseDN         string     `mapstructure:"base_dn"`
-	UserFilter     string     `mapstructure:"userfilter"`
-	LoginFilter    string     `mapstructure:"loginfilter"`
-	Idp            string     `mapstructure:"idp"`
-	GatewaySvc     string     `mapstructure:"gatewaysvc"`
-	Schema         attributes `mapstructure:"schema"`
-	Nobody         int64      `mapstructure:"nobody"`
+	utils.LDAPConn     `mapstructure:",squash"`
+	BaseDN             string     `mapstructure:"base_dn"`
+	UserFilter         string     `mapstructure:"userfilter"`
+	LoginFilter        string     `mapstructure:"loginfilter"`
+	Idp                string     `mapstructure:"idp"`
+	GatewaySvc         string     `mapstructure:"gatewaysvc"`
+	Schema             attributes `mapstructure:"schema"`
+	Nobody             int64      `mapstructure:"nobody"`
+	MaxCallRecvMsgSize int        `mapstructure:"client_recv_msg_size"`
 }
 
 type attributes struct {

--- a/pkg/auth/manager/ldap/ldap.go
+++ b/pkg/auth/manager/ldap/ldap.go
@@ -171,7 +171,7 @@ func (am *mgr) Authenticate(ctx context.Context, clientID, clientSecret string) 
 		OpaqueId: sr.Entries[0].GetEqualFoldAttributeValue(am.c.Schema.UID),
 		Type:     user.UserType_USER_TYPE_PRIMARY, // TODO: assign the appropriate user type
 	}
-	gwc, err := pool.GetGatewayServiceClient(pool.Endpoint(am.c.GatewaySvc))
+	gwc, err := pool.GetGatewayServiceClient(am.c, pool.Endpoint(am.c.GatewaySvc))
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "ldap: error getting gateway grpc client")
 	}

--- a/pkg/auth/manager/machine/machine.go
+++ b/pkg/auth/manager/machine/machine.go
@@ -42,8 +42,9 @@ import (
 var claims = []string{"mail", "uid", "username", "gid", "userid"}
 
 type manager struct {
-	APIKey      string `mapstructure:"api_key"`
-	GatewayAddr string `mapstructure:"gateway_addr"`
+	APIKey             string `mapstructure:"api_key"`
+	GatewayAddr        string `mapstructure:"gateway_addr"`
+	MaxCallRecvMsgSize int    `mapstructure:"client_recv_msg_size"`
 }
 
 func init() {

--- a/pkg/auth/manager/machine/machine.go
+++ b/pkg/auth/manager/machine/machine.go
@@ -75,7 +75,7 @@ func (m *manager) Authenticate(ctx context.Context, user, secret string) (*userp
 		return nil, nil, errtypes.InvalidCredentials("")
 	}
 
-	gtw, err := pool.GetGatewayServiceClient(pool.Endpoint(m.GatewayAddr))
+	gtw, err := pool.GetGatewayServiceClient(m, pool.Endpoint(m.GatewayAddr))
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/auth/manager/oidc/oidc.go
+++ b/pkg/auth/manager/oidc/oidc.go
@@ -58,14 +58,15 @@ type mgr struct {
 }
 
 type config struct {
-	Insecure     bool   `mapstructure:"insecure" docs:"false;Whether to skip certificate checks when sending requests."`
-	Issuer       string `mapstructure:"issuer" docs:";The issuer of the OIDC token."`
-	IDClaim      string `mapstructure:"id_claim" docs:"sub;The claim containing the ID of the user."`
-	UIDClaim     string `mapstructure:"uid_claim" docs:";The claim containing the UID of the user."`
-	GIDClaim     string `mapstructure:"gid_claim" docs:";The claim containing the GID of the user."`
-	GatewaySvc   string `mapstructure:"gatewaysvc" docs:";The endpoint at which the GRPC gateway is exposed."`
-	UsersMapping string `mapstructure:"users_mapping" docs:"; The optional OIDC users mapping file path"`
-	GroupClaim   string `mapstructure:"group_claim" docs:"; The group claim to be looked up to map the user (default to 'groups')."`
+	Insecure           bool   `mapstructure:"insecure" docs:"false;Whether to skip certificate checks when sending requests."`
+	Issuer             string `mapstructure:"issuer" docs:";The issuer of the OIDC token."`
+	IDClaim            string `mapstructure:"id_claim" docs:"sub;The claim containing the ID of the user."`
+	UIDClaim           string `mapstructure:"uid_claim" docs:";The claim containing the UID of the user."`
+	GIDClaim           string `mapstructure:"gid_claim" docs:";The claim containing the GID of the user."`
+	GatewaySvc         string `mapstructure:"gatewaysvc" docs:";The endpoint at which the GRPC gateway is exposed."`
+	UsersMapping       string `mapstructure:"users_mapping" docs:"; The optional OIDC users mapping file path"`
+	GroupClaim         string `mapstructure:"group_claim" docs:"; The group claim to be looked up to map the user (default to 'groups')."`
+	MaxCallRecvMsgSize int    `mapstructure:"client_recv_msg_size"`
 }
 
 type oidcUserMapping struct {

--- a/pkg/auth/manager/oidc/oidc.go
+++ b/pkg/auth/manager/oidc/oidc.go
@@ -216,7 +216,7 @@ func (am *mgr) Authenticate(ctx context.Context, clientID, clientSecret string) 
 		Type:     getUserType(claims[am.c.IDClaim].(string)),
 	}
 
-	gwc, err := pool.GetGatewayServiceClient(pool.Endpoint(am.c.GatewaySvc))
+	gwc, err := pool.GetGatewayServiceClient(am.c, pool.Endpoint(am.c.GatewaySvc))
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "oidc: error getting gateway grpc client")
 	}
@@ -323,7 +323,7 @@ func (am *mgr) resolveUser(ctx context.Context, claims map[string]interface{}) e
 			username = am.oidcUsersMapping[m.(string)].Username
 		}
 
-		upsc, err := pool.GetUserProviderServiceClient(pool.Endpoint(am.c.GatewaySvc))
+		upsc, err := pool.GetUserProviderServiceClient(am.c, pool.Endpoint(am.c.GatewaySvc))
 		if err != nil {
 			return errors.Wrap(err, "error getting user provider grpc client")
 		}

--- a/pkg/auth/manager/publicshares/publicshares.go
+++ b/pkg/auth/manager/publicshares/publicshares.go
@@ -79,7 +79,7 @@ func (m *manager) Configure(ml map[string]interface{}) error {
 }
 
 func (m *manager) Authenticate(ctx context.Context, token, secret string) (*user.User, map[string]*authpb.Scope, error) {
-	gwConn, err := pool.GetGatewayServiceClient(pool.Endpoint(m.c.GatewayAddr))
+	gwConn, err := pool.GetGatewayServiceClient(m.c, pool.Endpoint(m.c.GatewayAddr))
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/auth/manager/publicshares/publicshares.go
+++ b/pkg/auth/manager/publicshares/publicshares.go
@@ -47,7 +47,8 @@ type manager struct {
 }
 
 type config struct {
-	GatewayAddr string `mapstructure:"gateway_addr"`
+	GatewayAddr        string `mapstructure:"gateway_addr"`
+	MaxCallRecvMsgSize int    `mapstructure:"client_recv_msg_size"`
 }
 
 func parseConfig(m map[string]interface{}) (*config, error) {

--- a/pkg/rgrpc/todo/pool/option.go
+++ b/pkg/rgrpc/todo/pool/option.go
@@ -33,19 +33,6 @@ type Options struct {
 	MaxCallRecvMsgSize int `mapstructure:"client_recv_msg_size"`
 }
 
-// newOptions initializes the available default options.
-func newOptions(opts ...Option) Options {
-	opt := Options{
-		MaxCallRecvMsgSize: defaultMaxCallRecvMsgSize,
-	}
-
-	for _, o := range opts {
-		o(&opt)
-	}
-
-	return opt
-}
-
 // NewOptions initializes the available default options.
 func NewOptions(conf interface{}, opts ...Option) (*Options, error) {
 	opt := &Options{}

--- a/pkg/rgrpc/todo/pool/option.go
+++ b/pkg/rgrpc/todo/pool/option.go
@@ -18,6 +18,8 @@
 
 package pool
 
+import "github.com/mitchellh/mapstructure"
+
 const (
 	defaultMaxCallRecvMsgSize = 10240000
 )
@@ -28,7 +30,7 @@ type Option func(o *Options)
 // Options defines the available options for this package.
 type Options struct {
 	Endpoint           string
-	MaxCallRecvMsgSize int
+	MaxCallRecvMsgSize int `mapstructure:"client_recv_msg_size"`
 }
 
 // newOptions initializes the available default options.
@@ -42,6 +44,33 @@ func newOptions(opts ...Option) Options {
 	}
 
 	return opt
+}
+
+// NewOptions initializes the available default options.
+func NewOptions(conf interface{}, opts ...Option) (*Options, error) {
+	opt := &Options{}
+	err := parseConfig(conf, opt)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, o := range opts {
+		o(opt)
+	}
+
+	return opt, err
+}
+
+func parseConfig(conf interface{}, opt *Options) error {
+	err := mapstructure.Decode(conf, opt)
+	opt.init()
+	return err
+}
+
+func (o *Options) init() {
+	if o.MaxCallRecvMsgSize <= 0 {
+		o.MaxCallRecvMsgSize = defaultMaxCallRecvMsgSize
+	}
 }
 
 // Endpoint provides a function to set the endpoint option.

--- a/pkg/rgrpc/todo/pool/pool.go
+++ b/pkg/rgrpc/todo/pool/pool.go
@@ -85,7 +85,7 @@ var (
 // NewConn creates a new connection to a grpc server
 // with open census tracing support.
 // TODO(labkode): make grpc tls configurable.
-func NewConn(options Options) (*grpc.ClientConn, error) {
+func NewConn(options *Options) (*grpc.ClientConn, error) {
 	conn, err := grpc.Dial(
 		options.Endpoint,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
@@ -119,11 +119,15 @@ func NewConn(options Options) (*grpc.ClientConn, error) {
 }
 
 // GetGatewayServiceClient returns a GatewayServiceClient.
-func GetGatewayServiceClient(opts ...Option) (gateway.GatewayAPIClient, error) {
+func GetGatewayServiceClient(c interface{}, opts ...Option) (gateway.GatewayAPIClient, error) {
 	gatewayProviders.m.Lock()
 	defer gatewayProviders.m.Unlock()
 
-	options := newOptions(opts...)
+	options, err := NewOptions(c, opts...)
+	if err != nil {
+		return nil, err
+	}
+
 	if val, ok := gatewayProviders.conn[options.Endpoint]; ok {
 		return val.(gateway.GatewayAPIClient), nil
 	}
@@ -140,11 +144,15 @@ func GetGatewayServiceClient(opts ...Option) (gateway.GatewayAPIClient, error) {
 }
 
 // GetUserProviderServiceClient returns a UserProviderServiceClient.
-func GetUserProviderServiceClient(opts ...Option) (user.UserAPIClient, error) {
+func GetUserProviderServiceClient(c interface{}, opts ...Option) (user.UserAPIClient, error) {
 	userProviders.m.Lock()
 	defer userProviders.m.Unlock()
 
-	options := newOptions(opts...)
+	options, err := NewOptions(c, opts...)
+	if err != nil {
+		return nil, err
+	}
+
 	if val, ok := userProviders.conn[options.Endpoint]; ok {
 		return val.(user.UserAPIClient), nil
 	}
@@ -160,11 +168,15 @@ func GetUserProviderServiceClient(opts ...Option) (user.UserAPIClient, error) {
 }
 
 // GetGroupProviderServiceClient returns a GroupProviderServiceClient.
-func GetGroupProviderServiceClient(opts ...Option) (group.GroupAPIClient, error) {
+func GetGroupProviderServiceClient(c interface{}, opts ...Option) (group.GroupAPIClient, error) {
 	groupProviders.m.Lock()
 	defer groupProviders.m.Unlock()
 
-	options := newOptions(opts...)
+	options, err := NewOptions(c, opts...)
+	if err != nil {
+		return nil, err
+	}
+
 	if val, ok := groupProviders.conn[options.Endpoint]; ok {
 		return val.(group.GroupAPIClient), nil
 	}
@@ -180,11 +192,15 @@ func GetGroupProviderServiceClient(opts ...Option) (group.GroupAPIClient, error)
 }
 
 // GetStorageProviderServiceClient returns a StorageProviderServiceClient.
-func GetStorageProviderServiceClient(opts ...Option) (storageprovider.ProviderAPIClient, error) {
+func GetStorageProviderServiceClient(c interface{}, opts ...Option) (storageprovider.ProviderAPIClient, error) {
 	storageProviders.m.Lock()
 	defer storageProviders.m.Unlock()
 
-	options := newOptions(opts...)
+	options, err := NewOptions(c, opts...)
+	if err != nil {
+		return nil, err
+	}
+
 	if c, ok := storageProviders.conn[options.Endpoint]; ok {
 		return c.(storageprovider.ProviderAPIClient), nil
 	}
@@ -200,12 +216,16 @@ func GetStorageProviderServiceClient(opts ...Option) (storageprovider.ProviderAP
 }
 
 // GetAuthRegistryServiceClient returns a new AuthRegistryServiceClient.
-func GetAuthRegistryServiceClient(opts ...Option) (authregistry.RegistryAPIClient, error) {
+func GetAuthRegistryServiceClient(c interface{}, opts ...Option) (authregistry.RegistryAPIClient, error) {
 	authRegistries.m.Lock()
 	defer authRegistries.m.Unlock()
 
 	// if there is already a connection to this node, use it.
-	options := newOptions(opts...)
+	options, err := NewOptions(c, opts...)
+	if err != nil {
+		return nil, err
+	}
+
 	if c, ok := authRegistries.conn[options.Endpoint]; ok {
 		return c.(authregistry.RegistryAPIClient), nil
 	}
@@ -223,11 +243,15 @@ func GetAuthRegistryServiceClient(opts ...Option) (authregistry.RegistryAPIClien
 }
 
 // GetAuthProviderServiceClient returns a new AuthProviderServiceClient.
-func GetAuthProviderServiceClient(opts ...Option) (authprovider.ProviderAPIClient, error) {
+func GetAuthProviderServiceClient(c interface{}, opts ...Option) (authprovider.ProviderAPIClient, error) {
 	authProviders.m.Lock()
 	defer authProviders.m.Unlock()
 
-	options := newOptions(opts...)
+	options, err := NewOptions(c, opts...)
+	if err != nil {
+		return nil, err
+	}
+
 	if c, ok := authProviders.conn[options.Endpoint]; ok {
 		return c.(authprovider.ProviderAPIClient), nil
 	}
@@ -243,11 +267,15 @@ func GetAuthProviderServiceClient(opts ...Option) (authprovider.ProviderAPIClien
 }
 
 // GetAppAuthProviderServiceClient returns a new AppAuthProviderServiceClient.
-func GetAppAuthProviderServiceClient(opts ...Option) (applicationauth.ApplicationsAPIClient, error) {
+func GetAppAuthProviderServiceClient(c interface{}, opts ...Option) (applicationauth.ApplicationsAPIClient, error) {
 	appAuthProviders.m.Lock()
 	defer appAuthProviders.m.Unlock()
 
-	options := newOptions(opts...)
+	options, err := NewOptions(c, opts...)
+	if err != nil {
+		return nil, err
+	}
+
 	if c, ok := appAuthProviders.conn[options.Endpoint]; ok {
 		return c.(applicationauth.ApplicationsAPIClient), nil
 	}
@@ -263,11 +291,15 @@ func GetAppAuthProviderServiceClient(opts ...Option) (applicationauth.Applicatio
 }
 
 // GetUserShareProviderClient returns a new UserShareProviderClient.
-func GetUserShareProviderClient(opts ...Option) (collaboration.CollaborationAPIClient, error) {
+func GetUserShareProviderClient(c interface{}, opts ...Option) (collaboration.CollaborationAPIClient, error) {
 	userShareProviders.m.Lock()
 	defer userShareProviders.m.Unlock()
 
-	options := newOptions(opts...)
+	options, err := NewOptions(c, opts...)
+	if err != nil {
+		return nil, err
+	}
+
 	if c, ok := userShareProviders.conn[options.Endpoint]; ok {
 		return c.(collaboration.CollaborationAPIClient), nil
 	}
@@ -283,11 +315,15 @@ func GetUserShareProviderClient(opts ...Option) (collaboration.CollaborationAPIC
 }
 
 // GetOCMShareProviderClient returns a new OCMShareProviderClient.
-func GetOCMShareProviderClient(opts ...Option) (ocm.OcmAPIClient, error) {
+func GetOCMShareProviderClient(c interface{}, opts ...Option) (ocm.OcmAPIClient, error) {
 	ocmShareProviders.m.Lock()
 	defer ocmShareProviders.m.Unlock()
 
-	options := newOptions(opts...)
+	options, err := NewOptions(c, opts...)
+	if err != nil {
+		return nil, err
+	}
+
 	if c, ok := ocmShareProviders.conn[options.Endpoint]; ok {
 		return c.(ocm.OcmAPIClient), nil
 	}
@@ -303,11 +339,15 @@ func GetOCMShareProviderClient(opts ...Option) (ocm.OcmAPIClient, error) {
 }
 
 // GetOCMInviteManagerClient returns a new OCMInviteManagerClient.
-func GetOCMInviteManagerClient(opts ...Option) (invitepb.InviteAPIClient, error) {
+func GetOCMInviteManagerClient(c interface{}, opts ...Option) (invitepb.InviteAPIClient, error) {
 	ocmInviteManagers.m.Lock()
 	defer ocmInviteManagers.m.Unlock()
 
-	options := newOptions(opts...)
+	options, err := NewOptions(c, opts...)
+	if err != nil {
+		return nil, err
+	}
+
 	if c, ok := ocmInviteManagers.conn[options.Endpoint]; ok {
 		return c.(invitepb.InviteAPIClient), nil
 	}
@@ -323,11 +363,15 @@ func GetOCMInviteManagerClient(opts ...Option) (invitepb.InviteAPIClient, error)
 }
 
 // GetPublicShareProviderClient returns a new PublicShareProviderClient.
-func GetPublicShareProviderClient(opts ...Option) (link.LinkAPIClient, error) {
+func GetPublicShareProviderClient(c interface{}, opts ...Option) (link.LinkAPIClient, error) {
 	publicShareProviders.m.Lock()
 	defer publicShareProviders.m.Unlock()
 
-	options := newOptions(opts...)
+	options, err := NewOptions(c, opts...)
+	if err != nil {
+		return nil, err
+	}
+
 	if c, ok := publicShareProviders.conn[options.Endpoint]; ok {
 		return c.(link.LinkAPIClient), nil
 	}
@@ -343,11 +387,15 @@ func GetPublicShareProviderClient(opts ...Option) (link.LinkAPIClient, error) {
 }
 
 // GetPreferencesClient returns a new PreferencesClient.
-func GetPreferencesClient(opts ...Option) (preferences.PreferencesAPIClient, error) {
+func GetPreferencesClient(c interface{}, opts ...Option) (preferences.PreferencesAPIClient, error) {
 	preferencesProviders.m.Lock()
 	defer preferencesProviders.m.Unlock()
 
-	options := newOptions(opts...)
+	options, err := NewOptions(c, opts...)
+	if err != nil {
+		return nil, err
+	}
+
 	if c, ok := preferencesProviders.conn[options.Endpoint]; ok {
 		return c.(preferences.PreferencesAPIClient), nil
 	}
@@ -363,11 +411,15 @@ func GetPreferencesClient(opts ...Option) (preferences.PreferencesAPIClient, err
 }
 
 // GetPermissionsClient returns a new PermissionsClient.
-func GetPermissionsClient(opts ...Option) (permissions.PermissionsAPIClient, error) {
+func GetPermissionsClient(c interface{}, opts ...Option) (permissions.PermissionsAPIClient, error) {
 	permissionsProviders.m.Lock()
 	defer permissionsProviders.m.Unlock()
 
-	options := newOptions(opts...)
+	options, err := NewOptions(c, opts...)
+	if err != nil {
+		return nil, err
+	}
+
 	if c, ok := permissionsProviders.conn[options.Endpoint]; ok {
 		return c.(permissions.PermissionsAPIClient), nil
 	}
@@ -383,11 +435,15 @@ func GetPermissionsClient(opts ...Option) (permissions.PermissionsAPIClient, err
 }
 
 // GetAppRegistryClient returns a new AppRegistryClient.
-func GetAppRegistryClient(opts ...Option) (appregistry.RegistryAPIClient, error) {
+func GetAppRegistryClient(c interface{}, opts ...Option) (appregistry.RegistryAPIClient, error) {
 	appRegistries.m.Lock()
 	defer appRegistries.m.Unlock()
 
-	options := newOptions(opts...)
+	options, err := NewOptions(c, opts...)
+	if err != nil {
+		return nil, err
+	}
+
 	if c, ok := appRegistries.conn[options.Endpoint]; ok {
 		return c.(appregistry.RegistryAPIClient), nil
 	}
@@ -403,11 +459,15 @@ func GetAppRegistryClient(opts ...Option) (appregistry.RegistryAPIClient, error)
 }
 
 // GetAppProviderClient returns a new AppRegistryClient.
-func GetAppProviderClient(opts ...Option) (appprovider.ProviderAPIClient, error) {
+func GetAppProviderClient(c interface{}, opts ...Option) (appprovider.ProviderAPIClient, error) {
 	appProviders.m.Lock()
 	defer appProviders.m.Unlock()
 
-	options := newOptions(opts...)
+	options, err := NewOptions(c, opts...)
+	if err != nil {
+		return nil, err
+	}
+
 	if c, ok := appProviders.conn[options.Endpoint]; ok {
 		return c.(appprovider.ProviderAPIClient), nil
 	}
@@ -423,11 +483,15 @@ func GetAppProviderClient(opts ...Option) (appprovider.ProviderAPIClient, error)
 }
 
 // GetStorageRegistryClient returns a new StorageRegistryClient.
-func GetStorageRegistryClient(opts ...Option) (storageregistry.RegistryAPIClient, error) {
+func GetStorageRegistryClient(c interface{}, opts ...Option) (storageregistry.RegistryAPIClient, error) {
 	storageRegistries.m.Lock()
 	defer storageRegistries.m.Unlock()
 
-	options := newOptions(opts...)
+	options, err := NewOptions(c, opts...)
+	if err != nil {
+		return nil, err
+	}
+
 	if c, ok := storageRegistries.conn[options.Endpoint]; ok {
 		return c.(storageregistry.RegistryAPIClient), nil
 	}
@@ -443,11 +507,15 @@ func GetStorageRegistryClient(opts ...Option) (storageregistry.RegistryAPIClient
 }
 
 // GetOCMProviderAuthorizerClient returns a new OCMProviderAuthorizerClient.
-func GetOCMProviderAuthorizerClient(opts ...Option) (ocmprovider.ProviderAPIClient, error) {
+func GetOCMProviderAuthorizerClient(c interface{}, opts ...Option) (ocmprovider.ProviderAPIClient, error) {
 	ocmProviderAuthorizers.m.Lock()
 	defer ocmProviderAuthorizers.m.Unlock()
 
-	options := newOptions(opts...)
+	options, err := NewOptions(c, opts...)
+	if err != nil {
+		return nil, err
+	}
+
 	if c, ok := ocmProviderAuthorizers.conn[options.Endpoint]; ok {
 		return c.(ocmprovider.ProviderAPIClient), nil
 	}
@@ -463,11 +531,15 @@ func GetOCMProviderAuthorizerClient(opts ...Option) (ocmprovider.ProviderAPIClie
 }
 
 // GetOCMCoreClient returns a new OCMCoreClient.
-func GetOCMCoreClient(opts ...Option) (ocmcore.OcmCoreAPIClient, error) {
+func GetOCMCoreClient(c interface{}, opts ...Option) (ocmcore.OcmCoreAPIClient, error) {
 	ocmCores.m.Lock()
 	defer ocmCores.m.Unlock()
 
-	options := newOptions(opts...)
+	options, err := NewOptions(c, opts...)
+	if err != nil {
+		return nil, err
+	}
+
 	if c, ok := ocmCores.conn[options.Endpoint]; ok {
 		return c.(ocmcore.OcmCoreAPIClient), nil
 	}
@@ -483,11 +555,15 @@ func GetOCMCoreClient(opts ...Option) (ocmcore.OcmCoreAPIClient, error) {
 }
 
 // GetDataTxClient returns a new DataTxClient.
-func GetDataTxClient(opts ...Option) (datatx.TxAPIClient, error) {
+func GetDataTxClient(c interface{}, opts ...Option) (datatx.TxAPIClient, error) {
 	dataTxs.m.Lock()
 	defer dataTxs.m.Unlock()
 
-	options := newOptions(opts...)
+	options, err := NewOptions(c, opts...)
+	if err != nil {
+		return nil, err
+	}
+
 	if c, ok := dataTxs.conn[options.Endpoint]; ok {
 		return c.(datatx.TxAPIClient), nil
 	}

--- a/pkg/share/cache/warmup/cbox/cbox.go
+++ b/pkg/share/cache/warmup/cbox/cbox.go
@@ -45,14 +45,15 @@ func init() {
 }
 
 type config struct {
-	DbUsername   string `mapstructure:"db_username"`
-	DbPassword   string `mapstructure:"db_password"`
-	DbHost       string `mapstructure:"db_host"`
-	DbPort       int    `mapstructure:"db_port"`
-	DbName       string `mapstructure:"db_name"`
-	EOSNamespace string `mapstructure:"namespace"`
-	GatewaySvc   string `mapstructure:"gatewaysvc"`
-	JWTSecret    string `mapstructure:"jwt_secret"`
+	DbUsername         string `mapstructure:"db_username"`
+	DbPassword         string `mapstructure:"db_password"`
+	DbHost             string `mapstructure:"db_host"`
+	DbPort             int    `mapstructure:"db_port"`
+	DbName             string `mapstructure:"db_name"`
+	EOSNamespace       string `mapstructure:"namespace"`
+	GatewaySvc         string `mapstructure:"gatewaysvc"`
+	JWTSecret          string `mapstructure:"jwt_secret"`
+	MaxCallRecvMsgSize int    `mapstructure:"client_recv_msg_size"`
 }
 
 type manager struct {

--- a/pkg/share/cache/warmup/cbox/cbox.go
+++ b/pkg/share/cache/warmup/cbox/cbox.go
@@ -119,7 +119,7 @@ func (m *manager) GetResourceInfos() ([]*provider.ResourceInfo, error) {
 	}
 	ctx := metadata.AppendToOutgoingContext(context.Background(), ctxpkg.TokenHeader, tkn)
 
-	client, err := pool.GetGatewayServiceClient(pool.Endpoint(m.conf.GatewaySvc))
+	client, err := pool.GetGatewayServiceClient(m.conf, pool.Endpoint(m.conf.GatewaySvc))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/share/manager/sql/conversions.go
+++ b/pkg/share/manager/sql/conversions.go
@@ -62,13 +62,15 @@ type UserConverter interface {
 
 // GatewayUserConverter converts usernames and ids using the gateway
 type GatewayUserConverter struct {
-	gwAddr string
+	gwAddr             string
+	maxCallRecvMsgSize int `mapstructure:"client_recv_msg_size"`
 }
 
 // NewGatewayUserConverter returns a instance of GatewayUserConverter
-func NewGatewayUserConverter(gwAddr string) *GatewayUserConverter {
+func NewGatewayUserConverter(gwAddr string, maxCallRecvMsgSize int) *GatewayUserConverter {
 	return &GatewayUserConverter{
-		gwAddr: gwAddr,
+		gwAddr:             gwAddr,
+		maxCallRecvMsgSize: maxCallRecvMsgSize,
 	}
 }
 

--- a/pkg/share/manager/sql/conversions.go
+++ b/pkg/share/manager/sql/conversions.go
@@ -74,7 +74,7 @@ func NewGatewayUserConverter(gwAddr string) *GatewayUserConverter {
 
 // UserIDToUserName converts a user ID to an username
 func (c *GatewayUserConverter) UserIDToUserName(ctx context.Context, userid *userpb.UserId) (string, error) {
-	gwConn, err := pool.GetGatewayServiceClient(pool.Endpoint(c.gwAddr))
+	gwConn, err := pool.GetGatewayServiceClient(c, pool.Endpoint(c.gwAddr))
 	if err != nil {
 		return "", err
 	}
@@ -93,7 +93,7 @@ func (c *GatewayUserConverter) UserIDToUserName(ctx context.Context, userid *use
 
 // UserNameToUserID converts a username to an user ID
 func (c *GatewayUserConverter) UserNameToUserID(ctx context.Context, username string) (*userpb.UserId, error) {
-	gwConn, err := pool.GetGatewayServiceClient(pool.Endpoint(c.gwAddr))
+	gwConn, err := pool.GetGatewayServiceClient(c, pool.Endpoint(c.gwAddr))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/share/manager/sql/sql.go
+++ b/pkg/share/manager/sql/sql.go
@@ -53,13 +53,14 @@ func init() {
 }
 
 type config struct {
-	GatewayAddr    string `mapstructure:"gateway_addr"`
-	StorageMountID string `mapstructure:"storage_mount_id"`
-	DbUsername     string `mapstructure:"db_username"`
-	DbPassword     string `mapstructure:"db_password"`
-	DbHost         string `mapstructure:"db_host"`
-	DbPort         int    `mapstructure:"db_port"`
-	DbName         string `mapstructure:"db_name"`
+	GatewayAddr        string `mapstructure:"gateway_addr"`
+	StorageMountID     string `mapstructure:"storage_mount_id"`
+	DbUsername         string `mapstructure:"db_username"`
+	DbPassword         string `mapstructure:"db_password"`
+	DbHost             string `mapstructure:"db_host"`
+	DbPort             int    `mapstructure:"db_port"`
+	DbName             string `mapstructure:"db_name"`
+	MaxCallRecvMsgSize int    `mapstructure:"client_recv_msg_size"`
 }
 
 type mgr struct {
@@ -82,7 +83,7 @@ func NewMysql(m map[string]interface{}) (share.Manager, error) {
 		return nil, err
 	}
 
-	userConverter := NewGatewayUserConverter(c.GatewayAddr)
+	userConverter := NewGatewayUserConverter(c.GatewayAddr, c.MaxCallRecvMsgSize)
 
 	return New("mysql", db, c.StorageMountID, userConverter)
 }

--- a/pkg/storage/fs/owncloud/owncloud.go
+++ b/pkg/storage/fs/owncloud/owncloud.go
@@ -485,7 +485,7 @@ func (fs *ocfs) getUser(ctx context.Context, usernameOrID string) (id *userpb.Us
 	// look up at the userprovider
 
 	// parts[0] contains the username or userid. use  user service to look up id
-	c, err := pool.GetUserProviderServiceClient(pool.Endpoint(fs.c.UserProviderEndpoint))
+	c, err := pool.GetUserProviderServiceClient(fs.c, pool.Endpoint(fs.c.UserProviderEndpoint))
 	if err != nil {
 		appctx.GetLogger(ctx).
 			Error().Err(err).

--- a/pkg/storage/fs/owncloud/owncloud.go
+++ b/pkg/storage/fs/owncloud/owncloud.go
@@ -118,6 +118,7 @@ type config struct {
 	EnableHome               bool   `mapstructure:"enable_home"`
 	Scan                     bool   `mapstructure:"scan"`
 	UserProviderEndpoint     string `mapstructure:"userprovidersvc"`
+	MaxCallRecvMsgSize       int    `mapstructure:"client_recv_msg_size"`
 }
 
 func parseConfig(m map[string]interface{}) (*config, error) {

--- a/pkg/storage/fs/owncloudsql/owncloudsql.go
+++ b/pkg/storage/fs/owncloudsql/owncloudsql.go
@@ -118,6 +118,7 @@ type config struct {
 	DbHost                   string `mapstructure:"dbhost"`
 	DbPort                   int    `mapstructure:"dbport"`
 	DbName                   string `mapstructure:"dbname"`
+	MaxCallRecvMsgSize       int    `mapstructure:"client_recv_msg_size"`
 }
 
 func parseConfig(m map[string]interface{}) (*config, error) {

--- a/pkg/storage/fs/owncloudsql/owncloudsql.go
+++ b/pkg/storage/fs/owncloudsql/owncloudsql.go
@@ -370,7 +370,7 @@ func (fs *owncloudsqlfs) getUser(ctx context.Context, usernameOrID string) (id *
 	// look up at the userprovider
 
 	// parts[0] contains the username or userid. use  user service to look up id
-	c, err := pool.GetUserProviderServiceClient(pool.Endpoint(fs.c.UserProviderEndpoint))
+	c, err := pool.GetUserProviderServiceClient(fs.c, pool.Endpoint(fs.c.UserProviderEndpoint))
 	if err != nil {
 		appctx.GetLogger(ctx).
 			Error().Err(err).

--- a/pkg/storage/utils/decomposedfs/options/options.go
+++ b/pkg/storage/utils/decomposedfs/options/options.go
@@ -54,7 +54,8 @@ type Options struct {
 	OwnerIDP  string `mapstructure:"owner_idp"`
 	OwnerType string `mapstructure:"owner_type"`
 
-	GatewayAddr string `mapstructure:"gateway_addr"`
+	GatewayAddr        string `mapstructure:"gateway_addr"`
+	MaxCallRecvMsgSize int    `mapstructure:"client_recv_msg_size"`
 }
 
 // New returns a new Options instance for the given configuration

--- a/pkg/storage/utils/decomposedfs/spaces.go
+++ b/pkg/storage/utils/decomposedfs/spaces.go
@@ -202,7 +202,7 @@ func (fs *Decomposedfs) ListStorageSpaces(ctx context.Context, filter []*provide
 		return spaces, nil
 	}
 
-	client, err := pool.GetGatewayServiceClient(pool.Endpoint(fs.o.GatewayAddr))
+	client, err := pool.GetGatewayServiceClient(fs.o, pool.Endpoint(fs.o.GatewayAddr))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/storage/utils/eosfs/config.go
+++ b/pkg/storage/utils/eosfs/config.go
@@ -168,4 +168,6 @@ type Config struct {
 	// TokenExpiry stores in seconds the time after which generated tokens will expire
 	// Default is 3600
 	TokenExpiry int
+
+	MaxCallRecvMsgSize int `mapstructure:"client_recv_msg_size"`
 }

--- a/pkg/storage/utils/eosfs/eosfs.go
+++ b/pkg/storage/utils/eosfs/eosfs.go
@@ -817,7 +817,7 @@ func (fs *eosfs) SetLock(ctx context.Context, ref *provider.Reference, l *provid
 }
 
 func (fs *eosfs) getUserFromID(ctx context.Context, userID *userpb.UserId) (*userpb.User, error) {
-	client, err := pool.GetGatewayServiceClient(pool.Endpoint(fs.conf.GatewaySvc))
+	client, err := pool.GetGatewayServiceClient(fs.conf, pool.Endpoint(fs.conf.GatewaySvc))
 	if err != nil {
 		return nil, err
 	}
@@ -2211,7 +2211,7 @@ func (fs *eosfs) getUIDGateway(ctx context.Context, u *userpb.UserId) (eosclient
 		return fs.extractUIDAndGID(userIDInterface.(*userpb.User))
 	}
 
-	client, err := pool.GetGatewayServiceClient(pool.Endpoint(fs.conf.GatewaySvc))
+	client, err := pool.GetGatewayServiceClient(fs.conf, pool.Endpoint(fs.conf.GatewaySvc))
 	if err != nil {
 		return eosclient.Authorization{}, errors.Wrap(err, "eosfs: error getting gateway grpc client")
 	}
@@ -2245,7 +2245,7 @@ func (fs *eosfs) getUserIDGateway(ctx context.Context, uid string) (*userpb.User
 	}
 
 	log.Debug().Msg("eosfs: retrieving user from gateway for uid " + uid)
-	client, err := pool.GetGatewayServiceClient(pool.Endpoint(fs.conf.GatewaySvc))
+	client, err := pool.GetGatewayServiceClient(fs.conf, pool.Endpoint(fs.conf.GatewaySvc))
 	if err != nil {
 		return nil, errors.Wrap(err, "eosfs: error getting gateway grpc client")
 	}

--- a/tests/integration/grpc/storageprovider_test.go
+++ b/tests/integration/grpc/storageprovider_test.go
@@ -91,7 +91,7 @@ var _ = Describe("storage providers", func() {
 
 		revads, err = startRevads(dependencies, variables)
 		Expect(err).ToNot(HaveOccurred())
-		serviceClient, err = pool.GetStorageProviderServiceClient(pool.Endpoint(revads["storage"].GrpcAddress))
+		serviceClient, err = pool.GetStorageProviderServiceClient(&struct{}{}, pool.Endpoint(revads["storage"].GrpcAddress))
 		Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/tests/integration/grpc/userprovider_test.go
+++ b/tests/integration/grpc/userprovider_test.go
@@ -68,7 +68,7 @@ var _ = Describe("user providers", func() {
 
 		revads, err = startRevads(dependencies, map[string]string{})
 		Expect(err).ToNot(HaveOccurred())
-		serviceClient, err = pool.GetUserProviderServiceClient(pool.Endpoint(revads["users"].GrpcAddress))
+		serviceClient, err = pool.GetUserProviderServiceClient(&struct{}{}, pool.Endpoint(revads["users"].GrpcAddress))
 		Expect(err).ToNot(HaveOccurred())
 	})
 


### PR DESCRIPTION
- Allows `grpc.MaxCallRecvMsgSize` to be configured.  `MaxCallRecvMsgSize` defaults to 10240000 if set to <= 0. 
- Adding new configurations to `pkg/pool` would be much easier with this PR and result in a much smaller diff.