### PR TITLE
Fix version

### DIFF
--- a/changelog/unreleased/version-fixes.md
+++ b/changelog/unreleased/version-fixes.md
@@ -1,0 +1,5 @@
+Bugfix: Fix version number in status page
+
+We needed to undo the version number changes on the status page to keep compatibility for legacy clients. We added a new field `productversion` for the actual version of the product.
+
+https://github.com/cs3org/reva/pull/2876

--- a/internal/http/services/owncloud/ocdav/ocdav.go
+++ b/internal/http/services/owncloud/ocdav/ocdav.go
@@ -223,7 +223,7 @@ func (s *svc) Close() error {
 }
 
 func (s *svc) Unprotected() []string {
-	return []string{"/status.php", "/remote.php/dav/public-files/", "/apps/files/", "/index.php/f/", "/index.php/s/"}
+	return []string{"/status.php", "/status", "/remote.php/dav/public-files/", "/apps/files/", "/index.php/f/", "/index.php/s/"}
 }
 
 func (s *svc) Handler() http.Handler {
@@ -248,7 +248,7 @@ func (s *svc) Handler() http.Handler {
 		head, r.URL.Path = router.ShiftPath(r.URL.Path)
 		log.Debug().Str("head", head).Str("tail", r.URL.Path).Msg("http routing")
 		switch head {
-		case "status.php":
+		case "status.php", "status":
 			s.doStatus(w, r)
 			return
 		case "remote.php":

--- a/internal/http/services/owncloud/ocdav/ocdav.go
+++ b/internal/http/services/owncloud/ocdav/ocdav.go
@@ -101,6 +101,7 @@ type Config struct {
 	Edition                string                            `mapstructure:"edition"`
 	Product                string                            `mapstructure:"product"`
 	ProductName            string                            `mapstructure:"product_name"`
+	ProductVersion         string                            `mapstructure:"product_version"`
 }
 
 func (c *Config) init() {
@@ -125,6 +126,10 @@ func (c *Config) init() {
 
 	if c.ProductName == "" {
 		c.ProductName = "reva"
+	}
+
+	if c.ProductVersion == "" {
+		c.ProductVersion = "10.0.11"
 	}
 
 	if c.Edition == "" {

--- a/internal/http/services/owncloud/ocdav/status.go
+++ b/internal/http/services/owncloud/ocdav/status.go
@@ -36,6 +36,7 @@ func (s *svc) doStatus(w http.ResponseWriter, r *http.Request) {
 		VersionString:  s.c.VersionString,
 		Edition:        s.c.Edition,
 		ProductName:    s.c.ProductName,
+		ProductVersion: s.c.ProductVersion,
 		Product:        s.c.Product,
 	}
 

--- a/internal/http/services/owncloud/ocs/data/capabilities.go
+++ b/internal/http/services/owncloud/ocs/data/capabilities.go
@@ -86,6 +86,7 @@ type Status struct {
 	Edition        string  `json:"edition" xml:"edition"`
 	ProductName    string  `json:"productname" xml:"productname"`
 	Product        string  `json:"product" xml:"product"`
+	ProductVersion string  `json:"productversion" xml:"productversion"`
 	Hostname       string  `json:"hostname,omitempty" xml:"hostname,omitempty"`
 }
 

--- a/pkg/micro/ocdav/option.go
+++ b/pkg/micro/ocdav/option.go
@@ -218,3 +218,10 @@ func ProductName(val string) Option {
 		o.config.ProductName = val
 	}
 }
+
+// ProductVersion provides a function to set the ProductVersion config option.
+func ProductVersion(val string) Option {
+	return func(o *Options) {
+		o.config.ProductVersion = val
+	}
+}


### PR DESCRIPTION
Bugfix: Fix version number in status page

We needed to undo the version number changes on the status page to keep compatibility for legacy clients. We added a new field `productversion` for the actual version of the product.
