### PR TITLE
Resharing

### DIFF
--- a/changelog/unreleased/resharing.md
+++ b/changelog/unreleased/resharing.md
@@ -1,0 +1,8 @@
+Change: Enable resharing
+
+This will allow resharing of files.
+-   All Viewers and Editors are now able to reshare files and folders
+-   One can still edit their own shares, even when loosing share permissions
+-   Viewers and Editors in a space are not affected
+
+https://github.com/cs3org/reva/pull/2877

--- a/go.mod
+++ b/go.mod
@@ -52,7 +52,6 @@ require (
 	github.com/mitchellh/go-testing-interface v1.14.1 // indirect
 	github.com/mitchellh/mapstructure v1.4.3
 	github.com/nats-io/nats-server/v2 v2.8.0
-	github.com/onsi/ginkgo v1.16.5 // indirect
 	github.com/onsi/ginkgo/v2 v2.1.3
 	github.com/onsi/gomega v1.19.0
 	github.com/pkg/errors v0.9.1

--- a/go.mod
+++ b/go.mod
@@ -91,6 +91,7 @@ require (
 go 1.16
 
 replace (
+	github.com/cs3org/go-cs3apis => github.com/kobergj/go-cs3apis v0.0.0-20220610101249-8067918fe8bf // temp fork
 	github.com/eventials/go-tus => github.com/andrewmostello/go-tus v0.0.0-20200314041820-904a9904af9a
 	github.com/oleiade/reflections => github.com/oleiade/reflections v1.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -756,9 +756,8 @@ github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
+github.com/onsi/ginkgo v1.16.4 h1:29JGrr5oVBm5ulCWet69zQkzWipVXIol6ygQUe/EzNc=
 github.com/onsi/ginkgo v1.16.4/go.mod h1:dX+/inL/fNMqNlz0e9LfyB9TswhZpCVdJM/Z6Vvnwo0=
-github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
-github.com/onsi/ginkgo v1.16.5/go.mod h1:+E8gABHa3K6zRBolWtd+ROzc/U5bkGt0FwiG042wbpU=
 github.com/onsi/ginkgo/v2 v2.1.3 h1:e/3Cwtogj0HA+25nMP1jCMDIf8RtRYbGwGGuBIFztkc=
 github.com/onsi/ginkgo/v2 v2.1.3/go.mod h1:vw5CSIxN1JObi/U8gcbwft7ZxR2dgaR70JSE3/PpL4c=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=

--- a/go.sum
+++ b/go.sum
@@ -216,8 +216,6 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/cs3org/cato v0.0.0-20200828125504-e418fc54dd5e h1:tqSPWQeueWTKnJVMJffz4pz0o1WuQxJ28+5x5JgaHD8=
 github.com/cs3org/cato v0.0.0-20200828125504-e418fc54dd5e/go.mod h1:XJEZ3/EQuI3BXTp/6DUzFr850vlxq11I6satRtz0YQ4=
-github.com/cs3org/go-cs3apis v0.0.0-20220512100524-551800f020d8 h1:31jPSD5BOjc4+h4xK1e+NFf34gtwHEexor3V7JbdcPM=
-github.com/cs3org/go-cs3apis v0.0.0-20220512100524-551800f020d8/go.mod h1:UXha4TguuB52H14EMoSsCqDj7k8a/t7g4gVP+bgY5LY=
 github.com/cubewise-code/go-mime v0.0.0-20200519001935-8c5762b177d8 h1:Z9lwXumT5ACSmJ7WGnFl+OMLLjpz5uR2fyz7dC255FI=
 github.com/cubewise-code/go-mime v0.0.0-20200519001935-8c5762b177d8/go.mod h1:4abs/jPXcmJzYoYGF91JF9Uq9s/KL5n1jvFDix8KcqY=
 github.com/cyberdelia/templates v0.0.0-20141128023046-ca7fffd4298c/go.mod h1:GyV+0YP4qX0UQ7r2MoYZ+AvYDp12OF5yg4q8rGnyNh4=
@@ -602,6 +600,8 @@ github.com/klauspost/compress v1.14.4/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47e
 github.com/klauspost/cpuid v1.2.3/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
 github.com/klauspost/cpuid v1.3.1 h1:5JNjFYYQrZeKRJ0734q51WCEEn2huer72Dc7K+R/b6s=
 github.com/klauspost/cpuid v1.3.1/go.mod h1:bYW4mA6ZgKPob1/Dlai2LviZJO7KGI3uoWLd42rAQw4=
+github.com/kobergj/go-cs3apis v0.0.0-20220610101249-8067918fe8bf h1:zQRKsQOGgt5aiPs4DoosUCnY8lmKbgHY7x9lpN6aWVA=
+github.com/kobergj/go-cs3apis v0.0.0-20220610101249-8067918fe8bf/go.mod h1:UXha4TguuB52H14EMoSsCqDj7k8a/t7g4gVP+bgY5LY=
 github.com/kolo/xmlrpc v0.0.0-20200310150728-e0350524596b/go.mod h1:o03bZfuBwAXHetKXuInt4S7omeXUu62/A845kiycsSQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=

--- a/internal/http/services/owncloud/ocs/conversions/permissions.go
+++ b/internal/http/services/owncloud/ocs/conversions/permissions.go
@@ -39,8 +39,6 @@ const (
 	PermissionDelete
 	// PermissionShare grants share permissions on a resource
 	PermissionShare
-	// PermissionManager grants manager permissions on a resource
-	PermissionManager // FIXME: this permissions exists to differentiate a editor from a manager. They are not distinguishable without.
 	// PermissionAll grants all permissions on a resource
 	PermissionAll Permissions = (1 << (iota - 1)) - 1
 )

--- a/internal/http/services/owncloud/ocs/conversions/permissions.go
+++ b/internal/http/services/owncloud/ocs/conversions/permissions.go
@@ -39,6 +39,8 @@ const (
 	PermissionDelete
 	// PermissionShare grants share permissions on a resource
 	PermissionShare
+	// PermissionManager grants manager permissions on a resource
+	PermissionManager // FIXME: this permissions exists to differentiate a editor from a manager. They are not distinguishable without.
 	// PermissionAll grants all permissions on a resource
 	PermissionAll Permissions = (1 << (iota - 1)) - 1
 )

--- a/internal/http/services/owncloud/ocs/conversions/permissions_test.go
+++ b/internal/http/services/owncloud/ocs/conversions/permissions_test.go
@@ -51,10 +51,10 @@ func TestContainPermissionAll(t *testing.T) {
 		4:  PermissionCreate,
 		8:  PermissionDelete,
 		16: PermissionShare,
-		63: PermissionAll,
+		31: PermissionAll,
 	}
 
-	p, _ := NewPermissions(63) // all permissions should contain all other permissions
+	p, _ := NewPermissions(31) // all permissions should contain all other permissions
 	for _, value := range table {
 		if !p.Contain(value) {
 			t.Errorf("permissions %d should contain %d", p, value)

--- a/internal/http/services/owncloud/ocs/conversions/permissions_test.go
+++ b/internal/http/services/owncloud/ocs/conversions/permissions_test.go
@@ -51,10 +51,10 @@ func TestContainPermissionAll(t *testing.T) {
 		4:  PermissionCreate,
 		8:  PermissionDelete,
 		16: PermissionShare,
-		31: PermissionAll,
+		63: PermissionAll,
 	}
 
-	p, _ := NewPermissions(31) // all permissions should contain all other permissions
+	p, _ := NewPermissions(63) // all permissions should contain all other permissions
 	for _, value := range table {
 		if !p.Contain(value) {
 			t.Errorf("permissions %d should contain %d", p, value)
@@ -144,7 +144,6 @@ func TestPermissions2Role(t *testing.T) {
 	table := map[Permissions]string{
 		PermissionRead | PermissionShare: RoleViewer,
 		PermissionRead | PermissionWrite | PermissionCreate | PermissionDelete | PermissionShare: RoleEditor,
-		//PermissionAll:                     RoleManager,
 		PermissionWrite:                   RoleLegacy,
 		PermissionShare:                   RoleLegacy,
 		PermissionWrite | PermissionShare: RoleLegacy,

--- a/internal/http/services/owncloud/ocs/conversions/permissions_test.go
+++ b/internal/http/services/owncloud/ocs/conversions/permissions_test.go
@@ -142,9 +142,9 @@ func TestPermissions2Role(t *testing.T) {
 	}
 
 	table := map[Permissions]string{
-		PermissionRead: RoleViewer,
-		PermissionRead | PermissionWrite | PermissionCreate | PermissionDelete: RoleEditor,
-		PermissionAll:                     RoleManager,
+		PermissionRead | PermissionShare: RoleViewer,
+		PermissionRead | PermissionWrite | PermissionCreate | PermissionDelete | PermissionShare: RoleEditor,
+		//PermissionAll:                     RoleManager,
 		PermissionWrite:                   RoleLegacy,
 		PermissionShare:                   RoleLegacy,
 		PermissionWrite | PermissionShare: RoleLegacy,

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/shares.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/shares.go
@@ -441,6 +441,7 @@ func (h *Handler) extractPermissions(w http.ResponseWriter, r *http.Request, ri 
 				Error:   errors.New("cannot set the requested share permissions"),
 			}
 		}
+		role = conversions.RoleFromOCSPermissions(permissions)
 	}
 
 	existingPermissions := conversions.RoleFromResourcePermissions(ri.PermissionSet).OCSPermissions()
@@ -452,7 +453,6 @@ func (h *Handler) extractPermissions(w http.ResponseWriter, r *http.Request, ri 
 		}
 	}
 
-	role = conversions.RoleFromOCSPermissions(permissions)
 	roleMap := map[string]string{"name": role.Name}
 	val, err := json.Marshal(roleMap)
 	if err != nil {

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/shares.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/shares.go
@@ -398,14 +398,16 @@ func (h *Handler) updateExistingShareMountpoints(ctx context.Context, shareType 
 	return response.MetaOK.StatusCode, "", nil
 }
 
-func (h *Handler) extractPermissions(w http.ResponseWriter, r *http.Request, ri *provider.ResourceInfo, defaultPermissions *conversions.Role) (*conversions.Role, []byte, *ocsError) {
-	reqRole, reqPermissions := r.FormValue("role"), r.FormValue("permissions")
+func (h *Handler) extractPermissions(reqRole string, reqPermissions string, ri *provider.ResourceInfo, defaultPermissions *conversions.Role) (*conversions.Role, []byte, *ocsError) {
 	var role *conversions.Role
 
 	// the share role overrides the requested permissions
 	if reqRole != "" {
 		role = conversions.RoleFromName(reqRole)
-	} else {
+	}
+
+	// if the role is unknown - fall back to reqPermissions or defaultPermissions
+	if role == nil || role.Name == conversions.RoleUnknown {
 		// map requested permissions
 		if reqPermissions == "" {
 			// TODO default link vs user share

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/spaces.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/spaces.go
@@ -249,10 +249,10 @@ func (h *Handler) findProvider(ctx context.Context, ref *provider.Reference) (*r
 
 func isSpaceManagerRemaining(grants []*provider.Grant, grantee provider.Grantee) bool {
 	for _, g := range grants {
-		// AddGrant is currently the way to check for the manager role
+		// RemoveGrant is currently the way to check for the manager role
 		// If it is not set than the current grant is not for a manager and
 		// we can just continue with the next one.
-		if g.Permissions.AddGrant && !isEqualGrantee(*g.Grantee, grantee) {
+		if g.Permissions.RemoveGrant && !isEqualGrantee(*g.Grantee, grantee) {
 			return true
 		}
 	}

--- a/pkg/storage/utils/ace/ace_test.go
+++ b/pkg/storage/utils/ace/ace_test.go
@@ -158,17 +158,20 @@ var _ = Describe("ACE", func() {
 			Expect(newGrant.Permissions.AddGrant).To(BeTrue())
 			Expect(newGrant.Permissions.Delete).To(BeFalse())
 
-			userGrant.Permissions.RemoveGrant = true
-			newGrant = ace.FromGrant(userGrant).Grant()
-			userGrant.Permissions.RemoveGrant = false
-			Expect(newGrant.Permissions.RemoveGrant).To(BeTrue())
-			Expect(newGrant.Permissions.Delete).To(BeFalse())
+			// TODO: test via manager permission
+			/*
+				userGrant.Permissions.RemoveGrant = true
+				newGrant = ace.FromGrant(userGrant).Grant()
+				userGrant.Permissions.RemoveGrant = false
+				Expect(newGrant.Permissions.RemoveGrant).To(BeTrue())
+				Expect(newGrant.Permissions.Delete).To(BeFalse())
 
-			userGrant.Permissions.UpdateGrant = true
-			newGrant = ace.FromGrant(userGrant).Grant()
-			userGrant.Permissions.UpdateGrant = false
-			Expect(newGrant.Permissions.UpdateGrant).To(BeTrue())
-			Expect(newGrant.Permissions.Delete).To(BeFalse())
+				userGrant.Permissions.UpdateGrant = true
+				newGrant = ace.FromGrant(userGrant).Grant()
+				userGrant.Permissions.UpdateGrant = false
+				Expect(newGrant.Permissions.UpdateGrant).To(BeTrue())
+				Expect(newGrant.Permissions.Delete).To(BeFalse())
+			*/
 		})
 
 		It("converts c", func() {

--- a/pkg/storage/utils/ace/ace_test.go
+++ b/pkg/storage/utils/ace/ace_test.go
@@ -43,6 +43,10 @@ var _ = Describe("ACE", func() {
 				},
 			},
 			Permissions: &provider.ResourcePermissions{},
+			Creator: &userpb.UserId{
+				OpaqueId: "baz",
+				Idp:      "idp",
+			},
 		}
 
 		groupGrant = &provider.Grant{
@@ -74,6 +78,8 @@ var _ = Describe("ACE", func() {
 		It("returns a proper Grant", func() {
 			ace := ace.FromGrant(userGrant)
 			grant := ace.Grant()
+			// do not check opaque values
+			grant.Grantee.Opaque = nil
 			Expect(grant).To(Equal(userGrant))
 		})
 	})
@@ -152,26 +158,11 @@ var _ = Describe("ACE", func() {
 		})
 
 		It("converts C", func() {
-			userGrant.Permissions.AddGrant = true
+			userGrant.Permissions.RemoveGrant = true
 			newGrant := ace.FromGrant(userGrant).Grant()
-			userGrant.Permissions.AddGrant = false
-			Expect(newGrant.Permissions.AddGrant).To(BeTrue())
+			userGrant.Permissions.RemoveGrant = false
+			Expect(newGrant.Permissions.RemoveGrant).To(BeTrue())
 			Expect(newGrant.Permissions.Delete).To(BeFalse())
-
-			// TODO: test via manager permission
-			/*
-				userGrant.Permissions.RemoveGrant = true
-				newGrant = ace.FromGrant(userGrant).Grant()
-				userGrant.Permissions.RemoveGrant = false
-				Expect(newGrant.Permissions.RemoveGrant).To(BeTrue())
-				Expect(newGrant.Permissions.Delete).To(BeFalse())
-
-				userGrant.Permissions.UpdateGrant = true
-				newGrant = ace.FromGrant(userGrant).Grant()
-				userGrant.Permissions.UpdateGrant = false
-				Expect(newGrant.Permissions.UpdateGrant).To(BeTrue())
-				Expect(newGrant.Permissions.Delete).To(BeFalse())
-			*/
 		})
 
 		It("converts c", func() {

--- a/pkg/storage/utils/decomposedfs/grants_test.go
+++ b/pkg/storage/utils/decomposedfs/grants_test.go
@@ -19,6 +19,7 @@
 package decomposedfs_test
 
 import (
+	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -114,10 +115,11 @@ var _ = Describe("Grants", func() {
 				err = env.Fs.AddGrant(env.Ctx, ref, grant)
 				Expect(err).ToNot(HaveOccurred())
 
+				o := env.Owner.GetId()
 				localPath := n.InternalPath()
 				attr, err := xattr.Get(localPath, xattrs.GrantUserAcePrefix+grant.Grantee.GetUserId().OpaqueId)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(string(attr)).To(Equal("\x00t=A:f=:p=rw"))
+				Expect(string(attr)).To(Equal(fmt.Sprintf("\x00t=A:f=:p=rw:c=%s", o.GetOpaqueId()+"!"+o.GetIdp()+"\n"))) // NOTE: this tests ace package
 			})
 
 			It("creates a storage space per created grant", func() {

--- a/pkg/storage/utils/decomposedfs/spaces.go
+++ b/pkg/storage/utils/decomposedfs/spaces.go
@@ -585,11 +585,7 @@ func (fs *Decomposedfs) storageSpaceFromNode(ctx context.Context, n *node.Node, 
 		}
 
 		if n.SpaceRoot.IsDisabled() {
-			ok, err := node.NewPermissions(fs.lu).HasPermission(ctx, n, func(p *provider.ResourcePermissions) bool {
-				// TODO: Which permission do I need to see the space?
-				return p.AddGrant
-			})
-			if err != nil || !ok {
+			if err := fs.checkManagerPermission(ctx, n); err != nil {
 				return nil, errtypes.PermissionDenied(fmt.Sprintf("user %s is not allowed to list deleted spaces %s", user.Username, n.ID))
 			}
 		}
@@ -752,9 +748,9 @@ func (fs *Decomposedfs) storageSpaceFromNode(ctx context.Context, n *node.Node, 
 
 func (fs *Decomposedfs) checkManagerPermission(ctx context.Context, n *node.Node) error {
 	// to update the space name or short description we need the manager role
-	// current workaround: check if AddGrant Permission exists
+	// current workaround: check if RemoveGrant Permission exists
 	managerPerm, err := fs.p.HasPermission(ctx, n, func(rp *provider.ResourcePermissions) bool {
-		return rp.AddGrant
+		return rp.RemoveGrant
 	})
 	switch {
 	case err != nil:

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -336,12 +336,8 @@ func GetViewMode(viewMode string) gateway.OpenInAppRequest_ViewMode {
 
 // AppendPlainToOpaque adds a new key value pair as a plain string on the given opaque and returns it
 func AppendPlainToOpaque(o *types.Opaque, key, value string) *types.Opaque {
-	if o == nil {
-		o = &types.Opaque{}
-	}
-	if o.Map == nil {
-		o.Map = map[string]*types.OpaqueEntry{}
-	}
+	o = ensureOpaque(o)
+
 	o.Map[key] = &types.OpaqueEntry{
 		Decoder: "plain",
 		Value:   []byte(value),
@@ -351,7 +347,7 @@ func AppendPlainToOpaque(o *types.Opaque, key, value string) *types.Opaque {
 
 // ReadPlainFromOpaque reads a plain string from the given opaque map
 func ReadPlainFromOpaque(o *types.Opaque, key string) string {
-	if o == nil || o.Map == nil {
+	if o.GetMap() == nil {
 		return ""
 	}
 	if e, ok := o.Map[key]; ok && e.Decoder == "plain" {
@@ -362,12 +358,33 @@ func ReadPlainFromOpaque(o *types.Opaque, key string) string {
 
 // ExistsInOpaque returns true if the key exists in the opaque (ignoring the value)
 func ExistsInOpaque(o *types.Opaque, key string) bool {
-	if o == nil || o.Map == nil {
+	if o.GetMap() == nil {
 		return false
 	}
 
 	_, ok := o.Map[key]
 	return ok
+}
+
+// MergeOpaques will merge the opaques. If a key exists in both opaques
+// the values from the first opaque will be taken
+func MergeOpaques(o *types.Opaque, p *types.Opaque) *types.Opaque {
+	p = ensureOpaque(p)
+	for k, v := range o.GetMap() {
+		p.Map[k] = v
+	}
+	return p
+}
+
+// ensures the opaque is initialized
+func ensureOpaque(o *types.Opaque) *types.Opaque {
+	if o == nil {
+		o = &types.Opaque{}
+	}
+	if o.Map == nil {
+		o.Map = map[string]*types.OpaqueEntry{}
+	}
+	return o
 }
 
 // RemoveItem removes the given item, its children and all empty parent folders

--- a/tests/acceptance/expected-failures-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-on-OCIS-storage.md
@@ -1499,10 +1499,12 @@ moving outside of the Shares folder gives 501 Not Implemented.
 - [apiTrashbin/trashbinFilesFolders.feature:438](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature#L438)
 - [apiTrashbin/trashbinFilesFolders.feature:475](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature#L475)
 
-#### [reShareUpdate API tests failing in reva](https://github.com/cs3org/reva/issues/2916)
-
-- [apiShareReshareToShares3/reShareUpdate.feature:152](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareReshareToShares3/reShareUpdate.feature#L152)
-- [apiShareReshareToShares3/reShareUpdate.feature:153](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareReshareToShares3/reShareUpdate.feature#L153)
+#### Resharing is allowed for viewers and editors
+- [apiShareCreateSpecialToShares2/createShareReceivedInMultipleWays.feature:602](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareCreateSpecialToShares2/createShareReceivedInMultipleWays.feature#L602)
+- [apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature:27](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature#L27)
+- [apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature:28](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature#L28)
+- [apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature:79](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature#L79)
+- [apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature:80](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature#L80)
 
 #### [apiShareOperationsToShares1/gettingShares.feature:28 fails in CI](https://github.com/cs3org/reva/issues/2926)
 

--- a/tests/acceptance/expected-failures-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-on-OCIS-storage.md
@@ -1499,15 +1499,7 @@ moving outside of the Shares folder gives 501 Not Implemented.
 - [apiTrashbin/trashbinFilesFolders.feature:438](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature#L438)
 - [apiTrashbin/trashbinFilesFolders.feature:475](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature#L475)
 
-#### Resharing is allowed for viewers and editors
-- [apiShareCreateSpecialToShares2/createShareReceivedInMultipleWays.feature:602](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareCreateSpecialToShares2/createShareReceivedInMultipleWays.feature#L602)
-- [apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature:27](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature#L27)
-- [apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature:28](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature#L28)
-- [apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature:79](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature#L79)
-- [apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature:80](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature#L80)
-
 #### [apiShareOperationsToShares1/gettingShares.feature:28 fails in CI](https://github.com/cs3org/reva/issues/2926)
-
 - [apiShareOperationsToShares1/gettingShares.feature:40](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareOperationsToShares1/gettingShares.feature#L40)
 - [apiShareOperationsToShares1/gettingShares.feature:39](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareOperationsToShares1/gettingShares.feature#L39)
 

--- a/tests/acceptance/expected-failures-on-S3NG-storage.md
+++ b/tests/acceptance/expected-failures-on-S3NG-storage.md
@@ -1497,10 +1497,12 @@ _ocs: api compatibility, return correct status code_
 - [apiTrashbin/trashbinFilesFolders.feature:438](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature#L438)
 - [apiTrashbin/trashbinFilesFolders.feature:475](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature#L475)
 
-#### [reShareUpdate API tests failing in reva](https://github.com/cs3org/reva/issues/2916)
-
-- [apiShareReshareToShares3/reShareUpdate.feature:152](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareReshareToShares3/reShareUpdate.feature#L152)
-- [apiShareReshareToShares3/reShareUpdate.feature:153](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareReshareToShares3/reShareUpdate.feature#L153)
+#### Resharing is allowed for viewers and editors
+- [apiShareCreateSpecialToShares2/createShareReceivedInMultipleWays.feature:602](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareCreateSpecialToShares2/createShareReceivedInMultipleWays.feature#L602)
+- [apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature:27](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature#L27)
+- [apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature:28](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature#L28)
+- [apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature:79](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature#L79)
+- [apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature:80](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature#L80)
 
 #### [apiShareOperationsToShares1/gettingShares.feature:28 fails in CI](https://github.com/cs3org/reva/issues/2926)
 

--- a/tests/acceptance/expected-failures-on-S3NG-storage.md
+++ b/tests/acceptance/expected-failures-on-S3NG-storage.md
@@ -1497,15 +1497,7 @@ _ocs: api compatibility, return correct status code_
 - [apiTrashbin/trashbinFilesFolders.feature:438](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature#L438)
 - [apiTrashbin/trashbinFilesFolders.feature:475](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature#L475)
 
-#### Resharing is allowed for viewers and editors
-- [apiShareCreateSpecialToShares2/createShareReceivedInMultipleWays.feature:602](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareCreateSpecialToShares2/createShareReceivedInMultipleWays.feature#L602)
-- [apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature:27](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature#L27)
-- [apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature:28](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature#L28)
-- [apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature:79](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature#L79)
-- [apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature:80](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature#L80)
-
 #### [apiShareOperationsToShares1/gettingShares.feature:28 fails in CI](https://github.com/cs3org/reva/issues/2926)
-
 - [apiShareOperationsToShares1/gettingShares.feature:40](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareOperationsToShares1/gettingShares.feature#L40)
 - [apiShareOperationsToShares1/gettingShares.feature:39](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareOperationsToShares1/gettingShares.feature#L39)
 


### PR DESCRIPTION
Enables proper resharing.

Adds `AddGrant` permission for viewers and editors. 

Introduces `spaceviewer` and `spaceeditor` roles

Uses `RemoveGrant` to identify Managers