### PR TITLE
File uploaded event in dataprovider

### DIFF
--- a/changelog/unreleased/fix-file-uploaded-event.md
+++ b/changelog/unreleased/fix-file-uploaded-event.md
@@ -1,0 +1,5 @@
+Bugfix: Fix FileUploaded event being emitted too early
+
+We fixed a problem where the FileUploaded event was emitted before the upload had actually finished.
+
+https://github.com/cs3org/reva/pull/2882

--- a/internal/grpc/interceptors/eventsmiddleware/events.go
+++ b/internal/grpc/interceptors/eventsmiddleware/events.go
@@ -108,10 +108,6 @@ func NewUnary(m map[string]interface{}) (grpc.UnaryServerInterceptor, int, error
 			if isSuccess(v) {
 				ev = ContainerCreated(v, req.(*provider.CreateContainerRequest), executantID)
 			}
-		case *provider.InitiateFileUploadResponse:
-			if isSuccess(v) {
-				ev = FileUploaded(v, req.(*provider.InitiateFileUploadRequest), executantID)
-			}
 		case *provider.InitiateFileDownloadResponse:
 			if isSuccess(v) {
 				ev = FileDownloaded(v, req.(*provider.InitiateFileDownloadRequest))

--- a/internal/grpc/services/storageprovider/storageprovider.go
+++ b/internal/grpc/services/storageprovider/storageprovider.go
@@ -371,6 +371,10 @@ func (s *service) InitiateFileUpload(ctx context.Context, req *provider.Initiate
 			metadata["mtime"] = string(req.Opaque.Map["X-OC-Mtime"].Value)
 		}
 	}
+
+	// pass on the provider it to be persisted with the upload info. that is required to correlate the upload with the proper provider later on
+	metadata["providerID"] = s.conf.MountID
+
 	uploadIDs, err := s.storage.InitiateUpload(ctx, req.Ref, uploadLength, metadata)
 	if err != nil {
 		var st *rpc.Status

--- a/internal/http/services/dataprovider/dataprovider.go
+++ b/internal/http/services/dataprovider/dataprovider.go
@@ -82,7 +82,9 @@ func New(m map[string]interface{}, log *zerolog.Logger) (global.Service, error) 
 
 	var publisher events.Publisher
 
-	if conf.NatsAddress != "" && conf.NatsClusterID != "" {
+	if conf.NatsAddress == "" || conf.NatsClusterID == "" {
+		log.Warn().Msg("missing or incomplete nats configuration. Events will not be published.")
+	} else {
 		publisher, err = server.NewNatsStream(natsjs.Address(conf.NatsAddress), natsjs.ClusterID(conf.NatsClusterID))
 		if err != nil {
 			return nil, err

--- a/pkg/rhttp/datatx/datatx.go
+++ b/pkg/rhttp/datatx/datatx.go
@@ -36,7 +36,7 @@ type DataTX interface {
 
 // EmitFileUploadedEvent is a helper function which publishes a FileUploaded event
 func EmitFileUploadedEvent(owner *userv1beta1.UserId, ref *provider.Reference, publisher events.Publisher) error {
-	if ref == nil {
+	if ref == nil || publisher == nil {
 		return nil
 	}
 

--- a/pkg/rhttp/datatx/datatx.go
+++ b/pkg/rhttp/datatx/datatx.go
@@ -34,6 +34,7 @@ type DataTX interface {
 	Handler(fs storage.FS) (http.Handler, error)
 }
 
+// EmitFileUploadedEvent is a helper function which publishes a FileUploaded event
 func EmitFileUploadedEvent(owner *userv1beta1.UserId, ref *provider.Reference, publisher events.Publisher) error {
 	if ref == nil {
 		return nil

--- a/pkg/rhttp/datatx/datatx.go
+++ b/pkg/rhttp/datatx/datatx.go
@@ -23,10 +23,27 @@ package datatx
 import (
 	"net/http"
 
+	userv1beta1 "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
+	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+	"github.com/cs3org/reva/v2/pkg/events"
 	"github.com/cs3org/reva/v2/pkg/storage"
 )
 
 // DataTX provides an abstraction around various data transfer protocols.
 type DataTX interface {
 	Handler(fs storage.FS) (http.Handler, error)
+}
+
+func EmitFileUploadedEvent(owner *userv1beta1.UserId, ref *provider.Reference, publisher events.Publisher) error {
+	if ref == nil {
+		return nil
+	}
+
+	uploadedEv := events.FileUploaded{
+		Owner:     owner,
+		Executant: owner,
+		Ref:       ref,
+	}
+
+	return events.Publish(publisher, uploadedEv)
 }

--- a/pkg/rhttp/datatx/manager/registry/registry.go
+++ b/pkg/rhttp/datatx/manager/registry/registry.go
@@ -18,11 +18,14 @@
 
 package registry
 
-import "github.com/cs3org/reva/v2/pkg/rhttp/datatx"
+import (
+	"github.com/cs3org/reva/v2/pkg/events"
+	"github.com/cs3org/reva/v2/pkg/rhttp/datatx"
+)
 
 // NewFunc is the function that data transfer implementations
 // should register at init time.
-type NewFunc func(map[string]interface{}) (datatx.DataTX, error)
+type NewFunc func(map[string]interface{}, events.Publisher) (datatx.DataTX, error)
 
 // NewFuncs is a map containing all the registered data transfers.
 var NewFuncs = map[string]NewFunc{}

--- a/pkg/rhttp/datatx/manager/simple/simple.go
+++ b/pkg/rhttp/datatx/manager/simple/simple.go
@@ -24,6 +24,7 @@ import (
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	"github.com/cs3org/reva/v2/pkg/appctx"
 	"github.com/cs3org/reva/v2/pkg/errtypes"
+	"github.com/cs3org/reva/v2/pkg/events"
 	"github.com/cs3org/reva/v2/pkg/rhttp/datatx"
 	"github.com/cs3org/reva/v2/pkg/rhttp/datatx/manager/registry"
 	"github.com/cs3org/reva/v2/pkg/rhttp/datatx/utils/download"
@@ -39,7 +40,8 @@ func init() {
 type config struct{}
 
 type manager struct {
-	conf *config
+	conf      *config
+	publisher events.Publisher
 }
 
 func parseConfig(m map[string]interface{}) (*config, error) {
@@ -52,13 +54,16 @@ func parseConfig(m map[string]interface{}) (*config, error) {
 }
 
 // New returns a datatx manager implementation that relies on HTTP PUT/GET.
-func New(m map[string]interface{}) (datatx.DataTX, error) {
+func New(m map[string]interface{}, publisher events.Publisher) (datatx.DataTX, error) {
 	c, err := parseConfig(m)
 	if err != nil {
 		return nil, err
 	}
 
-	return &manager{conf: c}, nil
+	return &manager{
+		conf:      c,
+		publisher: publisher,
+	}, nil
 }
 
 func (m *manager) Handler(fs storage.FS) (http.Handler, error) {

--- a/pkg/rhttp/datatx/manager/spaces/spaces.go
+++ b/pkg/rhttp/datatx/manager/spaces/spaces.go
@@ -26,6 +26,7 @@ import (
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	"github.com/cs3org/reva/v2/pkg/appctx"
 	"github.com/cs3org/reva/v2/pkg/errtypes"
+	"github.com/cs3org/reva/v2/pkg/events"
 	"github.com/cs3org/reva/v2/pkg/rhttp/datatx"
 	"github.com/cs3org/reva/v2/pkg/rhttp/datatx/manager/registry"
 	"github.com/cs3org/reva/v2/pkg/rhttp/datatx/utils/download"
@@ -43,7 +44,8 @@ func init() {
 type config struct{}
 
 type manager struct {
-	conf *config
+	conf      *config
+	publisher events.Publisher
 }
 
 func parseConfig(m map[string]interface{}) (*config, error) {
@@ -56,13 +58,16 @@ func parseConfig(m map[string]interface{}) (*config, error) {
 }
 
 // New returns a datatx manager implementation that relies on HTTP PUT/GET.
-func New(m map[string]interface{}) (datatx.DataTX, error) {
+func New(m map[string]interface{}, publisher events.Publisher) (datatx.DataTX, error) {
 	c, err := parseConfig(m)
 	if err != nil {
 		return nil, err
 	}
 
-	return &manager{conf: c}, nil
+	return &manager{
+		conf:      c,
+		publisher: publisher,
+	}, nil
 }
 
 func (m *manager) Handler(fs storage.FS) (http.Handler, error) {

--- a/pkg/storage/fs/cephfs/upload.go
+++ b/pkg/storage/fs/cephfs/upload.go
@@ -111,6 +111,7 @@ func (fs *cephfs) InitiateUpload(ctx context.Context, ref *provider.Reference, u
 	}
 
 	if metadata != nil {
+		info.MetaData["providerID"] = metadata["providerID"]
 		if metadata["mtime"] != "" {
 			info.MetaData["mtime"] = metadata["mtime"]
 		}

--- a/pkg/storage/fs/nextcloud/nextcloud.go
+++ b/pkg/storage/fs/nextcloud/nextcloud.go
@@ -395,7 +395,7 @@ func (nc *StorageDriver) InitiateUpload(ctx context.Context, ref *provider.Refer
 }
 
 // Upload as defined in the storage.FS interface
-func (nc *StorageDriver) Upload(ctx context.Context, ref *provider.Reference, r io.ReadCloser) error {
+func (nc *StorageDriver) Upload(ctx context.Context, ref *provider.Reference, r io.ReadCloser, _ storage.UploadFinishedFunc) error {
 	return nc.doUpload(ctx, ref.Path, r)
 }
 

--- a/pkg/storage/fs/nextcloud/nextcloud_server_mock.go
+++ b/pkg/storage/fs/nextcloud/nextcloud_server_mock.go
@@ -111,7 +111,7 @@ var responses = map[string]Response{
 
 	`POST /apps/sciencemesh/~f7fbf8c8-139b-4376-b307-cf0a8c2d0d9c/api/storage/GetPathByID {"storage_id":"00000000-0000-0000-0000-000000000000","opaque_id":"fileid-/some/path"} EMPTY`: {200, "/subdir", serverStateEmpty},
 
-	`POST /apps/sciencemesh/~f7fbf8c8-139b-4376-b307-cf0a8c2d0d9c/api/storage/InitiateUpload {"ref":{"path":"/file"},"uploadLength":0,"metadata":{}}`:                                                                              {200, `{"simple": "yes","tus": "yes"}`, serverStateEmpty},
+	`POST /apps/sciencemesh/~f7fbf8c8-139b-4376-b307-cf0a8c2d0d9c/api/storage/InitiateUpload {"ref":{"path":"/file"},"uploadLength":0,"metadata":{"providerID":""}}`:                                                               {200, `{"simple": "yes","tus": "yes"}`, serverStateEmpty},
 	`POST /apps/sciencemesh/~f7fbf8c8-139b-4376-b307-cf0a8c2d0d9c/api/storage/InitiateUpload {"ref":{"resource_id":{"storage_id":"f7fbf8c8-139b-4376-b307-cf0a8c2d0d9c"},"path":"/versionedFile"},"uploadLength":0,"metadata":{}}`: {200, `{"simple": "yes","tus": "yes"}`, serverStateEmpty},
 
 	`POST /apps/sciencemesh/~f7fbf8c8-139b-4376-b307-cf0a8c2d0d9c/api/storage/ListFolder {"ref":{"path":"/"},"mdKeys":null}`: {200, `[{"opaque":{},"type":2,"id":{"opaque_id":"fileid-/subdir"},"checksum":{},"etag":"deadbeef","mime_type":"text/plain","mtime":{"seconds":1234567890},"path":"/subdir","permission_set":{},"size":12345,"canonical_metadata":{},"owner":{"opaque_id":"f7fbf8c8-139b-4376-b307-cf0a8c2d0d9c"},"arbitrary_metadata":{"metadata":{"da":"ta","some":"arbi","trary":"meta"}}}]`, serverStateEmpty},

--- a/pkg/storage/fs/nextcloud/nextcloud_test.go
+++ b/pkg/storage/fs/nextcloud/nextcloud_test.go
@@ -447,7 +447,7 @@ var _ = Describe("Nextcloud", func() {
 			}
 			stringReader := strings.NewReader("shiny!")
 			stringReadCloser := io.NopCloser(stringReader)
-			err := nc.Upload(ctx, ref, stringReadCloser)
+			err := nc.Upload(ctx, ref, stringReadCloser, nil)
 			Expect(err).ToNot(HaveOccurred())
 			checkCalled(called, `PUT /apps/sciencemesh/~tester/api/storage/Upload/some/file/path.txt shiny!`)
 		})

--- a/pkg/storage/fs/owncloudsql/upload.go
+++ b/pkg/storage/fs/owncloudsql/upload.go
@@ -37,6 +37,7 @@ import (
 	"github.com/cs3org/reva/v2/pkg/errtypes"
 	"github.com/cs3org/reva/v2/pkg/logger"
 	"github.com/cs3org/reva/v2/pkg/mime"
+	"github.com/cs3org/reva/v2/pkg/storage"
 	"github.com/cs3org/reva/v2/pkg/storage/utils/chunking"
 	"github.com/cs3org/reva/v2/pkg/storage/utils/templates"
 	"github.com/google/uuid"
@@ -47,7 +48,7 @@ import (
 
 var defaultFilePerm = os.FileMode(0664)
 
-func (fs *owncloudsqlfs) Upload(ctx context.Context, ref *provider.Reference, r io.ReadCloser) error {
+func (fs *owncloudsqlfs) Upload(ctx context.Context, ref *provider.Reference, r io.ReadCloser, _ storage.UploadFinishedFunc) error {
 	upload, err := fs.GetUpload(ctx, ref.GetPath())
 	if err != nil {
 		return errors.Wrap(err, "owncloudsql: error retrieving upload")

--- a/pkg/storage/fs/owncloudsql/upload.go
+++ b/pkg/storage/fs/owncloudsql/upload.go
@@ -107,6 +107,7 @@ func (fs *owncloudsqlfs) InitiateUpload(ctx context.Context, ref *provider.Refer
 	}
 
 	if metadata != nil {
+		info.MetaData["providerID"] = metadata["providerID"]
 		if metadata["mtime"] != "" {
 			info.MetaData["mtime"] = metadata["mtime"]
 		}

--- a/pkg/storage/fs/s3/s3.go
+++ b/pkg/storage/fs/s3/s3.go
@@ -615,7 +615,7 @@ func (fs *s3FS) ListFolder(ctx context.Context, ref *provider.Reference, mdKeys 
 	return finfos, nil
 }
 
-func (fs *s3FS) Upload(ctx context.Context, ref *provider.Reference, r io.ReadCloser) error {
+func (fs *s3FS) Upload(ctx context.Context, ref *provider.Reference, r io.ReadCloser, _ storage.UploadFinishedFunc) error {
 	log := appctx.GetLogger(ctx)
 
 	fn, err := fs.resolve(ctx, ref)

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -23,9 +23,13 @@ import (
 	"io"
 	"net/url"
 
+	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	registry "github.com/cs3org/go-cs3apis/cs3/storage/registry/v1beta1"
 )
+
+// UploadFinishedFunc is a callback function used in storage drivers to indicate that an upload has finished
+type UploadFinishedFunc func(owner *userpb.UserId, ref *provider.Reference)
 
 // FS is the interface to implement access to the storage.
 type FS interface {
@@ -38,7 +42,7 @@ type FS interface {
 	GetMD(ctx context.Context, ref *provider.Reference, mdKeys []string) (*provider.ResourceInfo, error)
 	ListFolder(ctx context.Context, ref *provider.Reference, mdKeys []string) ([]*provider.ResourceInfo, error)
 	InitiateUpload(ctx context.Context, ref *provider.Reference, uploadLength int64, metadata map[string]string) (map[string]string, error)
-	Upload(ctx context.Context, ref *provider.Reference, r io.ReadCloser) error
+	Upload(ctx context.Context, ref *provider.Reference, r io.ReadCloser, uploadFunc UploadFinishedFunc) error
 	Download(ctx context.Context, ref *provider.Reference) (io.ReadCloser, error)
 	ListRevisions(ctx context.Context, ref *provider.Reference) ([]*provider.FileVersion, error)
 	DownloadRevision(ctx context.Context, ref *provider.Reference, key string) (io.ReadCloser, error)

--- a/pkg/storage/utils/decomposedfs/upload.go
+++ b/pkg/storage/utils/decomposedfs/upload.go
@@ -95,7 +95,7 @@ func (fs *Decomposedfs) Upload(ctx context.Context, ref *provider.Reference, r i
 	}
 
 	if err := uploadInfo.FinishUpload(ctx); err != nil {
-		return errors.Wrap(err, "Decomposedfs: error finishing upload")
+		return err
 	}
 
 	if uff != nil {

--- a/pkg/storage/utils/decomposedfs/upload.go
+++ b/pkg/storage/utils/decomposedfs/upload.go
@@ -99,7 +99,6 @@ func (fs *Decomposedfs) Upload(ctx context.Context, ref *provider.Reference, r i
 // TODO read optional content for small files in this request
 // TODO InitiateUpload (and Upload) needs a way to receive the expected checksum. Maybe in metadata as 'checksum' => 'sha1 aeosvp45w5xaeoe' = lowercase, space separated?
 func (fs *Decomposedfs) InitiateUpload(ctx context.Context, ref *provider.Reference, uploadLength int64, metadata map[string]string) (map[string]string, error) {
-
 	log := appctx.GetLogger(ctx)
 
 	n, err := fs.lu.NodeFromResource(ctx, ref)
@@ -129,6 +128,7 @@ func (fs *Decomposedfs) InitiateUpload(ctx context.Context, ref *provider.Refere
 	}
 
 	if metadata != nil {
+		info.MetaData["providerID"] = metadata["providerID"]
 		if mtime, ok := metadata["mtime"]; ok {
 			info.MetaData["mtime"] = mtime
 		}

--- a/pkg/storage/utils/decomposedfs/upload_test.go
+++ b/pkg/storage/utils/decomposedfs/upload_test.go
@@ -231,7 +231,7 @@ var _ = Describe("File uploads", func() {
 
 				uploadRef := &provider.Reference{Path: "/" + uploadIds["simple"]}
 
-				bs.On("Upload", mock.AnythingOfType("*node.Node"), mock.AnythingOfType("*os.File")).
+				bs.On("Upload", mock.AnythingOfType("*node.Node"), mock.AnythingOfType("*os.File"), mock.Anything).
 					Return(nil).
 					Run(func(args mock.Arguments) {
 						reader := args.Get(1).(io.Reader)
@@ -241,10 +241,10 @@ var _ = Describe("File uploads", func() {
 						Expect(data).To(Equal([]byte("0123456789")))
 					})
 
-				err = fs.Upload(ctx, uploadRef, ioutil.NopCloser(bytes.NewReader(fileContent)))
+				err = fs.Upload(ctx, uploadRef, ioutil.NopCloser(bytes.NewReader(fileContent)), nil)
 
 				Expect(err).ToNot(HaveOccurred())
-				bs.AssertCalled(GinkgoT(), "Upload", mock.Anything, mock.Anything)
+				bs.AssertCalled(GinkgoT(), "Upload", mock.Anything, mock.Anything, mock.Anything)
 
 				resources, err := fs.ListFolder(ctx, rootRef, []string{})
 
@@ -269,7 +269,7 @@ var _ = Describe("File uploads", func() {
 
 				uploadRef := &provider.Reference{Path: "/" + uploadIds["simple"]}
 
-				bs.On("Upload", mock.AnythingOfType("*node.Node"), mock.AnythingOfType("*os.File")).
+				bs.On("Upload", mock.AnythingOfType("*node.Node"), mock.AnythingOfType("*os.File"), mock.Anything).
 					Return(nil).
 					Run(func(args mock.Arguments) {
 						reader := args.Get(1).(io.Reader)
@@ -279,10 +279,10 @@ var _ = Describe("File uploads", func() {
 						Expect(data).To(Equal([]byte("")))
 					})
 
-				err = fs.Upload(ctx, uploadRef, ioutil.NopCloser(bytes.NewReader(fileContent)))
+				err = fs.Upload(ctx, uploadRef, ioutil.NopCloser(bytes.NewReader(fileContent)), nil)
 
 				Expect(err).ToNot(HaveOccurred())
-				bs.AssertCalled(GinkgoT(), "Upload", mock.Anything, mock.Anything)
+				bs.AssertCalled(GinkgoT(), "Upload", mock.Anything, mock.Anything, mock.Anything)
 
 				resources, err := fs.ListFolder(ctx, rootRef, []string{})
 
@@ -299,7 +299,7 @@ var _ = Describe("File uploads", func() {
 				)
 
 				uploadRef := &provider.Reference{Path: "/some-non-existent-upload-reference"}
-				err := fs.Upload(ctx, uploadRef, ioutil.NopCloser(bytes.NewReader(fileContent)))
+				err := fs.Upload(ctx, uploadRef, ioutil.NopCloser(bytes.NewReader(fileContent)), nil)
 
 				Expect(err).To(HaveOccurred())
 

--- a/pkg/storage/utils/eosfs/upload.go
+++ b/pkg/storage/utils/eosfs/upload.go
@@ -26,11 +26,12 @@ import (
 
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	"github.com/cs3org/reva/v2/pkg/errtypes"
+	"github.com/cs3org/reva/v2/pkg/storage"
 	"github.com/cs3org/reva/v2/pkg/storage/utils/chunking"
 	"github.com/pkg/errors"
 )
 
-func (fs *eosfs) Upload(ctx context.Context, ref *provider.Reference, r io.ReadCloser) error {
+func (fs *eosfs) Upload(ctx context.Context, ref *provider.Reference, r io.ReadCloser, _ storage.UploadFinishedFunc) error {
 	p, err := fs.resolve(ctx, ref)
 	if err != nil {
 		return errors.Wrap(err, "eos: error resolving reference")

--- a/pkg/storage/utils/localfs/upload.go
+++ b/pkg/storage/utils/localfs/upload.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cs3org/reva/v2/pkg/appctx"
 	ctxpkg "github.com/cs3org/reva/v2/pkg/ctx"
 	"github.com/cs3org/reva/v2/pkg/errtypes"
+	"github.com/cs3org/reva/v2/pkg/storage"
 	"github.com/cs3org/reva/v2/pkg/storage/utils/chunking"
 	"github.com/cs3org/reva/v2/pkg/utils"
 	"github.com/google/uuid"
@@ -40,7 +41,7 @@ import (
 
 var defaultFilePerm = os.FileMode(0664)
 
-func (fs *localfs) Upload(ctx context.Context, ref *provider.Reference, r io.ReadCloser) error {
+func (fs *localfs) Upload(ctx context.Context, ref *provider.Reference, r io.ReadCloser, _ storage.UploadFinishedFunc) error {
 	upload, err := fs.GetUpload(ctx, ref.GetPath())
 	if err != nil {
 		return errors.Wrap(err, "localfs: error retrieving upload")

--- a/pkg/storage/utils/localfs/upload.go
+++ b/pkg/storage/utils/localfs/upload.go
@@ -99,6 +99,7 @@ func (fs *localfs) InitiateUpload(ctx context.Context, ref *provider.Reference, 
 	}
 
 	if metadata != nil {
+		info.MetaData["providerID"] = metadata["providerID"]
 		if metadata["mtime"] != "" {
 			info.MetaData["mtime"] = metadata["mtime"]
 		}

--- a/tests/helpers/helpers.go
+++ b/tests/helpers/helpers.go
@@ -62,6 +62,6 @@ func Upload(ctx context.Context, fs storage.FS, ref *provider.Reference, content
 		return errors.New("simple upload method not available")
 	}
 	uploadRef := &provider.Reference{Path: "/" + uploadID}
-	err = fs.Upload(ctx, uploadRef, ioutil.NopCloser(bytes.NewReader(content)))
+	err = fs.Upload(ctx, uploadRef, ioutil.NopCloser(bytes.NewReader(content)), nil)
 	return err
 }


### PR DESCRIPTION
This pr fixes a problem with the `FileUploaded` event which has been emitted too early until now.

The previous code emitted `FileUploaded` after the `InitiateFileUpload` call already, which is too early because the file hasn't actually been uploaded yet at that point and isn't available to be statted yet, for example.

The fix is to emit the event from the dataprovider only when the upload has actually finished.

*Note*: This PR only implements this functionality for the decomposedfs storage driver, other drivers might still need to be adapted.