### PR TITLE
move stat out of usershareprovider

### DIFF
--- a/changelog/unreleased/move-stat-out-of-usershareprovider.md
+++ b/changelog/unreleased/move-stat-out-of-usershareprovider.md
@@ -1,0 +1,5 @@
+Bugfix: Move stat out of usershareprovider
+
+The sharesstorageprovider now only stats the acceptet shares when necessary. 
+
+https://github.com/cs3org/reva/pull/2885


### PR DESCRIPTION
When moving the stat to the shgaresstorageprovider we can at least omit stating unaccepted shares. Should reduce the overall amount of stats when listing shares.

First step related to https://github.com/cs3org/reva/issues/2881 and https://github.com/owncloud/ocis/issues/3839

This optimization can be pushed further to the usershareprovider and the backends by adding a State Filter to CS3 https://github.com/owncloud/ocis/issues/3843
