### PR TITLE
Introduce spaces field mask

### DIFF
--- a/changelog/unreleased/spaces-field-mask.md
+++ b/changelog/unreleased/spaces-field-mask.md
@@ -1,0 +1,5 @@
+Enhancement: introduce spaces field mask
+
+We now use a field mask to select which properties to retrieve when looking up storage spaces. This allows the gateway to only ask for `root` when trying to forward id or path based requests.
+
+https://github.com/cs3org/reva/pull/2888

--- a/internal/grpc/services/gateway/storageprovider.go
+++ b/internal/grpc/services/gateway/storageprovider.go
@@ -217,7 +217,10 @@ func (s *svc) CreateStorageSpace(ctx context.Context, req *provider.CreateStorag
 
 func (s *svc) ListStorageSpaces(ctx context.Context, req *provider.ListStorageSpacesRequest) (*provider.ListStorageSpacesResponse, error) {
 	// TODO update CS3 api to forward the filters to the registry so it can filter the number of providers the gateway needs to query
-	filters := map[string]string{}
+	filters := map[string]string{
+		// TODO add opaque / CS3 api to expand 'path,root' properties / field mask
+		"mask": "*", // fetch all properties when listing storage spaces
+	}
 
 	for _, f := range req.Filters {
 		switch f.Type {
@@ -1093,6 +1096,7 @@ func (s *svc) findSpaces(ctx context.Context, ref *provider.Reference) ([]*regis
 	}
 
 	filters := map[string]string{
+		"mask": "root", // we only need the root for routing
 		"path": ref.Path,
 	}
 	if ref.ResourceId != nil {

--- a/internal/grpc/services/gateway/storageprovider.go
+++ b/internal/grpc/services/gateway/storageprovider.go
@@ -218,8 +218,14 @@ func (s *svc) CreateStorageSpace(ctx context.Context, req *provider.CreateStorag
 func (s *svc) ListStorageSpaces(ctx context.Context, req *provider.ListStorageSpacesRequest) (*provider.ListStorageSpacesResponse, error) {
 	// TODO update CS3 api to forward the filters to the registry so it can filter the number of providers the gateway needs to query
 	filters := map[string]string{
-		// TODO add opaque / CS3 api to expand 'path,root' properties / field mask
+		// TODO add opaque / CS3 api to expand 'path,root,stat?' properties / field mask
 		"mask": "*", // fetch all properties when listing storage spaces
+	}
+
+	mask := utils.ReadPlainFromOpaque(req.Opaque, "mask")
+	if mask != "" {
+		// TODO check for allowed filters
+		filters["mask"] = mask
 	}
 
 	for _, f := range req.Filters {

--- a/internal/grpc/services/storageprovider/storageprovider.go
+++ b/internal/grpc/services/storageprovider/storageprovider.go
@@ -501,8 +501,10 @@ func (s *service) CreateStorageSpace(ctx context.Context, req *provider.CreateSt
 		}, nil
 	}
 
-	resp.StorageSpace.Id.OpaqueId = storagespace.FormatStorageID(s.conf.MountID, resp.StorageSpace.Id.GetOpaqueId())
-	resp.StorageSpace.Root.StorageId = storagespace.FormatStorageID(s.conf.MountID, resp.StorageSpace.Root.GetStorageId())
+	if resp.StorageSpace != nil {
+		resp.StorageSpace.Id.OpaqueId = storagespace.FormatStorageID(s.conf.MountID, resp.StorageSpace.Id.GetOpaqueId())
+		resp.StorageSpace.Root.StorageId = storagespace.FormatStorageID(s.conf.MountID, resp.StorageSpace.Root.GetStorageId())
+	}
 	return resp, nil
 }
 
@@ -578,8 +580,10 @@ func (s *service) UpdateStorageSpace(ctx context.Context, req *provider.UpdateSt
 			Msg("failed to update storage space")
 		return nil, err
 	}
-	res.StorageSpace.Id.OpaqueId = storagespace.FormatStorageID(s.conf.MountID, res.StorageSpace.Id.GetOpaqueId())
-	res.StorageSpace.Root.StorageId = storagespace.FormatStorageID(s.conf.MountID, res.StorageSpace.Root.GetStorageId())
+	if res.StorageSpace != nil {
+		res.StorageSpace.Id.OpaqueId = storagespace.FormatStorageID(s.conf.MountID, res.StorageSpace.Id.GetOpaqueId())
+		res.StorageSpace.Root.StorageId = storagespace.FormatStorageID(s.conf.MountID, res.StorageSpace.Root.GetStorageId())
+	}
 	return res, nil
 }
 

--- a/internal/http/services/owncloud/ocdav/propfind/propfind.go
+++ b/internal/http/services/owncloud/ocdav/propfind/propfind.go
@@ -381,7 +381,9 @@ func (p *Handler) getResourceInfos(ctx context.Context, w http.ResponseWriter, r
 		}
 		spacePath := string(space.Opaque.Map["path"].Value)
 		// TODO separate stats to the path or to the children, after statting all children update the mtime/etag
-		// TODO get mtime, and size from space as well, so we no longer have to stat here?
+		// TODO get mtime, and size from space as well, so we no longer have to stat here? would require sending the requested metadata keys as well
+		// root should be a ResourceInfo so it can contain the full stat, not only the id ... do we even need spaces then?
+		// metadata keys could all be prefixed with "root." to indicate we want more than the root id ...
 		spaceRef := spacelookup.MakeRelativeReference(space, requestPath, spacesPropfind)
 		info, status, err := p.statSpace(ctx, client, space, spaceRef, metadataKeys)
 		if err != nil || status.GetCode() != rpc.Code_CODE_OK {


### PR DESCRIPTION
We now use a field mask to select which properties to retrieve when looking up storage spaces. This allows the gateway to only ask for `root` when trying to forward id or path based requests. It allows the spaces storage registry to omit calling ListStorageSpaces on the storage provider.

Related: https://github.com/cs3org/reva/issues/2881