### PR TITLE
[tests-only][full-ci] Bump core commit id to the latest upto 2022-05-25

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The test runner source for API tests
-CORE_COMMITID=6321f96cf6739d9130c10376e8e4fc96af75edef
+CORE_COMMITID=ebd482eebdea119df2a8c02e243a6b8eb39dd5ba
 CORE_BRANCH=master


### PR DESCRIPTION
## Description
Update owncloud/core commit id to the latest up to `2022-05-25`

Signed-off-by: Kiran Parajuli <kiranparajuli589@gmail.com>