### PR TITLE
fix quota check for unlimitted quota "0"

### DIFF
--- a/changelog/unreleased/fix-unlimited-quota.md
+++ b/changelog/unreleased/fix-unlimited-quota.md
@@ -1,0 +1,6 @@
+Bugfix: Fix unlimitted quota in spaces
+
+Fixed the quota check when unlimitting a space, i.e. when setting the quota to "0".
+
+https://github.com/owncloud/ocis/issues/3810
+https://github.com/cs3org/reva/pull/2895

--- a/pkg/storage/utils/decomposedfs/node/node.go
+++ b/pkg/storage/utils/decomposedfs/node/node.go
@@ -1131,7 +1131,7 @@ var CheckQuota = func(spaceRoot *Node, overwrite bool, oldSize, newSize uint64) 
 		return false, errtypes.InsufficientStorage("disk full")
 	}
 	quotaByteStr, _ := xattrs.Get(spaceRoot.InternalPath(), xattrs.QuotaAttr)
-	if quotaByteStr == "" {
+	if quotaByteStr == "" || quotaByteStr == QuotaUnlimited {
 		// if quota is not set, it means unlimited
 		return true, nil
 	}


### PR DESCRIPTION
Fixed the quota check when unlimitting a space, i.e. when setting the quota to "0".