### PR TITLE
stat only after put

### DIFF
--- a/changelog/unreleased/stat-after-put.md
+++ b/changelog/unreleased/stat-after-put.md
@@ -1,0 +1,5 @@
+Enhancement: stat only after PUT
+
+OCDAV no longer makes a Stat call before making an InitiateFileUpload request. The storageprovider will call GetMD to check if a file exists before initiating the upload and return `"exists"="true"` the opaque data of the InitiateUploadResponse. Storage drivers now should return an Already Exists error when an upload tries to overwrite a directory. 
+
+https://github.com/cs3org/reva/pull/2896

--- a/pkg/storage/utils/decomposedfs/node/node.go
+++ b/pkg/storage/utils/decomposedfs/node/node.go
@@ -567,6 +567,25 @@ func (n *Node) SetFavorite(uid *userpb.UserId, val string) error {
 	return xattrs.Set(nodePath, fa, val)
 }
 
+// IsDir checks if the node represents a directory
+func (n *Node) IsDir(tx context.Context) (isDir bool, err error) {
+	if n.Exists == false {
+		return false, nil
+	}
+
+	var fi os.FileInfo
+	if fi, err = os.Lstat(n.InternalPath()); err != nil {
+		return false, err
+	}
+	if !fi.IsDir() {
+		return false, nil
+	}
+	if _, err := xattrs.Get(n.InternalPath(), xattrs.ReferenceAttr); err == nil {
+		return false, nil
+	}
+	return true, nil
+}
+
 // AsResourceInfo return the node as CS3 ResourceInfo
 func (n *Node) AsResourceInfo(ctx context.Context, rp *provider.ResourcePermissions, mdKeys []string, returnBasename bool) (ri *provider.ResourceInfo, err error) {
 	sublog := appctx.GetLogger(ctx).With().Interface("node", n.ID).Logger()

--- a/pkg/storage/utils/decomposedfs/upload.go
+++ b/pkg/storage/utils/decomposedfs/upload.go
@@ -246,6 +246,13 @@ func (fs *Decomposedfs) NewUpload(ctx context.Context, info tusd.FileInfo) (uplo
 		ok, err = fs.p.HasPermission(ctx, n, func(rp *provider.ResourcePermissions) bool {
 			return rp.InitiateFileUpload
 		})
+		isDir, derr := n.IsDir(ctx)
+		if derr != nil {
+			return nil, errors.Wrap(derr, "Decomposedfs: could check if node IsDir")
+		}
+		if isDir {
+			return nil, errtypes.AlreadyExists("cannot overwrite directory")
+		}
 	} else {
 		// check permissions of parent
 		ok, err = fs.p.HasPermission(ctx, p, func(rp *provider.ResourcePermissions) bool {


### PR DESCRIPTION
OCDAV no longer makes a Stat call before making an InitiateFileUpload request. The storageprovider will call GetMD to check if a file exists before initiating the upload and return `"exists"="true"` the opaque data of the InitiateUploadResponse. Storage drivers now should return an Already Exists error when an upload tries to overwrite a directory. 

There is a race condition when two requests try to PUT a file at the same time, both might return a 201 created, but one of them actually creates a new revision. I tried avoiding that by making `FS.Upload()` return a `created` flag. Then the  simple and spaces dataproviders could return 201 / 204 for PUT requests and the ocdav PUT could use that response code. However, an indirection to a new resource eg. when storing on an S3 bucket would always lead to a 201, even for existing files ... and returning a created flag would require the implementation to be able to report if the file existed (the s3 client used currently does not reveal if a file was overwritten or created).

Furthermore, it would be nice to report back more metadata, eg the etag, mtime and fileid. Currently, ocdav still does an additional stat request to do that.

The tus driver for the dataprovider does not need to differentiate between 201 vs 200/204 for PUT requests as it uses PATCH requests returning 204 No Content or POST requests with 201 created on upload URLs which are ephemeral anyway.

related: https://github.com/cs3org/reva/issues/2881



