### PR TITLE
user owncloudsql: use correct user id

### DIFF
--- a/changelog/unreleased/user-owncloudsql-fixes.md
+++ b/changelog/unreleased/user-owncloudsql-fixes.md
@@ -1,0 +1,3 @@
+Bugfix: user owncloudsql now uses the correct userid
+
+https://github.com/cs3org/reva/pull/2903

--- a/pkg/user/manager/owncloudsql/owncloudsql.go
+++ b/pkg/user/manager/owncloudsql/owncloudsql.go
@@ -157,7 +157,8 @@ func (m *manager) convertToCS3User(ctx context.Context, a *accounts.Account, ski
 	u := &userpb.User{
 		Id: &userpb.UserId{
 			Idp:      m.c.Idp,
-			OpaqueId: a.UserID,
+			OpaqueId: a.OwnCloudUUID.String,
+			Type:     userpb.UserType_USER_TYPE_PRIMARY,
 		},
 		Username:    a.Username.String,
 		Mail:        a.Email.String,


### PR DESCRIPTION
fixes owncloudsql backed users having the wrong userid when a ownclouduuid property is configured