### PR TITLE
enforce sharee's permissions when editing public shares

### DIFF
--- a/changelog/unreleased/publicshare-permissions.md
+++ b/changelog/unreleased/publicshare-permissions.md
@@ -1,0 +1,6 @@
+Bugfix: Check user permissions before updating/removing public shares
+
+Added permission checks before updating or deleting public shares. These methods previously didn't enforce the users permissions. 
+
+https://github.com/owncloud/ocis/issues/3498
+https://github.com/cs3org/reva/pull/3900


### PR DESCRIPTION
Added permission checks before updating or deleting public shares. These methods previously didn't enforce the users permissions. 

This is a fix for: https://github.com/owncloud/ocis/issues/3498