### PR TITLE
correct share jail child aggregation

### DIFF
--- a/changelog/unreleased/fix-shares-jail-child-size.md
+++ b/changelog/unreleased/fix-shares-jail-child-size.md
@@ -1,0 +1,5 @@
+Bugfix: correct share jail child aggregation
+
+We now add up the size of all mount points when aggregating the size for a child with the same name. Furthermore, the listing should no longer contain duplicate entries.
+
+https://github.com/cs3org/reva/pull/2907

--- a/internal/http/services/owncloud/ocdav/propfind/propfind.go
+++ b/internal/http/services/owncloud/ocdav/propfind/propfind.go
@@ -482,11 +482,12 @@ func (p *Handler) getResourceInfos(ctx context.Context, w http.ResponseWriter, r
 		}
 		spaceInfo.Path = path.Join(requestPath, childName)
 		if existingChild, ok := childInfos[childName]; ok {
+			// aggregate size
+			childInfos[childName].Size += spaceInfo.Size
 			// use most recent child
 			if existingChild.Mtime == nil || (spaceInfo.Mtime != nil && utils.TSToUnixNano(spaceInfo.Mtime) > utils.TSToUnixNano(existingChild.Mtime)) {
 				childInfos[childName].Mtime = spaceInfo.Mtime
 				childInfos[childName].Etag = spaceInfo.Etag
-				childInfos[childName].Size += spaceInfo.Size
 			}
 			// only update fileid if the resource is a direct child
 			if tail == "/" {

--- a/internal/http/services/owncloud/ocdav/propfind/propfind.go
+++ b/internal/http/services/owncloud/ocdav/propfind/propfind.go
@@ -144,7 +144,8 @@ type PropstatUnmarshalXML struct {
 	ResponseDescription string              `xml:"responsedescription,omitempty"`
 }
 
-type SpaceData struct {
+// spaceData is used to remember the space for a resource info
+type spaceData struct {
 	Ref   *provider.Reference
 	Space *provider.StorageSpace
 }
@@ -394,7 +395,7 @@ func (p *Handler) getResourceInfos(ctx context.Context, w http.ResponseWriter, r
 	var mostRecentChildInfo *provider.ResourceInfo
 	var aggregatedChildSize uint64
 	spaceInfos := make([]*provider.ResourceInfo, 0, len(spaces))
-	spaceMap := map[*provider.ResourceInfo]SpaceData{}
+	spaceMap := map[*provider.ResourceInfo]spaceData{}
 	for _, space := range spaces {
 		if space.Opaque == nil || space.Opaque.Map == nil || space.Opaque.Map["path"] == nil || space.Opaque.Map["path"].Decoder != "plain" {
 			continue // not mounted
@@ -418,7 +419,7 @@ func (p *Handler) getResourceInfos(ctx context.Context, w http.ResponseWriter, r
 			info.Path = filepath.Join(spacePath, spaceRef.Path)
 		}
 
-		spaceMap[info] = SpaceData{Ref: spaceRef, Space: space}
+		spaceMap[info] = spaceData{Ref: spaceRef, Space: space}
 		spaceInfos = append(spaceInfos, info)
 
 		if rootInfo == nil && (requestPath == info.Path || (spacesPropfind && requestPath == path.Join("/", info.Path))) {
@@ -1341,10 +1342,6 @@ func (pn *Props) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 			*pn = append(*pn, e.Name)
 		}
 	}
-}
-
-func isVirtualRoot(ref *provider.Reference) bool {
-	return isVirtualRootResourceID(ref.ResourceId) && (ref.Path == "" || ref.Path == "." || ref.Path == "./")
 }
 
 func isVirtualRootResourceID(id *provider.ResourceId) bool {

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/pending.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/pending.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 	"path"
 	"sort"
+	"strconv"
 
 	gateway "github.com/cs3org/go-cs3apis/cs3/gateway/v1beta1"
 	rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
@@ -94,13 +95,12 @@ func (h *Handler) AcceptReceivedShare(w http.ResponseWriter, r *http.Request) {
 
 	// now we have a list of shares, we want to iterate over all of them and check for name collisions
 	// FIXME: adjust logic
-	/*
-		for i, mp := range mountPoints {
-			if mp == mount {
-				mount = fmt.Sprintf("%s (%s)", base, strconv.Itoa(i+1))
-			}
+
+	for i, mp := range mountPoints {
+		if mp == mount {
+			mount = fmt.Sprintf("%s (%s)", base, strconv.Itoa(i+1))
 		}
-	*/
+	}
 
 	for id := range sharesToAccept {
 		data := h.updateReceivedShare(w, r, id, false, mount)


### PR DESCRIPTION
We now add up the size of all mount points when aggregating the size for a child with the same name. Furthermore, the listing should no longer contain duplicate entries.


Related: https://github.com/owncloud/ocis/issues/3880