### PR TITLE
decomposedfs: actually check GetPath permission

### DIFF
--- a/changelog/unreleased/decomposedfs-check-get-path-permission.md
+++ b/changelog/unreleased/decomposedfs-check-get-path-permission.md
@@ -1,0 +1,5 @@
+Bugfix: the decomposedfs now checks the GetPath permission
+
+After fixing the meta endpoint and introducing the fieldmask the GetPath call is made directly to the storageprovider. The decomposedfs now checks if the current user actually has the permission to get the path. Before the two previous PRs this was covered by the list storage spaces call which used a stat request and the stat permission. 
+
+https://github.com/cs3org/reva/pull/2909

--- a/internal/grpc/services/storageprovider/storageprovider.go
+++ b/internal/grpc/services/storageprovider/storageprovider.go
@@ -440,12 +440,8 @@ func (s *service) GetPath(ctx context.Context, req *provider.GetPathRequest) (*p
 	// TODO(labkode): check that the storage ID is the same as the storage provider id.
 	fn, err := s.storage.GetPathByID(ctx, req.ResourceId)
 	if err != nil {
-		appctx.GetLogger(ctx).Error().
-			Err(err).
-			Interface("resource_id", req.ResourceId).
-			Msg("error getting path by id")
 		return &provider.GetPathResponse{
-			Status: status.NewInternal(ctx, "error getting path by id"),
+			Status: status.NewStatusFromErrType(ctx, "get path", err),
 		}, nil
 	}
 	res := &provider.GetPathResponse{

--- a/pkg/storage/utils/decomposedfs/decomposedfs.go
+++ b/pkg/storage/utils/decomposedfs/decomposedfs.go
@@ -259,6 +259,15 @@ func (fs *Decomposedfs) GetPathByID(ctx context.Context, id *provider.ResourceId
 	if err != nil {
 		return "", err
 	}
+	ok, err := fs.p.HasPermission(ctx, node, func(rp *provider.ResourcePermissions) bool {
+		return rp.GetPath
+	})
+	switch {
+	case err != nil:
+		return "", errtypes.InternalError(err.Error())
+	case !ok:
+		return "", errtypes.PermissionDenied(filepath.Join(node.ParentID, node.Name))
+	}
 
 	return fs.lu.Path(ctx, node)
 }


### PR DESCRIPTION
After fixing the meta endpoint and introducing the fieldmask the GetPath call is made directly to the storageprovider. The decomposedfs now checks if the current user actually has the permission to get the path. Before the two previous PRs this was covered by the list storage spaces call which used a stat request and the stat permission. 


I assume we broke edge beclause the two PRs got merged because each on its own did not trigger the bug ... 🤷‍♂️ 
