### PR TITLE
Share manager migration

### DIFF
--- a/changelog/unreleased/share-manager-migration.md
+++ b/changelog/unreleased/share-manager-migration.md
@@ -1,0 +1,5 @@
+Enhancement: Allow for dumping and loading shares
+
+We now have interfaces for dumpable and loadable share manages which can be used to migrate shares between share managers
+
+https://github.com/cs3org/reva/pull/2911

--- a/pkg/publicshare/manager/cs3/cs3.go
+++ b/pkg/publicshare/manager/cs3/cs3.go
@@ -157,7 +157,7 @@ func (m *Manager) initialize() error {
 }
 
 // Load imports public shares and received shares from channels (e.g. during migration)
-func (m *Manager) Load(ctx context.Context, shareChan <-chan *publicshare.PublicShareWithPassword) error {
+func (m *Manager) Load(ctx context.Context, shareChan <-chan *publicshare.WithPassword) error {
 	log := appctx.GetLogger(ctx)
 	if err := m.initialize(); err != nil {
 		return err
@@ -209,7 +209,7 @@ func (m *Manager) CreatePublicShare(ctx context.Context, u *user.User, ri *provi
 		Nanos:   uint32(now % int64(time.Second)),
 	}
 
-	s := &publicshare.PublicShareWithPassword{
+	s := &publicshare.WithPassword{
 		PublicShare: link.PublicShare{
 			Id:                id,
 			Owner:             ri.GetOwner(),
@@ -293,7 +293,7 @@ func (m *Manager) GetPublicShare(ctx context.Context, u *user.User, ref *link.Pu
 	return &ps.PublicShare, nil
 }
 
-func (m *Manager) getWithPassword(ctx context.Context, ref *link.PublicShareReference) (*publicshare.PublicShareWithPassword, error) {
+func (m *Manager) getWithPassword(ctx context.Context, ref *link.PublicShareReference) (*publicshare.WithPassword, error) {
 	switch {
 	case ref.GetToken() != "":
 		return m.getByToken(ctx, ref.GetToken())
@@ -304,7 +304,7 @@ func (m *Manager) getWithPassword(ctx context.Context, ref *link.PublicShareRefe
 	}
 }
 
-func (m *Manager) getByID(ctx context.Context, id string) (*publicshare.PublicShareWithPassword, error) {
+func (m *Manager) getByID(ctx context.Context, id string) (*publicshare.WithPassword, error) {
 	tokens, err := m.indexer.FindBy(&link.PublicShare{},
 		indexer.NewField("Id.OpaqueId", id),
 	)
@@ -317,14 +317,14 @@ func (m *Manager) getByID(ctx context.Context, id string) (*publicshare.PublicSh
 	return m.getByToken(ctx, tokens[0])
 }
 
-func (m *Manager) getByToken(ctx context.Context, token string) (*publicshare.PublicShareWithPassword, error) {
+func (m *Manager) getByToken(ctx context.Context, token string) (*publicshare.WithPassword, error) {
 	fn := path.Join("publicshares", token)
 	data, err := m.storage.SimpleDownload(ctx, fn)
 	if err != nil {
 		return nil, err
 	}
 
-	ps := &publicshare.PublicShareWithPassword{}
+	ps := &publicshare.WithPassword{}
 	err = json.Unmarshal(data, ps)
 	if err != nil {
 		return nil, err
@@ -527,7 +527,7 @@ func resourceIDToIndex(id *provider.ResourceId) string {
 	return strings.Join([]string{id.StorageId, id.OpaqueId}, "!")
 }
 
-func (m *Manager) persist(ctx context.Context, ps *publicshare.PublicShareWithPassword) error {
+func (m *Manager) persist(ctx context.Context, ps *publicshare.WithPassword) error {
 	data, err := json.Marshal(ps)
 	if err != nil {
 		return err

--- a/pkg/publicshare/manager/cs3/cs3.go
+++ b/pkg/publicshare/manager/cs3/cs3.go
@@ -45,6 +45,7 @@ import (
 	"github.com/cs3org/reva/v2/pkg/publicshare/manager/registry"
 	"github.com/cs3org/reva/v2/pkg/rgrpc/todo/pool"
 	"github.com/cs3org/reva/v2/pkg/storage/utils/indexer"
+	indexerErrors "github.com/cs3org/reva/v2/pkg/storage/utils/indexer/errors"
 	"github.com/cs3org/reva/v2/pkg/storage/utils/indexer/option"
 	"github.com/cs3org/reva/v2/pkg/storage/utils/metadata"
 	"github.com/cs3org/reva/v2/pkg/utils"
@@ -539,8 +540,8 @@ func (m *Manager) persist(ctx context.Context, ps *publicshare.PublicShareWithPa
 
 	_, err = m.indexer.Add(&ps.PublicShare)
 	if err != nil {
-		if _, ok := err.(errtypes.IsAlreadyExists); !ok {
-			return err
+		if _, ok := err.(*indexerErrors.AlreadyExistsErr); ok {
+			return nil
 		}
 		err = m.indexer.Delete(&ps.PublicShare)
 		if err != nil {

--- a/pkg/publicshare/manager/cs3/cs3.go
+++ b/pkg/publicshare/manager/cs3/cs3.go
@@ -157,13 +157,14 @@ func (m *Manager) initialize() error {
 }
 
 // Load imports public shares and received shares from channels (e.g. during migration)
-func (m *Manager) Load(shareChan <-chan *publicshare.PublicShareWithPassword) error {
+func (m *Manager) Load(ctx context.Context, shareChan <-chan *publicshare.PublicShareWithPassword) error {
+	log := appctx.GetLogger(ctx)
 	if err := m.initialize(); err != nil {
 		return err
 	}
 	for ps := range shareChan {
 		if err := m.persist(context.Background(), ps); err != nil {
-			fmt.Println("error loading public share", ps, err)
+			log.Error().Err(err).Interface("publicshare", ps).Msg("error loading public share")
 		}
 	}
 	return nil

--- a/pkg/publicshare/manager/cs3/cs3_test.go
+++ b/pkg/publicshare/manager/cs3/cs3_test.go
@@ -200,7 +200,8 @@ var _ = Describe("Cs3", func() {
 				wg := sync.WaitGroup{}
 				wg.Add(2)
 				go func() {
-					m.Load(ctx, sharesChan)
+					err := m.Load(ctx, sharesChan)
+					Expect(err).ToNot(HaveOccurred())
 					wg.Done()
 				}()
 				go func() {

--- a/pkg/publicshare/manager/cs3/cs3_test.go
+++ b/pkg/publicshare/manager/cs3/cs3_test.go
@@ -200,7 +200,7 @@ var _ = Describe("Cs3", func() {
 				wg := sync.WaitGroup{}
 				wg.Add(2)
 				go func() {
-					m.Load(sharesChan)
+					m.Load(ctx, sharesChan)
 					wg.Done()
 				}()
 				go func() {

--- a/pkg/publicshare/manager/cs3/cs3_test.go
+++ b/pkg/publicshare/manager/cs3/cs3_test.go
@@ -147,7 +147,7 @@ var _ = Describe("Cs3", func() {
 			Expect(link.Token).ToNot(Equal(""))
 			Expect(link.PasswordProtected).To(BeTrue())
 			storage.AssertCalled(GinkgoT(), "SimpleUpload", mock.Anything, mock.Anything, mock.MatchedBy(func(in []byte) bool {
-				ps := publicshare.PublicShareWithPassword{}
+				ps := publicshare.WithPassword{}
 				err = json.Unmarshal(in, &ps)
 				Expect(err).ToNot(HaveOccurred())
 				return bcrypt.CompareHashAndPassword([]byte(ps.Password), []byte("secret123")) == nil
@@ -183,7 +183,7 @@ var _ = Describe("Cs3", func() {
 			h, err := bcrypt.GenerateFromPassword([]byte(grant.Password), bcrypt.DefaultCost)
 			Expect(err).ToNot(HaveOccurred())
 			hashedPassword = string(h)
-			shareJSON, err := json.Marshal(publicshare.PublicShareWithPassword{PublicShare: *existingShare, Password: hashedPassword})
+			shareJSON, err := json.Marshal(publicshare.WithPassword{PublicShare: *existingShare, Password: hashedPassword})
 			Expect(err).ToNot(HaveOccurred())
 			storage.On("SimpleDownload", mock.Anything, mock.MatchedBy(func(in string) bool {
 				return strings.HasPrefix(in, "publicshares/")
@@ -195,7 +195,7 @@ var _ = Describe("Cs3", func() {
 				m, err := cs3.New(nil, storage, indexer, bcrypt.DefaultCost)
 				Expect(err).ToNot(HaveOccurred())
 
-				sharesChan := make(chan *publicshare.PublicShareWithPassword)
+				sharesChan := make(chan *publicshare.WithPassword)
 
 				wg := sync.WaitGroup{}
 				wg.Add(2)
@@ -204,7 +204,7 @@ var _ = Describe("Cs3", func() {
 					wg.Done()
 				}()
 				go func() {
-					sharesChan <- &publicshare.PublicShareWithPassword{
+					sharesChan <- &publicshare.WithPassword{
 						Password:    "foo",
 						PublicShare: *existingShare,
 					}
@@ -469,7 +469,7 @@ var _ = Describe("Cs3", func() {
 				Expect(ps).ToNot(BeNil())
 				Expect(ps.DisplayName).To(Equal("new displayname"))
 				storage.AssertCalled(GinkgoT(), "SimpleUpload", mock.Anything, path.Join("publicshares", ps.Token), mock.MatchedBy(func(data []byte) bool {
-					s := publicshare.PublicShareWithPassword{}
+					s := publicshare.WithPassword{}
 					err := json.Unmarshal(data, &s)
 					Expect(err).ToNot(HaveOccurred())
 					return s.PublicShare.DisplayName == "new displayname"
@@ -487,7 +487,7 @@ var _ = Describe("Cs3", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ps).ToNot(BeNil())
 				storage.AssertCalled(GinkgoT(), "SimpleUpload", mock.Anything, path.Join("publicshares", ps.Token), mock.MatchedBy(func(data []byte) bool {
-					s := publicshare.PublicShareWithPassword{}
+					s := publicshare.WithPassword{}
 					err := json.Unmarshal(data, &s)
 					Expect(err).ToNot(HaveOccurred())
 					return s.Password != ""
@@ -505,7 +505,7 @@ var _ = Describe("Cs3", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ps).ToNot(BeNil())
 				storage.AssertCalled(GinkgoT(), "SimpleUpload", mock.Anything, path.Join("publicshares", ps.Token), mock.MatchedBy(func(data []byte) bool {
-					s := publicshare.PublicShareWithPassword{}
+					s := publicshare.WithPassword{}
 					err := json.Unmarshal(data, &s)
 					Expect(err).ToNot(HaveOccurred())
 					return s.PublicShare.Permissions.Permissions.Delete
@@ -524,7 +524,7 @@ var _ = Describe("Cs3", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ps).ToNot(BeNil())
 				storage.AssertCalled(GinkgoT(), "SimpleUpload", mock.Anything, path.Join("publicshares", ps.Token), mock.MatchedBy(func(data []byte) bool {
-					s := publicshare.PublicShareWithPassword{}
+					s := publicshare.WithPassword{}
 					err := json.Unmarshal(data, &s)
 					Expect(err).ToNot(HaveOccurred())
 					return s.PublicShare.Expiration != nil && s.PublicShare.Expiration.Seconds == ts.Seconds

--- a/pkg/publicshare/manager/cs3/cs3_test.go
+++ b/pkg/publicshare/manager/cs3/cs3_test.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"path"
 	"strings"
+	"sync"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -146,10 +147,10 @@ var _ = Describe("Cs3", func() {
 			Expect(link.Token).ToNot(Equal(""))
 			Expect(link.PasswordProtected).To(BeTrue())
 			storage.AssertCalled(GinkgoT(), "SimpleUpload", mock.Anything, mock.Anything, mock.MatchedBy(func(in []byte) bool {
-				ps := cs3.PublicShareWithPassword{}
+				ps := publicshare.PublicShareWithPassword{}
 				err = json.Unmarshal(in, &ps)
 				Expect(err).ToNot(HaveOccurred())
-				return bcrypt.CompareHashAndPassword([]byte(ps.HashedPassword), []byte("secret123")) == nil
+				return bcrypt.CompareHashAndPassword([]byte(ps.Password), []byte("secret123")) == nil
 			}))
 		})
 
@@ -182,11 +183,40 @@ var _ = Describe("Cs3", func() {
 			h, err := bcrypt.GenerateFromPassword([]byte(grant.Password), bcrypt.DefaultCost)
 			Expect(err).ToNot(HaveOccurred())
 			hashedPassword = string(h)
-			shareJSON, err := json.Marshal(cs3.PublicShareWithPassword{PublicShare: existingShare, HashedPassword: hashedPassword})
+			shareJSON, err := json.Marshal(publicshare.PublicShareWithPassword{PublicShare: *existingShare, Password: hashedPassword})
 			Expect(err).ToNot(HaveOccurred())
 			storage.On("SimpleDownload", mock.Anything, mock.MatchedBy(func(in string) bool {
 				return strings.HasPrefix(in, "publicshares/")
 			})).Return(shareJSON, nil)
+		})
+
+		Describe("Load", func() {
+			It("loads shares including state and mountpoint information", func() {
+				m, err := cs3.New(nil, storage, indexer, bcrypt.DefaultCost)
+				Expect(err).ToNot(HaveOccurred())
+
+				sharesChan := make(chan *publicshare.PublicShareWithPassword)
+
+				wg := sync.WaitGroup{}
+				wg.Add(2)
+				go func() {
+					m.Load(sharesChan)
+					wg.Done()
+				}()
+				go func() {
+					sharesChan <- &publicshare.PublicShareWithPassword{
+						Password:    "foo",
+						PublicShare: *existingShare,
+					}
+					close(sharesChan)
+					wg.Done()
+				}()
+				wg.Wait()
+				Eventually(sharesChan).Should(BeClosed())
+
+				expectedPath := path.Join("publicshares", existingShare.Token)
+				storage.AssertCalled(GinkgoT(), "SimpleUpload", mock.Anything, expectedPath, mock.Anything)
+			})
 		})
 
 		Describe("ListPublicShares", func() {
@@ -439,7 +469,7 @@ var _ = Describe("Cs3", func() {
 				Expect(ps).ToNot(BeNil())
 				Expect(ps.DisplayName).To(Equal("new displayname"))
 				storage.AssertCalled(GinkgoT(), "SimpleUpload", mock.Anything, path.Join("publicshares", ps.Token), mock.MatchedBy(func(data []byte) bool {
-					s := cs3.PublicShareWithPassword{}
+					s := publicshare.PublicShareWithPassword{}
 					err := json.Unmarshal(data, &s)
 					Expect(err).ToNot(HaveOccurred())
 					return s.PublicShare.DisplayName == "new displayname"
@@ -457,10 +487,10 @@ var _ = Describe("Cs3", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ps).ToNot(BeNil())
 				storage.AssertCalled(GinkgoT(), "SimpleUpload", mock.Anything, path.Join("publicshares", ps.Token), mock.MatchedBy(func(data []byte) bool {
-					s := cs3.PublicShareWithPassword{}
+					s := publicshare.PublicShareWithPassword{}
 					err := json.Unmarshal(data, &s)
 					Expect(err).ToNot(HaveOccurred())
-					return s.HashedPassword != ""
+					return s.Password != ""
 				}))
 			})
 
@@ -475,7 +505,7 @@ var _ = Describe("Cs3", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ps).ToNot(BeNil())
 				storage.AssertCalled(GinkgoT(), "SimpleUpload", mock.Anything, path.Join("publicshares", ps.Token), mock.MatchedBy(func(data []byte) bool {
-					s := cs3.PublicShareWithPassword{}
+					s := publicshare.PublicShareWithPassword{}
 					err := json.Unmarshal(data, &s)
 					Expect(err).ToNot(HaveOccurred())
 					return s.PublicShare.Permissions.Permissions.Delete
@@ -494,7 +524,7 @@ var _ = Describe("Cs3", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ps).ToNot(BeNil())
 				storage.AssertCalled(GinkgoT(), "SimpleUpload", mock.Anything, path.Join("publicshares", ps.Token), mock.MatchedBy(func(data []byte) bool {
-					s := cs3.PublicShareWithPassword{}
+					s := publicshare.PublicShareWithPassword{}
 					err := json.Unmarshal(data, &s)
 					Expect(err).ToNot(HaveOccurred())
 					return s.PublicShare.Expiration != nil && s.PublicShare.Expiration.Seconds == ts.Seconds

--- a/pkg/publicshare/manager/json/json.go
+++ b/pkg/publicshare/manager/json/json.go
@@ -147,7 +147,7 @@ func (m *manager) startJanitorRun() {
 }
 
 // Dump exports public shares to channels (e.g. during migration)
-func (m *manager) Dump(ctx context.Context, shareChan chan<- *publicshare.PublicShareWithPassword) error {
+func (m *manager) Dump(ctx context.Context, shareChan chan<- *publicshare.WithPassword) error {
 	log := appctx.GetLogger(ctx)
 
 	m.mutex.Lock()
@@ -159,7 +159,7 @@ func (m *manager) Dump(ctx context.Context, shareChan chan<- *publicshare.Public
 	}
 
 	for _, v := range db {
-		var local publicshare.PublicShareWithPassword
+		var local publicshare.WithPassword
 		if err := utils.UnmarshalJSONToProtoV1([]byte(v.(map[string]interface{})["share"].(string)), &local.PublicShare); err != nil {
 			log.Error().Err(err).Msg("error unmarshalling share")
 		}

--- a/pkg/publicshare/manager/json/json.go
+++ b/pkg/publicshare/manager/json/json.go
@@ -147,7 +147,9 @@ func (m *manager) startJanitorRun() {
 }
 
 // Dump exports public shares to channels (e.g. during migration)
-func (m *manager) Dump(shareChan chan<- *publicshare.PublicShareWithPassword) error {
+func (m *manager) Dump(ctx context.Context, shareChan chan<- *publicshare.PublicShareWithPassword) error {
+	log := appctx.GetLogger(ctx)
+
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 
@@ -159,7 +161,7 @@ func (m *manager) Dump(shareChan chan<- *publicshare.PublicShareWithPassword) er
 	for _, v := range db {
 		var local publicshare.PublicShareWithPassword
 		if err := utils.UnmarshalJSONToProtoV1([]byte(v.(map[string]interface{})["share"].(string)), &local.PublicShare); err != nil {
-			fmt.Printf("error unmarshalling share")
+			log.Error().Err(err).Msg("error unmarshalling share")
 		}
 		local.Password = v.(map[string]interface{})["password"].(string)
 		shareChan <- &local

--- a/pkg/publicshare/manager/json/json.go
+++ b/pkg/publicshare/manager/json/json.go
@@ -615,11 +615,7 @@ func (m *manager) writeDb(db map[string]interface{}) error {
 		return err
 	}
 
-	if err := ioutil.WriteFile(m.file, dbAsJSON, 0644); err != nil {
-		return err
-	}
-
-	return nil
+	return ioutil.WriteFile(m.file, dbAsJSON, 0644)
 }
 
 type publicShare struct {

--- a/pkg/publicshare/manager/json/json.go
+++ b/pkg/publicshare/manager/json/json.go
@@ -161,6 +161,7 @@ func (m *manager) Dump(shareChan chan<- *publicshare.PublicShareWithPassword) er
 		if err := utils.UnmarshalJSONToProtoV1([]byte(v.(map[string]interface{})["share"].(string)), &local.PublicShare); err != nil {
 			fmt.Printf("error unmarshalling share")
 		}
+		local.Password = v.(map[string]interface{})["password"].(string)
 		shareChan <- &local
 	}
 	close(shareChan)

--- a/pkg/publicshare/manager/json/json_suite_test.go
+++ b/pkg/publicshare/manager/json/json_suite_test.go
@@ -1,0 +1,31 @@
+// Copyright 2018-2022 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package json_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestJson(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Json Suite")
+}

--- a/pkg/publicshare/manager/json/json_test.go
+++ b/pkg/publicshare/manager/json/json_test.go
@@ -103,7 +103,7 @@ var _ = Describe("Json", func() {
 				}
 				wg.Done()
 			}()
-			m.(publicshare.DumpableManager).Dump(psharesChan)
+			m.(publicshare.DumpableManager).Dump(ctx, psharesChan)
 			wg.Wait()
 			Eventually(psharesChan).Should(BeClosed())
 

--- a/pkg/publicshare/manager/json/json_test.go
+++ b/pkg/publicshare/manager/json/json_test.go
@@ -103,7 +103,8 @@ var _ = Describe("Json", func() {
 				}
 				wg.Done()
 			}()
-			m.(publicshare.DumpableManager).Dump(ctx, psharesChan)
+			err := m.(publicshare.DumpableManager).Dump(ctx, psharesChan)
+			Expect(err).ToNot(HaveOccurred())
 			wg.Wait()
 			Eventually(psharesChan).Should(BeClosed())
 

--- a/pkg/publicshare/manager/json/json_test.go
+++ b/pkg/publicshare/manager/json/json_test.go
@@ -1,0 +1,112 @@
+// Copyright 2018-2022 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package json_test
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"sync"
+
+	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
+	link "github.com/cs3org/go-cs3apis/cs3/sharing/link/v1beta1"
+	providerv1beta1 "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+	ctxpkg "github.com/cs3org/reva/v2/pkg/ctx"
+	"github.com/cs3org/reva/v2/pkg/publicshare"
+	"github.com/cs3org/reva/v2/pkg/publicshare/manager/json"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Json", func() {
+	var (
+		user1 = &userpb.User{
+			Id: &userpb.UserId{
+				Idp:      "https://localhost:9200",
+				OpaqueId: "admin",
+			},
+		}
+
+		sharedResource = &providerv1beta1.ResourceInfo{
+			Id: &providerv1beta1.ResourceId{
+				StorageId: "storageid",
+				OpaqueId:  "opaqueid",
+			},
+			ArbitraryMetadata: &providerv1beta1.ArbitraryMetadata{
+				Metadata: map[string]string{
+					"name": "publicshare",
+				},
+			},
+		}
+
+		m       publicshare.Manager
+		tmpFile *os.File
+		ctx     context.Context
+	)
+
+	BeforeEach(func() {
+		var err error
+		tmpFile, err = ioutil.TempFile("", "reva-unit-test-*.json")
+		Expect(err).ToNot(HaveOccurred())
+
+		config := map[string]interface{}{
+			"file":         tmpFile.Name(),
+			"gateway_addr": "https://localhost:9200",
+		}
+		m, err = json.New(config)
+		Expect(err).ToNot(HaveOccurred())
+
+		ctx = ctxpkg.ContextSetUser(context.Background(), user1)
+	})
+
+	AfterEach(func() {
+		os.Remove(tmpFile.Name())
+	})
+
+	Describe("Dump", func() {
+		JustBeforeEach(func() {
+			_, err := m.CreatePublicShare(ctx, user1, sharedResource, &link.Grant{})
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("dumps all public shares", func() {
+			psharesChan := make(chan *publicshare.PublicShareWithPassword)
+			pshares := []*publicshare.PublicShareWithPassword{}
+
+			wg := sync.WaitGroup{}
+			wg.Add(1)
+			go func() {
+				for ps := range psharesChan {
+					if ps != nil {
+						pshares = append(pshares, ps)
+					}
+				}
+				wg.Done()
+			}()
+			m.(publicshare.DumpableManager).Dump(psharesChan)
+			wg.Wait()
+			Eventually(psharesChan).Should(BeClosed())
+
+			Expect(len(pshares)).To(Equal(1))
+			Expect(pshares[0].PublicShare.Creator).To(Equal(user1.Id))
+			Expect(pshares[0].PublicShare.ResourceId).To(Equal(sharedResource.Id))
+		})
+	})
+})

--- a/pkg/publicshare/manager/json/json_test.go
+++ b/pkg/publicshare/manager/json/json_test.go
@@ -30,6 +30,7 @@ import (
 	ctxpkg "github.com/cs3org/reva/v2/pkg/ctx"
 	"github.com/cs3org/reva/v2/pkg/publicshare"
 	"github.com/cs3org/reva/v2/pkg/publicshare/manager/json"
+	"golang.org/x/crypto/bcrypt"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -82,7 +83,9 @@ var _ = Describe("Json", func() {
 
 	Describe("Dump", func() {
 		JustBeforeEach(func() {
-			_, err := m.CreatePublicShare(ctx, user1, sharedResource, &link.Grant{})
+			_, err := m.CreatePublicShare(ctx, user1, sharedResource, &link.Grant{
+				Password: "foo",
+			})
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -105,6 +108,7 @@ var _ = Describe("Json", func() {
 			Eventually(psharesChan).Should(BeClosed())
 
 			Expect(len(pshares)).To(Equal(1))
+			Expect(bcrypt.CompareHashAndPassword([]byte(pshares[0].Password), []byte("foo"))).To(Succeed())
 			Expect(pshares[0].PublicShare.Creator).To(Equal(user1.Id))
 			Expect(pshares[0].PublicShare.ResourceId).To(Equal(sharedResource.Id))
 		})

--- a/pkg/publicshare/manager/json/json_test.go
+++ b/pkg/publicshare/manager/json/json_test.go
@@ -90,8 +90,8 @@ var _ = Describe("Json", func() {
 		})
 
 		It("dumps all public shares", func() {
-			psharesChan := make(chan *publicshare.PublicShareWithPassword)
-			pshares := []*publicshare.PublicShareWithPassword{}
+			psharesChan := make(chan *publicshare.WithPassword)
+			pshares := []*publicshare.WithPassword{}
 
 			wg := sync.WaitGroup{}
 			wg.Add(1)

--- a/pkg/publicshare/publicshare.go
+++ b/pkg/publicshare/publicshare.go
@@ -58,12 +58,12 @@ type PublicShareWithPassword struct {
 
 // DumpableManager defines a share manager which supports dumping its contents
 type DumpableManager interface {
-	Dump(shareChan chan<- *PublicShareWithPassword) error
+	Dump(ctx context.Context, shareChan chan<- *PublicShareWithPassword) error
 }
 
 // LoadableManager defines a share manager which supports loading contents from a dump
 type LoadableManager interface {
-	Load(shareChan <-chan *PublicShareWithPassword) error
+	Load(ctx context.Context, shareChan <-chan *PublicShareWithPassword) error
 }
 
 // CreateSignature calculates a signature for a public share.

--- a/pkg/publicshare/publicshare.go
+++ b/pkg/publicshare/publicshare.go
@@ -50,20 +50,20 @@ type Manager interface {
 	GetPublicShareByToken(ctx context.Context, token string, auth *link.PublicShareAuthentication, sign bool) (*link.PublicShare, error)
 }
 
-// PublicShareWithPassword holds the relevant information for representing a public share
-type PublicShareWithPassword struct {
+// WithPassword holds the relevant information for representing a public share
+type WithPassword struct {
 	Password    string `json:"password"`
 	PublicShare link.PublicShare
 }
 
 // DumpableManager defines a share manager which supports dumping its contents
 type DumpableManager interface {
-	Dump(ctx context.Context, shareChan chan<- *PublicShareWithPassword) error
+	Dump(ctx context.Context, shareChan chan<- *WithPassword) error
 }
 
 // LoadableManager defines a share manager which supports loading contents from a dump
 type LoadableManager interface {
-	Load(ctx context.Context, shareChan <-chan *PublicShareWithPassword) error
+	Load(ctx context.Context, shareChan <-chan *WithPassword) error
 }
 
 // CreateSignature calculates a signature for a public share.

--- a/pkg/publicshare/publicshare.go
+++ b/pkg/publicshare/publicshare.go
@@ -50,6 +50,22 @@ type Manager interface {
 	GetPublicShareByToken(ctx context.Context, token string, auth *link.PublicShareAuthentication, sign bool) (*link.PublicShare, error)
 }
 
+// PublicShareWithPassword holds the relevant information for representing a public share
+type PublicShareWithPassword struct {
+	Password    string `json:"password"`
+	PublicShare link.PublicShare
+}
+
+// DumpableManager defines a share manager which supports dumping its contents
+type DumpableManager interface {
+	Dump(shareChan chan<- *PublicShareWithPassword) error
+}
+
+// LoadableManager defines a share manager which supports loading contents from a dump
+type LoadableManager interface {
+	Load(shareChan <-chan *PublicShareWithPassword) error
+}
+
 // CreateSignature calculates a signature for a public share.
 func CreateSignature(token, pw string, expiration time.Time) (string, error) {
 	h := sha256.New()

--- a/pkg/share/manager/cs3/cs3.go
+++ b/pkg/share/manager/cs3/cs3.go
@@ -166,7 +166,7 @@ func (m *Manager) initialize() error {
 }
 
 // Load imports shares and received shares from channels (e.g. during migration)
-func (m *Manager) Load(ctx context.Context, shareChan <-chan *collaboration.Share, receivedShareChan <-chan share.ReceivedShareDump) error {
+func (m *Manager) Load(ctx context.Context, shareChan <-chan *collaboration.Share, receivedShareChan <-chan share.ReceivedShareWithUser) error {
 	log := appctx.GetLogger(ctx)
 	if err := m.initialize(); err != nil {
 		return err

--- a/pkg/share/manager/cs3/cs3.go
+++ b/pkg/share/manager/cs3/cs3.go
@@ -39,6 +39,7 @@ import (
 	"github.com/cs3org/reva/v2/pkg/share"
 	"github.com/cs3org/reva/v2/pkg/share/manager/registry"
 	"github.com/cs3org/reva/v2/pkg/storage/utils/indexer"
+	indexerErrors "github.com/cs3org/reva/v2/pkg/storage/utils/indexer/errors"
 	"github.com/cs3org/reva/v2/pkg/storage/utils/indexer/option"
 	"github.com/cs3org/reva/v2/pkg/storage/utils/metadata"
 	"github.com/cs3org/reva/v2/pkg/utils"
@@ -187,7 +188,7 @@ func (m *Manager) Load(shareChan <-chan *collaboration.Share, receivedShareChan 
 			if s.ReceivedShare != nil && s.UserId != nil {
 				fmt.Println("Loading received share", s.ReceivedShare.Share.Id)
 				if err := m.persistReceivedShare(context.Background(), s.UserId, s.ReceivedShare); err != nil {
-					fmt.Println("error persisting share:", s, err)
+					fmt.Println("error persisting received share:", s, err)
 				}
 			}
 		}
@@ -241,6 +242,9 @@ func (m *Manager) persistShare(ctx context.Context, share *collaboration.Share) 
 	}
 
 	_, err = m.indexer.Add(share)
+	if _, ok := err.(*indexerErrors.AlreadyExistsErr); ok {
+		return nil
+	}
 	return err
 }
 

--- a/pkg/share/manager/cs3/cs3_test.go
+++ b/pkg/share/manager/cs3/cs3_test.go
@@ -185,7 +185,8 @@ var _ = Describe("Manager", func() {
 			wg := sync.WaitGroup{}
 			wg.Add(2)
 			go func() {
-				m.Load(ctx, sharesChan, receivedChan)
+				err := m.Load(ctx, sharesChan, receivedChan)
+				Expect(err).ToNot(HaveOccurred())
 				wg.Done()
 			}()
 			go func() {
@@ -638,7 +639,6 @@ var _ = Describe("Manager", func() {
 					err := json.Unmarshal(data, &meta)
 					Expect(err).ToNot(HaveOccurred())
 					return meta.MountPoint != nil && meta.State == collaboration.ShareState_SHARE_STATE_PENDING && meta.MountPoint.Path == "newPath/"
-					return true
 				}))
 			})
 		})

--- a/pkg/share/manager/cs3/cs3_test.go
+++ b/pkg/share/manager/cs3/cs3_test.go
@@ -30,6 +30,7 @@ import (
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	ctxpkg "github.com/cs3org/reva/v2/pkg/ctx"
 	"github.com/cs3org/reva/v2/pkg/errtypes"
+	sharespkg "github.com/cs3org/reva/v2/pkg/share"
 	"github.com/cs3org/reva/v2/pkg/share/manager/cs3"
 	indexerpkg "github.com/cs3org/reva/v2/pkg/storage/utils/indexer"
 	indexermocks "github.com/cs3org/reva/v2/pkg/storage/utils/indexer/mocks"
@@ -169,6 +170,30 @@ var _ = Describe("Manager", func() {
 
 		It("does not initialize the storage yet", func() {
 			storage.AssertNotCalled(GinkgoT(), "Init", mock.Anything, mock.Anything)
+		})
+	})
+
+	Describe("Load", func() {
+		It("loads shares including state and mountpoint information", func() {
+			m, err := cs3.New(nil, storage, indexer)
+			Expect(err).ToNot(HaveOccurred())
+
+			sharesChan := make(chan *collaboration.Share)
+			receivedChan := make(chan sharespkg.ReceivedShareDump)
+
+			go func() {
+				m.Load(sharesChan, receivedChan)
+			}()
+			go func() {
+				sharesChan <- share
+				close(sharesChan)
+				close(receivedChan)
+			}()
+			Eventually(sharesChan).Should(BeClosed())
+			Eventually(receivedChan).Should(BeClosed())
+
+			expectedPath := path.Join("shares", share.Id.OpaqueId)
+			storage.AssertCalled(GinkgoT(), "SimpleUpload", mock.Anything, expectedPath, mock.Anything)
 		})
 	})
 
@@ -585,9 +610,7 @@ var _ = Describe("Manager", func() {
 					meta := cs3.ReceivedShareMetadata{}
 					err := json.Unmarshal(data, &meta)
 					Expect(err).ToNot(HaveOccurred())
-					Expect(meta.State).To(Equal(collaboration.ShareState_SHARE_STATE_ACCEPTED))
-					Expect(meta.MountPoint.Path).To(Equal("newPath/"))
-					return true
+					return meta.MountPoint != nil && meta.State == collaboration.ShareState_SHARE_STATE_ACCEPTED && meta.MountPoint.Path == "newPath/"
 				}))
 			})
 
@@ -608,8 +631,7 @@ var _ = Describe("Manager", func() {
 					meta := cs3.ReceivedShareMetadata{}
 					err := json.Unmarshal(data, &meta)
 					Expect(err).ToNot(HaveOccurred())
-					Expect(meta.State).To(Equal(collaboration.ShareState_SHARE_STATE_PENDING))
-					Expect(meta.MountPoint.Path).To(Equal("newPath/"))
+					return meta.MountPoint != nil && meta.State == collaboration.ShareState_SHARE_STATE_PENDING && meta.MountPoint.Path == "newPath/"
 					return true
 				}))
 			})

--- a/pkg/share/manager/cs3/cs3_test.go
+++ b/pkg/share/manager/cs3/cs3_test.go
@@ -180,7 +180,7 @@ var _ = Describe("Manager", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			sharesChan := make(chan *collaboration.Share)
-			receivedChan := make(chan sharespkg.ReceivedShareDump)
+			receivedChan := make(chan sharespkg.ReceivedShareWithUser)
 
 			wg := sync.WaitGroup{}
 			wg.Add(2)

--- a/pkg/share/manager/cs3/cs3_test.go
+++ b/pkg/share/manager/cs3/cs3_test.go
@@ -185,7 +185,7 @@ var _ = Describe("Manager", func() {
 			wg := sync.WaitGroup{}
 			wg.Add(2)
 			go func() {
-				m.Load(sharesChan, receivedChan)
+				m.Load(ctx, sharesChan, receivedChan)
 				wg.Done()
 			}()
 			go func() {

--- a/pkg/share/manager/json/json.go
+++ b/pkg/share/manager/json/json.go
@@ -189,6 +189,7 @@ func parseConfig(m map[string]interface{}) (*config, error) {
 	return c, nil
 }
 
+// Dump exports shares and received shares to channels (e.g. during migration)
 func (m *mgr) Dump(shareChan chan<- *collaboration.Share, receivedShareChan chan<- share.ReceivedShareDump) error {
 	for _, s := range m.model.Shares {
 		shareChan <- s

--- a/pkg/share/manager/json/json.go
+++ b/pkg/share/manager/json/json.go
@@ -194,16 +194,16 @@ func (m *mgr) Dump(shareChan chan<- *collaboration.Share, receivedShareChan chan
 		shareChan <- s
 	}
 
-	for userIdString, states := range m.model.State {
-		userMountPoints := m.model.MountPoint[userIdString]
+	for userIDString, states := range m.model.State {
+		userMountPoints := m.model.MountPoint[userIDString]
 		id := &userv1beta1.UserId{}
 		mV2 := proto.MessageV2(id)
-		prototext.Unmarshal([]byte(userIdString), mV2)
+		prototext.Unmarshal([]byte(userIDString), mV2)
 
-		for shareIdString, state := range states {
+		for shareIDString, state := range states {
 			sid := &collaboration.ShareId{}
 			mV2 := proto.MessageV2(sid)
-			prototext.Unmarshal([]byte(shareIdString), mV2)
+			prototext.Unmarshal([]byte(shareIDString), mV2)
 
 			var s *collaboration.Share
 			for _, is := range m.model.Shares {
@@ -218,11 +218,11 @@ func (m *mgr) Dump(shareChan chan<- *collaboration.Share, receivedShareChan chan
 
 			var mp *provider.Reference
 			if userMountPoints != nil {
-				mp = userMountPoints[shareIdString]
+				mp = userMountPoints[shareIDString]
 			}
 
 			receivedShareChan <- share.ReceivedShareDump{
-				UserId: id,
+				UserID: id,
 				ReceivedShare: &collaboration.ReceivedShare{
 					Share:      s,
 					State:      state,

--- a/pkg/share/manager/json/json.go
+++ b/pkg/share/manager/json/json.go
@@ -38,7 +38,7 @@ import (
 	"github.com/cs3org/reva/v2/pkg/errtypes"
 	"github.com/cs3org/reva/v2/pkg/rgrpc/todo/pool"
 	"github.com/cs3org/reva/v2/pkg/share"
-	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/proto" // nolint:staticcheck // we need the legacy package to convert V1 to V2 messages
 	"github.com/google/uuid"
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"

--- a/pkg/share/manager/json/json.go
+++ b/pkg/share/manager/json/json.go
@@ -190,7 +190,7 @@ func parseConfig(m map[string]interface{}) (*config, error) {
 }
 
 // Dump exports shares and received shares to channels (e.g. during migration)
-func (m *mgr) Dump(ctx context.Context, shareChan chan<- *collaboration.Share, receivedShareChan chan<- share.ReceivedShareDump) error {
+func (m *mgr) Dump(ctx context.Context, shareChan chan<- *collaboration.Share, receivedShareChan chan<- share.ReceivedShareWithUser) error {
 	log := appctx.GetLogger(ctx)
 	for _, s := range m.model.Shares {
 		shareChan <- s
@@ -230,7 +230,7 @@ func (m *mgr) Dump(ctx context.Context, shareChan chan<- *collaboration.Share, r
 				mp = userMountPoints[shareIDString]
 			}
 
-			receivedShareChan <- share.ReceivedShareDump{
+			receivedShareChan <- share.ReceivedShareWithUser{
 				UserID: id,
 				ReceivedShare: &collaboration.ReceivedShare{
 					Share:      s,

--- a/pkg/share/manager/json/json_suite_test.go
+++ b/pkg/share/manager/json/json_suite_test.go
@@ -1,0 +1,13 @@
+package json_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestJson(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Json Suite")
+}

--- a/pkg/share/manager/json/json_suite_test.go
+++ b/pkg/share/manager/json/json_suite_test.go
@@ -1,3 +1,21 @@
+// Copyright 2018-2022 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
 package json_test
 
 import (

--- a/pkg/share/manager/json/json_test.go
+++ b/pkg/share/manager/json/json_test.go
@@ -112,10 +112,10 @@ var _ = Describe("Json", func() {
 			Expect(len(shares)).To(Equal(1))
 			Expect(shares[0].Creator).To(Equal(user1.Id))
 			Expect(shares[0].Grantee.GetUserId()).To(Equal(user2.Id))
-			Expect(shares[0].ResourceId).To(Equal(sharedResource))
+			Expect(shares[0].ResourceId).To(Equal(sharedResource.Id))
 		})
 
-		FIt("dumps all received shares", func() {
+		It("dumps all received shares", func() {
 			sharesChan := make(chan *collaboration.Share)
 			receivedChan := make(chan share.ReceivedShareDump)
 

--- a/pkg/share/manager/json/json_test.go
+++ b/pkg/share/manager/json/json_test.go
@@ -107,7 +107,7 @@ var _ = Describe("Json", func() {
 
 		It("dumps all shares", func() {
 			sharesChan := make(chan *collaboration.Share)
-			receivedChan := make(chan share.ReceivedShareDump)
+			receivedChan := make(chan share.ReceivedShareWithUser)
 
 			shares := []*collaboration.Share{}
 
@@ -139,9 +139,9 @@ var _ = Describe("Json", func() {
 
 		It("dumps all received shares", func() {
 			sharesChan := make(chan *collaboration.Share)
-			receivedChan := make(chan share.ReceivedShareDump)
+			receivedChan := make(chan share.ReceivedShareWithUser)
 
-			shares := []share.ReceivedShareDump{}
+			shares := []share.ReceivedShareWithUser{}
 
 			wg := sync.WaitGroup{}
 			wg.Add(2)

--- a/pkg/share/manager/json/json_test.go
+++ b/pkg/share/manager/json/json_test.go
@@ -1,3 +1,21 @@
+// Copyright 2018-2022 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
 package json_test
 
 import (

--- a/pkg/share/manager/json/json_test.go
+++ b/pkg/share/manager/json/json_test.go
@@ -1,0 +1,150 @@
+package json_test
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+
+	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
+	collaboration "github.com/cs3org/go-cs3apis/cs3/sharing/collaboration/v1beta1"
+	providerv1beta1 "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+	ctxpkg "github.com/cs3org/reva/v2/pkg/ctx"
+	"github.com/cs3org/reva/v2/pkg/share"
+	"github.com/cs3org/reva/v2/pkg/share/manager/json"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Json", func() {
+	var (
+		user1 = &userpb.User{
+			Id: &userpb.UserId{
+				Idp:      "https://localhost:9200",
+				OpaqueId: "admin",
+			},
+		}
+		user2 = &userpb.User{
+			Id: &userpb.UserId{
+				Idp:      "https://localhost:9200",
+				OpaqueId: "einstein",
+			},
+		}
+
+		sharedResource = &providerv1beta1.ResourceInfo{
+			Id: &providerv1beta1.ResourceId{
+				StorageId: "storageid",
+				OpaqueId:  "opaqueid",
+			},
+		}
+
+		m          share.Manager
+		tmpFile    *os.File
+		ctx        context.Context
+		granteeCtx context.Context
+	)
+
+	BeforeEach(func() {
+		var err error
+		tmpFile, err = ioutil.TempFile("", "reva-unit-test-*.json")
+		Expect(err).ToNot(HaveOccurred())
+
+		config := map[string]interface{}{
+			"file":         tmpFile.Name(),
+			"gateway_addr": "https://localhost:9200",
+		}
+		m, err = json.New(config)
+		Expect(err).ToNot(HaveOccurred())
+
+		ctx = ctxpkg.ContextSetUser(context.Background(), user1)
+		granteeCtx = ctxpkg.ContextSetUser(context.Background(), user2)
+	})
+
+	AfterEach(func() {
+		os.Remove(tmpFile.Name())
+	})
+
+	Describe("Dump", func() {
+		JustBeforeEach(func() {
+			share, err := m.Share(ctx, sharedResource, &collaboration.ShareGrant{
+				Grantee: &providerv1beta1.Grantee{
+					Type: providerv1beta1.GranteeType_GRANTEE_TYPE_USER,
+					Id:   &providerv1beta1.Grantee_UserId{UserId: user2.Id},
+				},
+			})
+			Expect(err).ToNot(HaveOccurred())
+
+			rs, err := m.GetReceivedShare(granteeCtx, &collaboration.ShareReference{Spec: &collaboration.ShareReference_Id{Id: share.Id}})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(rs.State).To(Equal(collaboration.ShareState_SHARE_STATE_PENDING))
+			rs.State = collaboration.ShareState_SHARE_STATE_ACCEPTED
+			rs.MountPoint = &providerv1beta1.Reference{Path: "newPath/"}
+
+			_, err = m.UpdateReceivedShare(granteeCtx,
+				rs, &fieldmaskpb.FieldMask{Paths: []string{"state", "mount_point"}})
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("dumps all shares", func() {
+			sharesChan := make(chan *collaboration.Share)
+			receivedChan := make(chan share.ReceivedShareDump)
+
+			shares := []*collaboration.Share{}
+
+			go func() {
+				for {
+					s := <-sharesChan
+					if s != nil {
+						shares = append(shares, s)
+					}
+				}
+			}()
+			go func() {
+				for {
+					_ = <-receivedChan
+				}
+			}()
+			m.(share.DumpableManager).Dump(sharesChan, receivedChan)
+			Eventually(sharesChan).Should(BeClosed())
+			Eventually(receivedChan).Should(BeClosed())
+
+			Expect(len(shares)).To(Equal(1))
+			Expect(shares[0].Creator).To(Equal(user1.Id))
+			Expect(shares[0].Grantee.GetUserId()).To(Equal(user2.Id))
+			Expect(shares[0].ResourceId).To(Equal(sharedResource))
+		})
+
+		FIt("dumps all received shares", func() {
+			sharesChan := make(chan *collaboration.Share)
+			receivedChan := make(chan share.ReceivedShareDump)
+
+			shares := []share.ReceivedShareDump{}
+
+			go func() {
+				for {
+					_ = <-sharesChan
+				}
+			}()
+			go func() {
+				for {
+					rs := <-receivedChan
+					if rs.UserId != nil && rs.ReceivedShare != nil {
+						shares = append(shares, rs)
+					}
+				}
+			}()
+			m.(share.DumpableManager).Dump(sharesChan, receivedChan)
+			Eventually(sharesChan).Should(BeClosed())
+			Eventually(receivedChan).Should(BeClosed())
+
+			Expect(len(shares)).To(Equal(1))
+			Expect(shares[0].UserId).To(Equal(user2.Id))
+			Expect(shares[0].ReceivedShare.State).To(Equal(collaboration.ShareState_SHARE_STATE_ACCEPTED))
+			Expect(shares[0].ReceivedShare.MountPoint.Path).To(Equal("newPath/"))
+			Expect(shares[0].ReceivedShare.Share.Creator).To(Equal(user1.Id))
+			Expect(shares[0].ReceivedShare.Share.Grantee.GetUserId()).To(Equal(user2.Id))
+			Expect(shares[0].ReceivedShare.Share.ResourceId).To(Equal(sharedResource.Id))
+		})
+	})
+})

--- a/pkg/share/manager/json/json_test.go
+++ b/pkg/share/manager/json/json_test.go
@@ -126,7 +126,8 @@ var _ = Describe("Json", func() {
 				}
 				wg.Done()
 			}()
-			m.(share.DumpableManager).Dump(ctx, sharesChan, receivedChan)
+			err := m.(share.DumpableManager).Dump(ctx, sharesChan, receivedChan)
+			Expect(err).ToNot(HaveOccurred())
 			wg.Wait()
 			Eventually(sharesChan).Should(BeClosed())
 			Eventually(receivedChan).Should(BeClosed())
@@ -158,7 +159,8 @@ var _ = Describe("Json", func() {
 				}
 				wg.Done()
 			}()
-			m.(share.DumpableManager).Dump(ctx, sharesChan, receivedChan)
+			err := m.(share.DumpableManager).Dump(ctx, sharesChan, receivedChan)
+			Expect(err).ToNot(HaveOccurred())
 			wg.Wait()
 
 			Eventually(sharesChan).Should(BeClosed())

--- a/pkg/share/manager/json/json_test.go
+++ b/pkg/share/manager/json/json_test.go
@@ -147,7 +147,7 @@ var _ = Describe("Json", func() {
 			go func() {
 				for {
 					rs := <-receivedChan
-					if rs.UserId != nil && rs.ReceivedShare != nil {
+					if rs.UserID != nil && rs.ReceivedShare != nil {
 						shares = append(shares, rs)
 					}
 				}
@@ -157,7 +157,7 @@ var _ = Describe("Json", func() {
 			Eventually(receivedChan).Should(BeClosed())
 
 			Expect(len(shares)).To(Equal(1))
-			Expect(shares[0].UserId).To(Equal(user2.Id))
+			Expect(shares[0].UserID).To(Equal(user2.Id))
 			Expect(shares[0].ReceivedShare.State).To(Equal(collaboration.ShareState_SHARE_STATE_ACCEPTED))
 			Expect(shares[0].ReceivedShare.MountPoint.Path).To(Equal("newPath/"))
 			Expect(shares[0].ReceivedShare.Share.Creator).To(Equal(user1.Id))

--- a/pkg/share/manager/json/json_test.go
+++ b/pkg/share/manager/json/json_test.go
@@ -126,7 +126,7 @@ var _ = Describe("Json", func() {
 				}
 				wg.Done()
 			}()
-			m.(share.DumpableManager).Dump(sharesChan, receivedChan)
+			m.(share.DumpableManager).Dump(ctx, sharesChan, receivedChan)
 			wg.Wait()
 			Eventually(sharesChan).Should(BeClosed())
 			Eventually(receivedChan).Should(BeClosed())
@@ -158,7 +158,7 @@ var _ = Describe("Json", func() {
 				}
 				wg.Done()
 			}()
-			m.(share.DumpableManager).Dump(sharesChan, receivedChan)
+			m.(share.DumpableManager).Dump(ctx, sharesChan, receivedChan)
 			wg.Wait()
 
 			Eventually(sharesChan).Should(BeClosed())

--- a/pkg/share/share.go
+++ b/pkg/share/share.go
@@ -72,8 +72,9 @@ type Manager interface {
 	UpdateReceivedShare(ctx context.Context, share *collaboration.ReceivedShare, fieldMask *field_mask.FieldMask) (*collaboration.ReceivedShare, error)
 }
 
+// ReceivedShareDump holds the relevant information for representing a received share of a user
 type ReceivedShareDump struct {
-	UserId        *userv1beta1.UserId
+	UserID        *userv1beta1.UserId
 	ReceivedShare *collaboration.ReceivedShare
 }
 

--- a/pkg/share/share.go
+++ b/pkg/share/share.go
@@ -80,12 +80,12 @@ type ReceivedShareDump struct {
 
 // DumpableManager defines a share manager which supports dumping its contents
 type DumpableManager interface {
-	Dump(shareChan chan<- *collaboration.Share, receivedShareChan chan<- ReceivedShareDump) error
+	Dump(ctx context.Context, shareChan chan<- *collaboration.Share, receivedShareChan chan<- ReceivedShareDump) error
 }
 
 // LoadableManager defines a share manager which supports loading contents from a dump
 type LoadableManager interface {
-	Load(shareChan <-chan *collaboration.Share, receivedShareChan <-chan ReceivedShareDump) error
+	Load(ctx context.Context, shareChan <-chan *collaboration.Share, receivedShareChan <-chan ReceivedShareDump) error
 }
 
 // GroupGranteeFilter is an abstraction for creating filter by grantee type group.

--- a/pkg/share/share.go
+++ b/pkg/share/share.go
@@ -72,20 +72,20 @@ type Manager interface {
 	UpdateReceivedShare(ctx context.Context, share *collaboration.ReceivedShare, fieldMask *field_mask.FieldMask) (*collaboration.ReceivedShare, error)
 }
 
-// ReceivedShareDump holds the relevant information for representing a received share of a user
-type ReceivedShareDump struct {
+// ReceivedShareWithUser holds the relevant information for representing a received share of a user
+type ReceivedShareWithUser struct {
 	UserID        *userv1beta1.UserId
 	ReceivedShare *collaboration.ReceivedShare
 }
 
 // DumpableManager defines a share manager which supports dumping its contents
 type DumpableManager interface {
-	Dump(ctx context.Context, shareChan chan<- *collaboration.Share, receivedShareChan chan<- ReceivedShareDump) error
+	Dump(ctx context.Context, shareChan chan<- *collaboration.Share, receivedShareChan chan<- ReceivedShareWithUser) error
 }
 
 // LoadableManager defines a share manager which supports loading contents from a dump
 type LoadableManager interface {
-	Load(ctx context.Context, shareChan <-chan *collaboration.Share, receivedShareChan <-chan ReceivedShareDump) error
+	Load(ctx context.Context, shareChan <-chan *collaboration.Share, receivedShareChan <-chan ReceivedShareWithUser) error
 }
 
 // GroupGranteeFilter is an abstraction for creating filter by grantee type group.

--- a/pkg/share/share.go
+++ b/pkg/share/share.go
@@ -72,6 +72,21 @@ type Manager interface {
 	UpdateReceivedShare(ctx context.Context, share *collaboration.ReceivedShare, fieldMask *field_mask.FieldMask) (*collaboration.ReceivedShare, error)
 }
 
+type ReceivedShareDump struct {
+	UserId        *userv1beta1.UserId
+	ReceivedShare *collaboration.ReceivedShare
+}
+
+// DumpableManager defines a share manager which supports dumping its contents
+type DumpableManager interface {
+	Dump(shareChan chan<- *collaboration.Share, receivedShareChan chan<- ReceivedShareDump) error
+}
+
+// LoadableManager defines a share manager which supports loading contents from a dump
+type LoadableManager interface {
+	Load(shareChan <-chan *collaboration.Share, receivedShareChan <-chan ReceivedShareDump) error
+}
+
 // GroupGranteeFilter is an abstraction for creating filter by grantee type group.
 func GroupGranteeFilter() *collaboration.Filter {
 	return &collaboration.Filter{


### PR DESCRIPTION
This PR introduces new interfaces for dumpable and loadable share managers and implements dumping shares from the `json` and loading dumps into `cs3` manager.