### PR TITLE
[tests-only] [full-ci] Bump core commit id in master for tests as at 2022-06-01

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The test runner source for API tests
-CORE_COMMITID=1252e5ddab6532c3d77d870e133fee4cafc74c70
+CORE_COMMITID=3e90678303c023a064a80809ed207af662b07ba0
 CORE_BRANCH=master

--- a/tests/acceptance/expected-failures-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-on-OCIS-storage.md
@@ -1430,5 +1430,10 @@ _ocs: api compatibility, return correct status code_
 - [apiVersions/fileVersions.feature:511](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiVersions/fileVersions.feature#L511)
 - [apiVersions/fileVersions.feature:512](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiVersions/fileVersions.feature#L512)
 
+#### [reShareUpdate API tests failing in reva](https://github.com/cs3org/reva/issues/2916)
+
+- [apiShareReshareToShares3/reShareUpdate.feature:152](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareReshareToShares3/reShareUpdate.feature#L152)
+- [apiShareReshareToShares3/reShareUpdate.feature:153](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareReshareToShares3/reShareUpdate.feature#L153)
+
 Note: always have an empty line at the end of this file.
 The bash script that processes this file may not process a scenario reference on the last line.

--- a/tests/acceptance/expected-failures-on-S3NG-storage.md
+++ b/tests/acceptance/expected-failures-on-S3NG-storage.md
@@ -1428,5 +1428,10 @@ _ocs: api compatibility, return correct status code_
 - [apiVersions/fileVersions.feature:511](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiVersions/fileVersions.feature#L511)
 - [apiVersions/fileVersions.feature:512](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiVersions/fileVersions.feature#L512)
 
+#### [reShareUpdate API tests failing in reva](https://github.com/cs3org/reva/issues/2916)
+
+- [apiShareReshareToShares3/reShareUpdate.feature:152](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareReshareToShares3/reShareUpdate.feature#L152)
+- [apiShareReshareToShares3/reShareUpdate.feature:153](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareReshareToShares3/reShareUpdate.feature#L153)
+
 Note: always have an empty line at the end of this file.
 The bash script that processes this file may not process a scenario reference on the last line.


### PR DESCRIPTION
Issue https://github.com/owncloud/QA/issues/742

This gets the test code from https://github.com/owncloud/core/pull/40114 running in CI.

Some new failures have been added to expected-failures. They are described in issue #2916 
IMO we can merge this PR, and tomorrow I will look into the detail of why these have started failing.