### PR TITLE
Use standard header for checksums

### DIFF
--- a/changelog/unreleased/gfal-cksum.md
+++ b/changelog/unreleased/gfal-cksum.md
@@ -1,0 +1,10 @@
+Enhancement: Use standard header for checksums
+
+On HEAD requests, we currently expose checksums (when available) using the
+ownCloud-specific header, which is typically consumed by the sync clients.
+
+This patch adds the standard Digest header using the standard format
+detailed at https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Digest.
+This is e.g. used by GFAL/Rucio clients in the context of managed transfers of datasets.
+
+https://github.com/cs3org/reva/pull/2921

--- a/internal/http/services/owncloud/ocdav/head.go
+++ b/internal/http/services/owncloud/ocdav/head.go
@@ -78,6 +78,7 @@ func (s *svc) handleHead(ctx context.Context, w http.ResponseWriter, r *http.Req
 	w.Header().Set(HeaderOCETag, info.Etag)
 	if info.Checksum != nil {
 		w.Header().Set(HeaderOCChecksum, fmt.Sprintf("%s:%s", strings.ToUpper(string(storageprovider.GRPC2PKGXS(info.Checksum.Type))), info.Checksum.Sum))
+		w.Header().Set(HeaderChecksum, fmt.Sprintf("%s=%s", strings.ToLower(string(storageprovider.GRPC2PKGXS(info.Checksum.Type))), info.Checksum.Sum))
 	}
 	t := utils.TSToTime(info.Mtime).UTC()
 	lastModifiedString := t.Format(time.RFC1123Z)

--- a/internal/http/services/owncloud/ocdav/webdav.go
+++ b/internal/http/services/owncloud/ocdav/webdav.go
@@ -51,6 +51,7 @@ const (
 	HeaderLocation                   = "Location"
 	HeaderRange                      = "Range"
 	HeaderIfMatch                    = "If-Match"
+	HeaderChecksum                   = "Digest"
 )
 
 // Non standard HTTP headers.


### PR DESCRIPTION
On HEAD requests, we currently expose checksums (when available) using the ownCloud-specific header, which is typically consumed by the sync clients.

This patch adds the standard `Digest` header using the standard format detailed at https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Digest. This is e.g. used by GFAL/Rucio clients in the context of managed transfers of datasets.