### PR TITLE
fix mkcol response code

### DIFF
--- a/changelog/unreleased/fix-mkcol-response-code.md
+++ b/changelog/unreleased/fix-mkcol-response-code.md
@@ -1,0 +1,5 @@
+Bugfix: Fix mkcol response code
+
+We now return the correct response code when an mkcol fails.
+
+https://github.com/cs3org/reva/pull/2928

--- a/internal/http/services/owncloud/ocdav/mkcol.go
+++ b/internal/http/services/owncloud/ocdav/mkcol.go
@@ -170,6 +170,6 @@ func (s *svc) handleMkcol(ctx context.Context, w http.ResponseWriter, r *http.Re
 	case res.Status.Code == rpc.Code_CODE_NOT_FOUND:
 		return http.StatusConflict, fmt.Errorf("intermediate collection does not exist")
 	default:
-		return rstatus.HTTPStatusFromCode(statRes.Status.Code), errtypes.NewErrtypeFromStatus(statRes.Status)
+		return rstatus.HTTPStatusFromCode(res.Status.Code), errtypes.NewErrtypeFromStatus(res.Status)
 	}
 }


### PR DESCRIPTION
We now return the correct response code when an mkcol fails.

found in https://drone.owncloud.com/owncloud/ocis/12322/37/6