### PR TITLE
allow listing share jail space

### DIFF
--- a/changelog/unreleased/alow-listing-share-jail-space.md
+++ b/changelog/unreleased/alow-listing-share-jail-space.md
@@ -1,0 +1,5 @@
+Bugfix: allow listing share jail space
+
+Clients can now list the share jail content via `PROPFIND /dav/spaces/{sharejailid}`
+
+https://github.com/cs3org/reva/pull/2931

--- a/internal/http/services/owncloud/ocdav/propfind/propfind.go
+++ b/internal/http/services/owncloud/ocdav/propfind/propfind.go
@@ -477,7 +477,7 @@ func (p *Handler) getResourceInfos(ctx context.Context, w http.ResponseWriter, r
 
 		case spaceInfo.Type == provider.ResourceType_RESOURCE_TYPE_CONTAINER && depth == net.DepthOne:
 			switch {
-			case strings.HasPrefix(requestPath, spaceInfo.Path) && spaceData.SpaceType != "virtual":
+			case strings.HasPrefix(requestPath, spaceInfo.Path) && (spacesPropfind || spaceData.SpaceType != "virtual"):
 				req := &provider.ListContainerRequest{
 					Ref:                   spaceData.Ref,
 					ArbitraryMetadataKeys: metadataKeys,


### PR DESCRIPTION
Clients can now list the share jail content via `PROPFIND /dav/spaces/{sharejailid}`

fixes https://github.com/owncloud/ocis/issues/3863