### PR TITLE
increase lint timeout to 10min

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ litmus-test-new: build
 	pkill revad
 lint:
 	go run tools/check-license/check-license.go
-	`go env GOPATH`/bin/golangci-lint run --timeout 3m0s
+	`go env GOPATH`/bin/golangci-lint run --timeout 10m0s
 
 contrib:
 	git shortlog -se | cut -c8- | sort -u | awk '{print "-", $$0}' | grep -v 'users.noreply.github.com' > CONTRIBUTORS.md

--- a/changelog/unreleased/sharpen-tooling.md
+++ b/changelog/unreleased/sharpen-tooling.md
@@ -1,0 +1,5 @@
+Enhancement: sharpen tooling
+
+* We increased the linting timeout to 10min which caused some release builds to time out
+
+https://github.com/cs3org/reva/pull/2938


### PR DESCRIPTION
We ran into timeouts when running tools/prepare-release

cc @kulmann