### PR TITLE
[build-deps] Revert "Use RFC3339 format for parsing dates (#2744)"

### DIFF
--- a/changelog/unreleased/rfc3339-fix.md
+++ b/changelog/unreleased/rfc3339-fix.md
@@ -1,6 +1,0 @@
-Bugfix: Use RFC3339 for parsing dates
-
-We have used the RFC3339 format for parsing dates to be consistent with oC Web.
-
-https://github.com/cs3org/reva/issues/2322
-https://github.com/cs3org/reva/pull/2744

--- a/internal/http/services/owncloud/ocs/conversions/main.go
+++ b/internal/http/services/owncloud/ocs/conversions/main.go
@@ -281,7 +281,7 @@ func timestampToExpiration(t *types.Timestamp) string {
 
 // ParseTimestamp tries to parses the ocs expiry into a CS3 Timestamp
 func ParseTimestamp(timestampString string) (*types.Timestamp, error) {
-	parsedTime, err := time.Parse(time.RFC3339, timestampString)
+	parsedTime, err := time.Parse("2006-01-02T15:04:05Z0700", timestampString)
 	if err != nil {
 		parsedTime, err = time.Parse("2006-01-02", timestampString)
 	}


### PR DESCRIPTION
This reverts commit 628915c2bf07610bb01d6a3b70f305c1ee834315.