### PR TITLE
Owncloudsql context and connections

### DIFF
--- a/changelog/unreleased/owncloudsql-context-and-connections.md
+++ b/changelog/unreleased/owncloudsql-context-and-connections.md
@@ -1,4 +1,4 @@
-Bugfix: increase max open connections and pass context to owncloudsql drivers to close connections
+Enhancement: improve owncloudsql connection management
 
 The owncloudsql storagedriver is now aware of the request context and will close db connections when http connections are closed or time out. We also increased the max number of open connections from 10 to 100 to prevent a corner case where all connections were used but idle connections were not freed.
 

--- a/changelog/unreleased/owncloudsql-context-and-connections.md
+++ b/changelog/unreleased/owncloudsql-context-and-connections.md
@@ -1,0 +1,5 @@
+Bugfix: increase max open connections and pass context to owncloudsql drivers to close connections
+
+The owncloudsql storagedriver is now aware of the request context and will close db connections when http connections are closed or time out. We also increased the max number of open connections from 10 to 100 to prevent a corner case where all connections were used but idle connections were not freed.
+
+https://github.com/cs3org/reva/pull/2944

--- a/pkg/auth/manager/owncloudsql/accounts/accounts.go
+++ b/pkg/auth/manager/owncloudsql/accounts/accounts.go
@@ -42,8 +42,11 @@ func NewMysql(dsn string, joinUsername, joinUUID, enableMedialSearch bool) (*Acc
 	if err != nil {
 		return nil, errors.Wrap(err, "error connecting to the database")
 	}
+
+	// FIXME make configurable
 	sqldb.SetConnMaxLifetime(time.Minute * 3)
-	sqldb.SetMaxOpenConns(10)
+	sqldb.SetConnMaxIdleTime(time.Second * 30)
+	sqldb.SetMaxOpenConns(100)
 	sqldb.SetMaxIdleConns(10)
 
 	err = sqldb.Ping()

--- a/pkg/share/manager/owncloudsql/owncloudsql_test.go
+++ b/pkg/share/manager/owncloudsql/owncloudsql_test.go
@@ -97,7 +97,7 @@ var _ = Describe("SQL manager", func() {
 			if err != nil {
 				return -1, err
 			}
-			result, err := stmt.Exec(stmtValues...)
+			result, err := stmt.ExecContext(ctx, stmtValues...)
 			if err != nil {
 				return -1, err
 			}

--- a/pkg/storage/fs/owncloudsql/spaces.go
+++ b/pkg/storage/fs/owncloudsql/spaces.go
@@ -61,7 +61,7 @@ func (fs *owncloudsqlfs) ListStorageSpaces(ctx context.Context, filter []*provid
 		if !ok {
 			return nil, errtypes.UserRequired("error getting user from context")
 		}
-		space, err := fs.getPersonalSpace(u)
+		space, err := fs.getPersonalSpace(ctx, u)
 		if err != nil {
 			return nil, err
 		}
@@ -113,16 +113,16 @@ func (fs *owncloudsqlfs) DeleteStorageSpace(ctx context.Context, req *provider.D
 // 	return spaces, nil
 // }
 
-func (fs *owncloudsqlfs) getPersonalSpace(owner *userpb.User) (*provider.StorageSpace, error) {
-	storageID, err := fs.filecache.GetNumericStorageID("home::" + owner.Username)
+func (fs *owncloudsqlfs) getPersonalSpace(ctx context.Context, owner *userpb.User) (*provider.StorageSpace, error) {
+	storageID, err := fs.filecache.GetNumericStorageID(ctx, "home::"+owner.Username)
 	if err != nil {
 		return nil, err
 	}
-	storage, err := fs.filecache.GetStorage(storageID)
+	storage, err := fs.filecache.GetStorage(ctx, storageID)
 	if err != nil {
 		return nil, err
 	}
-	root, err := fs.filecache.Get(storage.NumericID, "")
+	root, err := fs.filecache.Get(ctx, storage.NumericID, "")
 	if err != nil {
 		return nil, err
 	}
@@ -142,7 +142,7 @@ func (fs *owncloudsqlfs) getPersonalSpace(owner *userpb.User) (*provider.Storage
 }
 
 func (fs *owncloudsqlfs) getSpaceByNumericID(ctx context.Context, spaceID int) (*provider.StorageSpace, error) {
-	storage, err := fs.filecache.GetStorage(spaceID)
+	storage, err := fs.filecache.GetStorage(ctx, spaceID)
 	if err != nil {
 		return nil, err
 	}
@@ -154,7 +154,7 @@ func (fs *owncloudsqlfs) getSpaceByNumericID(ctx context.Context, spaceID int) (
 }
 
 func (fs *owncloudsqlfs) storageToSpace(ctx context.Context, storage *filecache.Storage) (*provider.StorageSpace, error) {
-	root, err := fs.filecache.Get(storage.NumericID, "")
+	root, err := fs.filecache.Get(ctx, storage.NumericID, "")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/storage/fs/owncloudsql/upload.go
+++ b/pkg/storage/fs/owncloudsql/upload.go
@@ -191,7 +191,7 @@ func (fs *owncloudsqlfs) NewUpload(ctx context.Context, info tusd.FileInfo) (upl
 		return nil, errors.Wrap(err, "owncloudsql: error resolving upload path")
 	}
 	usr := ctxpkg.ContextMustGetUser(ctx)
-	storageID, err := fs.getStorage(ip)
+	storageID, err := fs.getStorage(ctx, ip)
 	if err != nil {
 		return nil, err
 	}
@@ -405,7 +405,7 @@ func (upload *fileUpload) FinishUpload(ctx context.Context) error {
 		"mtime":         upload.info.MetaData["mtime"],
 		"storage_mtime": upload.info.MetaData["mtime"],
 	}
-	_, err = upload.fs.filecache.InsertOrUpdate(upload.info.Storage["StorageId"], data, false)
+	_, err = upload.fs.filecache.InsertOrUpdate(ctx, upload.info.Storage["StorageId"], data, false)
 	if err != nil {
 		return err
 	}

--- a/pkg/user/manager/owncloudsql/accounts/accounts.go
+++ b/pkg/user/manager/owncloudsql/accounts/accounts.go
@@ -42,8 +42,11 @@ func NewMysql(dsn string, joinUsername, joinUUID, enableMedialSearch bool) (*Acc
 	if err != nil {
 		return nil, errors.Wrap(err, "error connecting to the database")
 	}
+
+	// FIXME make configurable
 	sqldb.SetConnMaxLifetime(time.Minute * 3)
-	sqldb.SetMaxOpenConns(10)
+	sqldb.SetConnMaxIdleTime(time.Second * 30)
+	sqldb.SetMaxOpenConns(100)
 	sqldb.SetMaxIdleConns(10)
 
 	err = sqldb.Ping()


### PR DESCRIPTION
The owncloudsql storagedriver is now aware of the request context and will close db connections when http connections are closed or time out. We also increased the max number of open connections from 10 to 100 to prevent a corner case where all connections were used but idle connections were not freed.
