### PR TITLE
[tests-only] [full-ci]  bumped core commit id to latest in reva edge

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The test runner source for API tests
-CORE_COMMITID=b12c3feb26db052d6743f14d1d65c4876b2b24f9
+CORE_COMMITID=3546cafcc3f75048a1c8ed106f583bbf63163e73
 CORE_BRANCH=master


### PR DESCRIPTION
### Description

#### Related issue: https://github.com/owncloud/QA/issues/744
Bumped owncloud/core commit id to latest.