### PR TITLE
Give space ref precedence over path in sharing

### DIFF
--- a/changelog/unreleased/fix-space-ref-sharing.md
+++ b/changelog/unreleased/fix-space-ref-sharing.md
@@ -1,0 +1,5 @@
+Bugfix: Fix sharing with space ref
+
+We've fixed a bug where share requests with `path` attribute present ignored the `space_ref` attribute. We now give the `space_ref` attribute precedence over the `path` attribute.
+
+https://github.com/cs3org/reva/pull/2950

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/shares.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/shares.go
@@ -167,12 +167,14 @@ func (h *Handler) startCacheWarmup(c cache.Warmup) {
 func (h *Handler) extractReference(r *http.Request) (provider.Reference, error) {
 	var ref provider.Reference
 
+	// NOTE: space_ref is deprecated and will be removed in ~2 weeks (1.6.22)
+	sr := r.FormValue("space_ref")
+	if sr != "" {
+		return storagespace.ParseReference(sr)
+	}
+
 	p, id := r.FormValue("path"), r.FormValue("space")
 	if p == "" && id == "" {
-		// NOTE: space_ref is deprecated and will be removed in ~2 weeks (1.6.22)
-		if sr := r.FormValue("space_ref"); sr != "" {
-			return storagespace.ParseReference(sr)
-		}
 		return ref, errors.New("need path or space to extract reference")
 	}
 


### PR DESCRIPTION
Share requests with both a `path` attribute and a `space_ref` attribute present ignored the `space_ref`. We want to prefer the `space_ref` attribute as it contains the space id and the path, thus is more appropriate for sharing than just a path without space id.

Credits to @kobergj as he is the author of that code change