### PR TITLE
Tracing improvements

### DIFF
--- a/changelog/unreleased/per-service-trace.md
+++ b/changelog/unreleased/per-service-trace.md
@@ -1,0 +1,7 @@
+Enhancement: Per service TracerProvider
+
+To improve tracing we create separate TracerProviders per service now.
+This is especially helpful when running multiple reva services in a single
+process (like e.g. oCIS does).
+
+https://github.com/cs3org/reva/pull/2962

--- a/internal/grpc/interceptors/appctx/appctx.go
+++ b/internal/grpc/interceptors/appctx/appctx.go
@@ -23,7 +23,6 @@ import (
 	"runtime"
 
 	"github.com/cs3org/reva/v2/pkg/appctx"
-	rtrace "github.com/cs3org/reva/v2/pkg/trace"
 	"github.com/rs/zerolog"
 	semconv "go.opentelemetry.io/otel/semconv/v1.10.0"
 	"go.opentelemetry.io/otel/trace"
@@ -34,12 +33,12 @@ import (
 const tracerName = "appctx"
 
 // NewUnary returns a new unary interceptor that creates the application context.
-func NewUnary(log zerolog.Logger) grpc.UnaryServerInterceptor {
+func NewUnary(log zerolog.Logger, tp trace.TracerProvider) grpc.UnaryServerInterceptor {
 	interceptor := func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
 		span := trace.SpanFromContext(ctx)
 		defer span.End()
 		if !span.SpanContext().HasTraceID() {
-			ctx, span = rtrace.Provider.Tracer(tracerName).Start(ctx, "grpc unary")
+			ctx, span = tp.Tracer(tracerName).Start(ctx, "grpc unary")
 		}
 		_, file, _, ok := runtime.Caller(1)
 		if ok {
@@ -56,14 +55,14 @@ func NewUnary(log zerolog.Logger) grpc.UnaryServerInterceptor {
 
 // NewStream returns a new server stream interceptor
 // that creates the application context.
-func NewStream(log zerolog.Logger) grpc.StreamServerInterceptor {
+func NewStream(log zerolog.Logger, tp trace.TracerProvider) grpc.StreamServerInterceptor {
 	interceptor := func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 		ctx := ss.Context()
 		span := trace.SpanFromContext(ctx)
 		defer span.End()
 
 		if !span.SpanContext().HasTraceID() {
-			ctx, span = rtrace.Provider.Tracer(tracerName).Start(ctx, "grpc stream")
+			ctx, span = tp.Tracer(tracerName).Start(ctx, "grpc stream")
 		}
 		_, file, _, ok := runtime.Caller(1)
 		if ok {

--- a/internal/grpc/interceptors/appctx/appctx.go
+++ b/internal/grpc/interceptors/appctx/appctx.go
@@ -47,6 +47,7 @@ func NewUnary(log zerolog.Logger, tp trace.TracerProvider) grpc.UnaryServerInter
 
 		sub := log.With().Str("traceid", span.SpanContext().TraceID().String()).Logger()
 		ctx = appctx.WithLogger(ctx, &sub)
+		ctx = appctx.WithTracerProvider(ctx, tp)
 		res, err := handler(ctx, req)
 		return res, err
 	}

--- a/internal/grpc/services/gateway/usershareprovider.go
+++ b/internal/grpc/services/gateway/usershareprovider.go
@@ -190,7 +190,7 @@ func (s *svc) GetReceivedShare(ctx context.Context, req *collaboration.GetReceiv
 //   1) if received share is mounted: we also do a rename in the storage
 //   2) if received share is not mounted: we only rename in user share provider.
 func (s *svc) UpdateReceivedShare(ctx context.Context, req *collaboration.UpdateReceivedShareRequest) (*collaboration.UpdateReceivedShareResponse, error) {
-	t := rtrace.Provider.Tracer("reva")
+	t := rtrace.DefaultProvider().Tracer("reva")
 	ctx, span := t.Start(ctx, "Gateway.UpdateReceivedShare")
 	defer span.End()
 

--- a/internal/grpc/services/gateway/usershareprovider.go
+++ b/internal/grpc/services/gateway/usershareprovider.go
@@ -33,7 +33,6 @@ import (
 	"github.com/cs3org/reva/v2/pkg/rgrpc/todo/pool"
 	"github.com/cs3org/reva/v2/pkg/storage/utils/grants"
 	"github.com/cs3org/reva/v2/pkg/storagespace"
-	rtrace "github.com/cs3org/reva/v2/pkg/trace"
 	"github.com/cs3org/reva/v2/pkg/utils"
 	"github.com/pkg/errors"
 )
@@ -190,8 +189,7 @@ func (s *svc) GetReceivedShare(ctx context.Context, req *collaboration.GetReceiv
 //   1) if received share is mounted: we also do a rename in the storage
 //   2) if received share is not mounted: we only rename in user share provider.
 func (s *svc) UpdateReceivedShare(ctx context.Context, req *collaboration.UpdateReceivedShareRequest) (*collaboration.UpdateReceivedShareResponse, error) {
-	t := rtrace.DefaultProvider().Tracer("reva")
-	ctx, span := t.Start(ctx, "Gateway.UpdateReceivedShare")
+	ctx, span := appctx.GetTracerProvider(ctx).Tracer("gateway").Start(ctx, "Gateway.UpdateReceivedShare")
 	defer span.End()
 
 	// sanity checks

--- a/internal/grpc/services/publicstorageprovider/publicstorageprovider.go
+++ b/internal/grpc/services/publicstorageprovider/publicstorageprovider.go
@@ -38,7 +38,6 @@ import (
 	"github.com/cs3org/reva/v2/pkg/rgrpc/status"
 	"github.com/cs3org/reva/v2/pkg/rgrpc/todo/pool"
 	"github.com/cs3org/reva/v2/pkg/storagespace"
-	rtrace "github.com/cs3org/reva/v2/pkg/trace"
 	"github.com/cs3org/reva/v2/pkg/utils"
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
@@ -555,7 +554,7 @@ func (s *service) CreateContainer(ctx context.Context, req *provider.CreateConta
 		_, req.Ref.ResourceId.StorageId = storagespace.SplitStorageID(req.Ref.ResourceId.StorageId)
 	}
 
-	ctx, span := rtrace.DefaultProvider().Tracer(tracerName).Start(ctx, "CreateContainer")
+	ctx, span := appctx.GetTracerProvider(ctx).Tracer(tracerName).Start(ctx, "CreateContainer")
 	defer span.End()
 
 	span.SetAttributes(attribute.KeyValue{
@@ -616,7 +615,7 @@ func (s *service) Delete(ctx context.Context, req *provider.DeleteRequest) (*pro
 		_, req.Ref.ResourceId.StorageId = storagespace.SplitStorageID(req.Ref.ResourceId.StorageId)
 	}
 
-	ctx, span := rtrace.DefaultProvider().Tracer(tracerName).Start(ctx, "Delete")
+	ctx, span := appctx.GetTracerProvider(ctx).Tracer(tracerName).Start(ctx, "Delete")
 	defer span.End()
 
 	span.SetAttributes(attribute.KeyValue{
@@ -663,7 +662,7 @@ func (s *service) Move(ctx context.Context, req *provider.MoveRequest) (*provide
 		_, req.Destination.ResourceId.StorageId = storagespace.SplitStorageID(req.Destination.ResourceId.StorageId)
 	}
 
-	ctx, span := rtrace.DefaultProvider().Tracer(tracerName).Start(ctx, "Move")
+	ctx, span := appctx.GetTracerProvider(ctx).Tracer(tracerName).Start(ctx, "Move")
 	defer span.End()
 
 	span.SetAttributes(
@@ -730,7 +729,7 @@ func (s *service) Stat(ctx context.Context, req *provider.StatRequest) (*provide
 		_, req.Ref.ResourceId.StorageId = storagespace.SplitStorageID(req.Ref.ResourceId.StorageId)
 	}
 
-	ctx, span := rtrace.DefaultProvider().Tracer(tracerName).Start(ctx, "Stat")
+	ctx, span := appctx.GetTracerProvider(ctx).Tracer(tracerName).Start(ctx, "Stat")
 	defer span.End()
 
 	span.SetAttributes(

--- a/internal/grpc/services/publicstorageprovider/publicstorageprovider.go
+++ b/internal/grpc/services/publicstorageprovider/publicstorageprovider.go
@@ -555,7 +555,7 @@ func (s *service) CreateContainer(ctx context.Context, req *provider.CreateConta
 		_, req.Ref.ResourceId.StorageId = storagespace.SplitStorageID(req.Ref.ResourceId.StorageId)
 	}
 
-	ctx, span := rtrace.Provider.Tracer(tracerName).Start(ctx, "CreateContainer")
+	ctx, span := rtrace.DefaultProvider().Tracer(tracerName).Start(ctx, "CreateContainer")
 	defer span.End()
 
 	span.SetAttributes(attribute.KeyValue{
@@ -616,7 +616,7 @@ func (s *service) Delete(ctx context.Context, req *provider.DeleteRequest) (*pro
 		_, req.Ref.ResourceId.StorageId = storagespace.SplitStorageID(req.Ref.ResourceId.StorageId)
 	}
 
-	ctx, span := rtrace.Provider.Tracer(tracerName).Start(ctx, "Delete")
+	ctx, span := rtrace.DefaultProvider().Tracer(tracerName).Start(ctx, "Delete")
 	defer span.End()
 
 	span.SetAttributes(attribute.KeyValue{
@@ -663,7 +663,7 @@ func (s *service) Move(ctx context.Context, req *provider.MoveRequest) (*provide
 		_, req.Destination.ResourceId.StorageId = storagespace.SplitStorageID(req.Destination.ResourceId.StorageId)
 	}
 
-	ctx, span := rtrace.Provider.Tracer(tracerName).Start(ctx, "Move")
+	ctx, span := rtrace.DefaultProvider().Tracer(tracerName).Start(ctx, "Move")
 	defer span.End()
 
 	span.SetAttributes(
@@ -730,7 +730,7 @@ func (s *service) Stat(ctx context.Context, req *provider.StatRequest) (*provide
 		_, req.Ref.ResourceId.StorageId = storagespace.SplitStorageID(req.Ref.ResourceId.StorageId)
 	}
 
-	ctx, span := rtrace.Provider.Tracer(tracerName).Start(ctx, "Stat")
+	ctx, span := rtrace.DefaultProvider().Tracer(tracerName).Start(ctx, "Stat")
 	defer span.End()
 
 	span.SetAttributes(

--- a/internal/grpc/services/storageprovider/storageprovider.go
+++ b/internal/grpc/services/storageprovider/storageprovider.go
@@ -714,7 +714,7 @@ func (s *service) Stat(ctx context.Context, req *provider.StatRequest) (*provide
 	providerID := unwrapProviderID(req.Ref.GetResourceId())
 	defer rewrapProviderID(req.Ref.GetResourceId(), providerID)
 
-	ctx, span := rtrace.Provider.Tracer(tracerName).Start(ctx, "stat")
+	ctx, span := rtrace.DefaultProvider().Tracer(tracerName).Start(ctx, "stat")
 	defer span.End()
 
 	span.SetAttributes(attribute.KeyValue{

--- a/internal/http/interceptors/appctx/appctx.go
+++ b/internal/http/interceptors/appctx/appctx.go
@@ -53,6 +53,7 @@ func handler(log zerolog.Logger, tp trace.TracerProvider, h http.Handler) http.H
 
 		sub := log.With().Str("traceid", span.SpanContext().TraceID().String()).Logger()
 		ctx = appctx.WithLogger(ctx, &sub)
+		ctx = appctx.WithTracerProvider(ctx, tp)
 		r = r.WithContext(ctx)
 		h.ServeHTTP(w, r)
 	})

--- a/internal/http/interceptors/appctx/appctx.go
+++ b/internal/http/interceptors/appctx/appctx.go
@@ -25,7 +25,6 @@ import (
 	"net/http"
 
 	"github.com/cs3org/reva/v2/pkg/appctx"
-	rtrace "github.com/cs3org/reva/v2/pkg/trace"
 	"github.com/rs/zerolog"
 	"go.opentelemetry.io/otel/trace"
 )
@@ -35,21 +34,21 @@ const tracerName = "appctx"
 
 // New returns a new HTTP middleware that stores the log
 // in the context with request ID information.
-func New(log zerolog.Logger) func(http.Handler) http.Handler {
+func New(log zerolog.Logger, tp trace.TracerProvider) func(http.Handler) http.Handler {
 	chain := func(h http.Handler) http.Handler {
-		return handler(log, h)
+		return handler(log, tp, h)
 	}
 	return chain
 }
 
-func handler(log zerolog.Logger, h http.Handler) http.Handler {
+func handler(log zerolog.Logger, tp trace.TracerProvider, h http.Handler) http.Handler {
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 		span := trace.SpanFromContext(ctx)
 		defer span.End()
 		if !span.SpanContext().HasTraceID() {
-			ctx, span = rtrace.Provider.Tracer(tracerName).Start(ctx, "http interceptor")
+			ctx, span = tp.Tracer(tracerName).Start(ctx, "http interceptor")
 		}
 
 		sub := log.With().Str("traceid", span.SpanContext().TraceID().String()).Logger()

--- a/internal/http/interceptors/auth/auth.go
+++ b/internal/http/interceptors/auth/auth.go
@@ -43,7 +43,6 @@ import (
 	"github.com/cs3org/reva/v2/pkg/sharedconf"
 	"github.com/cs3org/reva/v2/pkg/token"
 	tokenmgr "github.com/cs3org/reva/v2/pkg/token/manager/registry"
-	rtrace "github.com/cs3org/reva/v2/pkg/trace"
 	"github.com/cs3org/reva/v2/pkg/utils"
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
@@ -84,7 +83,7 @@ func parseConfig(m map[string]interface{}) (*config, error) {
 }
 
 // New returns a new middleware with defined priority.
-func New(m map[string]interface{}, unprotected []string) (global.Middleware, error) {
+func New(m map[string]interface{}, unprotected []string, tp trace.TracerProvider) (global.Middleware, error) {
 	conf, err := parseConfig(m)
 	if err != nil {
 		return nil, err
@@ -168,7 +167,7 @@ func New(m map[string]interface{}, unprotected []string) (global.Middleware, err
 			span := trace.SpanFromContext(ctx)
 			defer span.End()
 			if !span.SpanContext().HasTraceID() {
-				_, span = rtrace.Provider.Tracer(tracerName).Start(ctx, "http auth interceptor")
+				_, span = tp.Tracer(tracerName).Start(ctx, "http auth interceptor")
 			}
 
 			if r.Method == "OPTIONS" {

--- a/internal/http/services/owncloud/ocdav/copy.go
+++ b/internal/http/services/owncloud/ocdav/copy.go
@@ -37,7 +37,6 @@ import (
 	"github.com/cs3org/reva/v2/pkg/appctx"
 	"github.com/cs3org/reva/v2/pkg/rhttp"
 	"github.com/cs3org/reva/v2/pkg/rhttp/router"
-	rtrace "github.com/cs3org/reva/v2/pkg/trace"
 	"github.com/cs3org/reva/v2/pkg/utils"
 	"github.com/rs/zerolog"
 )
@@ -51,7 +50,7 @@ type copy struct {
 }
 
 func (s *svc) handlePathCopy(w http.ResponseWriter, r *http.Request, ns string) {
-	ctx, span := rtrace.Provider.Tracer(tracerName).Start(r.Context(), "copy")
+	ctx, span := s.tracerProvider.Tracer(tracerName).Start(r.Context(), "copy")
 	defer span.End()
 
 	if s.c.EnableHTTPTpc {
@@ -291,7 +290,7 @@ func (s *svc) executePathCopy(ctx context.Context, client gateway.GatewayAPIClie
 }
 
 func (s *svc) handleSpacesCopy(w http.ResponseWriter, r *http.Request, spaceID string) {
-	ctx, span := rtrace.Provider.Tracer(tracerName).Start(r.Context(), "spaces_copy")
+	ctx, span := s.tracerProvider.Tracer(tracerName).Start(r.Context(), "spaces_copy")
 	defer span.End()
 
 	dh := r.Header.Get(net.HeaderDestination)

--- a/internal/http/services/owncloud/ocdav/delete.go
+++ b/internal/http/services/owncloud/ocdav/delete.go
@@ -31,7 +31,6 @@ import (
 	"github.com/cs3org/reva/v2/internal/http/services/owncloud/ocdav/spacelookup"
 	"github.com/cs3org/reva/v2/pkg/appctx"
 	"github.com/cs3org/reva/v2/pkg/rgrpc/status"
-	rtrace "github.com/cs3org/reva/v2/pkg/trace"
 	"github.com/cs3org/reva/v2/pkg/utils"
 	"github.com/rs/zerolog"
 )
@@ -61,7 +60,7 @@ func (s *svc) handlePathDelete(w http.ResponseWriter, r *http.Request, ns string
 }
 
 func (s *svc) handleDelete(ctx context.Context, w http.ResponseWriter, r *http.Request, ref *provider.Reference, log zerolog.Logger) {
-	ctx, span := rtrace.Provider.Tracer(tracerName).Start(ctx, "delete")
+	ctx, span := s.tracerProvider.Tracer(tracerName).Start(ctx, "delete")
 	defer span.End()
 
 	req := &provider.DeleteRequest{Ref: ref}
@@ -130,7 +129,7 @@ func (s *svc) handleDelete(ctx context.Context, w http.ResponseWriter, r *http.R
 
 func (s *svc) handleSpacesDelete(w http.ResponseWriter, r *http.Request, spaceID string) {
 	ctx := r.Context()
-	ctx, span := rtrace.Provider.Tracer(tracerName).Start(ctx, "spaces_delete")
+	ctx, span := s.tracerProvider.Tracer(tracerName).Start(ctx, "spaces_delete")
 	defer span.End()
 
 	sublog := appctx.GetLogger(ctx).With().Logger()

--- a/internal/http/services/owncloud/ocdav/get.go
+++ b/internal/http/services/owncloud/ocdav/get.go
@@ -38,13 +38,12 @@ import (
 	"github.com/cs3org/reva/v2/pkg/appctx"
 	"github.com/cs3org/reva/v2/pkg/rhttp"
 	"github.com/cs3org/reva/v2/pkg/storagespace"
-	rtrace "github.com/cs3org/reva/v2/pkg/trace"
 	"github.com/cs3org/reva/v2/pkg/utils"
 	"github.com/rs/zerolog"
 )
 
 func (s *svc) handlePathGet(w http.ResponseWriter, r *http.Request, ns string) {
-	ctx, span := rtrace.Provider.Tracer(tracerName).Start(r.Context(), "get")
+	ctx, span := s.tracerProvider.Tracer(tracerName).Start(r.Context(), "get")
 	defer span.End()
 
 	fn := path.Join(ns, r.URL.Path)
@@ -179,7 +178,7 @@ func (s *svc) handleGet(ctx context.Context, w http.ResponseWriter, r *http.Requ
 }
 
 func (s *svc) handleSpacesGet(w http.ResponseWriter, r *http.Request, spaceID string) {
-	ctx, span := rtrace.Provider.Tracer(tracerName).Start(r.Context(), "spaces_get")
+	ctx, span := s.tracerProvider.Tracer(tracerName).Start(r.Context(), "spaces_get")
 	defer span.End()
 
 	sublog := appctx.GetLogger(ctx).With().Str("path", r.URL.Path).Str("spaceid", spaceID).Str("handler", "get").Logger()

--- a/internal/http/services/owncloud/ocdav/head.go
+++ b/internal/http/services/owncloud/ocdav/head.go
@@ -28,7 +28,6 @@ import (
 	"time"
 
 	"github.com/cs3org/reva/v2/pkg/storagespace"
-	rtrace "github.com/cs3org/reva/v2/pkg/trace"
 
 	rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
@@ -42,7 +41,7 @@ import (
 )
 
 func (s *svc) handlePathHead(w http.ResponseWriter, r *http.Request, ns string) {
-	ctx, span := rtrace.Provider.Tracer(tracerName).Start(r.Context(), "head")
+	ctx, span := s.tracerProvider.Tracer(tracerName).Start(r.Context(), "head")
 	defer span.End()
 
 	fn := path.Join(ns, r.URL.Path)
@@ -109,7 +108,7 @@ func (s *svc) handleHead(ctx context.Context, w http.ResponseWriter, r *http.Req
 }
 
 func (s *svc) handleSpacesHead(w http.ResponseWriter, r *http.Request, spaceID string) {
-	ctx, span := rtrace.Provider.Tracer(tracerName).Start(r.Context(), "spaces_head")
+	ctx, span := s.tracerProvider.Tracer(tracerName).Start(r.Context(), "spaces_head")
 	defer span.End()
 
 	sublog := appctx.GetLogger(ctx).With().Str("spaceid", spaceID).Str("path", r.URL.Path).Logger()

--- a/internal/http/services/owncloud/ocdav/locks.go
+++ b/internal/http/services/owncloud/ocdav/locks.go
@@ -41,7 +41,6 @@ import (
 	"github.com/cs3org/reva/v2/pkg/appctx"
 	ctxpkg "github.com/cs3org/reva/v2/pkg/ctx"
 	"github.com/cs3org/reva/v2/pkg/errtypes"
-	rtrace "github.com/cs3org/reva/v2/pkg/trace"
 	"github.com/google/uuid"
 	"go.opentelemetry.io/otel/attribute"
 )
@@ -371,7 +370,7 @@ func parseDepth(s string) int {
 		}
 */
 func (s *svc) handleLock(w http.ResponseWriter, r *http.Request, ns string) (retStatus int, retErr error) {
-	ctx, span := rtrace.Provider.Tracer(tracerName).Start(r.Context(), fmt.Sprintf("%s %v", r.Method, r.URL.Path))
+	ctx, span := s.tracerProvider.Tracer(tracerName).Start(r.Context(), fmt.Sprintf("%s %v", r.Method, r.URL.Path))
 	defer span.End()
 
 	span.SetAttributes(attribute.String("component", "ocdav"))
@@ -396,7 +395,7 @@ func (s *svc) handleLock(w http.ResponseWriter, r *http.Request, ns string) (ret
 }
 
 func (s *svc) handleSpacesLock(w http.ResponseWriter, r *http.Request, spaceID string) (retStatus int, retErr error) {
-	ctx, span := rtrace.Provider.Tracer(tracerName).Start(r.Context(), fmt.Sprintf("%s %v", r.Method, r.URL.Path))
+	ctx, span := s.tracerProvider.Tracer(tracerName).Start(r.Context(), fmt.Sprintf("%s %v", r.Method, r.URL.Path))
 	defer span.End()
 
 	span.SetAttributes(attribute.String("component", "ocdav"))
@@ -565,7 +564,7 @@ func writeLockInfo(w io.Writer, token string, ld LockDetails) (int, error) {
 }
 
 func (s *svc) handleUnlock(w http.ResponseWriter, r *http.Request, ns string) (status int, err error) {
-	ctx, span := rtrace.Provider.Tracer(tracerName).Start(r.Context(), fmt.Sprintf("%s %v", r.Method, r.URL.Path))
+	ctx, span := s.tracerProvider.Tracer(tracerName).Start(r.Context(), fmt.Sprintf("%s %v", r.Method, r.URL.Path))
 	defer span.End()
 
 	span.SetAttributes(attribute.String("component", "ocdav"))

--- a/internal/http/services/owncloud/ocdav/meta.go
+++ b/internal/http/services/owncloud/ocdav/meta.go
@@ -91,7 +91,7 @@ func (h *MetaHandler) Handler(s *svc) http.Handler {
 }
 
 func (h *MetaHandler) handlePathForUser(w http.ResponseWriter, r *http.Request, s *svc, rid *provider.ResourceId) {
-	ctx, span := rtrace.Provider.Tracer(tracerName).Start(r.Context(), "meta_propfind")
+	ctx, span := rtrace.DefaultProvider().Tracer(tracerName).Start(r.Context(), "meta_propfind")
 	defer span.End()
 
 	id := storagespace.FormatResourceID(*rid)
@@ -178,7 +178,7 @@ func (h *MetaHandler) handlePathForUser(w http.ResponseWriter, r *http.Request, 
 }
 
 func (h *MetaHandler) handleEmptyID(w http.ResponseWriter, r *http.Request) {
-	ctx, span := rtrace.Provider.Tracer(tracerName).Start(r.Context(), "meta_propfind")
+	ctx, span := rtrace.DefaultProvider().Tracer(tracerName).Start(r.Context(), "meta_propfind")
 	defer span.End()
 
 	sublog := appctx.GetLogger(ctx).With().Str("path", r.URL.Path).Logger()

--- a/internal/http/services/owncloud/ocdav/meta.go
+++ b/internal/http/services/owncloud/ocdav/meta.go
@@ -33,7 +33,6 @@ import (
 	"github.com/cs3org/reva/v2/pkg/appctx"
 	"github.com/cs3org/reva/v2/pkg/rhttp/router"
 	"github.com/cs3org/reva/v2/pkg/storagespace"
-	rtrace "github.com/cs3org/reva/v2/pkg/trace"
 )
 
 // MetaHandler handles meta requests
@@ -91,7 +90,7 @@ func (h *MetaHandler) Handler(s *svc) http.Handler {
 }
 
 func (h *MetaHandler) handlePathForUser(w http.ResponseWriter, r *http.Request, s *svc, rid *provider.ResourceId) {
-	ctx, span := rtrace.DefaultProvider().Tracer(tracerName).Start(r.Context(), "meta_propfind")
+	ctx, span := appctx.GetTracerProvider(r.Context()).Tracer(tracerName).Start(r.Context(), "meta_propfind")
 	defer span.End()
 
 	id := storagespace.FormatResourceID(*rid)
@@ -178,7 +177,7 @@ func (h *MetaHandler) handlePathForUser(w http.ResponseWriter, r *http.Request, 
 }
 
 func (h *MetaHandler) handleEmptyID(w http.ResponseWriter, r *http.Request) {
-	ctx, span := rtrace.DefaultProvider().Tracer(tracerName).Start(r.Context(), "meta_propfind")
+	ctx, span := appctx.GetTracerProvider(r.Context()).Tracer(tracerName).Start(r.Context(), "meta_propfind")
 	defer span.End()
 
 	sublog := appctx.GetLogger(ctx).With().Str("path", r.URL.Path).Logger()

--- a/internal/http/services/owncloud/ocdav/mkcol.go
+++ b/internal/http/services/owncloud/ocdav/mkcol.go
@@ -30,12 +30,11 @@ import (
 	"github.com/cs3org/reva/v2/pkg/appctx"
 	"github.com/cs3org/reva/v2/pkg/errtypes"
 	rstatus "github.com/cs3org/reva/v2/pkg/rgrpc/status"
-	rtrace "github.com/cs3org/reva/v2/pkg/trace"
 	"github.com/rs/zerolog"
 )
 
 func (s *svc) handlePathMkcol(w http.ResponseWriter, r *http.Request, ns string) (status int, err error) {
-	ctx, span := rtrace.Provider.Tracer(tracerName).Start(r.Context(), "mkcol")
+	ctx, span := s.tracerProvider.Tracer(tracerName).Start(r.Context(), "mkcol")
 	defer span.End()
 
 	fn := path.Join(ns, r.URL.Path)
@@ -88,7 +87,7 @@ func (s *svc) handlePathMkcol(w http.ResponseWriter, r *http.Request, ns string)
 }
 
 func (s *svc) handleSpacesMkCol(w http.ResponseWriter, r *http.Request, spaceID string) (status int, err error) {
-	ctx, span := rtrace.Provider.Tracer(tracerName).Start(r.Context(), "spaces_mkcol")
+	ctx, span := s.tracerProvider.Tracer(tracerName).Start(r.Context(), "spaces_mkcol")
 	defer span.End()
 
 	sublog := appctx.GetLogger(ctx).With().Str("path", r.URL.Path).Str("spaceid", spaceID).Str("handler", "mkcol").Logger()

--- a/internal/http/services/owncloud/ocdav/move.go
+++ b/internal/http/services/owncloud/ocdav/move.go
@@ -32,13 +32,12 @@ import (
 	"github.com/cs3org/reva/v2/pkg/appctx"
 	"github.com/cs3org/reva/v2/pkg/rhttp/router"
 	"github.com/cs3org/reva/v2/pkg/storagespace"
-	rtrace "github.com/cs3org/reva/v2/pkg/trace"
 	"github.com/cs3org/reva/v2/pkg/utils"
 	"github.com/rs/zerolog"
 )
 
 func (s *svc) handlePathMove(w http.ResponseWriter, r *http.Request, ns string) {
-	ctx, span := rtrace.Provider.Tracer(tracerName).Start(r.Context(), "move")
+	ctx, span := s.tracerProvider.Tracer(tracerName).Start(r.Context(), "move")
 	defer span.End()
 
 	srcPath := path.Join(ns, r.URL.Path)
@@ -92,7 +91,7 @@ func (s *svc) handlePathMove(w http.ResponseWriter, r *http.Request, ns string) 
 }
 
 func (s *svc) handleSpacesMove(w http.ResponseWriter, r *http.Request, srcSpaceID string) {
-	ctx, span := rtrace.Provider.Tracer(tracerName).Start(r.Context(), "spaces_move")
+	ctx, span := s.tracerProvider.Tracer(tracerName).Start(r.Context(), "spaces_move")
 	defer span.End()
 
 	dh := r.Header.Get(net.HeaderDestination)

--- a/internal/http/services/owncloud/ocdav/propfind/propfind.go
+++ b/internal/http/services/owncloud/ocdav/propfind/propfind.go
@@ -179,7 +179,7 @@ func NewHandler(publicURL string, getClientFunc GetGatewayServiceClientFunc) *Ha
 // HandlePathPropfind handles a path based propfind request
 // ns is the namespace that is prefixed to the path in the cs3 namespace
 func (p *Handler) HandlePathPropfind(w http.ResponseWriter, r *http.Request, ns string) {
-	ctx, span := rtrace.Provider.Tracer(tracerName).Start(r.Context(), fmt.Sprintf("%s %v", r.Method, r.URL.Path))
+	ctx, span := rtrace.DefaultProvider().Tracer(tracerName).Start(r.Context(), fmt.Sprintf("%s %v", r.Method, r.URL.Path))
 	defer span.End()
 
 	fn := path.Join(ns, r.URL.Path) // TODO do we still need to jail if we query the registry about the spaces?
@@ -238,7 +238,7 @@ func (p *Handler) HandlePathPropfind(w http.ResponseWriter, r *http.Request, ns 
 
 // HandleSpacesPropfind handles a spaces based propfind request
 func (p *Handler) HandleSpacesPropfind(w http.ResponseWriter, r *http.Request, spaceID string) {
-	ctx, span := rtrace.Provider.Tracer(tracerName).Start(r.Context(), "spaces_propfind")
+	ctx, span := rtrace.DefaultProvider().Tracer(tracerName).Start(r.Context(), "spaces_propfind")
 	defer span.End()
 
 	sublog := appctx.GetLogger(ctx).With().Str("path", r.URL.Path).Str("spaceid", spaceID).Logger()
@@ -285,7 +285,7 @@ func (p *Handler) HandleSpacesPropfind(w http.ResponseWriter, r *http.Request, s
 }
 
 func (p *Handler) propfindResponse(ctx context.Context, w http.ResponseWriter, r *http.Request, namespace, spaceType string, pf XML, sendTusHeaders bool, resourceInfos []*provider.ResourceInfo, log zerolog.Logger) {
-	ctx, span := rtrace.Provider.Tracer(tracerName).Start(ctx, "propfind_response")
+	ctx, span := rtrace.DefaultProvider().Tracer(tracerName).Start(ctx, "propfind_response")
 	defer span.End()
 
 	filters := make([]*link.ListPublicSharesRequest_Filter, 0, len(resourceInfos))

--- a/internal/http/services/owncloud/ocdav/propfind/propfind.go
+++ b/internal/http/services/owncloud/ocdav/propfind/propfind.go
@@ -47,7 +47,6 @@ import (
 	"github.com/cs3org/reva/v2/pkg/publicshare"
 	"github.com/cs3org/reva/v2/pkg/rhttp/router"
 	"github.com/cs3org/reva/v2/pkg/storagespace"
-	rtrace "github.com/cs3org/reva/v2/pkg/trace"
 	"github.com/cs3org/reva/v2/pkg/utils"
 	"github.com/rs/zerolog"
 	"go.opentelemetry.io/otel/codes"
@@ -179,7 +178,7 @@ func NewHandler(publicURL string, getClientFunc GetGatewayServiceClientFunc) *Ha
 // HandlePathPropfind handles a path based propfind request
 // ns is the namespace that is prefixed to the path in the cs3 namespace
 func (p *Handler) HandlePathPropfind(w http.ResponseWriter, r *http.Request, ns string) {
-	ctx, span := rtrace.DefaultProvider().Tracer(tracerName).Start(r.Context(), fmt.Sprintf("%s %v", r.Method, r.URL.Path))
+	ctx, span := appctx.GetTracerProvider(r.Context()).Tracer(tracerName).Start(r.Context(), fmt.Sprintf("%s %v", r.Method, r.URL.Path))
 	defer span.End()
 
 	fn := path.Join(ns, r.URL.Path) // TODO do we still need to jail if we query the registry about the spaces?
@@ -238,7 +237,7 @@ func (p *Handler) HandlePathPropfind(w http.ResponseWriter, r *http.Request, ns 
 
 // HandleSpacesPropfind handles a spaces based propfind request
 func (p *Handler) HandleSpacesPropfind(w http.ResponseWriter, r *http.Request, spaceID string) {
-	ctx, span := rtrace.DefaultProvider().Tracer(tracerName).Start(r.Context(), "spaces_propfind")
+	ctx, span := appctx.GetTracerProvider(r.Context()).Tracer(tracerName).Start(r.Context(), "spaces_propfind")
 	defer span.End()
 
 	sublog := appctx.GetLogger(ctx).With().Str("path", r.URL.Path).Str("spaceid", spaceID).Logger()
@@ -285,7 +284,7 @@ func (p *Handler) HandleSpacesPropfind(w http.ResponseWriter, r *http.Request, s
 }
 
 func (p *Handler) propfindResponse(ctx context.Context, w http.ResponseWriter, r *http.Request, namespace, spaceType string, pf XML, sendTusHeaders bool, resourceInfos []*provider.ResourceInfo, log zerolog.Logger) {
-	ctx, span := rtrace.DefaultProvider().Tracer(tracerName).Start(ctx, "propfind_response")
+	ctx, span := appctx.GetTracerProvider(r.Context()).Tracer(tracerName).Start(ctx, "propfind_response")
 	defer span.End()
 
 	filters := make([]*link.ListPublicSharesRequest_Filter, 0, len(resourceInfos))

--- a/internal/http/services/owncloud/ocdav/proppatch.go
+++ b/internal/http/services/owncloud/ocdav/proppatch.go
@@ -39,12 +39,11 @@ import (
 	ctxpkg "github.com/cs3org/reva/v2/pkg/ctx"
 	"github.com/cs3org/reva/v2/pkg/errtypes"
 	rstatus "github.com/cs3org/reva/v2/pkg/rgrpc/status"
-	rtrace "github.com/cs3org/reva/v2/pkg/trace"
 	"github.com/rs/zerolog"
 )
 
 func (s *svc) handlePathProppatch(w http.ResponseWriter, r *http.Request, ns string) (status int, err error) {
-	ctx, span := rtrace.Provider.Tracer(tracerName).Start(r.Context(), "proppatch")
+	ctx, span := s.tracerProvider.Tracer(tracerName).Start(r.Context(), "proppatch")
 	defer span.End()
 
 	fn := path.Join(ns, r.URL.Path)
@@ -95,7 +94,7 @@ func (s *svc) handlePathProppatch(w http.ResponseWriter, r *http.Request, ns str
 }
 
 func (s *svc) handleSpacesProppatch(w http.ResponseWriter, r *http.Request, spaceID string) (status int, err error) {
-	ctx, span := rtrace.Provider.Tracer(tracerName).Start(r.Context(), "spaces_proppatch")
+	ctx, span := s.tracerProvider.Tracer(tracerName).Start(r.Context(), "spaces_proppatch")
 	defer span.End()
 
 	sublog := appctx.GetLogger(ctx).With().Str("path", r.URL.Path).Str("spaceid", spaceID).Logger()

--- a/internal/http/services/owncloud/ocdav/publicfile.go
+++ b/internal/http/services/owncloud/ocdav/publicfile.go
@@ -29,7 +29,6 @@ import (
 	"github.com/cs3org/reva/v2/internal/http/services/owncloud/ocdav/propfind"
 	"github.com/cs3org/reva/v2/pkg/appctx"
 	"github.com/cs3org/reva/v2/pkg/rhttp/router"
-	rtrace "github.com/cs3org/reva/v2/pkg/trace"
 )
 
 // PublicFileHandler handles requests on a shared file. it needs to be wrapped in a collection
@@ -85,7 +84,7 @@ func (h *PublicFileHandler) Handler(s *svc) http.Handler {
 
 // ns is the namespace that is prefixed to the path in the cs3 namespace
 func (s *svc) handlePropfindOnToken(w http.ResponseWriter, r *http.Request, ns string, onContainer bool) {
-	ctx, span := rtrace.Provider.Tracer(tracerName).Start(r.Context(), "token_propfind")
+	ctx, span := s.tracerProvider.Tracer(tracerName).Start(r.Context(), "token_propfind")
 	defer span.End()
 
 	tokenStatInfo := ctx.Value(tokenStatInfoKey{}).(*provider.ResourceInfo)

--- a/internal/http/services/owncloud/ocdav/put.go
+++ b/internal/http/services/owncloud/ocdav/put.go
@@ -38,7 +38,6 @@ import (
 	"github.com/cs3org/reva/v2/pkg/rhttp"
 	"github.com/cs3org/reva/v2/pkg/storage/utils/chunking"
 	"github.com/cs3org/reva/v2/pkg/storagespace"
-	rtrace "github.com/cs3org/reva/v2/pkg/trace"
 	"github.com/cs3org/reva/v2/pkg/utils"
 	"github.com/rs/zerolog"
 )
@@ -109,7 +108,7 @@ func isContentRange(r *http.Request) bool {
 }
 
 func (s *svc) handlePathPut(w http.ResponseWriter, r *http.Request, ns string) {
-	ctx, span := rtrace.Provider.Tracer(tracerName).Start(r.Context(), "put")
+	ctx, span := s.tracerProvider.Tracer(tracerName).Start(r.Context(), "put")
 	defer span.End()
 
 	fn := path.Join(ns, r.URL.Path)
@@ -344,7 +343,7 @@ func (s *svc) handlePut(ctx context.Context, w http.ResponseWriter, r *http.Requ
 }
 
 func (s *svc) handleSpacesPut(w http.ResponseWriter, r *http.Request, spaceID string) {
-	ctx, span := rtrace.Provider.Tracer(tracerName).Start(r.Context(), "spaces_put")
+	ctx, span := s.tracerProvider.Tracer(tracerName).Start(r.Context(), "spaces_put")
 	defer span.End()
 
 	sublog := appctx.GetLogger(ctx).With().Str("spaceid", spaceID).Str("path", r.URL.Path).Logger()

--- a/internal/http/services/owncloud/ocdav/trashbin.go
+++ b/internal/http/services/owncloud/ocdav/trashbin.go
@@ -35,7 +35,6 @@ import (
 	"github.com/cs3org/reva/v2/internal/http/services/owncloud/ocdav/propfind"
 	"github.com/cs3org/reva/v2/internal/http/services/owncloud/ocdav/spacelookup"
 	"github.com/cs3org/reva/v2/pkg/storagespace"
-	rtrace "github.com/cs3org/reva/v2/pkg/trace"
 
 	rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
@@ -177,7 +176,7 @@ func (h *TrashbinHandler) Handler(s *svc) http.Handler {
 }
 
 func (h *TrashbinHandler) listTrashbin(w http.ResponseWriter, r *http.Request, s *svc, ref *provider.Reference, refBase, key, itemPath string) {
-	ctx, span := rtrace.Provider.Tracer(tracerName).Start(r.Context(), "list_trashbin")
+	ctx, span := s.tracerProvider.Tracer(tracerName).Start(r.Context(), "list_trashbin")
 	defer span.End()
 
 	sublog := appctx.GetLogger(ctx).With().Logger()
@@ -453,7 +452,7 @@ func (h *TrashbinHandler) itemToPropResponse(ctx context.Context, s *svc, spaceI
 }
 
 func (h *TrashbinHandler) restore(w http.ResponseWriter, r *http.Request, s *svc, ref, dst *provider.Reference, key, itemPath string) {
-	ctx, span := rtrace.Provider.Tracer(tracerName).Start(r.Context(), "restore")
+	ctx, span := s.tracerProvider.Tracer(tracerName).Start(r.Context(), "restore")
 	defer span.End()
 
 	sublog := appctx.GetLogger(ctx).With().Logger()
@@ -581,7 +580,7 @@ func (h *TrashbinHandler) restore(w http.ResponseWriter, r *http.Request, s *svc
 
 // delete has only a key
 func (h *TrashbinHandler) delete(w http.ResponseWriter, r *http.Request, s *svc, ref *provider.Reference, key, itemPath string) {
-	ctx, span := rtrace.Provider.Tracer(tracerName).Start(r.Context(), "erase")
+	ctx, span := s.tracerProvider.Tracer(tracerName).Start(r.Context(), "erase")
 	defer span.End()
 
 	sublog := appctx.GetLogger(ctx).With().Interface("reference", ref).Str("key", key).Str("item_path", itemPath).Logger()

--- a/internal/http/services/owncloud/ocdav/tus.go
+++ b/internal/http/services/owncloud/ocdav/tus.go
@@ -38,14 +38,13 @@ import (
 	"github.com/cs3org/reva/v2/pkg/appctx"
 	"github.com/cs3org/reva/v2/pkg/rhttp"
 	"github.com/cs3org/reva/v2/pkg/storagespace"
-	rtrace "github.com/cs3org/reva/v2/pkg/trace"
 	"github.com/cs3org/reva/v2/pkg/utils"
 	"github.com/rs/zerolog"
 	tusd "github.com/tus/tusd/pkg/handler"
 )
 
 func (s *svc) handlePathTusPost(w http.ResponseWriter, r *http.Request, ns string) {
-	ctx, span := rtrace.Provider.Tracer(tracerName).Start(r.Context(), "tus-post")
+	ctx, span := s.tracerProvider.Tracer(tracerName).Start(r.Context(), "tus-post")
 	defer span.End()
 
 	// read filename from metadata
@@ -71,7 +70,7 @@ func (s *svc) handlePathTusPost(w http.ResponseWriter, r *http.Request, ns strin
 }
 
 func (s *svc) handleSpacesTusPost(w http.ResponseWriter, r *http.Request, spaceID string) {
-	ctx, span := rtrace.Provider.Tracer(tracerName).Start(r.Context(), "spaces-tus-post")
+	ctx, span := s.tracerProvider.Tracer(tracerName).Start(r.Context(), "spaces-tus-post")
 	defer span.End()
 
 	// read filename from metadata

--- a/internal/http/services/owncloud/ocdav/versions.go
+++ b/internal/http/services/owncloud/ocdav/versions.go
@@ -27,7 +27,6 @@ import (
 	"github.com/cs3org/reva/v2/internal/http/services/owncloud/ocdav/net"
 	"github.com/cs3org/reva/v2/internal/http/services/owncloud/ocdav/propfind"
 	"github.com/cs3org/reva/v2/pkg/storagespace"
-	rtrace "github.com/cs3org/reva/v2/pkg/trace"
 	"github.com/cs3org/reva/v2/pkg/utils"
 
 	rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
@@ -109,7 +108,7 @@ func (h *VersionsHandler) Handler(s *svc, rid *provider.ResourceId) http.Handler
 }
 
 func (h *VersionsHandler) doListVersions(w http.ResponseWriter, r *http.Request, s *svc, rid *provider.ResourceId) {
-	ctx, span := rtrace.Provider.Tracer(tracerName).Start(r.Context(), "listVersions")
+	ctx, span := s.tracerProvider.Tracer(tracerName).Start(r.Context(), "listVersions")
 	defer span.End()
 
 	sublog := appctx.GetLogger(ctx).With().Interface("resourceid", rid).Logger()
@@ -208,7 +207,7 @@ func (h *VersionsHandler) doListVersions(w http.ResponseWriter, r *http.Request,
 }
 
 func (h *VersionsHandler) doRestore(w http.ResponseWriter, r *http.Request, s *svc, rid *provider.ResourceId, key string) {
-	ctx, span := rtrace.Provider.Tracer(tracerName).Start(r.Context(), "restore")
+	ctx, span := s.tracerProvider.Tracer(tracerName).Start(r.Context(), "restore")
 	defer span.End()
 
 	sublog := appctx.GetLogger(ctx).With().Interface("resourceid", rid).Str("key", key).Logger()

--- a/pkg/appctx/appctx.go
+++ b/pkg/appctx/appctx.go
@@ -21,7 +21,9 @@ package appctx
 import (
 	"context"
 
+	rtrace "github.com/cs3org/reva/v2/pkg/trace"
 	"github.com/rs/zerolog"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // DeletingSharedResource flags to a storage a shared resource is being deleted not by the owner.
@@ -36,4 +38,16 @@ func WithLogger(ctx context.Context, l *zerolog.Logger) context.Context {
 // or a disabled logger in case no logger is stored inside the context.
 func GetLogger(ctx context.Context) *zerolog.Logger {
 	return zerolog.Ctx(ctx)
+}
+
+// WithTracerProvider returns a context with an associated TracerProvider
+func WithTracerProvider(ctx context.Context, p trace.TracerProvider) context.Context {
+	return rtrace.ContextSetTracerProvider(ctx, p)
+}
+
+// GetTracerProvider returns the TracerProvider associated with
+// the given context. (Or the global default TracerProvider if there
+// is no TracerProvider in the context)
+func GetTracerProvider(ctx context.Context) trace.TracerProvider {
+	return rtrace.ContextGetTracerProvider(ctx)
 }

--- a/pkg/rgrpc/todo/pool/pool.go
+++ b/pkg/rgrpc/todo/pool/pool.go
@@ -96,7 +96,7 @@ func NewConn(endpoint string) (*grpc.ClientConn, error) {
 		),
 		grpc.WithStreamInterceptor(otelgrpc.StreamClientInterceptor(
 			otelgrpc.WithTracerProvider(
-				rtrace.Provider,
+				rtrace.DefaultProvider(),
 			),
 			otelgrpc.WithPropagators(
 				rtrace.Propagator,
@@ -105,7 +105,7 @@ func NewConn(endpoint string) (*grpc.ClientConn, error) {
 		grpc.WithUnaryInterceptor(
 			otelgrpc.UnaryClientInterceptor(
 				otelgrpc.WithTracerProvider(
-					rtrace.Provider,
+					rtrace.DefaultProvider(),
 				),
 				otelgrpc.WithPropagators(
 					rtrace.Propagator,

--- a/pkg/storage/utils/decomposedfs/decomposedfs.go
+++ b/pkg/storage/utils/decomposedfs/decomposedfs.go
@@ -50,7 +50,6 @@ import (
 	"github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/tree"
 	"github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/xattrs"
 	"github.com/cs3org/reva/v2/pkg/storage/utils/templates"
-	rtrace "github.com/cs3org/reva/v2/pkg/trace"
 	"github.com/cs3org/reva/v2/pkg/utils"
 	"github.com/pkg/errors"
 	"go.opentelemetry.io/otel/codes"
@@ -347,7 +346,7 @@ func (fs *Decomposedfs) TouchFile(ctx context.Context, ref *provider.Reference) 
 // To mimic the eos and owncloud driver we only allow references as children of the "/Shares" folder
 // FIXME: This comment should explain briefly what a reference is in this context.
 func (fs *Decomposedfs) CreateReference(ctx context.Context, p string, targetURI *url.URL) (err error) {
-	ctx, span := rtrace.DefaultProvider().Tracer("reva").Start(ctx, "CreateReference")
+	ctx, span := appctx.GetTracerProvider(ctx).Tracer("reva").Start(ctx, "CreateReference")
 	defer span.End()
 
 	p = strings.Trim(p, "/")
@@ -496,7 +495,7 @@ func (fs *Decomposedfs) ListFolder(ctx context.Context, ref *provider.Reference,
 		return
 	}
 
-	ctx, span := rtrace.DefaultProvider().Tracer(tracerName).Start(ctx, "ListFolder")
+	ctx, span := appctx.GetTracerProvider(ctx).Tracer(tracerName).Start(ctx, "ListFolder")
 	defer span.End()
 
 	if !n.Exists {

--- a/pkg/storage/utils/decomposedfs/decomposedfs.go
+++ b/pkg/storage/utils/decomposedfs/decomposedfs.go
@@ -347,7 +347,7 @@ func (fs *Decomposedfs) TouchFile(ctx context.Context, ref *provider.Reference) 
 // To mimic the eos and owncloud driver we only allow references as children of the "/Shares" folder
 // FIXME: This comment should explain briefly what a reference is in this context.
 func (fs *Decomposedfs) CreateReference(ctx context.Context, p string, targetURI *url.URL) (err error) {
-	ctx, span := rtrace.Provider.Tracer("reva").Start(ctx, "CreateReference")
+	ctx, span := rtrace.DefaultProvider().Tracer("reva").Start(ctx, "CreateReference")
 	defer span.End()
 
 	p = strings.Trim(p, "/")
@@ -496,7 +496,7 @@ func (fs *Decomposedfs) ListFolder(ctx context.Context, ref *provider.Reference,
 		return
 	}
 
-	ctx, span := rtrace.Provider.Tracer(tracerName).Start(ctx, "ListFolder")
+	ctx, span := rtrace.DefaultProvider().Tracer(tracerName).Start(ctx, "ListFolder")
 	defer span.End()
 
 	if !n.Exists {

--- a/pkg/trace/trace.go
+++ b/pkg/trace/trace.go
@@ -19,6 +19,7 @@
 package trace
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"os"
@@ -45,6 +46,28 @@ type revaDefaultTracerProvider struct {
 	mutex       sync.RWMutex
 	initialized bool
 	provider    trace.TracerProvider
+}
+
+type ctxKey struct{}
+
+// ContextSetTracerProvider returns a copy of ctx with p associated.
+func ContextSetTracerProvider(ctx context.Context, p trace.TracerProvider) context.Context {
+	if tp, ok := ctx.Value(ctxKey{}).(trace.TracerProvider); ok {
+		if tp == p {
+			return ctx
+		}
+	}
+	return context.WithValue(ctx, ctxKey{}, p)
+}
+
+// ContextGetTracerProvider returns the TracerProvider associated with the ctx.
+// If no TracerProvider is associated is associated, the global default TracerProvider
+// is returned
+func ContextGetTracerProvider(ctx context.Context) trace.TracerProvider {
+	if p, ok := ctx.Value(ctxKey{}).(trace.TracerProvider); ok {
+		return p
+	}
+	return DefaultProvider()
 }
 
 // InitDefaultTracerProvider initializes a global default TracerProvider at a package level.


### PR DESCRIPTION
Create separate TracerProviders per service to improve tracing when
running multiple services in a single process (like e.g. ocis does).
Previously all service were referring to the same package-level
TracerProvider (which, among other things, caused the services to
overwrite each others services names).

We still create a "global" TracerProvider to cover the cases where
we don't have access to the per service Provider yet. This will be
improved in a follow up change.