### PR TITLE
return early on ocdav move requests with body

### DIFF
--- a/changelog/unreleased/ocdav-move-body.md
+++ b/changelog/unreleased/ocdav-move-body.md
@@ -1,0 +1,6 @@
+Enhancement: Explicitly return on ocdav move requests with body
+
+Added a check if a ocdav move request contains a body. If it does a 415 415 (Unsupported Media Type) will be returned.
+
+https://github.com/owncloud/ocis/issues/3882
+https://github.com/cs3org/reva/pull/2974

--- a/internal/http/services/owncloud/ocdav/move.go
+++ b/internal/http/services/owncloud/ocdav/move.go
@@ -41,6 +41,11 @@ func (s *svc) handlePathMove(w http.ResponseWriter, r *http.Request, ns string) 
 	ctx, span := rtrace.Provider.Tracer(tracerName).Start(r.Context(), "move")
 	defer span.End()
 
+	if r.Body != http.NoBody {
+		w.WriteHeader(http.StatusUnsupportedMediaType)
+		return
+	}
+
 	srcPath := path.Join(ns, r.URL.Path)
 	dh := r.Header.Get(net.HeaderDestination)
 	baseURI := r.Context().Value(net.CtxKeyBaseURI).(string)
@@ -94,6 +99,11 @@ func (s *svc) handlePathMove(w http.ResponseWriter, r *http.Request, ns string) 
 func (s *svc) handleSpacesMove(w http.ResponseWriter, r *http.Request, srcSpaceID string) {
 	ctx, span := rtrace.Provider.Tracer(tracerName).Start(r.Context(), "spaces_move")
 	defer span.End()
+
+	if r.Body != http.NoBody {
+		w.WriteHeader(http.StatusUnsupportedMediaType)
+		return
+	}
 
 	dh := r.Header.Get(net.HeaderDestination)
 	baseURI := r.Context().Value(net.CtxKeyBaseURI).(string)


### PR DESCRIPTION
 Added a check if a ocdav move request contains a body. If it does a 415 415 (Unsupported Media Type) will be returned.

https://datatracker.ietf.org/doc/html/rfc4918#section-8.4