### PR TITLE
Use email as display name for external users opening WOPI apps

### DIFF
--- a/changelog/unreleased/wopi-ext-users.md
+++ b/changelog/unreleased/wopi-ext-users.md
@@ -1,0 +1,7 @@
+Enhancement: use email as display name for external users opening WOPI apps
+
+We use now the email claim for external/federated accounts as the
+`username` that is then passed to the wopiserver and used as
+`displayName` in the WOPI context.
+
+https://github.com/cs3org/reva/pull/2986

--- a/pkg/app/provider/wopi/wopi.go
+++ b/pkg/app/provider/wopi/wopi.go
@@ -147,11 +147,6 @@ func (p *wopiProvider) GetAppURL(ctx context.Context, resource *provider.Resourc
 
 	u, ok := ctxpkg.ContextGetUser(ctx)
 	if ok { // else defaults to "Guest xyz"
-		if u.Id.Type == userpb.UserType_USER_TYPE_LIGHTWEIGHT || u.Id.Type == userpb.UserType_USER_TYPE_FEDERATED {
-			q.Add("userid", resource.Owner.OpaqueId+"@"+resource.Owner.Idp)
-		} else {
-			q.Add("userid", u.Id.OpaqueId+"@"+u.Id.Idp)
-		}
 		var isPublicShare bool
 		if u.Opaque != nil {
 			if _, ok := u.Opaque.Map["public-share-role"]; ok {
@@ -159,8 +154,17 @@ func (p *wopiProvider) GetAppURL(ctx context.Context, resource *provider.Resourc
 			}
 		}
 
-		if !isPublicShare {
-			q.Add("username", u.Username)
+		if u.Id.Type == userpb.UserType_USER_TYPE_LIGHTWEIGHT || u.Id.Type == userpb.UserType_USER_TYPE_FEDERATED {
+			q.Add("userid", resource.Owner.OpaqueId+"@"+resource.Owner.Idp)
+			if !isPublicShare {
+				// for visual display, federated/external accounts are shown with their email but act on behalf of the owner
+				q.Add("username", u.Mail)
+			}
+		} else {
+			q.Add("userid", u.Id.OpaqueId+"@"+u.Id.Idp)
+			if !isPublicShare {
+				q.Add("username", u.Username)
+			}
 		}
 	}
 


### PR DESCRIPTION
This mini PR sets the `username` passed over to the wopiserver also for external/federated accounts. This is then used as a `displayName` in WOPI.