### PR TITLE
let archiver handle all error codes

### DIFF
--- a/changelog/unreleased/archiver-error-handling.md
+++ b/changelog/unreleased/archiver-error-handling.md
@@ -1,0 +1,5 @@
+Bugfix: let archiver handle all error codes
+
+We fixed the archiver handler to handle all error codes
+
+https://github.com/cs3org/reva/pull/2987

--- a/internal/http/services/archiver/handler.go
+++ b/internal/http/services/archiver/handler.go
@@ -201,7 +201,7 @@ func (s *svc) writeHTTPError(rw http.ResponseWriter, err error) {
 	s.log.Error().Msg(err.Error())
 
 	switch err.(type) {
-	case errtypes.NotFound:
+	case errtypes.NotFound, errtypes.PermissionDenied:
 		rw.WriteHeader(http.StatusNotFound)
 	case manager.ErrMaxSize, manager.ErrMaxFileCount:
 		rw.WriteHeader(http.StatusRequestEntityTooLarge)

--- a/pkg/storage/utils/walker/walker.go
+++ b/pkg/storage/utils/walker/walker.go
@@ -20,7 +20,6 @@ package walker
 
 import (
 	"context"
-	"fmt"
 	"path/filepath"
 
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
@@ -101,10 +100,8 @@ func (r *revaWalker) readDir(ctx context.Context, id *provider.ResourceId) ([]*p
 	switch {
 	case err != nil:
 		return nil, err
-	case resp.Status.Code == rpc.Code_CODE_NOT_FOUND:
-		return nil, errtypes.NotFound(id.String())
 	case resp.Status.Code != rpc.Code_CODE_OK:
-		return nil, errtypes.InternalError(fmt.Sprintf("error listing container %+v", id))
+		return nil, errtypes.NewErrtypeFromStatus(resp.Status)
 	}
 
 	return resp.Infos, nil
@@ -116,10 +113,8 @@ func (r *revaWalker) stat(ctx context.Context, id *provider.ResourceId) (*provid
 	switch {
 	case err != nil:
 		return nil, err
-	case resp.Status.Code == rpc.Code_CODE_NOT_FOUND:
-		return nil, errtypes.NotFound(id.String())
 	case resp.Status.Code != rpc.Code_CODE_OK:
-		return nil, errtypes.InternalError(fmt.Sprintf("error stating %+v", id))
+		return nil, errtypes.NewErrtypeFromStatus(resp.Status)
 	}
 
 	return resp.Info, nil


### PR DESCRIPTION
We fixed the archiver handler to handle all error codes

found during [CI run](https://drone.owncloud.com/owncloud/ocis/12580/39/7) for https://github.com/owncloud/ocis/pull/3982