### PR TITLE
remove unused configuration

### DIFF
--- a/changelog/unreleased/fix-remove-unused-config.md
+++ b/changelog/unreleased/fix-remove-unused-config.md
@@ -1,0 +1,8 @@
+Bugfix: Remove unused configuration
+
+We've fixed removed unused configuration:
+
+- `insecure` from the dataprovider
+- `tmp_folder` from the storageprovider
+
+https://github.com/cs3org/reva/pull/2993

--- a/changelog/unreleased/fix-remove-unused-config.md
+++ b/changelog/unreleased/fix-remove-unused-config.md
@@ -3,6 +3,7 @@ Bugfix: Remove unused configuration
 We've fixed removed unused configuration:
 
 - `insecure` from the dataprovider
+- `timeout` from the dataprovider
 - `tmp_folder` from the storageprovider
 
 https://github.com/cs3org/reva/pull/2993

--- a/internal/grpc/services/storageprovider/storageprovider.go
+++ b/internal/grpc/services/storageprovider/storageprovider.go
@@ -60,7 +60,6 @@ func init() {
 type config struct {
 	Driver              string                            `mapstructure:"driver" docs:"localhome;The storage driver to be used."`
 	Drivers             map[string]map[string]interface{} `mapstructure:"drivers" docs:"url:pkg/storage/fs/localhome/localhome.go"`
-	TmpFolder           string                            `mapstructure:"tmp_folder" docs:"/var/tmp;Path to temporary folder."`
 	DataServerURL       string                            `mapstructure:"data_server_url" docs:"http://localhost/data;The URL for the data server."`
 	ExposeDataServer    bool                              `mapstructure:"expose_data_server" docs:"false;Whether to expose data server."` // if true the client will be able to upload/download directly to it
 	AvailableXS         map[string]uint32                 `mapstructure:"available_checksums" docs:"nil;List of available checksums."`
@@ -71,10 +70,6 @@ type config struct {
 func (c *config) init() {
 	if c.Driver == "" {
 		c.Driver = "localhome"
-	}
-
-	if c.TmpFolder == "" {
-		c.TmpFolder = "/var/tmp/reva/tmp"
 	}
 
 	if c.DataServerURL == "" {
@@ -95,7 +90,6 @@ func (c *config) init() {
 type service struct {
 	conf          *config
 	storage       storage.FS
-	tmpFolder     string
 	dataServerURL *url.URL
 	availableXS   []*provider.ResourceChecksumPriority
 }
@@ -164,10 +158,6 @@ func New(m map[string]interface{}, ss *grpc.Server) (rgrpc.Service, error) {
 
 	c.init()
 
-	if err := os.MkdirAll(c.TmpFolder, 0755); err != nil {
-		return nil, err
-	}
-
 	fs, err := getFS(c)
 	if err != nil {
 		return nil, err
@@ -198,7 +188,6 @@ func New(m map[string]interface{}, ss *grpc.Server) (rgrpc.Service, error) {
 	service := &service{
 		conf:          c,
 		storage:       fs,
-		tmpFolder:     c.TmpFolder,
 		dataServerURL: u,
 		availableXS:   xsTypes,
 	}

--- a/internal/http/services/dataprovider/dataprovider.go
+++ b/internal/http/services/dataprovider/dataprovider.go
@@ -45,7 +45,6 @@ type config struct {
 	Drivers       map[string]map[string]interface{} `mapstructure:"drivers" docs:"url:pkg/storage/fs/localhome/localhome.go;The configuration for the storage driver"`
 	DataTXs       map[string]map[string]interface{} `mapstructure:"data_txs" docs:"url:pkg/rhttp/datatx/manager/simple/simple.go;The configuration for the data tx protocols"`
 	Timeout       int64                             `mapstructure:"timeout"`
-	Insecure      bool                              `mapstructure:"insecure"`
 	NatsAddress   string                            `mapstructure:"nats_address"`
 	NatsClusterID string                            `mapstructure:"nats_clusterID"`
 }

--- a/internal/http/services/dataprovider/dataprovider.go
+++ b/internal/http/services/dataprovider/dataprovider.go
@@ -44,7 +44,6 @@ type config struct {
 	Driver        string                            `mapstructure:"driver" docs:"localhome;The storage driver to be used."`
 	Drivers       map[string]map[string]interface{} `mapstructure:"drivers" docs:"url:pkg/storage/fs/localhome/localhome.go;The configuration for the storage driver"`
 	DataTXs       map[string]map[string]interface{} `mapstructure:"data_txs" docs:"url:pkg/rhttp/datatx/manager/simple/simple.go;The configuration for the data tx protocols"`
-	Timeout       int64                             `mapstructure:"timeout"`
 	NatsAddress   string                            `mapstructure:"nats_address"`
 	NatsClusterID string                            `mapstructure:"nats_clusterID"`
 }


### PR DESCRIPTION
Bugfix: Remove unused configuration

We've fixed removed unused configuration:

- `insecure` from the dataprovider
- `tmp_folder` from the storageprovider
