### PR TITLE
Fix loading shares

### DIFF
--- a/changelog/unreleased/fix-loading-shares.md
+++ b/changelog/unreleased/fix-loading-shares.md
@@ -1,0 +1,5 @@
+Bugfix: Fix errors when loading shares
+
+We fixed a bug where loading shares and associated received shares ran into issues when handling them simultaneously.
+
+https://github.com/cs3org/reva/pull/2994

--- a/pkg/storage/utils/decomposedfs/decomposedfs.go
+++ b/pkg/storage/utils/decomposedfs/decomposedfs.go
@@ -315,7 +315,7 @@ func (fs *Decomposedfs) CreateDir(ctx context.Context, ref *provider.Reference) 
 		return
 	}
 	if n.Exists {
-		return errtypes.AlreadyExists(parentRef.Path)
+		return errtypes.AlreadyExists(ref.Path)
 	}
 
 	if err = fs.tp.CreateDir(ctx, n); err != nil {


### PR DESCRIPTION
This PR makes sure to only load one share/received share at a time. This prevents issues when a share and a received share referencing the same share are imported simultaneously.
