### PR TITLE
Do not close share dump channels

### DIFF
--- a/changelog/unreleased/fix-loading-shares2.md
+++ b/changelog/unreleased/fix-loading-shares2.md
@@ -1,0 +1,5 @@
+Bugfix: Do not close share dump channels
+
+We no longer close the channels when dumping shares, it's the responsibility of the caller.
+
+https://github.com/cs3org/reva/pull/2996

--- a/pkg/share/manager/json/json.go
+++ b/pkg/share/manager/json/json.go
@@ -241,9 +241,6 @@ func (m *mgr) Dump(ctx context.Context, shareChan chan<- *collaboration.Share, r
 		}
 	}
 
-	close(shareChan)
-	close(receivedShareChan)
-
 	return nil
 }
 

--- a/pkg/share/manager/json/json_test.go
+++ b/pkg/share/manager/json/json_test.go
@@ -128,9 +128,9 @@ var _ = Describe("Json", func() {
 			}()
 			err := m.(share.DumpableManager).Dump(ctx, sharesChan, receivedChan)
 			Expect(err).ToNot(HaveOccurred())
+			close(sharesChan)
+			close(receivedChan)
 			wg.Wait()
-			Eventually(sharesChan).Should(BeClosed())
-			Eventually(receivedChan).Should(BeClosed())
 
 			Expect(len(shares)).To(Equal(1))
 			Expect(shares[0].Creator).To(Equal(user1.Id))
@@ -157,14 +157,14 @@ var _ = Describe("Json", func() {
 						shares = append(shares, rs)
 					}
 				}
+
 				wg.Done()
 			}()
 			err := m.(share.DumpableManager).Dump(ctx, sharesChan, receivedChan)
 			Expect(err).ToNot(HaveOccurred())
+			close(sharesChan)
+			close(receivedChan)
 			wg.Wait()
-
-			Eventually(sharesChan).Should(BeClosed())
-			Eventually(receivedChan).Should(BeClosed())
 
 			Expect(len(shares)).To(Equal(1))
 			Expect(shares[0].UserID).To(Equal(user2.Id))


### PR DESCRIPTION
We no longer close the channels when dumping shares, it's the responsibility of the caller.