### PR TITLE
Fix 0 byte uploads

### DIFF
--- a/changelog/unreleased/fix-0-byte-uploads.md
+++ b/changelog/unreleased/fix-0-byte-uploads.md
@@ -1,0 +1,5 @@
+Bugfix: Fix 0-byte-uploads
+
+We fixed a problem with 0-byte uploads by using TouchFile instead of going through TUS (decomposedfs and owncloudsql storage drivers only for now).
+
+https://github.com/cs3org/reva/pull/2998

--- a/internal/grpc/interceptors/eventsmiddleware/conversion.go
+++ b/internal/grpc/interceptors/eventsmiddleware/conversion.go
@@ -165,6 +165,14 @@ func LinkRemoved(r *link.RemovePublicShareResponse, req *link.RemovePublicShareR
 	}
 }
 
+// FileTouched converts the response to an event
+func FileTouched(r *provider.TouchFileResponse, req *provider.TouchFileRequest, executant *user.UserId) events.FileTouched {
+	return events.FileTouched{
+		Executant: executant,
+		Ref:       req.Ref,
+	}
+}
+
 // FileUploaded converts the response to an event
 func FileUploaded(r *provider.InitiateFileUploadResponse, req *provider.InitiateFileUploadRequest, executant *user.UserId) events.FileUploaded {
 	return events.FileUploaded{

--- a/internal/grpc/interceptors/eventsmiddleware/events.go
+++ b/internal/grpc/interceptors/eventsmiddleware/events.go
@@ -156,6 +156,10 @@ func NewUnary(m map[string]interface{}) (grpc.UnaryServerInterceptor, int, error
 					ev = SpaceDisabled(v, r, executantID)
 				}
 			}
+		case *provider.TouchFileResponse:
+			if isSuccess(v) {
+				ev = FileTouched(v, req.(*provider.TouchFileRequest), executantID)
+			}
 		}
 
 		if ev != nil {

--- a/internal/grpc/services/gateway/storageprovider.go
+++ b/internal/grpc/services/gateway/storageprovider.go
@@ -626,7 +626,9 @@ func (s *svc) CreateContainer(ctx context.Context, req *provider.CreateContainer
 }
 
 func (s *svc) TouchFile(ctx context.Context, req *provider.TouchFileRequest) (*provider.TouchFileResponse, error) {
-	c, _, err := s.find(ctx, req.Ref)
+	var c provider.ProviderAPIClient
+	var err error
+	c, _, req.Ref, err = s.findAndUnwrap(ctx, req.Ref)
 	if err != nil {
 		return &provider.TouchFileResponse{
 			Status: status.NewStatusFromErrType(ctx, "TouchFile ref="+req.Ref.String(), err),

--- a/pkg/events/files.go
+++ b/pkg/events/files.go
@@ -53,6 +53,19 @@ func (FileUploaded) Unmarshal(v []byte) (interface{}, error) {
 	return e, err
 }
 
+// FileTouched is emitted when a file is uploaded
+type FileTouched struct {
+	Executant *user.UserId
+	Ref       *provider.Reference
+}
+
+// Unmarshal to fulfill umarshaller interface
+func (FileTouched) Unmarshal(v []byte) (interface{}, error) {
+	e := FileTouched{}
+	err := json.Unmarshal(v, &e)
+	return e, err
+}
+
 // FileDownloaded is emitted when a file is downloaded
 type FileDownloaded struct {
 	Executant *user.UserId

--- a/pkg/storage/utils/decomposedfs/mocks/Tree.go
+++ b/pkg/storage/utils/decomposedfs/mocks/Tree.go
@@ -265,6 +265,20 @@ func (_m *Tree) Setup() error {
 	return r0
 }
 
+// TouchFile provides a mock function with given fields: ctx, _a1
+func (_m *Tree) TouchFile(ctx context.Context, _a1 *node.Node) error {
+	ret := _m.Called(ctx, _a1)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, *node.Node) error); ok {
+		r0 = rf(ctx, _a1)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // WriteBlob provides a mock function with given fields: _a0, reader
 func (_m *Tree) WriteBlob(_a0 *node.Node, reader io.Reader) error {
 	ret := _m.Called(_a0, reader)

--- a/pkg/storage/utils/decomposedfs/tree/tree_test.go
+++ b/pkg/storage/utils/decomposedfs/tree/tree_test.go
@@ -233,6 +233,25 @@ var _ = Describe("Tree", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
+		Describe("TouchFile", func() {
+			It("creates a file inside", func() {
+				ref := &provider.Reference{
+					ResourceId: env.SpaceRootRes,
+					Path:       "emptydir/newFile",
+				}
+				fileToBeCreated, err := env.Lookup.NodeFromResource(env.Ctx, ref)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(fileToBeCreated.Exists).To(BeFalse())
+
+				err = t.TouchFile(env.Ctx, fileToBeCreated)
+				Expect(err).ToNot(HaveOccurred())
+
+				existingFile, err := env.Lookup.NodeFromResource(env.Ctx, ref)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(existingFile.Exists).To(BeTrue())
+			})
+		})
+
 		Context("that was deleted", func() {
 			var (
 				trashPath string


### PR DESCRIPTION
This PR fixes a problem with 0-byte uploads by using `TouchFile` instead of going through TUS (decomposedfs and owncloudsql storage drivers only for now).

Fixes https://github.com/owncloud/ocis/issues/3154