### PR TITLE
Preconditionfailed vs aborted

### DIFF
--- a/changelog/unreleased/preconditionfailed-vs-aborted.md
+++ b/changelog/unreleased/preconditionfailed-vs-aborted.md
@@ -1,0 +1,11 @@
+Enhancement: distinguish GRPC FAILED_PRECONDITION and ABORTED codes
+
+Webdav distinguishes between 412 precondition failed for if match errors for locks or etags, uses 405 Method Not Allowed when trying to MKCOL an already existing collection and 409 Conflict when intermediate collections are missing.
+
+The CS3 GRPC status codes are modeled after https://github.com/googleapis/googleapis/blob/master/google/rpc/code.proto. When trying to use the error codes to distinguish these cases on a storageprovider CreateDir call we can map ALREADY_EXISTS to 405, FAILED_PRECONDITION to 409 and ABORTED to 412.
+
+Unfortunately, we currently use and map FAILED_PRECONDITION to 412. I assume because the naming is very similar to PreconditionFailed. However the GRPC docs ar very clear that ABORTED should be used, specifically mentioning etas and locks.
+
+With this PR we internally clean up the usage in the decompesedfs and mapping in the ocdav handler.
+
+https://github.com/cs3org/reva/pull/3003

--- a/internal/grpc/services/storageprovider/storageprovider.go
+++ b/internal/grpc/services/storageprovider/storageprovider.go
@@ -327,7 +327,7 @@ func (s *service) InitiateFileUpload(ctx context.Context, req *provider.Initiate
 		case rpc.Code_CODE_OK:
 			if sRes.Info.Etag != ifMatch {
 				return &provider.InitiateFileUploadResponse{
-					Status: status.NewFailedPrecondition(ctx, errors.New("etag doesn't match"), "etag doesn't match"),
+					Status: status.NewAborted(ctx, errors.New("etag mismatch"), "etag mismatch"),
 				}, nil
 			}
 		case rpc.Code_CODE_NOT_FOUND:

--- a/internal/http/services/owncloud/ocdav/errors/error.go
+++ b/internal/http/services/owncloud/ocdav/errors/error.go
@@ -165,6 +165,11 @@ var (
 // and writes an appropriate http status
 func HandleErrorStatus(log *zerolog.Logger, w http.ResponseWriter, s *rpc.Status) {
 	hsc := status.HTTPStatusFromCode(s.Code)
+	if s.Code == rpc.Code_CODE_ABORTED {
+		// aborted is used for etag an lock mismatches, which translates to 412
+		// in case a real Conflict response is needed, the calling code needs to send the header
+		hsc = http.StatusPreconditionFailed
+	}
 	if hsc == http.StatusInternalServerError {
 		log.Error().Interface("status", s).Int("code", hsc).Msg(http.StatusText(hsc))
 	} else {

--- a/internal/http/services/owncloud/ocdav/locks.go
+++ b/internal/http/services/owncloud/ocdav/locks.go
@@ -484,7 +484,7 @@ func (s *svc) lockReference(ctx context.Context, w http.ResponseWriter, r *http.
 		//      this actually is a name based lock ... ugh
 		token, err = s.LockSystem.Create(ctx, now, ld)
 		if err != nil {
-			if _, ok := err.(errtypes.PreconditionFailed); ok {
+			if _, ok := err.(errtypes.Aborted); ok {
 				return http.StatusLocked, err
 			}
 			return http.StatusInternalServerError, err

--- a/internal/http/services/owncloud/ocdav/mkcol.go
+++ b/internal/http/services/owncloud/ocdav/mkcol.go
@@ -63,6 +63,8 @@ func (s *svc) handlePathMkcol(w http.ResponseWriter, r *http.Request, ns string)
 		// https://www.rfc-editor.org/rfc/rfc4918#section-9.3.1:
 		// 405 (Method Not Allowed) - MKCOL can only be executed on an unmapped URL.
 		return http.StatusMethodNotAllowed, fmt.Errorf("The resource you tried to create already exists")
+	case sr.Status.Code == rpc.Code_CODE_ABORTED:
+		return http.StatusPreconditionFailed, errtypes.NewErrtypeFromStatus(sr.Status)
 	case sr.Status.Code != rpc.Code_CODE_NOT_FOUND:
 		return rstatus.HTTPStatusFromCode(sr.Status.Code), errtypes.NewErrtypeFromStatus(sr.Status)
 	}
@@ -79,6 +81,8 @@ func (s *svc) handlePathMkcol(w http.ResponseWriter, r *http.Request, ns string)
 		// one or more intermediate collections have been created.  The server
 		// MUST NOT create those intermediate collections automatically.
 		return http.StatusConflict, fmt.Errorf("intermediate collection does not exist")
+	case rpcStatus.Code == rpc.Code_CODE_ABORTED:
+		return http.StatusPreconditionFailed, errtypes.NewErrtypeFromStatus(rpcStatus)
 	case rpcStatus.Code != rpc.Code_CODE_OK:
 		return rstatus.HTTPStatusFromCode(rpcStatus.Code), errtypes.NewErrtypeFromStatus(rpcStatus)
 	}
@@ -125,6 +129,8 @@ func (s *svc) handleMkcol(ctx context.Context, w http.ResponseWriter, r *http.Re
 		// one or more intermediate collections have been created.  The server
 		// MUST NOT create those intermediate collections automatically.
 		return http.StatusConflict, fmt.Errorf("intermediate collection does not exist")
+	case parentStatRes.Status.Code == rpc.Code_CODE_ABORTED:
+		return http.StatusPreconditionFailed, errtypes.NewErrtypeFromStatus(parentStatRes.Status)
 	case parentStatRes.Status.Code != rpc.Code_CODE_OK:
 		return rstatus.HTTPStatusFromCode(parentStatRes.Status.Code), errtypes.NewErrtypeFromStatus(parentStatRes.Status)
 	}
@@ -140,6 +146,8 @@ func (s *svc) handleMkcol(ctx context.Context, w http.ResponseWriter, r *http.Re
 		// https://www.rfc-editor.org/rfc/rfc4918#section-9.3.1:
 		// 405 (Method Not Allowed) - MKCOL can only be executed on an unmapped URL.
 		return http.StatusMethodNotAllowed, fmt.Errorf("The resource you tried to create already exists")
+	case statRes.Status.Code == rpc.Code_CODE_ABORTED:
+		return http.StatusPreconditionFailed, errtypes.NewErrtypeFromStatus(statRes.Status)
 	case statRes.Status.Code != rpc.Code_CODE_NOT_FOUND:
 		return rstatus.HTTPStatusFromCode(statRes.Status.Code), errtypes.NewErrtypeFromStatus(statRes.Status)
 	}

--- a/pkg/rgrpc/status/status.go
+++ b/pkg/rgrpc/status/status.go
@@ -86,6 +86,15 @@ func NewPermissionDenied(ctx context.Context, err error, msg string) *rpc.Status
 	}
 }
 
+// NewAborted returns a Status with ABORTED.
+func NewAborted(ctx context.Context, err error, msg string) *rpc.Status {
+	return &rpc.Status{
+		Code:    rpc.Code_CODE_ABORTED,
+		Message: msg,
+		Trace:   getTrace(ctx),
+	}
+}
+
 // NewFailedPrecondition returns a Status with FAILED_PRECONDITION.
 func NewFailedPrecondition(ctx context.Context, err error, msg string) *rpc.Status {
 	return &rpc.Status{
@@ -131,6 +140,10 @@ func NewInvalidArg(ctx context.Context, msg string) *rpc.Status {
 }
 
 // NewConflict returns a Status with Code_CODE_ABORTED.
+//
+// Deprecated: NewConflict exists for historical compatibility
+// and should not be used. To create a Status with code ABORTED,
+// use NewAborted.
 func NewConflict(ctx context.Context, err error, msg string) *rpc.Status {
 	return &rpc.Status{
 		Code:    rpc.Code_CODE_ABORTED,
@@ -155,7 +168,10 @@ func NewStatusFromErrType(ctx context.Context, msg string, err error) *rpc.Statu
 		return NewPermissionDenied(ctx, e, msg+": "+err.Error())
 	case errtypes.Locked:
 		// FIXME a locked error returns the current lockid
+		// FIXME use NewAborted as per the rpc code docs
 		return NewPermissionDenied(ctx, e, msg+": "+err.Error())
+	case errtypes.Aborted:
+		return NewAborted(ctx, e, msg+": "+err.Error())
 	case errtypes.PreconditionFailed:
 		return NewFailedPrecondition(ctx, e, msg+": "+err.Error())
 	case errtypes.IsNotSupported:

--- a/pkg/rhttp/datatx/manager/simple/simple.go
+++ b/pkg/rhttp/datatx/manager/simple/simple.go
@@ -101,7 +101,7 @@ func (m *manager) Handler(fs storage.FS) (http.Handler, error) {
 				w.WriteHeader(http.StatusUnauthorized)
 			case errtypes.InsufficientStorage:
 				w.WriteHeader(http.StatusInsufficientStorage)
-			case errtypes.PreconditionFailed:
+			case errtypes.PreconditionFailed, errtypes.Aborted:
 				w.WriteHeader(http.StatusPreconditionFailed)
 			default:
 				sublog.Error().Err(v).Msg("error uploading file")

--- a/pkg/rhttp/datatx/manager/spaces/spaces.go
+++ b/pkg/rhttp/datatx/manager/spaces/spaces.go
@@ -112,7 +112,7 @@ func (m *manager) Handler(fs storage.FS) (http.Handler, error) {
 				w.WriteHeader(http.StatusUnauthorized)
 			case errtypes.InsufficientStorage:
 				w.WriteHeader(http.StatusInsufficientStorage)
-			case errtypes.PreconditionFailed:
+			case errtypes.PreconditionFailed, errtypes.Aborted:
 				w.WriteHeader(http.StatusPreconditionFailed)
 			default:
 				sublog.Error().Err(v).Msg("error uploading file")

--- a/pkg/storage/utils/decomposedfs/node/locks.go
+++ b/pkg/storage/utils/decomposedfs/node/locks.go
@@ -67,7 +67,7 @@ func (n *Node) SetLock(ctx context.Context, lock *provider.Lock) error {
 		// file not locked, continue
 	case nil:
 		if l != nil {
-			return errtypes.PreconditionFailed("already locked")
+			return errtypes.Aborted("already locked")
 		}
 	default:
 		return errors.Wrap(err, "Decomposedfs: could check if file already is locked")
@@ -165,7 +165,7 @@ func (n *Node) RefreshLock(ctx context.Context, lock *provider.Lock) error {
 	f, err := os.OpenFile(n.LockFilePath(), os.O_RDWR, os.ModeExclusive)
 	switch {
 	case errors.Is(err, fs.ErrNotExist):
-		return errtypes.PreconditionFailed("lock does not exist")
+		return errtypes.Aborted("lock does not exist")
 	case err != nil:
 		return errors.Wrap(err, "Decomposedfs: could not open lock file")
 	}
@@ -178,7 +178,7 @@ func (n *Node) RefreshLock(ctx context.Context, lock *provider.Lock) error {
 
 	// check lock
 	if oldLock.LockId != lock.LockId {
-		return errtypes.PreconditionFailed("mismatching lock")
+		return errtypes.Aborted("mismatching lock")
 	}
 
 	if ok, err := isLockModificationAllowed(ctx, oldLock, lock); !ok {
@@ -217,7 +217,7 @@ func (n *Node) Unlock(ctx context.Context, lock *provider.Lock) error {
 	f, err := os.OpenFile(n.LockFilePath(), os.O_RDONLY, os.ModeExclusive)
 	switch {
 	case errors.Is(err, fs.ErrNotExist):
-		return errtypes.PreconditionFailed("lock does not exist")
+		return errtypes.Aborted("lock does not exist")
 	case err != nil:
 		return errors.Wrap(err, "Decomposedfs: could not open lock file")
 	}
@@ -254,11 +254,11 @@ func (n *Node) CheckLock(ctx context.Context) error {
 		case lock.LockId:
 			return nil // ok
 		default:
-			return errtypes.PreconditionFailed("mismatching lock")
+			return errtypes.Aborted("mismatching lock")
 		}
 	}
 	if lockID != "" {
-		return errtypes.PreconditionFailed("not locked")
+		return errtypes.Aborted("not locked")
 	}
 	return nil // ok
 }

--- a/pkg/storage/utils/decomposedfs/node/locks_test.go
+++ b/pkg/storage/utils/decomposedfs/node/locks_test.go
@@ -109,7 +109,7 @@ var _ = Describe("Node locks", func() {
 
 			err = n.SetLock(env.Ctx, lockByUser)
 			Expect(err).To(HaveOccurred())
-			_, ok := err.(errtypes.PreconditionFailed)
+			_, ok := err.(errtypes.Aborted)
 			Expect(ok).To(BeTrue())
 		})
 	})
@@ -132,7 +132,7 @@ var _ = Describe("Node locks", func() {
 
 			err = n.SetLock(env.Ctx, lockByApp)
 			Expect(err).To(HaveOccurred())
-			_, ok := err.(errtypes.PreconditionFailed)
+			_, ok := err.(errtypes.Aborted)
 			Expect(ok).To(BeTrue())
 		})
 

--- a/pkg/storage/utils/decomposedfs/upload.go
+++ b/pkg/storage/utils/decomposedfs/upload.go
@@ -584,7 +584,7 @@ func (upload *fileUpload) FinishUpload(ctx context.Context) (err error) {
 				return errtypes.InternalError(err.Error())
 			}
 			if ifMatch != targetEtag {
-				return errtypes.PreconditionFailed("etag doesn't match")
+				return errtypes.Aborted("etag mismatch")
 			}
 		}
 


### PR DESCRIPTION
Webdav distinguishes between 412 precondition failed for if match errors for locks or etags, uses 405 Method Not Allowed when trying to MKCOL an already existing collection and 409 Conflict when intermediate collections are missing.

The CS3 GRPC status codes are modeled after https://github.com/googleapis/googleapis/blob/master/google/rpc/code.proto. When trying to use the error codes to distinguish these cases on a storageprovider CreateDir call we can map ALREADY_EXISTS to 405, FAILED_PRECONDITION to 409 and ABORTED to 412.

Unfortunately, we currently use and map FAILED_PRECONDITION to 412. I assume because the naming is very similar to PreconditionFailed. However the GRPC docs ar very clear that ABORTED should be used, specifically mentioning etas and locks.

With this PR we internally clean up the usage in the decompesedfs and mapping in the ocdav handler.
