### PR TITLE
remove obsolete HomeMapping variable

### DIFF
--- a/changelog/unreleased/remove-unused-homemapping.md
+++ b/changelog/unreleased/remove-unused-homemapping.md
@@ -1,0 +1,5 @@
+Enhancement: Remove unused HomeMapping variable
+
+We have removed the unused HomeMapping variable from the gateway.
+
+https://github.com/cs3org/reva/pull/3005

--- a/internal/grpc/services/gateway/gateway.go
+++ b/internal/grpc/services/gateway/gateway.go
@@ -65,7 +65,6 @@ type config struct {
 	// FIXME get rid of ShareFolder, there are findByPath calls in the ocmshareporvider.go and usershareprovider.go
 	ShareFolder                  string                            `mapstructure:"share_folder"`
 	DataTransfersFolder          string                            `mapstructure:"data_transfers_folder"`
-	HomeMapping                  string                            `mapstructure:"home_mapping"`
 	TokenManagers                map[string]map[string]interface{} `mapstructure:"token_managers"`
 	EtagCacheTTL                 int                               `mapstructure:"etag_cache_ttl"`
 	AllowedUserAgents            map[string][]string               `mapstructure:"allowed_user_agents"` // map[path][]user-agent


### PR DESCRIPTION
This PR removes the unused `HomeMapping` variable.