### PR TITLE
fix eos dockerfile

### DIFF
--- a/Dockerfile.revad-eos
+++ b/Dockerfile.revad-eos
@@ -16,32 +16,28 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
-FROM golang:alpine3.13 as builder
+FROM gitlab-registry.cern.ch/dss/eos/eos-all:4.8.66 as builder
 
-RUN apk --no-cache add \
-  ca-certificates \
-  bash \
-  git \
-  gcc \
-  libc-dev \
-  make
+RUN yum -y update && yum clean all
+
+RUN yum -y install https://packages.endpointdev.com/rhel/7/os/x86_64/endpoint-repo.x86_64.rpm
+RUN yum install -y make git gcc libc-dev bash epel-release golang && \
+  yum clean all && \
+  rm -rf /var/cache/yum
 
 ENV PATH /go/bin:/usr/local/go/bin:$PATH
 ENV GOPATH /go
 
 WORKDIR /go/src/github/cs3org/reva
 COPY . .
-RUN make build-revad-docker && \
-    cp /go/src/github/cs3org/reva/cmd/revad/revad /go/bin/revad
+RUN make build-revad-docker && cp /go/src/github/cs3org/reva/cmd/revad/revad /usr/bin/revad
+
+FROM gitlab-registry.cern.ch/dss/eos/eos-all:4.8.66
+
+COPY --from=builder /usr/bin/revad /usr/bin/revad
 
 RUN mkdir -p /etc/revad/ && echo "" > /etc/revad/revad.toml
-
-FROM gitlab-registry.cern.ch/dss/eos/eos-all:4.8.57
-
 RUN mkdir -p /usr/local/bin
-
-COPY --from=builder /go/bin/revad /usr/bin/revad
-COPY --from=builder /etc/revad /etc/revad
 
 RUN chmod +x /usr/bin/revad
 

--- a/changelog/unreleased/fix-eos-docker-image.md
+++ b/changelog/unreleased/fix-eos-docker-image.md
@@ -1,0 +1,6 @@
+Bugfix: Fix revad with EOS docker image
+
+We've fixed the revad with EOS docker image. Previously the revad
+binary was build on Alpine and not executable on the final RHEL based image.
+
+https://github.com/cs3org/reva/issues/3036


### PR DESCRIPTION
Bugfix: Fix revad with EOS docker image

We've fixed the revad with EOS docker image. Previously the revad
binary was build on Alpine and not executable on the final RHEL based image.
