### PR TITLE
[tests-only] commit-7:  Revert "Populate owner data in the ocs and ocdav serv…

### DIFF
--- a/changelog/1.18.0_2022-02-11/ocs-user-data.md
+++ b/changelog/1.18.0_2022-02-11/ocs-user-data.md
@@ -1,3 +1,0 @@
-Enhancement:  Populate owner data in the ocs and ocdav services
-
-https://github.com/cs3org/reva/pull/2233

--- a/internal/http/services/owncloud/ocdav/ocdav.go
+++ b/internal/http/services/owncloud/ocdav/ocdav.go
@@ -28,7 +28,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ReneKroon/ttlcache/v2"
 	gateway "github.com/cs3org/go-cs3apis/cs3/gateway/v1beta1"
 	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	"github.com/cs3org/reva/pkg/appctx"
@@ -117,12 +116,11 @@ func (c *Config) init() {
 }
 
 type svc struct {
-	c                   *Config
-	webDavHandler       *WebDavHandler
-	davHandler          *DavHandler
-	favoritesManager    favorite.Manager
-	client              *http.Client
-	userIdentifierCache *ttlcache.Cache
+	c                *Config
+	webDavHandler    *WebDavHandler
+	davHandler       *DavHandler
+	favoritesManager favorite.Manager
+	client           *http.Client
 }
 
 func getFavoritesManager(c *Config) (favorite.Manager, error) {
@@ -154,11 +152,8 @@ func New(m map[string]interface{}, log *zerolog.Logger) (global.Service, error) 
 			rhttp.Timeout(time.Duration(conf.Timeout*int64(time.Second))),
 			rhttp.Insecure(conf.Insecure),
 		),
-		favoritesManager:    fm,
-		userIdentifierCache: ttlcache.NewCache(),
+		favoritesManager: fm,
 	}
-	_ = s.userIdentifierCache.SetTTL(60 * time.Second)
-
 	// initialize handlers and set default configs
 	if err := s.webDavHandler.init(conf.WebdavNamespace, true); err != nil {
 		return nil, err

--- a/internal/http/services/owncloud/ocs/handlers/cloud/users/users.go
+++ b/internal/http/services/owncloud/ocs/handlers/cloud/users/users.go
@@ -49,22 +49,7 @@ func (h *Handler) Init(c *config.Config) {
 // GetGroups handles GET requests on /cloud/users/groups
 // TODO: implement
 func (h *Handler) GetGroups(w http.ResponseWriter, r *http.Request) {
-	ctx := r.Context()
-
-	user := chi.URLParam(r, "userid")
-	// FIXME use ldap to fetch user info
-	u, ok := ctxpkg.ContextGetUser(ctx)
-	if !ok {
-		response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "missing user in context", fmt.Errorf("missing user in context"))
-		return
-	}
-	if user != u.Username {
-		// FIXME allow fetching other users info? only for admins
-		response.WriteOCSError(w, r, http.StatusForbidden, "user id mismatch", fmt.Errorf("%s tried to access %s user info endpoint", u.Id.OpaqueId, user))
-		return
-	}
-
-	response.WriteOCSSuccess(w, r, &Groups{Groups: u.Groups})
+	response.WriteOCSSuccess(w, r, &Groups{})
 }
 
 // Quota holds quota information


### PR DESCRIPTION
This PR reverts an original addition that filled the user info with groups and additional metadata on ocs and webdav services.
The original code made usage of these two interfaces significantly slower and we have been running with this patch (reverted logic) for months now without any issue. When required, the user info will be populated.