### PR TITLE
make CS3 sharing drivers parse legacy resource id

### DIFF
--- a/changelog/unreleased/make-cs3-sharing-drivers-parse-legacy-resourceid.md
+++ b/changelog/unreleased/make-cs3-sharing-drivers-parse-legacy-resourceid.md
@@ -1,0 +1,5 @@
+Bugfix: Make CS3 sharing drivers parse legacy resource id
+
+The CS3 public and user sharing drivers will now correct a resource id that is missing a spaceid when it can split the storageid.
+
+https://github.com/cs3org/reva/pull/3071

--- a/pkg/publicshare/manager/cs3/cs3.go
+++ b/pkg/publicshare/manager/cs3/cs3.go
@@ -48,6 +48,7 @@ import (
 	indexerErrors "github.com/cs3org/reva/v2/pkg/storage/utils/indexer/errors"
 	"github.com/cs3org/reva/v2/pkg/storage/utils/indexer/option"
 	"github.com/cs3org/reva/v2/pkg/storage/utils/metadata"
+	"github.com/cs3org/reva/v2/pkg/storagespace"
 	"github.com/cs3org/reva/v2/pkg/utils"
 )
 
@@ -329,6 +330,8 @@ func (m *Manager) getByToken(ctx context.Context, token string) (*publicshare.Wi
 	if err != nil {
 		return nil, err
 	}
+	id := storagespace.UpdateLegacyResourceID(*ps.PublicShare.ResourceId)
+	ps.PublicShare.ResourceId = &id
 	return ps, nil
 }
 

--- a/pkg/share/manager/cs3/cs3.go
+++ b/pkg/share/manager/cs3/cs3.go
@@ -43,6 +43,7 @@ import (
 	indexerErrors "github.com/cs3org/reva/v2/pkg/storage/utils/indexer/errors"
 	"github.com/cs3org/reva/v2/pkg/storage/utils/indexer/option"
 	"github.com/cs3org/reva/v2/pkg/storage/utils/metadata"
+	"github.com/cs3org/reva/v2/pkg/storagespace"
 	"github.com/cs3org/reva/v2/pkg/utils"
 	"github.com/google/uuid"
 	"github.com/mitchellh/mapstructure"
@@ -607,6 +608,8 @@ func (m *Manager) getShareByID(ctx context.Context, id string) (*collaboration.S
 	}
 	err = json.Unmarshal(data, userShare)
 	if err == nil && userShare.Grantee.GetUserId() != nil {
+		id := storagespace.UpdateLegacyResourceID(*userShare.GetResourceId())
+		userShare.ResourceId = &id
 		return userShare, nil
 	}
 
@@ -615,6 +618,8 @@ func (m *Manager) getShareByID(ctx context.Context, id string) (*collaboration.S
 	}
 	err = json.Unmarshal(data, groupShare) // try to unmarshal to a group share if the user share unmarshalling failed
 	if err == nil && groupShare.Grantee.GetGroupId() != nil {
+		id := storagespace.UpdateLegacyResourceID(*groupShare.GetResourceId())
+		groupShare.ResourceId = &id
 		return groupShare, nil
 	}
 

--- a/pkg/storagespace/storagespace.go
+++ b/pkg/storagespace/storagespace.go
@@ -143,3 +143,16 @@ func FormatReference(ref *provider.Reference) (string, error) {
 	ssid := FormatResourceID(*ref.ResourceId)
 	return path.Join(ssid, ref.Path), nil
 }
+
+// UpdateLegacyResourceID checks if the given resource id contains a correct triple and will convert legacy ids without a spaceid
+// by splitting the storageid.
+func UpdateLegacyResourceID(id provider.ResourceId) provider.ResourceId {
+	if storageid, spaceid := SplitStorageID(id.StorageId); storageid != "" && id.SpaceId == "" {
+		return provider.ResourceId{
+			StorageId: storageid,
+			SpaceId:   spaceid,
+			OpaqueId:  id.OpaqueId,
+		}
+	}
+	return id
+}

--- a/pkg/storagespace/storagespace_test.go
+++ b/pkg/storagespace/storagespace_test.go
@@ -317,3 +317,26 @@ func TestFormatAndParseReference(t *testing.T) {
 		}
 	}
 }
+
+func TestUpdateLegacyResourceID(t *testing.T) {
+	tests := []struct {
+		orig     provider.ResourceId
+		expected provider.ResourceId
+	}{
+		{
+			orig:     provider.ResourceId{StorageId: "storageid", SpaceId: "spaceid", OpaqueId: "opaqueid"},
+			expected: provider.ResourceId{StorageId: "storageid", SpaceId: "spaceid", OpaqueId: "opaqueid"},
+		},
+		{
+			orig:     provider.ResourceId{StorageId: "storageid$spaceid", SpaceId: "", OpaqueId: "opaqueid"},
+			expected: provider.ResourceId{StorageId: "storageid", SpaceId: "spaceid", OpaqueId: "opaqueid"},
+		},
+	}
+
+	for _, tt := range tests {
+		updated := UpdateLegacyResourceID(tt.orig)
+		if !(utils.ResourceIDEqual(&updated, &tt.expected)) {
+			t.Errorf("Updating resourceid failed, got: %v expected %v", updated, tt.expected)
+		}
+	}
+}


### PR DESCRIPTION
The CS3 public and user sharing drivers will now correct a resource id that is missing a spaceid when it can split the storageid.
