### PR TITLE
send storage provider and space id to wopi server

### DIFF
--- a/changelog/unreleased/send-provider-and-space-to-wopi.md
+++ b/changelog/unreleased/send-provider-and-space-to-wopi.md
@@ -1,0 +1,5 @@
+Bugfix: Send storage provider and space id to wopi server
+
+We are now concatenating storage provider id and space id into the endpoint that is sent to the wopiserver
+
+https://github.com/cs3org/reva/issues/3074

--- a/pkg/app/provider/wopi/wopi.go
+++ b/pkg/app/provider/wopi/wopi.go
@@ -46,6 +46,7 @@ import (
 	"github.com/cs3org/reva/v2/pkg/mime"
 	"github.com/cs3org/reva/v2/pkg/rhttp"
 	"github.com/cs3org/reva/v2/pkg/sharedconf"
+	"github.com/cs3org/reva/v2/pkg/storagespace"
 	"github.com/golang-jwt/jwt"
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
@@ -134,8 +135,9 @@ func (p *wopiProvider) GetAppURL(ctx context.Context, resource *provider.Resourc
 	}
 
 	q := httpReq.URL.Query()
+
+	q.Add("endpoint", storagespace.FormatStorageID(resource.GetId().GetStorageId(), resource.GetId().GetSpaceId()))
 	q.Add("fileid", resource.GetId().OpaqueId)
-	q.Add("endpoint", resource.GetId().SpaceId)
 	q.Add("viewmode", viewMode.String())
 
 	u, ok := ctxpkg.ContextGetUser(ctx)


### PR DESCRIPTION
We are now concatenating storage provider id and space id into the endpoint that is sent to the wopiserver.

needs https://github.com/cs3org/wopiserver/pull/79

Signed-off-by: Jörn Friedrich Dreyer <jfd@butonic.de>