### PR TITLE
Check move destination perms

### DIFF
--- a/changelog/unreleased/check-move-destination-permissions.md
+++ b/changelog/unreleased/check-move-destination-permissions.md
@@ -1,0 +1,6 @@
+Bugfix: Check permissions of the move operation destination
+
+We now properly check the permissions on the target of move operations.
+
+https://github.com/cs3org/reva/pull/3075
+https://github.com/owncloud/ocis/issues/4192


### PR DESCRIPTION
We now properly check the permissions on the target of move operations.

Fixes https://github.com/owncloud/ocis/issues/4192