### PR TITLE
Allow empty permissions on links again

### DIFF
--- a/changelog/unreleased/allow-empty-permissions.md
+++ b/changelog/unreleased/allow-empty-permissions.md
@@ -1,0 +1,7 @@
+Bugfix: Allow empty permissions
+
+For alias link we need the ability to set no permission on an link.
+The permissions will then come from the natural permissions the receiving user
+has on that file/folder
+
+https://github.com/cs3org/reva/pull/3079

--- a/internal/http/services/owncloud/ocs/conversions/permissions.go
+++ b/internal/http/services/owncloud/ocs/conversions/permissions.go
@@ -19,6 +19,7 @@
 package conversions
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 )
@@ -50,13 +51,15 @@ const (
 var (
 	// ErrPermissionNotInRange defines a permission specific error.
 	ErrPermissionNotInRange = fmt.Errorf("The provided permission is not between %d and %d", PermissionMinInput, PermissionMaxInput)
+	// ErrZeroPermission defines a permission specific error
+	ErrZeroPermission = errors.New("permission is zero")
 )
 
 // NewPermissions creates a new Permissions instance.
 // The value must be in the valid range.
 func NewPermissions(val int) (Permissions, error) {
 	if val == int(PermissionInvalid) {
-		return PermissionInvalid, nil
+		return PermissionInvalid, ErrZeroPermission
 	} else if val < int(PermissionInvalid) || int(PermissionMaxInput) < val {
 		return PermissionInvalid, ErrPermissionNotInRange
 	}

--- a/internal/http/services/owncloud/ocs/conversions/permissions.go
+++ b/internal/http/services/owncloud/ocs/conversions/permissions.go
@@ -56,7 +56,7 @@ var (
 // The value must be in the valid range.
 func NewPermissions(val int) (Permissions, error) {
 	if val == int(PermissionInvalid) {
-		return PermissionInvalid, fmt.Errorf("permissions %d out of range %d - %d", val, PermissionMinInput, PermissionMaxInput)
+		return PermissionInvalid, nil
 	} else if val < int(PermissionInvalid) || int(PermissionMaxInput) < val {
 		return PermissionInvalid, ErrPermissionNotInRange
 	}

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/public.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/public.go
@@ -529,7 +529,7 @@ func ocPublicPermToCs3(permKey int, h *Handler) (*provider.ResourcePermissions, 
 	}
 
 	perm, err := conversions.NewPermissions(permKey)
-	if err != nil {
+	if err != nil && err != conversions.ErrZeroPermission { // we allow empty permissions for public links
 		return nil, err
 	}
 

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/shares.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/shares.go
@@ -292,7 +292,7 @@ func (h *Handler) CreateShare(w http.ResponseWriter, r *http.Request) {
 	case int(conversions.ShareTypePublicLink):
 		// public links default to read only
 		_, _, ocsErr := h.extractPermissions(reqRole, reqPermissions, statRes.Info, conversions.NewViewerRole())
-		if ocsErr != nil {
+		if ocsErr != nil && ocsErr.Error != conversions.ErrZeroPermission {
 			response.WriteOCSError(w, r, http.StatusNotFound, "No share permission", nil)
 			return
 		}


### PR DESCRIPTION
Empty permissions are needed for infamous alias links. Through some PR that functionailty was dropped. Now it is back again