### PR TITLE
Fix item trashed event

### DIFF
--- a/changelog/unreleased/fix-item-trashed-event.md
+++ b/changelog/unreleased/fix-item-trashed-event.md
@@ -1,0 +1,6 @@
+Bugfix: Add space id to ItemTrashed event
+
+We fixed the resource IDs in the ItemTrashed events which were missing the
+recently introduced space ID in the resource ID.
+
+https://github.com/cs3org/reva/pull/3083

--- a/internal/grpc/interceptors/eventsmiddleware/conversion.go
+++ b/internal/grpc/interceptors/eventsmiddleware/conversion.go
@@ -197,6 +197,7 @@ func ItemTrashed(r *provider.DeleteResponse, req *provider.DeleteRequest, execut
 		Ref:       req.Ref,
 		ID: &provider.ResourceId{
 			StorageId: req.Ref.GetResourceId().GetStorageId(),
+			SpaceId:   req.Ref.GetResourceId().GetSpaceId(),
 			OpaqueId:  opaqueID,
 		},
 	}


### PR DESCRIPTION
This PR fixes the resource IDs in the ItemTrashed events which were missing the recently introduced space ID in the resource ID.
