### PR TITLE
Cleanup uploads

### DIFF
--- a/changelog/unreleased/upload-expiration.md
+++ b/changelog/unreleased/upload-expiration.md
@@ -1,0 +1,9 @@
+Enhancement: Upload expiration and cleanup
+
+We made storage providers aware of upload expiration and added an interface
+for FS which support listing and purging expired uploads.
+
+We also implemented said interface for decomposedfs.
+
+https://github.com/cs3org/reva/pull/3095
+https://github.com/owncloud/ocis/pull/4256

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/cheggaaa/pb v1.0.29
 	github.com/coreos/go-oidc v2.2.1+incompatible
 	github.com/cs3org/cato v0.0.0-20200828125504-e418fc54dd5e
-	github.com/cs3org/go-cs3apis v0.0.0-20220711084433-8f71d4e812a3
+	github.com/cs3org/go-cs3apis v0.0.0-20220719130120-361e9f987d64
 	github.com/cubewise-code/go-mime v0.0.0-20200519001935-8c5762b177d8
 	github.com/dgraph-io/ristretto v0.1.0
 	github.com/eventials/go-tus v0.0.0-20200718001131-45c7ec8f5d59

--- a/go.sum
+++ b/go.sum
@@ -216,8 +216,8 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/cs3org/cato v0.0.0-20200828125504-e418fc54dd5e h1:tqSPWQeueWTKnJVMJffz4pz0o1WuQxJ28+5x5JgaHD8=
 github.com/cs3org/cato v0.0.0-20200828125504-e418fc54dd5e/go.mod h1:XJEZ3/EQuI3BXTp/6DUzFr850vlxq11I6satRtz0YQ4=
-github.com/cs3org/go-cs3apis v0.0.0-20220711084433-8f71d4e812a3 h1:QSQ2DGKPMChB4vHSs1Os9TnOJl21BrzKX9D5EtQfDog=
-github.com/cs3org/go-cs3apis v0.0.0-20220711084433-8f71d4e812a3/go.mod h1:UXha4TguuB52H14EMoSsCqDj7k8a/t7g4gVP+bgY5LY=
+github.com/cs3org/go-cs3apis v0.0.0-20220719130120-361e9f987d64 h1:cFnankJOCWndnOns4sKRG7yzH61ammK2Am6rEGWCK40=
+github.com/cs3org/go-cs3apis v0.0.0-20220719130120-361e9f987d64/go.mod h1:UXha4TguuB52H14EMoSsCqDj7k8a/t7g4gVP+bgY5LY=
 github.com/cubewise-code/go-mime v0.0.0-20200519001935-8c5762b177d8 h1:Z9lwXumT5ACSmJ7WGnFl+OMLLjpz5uR2fyz7dC255FI=
 github.com/cubewise-code/go-mime v0.0.0-20200519001935-8c5762b177d8/go.mod h1:4abs/jPXcmJzYoYGF91JF9Uq9s/KL5n1jvFDix8KcqY=
 github.com/cyberdelia/templates v0.0.0-20141128023046-ca7fffd4298c/go.mod h1:GyV+0YP4qX0UQ7r2MoYZ+AvYDp12OF5yg4q8rGnyNh4=

--- a/internal/grpc/services/gateway/storageprovider.go
+++ b/internal/grpc/services/gateway/storageprovider.go
@@ -509,7 +509,7 @@ func (s *svc) InitiateFileDownload(ctx context.Context, req *provider.InitiateFi
 
 			// TODO(labkode): calculate signature of the whole request? we only sign the URI now. Maybe worth https://tools.ietf.org/html/draft-cavage-http-signatures-11
 			target := u.String()
-			token, err := s.sign(ctx, target, s.c.TransferExpires)
+			token, err := s.sign(ctx, target, time.Now().UTC().Add(time.Duration(s.c.TransferExpires)*time.Second).Unix())
 			if err != nil {
 				return &gateway.InitiateFileDownloadResponse{
 					Status: status.NewStatusFromErrType(ctx, "error creating signature for download", err),

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -77,6 +77,12 @@ type FS interface {
 	DeleteStorageSpace(ctx context.Context, req *provider.DeleteStorageSpaceRequest) error
 }
 
+// UploadsManager defines the interface for FS implementations that allow for managing uploads
+type UploadsManager interface {
+	ListUploads() ([]tusd.FileInfo, error)
+	PurgeExpiredUploads(chan<- tusd.FileInfo) error
+}
+
 // Registry is the interface that storage registries implement
 // for discovering storage providers
 type Registry interface {

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -23,6 +23,8 @@ import (
 	"io"
 	"net/url"
 
+	tusd "github.com/tus/tusd/pkg/handler"
+
 	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	registry "github.com/cs3org/go-cs3apis/cs3/storage/registry/v1beta1"

--- a/pkg/storage/utils/decomposedfs/upload.go
+++ b/pkg/storage/utils/decomposedfs/upload.go
@@ -444,8 +444,14 @@ func (fs *Decomposedfs) PurgeExpiredUploads(purgedChan chan<- tusd.FileInfo) err
 		}
 		if int64(expires) < time.Now().Unix() {
 			purgedChan <- info
-			os.Remove(info.Storage["BinPath"])
-			os.Remove(filepath.Join(fs.o.Root, "uploads", info.ID+".info"))
+			err = os.Remove(info.Storage["BinPath"])
+			if err != nil {
+				return err
+			}
+			err = os.Remove(filepath.Join(fs.o.Root, "uploads", info.ID+".info"))
+			if err != nil {
+				return err
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION
This PR makes storage providers aware of upload expiration and adds an interface for FS which support listing and purging expired uploads. It also implements said interface for decomposedfs.

This is required for https://github.com/owncloud/ocis/issues/2622