### PR TITLE
use Form instead of Query to also support `application/x-www-form-urlencoded` for the app provider http endpoint

### DIFF
--- a/changelog/unreleased/enhancement-app-provider-form-instead-query.md
+++ b/changelog/unreleased/enhancement-app-provider-form-instead-query.md
@@ -1,0 +1,7 @@
+Enhancement: app provider http endpoint uses Form instead of Query
+
+We've improved the http endpoint now uses the Form instead of Query
+to also support `application/x-www-form-urlencoded` parameters on
+ the app provider http endpoint.
+
+https://github.com/cs3org/reva/pull/3098

--- a/internal/http/services/appprovider/appprovider.go
+++ b/internal/http/services/appprovider/appprovider.go
@@ -123,13 +123,18 @@ func (s *svc) handleNew(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if r.URL.Query().Get("template") != "" {
+	err = r.ParseForm()
+	if err != nil {
+		writeError(w, r, appErrorInvalidParameter, "parameters could not be parsed", nil)
+	}
+
+	if r.Form.Get("template") != "" {
 		// TODO in the future we want to create a file out of the given template
 		writeError(w, r, appErrorUnimplemented, "template is not implemented", nil)
 		return
 	}
 
-	parentContainerIDStr := r.URL.Query().Get("parent_container_id")
+	parentContainerIDStr := r.Form.Get("parent_container_id")
 	if parentContainerIDStr == "" {
 		writeError(w, r, appErrorInvalidParameter, "missing parent container ID", nil)
 		return
@@ -141,7 +146,7 @@ func (s *svc) handleNew(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	filename := r.URL.Query().Get("filename")
+	filename := r.Form.Get("filename")
 	if filename == "" {
 		writeError(w, r, appErrorInvalidParameter, "missing filename", nil)
 		return
@@ -328,7 +333,12 @@ func (s *svc) handleOpen(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	fileID := r.URL.Query().Get("file_id")
+	err = r.ParseForm()
+	if err != nil {
+		writeError(w, r, appErrorInvalidParameter, "parameters could not be parsed", nil)
+	}
+
+	fileID := r.Form.Get("file_id")
 
 	if fileID == "" {
 		writeError(w, r, appErrorInvalidParameter, "missing file ID", nil)
@@ -365,7 +375,7 @@ func (s *svc) handleOpen(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	viewMode := getViewMode(statRes.Info, r.URL.Query().Get("view_mode"))
+	viewMode := getViewMode(statRes.Info, r.Form.Get("view_mode"))
 	if viewMode == gateway.OpenInAppRequest_VIEW_MODE_INVALID {
 		writeError(w, r, appErrorInvalidParameter, "invalid view mode", err)
 		return
@@ -374,7 +384,7 @@ func (s *svc) handleOpen(w http.ResponseWriter, r *http.Request) {
 	openReq := gateway.OpenInAppRequest{
 		Ref:      fileRef,
 		ViewMode: viewMode,
-		App:      r.URL.Query().Get("app_name"),
+		App:      r.Form.Get("app_name"),
 	}
 	openRes, err := client.OpenInApp(ctx, &openReq)
 	if err != nil {


### PR DESCRIPTION
Enhancement: app provider http endpoint uses Form instead of Query

We've improved the http endpoint now uses the Form instead of Query
to also support `application/x-www-form-urlencoded` parameters on
 the app provider http endpoint.

The support for query parameter stays the same. See https://pkg.go.dev/net/http#Request.ParseForm. https://pkg.go.dev/net/url#URL.Query only parses the parameters from the URL