### PR TITLE
Add missing condition for permission checks on spaces

### DIFF
--- a/changelog/unreleased/add-missing-check.md
+++ b/changelog/unreleased/add-missing-check.md
@@ -1,0 +1,5 @@
+Bugfix: Fix missing check in MustCheckNodePermissions
+
+We added a missing check to the MustCheckNodePermissions function, so space managers can see disabled spaces.
+
+https://github.com/cs3org/reva/pull/3109

--- a/pkg/storage/utils/decomposedfs/spaces.go
+++ b/pkg/storage/utils/decomposedfs/spaces.go
@@ -432,6 +432,8 @@ func (fs *Decomposedfs) ListStorageSpaces(ctx context.Context, filter []*provide
 func (fs *Decomposedfs) MustCheckNodePermissions(ctx context.Context, requestedUserID string, unrestricted bool) bool {
 	canListAllSpaces := fs.canListAllSpaces(ctx)
 	switch {
+	case canListAllSpaces && unrestricted == false:
+		return true
 	case (canListAllSpaces && requestedUserID == userIDAny):
 		// admins should not see any other spaces when they request their own, without settings filters
 		return true

--- a/pkg/storage/utils/decomposedfs/spaces.go
+++ b/pkg/storage/utils/decomposedfs/spaces.go
@@ -432,7 +432,7 @@ func (fs *Decomposedfs) ListStorageSpaces(ctx context.Context, filter []*provide
 func (fs *Decomposedfs) MustCheckNodePermissions(ctx context.Context, requestedUserID string, unrestricted bool) bool {
 	canListAllSpaces := fs.canListAllSpaces(ctx)
 	switch {
-	case canListAllSpaces && unrestricted == false:
+	case canListAllSpaces && !unrestricted:
 		return true
 	case (canListAllSpaces && requestedUserID == userIDAny):
 		// admins should not see any other spaces when they request their own, without settings filters

--- a/pkg/storage/utils/decomposedfs/spaces_test.go
+++ b/pkg/storage/utils/decomposedfs/spaces_test.go
@@ -88,14 +88,18 @@ var _ = Describe("Spaces", func() {
 		})
 
 		Context("needs to check node permissions", func() {
+			It("returns false on requesting for other user with canlistallspaces und no unrestricted privilege", func() {
+				resp := env.Fs.MustCheckNodePermissions(env.Ctx, helpers.User0ID, false)
+				Expect(resp).To(Equal(true))
+			})
 			It("returns true on requesting for other user as non-admin", func() {
 				ctx := ruser.ContextSetUser(context.Background(), env.Users[0])
 				resp := env.Fs.MustCheckNodePermissions(ctx, helpers.User1ID, false)
 				Expect(resp).To(Equal(true))
 			})
-			It("returns false on requesting for other user as admin", func() {
+			It("returns true on requesting for other user as admin", func() {
 				resp := env.Fs.MustCheckNodePermissions(env.Ctx, helpers.User0ID, false)
-				Expect(resp).To(Equal(false))
+				Expect(resp).To(Equal(true))
 			})
 			It("returns true on requesting for own spaces", func() {
 				ctx := ruser.ContextSetUser(context.Background(), env.Users[0])


### PR DESCRIPTION
We added a missing check to the MustCheckNodePermissions function, so space managers can see disabled spaces.
