### PR TITLE
fix indexes and list all spaces

### DIFF
--- a/changelog/unreleased/fix-user-filter.md
+++ b/changelog/unreleased/fix-user-filter.md
@@ -3,3 +3,4 @@ Bugfix: Fix user filter
 We fixed the user filter to display the users drives properly and allow admins to list other users drives.
 
 https://github.com/cs3org/reva/pull/3096
+https://github.com/cs3org/reva/pull/3110

--- a/internal/grpc/services/gateway/ocmshareprovider.go
+++ b/internal/grpc/services/gateway/ocmshareprovider.go
@@ -103,7 +103,7 @@ func (s *svc) RemoveOCMShare(ctx context.Context, req *ocm.RemoveOCMShareRequest
 	}
 
 	if s.c.CommitShareToStorageGrant {
-		removeGrantStatus, err := s.removeGrant(ctx, share.ResourceId, share.Grantee, share.Permissions.Permissions)
+		removeGrantStatus, err := s.removeGrant(ctx, share.ResourceId, share.Grantee, share.Permissions.Permissions, nil)
 		if err != nil {
 			return nil, errors.Wrap(err, "gateway: error removing OCM grant from storage")
 		}

--- a/pkg/storage/utils/decomposedfs/spaces_test.go
+++ b/pkg/storage/utils/decomposedfs/spaces_test.go
@@ -90,25 +90,21 @@ var _ = Describe("Spaces", func() {
 
 		Context("needs to check node permissions", func() {
 			It("returns false on requesting for other user with canlistallspaces und no unrestricted privilege", func() {
-				resp := env.Fs.MustCheckNodePermissions(env.Ctx, helpers.User0ID, false)
+				resp := env.Fs.MustCheckNodePermissions(env.Ctx, false)
 				Expect(resp).To(Equal(true))
 			})
-			It("returns true on requesting for other user as non-admin", func() {
+			It("returns true on requesting unrestricted as non-admin", func() {
 				ctx := ruser.ContextSetUser(context.Background(), env.Users[0])
-				resp := env.Fs.MustCheckNodePermissions(ctx, helpers.User1ID, false)
-				Expect(resp).To(Equal(true))
-			})
-			It("returns true on requesting for other user as admin", func() {
-				resp := env.Fs.MustCheckNodePermissions(env.Ctx, helpers.User0ID, false)
+				resp := env.Fs.MustCheckNodePermissions(ctx, true)
 				Expect(resp).To(Equal(true))
 			})
 			It("returns true on requesting for own spaces", func() {
 				ctx := ruser.ContextSetUser(context.Background(), env.Users[0])
-				resp := env.Fs.MustCheckNodePermissions(ctx, helpers.User0ID, false)
+				resp := env.Fs.MustCheckNodePermissions(ctx, false)
 				Expect(resp).To(Equal(true))
 			})
 			It("returns false on unrestricted", func() {
-				resp := env.Fs.MustCheckNodePermissions(env.Ctx, "some-uuid-that-does-not-make-sense", true)
+				resp := env.Fs.MustCheckNodePermissions(env.Ctx, true)
 				Expect(resp).To(Equal(false))
 			})
 		})


### PR DESCRIPTION
# Fix the indexes on the DecomposedFS

The spacetype index was not updated during space creation.

@kobergj @C0rby Open for suggestions / improvements

## To-Do

- [x] Check RemoveGrant()

The user-id-index needed a change when removing a space grant