### PR TITLE
Allow stating links with no permissions

### DIFF
--- a/changelog/unreleased/allow-stating-empty-permission-links.md
+++ b/changelog/unreleased/allow-stating-empty-permission-links.md
@@ -1,0 +1,6 @@
+Enhancement: Allow stating links that have no permissions
+
+We need a way to resolve the id when we have a token. This also needs to work for
+links that have no permissions assigned
+
+https://github.com/cs3org/reva/pull/3123


### PR DESCRIPTION
This is needed for alias links. 

Before it wasn't allowed to stat a link that has empty permission assigned. This needs to be possible as alias links need to be resolved by their receivers