### PR TITLE
[tests-only] Allow setting quota when creating personal spaces

### DIFF
--- a/internal/grpc/services/gateway/storageprovider.go
+++ b/internal/grpc/services/gateway/storageprovider.go
@@ -24,6 +24,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -112,10 +113,19 @@ func (s *svc) CreateHome(ctx context.Context, req *provider.CreateHomeRequest) (
 		}, nil
 
 	}
+
+	var quota *provider.Quota
+	if q := utils.ReadPlainFromOpaque(req.Opaque, "quota"); q != "" {
+		qq, err := strconv.ParseUint(q, 10, 64)
+		if err == nil {
+			quota = &provider.Quota{QuotaMaxBytes: qq}
+		}
+	}
 	createReq := &provider.CreateStorageSpaceRequest{
 		Type:  "personal",
 		Owner: u,
 		Name:  u.DisplayName,
+		Quota: quota,
 	}
 
 	// send the user id as the space id, makes debugging easier


### PR DESCRIPTION
Previously it was not possible setting a quota using the `CreateHome` handler