### PR TITLE
fix set space quota as admin

### DIFF
--- a/changelog/unreleased/set-quota-admin.md
+++ b/changelog/unreleased/set-quota-admin.md
@@ -1,0 +1,5 @@
+Enhancement: Admins can set quota on all spaces
+
+Admins which have the correct permissions should be able to set quota on all spaces. This is implemented via the existing permissions client.
+
+https://github.com/cs3org/reva/pull/3133

--- a/pkg/storage/utils/decomposedfs/decomposedfs.go
+++ b/pkg/storage/utils/decomposedfs/decomposedfs.go
@@ -169,7 +169,7 @@ func (fs *Decomposedfs) GetQuota(ctx context.Context, ref *provider.Reference) (
 	switch {
 	case err != nil:
 		return 0, 0, 0, errtypes.InternalError(err.Error())
-	case !rp.GetQuota:
+	case !rp.GetQuota && !fs.canListAllSpaces(ctx):
 		return 0, 0, 0, errtypes.PermissionDenied(n.ID)
 	}
 


### PR DESCRIPTION
# Description

Admins which have the correct permissions should be able to set quota on all spaces. This is implemented via the existing permissions client.