### PR TITLE
Add locking to xattrs Get() and Remove()

### DIFF
--- a/changelog/unreleased/improve-propagation.md
+++ b/changelog/unreleased/improve-propagation.md
@@ -1,0 +1,5 @@
+Bugfix: Return add Lock to xattrs.Get and Remove
+
+Add Lock handling on writes of xattrs.
+
+https://github.com/cs3org/reva/pull/3135


### PR DESCRIPTION
In case of other processes having a Write lock that needs to be respected.

refs https://github.com/owncloud/ocis/issues/4251