### PR TITLE
[tests-only] Improve Tags pkg

### DIFF
--- a/pkg/tags/tags.go
+++ b/pkg/tags/tags.go
@@ -79,6 +79,11 @@ func (t *Tags) AsList() string {
 	return strings.Join(t.t, t.sep)
 }
 
+// AsSlice returns the tags as slice of strings
+func (t *Tags) AsSlice() []string {
+	return t.t
+}
+
 // adds the tags and returns a list of added tags
 func (t *Tags) addTags(s string) []string {
 	added := make([]string, 0)

--- a/pkg/tags/tags_test.go
+++ b/pkg/tags/tags_test.go
@@ -19,6 +19,7 @@
 package tags
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -110,6 +111,7 @@ func TestAddTags(t *testing.T) {
 		added := ts.AddList(tc.TagsToAdd)
 		require.Equal(t, tc.ExpectNoTagsAdded, !added, tc.Alias)
 		require.Equal(t, tc.ExpectedTags, ts.AsList(), tc.Alias)
+		require.Equal(t, strings.Split(tc.ExpectedTags, ","), ts.AsSlice(), tc.Alias)
 	}
 
 }


### PR DESCRIPTION
Allow returning a slice of tags with new `AsSlice` method. Adjust unit tests to test also slices.