### PR TITLE
[tests-only] Add vendor-php to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ bin/
 # API acceptance tests
 composer.lock
 /vendor
+/vendor-php
 vendor-bin/**/vendor
 vendor-bin/**/composer.lock
 tests/acceptance/output


### PR DESCRIPTION
This was done in the edge branch in PR #3106 commit https://github.com/cs3org/reva/pull/3106/commits/98e8bb602f619f6e8b85f36cc75f0fab7128b973

Do it in master branch also.

The PHP test code dependencies were moved into `vendor-php` in master PR #2539 commit https://github.com/cs3org/reva/pull/2539/commits/d09c6b9879e41080d72b19a6fe0feddf56ee1dfb about 6 months ago. We should have added `vendor-php` to `.gitignore` back then.