### PR TITLE
check listGrants permission when listing shares

### DIFF
--- a/changelog/unreleased/fix-list-shares.md
+++ b/changelog/unreleased/fix-list-shares.md
@@ -1,0 +1,5 @@
+Bugfix: Check ListGrants permission when listing shares
+
+We now check the ListGrants permission when listing outgoing shares. If this permission is set, users can list all shares in all spaces.
+
+https://github.com/cs3org/reva/pull/3141


### PR DESCRIPTION
# Description

We now check the ListGrants permission when listing outgoing shares. If this permission is set, users can list all shares in all spaces.