### PR TITLE
Add a jsoncs3 share manager

### DIFF
--- a/changelog/unreleased/jsoncs3-share-manager.md
+++ b/changelog/unreleased/jsoncs3-share-manager.md
@@ -1,0 +1,6 @@
+Enhancement: Add new jsoncs3 share manager
+
+We've added a new jsoncs3 share manager which splits the json file per storage
+space and caches data locally.
+
+https://github.com/cs3org/reva/pull/3148

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/cheggaaa/pb v1.0.29
 	github.com/coreos/go-oidc v2.2.1+incompatible
 	github.com/cs3org/cato v0.0.0-20200828125504-e418fc54dd5e
-	github.com/cs3org/go-cs3apis v0.0.0-20220719130120-361e9f987d64
+	github.com/cs3org/go-cs3apis v0.0.0-20220818202316-e92afdddac6d
 	github.com/cubewise-code/go-mime v0.0.0-20200519001935-8c5762b177d8
 	github.com/dgraph-io/ristretto v0.1.0
 	github.com/emvi/iso-639-1 v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -170,8 +170,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsr
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/cs3org/cato v0.0.0-20200828125504-e418fc54dd5e h1:tqSPWQeueWTKnJVMJffz4pz0o1WuQxJ28+5x5JgaHD8=
 github.com/cs3org/cato v0.0.0-20200828125504-e418fc54dd5e/go.mod h1:XJEZ3/EQuI3BXTp/6DUzFr850vlxq11I6satRtz0YQ4=
-github.com/cs3org/go-cs3apis v0.0.0-20220719130120-361e9f987d64 h1:cFnankJOCWndnOns4sKRG7yzH61ammK2Am6rEGWCK40=
-github.com/cs3org/go-cs3apis v0.0.0-20220719130120-361e9f987d64/go.mod h1:UXha4TguuB52H14EMoSsCqDj7k8a/t7g4gVP+bgY5LY=
+github.com/cs3org/go-cs3apis v0.0.0-20220818202316-e92afdddac6d h1:toyZ7IsXlUdEPZ/IG8fg7hbM8HcLPY0bkX4FKBmgLVI=
+github.com/cs3org/go-cs3apis v0.0.0-20220818202316-e92afdddac6d/go.mod h1:UXha4TguuB52H14EMoSsCqDj7k8a/t7g4gVP+bgY5LY=
 github.com/cubewise-code/go-mime v0.0.0-20200519001935-8c5762b177d8 h1:Z9lwXumT5ACSmJ7WGnFl+OMLLjpz5uR2fyz7dC255FI=
 github.com/cubewise-code/go-mime v0.0.0-20200519001935-8c5762b177d8/go.mod h1:4abs/jPXcmJzYoYGF91JF9Uq9s/KL5n1jvFDix8KcqY=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/pkg/share/manager/jsoncs3/jsoncs3.go
+++ b/pkg/share/manager/jsoncs3/jsoncs3.go
@@ -98,6 +98,7 @@ type config struct {
 	MachineAuthAPIKey string `mapstructure:"machine_auth_apikey"`
 }
 
+// Manager implements a share manager using a cs3 storage backend with local caching
 type Manager struct {
 	sync.RWMutex
 
@@ -418,7 +419,7 @@ func (m *Manager) ListShares(ctx context.Context, filters []*collaboration.Filte
 			continue
 		}
 		spaceShares := m.Cache.ListSpace(storageID, spaceID)
-		for shareid, _ := range spaceShareIDs.IDs {
+		for shareid := range spaceShareIDs.IDs {
 			s := spaceShares.Shares[shareid]
 			if s == nil {
 				continue
@@ -462,7 +463,7 @@ func (m *Manager) ListReceivedShares(ctx context.Context, filters []*collaborati
 				States: make(map[string]*receivedsharecache.State, len(spaceShareIDs.IDs)),
 			}
 
-			for shareid, _ := range spaceShareIDs.IDs {
+			for shareid := range spaceShareIDs.IDs {
 				rs.States[shareid] = &receivedsharecache.State{
 					State: collaboration.ShareState_SHARE_STATE_PENDING,
 				}
@@ -496,8 +497,8 @@ func (m *Manager) ListReceivedShares(ctx context.Context, filters []*collaborati
 		if err != nil {
 			continue
 		}
-		for shareId, state := range rspace.States {
-			s := m.Cache.Get(storageID, spaceID, shareId)
+		for shareID, state := range rspace.States {
+			s := m.Cache.Get(storageID, spaceID, shareID)
 			if s == nil {
 				continue
 			}

--- a/pkg/share/manager/jsoncs3/jsoncs3.go
+++ b/pkg/share/manager/jsoncs3/jsoncs3.go
@@ -453,7 +453,7 @@ func (m *manager) ListShares(ctx context.Context, filters []*collaboration.Filte
 		mtime = usc.mtime
 		//    - y: set If-Modified-Since header to only download if it changed
 	} else {
-		mtime = time.Now()
+		mtime = time.Time{}
 	}
 	//  - read /users/{userid}/created.json (with If-Modified-Since header) aka read if changed
 	userCreatedPath := userCreatedPath(userid)

--- a/pkg/share/manager/jsoncs3/jsoncs3.go
+++ b/pkg/share/manager/jsoncs3/jsoncs3.go
@@ -492,7 +492,7 @@ func (m *Manager) ListReceivedShares(ctx context.Context, filters []*collaborati
 			if s == nil {
 				continue
 			}
-			if utils.UserEqual(user.GetId(), s.GetGrantee().GetUserId()) {
+			if share.IsGrantedToUser(s, user) {
 				if share.MatchesFilters(s, filters) {
 					rs := &collaboration.ReceivedShare{
 						Share:      s,

--- a/pkg/share/manager/jsoncs3/jsoncs3.go
+++ b/pkg/share/manager/jsoncs3/jsoncs3.go
@@ -410,9 +410,6 @@ func (m *Manager) ListShares(ctx context.Context, filters []*collaboration.Filte
 
 	m.CreatedCache.Sync(ctx, user.Id.OpaqueId)
 	for ssid, spaceShareIDs := range m.CreatedCache.List(user.Id.OpaqueId) {
-		if time.Now().Sub(spaceShareIDs.Mtime) > time.Second*30 {
-			// TODO reread from disk
-		}
 		storageID, spaceID, _ := shareid.Decode(ssid)
 		err := m.Cache.Sync(ctx, storageID, spaceID)
 		if err != nil {
@@ -453,9 +450,6 @@ func (m *Manager) ListReceivedShares(ctx context.Context, filters []*collaborati
 	for _, group := range user.Groups {
 		m.GroupReceivedCache.Sync(ctx, group)
 		for ssid, spaceShareIDs := range m.GroupReceivedCache.List(group) {
-			if time.Now().Sub(spaceShareIDs.Mtime) > time.Second*30 {
-				// TODO reread from disk
-			}
 			// add a pending entry, the state will be updated
 			// when reading the received shares below if they have already been accepted or denied
 			rs := receivedsharecache.Space{
@@ -476,10 +470,6 @@ func (m *Manager) ListReceivedShares(ctx context.Context, filters []*collaborati
 	m.UserReceivedStates.Sync(ctx, user.Id.OpaqueId)
 	if m.UserReceivedStates.ReceivedSpaces[user.Id.OpaqueId] != nil {
 		for ssid, rspace := range m.UserReceivedStates.ReceivedSpaces[user.Id.OpaqueId].Spaces {
-			if time.Now().Sub(rspace.Mtime) > time.Second*30 {
-				// TODO reread from disk
-			}
-			// TODO use younger mtime to determine if
 			if rs, ok := ssids[ssid]; ok {
 				for shareid, state := range rspace.States {
 					// overwrite state

--- a/pkg/share/manager/jsoncs3/jsoncs3.go
+++ b/pkg/share/manager/jsoncs3/jsoncs3.go
@@ -90,10 +90,8 @@ type Manager struct {
 	// userReceivedStates holds the state of shares a user has received, sharded by user id and space id
 	userReceivedStates receivedCache
 
-	storage     metadata.Storage
-	serviceUser *userv1beta1.User
-	SpaceRoot   *provider.ResourceId
-	initialized bool
+	storage   metadata.Storage
+	SpaceRoot *provider.ResourceId
 }
 
 // NewDefault returns a new manager instance with default dependencies
@@ -125,7 +123,6 @@ func New(s metadata.Storage) (*Manager, error) {
 
 // File structure in the jsoncs3 space:
 //
-// /shares/{shareid.json}                     				// points to {storageid}/{spaceid} for looking up the share information
 // /storages/{storageid}/{spaceid.json}                     // contains all share information of all shares in that space
 // /users/{userid}/created/{storageid}/{spaceid}			// points to a space the user created shares in
 // /users/{userid}/received/{storageid}/{spaceid}.json		// holds the states of received shares of the users in the according space

--- a/pkg/share/manager/jsoncs3/jsoncs3.go
+++ b/pkg/share/manager/jsoncs3/jsoncs3.go
@@ -524,6 +524,7 @@ func (m *Manager) convert(ctx context.Context, userID string, s *collaboration.S
 		StorageId: providerid,
 		SpaceId:   sid,
 	})
+
 	m.UserReceivedStates.Sync(ctx, userID)
 	state := m.UserReceivedStates.Get(userID, spaceID, s.Id.GetOpaqueId())
 	if state != nil {

--- a/pkg/share/manager/jsoncs3/jsoncs3.go
+++ b/pkg/share/manager/jsoncs3/jsoncs3.go
@@ -21,7 +21,6 @@ package jsoncs3
 import (
 	"context"
 	"sync"
-	"time"
 
 	"github.com/google/uuid"
 	"github.com/mitchellh/mapstructure"
@@ -31,7 +30,6 @@ import (
 	userv1beta1 "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	collaboration "github.com/cs3org/go-cs3apis/cs3/sharing/collaboration/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
-	typespb "github.com/cs3org/go-cs3apis/cs3/types/v1beta1"
 	ctxpkg "github.com/cs3org/reva/v2/pkg/ctx"
 	"github.com/cs3org/reva/v2/pkg/errtypes"
 	"github.com/cs3org/reva/v2/pkg/share"
@@ -183,11 +181,7 @@ func (m *Manager) Share(ctx context.Context, md *provider.ResourceInfo, g *colla
 	}
 
 	user := ctxpkg.ContextMustGetUser(ctx)
-	now := time.Now().UnixNano()
-	ts := &typespb.Timestamp{
-		Seconds: uint64(now / int64(time.Second)),
-		Nanos:   uint32(now % int64(time.Second)),
-	}
+	ts := utils.TSNow()
 
 	// do not allow share to myself or the owner if share is for a user
 	// TODO(labkode): should not this be caught already at the gw level?
@@ -378,12 +372,8 @@ func (m *Manager) UpdateShare(ctx context.Context, ref *collaboration.ShareRefer
 		return nil, errtypes.NotFound(ref.String())
 	}
 
-	now := time.Now().UnixNano()
 	s.Permissions = p
-	s.Mtime = &typespb.Timestamp{
-		Seconds: uint64(now / int64(time.Second)),
-		Nanos:   uint32(now % int64(time.Second)),
-	}
+	s.Mtime = utils.TSNow()
 
 	// Update provider cache
 	m.Cache.Persist(ctx, s.ResourceId.StorageId, s.ResourceId.SpaceId)

--- a/pkg/share/manager/jsoncs3/jsoncs3.go
+++ b/pkg/share/manager/jsoncs3/jsoncs3.go
@@ -270,7 +270,16 @@ func (m *Manager) getByID(id *collaboration.ShareId) (*collaboration.Share, erro
 	}
 	share := m.Cache.Get(shareid.StorageId, shareid.SpaceId, id.OpaqueId)
 	if share == nil {
-		return nil, errtypes.NotFound(id.String())
+		// reload cache, maybe out data is outdated
+		err = m.Cache.Sync(context.Background(), shareid.StorageId, shareid.SpaceId)
+		if err != nil {
+			return nil, err
+		}
+
+		share = m.Cache.Get(shareid.StorageId, shareid.SpaceId, id.OpaqueId)
+		if share == nil {
+			return nil, errtypes.NotFound(id.String())
+		}
 	}
 	return share, nil
 }

--- a/pkg/share/manager/jsoncs3/jsoncs3.go
+++ b/pkg/share/manager/jsoncs3/jsoncs3.go
@@ -279,12 +279,6 @@ func (m *Manager) getByKey(ctx context.Context, key *collaboration.ShareKey) (*c
 		return nil, err
 	}
 
-	// sync cache, maybe our data is outdated
-	err = m.Cache.Sync(context.Background(), key.ResourceId.StorageId, key.ResourceId.SpaceId)
-	if err != nil {
-		return nil, err
-	}
-
 	spaceShares := m.Cache.ListSpace(key.ResourceId.StorageId, key.ResourceId.SpaceId)
 	for _, share := range spaceShares.Shares {
 		if utils.GranteeEqual(key.Grantee, share.Grantee) && utils.ResourceIDEqual(share.ResourceId, key.ResourceId) {

--- a/pkg/share/manager/jsoncs3/jsoncs3.go
+++ b/pkg/share/manager/jsoncs3/jsoncs3.go
@@ -384,10 +384,8 @@ func (m *Manager) UpdateShare(ctx context.Context, ref *collaboration.ShareRefer
 		Nanos:   uint32(now % int64(time.Second)),
 	}
 
-	err = m.CreatedCache.Add(ctx, s.GetCreator().GetOpaqueId(), s.Id.OpaqueId)
-	if err != nil {
-		return nil, err
-	}
+	// Update provider cache
+	m.Cache.Persist(ctx, s.ResourceId.StorageId, s.ResourceId.SpaceId)
 
 	return s, nil
 }

--- a/pkg/share/manager/jsoncs3/jsoncs3.go
+++ b/pkg/share/manager/jsoncs3/jsoncs3.go
@@ -103,9 +103,9 @@ func NewDefault(m map[string]interface{}) (share.Manager, error) {
 func New(s metadata.Storage) (*Manager, error) {
 	return &Manager{
 		Cache:              providercache.New(s),
-		CreatedCache:       sharecache.New(s),
+		CreatedCache:       sharecache.New(s, "users", "created.json"),
 		UserReceivedStates: receivedsharecache.New(s),
-		GroupReceivedCache: sharecache.New(s),
+		GroupReceivedCache: sharecache.New(s, "groups", "received.json"),
 		storage:            s,
 	}, nil
 }

--- a/pkg/share/manager/jsoncs3/jsoncs3.go
+++ b/pkg/share/manager/jsoncs3/jsoncs3.go
@@ -431,7 +431,7 @@ func (m *Manager) listSharesByIDs(ctx context.Context, user *userv1beta1.User, f
 	}
 
 	for providerID, spaces := range providerSpaces {
-		for spaceID, _ := range spaces {
+		for spaceID := range spaces {
 			err := m.Cache.Sync(ctx, providerID, spaceID)
 			if err != nil {
 				return nil, err

--- a/pkg/share/manager/jsoncs3/jsoncs3.go
+++ b/pkg/share/manager/jsoncs3/jsoncs3.go
@@ -220,11 +220,7 @@ func (m *Manager) Share(ctx context.Context, md *provider.ResourceInfo, g *colla
 		Mtime:       ts,
 	}
 
-	m.Cache.Add(md.Id.StorageId, md.Id.SpaceId, shareID, s)
-	err = m.Cache.Persist(ctx, md.Id.StorageId, md.Id.SpaceId)
-	if err != nil {
-		return nil, err
-	}
+	m.Cache.Add(ctx, md.Id.StorageId, md.Id.SpaceId, shareID, s)
 
 	err = m.setCreatedCache(ctx, s.GetCreator().GetOpaqueId(), shareID)
 	if err != nil {
@@ -352,11 +348,7 @@ func (m *Manager) Unshare(ctx context.Context, ref *collaboration.ShareReference
 	if err != nil {
 		return err
 	}
-	m.Cache.Remove(shareid.StorageId, shareid.SpaceId, s.Id.OpaqueId)
-	err = m.Cache.Persist(ctx, shareid.StorageId, shareid.SpaceId)
-	if err != nil {
-		return err
-	}
+	m.Cache.Remove(ctx, shareid.StorageId, shareid.SpaceId, s.Id.OpaqueId)
 
 	// remove from created cache
 	err = m.CreatedCache.Remove(s.GetCreator().GetOpaqueId(), s.Id.OpaqueId)

--- a/pkg/share/manager/jsoncs3/jsoncs3.go
+++ b/pkg/share/manager/jsoncs3/jsoncs3.go
@@ -502,6 +502,10 @@ func (m *Manager) ListReceivedShares(ctx context.Context, filters []*collaborati
 		if err != nil {
 			continue
 		}
+		err = m.Cache.Sync(ctx, providerid, spaceid)
+		if err != nil {
+			continue
+		}
 		spaceShares := m.Cache.ListSpace(providerid, spaceid)
 		for shareId, state := range rspace.receivedShareStates {
 			s := spaceShares.Shares[shareId]

--- a/pkg/share/manager/jsoncs3/jsoncs3.go
+++ b/pkg/share/manager/jsoncs3/jsoncs3.go
@@ -486,12 +486,12 @@ func (m *Manager) ListReceivedShares(ctx context.Context, filters []*collaborati
 		if err != nil {
 			continue
 		}
-		spaceShares := m.Cache.ListSpace(providerid, spaceid)
 		for shareId, state := range rspace.States {
-			s := spaceShares.Shares[shareId]
+			s := m.Cache.Get(providerid, spaceid, shareId)
 			if s == nil {
 				continue
 			}
+
 			if share.IsGrantedToUser(s, user) {
 				if share.MatchesFilters(s, filters) {
 					rs := &collaboration.ReceivedShare{

--- a/pkg/share/manager/jsoncs3/jsoncs3.go
+++ b/pkg/share/manager/jsoncs3/jsoncs3.go
@@ -292,7 +292,7 @@ func (m *Manager) getByKey(ctx context.Context, key *collaboration.ShareKey) (*c
 	}
 	spaceShares := m.Cache.ListSpace(key.ResourceId.StorageId, key.ResourceId.SpaceId)
 	for _, share := range spaceShares.Shares {
-		if utils.GranteeEqual(key.Grantee, share.Grantee) {
+		if utils.GranteeEqual(key.Grantee, share.Grantee) && utils.ResourceIDEqual(share.ResourceId, key.ResourceId) {
 			return share, nil
 		}
 	}

--- a/pkg/share/manager/jsoncs3/jsoncs3.go
+++ b/pkg/share/manager/jsoncs3/jsoncs3.go
@@ -164,7 +164,6 @@ func New(s metadata.Storage) (*Manager, error) {
 // /{userid}/created/{storageid}/{spaceid}
 
 func (m *Manager) Share(ctx context.Context, md *provider.ResourceInfo, g *collaboration.ShareGrant) (*collaboration.Share, error) {
-
 	user := ctxpkg.ContextMustGetUser(ctx)
 	now := time.Now().UnixNano()
 	ts := &typespb.Timestamp{
@@ -421,6 +420,10 @@ func (m *Manager) ListShares(ctx context.Context, filters []*collaboration.Filte
 			// TODO reread from disk
 		}
 		providerid, spaceid, _, err := storagespace.SplitID(ssid)
+		if err != nil {
+			continue
+		}
+		err = m.Cache.Sync(ctx, providerid, spaceid)
 		if err != nil {
 			continue
 		}

--- a/pkg/share/manager/jsoncs3/jsoncs3_test.go
+++ b/pkg/share/manager/jsoncs3/jsoncs3_test.go
@@ -110,10 +110,9 @@ var _ = Describe("Jsoncs3", func() {
 			},
 		}
 		cacheStatInfo = &provider.ResourceInfo{
-			Etag:  "someetag",
 			Name:  "created.json",
 			Size:  10,
-			Mtime: &typesv1beta1.Timestamp{},
+			Mtime: &typesv1beta1.Timestamp{Seconds: 100},
 		}
 
 		storage *storagemocks.Storage
@@ -346,6 +345,15 @@ var _ = Describe("Jsoncs3", func() {
 			})
 		})
 		Describe("ListShares", func() {
+			It("loads the list of created shares if it hasn't been cashed yet", func() {
+				storage.On("SimpleDownload", mock.Anything, mock.Anything).Return([]byte{}, nil)
+
+				shares, err := m.ListShares(otherCtx, nil)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(shares).To(HaveLen(0))
+				storage.AssertCalled(GinkgoT(), "SimpleDownload", mock.Anything, "/users/otheruser/created.json")
+			})
+
 			It("lists an existing share", func() {
 				shares, err := m.ListShares(ctx, nil)
 				Expect(err).ToNot(HaveOccurred())

--- a/pkg/share/manager/jsoncs3/jsoncs3_test.go
+++ b/pkg/share/manager/jsoncs3/jsoncs3_test.go
@@ -263,6 +263,18 @@ var _ = Describe("Jsoncs3", func() {
 				Expect(s.Permissions.Permissions.InitiateFileUpload).To(BeTrue())
 			})
 
+			It("loads the cache when it doesn't have an entry", func() {
+				err := m.Cache.Persist(context.Background(), "storageid", "spaceid")
+				Expect(err).ToNot(HaveOccurred())
+
+				m, err = jsoncs3.New(storage)
+				Expect(err).ToNot(HaveOccurred())
+
+				s, err := m.GetShare(ctx, shareRef)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(s).ToNot(BeNil())
+			})
+
 			It("does not return other users' shares", func() {
 				s, err := m.GetShare(otherCtx, shareRef)
 				Expect(err).To(HaveOccurred())

--- a/pkg/share/manager/jsoncs3/jsoncs3_test.go
+++ b/pkg/share/manager/jsoncs3/jsoncs3_test.go
@@ -440,7 +440,7 @@ var _ = Describe("Jsoncs3", func() {
 				Expect(len(shares)).To(Equal(1))
 
 				// Add a second cache to the provider cache so it can be referenced
-				m.Cache.Add("storageid", "spaceid", "storageid$spaceid!secondshare", &collaboration.Share{
+				m.Cache.Add(ctx, "storageid", "spaceid", "storageid$spaceid!secondshare", &collaboration.Share{
 					Creator: user1.Id,
 				})
 

--- a/pkg/share/manager/jsoncs3/jsoncs3_test.go
+++ b/pkg/share/manager/jsoncs3/jsoncs3_test.go
@@ -247,6 +247,23 @@ var _ = Describe("Jsoncs3", func() {
 				Expect(err).To(HaveOccurred())
 			})
 
+			It("considers the resource id part of the key", func() {
+				s, err := m.GetShare(ctx, &collaboration.ShareReference{
+					Spec: &collaboration.ShareReference_Key{
+						Key: &collaboration.ShareKey{
+							ResourceId: &providerv1beta1.ResourceId{
+								StorageId: "storageid",
+								SpaceId:   "spaceid",
+								OpaqueId:  "unknown",
+							},
+							Grantee: grant.Grantee,
+						},
+					},
+				})
+				Expect(s).To(BeNil())
+				Expect(err).To(HaveOccurred())
+			})
+
 			It("retrieves an existing share by id", func() {
 				s, err := m.GetShare(ctx, shareRef)
 				Expect(err).ToNot(HaveOccurred())

--- a/pkg/share/manager/jsoncs3/jsoncs3_test.go
+++ b/pkg/share/manager/jsoncs3/jsoncs3_test.go
@@ -685,6 +685,43 @@ var _ = Describe("Jsoncs3", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(rs.State).To(Equal(collaboration.ShareState_SHARE_STATE_ACCEPTED))
 			})
+
+			It("updates the mountpoint", func() {
+				rs, err := m.GetReceivedShare(granteeCtx, &collaboration.ShareReference{
+					Spec: &collaboration.ShareReference_Id{
+						Id: share.Id,
+					},
+				})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(rs.MountPoint).To(BeNil())
+
+				rs.MountPoint = &providerv1beta1.Reference{
+					Path: "newMP",
+				}
+				rs, err = m.UpdateReceivedShare(granteeCtx, rs, &fieldmaskpb.FieldMask{Paths: []string{"mount_point"}})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(rs.MountPoint.Path).To(Equal("newMP"))
+
+				rs, err = m.GetReceivedShare(granteeCtx, &collaboration.ShareReference{
+					Spec: &collaboration.ShareReference_Id{
+						Id: share.Id,
+					},
+				})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(rs.MountPoint.Path).To(Equal("newMP"))
+			})
+
+			It("handles invalid field masks", func() {
+				rs, err := m.GetReceivedShare(granteeCtx, &collaboration.ShareReference{
+					Spec: &collaboration.ShareReference_Id{
+						Id: share.Id,
+					},
+				})
+				Expect(err).ToNot(HaveOccurred())
+
+				_, err = m.UpdateReceivedShare(granteeCtx, rs, &fieldmaskpb.FieldMask{Paths: []string{"invalid"}})
+				Expect(err).To(HaveOccurred())
+			})
 		})
 	})
 })

--- a/pkg/share/manager/jsoncs3/jsoncs3_test.go
+++ b/pkg/share/manager/jsoncs3/jsoncs3_test.go
@@ -553,8 +553,6 @@ var _ = Describe("Jsoncs3", func() {
 		})
 
 		Describe("ListReceivedShares", func() {
-			PIt("syncronizes the group received cache before listing")
-
 			It("lists the received shares", func() {
 				received, err := m.ListReceivedShares(granteeCtx, []*collaboration.Filter{})
 				Expect(err).ToNot(HaveOccurred())
@@ -645,6 +643,20 @@ var _ = Describe("Jsoncs3", func() {
 				})
 
 				It("lists the group share", func() {
+					received, err := m.ListReceivedShares(granteeCtx, []*collaboration.Filter{})
+					Expect(err).ToNot(HaveOccurred())
+					Expect(len(received)).To(Equal(2))
+					ids := []string{}
+					for _, s := range received {
+						ids = append(ids, s.Share.Id.OpaqueId)
+					}
+					Expect(ids).To(ConsistOf(share.Id.OpaqueId, gshare.Id.OpaqueId))
+				})
+
+				It("syncronizes the group received cache before listing", func() {
+					m, err := jsoncs3.New(storage) // Reset in-memory cache
+					Expect(err).ToNot(HaveOccurred())
+
 					received, err := m.ListReceivedShares(granteeCtx, []*collaboration.Filter{})
 					Expect(err).ToNot(HaveOccurred())
 					Expect(len(received)).To(Equal(2))

--- a/pkg/share/manager/jsoncs3/jsoncs3_test.go
+++ b/pkg/share/manager/jsoncs3/jsoncs3_test.go
@@ -550,6 +550,23 @@ var _ = Describe("Jsoncs3", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(len(shares)).To(Equal(2))
 			})
+
+			It("filters by resource id", func() {
+				shares, err := m.ListShares(ctx, []*collaboration.Filter{
+					{
+						Type: collaboration.Filter_TYPE_RESOURCE_ID,
+						Term: &collaboration.Filter_ResourceId{
+							ResourceId: &providerv1beta1.ResourceId{
+								StorageId: "storageid",
+								SpaceId:   "spaceid",
+								OpaqueId:  "somethingelse",
+							},
+						},
+					},
+				})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(shares).To(HaveLen(0))
+			})
 		})
 
 		Describe("ListReceivedShares", func() {

--- a/pkg/share/manager/jsoncs3/jsoncs3_test.go
+++ b/pkg/share/manager/jsoncs3/jsoncs3_test.go
@@ -227,6 +227,7 @@ var _ = Describe("Jsoncs3", func() {
 					Permissions: conversions.NewManagerRole().CS3ResourcePermissions(),
 				},
 			})
+			Expect(err).ToNot(HaveOccurred())
 		})
 
 		Describe("ListShares", func() {
@@ -338,7 +339,7 @@ var _ = Describe("Jsoncs3", func() {
 				cache.Shares[share.Id.OpaqueId].Permissions.Permissions.InitiateFileUpload = true
 				bytes, err := json.Marshal(cache)
 				Expect(err).ToNot(HaveOccurred())
-				storage.SimpleUpload(context.Background(), "storages/storageid/spaceid.json", bytes)
+				Expect(storage.SimpleUpload(context.Background(), "storages/storageid/spaceid.json", bytes)).To(Succeed())
 				Expect(err).ToNot(HaveOccurred())
 
 				// Reset providercache in memory
@@ -559,7 +560,7 @@ var _ = Describe("Jsoncs3", func() {
 				cache.Shares[share.Id.OpaqueId].Permissions.Permissions.InitiateFileUpload = true
 				bytes, err := json.Marshal(cache)
 				Expect(err).ToNot(HaveOccurred())
-				storage.SimpleUpload(context.Background(), "storages/storageid/spaceid.json", bytes)
+				Expect(storage.SimpleUpload(context.Background(), "storages/storageid/spaceid.json", bytes)).To(Succeed())
 				Expect(err).ToNot(HaveOccurred())
 
 				// Reset providercache in memory
@@ -579,9 +580,9 @@ var _ = Describe("Jsoncs3", func() {
 				Expect(len(shares)).To(Equal(1))
 
 				// Add a second cache to the provider cache so it can be referenced
-				m.Cache.Add(ctx, "storageid", "spaceid", "storageid^spaceid°secondshare", &collaboration.Share{
+				Expect(m.Cache.Add(ctx, "storageid", "spaceid", "storageid^spaceid°secondshare", &collaboration.Share{
 					Creator: user1.Id,
-				})
+				})).To(Succeed())
 
 				cache := sharecache.UserShareCache{
 					Mtime: time.Now(),
@@ -644,7 +645,7 @@ var _ = Describe("Jsoncs3", func() {
 				cache.Shares[share.Id.OpaqueId].Permissions.Permissions.InitiateFileUpload = true
 				bytes, err := json.Marshal(cache)
 				Expect(err).ToNot(HaveOccurred())
-				storage.SimpleUpload(context.Background(), "storages/storageid/spaceid.json", bytes)
+				Expect(storage.SimpleUpload(context.Background(), "storages/storageid/spaceid.json", bytes)).To(Succeed())
 				Expect(err).ToNot(HaveOccurred())
 
 				// Reset providercache in memory

--- a/pkg/share/manager/jsoncs3/jsoncs3_test.go
+++ b/pkg/share/manager/jsoncs3/jsoncs3_test.go
@@ -524,18 +524,18 @@ var _ = Describe("Jsoncs3", func() {
 				Expect(len(shares)).To(Equal(1))
 
 				// Add a second cache to the provider cache so it can be referenced
-				m.Cache.Add(ctx, "storageid", "spaceid", "storageid$spaceid!secondshare", &collaboration.Share{
+				m.Cache.Add(ctx, "storageid", "spaceid", "storageid^spaceid°secondshare", &collaboration.Share{
 					Creator: user1.Id,
 				})
 
 				cache := sharecache.UserShareCache{
 					Mtime: time.Now(),
 					UserShares: map[string]*sharecache.SpaceShareIDs{
-						"storageid$spaceid": {
+						"storageid^spaceid": {
 							Mtime: time.Now(),
 							IDs: map[string]struct{}{
 								shares[0].Id.OpaqueId:           {},
-								"storageid$spaceid!secondshare": {},
+								"storageid^spaceid°secondshare": {},
 							},
 						},
 					},

--- a/pkg/share/manager/jsoncs3/jsoncs3_test.go
+++ b/pkg/share/manager/jsoncs3/jsoncs3_test.go
@@ -473,7 +473,7 @@ var _ = Describe("Jsoncs3", func() {
 				})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(us).ToNot(BeNil())
-				Expect(s.GetPermissions().GetPermissions().InitiateFileUpload).To(BeTrue())
+				Expect(us.GetPermissions().GetPermissions().InitiateFileUpload).To(BeTrue())
 
 				s = shareBykey(&collaboration.ShareKey{
 					ResourceId: sharedResource.Id,
@@ -495,7 +495,7 @@ var _ = Describe("Jsoncs3", func() {
 				})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(us).ToNot(BeNil())
-				Expect(s.GetPermissions().GetPermissions().InitiateFileUpload).To(BeFalse())
+				Expect(us.GetPermissions().GetPermissions().InitiateFileUpload).To(BeFalse())
 
 				s = shareBykey(&collaboration.ShareKey{
 					ResourceId: sharedResource.Id,
@@ -525,7 +525,7 @@ var _ = Describe("Jsoncs3", func() {
 				})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(us).ToNot(BeNil())
-				Expect(s.GetPermissions().GetPermissions().InitiateFileUpload).To(BeTrue())
+				Expect(us.GetPermissions().GetPermissions().InitiateFileUpload).To(BeTrue())
 
 				m, err = jsoncs3.New(storage) // Reset in-memory cache
 				Expect(err).ToNot(HaveOccurred())

--- a/pkg/share/manager/jsoncs3/jsoncs3_test.go
+++ b/pkg/share/manager/jsoncs3/jsoncs3_test.go
@@ -31,6 +31,7 @@ import (
 	typesv1beta1 "github.com/cs3org/go-cs3apis/cs3/types/v1beta1"
 	ctxpkg "github.com/cs3org/reva/v2/pkg/ctx"
 	"github.com/cs3org/reva/v2/pkg/share/manager/jsoncs3"
+	"github.com/cs3org/reva/v2/pkg/share/manager/jsoncs3/sharecache"
 	storagemocks "github.com/cs3org/reva/v2/pkg/storage/utils/metadata/mocks"
 	"github.com/stretchr/testify/mock"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
@@ -246,6 +247,9 @@ var _ = Describe("Jsoncs3", func() {
 				Expect(err).To(HaveOccurred())
 				Expect(s).To(BeNil())
 			})
+
+			PIt("reloads the provider cache when it is outdated")
+			PIt("uses the new data after reload")
 		})
 
 		Describe("UnShare", func() {
@@ -389,9 +393,9 @@ var _ = Describe("Jsoncs3", func() {
 					Creator: user1.Id,
 				})
 
-				cache := jsoncs3.UserShareCache{
+				cache := sharecache.UserShareCache{
 					Mtime: time.Now(),
-					UserShares: map[string]*jsoncs3.SpaceShareIDs{
+					UserShares: map[string]*sharecache.SpaceShareIDs{
 						"storageid$spaceid": {
 							Mtime: time.Now(),
 							IDs: map[string]struct{}{

--- a/pkg/share/manager/jsoncs3/jsoncs3_test.go
+++ b/pkg/share/manager/jsoncs3/jsoncs3_test.go
@@ -177,13 +177,22 @@ var _ = Describe("Jsoncs3", func() {
 
 	Context("with an existing share", func() {
 		var (
-			share *collaboration.Share
+			share    *collaboration.Share
+			shareRef *collaboration.ShareReference
 		)
 
 		BeforeEach(func() {
 			var err error
 			share, err = m.Share(ctx, sharedResource, grant)
 			Expect(err).ToNot(HaveOccurred())
+
+			shareRef = &collaboration.ShareReference{
+				Spec: &collaboration.ShareReference_Id{
+					Id: &collaboration.ShareId{
+						OpaqueId: share.Id.OpaqueId,
+					},
+				},
+			}
 		})
 
 		Describe("GetShare", func() {
@@ -215,13 +224,7 @@ var _ = Describe("Jsoncs3", func() {
 			})
 
 			It("retrieves an existing share by id", func() {
-				s, err := m.GetShare(ctx, &collaboration.ShareReference{
-					Spec: &collaboration.ShareReference_Id{
-						Id: &collaboration.ShareId{
-							OpaqueId: share.Id.OpaqueId,
-						},
-					},
-				})
+				s, err := m.GetShare(ctx, shareRef)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(s).ToNot(BeNil())
 				Expect(share.ResourceId).To(Equal(sharedResource.Id))
@@ -237,13 +240,7 @@ var _ = Describe("Jsoncs3", func() {
 			})
 
 			It("does not return other users' shares", func() {
-				s, err := m.GetShare(otherCtx, &collaboration.ShareReference{
-					Spec: &collaboration.ShareReference_Id{
-						Id: &collaboration.ShareId{
-							OpaqueId: share.Id.OpaqueId,
-						},
-					},
-				})
+				s, err := m.GetShare(otherCtx, shareRef)
 				Expect(err).To(HaveOccurred())
 				Expect(s).To(BeNil())
 			})

--- a/pkg/share/manager/jsoncs3/jsoncs3_test.go
+++ b/pkg/share/manager/jsoncs3/jsoncs3_test.go
@@ -666,6 +666,23 @@ var _ = Describe("Jsoncs3", func() {
 					}
 					Expect(ids).To(ConsistOf(share.Id.OpaqueId, gshare.Id.OpaqueId))
 				})
+
+				It("merges the user state with the group share", func() {
+					rs, err := m.GetReceivedShare(granteeCtx, &collaboration.ShareReference{
+						Spec: &collaboration.ShareReference_Id{
+							Id: gshare.Id,
+						},
+					})
+					Expect(err).ToNot(HaveOccurred())
+
+					rs.State = collaboration.ShareState_SHARE_STATE_ACCEPTED
+					_, err = m.UpdateReceivedShare(granteeCtx, rs, &fieldmaskpb.FieldMask{Paths: []string{"state"}})
+					Expect(err).ToNot(HaveOccurred())
+
+					received, err := m.ListReceivedShares(granteeCtx, []*collaboration.Filter{})
+					Expect(err).ToNot(HaveOccurred())
+					Expect(len(received)).To(Equal(2))
+				})
 			})
 		})
 

--- a/pkg/share/manager/jsoncs3/jsoncs3_test.go
+++ b/pkg/share/manager/jsoncs3/jsoncs3_test.go
@@ -498,6 +498,7 @@ var _ = Describe("Jsoncs3", func() {
 				Expect(shares[0].Id.OpaqueId).To(Equal(share.Id.OpaqueId))
 				Expect(shares[0].Permissions.Permissions.InitiateFileUpload).To(BeFalse())
 
+				// Change providercache on disk
 				cache := m.Cache.Providers["storageid"].Spaces["spaceid"]
 				cache.Shares[share.Id.OpaqueId].Permissions.Permissions.InitiateFileUpload = true
 				bytes, err := json.Marshal(cache)
@@ -505,7 +506,10 @@ var _ = Describe("Jsoncs3", func() {
 				storage.SimpleUpload(context.Background(), "storages/storageid/spaceid.json", bytes)
 				Expect(err).ToNot(HaveOccurred())
 
-				m.CreatedCache.UserShares["admin"].Mtime = time.Time{} // trigger reload
+				// Reset providercache in memory
+				cache.Shares[share.Id.OpaqueId].Permissions.Permissions.InitiateFileUpload = false
+
+				m.Cache.Providers["storageid"].Spaces["spaceid"].Mtime = time.Time{} // trigger reload
 				shares, err = m.ListShares(ctx, nil)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(len(shares)).To(Equal(1))

--- a/pkg/share/manager/jsoncs3/providercache.go
+++ b/pkg/share/manager/jsoncs3/providercache.go
@@ -1,0 +1,76 @@
+// Copyright 2018-2021 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package jsoncs3
+
+import collaboration "github.com/cs3org/go-cs3apis/cs3/sharing/collaboration/v1beta1"
+
+type ProviderCache struct {
+	Providers map[string]*ProviderSpaces
+}
+
+type ProviderSpaces struct {
+	Spaces map[string]*ProviderShares
+}
+
+type ProviderShares struct {
+	Shares map[string]*collaboration.Share
+}
+
+func NewProviderCache() ProviderCache {
+	return ProviderCache{
+		Providers: map[string]*ProviderSpaces{},
+	}
+}
+
+func (pc *ProviderCache) Add(storageID, spaceID, shareID string, share *collaboration.Share) {
+	if pc.Providers[storageID] == nil {
+		pc.Providers[storageID] = &ProviderSpaces{
+			Spaces: map[string]*ProviderShares{},
+		}
+	}
+	if pc.Providers[storageID].Spaces[spaceID] == nil {
+		pc.Providers[storageID].Spaces[spaceID] = &ProviderShares{
+			Shares: map[string]*collaboration.Share{},
+		}
+	}
+	pc.Providers[storageID].Spaces[spaceID].Shares[shareID] = share
+}
+
+func (pc *ProviderCache) Remove(storageID, spaceID, shareID string) {
+	if pc.Providers[storageID] == nil ||
+		pc.Providers[storageID].Spaces[spaceID] == nil {
+		return
+	}
+	delete(pc.Providers[storageID].Spaces[spaceID].Shares, shareID)
+}
+
+func (pc *ProviderCache) Get(storageID, spaceID, shareID string) *collaboration.Share {
+	if pc.Providers[storageID] == nil ||
+		pc.Providers[storageID].Spaces[spaceID] == nil {
+		return nil
+	}
+	return pc.Providers[storageID].Spaces[spaceID].Shares[shareID]
+}
+
+func (pc *ProviderCache) ListSpace(storageID, spaceID string) *ProviderShares {
+	if pc.Providers[storageID] == nil {
+		return &ProviderShares{}
+	}
+	return pc.Providers[storageID].Spaces[spaceID]
+}

--- a/pkg/share/manager/jsoncs3/providercache/providercache.go
+++ b/pkg/share/manager/jsoncs3/providercache/providercache.go
@@ -16,43 +16,49 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-package jsoncs3
+package providercache
 
-import collaboration "github.com/cs3org/go-cs3apis/cs3/sharing/collaboration/v1beta1"
+import (
+	collaboration "github.com/cs3org/go-cs3apis/cs3/sharing/collaboration/v1beta1"
+	"github.com/cs3org/reva/v2/pkg/storage/utils/metadata"
+)
 
-type ProviderCache struct {
-	Providers map[string]*ProviderSpaces
+type Cache struct {
+	Providers map[string]*Spaces
+
+	storage metadata.Storage
 }
 
-type ProviderSpaces struct {
-	Spaces map[string]*ProviderShares
+type Spaces struct {
+	Spaces map[string]*Shares
 }
 
-type ProviderShares struct {
+type Shares struct {
 	Shares map[string]*collaboration.Share
 }
 
-func NewProviderCache() ProviderCache {
-	return ProviderCache{
-		Providers: map[string]*ProviderSpaces{},
+func New(s metadata.Storage) Cache {
+	return Cache{
+		Providers: map[string]*Spaces{},
+		storage:   s,
 	}
 }
 
-func (pc *ProviderCache) Add(storageID, spaceID, shareID string, share *collaboration.Share) {
+func (pc *Cache) Add(storageID, spaceID, shareID string, share *collaboration.Share) {
 	if pc.Providers[storageID] == nil {
-		pc.Providers[storageID] = &ProviderSpaces{
-			Spaces: map[string]*ProviderShares{},
+		pc.Providers[storageID] = &Spaces{
+			Spaces: map[string]*Shares{},
 		}
 	}
 	if pc.Providers[storageID].Spaces[spaceID] == nil {
-		pc.Providers[storageID].Spaces[spaceID] = &ProviderShares{
+		pc.Providers[storageID].Spaces[spaceID] = &Shares{
 			Shares: map[string]*collaboration.Share{},
 		}
 	}
 	pc.Providers[storageID].Spaces[spaceID].Shares[shareID] = share
 }
 
-func (pc *ProviderCache) Remove(storageID, spaceID, shareID string) {
+func (pc *Cache) Remove(storageID, spaceID, shareID string) {
 	if pc.Providers[storageID] == nil ||
 		pc.Providers[storageID].Spaces[spaceID] == nil {
 		return
@@ -60,7 +66,7 @@ func (pc *ProviderCache) Remove(storageID, spaceID, shareID string) {
 	delete(pc.Providers[storageID].Spaces[spaceID].Shares, shareID)
 }
 
-func (pc *ProviderCache) Get(storageID, spaceID, shareID string) *collaboration.Share {
+func (pc *Cache) Get(storageID, spaceID, shareID string) *collaboration.Share {
 	if pc.Providers[storageID] == nil ||
 		pc.Providers[storageID].Spaces[spaceID] == nil {
 		return nil
@@ -68,9 +74,9 @@ func (pc *ProviderCache) Get(storageID, spaceID, shareID string) *collaboration.
 	return pc.Providers[storageID].Spaces[spaceID].Shares[shareID]
 }
 
-func (pc *ProviderCache) ListSpace(storageID, spaceID string) *ProviderShares {
+func (pc *Cache) ListSpace(storageID, spaceID string) *Shares {
 	if pc.Providers[storageID] == nil {
-		return &ProviderShares{}
+		return &Shares{}
 	}
 	return pc.Providers[storageID].Spaces[spaceID]
 }

--- a/pkg/share/manager/jsoncs3/providercache/providercache.go
+++ b/pkg/share/manager/jsoncs3/providercache/providercache.go
@@ -67,7 +67,7 @@ func (s *Shares) UnmarshalJSON(data []byte) error {
 			Grantee: &provider.Grantee{Id: &provider.Grantee_UserId{}},
 		}
 		err = json.Unmarshal(genericShare, userShare) // is this a user share?
-		if err == nil {
+		if err == nil && userShare.Grantee.Type == provider.GranteeType_GRANTEE_TYPE_USER {
 			s.Shares[id] = userShare
 			continue
 		}

--- a/pkg/share/manager/jsoncs3/providercache/providercache.go
+++ b/pkg/share/manager/jsoncs3/providercache/providercache.go
@@ -45,7 +45,7 @@ type Spaces struct {
 	Spaces map[string]*Shares
 }
 
-// Shares hols the share information of one space
+// Shares holds the share information of one space
 type Shares struct {
 	Shares map[string]*collaboration.Share
 	Mtime  time.Time
@@ -161,11 +161,15 @@ func (c *Cache) Persist(ctx context.Context, storageID, spaceID string) error {
 		return err
 	}
 
-	info, err := c.storage.Stat(ctx, jsonPath)
-	if err != nil {
-		return err
-	}
-	c.Providers[storageID].Spaces[spaceID].Mtime = utils.TSToTime(info.Mtime)
+	/*
+		FIXME stating here introduces a lost read because the file might have been overwritten written between the above upload and this stat
+		the local cache is updated with Sync during reads
+		info, err := c.storage.Stat(ctx, jsonPath)
+		if err != nil {
+			return err
+		}
+		c.Providers[storageID].Spaces[spaceID].Mtime = utils.TSToTime(info.Mtime)
+	*/
 	return nil
 }
 

--- a/pkg/share/manager/jsoncs3/providercache/providercache.go
+++ b/pkg/share/manager/jsoncs3/providercache/providercache.go
@@ -152,7 +152,7 @@ func (c *Cache) Persist(ctx context.Context, storageID, spaceID string) error {
 	if err := c.storage.MakeDirIfNotExist(ctx, path.Dir(jsonPath)); err != nil {
 		return err
 	}
-	// FIXME needs stat & upload if match combo to prevent lost update in redundant deployments
+
 	if err := c.storage.Upload(ctx, metadata.UploadRequest{
 		Path:              jsonPath,
 		Content:           createdBytes,
@@ -160,6 +160,12 @@ func (c *Cache) Persist(ctx context.Context, storageID, spaceID string) error {
 	}); err != nil {
 		return err
 	}
+
+	info, err := c.storage.Stat(ctx, jsonPath)
+	if err != nil {
+		return err
+	}
+	c.Providers[storageID].Spaces[spaceID].Mtime = utils.TSToTime(info.Mtime)
 	return nil
 }
 

--- a/pkg/share/manager/jsoncs3/providercache/providercache.go
+++ b/pkg/share/manager/jsoncs3/providercache/providercache.go
@@ -92,19 +92,23 @@ func New(s metadata.Storage) Cache {
 	}
 }
 
-func (c *Cache) Add(storageID, spaceID, shareID string, share *collaboration.Share) {
+func (c *Cache) Add(ctx context.Context, storageID, spaceID, shareID string, share *collaboration.Share) error {
 	c.initializeIfNeeded(storageID, spaceID)
 	c.Providers[storageID].Spaces[spaceID].Shares[shareID] = share
 	c.Providers[storageID].Spaces[spaceID].Mtime = time.Now()
+
+	return c.Persist(ctx, storageID, spaceID)
 }
 
-func (c *Cache) Remove(storageID, spaceID, shareID string) {
+func (c *Cache) Remove(ctx context.Context, storageID, spaceID, shareID string) error {
 	if c.Providers[storageID] == nil ||
 		c.Providers[storageID].Spaces[spaceID] == nil {
-		return
+		return nil
 	}
 	delete(c.Providers[storageID].Spaces[spaceID].Shares, shareID)
 	c.Providers[storageID].Spaces[spaceID].Mtime = time.Now()
+
+	return c.Persist(ctx, storageID, spaceID)
 }
 
 func (c *Cache) Get(storageID, spaceID, shareID string) *collaboration.Share {

--- a/pkg/share/manager/jsoncs3/providercache/providercache.go
+++ b/pkg/share/manager/jsoncs3/providercache/providercache.go
@@ -166,7 +166,7 @@ func (c *Cache) Persist(ctx context.Context, storageID, spaceID string) error {
 // Sync updates the in-memory data with the data from the storage if it is outdated
 func (c *Cache) Sync(ctx context.Context, storageID, spaceID string) error {
 	log := appctx.GetLogger(ctx).With().Str("storageID", storageID).Str("spaceID", spaceID).Logger()
-	log.Debug().Msg("Syncing provider cache..")
+	log.Debug().Msg("Syncing provider cache...")
 
 	var mtime time.Time
 	if c.Providers[storageID] != nil && c.Providers[storageID].Spaces[spaceID] != nil {
@@ -187,7 +187,7 @@ func (c *Cache) Sync(ctx context.Context, storageID, spaceID string) error {
 	}
 	// check mtime of /users/{userid}/created.json
 	if utils.TSToTime(info.Mtime).After(mtime) {
-		log.Error().Err(err).Msg("Updating...")
+		log.Debug().Msg("Updating provider cache...")
 		//  - update cached list of created shares for the user in memory if changed
 		createdBlob, err := c.storage.SimpleDownload(ctx, jsonPath)
 		if err != nil {
@@ -203,7 +203,7 @@ func (c *Cache) Sync(ctx context.Context, storageID, spaceID string) error {
 		c.initializeIfNeeded(storageID, spaceID)
 		c.Providers[storageID].Spaces[spaceID] = newShares
 	}
-	log.Error().Err(err).Msg("Provider cache ist up to date")
+	log.Debug().Msg("Provider cache is up to date")
 	return nil
 }
 

--- a/pkg/share/manager/jsoncs3/providercache/providercache.go
+++ b/pkg/share/manager/jsoncs3/providercache/providercache.go
@@ -181,10 +181,9 @@ func (c *Cache) Sync(ctx context.Context, storageID, spaceID string) error {
 	if err != nil {
 		if _, ok := err.(errtypes.NotFound); ok {
 			return nil // Nothing to sync against
-		} else {
-			log.Error().Err(err).Msg("Failed to stat the provider cache")
-			return err
 		}
+		log.Error().Err(err).Msg("Failed to stat the provider cache")
+		return err
 	}
 	// check mtime of /users/{userid}/created.json
 	if utils.TSToTime(info.Mtime).After(mtime) {

--- a/pkg/share/manager/jsoncs3/providercache/providercache.go
+++ b/pkg/share/manager/jsoncs3/providercache/providercache.go
@@ -55,6 +55,7 @@ func New(s metadata.Storage) Cache {
 func (c *Cache) Add(storageID, spaceID, shareID string, share *collaboration.Share) {
 	c.initializeIfNeeded(storageID, spaceID)
 	c.Providers[storageID].Spaces[spaceID].Shares[shareID] = share
+	c.Providers[storageID].Spaces[spaceID].Mtime = time.Now()
 }
 
 func (c *Cache) Remove(storageID, spaceID, shareID string) {
@@ -63,6 +64,7 @@ func (c *Cache) Remove(storageID, spaceID, shareID string) {
 		return
 	}
 	delete(c.Providers[storageID].Spaces[spaceID].Shares, shareID)
+	c.Providers[storageID].Spaces[spaceID].Mtime = time.Now()
 }
 
 func (c *Cache) Get(storageID, spaceID, shareID string) *collaboration.Share {

--- a/pkg/share/manager/jsoncs3/providercache/providercache_suite_test.go
+++ b/pkg/share/manager/jsoncs3/providercache/providercache_suite_test.go
@@ -1,3 +1,21 @@
+// Copyright 2018-2022 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
 package providercache_test
 
 import (

--- a/pkg/share/manager/jsoncs3/providercache/providercache_suite_test.go
+++ b/pkg/share/manager/jsoncs3/providercache/providercache_suite_test.go
@@ -1,0 +1,13 @@
+package providercache_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestProvidercache(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Providercache Suite")
+}

--- a/pkg/share/manager/jsoncs3/providercache/providercache_test.go
+++ b/pkg/share/manager/jsoncs3/providercache/providercache_test.go
@@ -1,3 +1,21 @@
+// Copyright 2018-2022 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
 package providercache_test
 
 import (

--- a/pkg/share/manager/jsoncs3/providercache/providercache_test.go
+++ b/pkg/share/manager/jsoncs3/providercache/providercache_test.go
@@ -59,7 +59,7 @@ var _ = Describe("Cache", func() {
 			s := c.Get(storageID, spaceID, shareID)
 			Expect(s).To(BeNil())
 
-			c.Add(storageID, spaceID, shareID, share1)
+			c.Add(ctx, storageID, spaceID, shareID, share1)
 
 			s = c.Get(storageID, spaceID, shareID)
 			Expect(s).ToNot(BeNil())
@@ -67,22 +67,21 @@ var _ = Describe("Cache", func() {
 		})
 
 		It("sets the mtime", func() {
-			c.Add(storageID, spaceID, shareID, share1)
+			c.Add(ctx, storageID, spaceID, shareID, share1)
 			Expect(c.Providers[storageID].Spaces[spaceID].Mtime).ToNot(Equal(time.Time{}))
 		})
 
 		It("updates the mtime", func() {
-			c.Add(storageID, spaceID, shareID, share1)
+			c.Add(ctx, storageID, spaceID, shareID, share1)
 			old := c.Providers[storageID].Spaces[spaceID].Mtime
-			c.Add(storageID, spaceID, shareID, share1)
+			c.Add(ctx, storageID, spaceID, shareID, share1)
 			Expect(c.Providers[storageID].Spaces[spaceID].Mtime).ToNot(Equal(old))
 		})
 	})
 
 	Context("with an existing entry", func() {
 		BeforeEach(func() {
-			c.Add(storageID, spaceID, shareID, share1)
-			Expect(c.Persist(context.Background(), storageID, spaceID)).To(Succeed())
+			Expect(c.Add(ctx, storageID, spaceID, shareID, share1)).To(Succeed())
 		})
 
 		Describe("Get", func() {
@@ -98,16 +97,16 @@ var _ = Describe("Cache", func() {
 				Expect(s).ToNot(BeNil())
 				Expect(s).To(Equal(share1))
 
-				c.Remove(storageID, spaceID, shareID)
+				c.Remove(ctx, storageID, spaceID, shareID)
 
 				s = c.Get(storageID, spaceID, shareID)
 				Expect(s).To(BeNil())
 			})
 
 			It("updates the mtime", func() {
-				c.Add(storageID, spaceID, shareID, share1)
+				c.Add(ctx, storageID, spaceID, shareID, share1)
 				old := c.Providers[storageID].Spaces[spaceID].Mtime
-				c.Remove(storageID, spaceID, shareID)
+				c.Remove(ctx, storageID, spaceID, shareID)
 				Expect(c.Providers[storageID].Spaces[spaceID].Mtime).ToNot(Equal(old))
 			})
 		})

--- a/pkg/share/manager/jsoncs3/providercache/providercache_test.go
+++ b/pkg/share/manager/jsoncs3/providercache/providercache_test.go
@@ -64,6 +64,18 @@ var _ = Describe("Cache", func() {
 			Expect(s).ToNot(BeNil())
 			Expect(s).To(Equal(share1))
 		})
+
+		It("sets the mtime", func() {
+			c.Add(storageId, spaceid, share1.Id.OpaqueId, share1)
+			Expect(c.Providers[storageId].Spaces[spaceid].Mtime).ToNot(Equal(time.Time{}))
+		})
+
+		It("updates the mtime", func() {
+			c.Add(storageId, spaceid, share1.Id.OpaqueId, share1)
+			old := c.Providers[storageId].Spaces[spaceid].Mtime
+			c.Add(storageId, spaceid, share1.Id.OpaqueId, share1)
+			Expect(c.Providers[storageId].Spaces[spaceid].Mtime).ToNot(Equal(old))
+		})
 	})
 
 	Context("with an existing entry", func() {
@@ -81,6 +93,13 @@ var _ = Describe("Cache", func() {
 
 				s = c.Get(storageId, spaceid, share1.Id.OpaqueId)
 				Expect(s).To(BeNil())
+			})
+
+			It("updates the mtime", func() {
+				c.Add(storageId, spaceid, share1.Id.OpaqueId, share1)
+				old := c.Providers[storageId].Spaces[spaceid].Mtime
+				c.Remove(storageId, spaceid, share1.Id.OpaqueId)
+				Expect(c.Providers[storageId].Spaces[spaceid].Mtime).ToNot(Equal(old))
 			})
 		})
 

--- a/pkg/share/manager/jsoncs3/providercache/providercache_test.go
+++ b/pkg/share/manager/jsoncs3/providercache/providercache_test.go
@@ -1,45 +1,135 @@
 package providercache_test
 
 import (
+	"context"
+	"io/ioutil"
+	"os"
+	"time"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	collaboration "github.com/cs3org/go-cs3apis/cs3/sharing/collaboration/v1beta1"
 	"github.com/cs3org/reva/v2/pkg/share/manager/jsoncs3/providercache"
-	storagemocks "github.com/cs3org/reva/v2/pkg/storage/utils/metadata/mocks"
+	"github.com/cs3org/reva/v2/pkg/storage/utils/metadata"
 )
 
 var _ = Describe("Cache", func() {
 	var (
 		c       providercache.Cache
-		storage *storagemocks.Storage
+		storage metadata.Storage
 
-		// storageId = "storageid"
-		// spaceid   = "spaceid"
-		// share1    = &collaboration.Share{
-		// 	Id: &collaboration.ShareId{
-		// 		OpaqueId: "share1",
-		// 	},
-		// }
+		storageId = "storageid"
+		spaceid   = "spaceid"
+		share1    = &collaboration.Share{
+			Id: &collaboration.ShareId{
+				OpaqueId: "share1",
+			},
+		}
+		ctx    context.Context
+		tmpdir string
 	)
 
 	BeforeEach(func() {
-		storage = &storagemocks.Storage{}
+		ctx = context.Background()
+
+		var err error
+		tmpdir, err = ioutil.TempDir("", "providercache-test")
+		Expect(err).ToNot(HaveOccurred())
+
+		err = os.MkdirAll(tmpdir, 0755)
+		Expect(err).ToNot(HaveOccurred())
+
+		storage, err = metadata.NewDiskStorage(tmpdir)
+		Expect(err).ToNot(HaveOccurred())
 
 		c = providercache.New(storage)
 		Expect(c).ToNot(BeNil())
 	})
 
+	AfterEach(func() {
+		if tmpdir != "" {
+			os.RemoveAll(tmpdir)
+		}
+	})
+
 	Describe("Add", func() {
 		It("adds a share", func() {
-			// oldMtime := c.Providers.
-			// s := c.Get(storageId, spaceid, share1.Id.OpaqueId)
-			// Expect(s).To(BeNil())
+			s := c.Get(storageId, spaceid, share1.Id.OpaqueId)
+			Expect(s).To(BeNil())
 
-			// c.Add(storageId, spaceid, share1.Id.OpaqueId, share1)
+			c.Add(storageId, spaceid, share1.Id.OpaqueId, share1)
 
-			// s = c.Get(storageId, spaceid, share1.Id.OpaqueId)
-			// Expect(s).ToNot(BeNil())
-			// Expect(s).To(Equal(share1))
+			s = c.Get(storageId, spaceid, share1.Id.OpaqueId)
+			Expect(s).ToNot(BeNil())
+			Expect(s).To(Equal(share1))
+		})
+	})
+
+	Context("with an existing entry", func() {
+		BeforeEach(func() {
+			c.Add(storageId, spaceid, share1.Id.OpaqueId, share1)
+		})
+
+		Describe("Remove", func() {
+			It("removes the entry", func() {
+				s := c.Get(storageId, spaceid, share1.Id.OpaqueId)
+				Expect(s).ToNot(BeNil())
+				Expect(s).To(Equal(share1))
+
+				c.Remove(storageId, spaceid, share1.Id.OpaqueId)
+
+				s = c.Get(storageId, spaceid, share1.Id.OpaqueId)
+				Expect(s).To(BeNil())
+			})
+		})
+
+		Describe("Persist", func() {
+			It("handles non-existent storages", func() {
+				Expect(c.Persist(ctx, "foo", "bar")).To(Succeed())
+			})
+			It("handles non-existent spaces", func() {
+				Expect(c.Persist(ctx, storageId, "bar")).To(Succeed())
+			})
+
+			It("persists", func() {
+				Expect(c.Persist(ctx, storageId, spaceid)).To(Succeed())
+			})
+		})
+
+		Describe("Sync", func() {
+			BeforeEach(func() {
+				Expect(c.Persist(ctx, storageId, spaceid)).To(Succeed())
+				// reset in-memory cache
+				c = providercache.New(storage)
+			})
+
+			It("downloads if needed", func() {
+				s := c.Get(storageId, spaceid, share1.Id.OpaqueId)
+				Expect(s).To(BeNil())
+
+				c.Sync(ctx, storageId, spaceid)
+
+				s = c.Get(storageId, spaceid, share1.Id.OpaqueId)
+				Expect(s).ToNot(BeNil())
+			})
+
+			It("does not download if not needed", func() {
+				s := c.Get(storageId, spaceid, share1.Id.OpaqueId)
+				Expect(s).To(BeNil())
+
+				c.Providers[storageId] = &providercache.Spaces{
+					Spaces: map[string]*providercache.Shares{
+						spaceid: {
+							Mtime: time.Now(),
+						},
+					},
+				}
+				c.Sync(ctx, storageId, spaceid)
+
+				s = c.Get(storageId, spaceid, share1.Id.OpaqueId)
+				Expect(s).To(BeNil()) // Sync from disk didn't happen because in-memory mtime is later than on disk
+			})
 		})
 	})
 })

--- a/pkg/share/manager/jsoncs3/providercache/providercache_test.go
+++ b/pkg/share/manager/jsoncs3/providercache/providercache_test.go
@@ -130,10 +130,11 @@ var _ = Describe("Cache", func() {
 				Expect(c.Providers[storageID].Spaces[spaceID].Mtime).ToNot(Equal(oldMtime))
 			})
 
-			It("does not persist if the etag changed on disk", func() {
-				c.Providers[storageID].Spaces[spaceID].Mtime = time.Now().Add(-3 * time.Hour)
+		})
 
-				Expect(c.Persist(ctx, storageID, spaceID)).ToNot(Succeed())
+		Describe("PersistWithTime", func() {
+			It("does not persist if the mtime on disk is more recent", func() {
+				Expect(c.PersistWithTime(ctx, storageID, spaceID, time.Now().Add(-3*time.Hour))).ToNot(Succeed())
 			})
 		})
 

--- a/pkg/share/manager/jsoncs3/providercache/providercache_test.go
+++ b/pkg/share/manager/jsoncs3/providercache/providercache_test.go
@@ -77,7 +77,7 @@ var _ = Describe("Cache", func() {
 			s := c.Get(storageID, spaceID, shareID)
 			Expect(s).To(BeNil())
 
-			c.Add(ctx, storageID, spaceID, shareID, share1)
+			Expect(c.Add(ctx, storageID, spaceID, shareID, share1)).To(Succeed())
 
 			s = c.Get(storageID, spaceID, shareID)
 			Expect(s).ToNot(BeNil())
@@ -85,14 +85,14 @@ var _ = Describe("Cache", func() {
 		})
 
 		It("sets the mtime", func() {
-			c.Add(ctx, storageID, spaceID, shareID, share1)
+			Expect(c.Add(ctx, storageID, spaceID, shareID, share1)).To(Succeed())
 			Expect(c.Providers[storageID].Spaces[spaceID].Mtime).ToNot(Equal(time.Time{}))
 		})
 
 		It("updates the mtime", func() {
-			c.Add(ctx, storageID, spaceID, shareID, share1)
+			Expect(c.Add(ctx, storageID, spaceID, shareID, share1)).To(Succeed())
 			old := c.Providers[storageID].Spaces[spaceID].Mtime
-			c.Add(ctx, storageID, spaceID, shareID, share1)
+			Expect(c.Add(ctx, storageID, spaceID, shareID, share1)).To(Succeed())
 			Expect(c.Providers[storageID].Spaces[spaceID].Mtime).ToNot(Equal(old))
 		})
 	})
@@ -115,16 +115,16 @@ var _ = Describe("Cache", func() {
 				Expect(s).ToNot(BeNil())
 				Expect(s).To(Equal(share1))
 
-				c.Remove(ctx, storageID, spaceID, shareID)
+				Expect(c.Remove(ctx, storageID, spaceID, shareID)).To(Succeed())
 
 				s = c.Get(storageID, spaceID, shareID)
 				Expect(s).To(BeNil())
 			})
 
 			It("updates the mtime", func() {
-				c.Add(ctx, storageID, spaceID, shareID, share1)
+				Expect(c.Add(ctx, storageID, spaceID, shareID, share1)).To(Succeed())
 				old := c.Providers[storageID].Spaces[spaceID].Mtime
-				c.Remove(ctx, storageID, spaceID, shareID)
+				Expect(c.Remove(ctx, storageID, spaceID, shareID)).To(Succeed())
 				Expect(c.Providers[storageID].Spaces[spaceID].Mtime).ToNot(Equal(old))
 			})
 		})
@@ -167,7 +167,7 @@ var _ = Describe("Cache", func() {
 				s := c.Get(storageID, spaceID, shareID)
 				Expect(s).To(BeNil())
 
-				c.Sync(ctx, storageID, spaceID)
+				Expect(c.Sync(ctx, storageID, spaceID)).To(Succeed())
 
 				s = c.Get(storageID, spaceID, shareID)
 				Expect(s).ToNot(BeNil())
@@ -184,7 +184,7 @@ var _ = Describe("Cache", func() {
 						},
 					},
 				}
-				c.Sync(ctx, storageID, spaceID) // Sync from disk won't happen because in-memory mtime is later than on disk
+				Expect(c.Sync(ctx, storageID, spaceID)).To(Succeed()) // Sync from disk won't happen because in-memory mtime is later than on disk
 
 				s = c.Get(storageID, spaceID, shareID)
 				Expect(s).To(BeNil())

--- a/pkg/share/manager/jsoncs3/providercache/providercache_test.go
+++ b/pkg/share/manager/jsoncs3/providercache/providercache_test.go
@@ -122,6 +122,13 @@ var _ = Describe("Cache", func() {
 			It("persists", func() {
 				Expect(c.Persist(ctx, storageID, spaceID)).To(Succeed())
 			})
+
+			It("updates the mtime", func() {
+				oldMtime := c.Providers[storageID].Spaces[spaceID].Mtime
+
+				Expect(c.Persist(ctx, storageID, spaceID)).To(Succeed())
+				Expect(c.Providers[storageID].Spaces[spaceID].Mtime).ToNot(Equal(oldMtime))
+			})
 		})
 
 		Describe("Sync", func() {

--- a/pkg/share/manager/jsoncs3/providercache/providercache_test.go
+++ b/pkg/share/manager/jsoncs3/providercache/providercache_test.go
@@ -1,0 +1,45 @@
+package providercache_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/cs3org/reva/v2/pkg/share/manager/jsoncs3/providercache"
+	storagemocks "github.com/cs3org/reva/v2/pkg/storage/utils/metadata/mocks"
+)
+
+var _ = Describe("Cache", func() {
+	var (
+		c       providercache.Cache
+		storage *storagemocks.Storage
+
+		// storageId = "storageid"
+		// spaceid   = "spaceid"
+		// share1    = &collaboration.Share{
+		// 	Id: &collaboration.ShareId{
+		// 		OpaqueId: "share1",
+		// 	},
+		// }
+	)
+
+	BeforeEach(func() {
+		storage = &storagemocks.Storage{}
+
+		c = providercache.New(storage)
+		Expect(c).ToNot(BeNil())
+	})
+
+	Describe("Add", func() {
+		It("adds a share", func() {
+			// oldMtime := c.Providers.
+			// s := c.Get(storageId, spaceid, share1.Id.OpaqueId)
+			// Expect(s).To(BeNil())
+
+			// c.Add(storageId, spaceid, share1.Id.OpaqueId, share1)
+
+			// s = c.Get(storageId, spaceid, share1.Id.OpaqueId)
+			// Expect(s).ToNot(BeNil())
+			// Expect(s).To(Equal(share1))
+		})
+	})
+})

--- a/pkg/share/manager/jsoncs3/providercache/providercache_test.go
+++ b/pkg/share/manager/jsoncs3/providercache/providercache_test.go
@@ -129,6 +129,12 @@ var _ = Describe("Cache", func() {
 				Expect(c.Persist(ctx, storageID, spaceID)).To(Succeed())
 				Expect(c.Providers[storageID].Spaces[spaceID].Mtime).ToNot(Equal(oldMtime))
 			})
+
+			It("does not persist if the etag changed on disk", func() {
+				c.Providers[storageID].Spaces[spaceID].Mtime = time.Now().Add(-3 * time.Hour)
+
+				Expect(c.Persist(ctx, storageID, spaceID)).ToNot(Succeed())
+			})
 		})
 
 		Describe("Sync", func() {

--- a/pkg/share/manager/jsoncs3/receivedsharecache/receivedShareCache_suite_test.go
+++ b/pkg/share/manager/jsoncs3/receivedsharecache/receivedShareCache_suite_test.go
@@ -1,3 +1,21 @@
+// Copyright 2018-2022 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
 package receivedsharecache_test
 
 import (

--- a/pkg/share/manager/jsoncs3/receivedsharecache/receivedShareCache_suite_test.go
+++ b/pkg/share/manager/jsoncs3/receivedsharecache/receivedShareCache_suite_test.go
@@ -1,0 +1,13 @@
+package receivedsharecache_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestReceivedShareCache(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "ReceivedShareCache Suite")
+}

--- a/pkg/share/manager/jsoncs3/receivedsharecache/receivedsharecache.go
+++ b/pkg/share/manager/jsoncs3/receivedsharecache/receivedsharecache.go
@@ -117,10 +117,9 @@ func (c *Cache) Sync(ctx context.Context, userID string) error {
 	if err != nil {
 		if _, ok := err.(errtypes.NotFound); ok {
 			return nil // Nothing to sync against
-		} else {
-			log.Error().Err(err).Msg("Failed to stat the received share")
-			return err
 		}
+		log.Error().Err(err).Msg("Failed to stat the received share")
+		return err
 	}
 	// check mtime of /users/{userid}/created.json
 	if utils.TSToTime(info.Mtime).After(mtime) {

--- a/pkg/share/manager/jsoncs3/receivedsharecache/receivedsharecache.go
+++ b/pkg/share/manager/jsoncs3/receivedsharecache/receivedsharecache.go
@@ -1,0 +1,144 @@
+// Copyright 2018-2022 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package receivedsharecache
+
+import (
+	"context"
+	"encoding/json"
+	"path"
+	"path/filepath"
+	"time"
+
+	collaboration "github.com/cs3org/go-cs3apis/cs3/sharing/collaboration/v1beta1"
+	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+	"github.com/cs3org/reva/v2/pkg/storage/utils/metadata"
+	"github.com/cs3org/reva/v2/pkg/utils"
+)
+
+type Cache struct {
+	ReceivedSpaces map[string]*Spaces
+
+	storage metadata.Storage
+}
+
+type Spaces struct {
+	Mtime  time.Time
+	Spaces map[string]*Space
+}
+
+type Space struct {
+	Mtime  time.Time
+	States map[string]*State
+}
+type State struct {
+	State      collaboration.ShareState
+	MountPoint *provider.Reference
+}
+
+func New(s metadata.Storage) Cache {
+	return Cache{
+		ReceivedSpaces: map[string]*Spaces{},
+		storage:        s,
+	}
+}
+
+func (c *Cache) Add(ctx context.Context, userID, spaceID string, rs *collaboration.ReceivedShare) error {
+	if c.ReceivedSpaces[userID] == nil {
+		c.ReceivedSpaces[userID] = &Spaces{
+			Spaces: map[string]*Space{},
+		}
+	}
+	if c.ReceivedSpaces[userID].Spaces[spaceID] == nil {
+		c.ReceivedSpaces[userID].Spaces[spaceID] = &Space{}
+	}
+
+	receivedSpace := c.ReceivedSpaces[userID].Spaces[spaceID]
+	receivedSpace.Mtime = time.Now()
+	if receivedSpace.States == nil {
+		receivedSpace.States = map[string]*State{}
+	}
+	receivedSpace.States[rs.Share.Id.GetOpaqueId()] = &State{
+		State:      rs.State,
+		MountPoint: rs.MountPoint,
+	}
+
+	return c.Persist(ctx, userID)
+}
+
+func (c *Cache) Get(userID, spaceID, shareID string) *State {
+	if c.ReceivedSpaces[userID] == nil || c.ReceivedSpaces[userID].Spaces[spaceID] == nil {
+		return nil
+	}
+	return c.ReceivedSpaces[userID].Spaces[spaceID].States[shareID]
+}
+
+func (c *Cache) Sync(ctx context.Context, userID string) error {
+	var mtime time.Time
+	if c.ReceivedSpaces[userID] != nil {
+		mtime = c.ReceivedSpaces[userID].Mtime
+	} else {
+		mtime = time.Time{} // Set zero time so that data from storage always takes precedence
+	}
+
+	jsonPath := userJSONPath(userID)
+	info, err := c.storage.Stat(ctx, jsonPath)
+	if err != nil {
+		return err
+	}
+	// check mtime of /users/{userid}/created.json
+	if utils.TSToTime(info.Mtime).After(mtime) {
+		//  - update cached list of created shares for the user in memory if changed
+		createdBlob, err := c.storage.SimpleDownload(ctx, jsonPath)
+		if err != nil {
+			return err
+		}
+		newSpaces := &Spaces{}
+		err = json.Unmarshal(createdBlob, newSpaces)
+		if err != nil {
+			return err
+		}
+		c.ReceivedSpaces[userID] = newSpaces
+	}
+	return nil
+}
+
+func (c *Cache) Persist(ctx context.Context, userID string) error {
+	if c.ReceivedSpaces[userID] == nil {
+		return nil
+	}
+
+	c.ReceivedSpaces[userID].Mtime = time.Now()
+	createdBytes, err := json.Marshal(c.ReceivedSpaces[userID])
+	if err != nil {
+		return err
+	}
+	jsonPath := userJSONPath(userID)
+	if err := c.storage.MakeDirIfNotExist(ctx, path.Dir(jsonPath)); err != nil {
+		return err
+	}
+	// FIXME needs stat & upload if match combo to prevent lost update in redundant deployments
+	if err := c.storage.SimpleUpload(ctx, jsonPath, createdBytes); err != nil {
+		return err
+	}
+	return nil
+}
+
+func userJSONPath(userID string) string {
+	return filepath.Join("/users", userID, "received.json")
+}

--- a/pkg/share/manager/jsoncs3/receivedsharecache/receivedsharecache.go
+++ b/pkg/share/manager/jsoncs3/receivedsharecache/receivedsharecache.go
@@ -46,7 +46,7 @@ type Spaces struct {
 	Spaces map[string]*Space
 }
 
-// Spaces holds the received shares in one space of one user
+// Space holds the received shares of one user in one space
 type Space struct {
 	Mtime  time.Time
 	States map[string]*State

--- a/pkg/share/manager/jsoncs3/receivedsharecache/receivedsharecache.go
+++ b/pkg/share/manager/jsoncs3/receivedsharecache/receivedsharecache.go
@@ -123,7 +123,7 @@ func (c *Cache) Sync(ctx context.Context, userID string) error {
 	}
 	// check mtime of /users/{userid}/created.json
 	if utils.TSToTime(info.Mtime).After(mtime) {
-		log.Debug().Msg("Updating...")
+		log.Debug().Msg("Updating received share cache...")
 		//  - update cached list of created shares for the user in memory if changed
 		createdBlob, err := c.storage.SimpleDownload(ctx, jsonPath)
 		if err != nil {
@@ -138,7 +138,7 @@ func (c *Cache) Sync(ctx context.Context, userID string) error {
 		}
 		c.ReceivedSpaces[userID] = newSpaces
 	}
-	log.Debug().Msg("Received share ist up to date")
+	log.Debug().Msg("Received share cache is up to date")
 	return nil
 }
 

--- a/pkg/share/manager/jsoncs3/receivedsharecache/receivedsharecache.go
+++ b/pkg/share/manager/jsoncs3/receivedsharecache/receivedsharecache.go
@@ -167,12 +167,15 @@ func (c *Cache) Persist(ctx context.Context, userID string) error {
 		return err
 	}
 
-	info, err := c.storage.Stat(ctx, jsonPath)
-	if err != nil {
-		return err
-	}
-	c.ReceivedSpaces[userID].Mtime = utils.TSToTime(info.Mtime)
-
+	/*
+		FIXME stating here introduces a lost read because the file might have been overwritten written between the above upload and this stat
+		the local cache is updated with Sync during reads
+		info, err := c.storage.Stat(ctx, jsonPath)
+		if err != nil {
+			return err
+		}
+		c.ReceivedSpaces[userID].Mtime = utils.TSToTime(info.Mtime)
+	*/
 	return nil
 }
 

--- a/pkg/share/manager/jsoncs3/receivedsharecache/receivedsharecache_test.go
+++ b/pkg/share/manager/jsoncs3/receivedsharecache/receivedsharecache_test.go
@@ -1,0 +1,134 @@
+// Copyright 2018-2022 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package receivedsharecache_test
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+
+	collaboration "github.com/cs3org/go-cs3apis/cs3/sharing/collaboration/v1beta1"
+	collaborationv1beta1 "github.com/cs3org/go-cs3apis/cs3/sharing/collaboration/v1beta1"
+	"github.com/cs3org/reva/v2/pkg/share/manager/jsoncs3/receivedsharecache"
+	"github.com/cs3org/reva/v2/pkg/storage/utils/metadata"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Cache", func() {
+	var (
+		c       receivedsharecache.Cache
+		storage metadata.Storage
+
+		userID  = "user"
+		spaceID = "spaceid"
+		shareID = "storageid$spaceid!share1"
+		share   = &collaboration.Share{
+			Id: &collaborationv1beta1.ShareId{
+				OpaqueId: shareID,
+			},
+		}
+		ctx    context.Context
+		tmpdir string
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+
+		var err error
+		tmpdir, err = ioutil.TempDir("", "providercache-test")
+		Expect(err).ToNot(HaveOccurred())
+
+		err = os.MkdirAll(tmpdir, 0755)
+		Expect(err).ToNot(HaveOccurred())
+
+		storage, err = metadata.NewDiskStorage(tmpdir)
+		Expect(err).ToNot(HaveOccurred())
+
+		c = receivedsharecache.New(storage)
+		Expect(c).ToNot(BeNil())
+	})
+
+	AfterEach(func() {
+		if tmpdir != "" {
+			os.RemoveAll(tmpdir)
+		}
+	})
+
+	Describe("Add", func() {
+		It("adds an entry", func() {
+			rs := &collaboration.ReceivedShare{
+				Share: share,
+				State: collaborationv1beta1.ShareState_SHARE_STATE_PENDING,
+			}
+			err := c.Add(ctx, userID, spaceID, rs)
+			Expect(err).ToNot(HaveOccurred())
+
+			s := c.Get(userID, spaceID, shareID)
+			Expect(s).ToNot(BeNil())
+		})
+
+		It("persists the new entry", func() {
+			rs := &collaboration.ReceivedShare{
+				Share: share,
+				State: collaborationv1beta1.ShareState_SHARE_STATE_PENDING,
+			}
+			err := c.Add(ctx, userID, spaceID, rs)
+			Expect(err).ToNot(HaveOccurred())
+
+			c = receivedsharecache.New(storage)
+			Expect(c.Sync(ctx, userID)).To(Succeed())
+			s := c.Get(userID, spaceID, shareID)
+			Expect(s).ToNot(BeNil())
+		})
+	})
+
+	Describe("with an existing entry", func() {
+		BeforeEach(func() {
+			rs := &collaboration.ReceivedShare{
+				Share: share,
+				State: collaborationv1beta1.ShareState_SHARE_STATE_PENDING,
+			}
+			Expect(c.Add(ctx, userID, spaceID, rs)).To(Succeed())
+		})
+
+		Describe("Get", func() {
+			It("handles unknown users", func() {
+				s := c.Get("something", spaceID, shareID)
+				Expect(s).To(BeNil())
+			})
+
+			It("handles unknown spaces", func() {
+				s := c.Get(userID, "something", shareID)
+				Expect(s).To(BeNil())
+			})
+
+			It("handles unknown shares", func() {
+				s := c.Get(userID, spaceID, "something")
+				Expect(s).To(BeNil())
+			})
+
+			It("gets the entry", func() {
+				s := c.Get(userID, spaceID, shareID)
+				Expect(s).ToNot(BeNil())
+			})
+		})
+	})
+})

--- a/pkg/share/manager/jsoncs3/sharecache.go
+++ b/pkg/share/manager/jsoncs3/sharecache.go
@@ -107,7 +107,11 @@ func (c *shareCache) Remove(userid, shareID string) error {
 }
 
 func (c *shareCache) List(userid string) map[string]spaceShareIDs {
-	r := make(map[string]spaceShareIDs)
+	r := map[string]spaceShareIDs{}
+	if c.userShares[userid] == nil {
+		return r
+	}
+
 	for ssid, cached := range c.userShares[userid].userShares {
 		r[ssid] = spaceShareIDs{
 			mtime: cached.mtime,

--- a/pkg/share/manager/jsoncs3/sharecache.go
+++ b/pkg/share/manager/jsoncs3/sharecache.go
@@ -25,38 +25,38 @@ import (
 	"github.com/cs3org/reva/v2/pkg/storagespace"
 )
 
-type shareCache struct {
-	userShares map[string]*userShareCache
+type ShareCache struct {
+	UserShares map[string]*UserShareCache
 }
 
-type userShareCache struct {
-	mtime      time.Time
-	userShares map[string]*spaceShareIDs
+type UserShareCache struct {
+	Mtime      time.Time
+	UserShares map[string]*SpaceShareIDs
 }
 
-type spaceShareIDs struct {
-	mtime time.Time
+type SpaceShareIDs struct {
+	Mtime time.Time
 	IDs   map[string]struct{}
 }
 
-func NewShareCache() shareCache {
-	return shareCache{
-		userShares: map[string]*userShareCache{},
+func NewShareCache() ShareCache {
+	return ShareCache{
+		UserShares: map[string]*UserShareCache{},
 	}
 }
 
-func (c *shareCache) Has(userid string) bool {
-	return c.userShares[userid] != nil
+func (c *ShareCache) Has(userid string) bool {
+	return c.UserShares[userid] != nil
 }
-func (c *shareCache) GetShareCache(userid string) *userShareCache {
-	return c.userShares[userid]
-}
-
-func (c *shareCache) SetShareCache(userid string, shareCache *userShareCache) {
-	c.userShares[userid] = shareCache
+func (c *ShareCache) GetShareCache(userid string) *UserShareCache {
+	return c.UserShares[userid]
 }
 
-func (c *shareCache) Add(userid, shareID string) error {
+func (c *ShareCache) SetShareCache(userid string, shareCache *UserShareCache) {
+	c.UserShares[userid] = shareCache
+}
+
+func (c *ShareCache) Add(userid, shareID string) error {
 	storageid, spaceid, _, err := storagespace.SplitID(shareID)
 	if err != nil {
 		return err
@@ -67,24 +67,24 @@ func (c *shareCache) Add(userid, shareID string) error {
 	})
 
 	now := time.Now()
-	if c.userShares[userid] == nil {
-		c.userShares[userid] = &userShareCache{
-			userShares: map[string]*spaceShareIDs{},
+	if c.UserShares[userid] == nil {
+		c.UserShares[userid] = &UserShareCache{
+			UserShares: map[string]*SpaceShareIDs{},
 		}
 	}
-	if c.userShares[userid].userShares[ssid] == nil {
-		c.userShares[userid].userShares[ssid] = &spaceShareIDs{
+	if c.UserShares[userid].UserShares[ssid] == nil {
+		c.UserShares[userid].UserShares[ssid] = &SpaceShareIDs{
 			IDs: map[string]struct{}{},
 		}
 	}
 	// add share id
-	c.userShares[userid].mtime = now
-	c.userShares[userid].userShares[ssid].mtime = now
-	c.userShares[userid].userShares[ssid].IDs[shareID] = struct{}{}
+	c.UserShares[userid].Mtime = now
+	c.UserShares[userid].UserShares[ssid].Mtime = now
+	c.UserShares[userid].UserShares[ssid].IDs[shareID] = struct{}{}
 	return nil
 }
 
-func (c *shareCache) Remove(userid, shareID string) error {
+func (c *ShareCache) Remove(userid, shareID string) error {
 	storageid, spaceid, _, err := storagespace.SplitID(shareID)
 	if err != nil {
 		return err
@@ -94,27 +94,27 @@ func (c *shareCache) Remove(userid, shareID string) error {
 		SpaceId:   spaceid,
 	})
 
-	if c.userShares[userid] != nil {
-		if c.userShares[userid].userShares[ssid] != nil {
+	if c.UserShares[userid] != nil {
+		if c.UserShares[userid].UserShares[ssid] != nil {
 			// remove share id
 			now := time.Now()
-			c.userShares[userid].mtime = now
-			c.userShares[userid].userShares[ssid].mtime = now
-			delete(c.userShares[userid].userShares[ssid].IDs, shareID)
+			c.UserShares[userid].Mtime = now
+			c.UserShares[userid].UserShares[ssid].Mtime = now
+			delete(c.UserShares[userid].UserShares[ssid].IDs, shareID)
 		}
 	}
 	return nil
 }
 
-func (c *shareCache) List(userid string) map[string]spaceShareIDs {
-	r := map[string]spaceShareIDs{}
-	if c.userShares[userid] == nil {
+func (c *ShareCache) List(userid string) map[string]SpaceShareIDs {
+	r := map[string]SpaceShareIDs{}
+	if c.UserShares[userid] == nil {
 		return r
 	}
 
-	for ssid, cached := range c.userShares[userid].userShares {
-		r[ssid] = spaceShareIDs{
-			mtime: cached.mtime,
+	for ssid, cached := range c.UserShares[userid].UserShares {
+		r[ssid] = SpaceShareIDs{
+			Mtime: cached.Mtime,
 			IDs:   cached.IDs,
 		}
 	}

--- a/pkg/share/manager/jsoncs3/sharecache/sharecache.go
+++ b/pkg/share/manager/jsoncs3/sharecache/sharecache.go
@@ -157,6 +157,8 @@ func (c *Cache) Sync(ctx context.Context, userid string) error {
 }
 
 func (c *Cache) Persist(ctx context.Context, userid string) error {
+	c.UserShares[userid].Mtime = time.Now()
+
 	createdBytes, err := json.Marshal(c.UserShares[userid])
 	if err != nil {
 		return err

--- a/pkg/share/manager/jsoncs3/sharecache/sharecache.go
+++ b/pkg/share/manager/jsoncs3/sharecache/sharecache.go
@@ -30,7 +30,7 @@ import (
 	"github.com/cs3org/reva/v2/pkg/utils"
 )
 
-type ShareCache struct {
+type Cache struct {
 	UserShares map[string]*UserShareCache
 
 	storage metadata.Storage
@@ -46,18 +46,18 @@ type SpaceShareIDs struct {
 	IDs   map[string]struct{}
 }
 
-func New(s metadata.Storage) ShareCache {
-	return ShareCache{
+func New(s metadata.Storage) Cache {
+	return Cache{
 		UserShares: map[string]*UserShareCache{},
 		storage:    s,
 	}
 }
 
-func (c *ShareCache) Has(userid string) bool {
+func (c *Cache) Has(userid string) bool {
 	return c.UserShares[userid] != nil
 }
 
-func (c *ShareCache) Add(userid, shareID string) error {
+func (c *Cache) Add(userid, shareID string) error {
 	storageid, spaceid, _, err := storagespace.SplitID(shareID)
 	if err != nil {
 		return err
@@ -85,7 +85,7 @@ func (c *ShareCache) Add(userid, shareID string) error {
 	return nil
 }
 
-func (c *ShareCache) Remove(userid, shareID string) error {
+func (c *Cache) Remove(userid, shareID string) error {
 	storageid, spaceid, _, err := storagespace.SplitID(shareID)
 	if err != nil {
 		return err
@@ -107,7 +107,7 @@ func (c *ShareCache) Remove(userid, shareID string) error {
 	return nil
 }
 
-func (c *ShareCache) List(userid string) map[string]SpaceShareIDs {
+func (c *Cache) List(userid string) map[string]SpaceShareIDs {
 	r := map[string]SpaceShareIDs{}
 	if c.UserShares[userid] == nil {
 		return r
@@ -122,7 +122,7 @@ func (c *ShareCache) List(userid string) map[string]SpaceShareIDs {
 	return r
 }
 
-func (c *ShareCache) Sync(ctx context.Context, userid string) error {
+func (c *Cache) Sync(ctx context.Context, userid string) error {
 	var mtime time.Time
 	//  - do we have a cached list of created shares for the user in memory?
 	if usc := c.UserShares[userid]; usc != nil {
@@ -154,7 +154,7 @@ func (c *ShareCache) Sync(ctx context.Context, userid string) error {
 	return nil
 }
 
-func (c *ShareCache) Persist(ctx context.Context, userid string) error {
+func (c *Cache) Persist(ctx context.Context, userid string) error {
 	createdBytes, err := json.Marshal(c.UserShares[userid])
 	if err != nil {
 		return err

--- a/pkg/share/manager/jsoncs3/sharecache/sharecache.go
+++ b/pkg/share/manager/jsoncs3/sharecache/sharecache.go
@@ -188,12 +188,15 @@ func (c *Cache) Persist(ctx context.Context, userid string) error {
 		return err
 	}
 
-	info, err := c.storage.Stat(ctx, jsonPath)
-	if err != nil {
-		return err
-	}
-	c.UserShares[userid].Mtime = utils.TSToTime(info.Mtime)
-
+	/*
+		FIXME stating here introduces a lost read because the file might have been overwritten written between the above upload and this stat
+		the local cache is updated with Sync during reads
+		info, err := c.storage.Stat(ctx, jsonPath)
+		if err != nil {
+			return err
+		}
+		c.UserShares[userid].Mtime = utils.TSToTime(info.Mtime)
+	*/
 	return nil
 }
 

--- a/pkg/share/manager/jsoncs3/sharecache/sharecache.go
+++ b/pkg/share/manager/jsoncs3/sharecache/sharecache.go
@@ -21,6 +21,7 @@ package sharecache
 import (
 	"context"
 	"encoding/json"
+	"path"
 	"path/filepath"
 	"time"
 
@@ -159,8 +160,12 @@ func (c *Cache) Persist(ctx context.Context, userid string) error {
 	if err != nil {
 		return err
 	}
+	jsonPath := userCreatedPath(userid)
+	if err := c.storage.MakeDirIfNotExist(ctx, path.Dir(jsonPath)); err != nil {
+		return err
+	}
 	// FIXME needs stat & upload if match combo to prevent lost update in redundant deployments
-	if err := c.storage.SimpleUpload(ctx, userCreatedPath(userid), createdBytes); err != nil {
+	if err := c.storage.SimpleUpload(ctx, jsonPath, createdBytes); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/share/manager/jsoncs3/sharecache/sharecache.go
+++ b/pkg/share/manager/jsoncs3/sharecache/sharecache.go
@@ -141,10 +141,9 @@ func (c *Cache) Sync(ctx context.Context, userID string) error {
 	if err != nil {
 		if _, ok := err.(errtypes.NotFound); ok {
 			return nil // Nothing to sync against
-		} else {
-			log.Error().Err(err).Msg("Failed to stat the share cache")
-			return err
 		}
+		log.Error().Err(err).Msg("Failed to stat the share cache")
+		return err
 	}
 	// check mtime of /users/{userid}/created.json
 	if utils.TSToTime(info.Mtime).After(mtime) {

--- a/pkg/share/manager/jsoncs3/sharecache/sharecache.go
+++ b/pkg/share/manager/jsoncs3/sharecache/sharecache.go
@@ -16,7 +16,7 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-package jsoncs3
+package sharecache
 
 import (
 	"time"
@@ -39,7 +39,7 @@ type SpaceShareIDs struct {
 	IDs   map[string]struct{}
 }
 
-func NewShareCache() ShareCache {
+func New() ShareCache {
 	return ShareCache{
 		UserShares: map[string]*UserShareCache{},
 	}

--- a/pkg/share/manager/jsoncs3/sharecache/sharecache.go
+++ b/pkg/share/manager/jsoncs3/sharecache/sharecache.go
@@ -147,7 +147,7 @@ func (c *Cache) Sync(ctx context.Context, userID string) error {
 	}
 	// check mtime of /users/{userid}/created.json
 	if utils.TSToTime(info.Mtime).After(mtime) {
-		log.Debug().Msg("Updating...")
+		log.Debug().Msg("Updating share cache...")
 		//  - update cached list of created shares for the user in memory if changed
 		createdBlob, err := c.storage.SimpleDownload(ctx, userCreatedPath)
 		if err != nil {
@@ -162,7 +162,7 @@ func (c *Cache) Sync(ctx context.Context, userID string) error {
 		}
 		c.UserShares[userID] = newShareCache
 	}
-	log.Debug().Msg("Share cache ist up to date")
+	log.Debug().Msg("Share cache is up to date")
 	return nil
 }
 

--- a/pkg/share/manager/jsoncs3/sharecache/sharecache.go
+++ b/pkg/share/manager/jsoncs3/sharecache/sharecache.go
@@ -58,7 +58,7 @@ func (c *Cache) Has(userid string) bool {
 	return c.UserShares[userid] != nil
 }
 
-func (c *Cache) Add(userid, shareID string) error {
+func (c *Cache) Add(ctx context.Context, userid, shareID string) error {
 	storageid, spaceid, _, err := storagespace.SplitID(shareID)
 	if err != nil {
 		return err
@@ -83,10 +83,10 @@ func (c *Cache) Add(userid, shareID string) error {
 	c.UserShares[userid].Mtime = now
 	c.UserShares[userid].UserShares[ssid].Mtime = now
 	c.UserShares[userid].UserShares[ssid].IDs[shareID] = struct{}{}
-	return nil
+	return c.Persist(ctx, userid)
 }
 
-func (c *Cache) Remove(userid, shareID string) error {
+func (c *Cache) Remove(ctx context.Context, userid, shareID string) error {
 	storageid, spaceid, _, err := storagespace.SplitID(shareID)
 	if err != nil {
 		return err
@@ -105,7 +105,8 @@ func (c *Cache) Remove(userid, shareID string) error {
 			delete(c.UserShares[userid].UserShares[ssid].IDs, shareID)
 		}
 	}
-	return nil
+
+	return c.Persist(ctx, userid)
 }
 
 func (c *Cache) List(userid string) map[string]SpaceShareIDs {

--- a/pkg/share/manager/jsoncs3/sharecache/sharecache.go
+++ b/pkg/share/manager/jsoncs3/sharecache/sharecache.go
@@ -25,9 +25,8 @@ import (
 	"path/filepath"
 	"time"
 
-	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+	"github.com/cs3org/reva/v2/pkg/share/manager/jsoncs3/shareid"
 	"github.com/cs3org/reva/v2/pkg/storage/utils/metadata"
-	"github.com/cs3org/reva/v2/pkg/storagespace"
 	"github.com/cs3org/reva/v2/pkg/utils"
 )
 
@@ -66,14 +65,8 @@ func New(s metadata.Storage, namespace, filename string) Cache {
 
 // Add adds a share to the cache
 func (c *Cache) Add(ctx context.Context, userid, shareID string) error {
-	storageid, spaceid, _, err := storagespace.SplitID(shareID)
-	if err != nil {
-		return err
-	}
-	ssid := storagespace.FormatResourceID(provider.ResourceId{
-		StorageId: storageid,
-		SpaceId:   spaceid,
-	})
+	storageid, spaceid, _ := shareid.Decode(shareID)
+	ssid := storageid + "^" + spaceid
 
 	now := time.Now()
 	if c.UserShares[userid] == nil {
@@ -95,14 +88,8 @@ func (c *Cache) Add(ctx context.Context, userid, shareID string) error {
 
 // Remove removes a share for the given user
 func (c *Cache) Remove(ctx context.Context, userid, shareID string) error {
-	storageid, spaceid, _, err := storagespace.SplitID(shareID)
-	if err != nil {
-		return err
-	}
-	ssid := storagespace.FormatResourceID(provider.ResourceId{
-		StorageId: storageid,
-		SpaceId:   spaceid,
-	})
+	storageid, spaceid, _ := shareid.Decode(shareID)
+	ssid := storageid + "^" + spaceid
 
 	if c.UserShares[userid] != nil {
 		if c.UserShares[userid].UserShares[ssid] != nil {

--- a/pkg/share/manager/jsoncs3/sharecache/sharecache.go
+++ b/pkg/share/manager/jsoncs3/sharecache/sharecache.go
@@ -167,6 +167,5 @@ func (c *Cache) Persist(ctx context.Context, userid string) error {
 }
 
 func userCreatedPath(userid string) string {
-	userCreatedPath := filepath.Join("/users", userid, "created.json")
-	return userCreatedPath
+	return filepath.Join("/users", userid, "created.json")
 }

--- a/pkg/share/manager/jsoncs3/sharecache/sharecache_suite_test.go
+++ b/pkg/share/manager/jsoncs3/sharecache/sharecache_suite_test.go
@@ -1,0 +1,13 @@
+package sharecache_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestSharecache(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Sharecache Suite")
+}

--- a/pkg/share/manager/jsoncs3/sharecache/sharecache_suite_test.go
+++ b/pkg/share/manager/jsoncs3/sharecache/sharecache_suite_test.go
@@ -1,3 +1,21 @@
+// Copyright 2018-2022 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
 package sharecache_test
 
 import (

--- a/pkg/share/manager/jsoncs3/sharecache/sharecache_test.go
+++ b/pkg/share/manager/jsoncs3/sharecache/sharecache_test.go
@@ -1,0 +1,65 @@
+package sharecache_test
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/cs3org/reva/v2/pkg/share/manager/jsoncs3/sharecache"
+	"github.com/cs3org/reva/v2/pkg/storage/utils/metadata"
+)
+
+var _ = Describe("Sharecache", func() {
+	var (
+		c       sharecache.Cache
+		storage metadata.Storage
+
+		userid  = "user"
+		shareID = "storageid$spaceid!share1"
+		ctx     context.Context
+		tmpdir  string
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+
+		var err error
+		tmpdir, err = ioutil.TempDir("", "providercache-test")
+		Expect(err).ToNot(HaveOccurred())
+
+		err = os.MkdirAll(tmpdir, 0755)
+		Expect(err).ToNot(HaveOccurred())
+
+		storage, err = metadata.NewDiskStorage(tmpdir)
+		Expect(err).ToNot(HaveOccurred())
+
+		c = sharecache.New(storage)
+		Expect(c).ToNot(BeNil())
+	})
+
+	AfterEach(func() {
+		if tmpdir != "" {
+			os.RemoveAll(tmpdir)
+		}
+	})
+
+	Describe("Persist", func() {
+		Context("with an existing entry", func() {
+			BeforeEach(func() {
+				Expect(c.Add(ctx, userid, shareID)).To(Succeed())
+			})
+
+			It("updates the mtime", func() {
+				oldMtime := c.UserShares[userid].Mtime
+				Expect(oldMtime).ToNot(Equal(time.Time{}))
+
+				Expect(c.Persist(ctx, userid)).To(Succeed())
+				Expect(c.UserShares[userid]).ToNot(Equal(oldMtime))
+			})
+		})
+	})
+})

--- a/pkg/share/manager/jsoncs3/sharecache/sharecache_test.go
+++ b/pkg/share/manager/jsoncs3/sharecache/sharecache_test.go
@@ -1,3 +1,21 @@
+// Copyright 2018-2022 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
 package sharecache_test
 
 import (

--- a/pkg/share/manager/jsoncs3/sharecache/sharecache_test.go
+++ b/pkg/share/manager/jsoncs3/sharecache/sharecache_test.go
@@ -37,7 +37,7 @@ var _ = Describe("Sharecache", func() {
 		storage, err = metadata.NewDiskStorage(tmpdir)
 		Expect(err).ToNot(HaveOccurred())
 
-		c = sharecache.New(storage)
+		c = sharecache.New(storage, "users", "created.json")
 		Expect(c).ToNot(BeNil())
 	})
 

--- a/pkg/share/manager/jsoncs3/shareid/shareid.go
+++ b/pkg/share/manager/jsoncs3/shareid/shareid.go
@@ -1,0 +1,41 @@
+// Copyright 2018-2021 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package shareid
+
+import "strings"
+
+func Encode(providerID, spaceID, shareID string) string {
+	return providerID + "^" + spaceID + "°" + shareID
+}
+
+// share ids are of the format <storageid>^<spaceid>°<shareid>
+func Decode(id string) (string, string, string) {
+	parts := strings.SplitN(id, "^", 2)
+	if len(parts) == 1 {
+		return "", "", parts[0]
+	}
+
+	storageid := parts[0]
+	parts = strings.SplitN(parts[1], "°", 2)
+	if len(parts) == 1 {
+		return storageid, parts[0], ""
+	}
+
+	return storageid, parts[0], parts[1]
+}

--- a/pkg/share/manager/jsoncs3/shareid/shareid.go
+++ b/pkg/share/manager/jsoncs3/shareid/shareid.go
@@ -20,10 +20,12 @@ package shareid
 
 import "strings"
 
+// Encode encodes a share id
 func Encode(providerID, spaceID, shareID string) string {
 	return providerID + "^" + spaceID + "°" + shareID
 }
 
+// Decode decodes an encoded shareid
 // share ids are of the format <storageid>^<spaceid>°<shareid>
 func Decode(id string) (string, string, string) {
 	parts := strings.SplitN(id, "^", 2)

--- a/pkg/storage/fs/nextcloud/nextcloud_server_mock.go
+++ b/pkg/storage/fs/nextcloud/nextcloud_server_mock.go
@@ -111,6 +111,7 @@ var responses = map[string]Response{
 
 	`POST /apps/sciencemesh/~f7fbf8c8-139b-4376-b307-cf0a8c2d0d9c/api/storage/GetPathByID {"storage_id":"00000000-0000-0000-0000-000000000000","opaque_id":"fileid-/some/path"} EMPTY`: {200, "/subdir", serverStateEmpty},
 
+	`POST /apps/sciencemesh/~f7fbf8c8-139b-4376-b307-cf0a8c2d0d9c/api/storage/GetMD {"ref":{"path":"/file"},"mdKeys":null}`:                                                                                                        {404, ``, serverStateEmpty},
 	`POST /apps/sciencemesh/~f7fbf8c8-139b-4376-b307-cf0a8c2d0d9c/api/storage/InitiateUpload {"ref":{"path":"/file"},"uploadLength":0,"metadata":{"providerID":""}}`:                                                               {200, `{"simple": "yes","tus": "yes"}`, serverStateEmpty},
 	`POST /apps/sciencemesh/~f7fbf8c8-139b-4376-b307-cf0a8c2d0d9c/api/storage/InitiateUpload {"ref":{"resource_id":{"storage_id":"f7fbf8c8-139b-4376-b307-cf0a8c2d0d9c"},"path":"/versionedFile"},"uploadLength":0,"metadata":{}}`: {200, `{"simple": "yes","tus": "yes"}`, serverStateEmpty},
 

--- a/pkg/storage/utils/decomposedfs/grants.go
+++ b/pkg/storage/utils/decomposedfs/grants.go
@@ -139,6 +139,10 @@ func (fs *Decomposedfs) RemoveGrant(ctx context.Context, ref *provider.Reference
 		return err
 	}
 
+	if grant == nil {
+		return errtypes.NotFound("grant not found")
+	}
+
 	// you are allowed to remove grants if you created them yourself or have the proper permission
 	if !utils.UserEqual(grant.Creator, ctxpkg.ContextMustGetUser(ctx).GetId()) {
 		ok, err := fs.p.HasPermission(ctx, node, func(rp *provider.ResourcePermissions) bool {

--- a/pkg/storage/utils/metadata/cs3.go
+++ b/pkg/storage/utils/metadata/cs3.go
@@ -145,7 +145,7 @@ func (cs3 *CS3) Upload(ctx context.Context, req UploadRequest) error {
 	}
 	if req.IfUnmodifiedSince != (time.Time{}) {
 		ifuReq.Options = &provider.InitiateFileUploadRequest_IfUnmodifiedSince{
-			IfUnmodifiedSince: &types.Timestamp{Seconds: uint64(req.IfUnmodifiedSince.Second())},
+			IfUnmodifiedSince: utils.TimeToTS(req.IfUnmodifiedSince),
 		}
 	}
 

--- a/pkg/storage/utils/metadata/cs3.go
+++ b/pkg/storage/utils/metadata/cs3.go
@@ -25,6 +25,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"time"
 
 	gateway "github.com/cs3org/go-cs3apis/cs3/gateway/v1beta1"
 	user "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
@@ -113,6 +114,14 @@ func (cs3 *CS3) Init(ctx context.Context, spaceid string) (err error) {
 
 // SimpleUpload uploads a file to the metadata storage
 func (cs3 *CS3) SimpleUpload(ctx context.Context, uploadpath string, content []byte) error {
+	return cs3.Upload(ctx, UploadRequest{
+		Path:    uploadpath,
+		Content: content,
+	})
+}
+
+// Upload uploads a file to the metadata storage
+func (cs3 *CS3) Upload(ctx context.Context, req UploadRequest) error {
 	client, err := cs3.providerClient()
 	if err != nil {
 		return err
@@ -122,14 +131,25 @@ func (cs3 *CS3) SimpleUpload(ctx context.Context, uploadpath string, content []b
 		return err
 	}
 
-	ref := provider.InitiateFileUploadRequest{
+	ifuReq := &provider.InitiateFileUploadRequest{
 		Ref: &provider.Reference{
 			ResourceId: cs3.SpaceRoot,
-			Path:       utils.MakeRelativePath(uploadpath),
+			Path:       utils.MakeRelativePath(req.Path),
 		},
 	}
 
-	res, err := client.InitiateFileUpload(ctx, &ref)
+	if req.IfMatchEtag != "" {
+		ifuReq.Options = &provider.InitiateFileUploadRequest_IfMatch{
+			IfMatch: req.IfMatchEtag,
+		}
+	}
+	if req.IfUnmodifiedSince != (time.Time{}) {
+		ifuReq.Options = &provider.InitiateFileUploadRequest_IfUnmodifiedSince{
+			IfUnmodifiedSince: &types.Timestamp{Seconds: uint64(req.IfUnmodifiedSince.Second())},
+		}
+	}
+
+	res, err := client.InitiateFileUpload(ctx, ifuReq)
 	if err != nil {
 		return err
 	}
@@ -149,14 +169,14 @@ func (cs3 *CS3) SimpleUpload(ctx context.Context, uploadpath string, content []b
 		return errors.New("metadata storage doesn't support the simple upload protocol")
 	}
 
-	req, err := http.NewRequest(http.MethodPut, endpoint, bytes.NewReader(content))
+	httpReq, err := http.NewRequest(http.MethodPut, endpoint, bytes.NewReader(req.Content))
 	if err != nil {
 		return err
 	}
 
 	md, _ := metadata.FromOutgoingContext(ctx)
-	req.Header.Add(ctxpkg.TokenHeader, md.Get(ctxpkg.TokenHeader)[0])
-	resp, err := cs3.dataGatewayClient.Do(req)
+	httpReq.Header.Add(ctxpkg.TokenHeader, md.Get(ctxpkg.TokenHeader)[0])
+	resp, err := cs3.dataGatewayClient.Do(httpReq)
 	if err != nil {
 		return err
 	}

--- a/pkg/storage/utils/metadata/cs3.go
+++ b/pkg/storage/utils/metadata/cs3.go
@@ -163,6 +163,7 @@ func (cs3 *CS3) SimpleUpload(ctx context.Context, uploadpath string, content []b
 	return resp.Body.Close()
 }
 
+// Stat returns the metadata for the given path
 func (cs3 *CS3) Stat(ctx context.Context, path string) (*provider.ResourceInfo, error) {
 	client, err := cs3.providerClient()
 	if err != nil {

--- a/pkg/storage/utils/metadata/disk.go
+++ b/pkg/storage/utils/metadata/disk.go
@@ -54,6 +54,7 @@ func (disk *Disk) Backend() string {
 	return "disk"
 }
 
+// Stat returns the metadata for the given path
 func (disk *Disk) Stat(ctx context.Context, path string) (*provider.ResourceInfo, error) {
 	info, err := os.Stat(disk.targetPath(path))
 	if err != nil {
@@ -83,6 +84,7 @@ func (disk *Disk) SimpleUpload(ctx context.Context, uploadpath string, content [
 	})
 }
 
+// Upload stores a file on disk
 func (disk *Disk) Upload(_ context.Context, req UploadRequest) error {
 	p := disk.targetPath(req.Path)
 	if req.IfMatchEtag != "" {

--- a/pkg/storage/utils/metadata/disk.go
+++ b/pkg/storage/utils/metadata/disk.go
@@ -21,6 +21,7 @@ package metadata
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io/fs"
 	"io/ioutil"
 	"os"
@@ -107,7 +108,7 @@ func (disk *Disk) Upload(_ context.Context, req UploadRequest) error {
 			return err
 		} else if err == nil {
 			if info.ModTime().After(req.IfUnmodifiedSince) {
-				return errtypes.PreconditionFailed("resource has been modified")
+				return errtypes.PreconditionFailed(fmt.Sprintf("resource has been modified, mtime: %s > since %s", info.ModTime(), req.IfUnmodifiedSince))
 			}
 		}
 	}

--- a/pkg/storage/utils/metadata/mocks/Storage.go
+++ b/pkg/storage/utils/metadata/mocks/Storage.go
@@ -23,6 +23,7 @@ package mocks
 import (
 	context "context"
 
+	metadata "github.com/cs3org/reva/v2/pkg/storage/utils/metadata"
 	mock "github.com/stretchr/testify/mock"
 
 	providerv1beta1 "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
@@ -230,6 +231,20 @@ func (_m *Storage) Stat(ctx context.Context, path string) (*providerv1beta1.Reso
 	}
 
 	return r0, r1
+}
+
+// Upload provides a mock function with given fields: ctx, req
+func (_m *Storage) Upload(ctx context.Context, req metadata.UploadRequest) error {
+	ret := _m.Called(ctx, req)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, metadata.UploadRequest) error); ok {
+		r0 = rf(ctx, req)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
 }
 
 // NewStorage creates a new instance of Storage. It also registers a cleanup function to assert the mocks expectations.

--- a/pkg/storage/utils/metadata/storage.go
+++ b/pkg/storage/utils/metadata/storage.go
@@ -30,11 +30,20 @@ import (
 
 //go:generate make --no-print-directory -C ../../../.. mockery NAME=Storage
 
+type UploadRequest struct {
+	Path    string
+	Content []byte
+
+	IfMatchEtag       string
+	IfUnmodifiedSince time.Time
+}
+
 // Storage is the interface to maintain metadata in a storage
 type Storage interface {
 	Backend() string
 
 	Init(ctx context.Context, name string) (err error)
+	Upload(ctx context.Context, req UploadRequest) error
 	SimpleUpload(ctx context.Context, uploadpath string, content []byte) error
 	SimpleDownload(ctx context.Context, path string) ([]byte, error)
 	Delete(ctx context.Context, path string) error

--- a/pkg/storage/utils/metadata/storage.go
+++ b/pkg/storage/utils/metadata/storage.go
@@ -30,6 +30,7 @@ import (
 
 //go:generate make --no-print-directory -C ../../../.. mockery NAME=Storage
 
+// UploadRequest represents an upload request and its options
 type UploadRequest struct {
 	Path    string
 	Content []byte

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -143,6 +143,14 @@ func TSToTime(ts *types.Timestamp) time.Time {
 	return time.Unix(int64(ts.Seconds), int64(ts.Nanos))
 }
 
+// TimeToTS converts Go's time.Time to a protobuf Timestamp.
+func TimeToTS(t time.Time) *types.Timestamp {
+	return &types.Timestamp{
+		Seconds: uint64(t.Unix()), // implicity returns UTC
+		Nanos:   uint32(t.Nanosecond()),
+	}
+}
+
 // LaterTS returns the timestamp which occurs later.
 func LaterTS(t1 *types.Timestamp, t2 *types.Timestamp) *types.Timestamp {
 	if TSToUnixNano(t1) > TSToUnixNano(t2) {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -146,7 +146,7 @@ func TSToTime(ts *types.Timestamp) time.Time {
 // TimeToTS converts Go's time.Time to a protobuf Timestamp.
 func TimeToTS(t time.Time) *types.Timestamp {
 	return &types.Timestamp{
-		Seconds: uint64(t.Unix()), // implicity returns UTC
+		Seconds: uint64(t.Unix()), // implicitly returns UTC
 		Nanos:   uint32(t.Nanosecond()),
 	}
 }


### PR DESCRIPTION
This PR adds a new jsoncs3 share manager which splits the json file per storage space and caches data locally.