### PR TITLE
dataproviders now return file metadata

### DIFF
--- a/changelog/unreleased/make-dataprovider-return-metadata.md
+++ b/changelog/unreleased/make-dataprovider-return-metadata.md
@@ -1,0 +1,5 @@
+Change: dataproviders now return file metadata
+
+Dataprovider drivers can now return file metadata. When the resource info contains a file id, the mtime or an etag, these will be included in the response as the corresponding http headers.
+
+https://github.com/cs3org/reva/pull/3154

--- a/internal/http/services/owncloud/ocdav/put.go
+++ b/internal/http/services/owncloud/ocdav/put.go
@@ -24,7 +24,6 @@ import (
 	"path"
 	"strconv"
 	"strings"
-	"time"
 
 	rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
@@ -36,8 +35,6 @@ import (
 	"github.com/cs3org/reva/v2/pkg/appctx"
 	"github.com/cs3org/reva/v2/pkg/errtypes"
 	"github.com/cs3org/reva/v2/pkg/rhttp"
-	"github.com/cs3org/reva/v2/pkg/storage/utils/chunking"
-	"github.com/cs3org/reva/v2/pkg/storagespace"
 	"github.com/cs3org/reva/v2/pkg/utils"
 	"github.com/rs/zerolog"
 )
@@ -295,41 +292,22 @@ func (s *svc) handlePut(ctx context.Context, w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	sReq := &provider.StatRequest{Ref: ref}
-	if chunking.IsChunked(ref.Path) {
-		chunk, err := chunking.GetChunkBLOBInfo(ref.Path)
-		if err != nil {
-			w.WriteHeader(http.StatusInternalServerError)
-			return
-		}
-		sReq = &provider.StatRequest{Ref: &provider.Reference{
-			ResourceId: ref.ResourceId,
-			Path:       chunk.Path,
-		}}
+	// the response content type should not be set, as the response body is emty
+	// TODO does the testsuite expect a content type? isn't that against the http spec?
+	//w.Header().Add(net.HeaderContentType, newInfo.MimeType)
+	// copy headers if they are present
+	if httpRes.Header.Get(net.HeaderETag) != "" {
+		w.Header().Set(net.HeaderETag, httpRes.Header.Get(net.HeaderETag))
 	}
-
-	// stat again to check the new file's metadata
-	sRes, err := client.Stat(ctx, sReq)
-	if err != nil {
-		log.Error().Err(err).Msg("error sending grpc stat request")
-		w.WriteHeader(http.StatusInternalServerError)
-		return
+	if httpRes.Header.Get(net.HeaderOCETag) != "" {
+		w.Header().Set(net.HeaderOCETag, httpRes.Header.Get(net.HeaderOCETag))
 	}
-
-	if sRes.Status.Code != rpc.Code_CODE_OK {
-		errors.HandleErrorStatus(&log, w, sRes.Status)
-		return
+	if httpRes.Header.Get(net.HeaderOCFileID) != "" {
+		w.Header().Set(net.HeaderOCFileID, httpRes.Header.Get(net.HeaderOCFileID))
 	}
-
-	newInfo := sRes.Info
-
-	w.Header().Add(net.HeaderContentType, newInfo.MimeType)
-	w.Header().Set(net.HeaderETag, newInfo.Etag)
-	w.Header().Set(net.HeaderOCFileID, storagespace.FormatResourceID(*newInfo.Id))
-	w.Header().Set(net.HeaderOCETag, newInfo.Etag)
-	t := utils.TSToTime(newInfo.Mtime).UTC()
-	lastModifiedString := t.Format(time.RFC1123Z)
-	w.Header().Set(net.HeaderLastModified, lastModifiedString)
+	if httpRes.Header.Get(net.HeaderLastModified) != "" {
+		w.Header().Set(net.HeaderLastModified, httpRes.Header.Get(net.HeaderLastModified))
+	}
 
 	// file was new
 	// FIXME make created flag a property on the InitiateFileUploadResponse

--- a/pkg/rhttp/datatx/manager/simple/simple.go
+++ b/pkg/rhttp/datatx/manager/simple/simple.go
@@ -20,12 +20,14 @@ package simple
 
 import (
 	"net/http"
+	"time"
 
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
 
 	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+	"github.com/cs3org/reva/v2/internal/http/services/owncloud/ocdav/net"
 	"github.com/cs3org/reva/v2/pkg/appctx"
 	"github.com/cs3org/reva/v2/pkg/errtypes"
 	"github.com/cs3org/reva/v2/pkg/events"
@@ -33,6 +35,8 @@ import (
 	"github.com/cs3org/reva/v2/pkg/rhttp/datatx/manager/registry"
 	"github.com/cs3org/reva/v2/pkg/rhttp/datatx/utils/download"
 	"github.com/cs3org/reva/v2/pkg/storage"
+	"github.com/cs3org/reva/v2/pkg/storagespace"
+	"github.com/cs3org/reva/v2/pkg/utils"
 )
 
 func init() {
@@ -81,13 +85,24 @@ func (m *manager) Handler(fs storage.FS) (http.Handler, error) {
 			defer r.Body.Close()
 
 			ref := &provider.Reference{Path: fn}
-			err := fs.Upload(ctx, ref, r.Body, func(owner *userpb.UserId, ref *provider.Reference) {
+			info, err := fs.Upload(ctx, ref, r.Body, func(owner *userpb.UserId, ref *provider.Reference) {
 				if err := datatx.EmitFileUploadedEvent(owner, ref, m.publisher); err != nil {
 					sublog.Error().Err(err).Msg("failed to publish FileUploaded event")
 				}
 			})
 			switch v := err.(type) {
 			case nil:
+				// set etag, mtime and file id
+				w.Header().Set(net.HeaderETag, info.Etag)
+				w.Header().Set(net.HeaderOCETag, info.Etag)
+				if info.Id != nil {
+					w.Header().Set(net.HeaderOCFileID, storagespace.FormatResourceID(*info.Id))
+				}
+				if info.Mtime != nil {
+					t := utils.TSToTime(info.Mtime).UTC()
+					lastModifiedString := t.Format(time.RFC1123Z)
+					w.Header().Set(net.HeaderLastModified, lastModifiedString)
+				}
 				w.WriteHeader(http.StatusOK)
 			case errtypes.PartialContent:
 				w.WriteHeader(http.StatusPartialContent)

--- a/pkg/storage/fs/nextcloud/nextcloud.go
+++ b/pkg/storage/fs/nextcloud/nextcloud.go
@@ -396,8 +396,10 @@ func (nc *StorageDriver) InitiateUpload(ctx context.Context, ref *provider.Refer
 }
 
 // Upload as defined in the storage.FS interface
-func (nc *StorageDriver) Upload(ctx context.Context, ref *provider.Reference, r io.ReadCloser, _ storage.UploadFinishedFunc) error {
-	return nc.doUpload(ctx, ref.Path, r)
+func (nc *StorageDriver) Upload(ctx context.Context, ref *provider.Reference, r io.ReadCloser, _ storage.UploadFinishedFunc) (provider.ResourceInfo, error) {
+	return provider.ResourceInfo{
+		// FIXME fill with at least fileid, mtime and etag
+	}, nc.doUpload(ctx, ref.Path, r)
 }
 
 // Download as defined in the storage.FS interface

--- a/pkg/storage/fs/nextcloud/nextcloud_test.go
+++ b/pkg/storage/fs/nextcloud/nextcloud_test.go
@@ -447,7 +447,7 @@ var _ = Describe("Nextcloud", func() {
 			}
 			stringReader := strings.NewReader("shiny!")
 			stringReadCloser := io.NopCloser(stringReader)
-			err := nc.Upload(ctx, ref, stringReadCloser, nil)
+			_, err := nc.Upload(ctx, ref, stringReadCloser, nil)
 			Expect(err).ToNot(HaveOccurred())
 			checkCalled(called, `PUT /apps/sciencemesh/~tester/api/storage/Upload/some/file/path.txt shiny!`)
 		})

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -44,7 +44,7 @@ type FS interface {
 	GetMD(ctx context.Context, ref *provider.Reference, mdKeys, fieldMask []string) (*provider.ResourceInfo, error)
 	ListFolder(ctx context.Context, ref *provider.Reference, mdKeys, fieldMask []string) ([]*provider.ResourceInfo, error)
 	InitiateUpload(ctx context.Context, ref *provider.Reference, uploadLength int64, metadata map[string]string) (map[string]string, error)
-	Upload(ctx context.Context, ref *provider.Reference, r io.ReadCloser, uploadFunc UploadFinishedFunc) error
+	Upload(ctx context.Context, ref *provider.Reference, r io.ReadCloser, uploadFunc UploadFinishedFunc) (provider.ResourceInfo, error)
 	Download(ctx context.Context, ref *provider.Reference) (io.ReadCloser, error)
 	ListRevisions(ctx context.Context, ref *provider.Reference) ([]*provider.FileVersion, error)
 	DownloadRevision(ctx context.Context, ref *provider.Reference, key string) (io.ReadCloser, error)

--- a/pkg/storage/utils/decomposedfs/upload_test.go
+++ b/pkg/storage/utils/decomposedfs/upload_test.go
@@ -242,7 +242,7 @@ var _ = Describe("File uploads", func() {
 						Expect(data).To(Equal([]byte("0123456789")))
 					})
 
-				err = fs.Upload(ctx, uploadRef, ioutil.NopCloser(bytes.NewReader(fileContent)), nil)
+				_, err = fs.Upload(ctx, uploadRef, ioutil.NopCloser(bytes.NewReader(fileContent)), nil)
 
 				Expect(err).ToNot(HaveOccurred())
 				bs.AssertCalled(GinkgoT(), "Upload", mock.Anything, mock.Anything, mock.Anything)
@@ -280,7 +280,7 @@ var _ = Describe("File uploads", func() {
 						Expect(data).To(Equal([]byte("")))
 					})
 
-				err = fs.Upload(ctx, uploadRef, ioutil.NopCloser(bytes.NewReader(fileContent)), nil)
+				_, err = fs.Upload(ctx, uploadRef, ioutil.NopCloser(bytes.NewReader(fileContent)), nil)
 
 				Expect(err).ToNot(HaveOccurred())
 				bs.AssertCalled(GinkgoT(), "Upload", mock.Anything, mock.Anything, mock.Anything)
@@ -300,7 +300,7 @@ var _ = Describe("File uploads", func() {
 				)
 
 				uploadRef := &provider.Reference{Path: "/some-non-existent-upload-reference"}
-				err := fs.Upload(ctx, uploadRef, ioutil.NopCloser(bytes.NewReader(fileContent)), nil)
+				_, err := fs.Upload(ctx, uploadRef, ioutil.NopCloser(bytes.NewReader(fileContent)), nil)
 
 				Expect(err).To(HaveOccurred())
 

--- a/pkg/storage/utils/eosfs/upload.go
+++ b/pkg/storage/utils/eosfs/upload.go
@@ -31,28 +31,28 @@ import (
 	"github.com/pkg/errors"
 )
 
-func (fs *eosfs) Upload(ctx context.Context, ref *provider.Reference, r io.ReadCloser, _ storage.UploadFinishedFunc) error {
+func (fs *eosfs) Upload(ctx context.Context, ref *provider.Reference, r io.ReadCloser, uff storage.UploadFinishedFunc) (provider.ResourceInfo, error) {
 	p, err := fs.resolve(ctx, ref)
 	if err != nil {
-		return errors.Wrap(err, "eos: error resolving reference")
+		return provider.ResourceInfo{}, errors.Wrap(err, "eos: error resolving reference")
 	}
 
 	if fs.isShareFolder(ctx, p) {
-		return errtypes.PermissionDenied("eos: cannot upload under the virtual share folder")
+		return provider.ResourceInfo{}, errtypes.PermissionDenied("eos: cannot upload under the virtual share folder")
 	}
 
 	if chunking.IsChunked(p) {
 		var assembledFile string
 		p, assembledFile, err = fs.chunkHandler.WriteChunk(p, r)
 		if err != nil {
-			return err
+			return provider.ResourceInfo{}, err
 		}
 		if p == "" {
-			return errtypes.PartialContent(ref.String())
+			return provider.ResourceInfo{}, errtypes.PartialContent(ref.String())
 		}
 		fd, err := os.Open(assembledFile)
 		if err != nil {
-			return errors.Wrap(err, "eos: error opening assembled file")
+			return provider.ResourceInfo{}, errors.Wrap(err, "eos: error opening assembled file")
 		}
 		defer fd.Close()
 		defer os.RemoveAll(assembledFile)
@@ -63,16 +63,23 @@ func (fs *eosfs) Upload(ctx context.Context, ref *provider.Reference, r io.ReadC
 
 	u, err := getUser(ctx)
 	if err != nil {
-		return errors.Wrap(err, "eos: no user in ctx")
+		return provider.ResourceInfo{}, errors.Wrap(err, "eos: no user in ctx")
 	}
 
 	// We need the auth corresponding to the parent directory
 	// as the file might not exist at the moment
 	auth, err := fs.getUserAuth(ctx, u, path.Dir(fn))
 	if err != nil {
-		return err
+		return provider.ResourceInfo{}, err
 	}
-	return fs.c.Write(ctx, auth, fn, r)
+
+	if err := fs.c.Write(ctx, auth, fn, r); err != nil {
+		return provider.ResourceInfo{}, err
+	}
+
+	return provider.ResourceInfo{
+		// FIXME fill with at least fileid, mtime and etag
+	}, nil
 }
 
 func (fs *eosfs) InitiateUpload(ctx context.Context, ref *provider.Reference, uploadLength int64, metadata map[string]string) (map[string]string, error) {

--- a/pkg/storage/utils/localfs/upload.go
+++ b/pkg/storage/utils/localfs/upload.go
@@ -41,10 +41,10 @@ import (
 
 var defaultFilePerm = os.FileMode(0664)
 
-func (fs *localfs) Upload(ctx context.Context, ref *provider.Reference, r io.ReadCloser, _ storage.UploadFinishedFunc) error {
+func (fs *localfs) Upload(ctx context.Context, ref *provider.Reference, r io.ReadCloser, uff storage.UploadFinishedFunc) (provider.ResourceInfo, error) {
 	upload, err := fs.GetUpload(ctx, ref.GetPath())
 	if err != nil {
-		return errors.Wrap(err, "localfs: error retrieving upload")
+		return provider.ResourceInfo{}, errors.Wrap(err, "localfs: error retrieving upload")
 	}
 
 	uploadInfo := upload.(*fileUpload)
@@ -54,18 +54,18 @@ func (fs *localfs) Upload(ctx context.Context, ref *provider.Reference, r io.Rea
 		var assembledFile string
 		p, assembledFile, err = fs.chunkHandler.WriteChunk(p, r)
 		if err != nil {
-			return err
+			return provider.ResourceInfo{}, err
 		}
 		if p == "" {
 			if err = uploadInfo.Terminate(ctx); err != nil {
-				return errors.Wrap(err, "localfs: error removing auxiliary files")
+				return provider.ResourceInfo{}, errors.Wrap(err, "localfs: error removing auxiliary files")
 			}
-			return errtypes.PartialContent(ref.String())
+			return provider.ResourceInfo{}, errtypes.PartialContent(ref.String())
 		}
 		uploadInfo.info.Storage["InternalDestination"] = p
 		fd, err := os.Open(assembledFile)
 		if err != nil {
-			return errors.Wrap(err, "localfs: error opening assembled file")
+			return provider.ResourceInfo{}, errors.Wrap(err, "localfs: error opening assembled file")
 		}
 		defer fd.Close()
 		defer os.RemoveAll(assembledFile)
@@ -73,10 +73,33 @@ func (fs *localfs) Upload(ctx context.Context, ref *provider.Reference, r io.Rea
 	}
 
 	if _, err := uploadInfo.WriteChunk(ctx, 0, r); err != nil {
-		return errors.Wrap(err, "localfs: error writing to binary file")
+		return provider.ResourceInfo{}, errors.Wrap(err, "localfs: error writing to binary file")
 	}
 
-	return uploadInfo.FinishUpload(ctx)
+	if err := uploadInfo.FinishUpload(ctx); err != nil {
+		return provider.ResourceInfo{}, err
+	}
+
+	if uff != nil {
+		info := uploadInfo.info
+		uploadRef := &provider.Reference{
+			ResourceId: &provider.ResourceId{
+				StorageId: info.MetaData["providerID"],
+				SpaceId:   info.Storage["SpaceRoot"],
+				OpaqueId:  info.Storage["SpaceRoot"],
+			},
+			Path: utils.MakeRelativePath(filepath.Join(info.MetaData["dir"], info.MetaData["filename"])),
+		}
+		owner, ok := ctxpkg.ContextGetUser(uploadInfo.ctx)
+		if !ok {
+			return provider.ResourceInfo{}, errtypes.PreconditionFailed("error getting user from uploadinfo context")
+		}
+		uff(owner.Id, uploadRef)
+	}
+
+	return provider.ResourceInfo{
+		// FIXME fill with at least fileid, mtime and etag
+	}, nil
 }
 
 // InitiateUpload returns upload ids corresponding to different protocols it supports

--- a/tests/helpers/helpers.go
+++ b/tests/helpers/helpers.go
@@ -62,6 +62,6 @@ func Upload(ctx context.Context, fs storage.FS, ref *provider.Reference, content
 		return errors.New("simple upload method not available")
 	}
 	uploadRef := &provider.Reference{Path: "/" + uploadID}
-	err = fs.Upload(ctx, uploadRef, ioutil.NopCloser(bytes.NewReader(content)), nil)
+	_, err = fs.Upload(ctx, uploadRef, ioutil.NopCloser(bytes.NewReader(content)), nil)
 	return err
 }


### PR DESCRIPTION
Dataprovider drivers can now return file metadata. When the resource info contains a file id, the mtime or an etag, these will be included in the response as the corresponding http headers.
