### PR TITLE
Add name to propfind response

### DIFF
--- a/changelog/unreleased/add-name-to-propfindresponse.md
+++ b/changelog/unreleased/add-name-to-propfindresponse.md
@@ -1,0 +1,6 @@
+Bugfix: Add name to the propfind response
+
+Previously the file- or foldername had to be extracted from the href. This is not nice and
+doesn't work for alias links. 
+
+https://github.com/cs3org/reva/pull/3158

--- a/internal/http/services/owncloud/ocdav/propfind/propfind.go
+++ b/internal/http/services/owncloud/ocdav/propfind/propfind.go
@@ -987,6 +987,10 @@ func mdToPropResponse(ctx context.Context, pf *XML, md *provider.ResourceInfo, p
 			)
 		}
 
+		if md.Name != "" {
+			propstatOK.Prop = append(propstatOK.Prop, prop.Raw("oc:name", md.Name))
+		}
+
 		if md.Etag != "" {
 			// etags must be enclosed in double quotes and cannot contain them.
 			// See https://tools.ietf.org/html/rfc7232#section-2.3 for details
@@ -1311,6 +1315,8 @@ func mdToPropResponse(ctx context.Context, pf *XML, md *provider.ResourceInfo, p
 							propstatNotFound.Prop = append(propstatNotFound.Prop, prop.NotFound("oc:signature-auth"))
 						}
 					}
+				case "name":
+					propstatOK.Prop = append(propstatOK.Prop, prop.Raw("oc:name", md.Name))
 				case "privatelink": // phoenix only
 					// <oc:privatelink>https://phoenix.owncloud.com/f/9</oc:privatelink>
 					fallthrough

--- a/pkg/storage/utils/decomposedfs/node/node.go
+++ b/pkg/storage/utils/decomposedfs/node/node.go
@@ -643,6 +643,7 @@ func (n *Node) AsResourceInfo(ctx context.Context, rp *provider.ResourcePermissi
 		PermissionSet: rp,
 		Owner:         n.Owner(),
 		ParentId:      parentID,
+		Name:          n.Name,
 	}
 
 	if nodeType == provider.ResourceType_RESOURCE_TYPE_CONTAINER {


### PR DESCRIPTION
Adds a field "oc:name" to the propfind response. Example:
```
curl --insecure -X PROPFIND -u katherine:gemini https://localhost:9200/remote.php/dav/spaces/1284d238-aa92-42ce-bdc4-0b0000009157\$534bb038-6f9d-4093-946f-133be61fa4e7\!1887651e-4f0b-4d7b-8057-50a6f3945522

<?xml version="1.0"?>                                                                                                                                                                                                                                                                     
<d:multistatus xmlns:s="http://sabredav.org/ns" xmlns:d="DAV:" xmlns:oc="http://owncloud.org/ns">                                                                                                                                                                                         
  <d:response>                                                                                                                                                                                                                                                                            
    <d:href>/remote.php/dav/spaces/1284d238-aa92-42ce-bdc4-0b0000009157$534bb038-6f9d-4093-946f-133be61fa4e7%211887651e-4f0b-4d7b-8057-50a6f3945522/</d:href>                                                                                                                             
    <d:propstat>                                                                                                                                                                                                                                                                          
      <d:prop>                                                                                                                                                                                                                                                                            
        <oc:id>1284d238-aa92-42ce-bdc4-0b0000009157$534bb038-6f9d-4093-946f-133be61fa4e7!1887651e-4f0b-4d7b-8057-50a6f3945522</oc:id>                                                                                                                                                     
        <oc:fileid>1284d238-aa92-42ce-bdc4-0b0000009157$534bb038-6f9d-4093-946f-133be61fa4e7!1887651e-4f0b-4d7b-8057-50a6f3945522</oc:fileid>                                                                                                                                             
        <oc:spaceid>534bb038-6f9d-4093-946f-133be61fa4e7</oc:spaceid>                                                                                                                                                                                                                     
        <oc:name>Foldername</oc:name>                                                                                                                                                                                                                                                        
        <d:getetag>"8fd786a26a0291255c2f6f25c2867f5e"</d:getetag>                                                                                                                                                                                                                         
        <oc:permissions>RDNVCK</oc:permissions>                                                                                                                                                                                                                                           
        <d:resourcetype>                                                                                                                                                                                                                                                                  
          <d:collection/>                                                                                                                                                                                                                                                                 
        </d:resourcetype>                                                                                                                                                                                                                                                                 
        <oc:size>8</oc:size>                                                                                                                                                                                                                                                              
        <d:getlastmodified>Wed, 17 Aug 2022 13:03:39 GMT</d:getlastmodified>                                                                                                                                                                                                              
        <oc:favorite>0</oc:favorite>                                                                                                                                                                                                                                                      
      </d:prop>                                                                                                                                                                                                                                                                           
      <d:status>HTTP/1.1 200 OK</d:status>                                                                                                                                                                                                                                                
    </d:propstat>                                                                                                                                                                                                                                                                         
  </d:response>              
</d:multistatus>
```