### PR TITLE
improve tokeninfo endpoint

### DIFF
--- a/changelog/unreleased/improve-tokeninfo-endpoint.md
+++ b/changelog/unreleased/improve-tokeninfo-endpoint.md
@@ -1,0 +1,7 @@
+Enhancement: Improve tokeninfo endpoint
+
+We added more information to the tokeninfo endpoint. `aliaslink` is a bool value indicating if the permissions are 0.
+`id` is the full id of the file. Both are available to all users having the link token. `spaceType` (indicating the space type) 
+is only available if the user has native access
+
+https://github.com/cs3org/reva/pull/3179

--- a/internal/http/services/owncloud/ocs/conversions/main.go
+++ b/internal/http/services/owncloud/ocs/conversions/main.go
@@ -175,8 +175,10 @@ type TokenInfo struct {
 	Token             string `json:"token" xml:"token"`
 	LinkURL           string `json:"link_url" xml:"link_url"`
 	PasswordProtected bool   `json:"password_protected" xml:"password_protected"`
+	Aliaslink         bool   `json:"alias_link" xml:"alias_link"`
 
 	// if not password protected
+	ID        string `json:"id" xml:"id"`
 	StorageID string `json:"storage_id" xml:"storage_id"`
 	SpaceID   string `json:"space_id" xml:"space_id"`
 	OpaqueID  string `json:"opaque_id" xml:"opaque_id"`
@@ -186,6 +188,7 @@ type TokenInfo struct {
 	SpacePath  string `json:"space_path" xml:"space_path"`
 	SpaceAlias string `json:"space_alias" xml:"space_alias"`
 	SpaceURL   string `json:"space_url" xml:"space_url"`
+	SpaceType  string `json:"space_type" xml:"space_type"`
 }
 
 // ExactMatchesData hold exact matches

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/sharees/token.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/sharees/token.go
@@ -87,6 +87,7 @@ func handleGetToken(ctx context.Context, tkn string, pw string, c gateway.Gatewa
 			t.SpacePath = utils.ReadPlainFromOpaque(space.Opaque, "path")
 			t.SpaceAlias = utils.ReadPlainFromOpaque(space.Opaque, "spaceAlias")
 			t.SpaceURL = path.Join(t.SpaceAlias, t.OpaqueID, t.Path)
+			t.SpaceType = space.SpaceType
 		}
 
 	}
@@ -110,9 +111,13 @@ func buildTokenInfo(owner *user.User, tkn string, token string, passProtected bo
 		return t, fmt.Errorf("can't stat resource. %+v %s", sRes, err)
 	}
 
+	t.ID = storagespace.FormatResourceID(*sRes.Share.GetResourceId())
 	t.StorageID = sRes.Share.ResourceId.GetStorageId()
 	t.SpaceID = sRes.Share.ResourceId.GetSpaceId()
 	t.OpaqueID = sRes.Share.ResourceId.GetOpaqueId()
+
+	role := conversions.RoleFromResourcePermissions(sRes.Share.Permissions.GetPermissions())
+	t.Aliaslink = role.OCSPermissions() == 0
 
 	return t, nil
 }


### PR DESCRIPTION
We added more information to the tokeninfo endpoint. `aliaslink` is a bool value indicating if the permissions are 0.
`id` is the full id of the file. Both are available to all users having the link token. `spaceType` (indicating the space type) 
is only available if the user has native access