### PR TITLE
Add permission checks on homespace delete

### DIFF
--- a/changelog/unreleased/check-home-space-delte-permission.md
+++ b/changelog/unreleased/check-home-space-delte-permission.md
@@ -1,0 +1,6 @@
+Enhancement: Add canDeleteAllHomeSpaces permission
+
+We added a permission to the admin role in ocis that allows deleting homespaces on user delete.
+
+https://github.com/cs3org/reva/pull/3180
+https://github.com/owncloud/ocis/pull/4447/files

--- a/pkg/storage/utils/decomposedfs/spaces_test.go
+++ b/pkg/storage/utils/decomposedfs/spaces_test.go
@@ -60,12 +60,7 @@ var _ = Describe("Spaces", func() {
 				nil)
 			env.Permissions.On("HasPermission", mock.Anything, mock.Anything, mock.Anything).Return(
 				func(ctx context.Context, n *node.Node, check func(*provider.ResourcePermissions) bool) bool {
-					if ctxpkg.ContextMustGetUser(ctx).Id.GetOpaqueId() == "25b69780-5f39-43be-a7ac-a9b9e9fe4230" {
-						// id of owner/admin
-						return true
-					}
-					// id of generic user
-					return false
+					return ctxpkg.ContextMustGetUser(ctx).Id.GetOpaqueId() == "25b69780-5f39-43be-a7ac-a9b9e9fe4230" // id of owner/admin
 				},
 				func(ctx context.Context, n *node.Node, check func(*provider.ResourcePermissions) bool) error {
 					if ctxpkg.ContextMustGetUser(ctx).Id.GetOpaqueId() == "25b69780-5f39-43be-a7ac-a9b9e9fe4230" {

--- a/pkg/storage/utils/decomposedfs/spaces_test.go
+++ b/pkg/storage/utils/decomposedfs/spaces_test.go
@@ -20,15 +20,16 @@ package decomposedfs_test
 
 import (
 	"context"
+	"fmt"
 	"os"
 
 	cs3permissions "github.com/cs3org/go-cs3apis/cs3/permissions/v1beta1"
-	permissionsv1beta1 "github.com/cs3org/go-cs3apis/cs3/permissions/v1beta1"
 	rpcv1beta1 "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	ctxpkg "github.com/cs3org/reva/v2/pkg/ctx"
-	ruser "github.com/cs3org/reva/v2/pkg/ctx"
+	"github.com/cs3org/reva/v2/pkg/errtypes"
 	"github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs"
+	"github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/node"
 	helpers "github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/testhelpers"
 	"github.com/cs3org/reva/v2/pkg/storagespace"
 	. "github.com/onsi/ginkgo/v2"
@@ -51,13 +52,30 @@ var _ = Describe("Spaces", func() {
 				func(ctx context.Context, in *cs3permissions.CheckPermissionRequest, opts ...grpc.CallOption) *cs3permissions.CheckPermissionResponse {
 					if ctxpkg.ContextMustGetUser(ctx).Id.GetOpaqueId() == "25b69780-5f39-43be-a7ac-a9b9e9fe4230" {
 						// id of owner/admin
-						return &permissionsv1beta1.CheckPermissionResponse{Status: &rpcv1beta1.Status{Code: rpcv1beta1.Code_CODE_OK}}
+						return &cs3permissions.CheckPermissionResponse{Status: &rpcv1beta1.Status{Code: rpcv1beta1.Code_CODE_OK}}
 					}
 					// id of generic user
-					return &permissionsv1beta1.CheckPermissionResponse{Status: &rpcv1beta1.Status{Code: rpcv1beta1.Code_CODE_PERMISSION_DENIED}}
+					return &cs3permissions.CheckPermissionResponse{Status: &rpcv1beta1.Status{Code: rpcv1beta1.Code_CODE_PERMISSION_DENIED}}
 				},
 				nil)
+			env.Permissions.On("HasPermission", mock.Anything, mock.Anything, mock.Anything).Return(
+				func(ctx context.Context, n *node.Node, check func(*provider.ResourcePermissions) bool) bool {
+					if ctxpkg.ContextMustGetUser(ctx).Id.GetOpaqueId() == "25b69780-5f39-43be-a7ac-a9b9e9fe4230" {
+						// id of owner/admin
+						return true
+					}
+					// id of generic user
+					return false
+				},
+				func(ctx context.Context, n *node.Node, check func(*provider.ResourcePermissions) bool) error {
+					if ctxpkg.ContextMustGetUser(ctx).Id.GetOpaqueId() == "25b69780-5f39-43be-a7ac-a9b9e9fe4230" {
+						// id of owner/admin
+						return nil
+					}
+					// id of generic user
+					return errtypes.PermissionDenied(fmt.Sprintf("user is not allowed to delete home space %s", n.ID))
 
+				})
 		})
 
 		AfterEach(func() {
@@ -95,12 +113,12 @@ var _ = Describe("Spaces", func() {
 				Expect(resp).To(Equal(true))
 			})
 			It("returns true on requesting unrestricted as non-admin", func() {
-				ctx := ruser.ContextSetUser(context.Background(), env.Users[0])
+				ctx := ctxpkg.ContextSetUser(context.Background(), env.Users[0])
 				resp := env.Fs.MustCheckNodePermissions(ctx, true)
 				Expect(resp).To(Equal(true))
 			})
 			It("returns true on requesting for own spaces", func() {
-				ctx := ruser.ContextSetUser(context.Background(), env.Users[0])
+				ctx := ctxpkg.ContextSetUser(context.Background(), env.Users[0])
 				resp := env.Fs.MustCheckNodePermissions(ctx, false)
 				Expect(resp).To(Equal(true))
 			})
@@ -112,7 +130,7 @@ var _ = Describe("Spaces", func() {
 
 		Context("can list spaces of requested user", func() {
 			It("returns false on requesting for other user as non-admin", func() {
-				ctx := ruser.ContextSetUser(context.Background(), env.Users[0])
+				ctx := ctxpkg.ContextSetUser(context.Background(), env.Users[0])
 				res := env.Fs.CanListSpacesOfRequestedUser(ctx, helpers.User1ID)
 				Expect(res).To(Equal(false))
 			})
@@ -123,6 +141,35 @@ var _ = Describe("Spaces", func() {
 			It("returns true on requesting for own spaces", func() {
 				res := env.Fs.CanListSpacesOfRequestedUser(env.Ctx, helpers.OwnerID)
 				Expect(res).To(Equal(true))
+			})
+		})
+
+		Context("can delete homespace", func() {
+			It("fails on trying to delete a homespace as non-admin", func() {
+				ctx := ctxpkg.ContextSetUser(context.Background(), env.Users[1])
+				resp, err := env.Fs.ListStorageSpaces(env.Ctx, nil, false)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(len(resp)).To(Equal(1))
+				Expect(string(resp[0].Opaque.GetMap()["spaceAlias"].Value)).To(Equal("personal/username"))
+				Expect(resp[0].Name).To(Equal("username"))
+				Expect(resp[0].SpaceType).To(Equal("personal"))
+				err = env.Fs.DeleteStorageSpace(ctx, &provider.DeleteStorageSpaceRequest{
+					Id: resp[0].GetId(),
+				})
+				Expect(err).To(HaveOccurred())
+			})
+			It("succeeds on trying to delete homespace as admin", func() {
+				ctx := ctxpkg.ContextSetUser(context.Background(), env.Owner)
+				resp, err := env.Fs.ListStorageSpaces(env.Ctx, nil, false)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(len(resp)).To(Equal(1))
+				Expect(string(resp[0].Opaque.GetMap()["spaceAlias"].Value)).To(Equal("personal/username"))
+				Expect(resp[0].Name).To(Equal("username"))
+				Expect(resp[0].SpaceType).To(Equal("personal"))
+				err = env.Fs.DeleteStorageSpace(ctx, &provider.DeleteStorageSpaceRequest{
+					Id: resp[0].GetId(),
+				})
+				Expect(err).To(Not(HaveOccurred()))
 			})
 		})
 
@@ -138,7 +185,7 @@ var _ = Describe("Spaces", func() {
 					"generalspacealias_template":  "{{.SpaceType}}:{{.SpaceName | replace \" \" \"-\" | upper}}",
 				})
 				Expect(err).ToNot(HaveOccurred())
-				env.PermissionsClient.On("CheckPermission", mock.Anything, mock.Anything, mock.Anything).Return(&permissionsv1beta1.CheckPermissionResponse{Status: &rpcv1beta1.Status{Code: rpcv1beta1.Code_CODE_OK}}, nil)
+				env.PermissionsClient.On("CheckPermission", mock.Anything, mock.Anything, mock.Anything).Return(&cs3permissions.CheckPermissionResponse{Status: &rpcv1beta1.Status{Code: rpcv1beta1.Code_CODE_OK}}, nil)
 			})
 
 			AfterEach(func() {
@@ -220,10 +267,10 @@ var _ = Describe("Spaces", func() {
 				func(ctx context.Context, in *cs3permissions.CheckPermissionRequest, opts ...grpc.CallOption) *cs3permissions.CheckPermissionResponse {
 					if ctxpkg.ContextMustGetUser(ctx).Id.GetOpaqueId() == "25b69780-5f39-43be-a7ac-a9b9e9fe4230" {
 						// id of owner/admin
-						return &permissionsv1beta1.CheckPermissionResponse{Status: &rpcv1beta1.Status{Code: rpcv1beta1.Code_CODE_OK}}
+						return &cs3permissions.CheckPermissionResponse{Status: &rpcv1beta1.Status{Code: rpcv1beta1.Code_CODE_OK}}
 					}
 					// id of generic user
-					return &permissionsv1beta1.CheckPermissionResponse{Status: &rpcv1beta1.Status{Code: rpcv1beta1.Code_CODE_PERMISSION_DENIED}}
+					return &cs3permissions.CheckPermissionResponse{Status: &rpcv1beta1.Status{Code: rpcv1beta1.Code_CODE_PERMISSION_DENIED}}
 				},
 				nil)
 
@@ -252,7 +299,7 @@ var _ = Describe("Spaces", func() {
 				Expect(updateResp.StorageSpace.Quota.QuotaMaxBytes, uint64(1000))
 			})
 			It("try to change quota as a non admin user", func() {
-				ctx := ruser.ContextSetUser(context.Background(), env.Users[0])
+				ctx := ctxpkg.ContextSetUser(context.Background(), env.Users[0])
 				updateResp, err := env.Fs.UpdateStorageSpace(
 					ctx,
 					&provider.UpdateStorageSpaceRequest{


### PR DESCRIPTION
This PR adds permission checks to the DeleteStorageSpace function, in case the user tries to delete a homespace.

refs https://github.com/owncloud/ocis/pull/4447
refs https://github.com/owncloud/ocis/issues/4195