### PR TITLE
Exclude vendor folder from docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,5 +4,6 @@ docs
 grpc-tests
 tests
 tools
+vendor
 vendor-bin
 *.md


### PR DESCRIPTION
I got an 'inconsistent vendoring' error when running 'docker build -f Dockerfile.revad .'
This change made the error go away.
Is there a reason not to exclude the the vendor folder from the docker build context?