### PR TITLE
Add rootinfo to storage space

### DIFF
--- a/changelog/unreleased/add-rootinfo-to-storagespace.md
+++ b/changelog/unreleased/add-rootinfo-to-storagespace.md
@@ -1,0 +1,6 @@
+Bugfix: Adds the rootinfo to storage spaces
+
+The sympton of the bug were search results not containing
+permissions
+
+https://github.com/cs3org/reva/pull/3194

--- a/pkg/storage/utils/decomposedfs/spaces.go
+++ b/pkg/storage/utils/decomposedfs/spaces.go
@@ -902,6 +902,10 @@ func (fs *Decomposedfs) storageSpaceFromNode(ctx context.Context, n *node.Node, 
 	if ok {
 		space.Opaque = utils.AppendPlainToOpaque(space.Opaque, "spaceAlias", spaceAlias)
 	}
+
+	// add rootinfo
+	ps := n.SpaceRoot.PermissionSet(ctx)
+	space.RootInfo, _ = n.SpaceRoot.AsResourceInfo(ctx, &ps, nil, nil, false)
 	return space, nil
 }
 


### PR DESCRIPTION
Adds to rootinfo to storage spaces. Needed to extract permissions for the space.