### PR TITLE
OCS get share for received shares

### DIFF
--- a/changelog/unreleased/get-received-share.md
+++ b/changelog/unreleased/get-received-share.md
@@ -1,0 +1,6 @@
+Enhancement: OCS get share now also handle received shares
+
+Requesting a specific share can now also correctly map the path to the mountpoint if the requested share is a received share.
+
+https://github.com/owncloud/ocis/issues/4322
+https://github.com/cs3org/reva/pull/3200


### PR DESCRIPTION
This fixes: https://github.com/owncloud/ocis/issues/4322
Requesting a specific share can now also correctly map the path to the mountpoint if the requested share is a received share.