### PR TITLE
Fix "delete-all-home-spaces" permission check

### DIFF
--- a/changelog/unreleased/check-home-space-delte-permission.md
+++ b/changelog/unreleased/check-home-space-delte-permission.md
@@ -3,4 +3,5 @@ Enhancement: Add canDeleteAllHomeSpaces permission
 We added a permission to the admin role in ocis that allows deleting homespaces on user delete.
 
 https://github.com/cs3org/reva/pull/3180
+https://github.com/cs3org/reva/pull/3202
 https://github.com/owncloud/ocis/pull/4447/files


### PR DESCRIPTION
We were using the wrong permission name and the permission check was implemented in a way, that the deleting user needed to have the "delete-all-home-spaces" permission AND manager access to the space.