### PR TITLE
[tests-only] Bump core commit id to latest `reva-master`

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The test runner source for API tests
-CORE_COMMITID=c9acf31ed161b66264ac5022b0d3fe148f349222
+CORE_COMMITID=10d56dc7c854a47efaec402a23f04e0368ce30ae
 CORE_BRANCH=master


### PR DESCRIPTION
Part of https://github.com/owncloud/QA/issues/763