### PR TITLE
Dump cs3 publicshare manager

### DIFF
--- a/changelog/unreleased/dump-cs3-publicsharemanager.md
+++ b/changelog/unreleased/dump-cs3-publicsharemanager.md
@@ -1,0 +1,5 @@
+Enhancement: Allow for dumping the public shares from the cs3 publicshare manager
+
+We enhanced the cs3 publicshare manager to support dumping its content during a publicshare manager migration.
+
+https://github.com/cs3org/reva/pull/3213


### PR DESCRIPTION
This PR enhances the cs3 publicshare manager to support dumping its content during a publicshare manager migration.