### PR TITLE
[tests-only] Update readme for tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ This will require some PHP-related tools to run, for instance on Ubuntu you will
         -e LDAP_ADMIN_PASSWORD=admin \
         --name docker-slapd \
         -p 127.0.0.1:389:389 \
-        -p 636:636 -d osixia/openldap
+        -p 636:636 -d osixia/openldap:1.3.0
     ```
 
 2.  start the needed services

--- a/tests/oc-integration-tests/local/ldap-users.toml
+++ b/tests/oc-integration-tests/local/ldap-users.toml
@@ -16,7 +16,7 @@ address = "0.0.0.0:18000"
 auth_manager = "ldap"
 
 [grpc.services.authprovider.auth_managers.ldap]
-uri="ldaps://openldap:636"
+uri="ldaps://localhost:636"
 insecure=true
 user_base_dn="ou=testusers,dc=owncloud,dc=com"
 user_filter=""
@@ -35,7 +35,7 @@ userName="cn"
 driver = "ldap"
 
 [grpc.services.userprovider.drivers.ldap]
-uri="ldaps://openldap:636"
+uri="ldaps://localhost:636"
 insecure=true
 user_base_dn="ou=testusers,dc=owncloud,dc=com"
 group_base_dn="ou=testgroups,dc=owncloud,dc=com"
@@ -62,7 +62,7 @@ member="memberUID"
 driver = "ldap"
 
 [grpc.services.groupprovider.drivers.ldap]
-uri="ldaps://openldap:636"
+uri="ldaps://localhost:636"
 insecure=true
 user_base_dn="ou=testusers,dc=owncloud,dc=com"
 group_base_dn="ou=testgroups,dc=owncloud,dc=com"


### PR DESCRIPTION
This PR updates the image for `ldap` and makes changes in `tests/oc-integration-tests/local/ldap-users.toml` for runnung tests locally. 