### PR TITLE
rfc8114: prefer return minimal

### DIFF
--- a/changelog/unreleased/prefer-return-minimal.md
+++ b/changelog/unreleased/prefer-return-minimal.md
@@ -1,0 +1,5 @@
+Enhancement: support Prefer: return=minimal in PROPFIND
+
+To reduce HTTP body size when listing folders we implemented https://datatracker.ietf.org/doc/html/rfc8144#section-2.1 to omit the 404 propstat part when a `Prefer: return=minimal` header is present.
+
+https://github.com/cs3org/reva/pull/3222

--- a/internal/http/services/owncloud/ocdav/net/headers.go
+++ b/internal/http/services/owncloud/ocdav/net/headers.go
@@ -33,6 +33,9 @@ const (
 	HeaderLocation                   = "Location"
 	HeaderRange                      = "Range"
 	HeaderIfMatch                    = "If-Match"
+	HeaderPrefer                     = "Prefer"
+	HeaderPreferenceApplied          = "Preference-Applied"
+	HeaderVary                       = "Vary"
 )
 
 // webdav headers
@@ -65,4 +68,9 @@ const (
 	HeaderExpectedEntityLength = "X-Expected-Entity-Length"
 	HeaderLitmus               = "X-Litmus"
 	HeaderTransferAuth         = "TransferHeaderAuthorization"
+)
+
+// HTTP Prefer header values
+const (
+	HeaderPreferReturn = "return" // eg. return=representation / return=minimal, depth-noroot
 )

--- a/internal/http/services/owncloud/ocdav/net/net.go
+++ b/internal/http/services/owncloud/ocdav/net/net.go
@@ -129,3 +129,18 @@ func ParseDestination(baseURI, s string) (string, error) {
 
 	return urlSplit[1], nil
 }
+
+// ParsePrefer parses the prefer header value defined in https://datatracker.ietf.org/doc/html/rfc8144
+func ParsePrefer(s string) map[string]string {
+	parts := strings.Split(s, ",")
+	m := make(map[string]string, len(parts))
+	for _, part := range parts {
+		kv := strings.SplitN(strings.ToLower(strings.Trim(part, " ")), "=", 2)
+		if len(kv) == 2 {
+			m[kv[0]] = kv[1]
+		} else {
+			m[kv[0]] = "1" // mark it as set
+		}
+	}
+	return m
+}


### PR DESCRIPTION
To reduce HTTP body size when listing folders we implemented https://datatracker.ietf.org/doc/html/rfc8144#section-2.1 to omit the 404 prop part when a Prefer header with return=minimal is present.
