### PR TITLE
Try to improve error handling on share creating

### DIFF
--- a/changelog/unreleased/improve-create-share-err.md
+++ b/changelog/unreleased/improve-create-share-err.md
@@ -1,0 +1,7 @@
+Enhancement: Improve CreateShare grpc error reporting
+
+The errorcode returned by the share provider when creating a share where the sharee
+is already the owner of the shared target is a bit more explicit now. Also debug logging
+was added for this.
+
+https://github.com/cs3org/reva/pull/3223

--- a/internal/grpc/services/usershareprovider/usershareprovider.go
+++ b/internal/grpc/services/usershareprovider/usershareprovider.go
@@ -150,7 +150,7 @@ func (s *service) CreateShare(ctx context.Context, req *collaboration.CreateShar
 	share, err := s.sm.Share(ctx, req.ResourceInfo, req.Grant)
 	if err != nil {
 		return &collaboration.CreateShareResponse{
-			Status: status.NewInternal(ctx, "error creating share"),
+			Status: status.NewStatusFromErrType(ctx, "error creating share", err),
 		}, nil
 	}
 

--- a/pkg/share/manager/cs3/cs3.go
+++ b/pkg/share/manager/cs3/cs3.go
@@ -272,6 +272,11 @@ func (m *Manager) Share(ctx context.Context, md *provider.ResourceInfo, g *colla
 		return nil, err
 	}
 	user := ctxpkg.ContextMustGetUser(ctx)
+	// do not allow share to myself or the owner if share is for a user
+	if g.Grantee.Type == provider.GranteeType_GRANTEE_TYPE_USER &&
+		(utils.UserEqual(g.Grantee.GetUserId(), user.Id) || utils.UserEqual(g.Grantee.GetUserId(), md.Owner)) {
+		return nil, errtypes.BadRequest("cs3: owner/creator and grantee are the same")
+	}
 	ts := utils.TSNow()
 
 	share := &collaboration.Share{

--- a/pkg/share/manager/json/json.go
+++ b/pkg/share/manager/json/json.go
@@ -257,7 +257,7 @@ func (m *mgr) Share(ctx context.Context, md *provider.ResourceInfo, g *collabora
 	// TODO(labkode): should not this be caught already at the gw level?
 	if g.Grantee.Type == provider.GranteeType_GRANTEE_TYPE_USER &&
 		(utils.UserEqual(g.Grantee.GetUserId(), user.Id) || utils.UserEqual(g.Grantee.GetUserId(), md.Owner)) {
-		return nil, errors.New("json: owner/creator and grantee are the same")
+		return nil, errtypes.BadRequest("json: owner/creator and grantee are the same")
 	}
 
 	// check if share already exists.

--- a/pkg/share/manager/jsoncs3/jsoncs3.go
+++ b/pkg/share/manager/jsoncs3/jsoncs3.go
@@ -209,7 +209,7 @@ func (m *Manager) Share(ctx context.Context, md *provider.ResourceInfo, g *colla
 	// TODO: should this not already be caught at the gw level?
 	if g.Grantee.Type == provider.GranteeType_GRANTEE_TYPE_USER &&
 		(utils.UserEqual(g.Grantee.GetUserId(), user.Id) || utils.UserEqual(g.Grantee.GetUserId(), md.Owner)) {
-		return nil, errors.New("json: owner/creator and grantee are the same")
+		return nil, errtypes.BadRequest("jsoncs3: owner/creator and grantee are the same")
 	}
 
 	// check if share already exists.

--- a/pkg/share/manager/memory/memory.go
+++ b/pkg/share/manager/memory/memory.go
@@ -20,7 +20,6 @@ package memory
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -83,7 +82,7 @@ func (m *manager) Share(ctx context.Context, md *provider.ResourceInfo, g *colla
 
 	if g.Grantee.Type == provider.GranteeType_GRANTEE_TYPE_USER &&
 		(utils.UserEqual(g.Grantee.GetUserId(), user.Id) || utils.UserEqual(g.Grantee.GetUserId(), md.Owner)) {
-		return nil, errors.New("memory: owner/creator and grantee are the same")
+		return nil, errtypes.BadRequest("memory: owner/creator and grantee are the same")
 	}
 
 	// check if share already exists.

--- a/pkg/share/manager/owncloudsql/owncloudsql.go
+++ b/pkg/share/manager/owncloudsql/owncloudsql.go
@@ -112,7 +112,7 @@ func (m *mgr) Share(ctx context.Context, md *provider.ResourceInfo, g *collabora
 	// TODO(labkode): should not this be caught already at the gw level?
 	if g.Grantee.Type == provider.GranteeType_GRANTEE_TYPE_USER &&
 		(utils.UserEqual(g.Grantee.GetUserId(), user.Id) || utils.UserEqual(g.Grantee.GetUserId(), md.Owner)) {
-		return nil, errors.New("owncloudsql: owner/creator and grantee are the same")
+		return nil, errtypes.BadRequest("owncloudsql: owner/creator and grantee are the same")
 	}
 
 	// check if share already exists.


### PR DESCRIPTION
Try to generate a more helpful error when trying to reshare something with the original owner of the shared target.

See: https://github.com/owncloud/ocis/issues/4336