### PR TITLE
Expose cache ttl config

### DIFF
--- a/changelog/unreleased/expose-cache-ttl-config.md
+++ b/changelog/unreleased/expose-cache-ttl-config.md
@@ -1,0 +1,6 @@
+Enhancement: Make the jsoncs3 share manager cache ttl configurable
+
+We added a new setting to the jsoncs3 share manager which allows to set
+the cache ttl.
+
+https://github.com/cs3org/reva/pull/3224

--- a/pkg/share/manager/jsoncs3/jsoncs3_test.go
+++ b/pkg/share/manager/jsoncs3/jsoncs3_test.go
@@ -156,7 +156,7 @@ var _ = Describe("Jsoncs3", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		client = &mocks.GatewayAPIClient{}
-		m, err = jsoncs3.New(storage, client)
+		m, err = jsoncs3.New(storage, client, 0)
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -251,7 +251,7 @@ var _ = Describe("Jsoncs3", func() {
 			})
 			Expect(s).ToNot(BeNil())
 
-			m, err = jsoncs3.New(storage, nil) // Reset in-memory cache
+			m, err = jsoncs3.New(storage, nil, 0) // Reset in-memory cache
 			Expect(err).ToNot(HaveOccurred())
 
 			s = shareBykey(&collaboration.ShareKey{
@@ -445,7 +445,7 @@ var _ = Describe("Jsoncs3", func() {
 			})
 
 			It("loads the cache when it doesn't have an entry", func() {
-				m, err := jsoncs3.New(storage, nil) // Reset in-memory cache
+				m, err := jsoncs3.New(storage, nil, 0) // Reset in-memory cache
 				Expect(err).ToNot(HaveOccurred())
 
 				s, err := m.GetShare(ctx, shareRef)
@@ -505,7 +505,7 @@ var _ = Describe("Jsoncs3", func() {
 				})
 				Expect(err).ToNot(HaveOccurred())
 
-				m, err = jsoncs3.New(storage, nil) // Reset in-memory cache
+				m, err = jsoncs3.New(storage, nil, 0) // Reset in-memory cache
 				Expect(err).ToNot(HaveOccurred())
 
 				s, err := m.GetShare(ctx, &collaboration.ShareReference{
@@ -618,7 +618,7 @@ var _ = Describe("Jsoncs3", func() {
 				Expect(us).ToNot(BeNil())
 				Expect(us.GetPermissions().GetPermissions().InitiateFileUpload).To(BeTrue())
 
-				m, err = jsoncs3.New(storage, nil) // Reset in-memory cache
+				m, err = jsoncs3.New(storage, nil, 0) // Reset in-memory cache
 				Expect(err).ToNot(HaveOccurred())
 
 				s = shareBykey(&collaboration.ShareKey{
@@ -749,7 +749,7 @@ var _ = Describe("Jsoncs3", func() {
 			})
 
 			It("syncronizes the user received cache before listing", func() {
-				m, err := jsoncs3.New(storage, nil) // Reset in-memory cache
+				m, err := jsoncs3.New(storage, nil, 0) // Reset in-memory cache
 				Expect(err).ToNot(HaveOccurred())
 
 				received, err := m.ListReceivedShares(granteeCtx, []*collaboration.Filter{})
@@ -817,7 +817,7 @@ var _ = Describe("Jsoncs3", func() {
 				})
 
 				It("syncronizes the group received cache before listing", func() {
-					m, err := jsoncs3.New(storage, nil) // Reset in-memory cache
+					m, err := jsoncs3.New(storage, nil, 0) // Reset in-memory cache
 					Expect(err).ToNot(HaveOccurred())
 
 					received, err := m.ListReceivedShares(granteeCtx, []*collaboration.Filter{})
@@ -861,7 +861,7 @@ var _ = Describe("Jsoncs3", func() {
 			})
 
 			It("syncs the cache", func() {
-				m, err := jsoncs3.New(storage, nil) // Reset in-memory cache
+				m, err := jsoncs3.New(storage, nil, 0) // Reset in-memory cache
 				Expect(err).ToNot(HaveOccurred())
 
 				rs, err := m.GetReceivedShare(granteeCtx, &collaboration.ShareReference{
@@ -895,7 +895,7 @@ var _ = Describe("Jsoncs3", func() {
 				})
 
 				It("syncs the cache", func() {
-					m, err := jsoncs3.New(storage, nil) // Reset in-memory cache
+					m, err := jsoncs3.New(storage, nil, 0) // Reset in-memory cache
 					Expect(err).ToNot(HaveOccurred())
 
 					rs, err := m.GetReceivedShare(granteeCtx, &collaboration.ShareReference{
@@ -1018,7 +1018,7 @@ var _ = Describe("Jsoncs3", func() {
 					Expect(err).ToNot(HaveOccurred())
 					Expect(rs.State).To(Equal(collaboration.ShareState_SHARE_STATE_ACCEPTED))
 
-					m, err := jsoncs3.New(storage, nil) // Reset in-memory cache
+					m, err := jsoncs3.New(storage, nil, 0) // Reset in-memory cache
 					Expect(err).ToNot(HaveOccurred())
 
 					rs, err = m.GetReceivedShare(granteeCtx, &collaboration.ShareReference{


### PR DESCRIPTION
This PR adds a new setting to the jsoncs3 share manager which allows to set the jsoncs3 share manager cache ttl.