### PR TITLE
ocs share: render parent id

### DIFF
--- a/changelog/unreleased/ocs-share-parent-id.md
+++ b/changelog/unreleased/ocs-share-parent-id.md
@@ -1,0 +1,5 @@
+Enhancement: render file parent id for ocs shares
+
+We brought back the `file_parent` property for ocs shares. The spaces concept makes navigating by path suboptimal. Having a parent id allows navigating without having to look up the full path.
+
+https://github.com/cs3org/reva/pull/3225

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/shares.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/shares.go
@@ -1157,7 +1157,10 @@ func (h *Handler) addFileInfo(ctx context.Context, s *conversions.ShareData, inf
 		}
 	}
 	s.StorageID = storageIDPrefix + s.FileTarget
-	// TODO FileParent:
+
+	if info.ParentId != nil {
+		s.FileParent = storagespace.FormatResourceID(*info.ParentId)
+	}
 	// item type
 	s.ItemType = conversions.ResourceType(info.GetType()).String()
 


### PR DESCRIPTION
We brought back the `file_parent` property for ocs shares. The spaces concept makes navigating by path suboptimal. Having a parent id allows navigating without having to look up the full path.