### PR TITLE
add prometheus middleware

### DIFF
--- a/changelog/unreleased/request-counting-middleware.md
+++ b/changelog/unreleased/request-counting-middleware.md
@@ -1,0 +1,5 @@
+Enhancement: request counting middleware
+
+We added a request counting `prometheus` HTTP middleware and GRPC interceptor that can be configured with a `namespace` and `subsystem` to count the number of requests.
+
+https://github.com/cs3org/reva/pull/3229

--- a/go.mod
+++ b/go.mod
@@ -58,6 +58,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/pkg/xattr v0.4.7
 	github.com/prometheus/alertmanager v0.24.0
+	github.com/prometheus/client_golang v1.13.0
 	github.com/rs/cors v1.8.2
 	github.com/rs/zerolog v1.28.0
 	github.com/sciencemesh/meshdirectory-web v1.0.4
@@ -171,7 +172,6 @@ require (
 	github.com/pkg/term v1.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/pquerna/cachecontrol v0.1.0 // indirect
-	github.com/prometheus/client_golang v1.13.0 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.37.0 // indirect
 	github.com/prometheus/procfs v0.8.0 // indirect

--- a/internal/grpc/interceptors/loader/loader.go
+++ b/internal/grpc/interceptors/loader/loader.go
@@ -21,6 +21,7 @@ package loader
 import (
 	// Load core GRPC services
 	_ "github.com/cs3org/reva/v2/internal/grpc/interceptors/eventsmiddleware"
+	_ "github.com/cs3org/reva/v2/internal/grpc/interceptors/prometheus"
 	_ "github.com/cs3org/reva/v2/internal/grpc/interceptors/readonly"
 	// Add your own service here
 )

--- a/internal/grpc/interceptors/prometheus/prometheus.go
+++ b/internal/grpc/interceptors/prometheus/prometheus.go
@@ -1,0 +1,77 @@
+// Copyright 2018-2021 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package prometheus
+
+import (
+	"context"
+
+	"github.com/cs3org/reva/v2/pkg/rgrpc"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"google.golang.org/grpc"
+)
+
+const (
+	defaultPriority = 100
+)
+
+func init() {
+	rgrpc.RegisterUnaryInterceptor("prometheus", NewUnary)
+}
+
+// NewUnary returns a new unary interceptor
+// that counts grpc calls.
+func NewUnary(m map[string]interface{}) (grpc.UnaryServerInterceptor, int, error) {
+	interceptor, err := interceptorFromConfig(m)
+	if err != nil {
+		return nil, 0, err
+	}
+	return interceptor, defaultPriority, nil
+}
+
+// NewStream returns a new server stream interceptor
+// that counts grpc calls.
+func NewStream() grpc.StreamServerInterceptor {
+	interceptor := func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		err := handler(srv, ss)
+		// TODO count res codes & errors
+		return err
+	}
+	return interceptor
+}
+
+func interceptorFromConfig(m map[string]interface{}) (grpc.UnaryServerInterceptor, error) {
+	namespace := m["namespace"].(string)
+	if namespace == "" {
+		namespace = "reva"
+	}
+	subsystem := m["subsystem"].(string)
+	reqProcessed := promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: namespace,
+		Subsystem: subsystem,
+		Name:      "grpc_requests_total",
+		Help:      "The total number of processed " + subsystem + " GRPC requests for " + namespace,
+	})
+	interceptor := func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+		res, err := handler(ctx, req)
+		reqProcessed.Inc()
+		return res, err
+	}
+	return interceptor, nil
+}

--- a/internal/http/interceptors/loader/loader.go
+++ b/internal/http/interceptors/loader/loader.go
@@ -21,6 +21,7 @@ package loader
 import (
 	// Load core HTTP middlewares.
 	_ "github.com/cs3org/reva/v2/internal/http/interceptors/cors"
+	_ "github.com/cs3org/reva/v2/internal/http/interceptors/prometheus"
 	_ "github.com/cs3org/reva/v2/internal/http/interceptors/providerauthorizer"
 	// Add your own middleware.
 )

--- a/internal/http/interceptors/prometheus/prometheus.go
+++ b/internal/http/interceptors/prometheus/prometheus.go
@@ -1,0 +1,69 @@
+// Copyright 2018-2021 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package prometheus
+
+import (
+	"net/http"
+
+	"github.com/cs3org/reva/v2/pkg/rhttp/global"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+const (
+	defaultPriority = 100
+)
+
+func init() {
+	global.RegisterMiddleware("prometheus", New)
+}
+
+// New returns a new HTTP middleware that counts requests for prometheus metrics
+func New(m map[string]interface{}) (global.Middleware, int, error) {
+	namespace := m["namespace"].(string)
+	if namespace == "" {
+		namespace = "reva"
+	}
+	subsystem := m["subsystem"].(string)
+	ph := prometheusHandler{
+		counter: promauto.NewCounter(prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: m["subsystem"].(string),
+			Name:      "http_requests_total",
+			Help:      "The total number of processed " + subsystem + " HTTP requests for " + namespace,
+		}),
+	}
+	return ph.handler, defaultPriority, nil
+}
+
+type prometheusHandler struct {
+	h       http.Handler
+	counter prometheus.Counter
+}
+
+// handler is a logging middleware
+func (ph prometheusHandler) handler(h http.Handler) http.Handler {
+	ph.h = h
+	return ph
+}
+
+func (ph prometheusHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ph.h.ServeHTTP(w, r)
+	ph.counter.Inc()
+}

--- a/pkg/micro/ocdav/option.go
+++ b/pkg/micro/ocdav/option.go
@@ -49,6 +49,10 @@ type Options struct {
 	TracingCollector string
 	TracingEndpoint  string
 
+	MetricsEnabled   bool
+	MetricsNamespace string
+	MetricsSubsystem string
+
 	// ocdav.* is internal so we need to set config options individually
 	config     ocdav.Config
 	lockSystem ocdav.LockSystem
@@ -239,5 +243,26 @@ func ProductName(val string) Option {
 func ProductVersion(val string) Option {
 	return func(o *Options) {
 		o.config.ProductVersion = val
+	}
+}
+
+// MetricsEnabled provides a function to set the MetricsEnabled config option.
+func MetricsEnabled(val bool) Option {
+	return func(o *Options) {
+		o.MetricsEnabled = val
+	}
+}
+
+// MetricsNamespace provides a function to set the MetricsNamespace config option.
+func MetricsNamespace(val string) Option {
+	return func(o *Options) {
+		o.MetricsNamespace = val
+	}
+}
+
+// MetricsSubsystem provides a function to set the MetricsSubsystem config option.
+func MetricsSubsystem(val string) Option {
+	return func(o *Options) {
+		o.MetricsSubsystem = val
 	}
 }


### PR DESCRIPTION
This allows collecting call metrics for https://github.com/cs3org/reva/issues/2976

I'll add A PR to ocis that adds sth like this to all ocis services:
```go
			"interceptors": map[string]interface{}{
				"prometheus": map[string]interface{}{
					"namespace": "ocis",
					"subsystem": "auth_basic",
				},
			},
```

it allows fetching metrics like this:
```
$ curl 127.0.0.1:9165/metrics -s | grep _requests | grep -v '#' | grep -v 'promhttp_metric_'
ocis_app_provider_grpc_requests_total 0
ocis_app_registry_grpc_requests_total 1
ocis_auth_basic_grpc_requests_total 0
ocis_auth_bearer_grpc_requests_total 0
ocis_auth_machine_grpc_requests_total 0
ocis_frontend_http_requests_total 0
ocis_gateway_grpc_requests_total 1
ocis_groups_grpc_requests_total 0
ocis_sharing_grpc_requests_total 0
ocis_storage_publiclink_grpc_requests_total 0
ocis_storage_shares_grpc_requests_total 0
ocis_storage_system_grpc_requests_total 6
ocis_storage_system_http_requests_total 0
ocis_storage_users_grpc_requests_total 0
ocis_users_grpc_requests_total 0
```

and after a single list received shares call with 500 accepted shares:
```
$ curl 127.0.0.1:9165/metrics -s | grep _requests | grep -v '#' | grep -v 'promhttp_metric_'
ocis_app_provider_grpc_requests_total 0
ocis_app_registry_grpc_requests_total 1
ocis_auth_basic_grpc_requests_total 1
ocis_auth_bearer_grpc_requests_total 0
ocis_auth_machine_grpc_requests_total 1
ocis_frontend_http_requests_total 1
ocis_gateway_grpc_requests_total 1013
ocis_groups_grpc_requests_total 0
ocis_sharing_grpc_requests_total 1
ocis_storage_publiclink_grpc_requests_total 0
ocis_storage_shares_grpc_requests_total 0
ocis_storage_system_grpc_requests_total 858
ocis_storage_system_http_requests_total 118
ocis_storage_users_grpc_requests_total 501
ocis_users_grpc_requests_total 5
```

This pr can easily be 
- [ ] ported to master and
- [ ] used to compare master vs edge