### PR TITLE
Allow to override default broker for micro

### DIFF
--- a/changelog/unreleased/ocdav-broker-conf.md
+++ b/changelog/unreleased/ocdav-broker-conf.md
@@ -1,0 +1,6 @@
+Enhancement: Allow to override default broker for go-micro base ocdav service
+    
+An option for setting an alternative go-micro Broker was introduced. This can
+be used to avoid ocdav from spawing the (unneeded) default http Broker.
+
+https://github.com/cs3org/reva/pull/3233

--- a/pkg/micro/ocdav/option.go
+++ b/pkg/micro/ocdav/option.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cs3org/reva/v2/internal/http/services/owncloud/ocdav"
 	"github.com/cs3org/reva/v2/pkg/storage/favorite"
 	"github.com/rs/zerolog"
+	"go-micro.dev/v4/broker"
 )
 
 // Option defines a single option function.
@@ -33,6 +34,7 @@ type Option func(o *Options)
 // Options defines the available options for this package.
 type Options struct {
 	TLSConfig *tls.Config
+	Broker    broker.Broker
 	Address   string
 	Logger    zerolog.Logger
 	Context   context.Context
@@ -67,6 +69,13 @@ func newOptions(opts ...Option) Options {
 func TLSConfig(config *tls.Config) Option {
 	return func(o *Options) {
 		o.TLSConfig = config
+	}
+}
+
+// Broker provides a function to set the Broker option.
+func Broker(b broker.Broker) Option {
+	return func(o *Options) {
+		o.Broker = b
 	}
 }
 

--- a/pkg/micro/ocdav/service.go
+++ b/pkg/micro/ocdav/service.go
@@ -57,6 +57,7 @@ func Service(opts ...Option) (micro.Service, error) {
 	sopts.Logger = sopts.Logger.With().Str("name", sopts.Name).Logger()
 
 	srv := httpServer.NewServer(
+		server.Broker(sopts.Broker),
 		server.TLSConfig(sopts.TLSConfig),
 		server.Name(sopts.Name),
 		server.Address(sopts.Address), // Address defaults to ":0" and will pick any free port


### PR DESCRIPTION
This adds an option to set an alternative Broker to avoid ocdav from spawing the (unneeded) default http Broker.