### PR TITLE
Add post create home hook for eos storage driver

### DIFF
--- a/changelog/unreleased/post-create-home-hook-eos.md
+++ b/changelog/unreleased/post-create-home-hook-eos.md
@@ -1,0 +1,3 @@
+Enhancement: Add post create home hook for eos storage driver
+
+https://github.com/cs3org/reva/pull/3234

--- a/pkg/storage/utils/eosfs/config.go
+++ b/pkg/storage/utils/eosfs/config.go
@@ -144,6 +144,9 @@ type Config struct {
 	// revisions-related operations.
 	ImpersonateOwnerforRevisions bool `mapstructure:"impersonate_owner_for_revisions"`
 
+	// Whether to enable the post create home hook
+	EnablePostCreateHomeHook bool `mapstructure:"enable_post_create_home_hook"`
+
 	// HTTP connections to EOS: max number of idle conns
 	MaxIdleConns int `mapstructure:"max_idle_conns"`
 
@@ -171,6 +174,4 @@ type Config struct {
 
 	// Path of the script to run after an user home folder has been created
 	OnPostCreateHomeHook string `mapstructure:"on_post_create_home_hook"`
-	// Whether to enable the post create home hook
-	EnablePostCreateHomeHook bool `mapstructure:"enable_post_create_home_hook"`
 }

--- a/pkg/storage/utils/eosfs/config.go
+++ b/pkg/storage/utils/eosfs/config.go
@@ -168,4 +168,9 @@ type Config struct {
 	// TokenExpiry stores in seconds the time after which generated tokens will expire
 	// Default is 3600
 	TokenExpiry int
+
+	// Path of the script to run after an user home folder has been created
+	OnPostCreateHomeHook string `mapstructure:"on_post_create_home_hook"`
+	// Whether to enable the post create home hook
+	EnablePostCreateHomeHook bool `mapstructure:"enable_post_create_home_hook"`
 }


### PR DESCRIPTION
This PR adds the possibility of define an hook that will run after the creation of an home folder.