### PR TITLE
Fix relative quota amount calculation

### DIFF
--- a/changelog/unreleased/ocs-relquota-value.md
+++ b/changelog/unreleased/ocs-relquota-value.md
@@ -1,0 +1,7 @@
+Bugfix: Return relative used quota amount as a percent value
+    
+The ocs/ocs/v1.php/cloud/users/ endpoint was fixed to return the relative amount
+of used quota as a percentage value.
+
+https://github.com/cs3org/reva/pull/3238
+https://github.com/owncloud/ocis/issues/4357

--- a/internal/http/services/owncloud/ocs/handlers/cloud/users/users.go
+++ b/internal/http/services/owncloud/ocs/handlers/cloud/users/users.go
@@ -223,7 +223,7 @@ func (h Handler) fillPersonalQuota(ctx context.Context, d *User, u *cs3identity.
 	// only calculate free and relative when total is available
 	if total > 0 {
 		d.Quota.Free = int64(total - used)
-		d.Quota.Relative = float32(float64(used) / float64(total))
+		d.Quota.Relative = float32((float64(used) / float64(total)) * 100.0)
 	} else {
 		d.Quota.Definition = "none" // this indicates no quota / unlimited to the ui
 	}


### PR DESCRIPTION
The relative amount is supposed to be return as a percentage value. See https://doc.owncloud.com/server/next/developer_manual/core/apis/provisioning-api.html#get-user