### PR TITLE
ocdav: Properly escape oc:name in propfind response

### DIFF
--- a/changelog/unreleased/fix-propfind-escape-name.md
+++ b/changelog/unreleased/fix-propfind-escape-name.md
@@ -1,0 +1,8 @@
+Bugfix: Properly escape oc:name in propfind response
+
+The oc:name property in the ocdav propfind response might contain
+XML special characters. We now apply the proper escaping on that
+property.
+
+https://github.com/cs3org/reva/pull/3255
+https://github.com/owncloud/ocis/issues/4474

--- a/internal/http/services/owncloud/ocdav/propfind/propfind.go
+++ b/internal/http/services/owncloud/ocdav/propfind/propfind.go
@@ -1010,7 +1010,7 @@ func mdToPropResponse(ctx context.Context, pf *XML, md *provider.ResourceInfo, p
 		}
 
 		if md.Name != "" {
-			appendToOK(prop.Raw("oc:name", md.Name))
+			appendToOK(prop.Escaped("oc:name", md.Name))
 		}
 
 		if md.Etag != "" {
@@ -1343,7 +1343,7 @@ func mdToPropResponse(ctx context.Context, pf *XML, md *provider.ResourceInfo, p
 						}
 					}
 				case "name":
-					appendToOK(prop.Raw("oc:name", md.Name))
+					appendToOK(prop.Escaped("oc:name", md.Name))
 				case "shareid":
 					if ref, err := storagespace.ParseReference(strings.TrimPrefix(md.Path, "/")); err == nil && ref.GetResourceId().GetSpaceId() == utils.ShareStorageSpaceID {
 						appendToOK(prop.Raw("oc:shareid", ref.GetResourceId().GetOpaqueId()))


### PR DESCRIPTION
The oc:name property in the ocdav propfind response might contain XML special characters. We now apply the proper escaping on that property

https://github.com/owncloud/ocis/issues/4474