### PR TITLE
Lock source node when moving

### DIFF
--- a/changelog/unreleased/lock-source-on-move.md
+++ b/changelog/unreleased/lock-source-on-move.md
@@ -1,0 +1,7 @@
+Bugfix: Lock source on move
+
+When moving files until now only the lock of the targeted node would be checked.
+This could lead to strange behaviour when using web editors like only office.
+With checking the source nodes lock too, it is now forbidden to rename a file while it is locked
+
+https://github.com/cs3org/reva/pull/3251

--- a/pkg/storage/utils/decomposedfs/decomposedfs.go
+++ b/pkg/storage/utils/decomposedfs/decomposedfs.go
@@ -504,6 +504,11 @@ func (fs *Decomposedfs) Move(ctx context.Context, oldRef, newRef *provider.Refer
 		return errtypes.PermissionDenied(newNode.ID)
 	}
 
+	// check lock on source
+	if err := oldNode.CheckLock(ctx); err != nil {
+		return err
+	}
+
 	// check lock on target
 	if err := newNode.CheckLock(ctx); err != nil {
 		return err


### PR DESCRIPTION
## Lock source on move

When moving files until now only the lock of the targeted node would be checked.
This could lead to strange behaviour when using web editors like only office.
With checking the source nodes lock too, it is now forbidden to rename a file while it is locked