### PR TITLE
Metadatastore

### DIFF
--- a/changelog/unreleased/metadatastore.md
+++ b/changelog/unreleased/metadatastore.md
@@ -1,0 +1,3 @@
+Enhancement: Decomposedfs can now store metadata in JSON
+
+https://github.com/cs3org/reva/pull/3261

--- a/pkg/storage/utils/decomposedfs/decomposedfs.go
+++ b/pkg/storage/utils/decomposedfs/decomposedfs.go
@@ -325,8 +325,7 @@ func (fs *Decomposedfs) CreateDir(ctx context.Context, ref *provider.Reference) 
 	}
 
 	if fs.o.TreeTimeAccounting || fs.o.TreeSizeAccounting {
-		// mark the home node as the end of propagation
-		if err = n.SetMetadata(xattrs.PropagationAttr, "1"); err != nil {
+		if err = n.EnablePropagation(); err != nil {
 			appctx.GetLogger(ctx).Error().Err(err).Interface("node", n).Msg("could not mark node to propagate")
 
 			// FIXME: This does not return an error at all, but results in a severe situation that the
@@ -449,12 +448,7 @@ func (fs *Decomposedfs) CreateReference(ctx context.Context, p string, targetURI
 	}
 	childCreated = true
 
-	if err := childNode.SetMetadata(xattrs.ReferenceAttr, targetURI.String()); err != nil {
-		// the reference could not be set - that would result in an lost reference?
-		err := errors.Wrapf(err, "Decomposedfs: error setting the target %s on the reference file %s",
-			targetURI.String(),
-			childNode.InternalPath(),
-		)
+	if err := childNode.SetReference(targetURI); err != nil {
 		span.SetStatus(codes.Error, err.Error())
 		return err
 	}

--- a/pkg/storage/utils/decomposedfs/decomposedfs_concurrency_test.go
+++ b/pkg/storage/utils/decomposedfs/decomposedfs_concurrency_test.go
@@ -19,7 +19,6 @@
 package decomposedfs_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"sync"
@@ -85,7 +84,7 @@ var _ = Describe("Decomposed", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(len(revisions)).To(Equal(1))
 
-				_, err = ioutil.ReadFile(path.Join(env.Root, "nodes", "root", "uploaded.txt"))
+				_, err = os.ReadFile(path.Join(env.Root, "nodes", "root", "uploaded.txt"))
 				Expect(err).ToNot(HaveOccurred())
 			})
 		})

--- a/pkg/storage/utils/decomposedfs/grants.go
+++ b/pkg/storage/utils/decomposedfs/grants.go
@@ -266,12 +266,7 @@ func (fs *Decomposedfs) storeGrant(ctx context.Context, n *node.Node, g *provide
 		spaceType = sg.SpaceType
 	}
 
-	// set the grant
-	e := ace.FromGrant(g)
-	principal, value := e.Marshal()
-	if err := n.SetMetadata(xattrs.GrantPrefix+principal, string(value)); err != nil {
-		appctx.GetLogger(ctx).Error().Err(err).
-			Str("principal", principal).Msg("Could not set grant for principal")
+	if err := n.SetGrant(g); err != nil {
 		return err
 	}
 

--- a/pkg/storage/utils/decomposedfs/lookup/lookup.go
+++ b/pkg/storage/utils/decomposedfs/lookup/lookup.go
@@ -29,7 +29,6 @@ import (
 	"github.com/cs3org/reva/v2/pkg/errtypes"
 	"github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/node"
 	"github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/options"
-	"github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/xattrs"
 )
 
 // Lookup implements transformations from filepath to node and back
@@ -133,10 +132,16 @@ func (lu *Lookup) WalkPath(ctx context.Context, r *node.Node, p string, followRe
 			return r, err
 		}
 
+		// TODO I think following references is unused
 		if followReferences {
-			if attrBytes, err := r.GetMetadata(xattrs.ReferenceAttr); err == nil {
-				realNodeID := attrBytes
-				ref, err := xattrs.ReferenceFromAttr([]byte(realNodeID))
+			if targetURI, err := r.GetReference(); err == nil {
+				ref := provider.Reference{
+					ResourceId: &provider.ResourceId{
+						StorageId: targetURI.Host,
+						// TODO spaceid?
+						OpaqueId: targetURI.Path,
+					},
+				}
 				if err != nil {
 					return nil, err
 				}

--- a/pkg/storage/utils/decomposedfs/lookup/lookup_test.go
+++ b/pkg/storage/utils/decomposedfs/lookup/lookup_test.go
@@ -21,7 +21,6 @@ package lookup_test
 import (
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	helpers "github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/testhelpers"
-	"github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/xattrs"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -119,14 +118,4 @@ var _ = Describe("Lookup", func() {
 		})
 	})
 
-	Describe("Reference Parsing", func() {
-		It("parses a valid cs3 reference", func() {
-			in := []byte("cs3:bede11a0-ea3d-11eb-a78b-bf907adce8ed/c402d01c-ea3d-11eb-a0fc-c32f9d32528f")
-			ref, err := xattrs.ReferenceFromAttr(in)
-
-			Expect(err).ToNot(HaveOccurred())
-			Expect(ref.ResourceId.StorageId).To(Equal("bede11a0-ea3d-11eb-a78b-bf907adce8ed"))
-			Expect(ref.ResourceId.OpaqueId).To(Equal("c402d01c-ea3d-11eb-a0fc-c32f9d32528f"))
-		})
-	})
 })

--- a/pkg/storage/utils/decomposedfs/metadata.go
+++ b/pkg/storage/utils/decomposedfs/metadata.go
@@ -32,7 +32,6 @@ import (
 	"github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/xattrs"
 	"github.com/cs3org/reva/v2/pkg/utils"
 	"github.com/pkg/errors"
-	"github.com/pkg/xattr"
 )
 
 // SetArbitraryMetadata sets the metadata on a resource
@@ -63,8 +62,6 @@ func (fs *Decomposedfs) SetArbitraryMetadata(ctx context.Context, ref *provider.
 	if err := n.CheckLock(ctx); err != nil {
 		return err
 	}
-
-	nodePath := n.InternalPath()
 
 	errs := []error{}
 	// TODO should we really continue updating when an error occurs?
@@ -109,9 +106,8 @@ func (fs *Decomposedfs) SetArbitraryMetadata(ctx context.Context, ref *provider.
 		}
 	}
 	for k, v := range md.Metadata {
-		attrName := xattrs.MetadataPrefix + k
-		if err = xattr.Set(nodePath, attrName, []byte(v)); err != nil {
-			errs = append(errs, errors.Wrap(err, "Decomposedfs: could not set metadata attribute "+attrName+" to "+k))
+		if err := n.SetArbitraryMetadata(k, v); err != nil {
+			errs = append(errs, errors.Wrap(err, "Decomposedfs: could not set arbitrary metadata "+k+" to "+v))
 		}
 	}
 

--- a/pkg/storage/utils/decomposedfs/node/node.go
+++ b/pkg/storage/utils/decomposedfs/node/node.go
@@ -76,7 +76,7 @@ type Node struct {
 	ParentID  string
 	ID        string
 	Name      string
-	Blobsize  int64
+	Blobsize  uint64
 	BlobID    string
 	owner     *userpb.UserId
 	Exists    bool
@@ -94,7 +94,7 @@ type PathLookup interface {
 }
 
 // New returns a new instance of Node
-func New(spaceID, id, parentID, name string, blobsize int64, blobID string, owner *userpb.UserId, lu PathLookup) *Node {
+func New(spaceID, id, parentID, name string, blobsize uint64, blobID string, owner *userpb.UserId, lu PathLookup) *Node {
 	if blobID == "" {
 		blobID = uuid.New().String()
 	}
@@ -244,7 +244,7 @@ func (n *Node) WriteAllNodeMetadata() (err error) {
 	attribs[xattrs.ParentidAttr] = n.ParentID
 	attribs[xattrs.NameAttr] = n.Name
 	attribs[xattrs.BlobIDAttr] = n.BlobID
-	attribs[xattrs.BlobsizeAttr] = strconv.FormatInt(n.Blobsize, 10)
+	attribs[xattrs.BlobsizeAttr] = strconv.FormatUint(n.Blobsize, 10)
 
 	nodePath := n.InternalPath()
 	return xattrs.SetMultiple(nodePath, attribs)
@@ -1185,12 +1185,12 @@ func (n *Node) ListGrants(ctx context.Context) ([]*provider.Grant, error) {
 }
 
 // GetBlobSize reads the blobsize from the xattrs
-func (n *Node) GetBlobSize() (int64, error) {
+func (n *Node) GetBlobSize() (uint64, error) {
 	val, err := n.getMetadata(xattrs.BlobsizeAttr)
 	if err != nil {
 		return 0, err
 	}
-	blobSize, err := strconv.ParseInt(val, 10, 64)
+	blobSize, err := strconv.ParseUint(val, 10, 64)
 	if err != nil {
 		return 0, errors.Wrapf(err, "invalid blobsize xattr format")
 	}

--- a/pkg/storage/utils/decomposedfs/node/node.go
+++ b/pkg/storage/utils/decomposedfs/node/node.go
@@ -26,6 +26,7 @@ import (
 	"hash"
 	"io"
 	"io/fs"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -131,6 +132,28 @@ func (n *Node) SetMetadata(key string, val string) (err error) {
 	nodePath := n.InternalPath()
 	if err := xattrs.Set(nodePath, key, val); err != nil {
 		return errors.Wrap(err, "Decomposedfs: could not set extended attribute")
+	}
+	return nil
+}
+
+// EnablePropagation enables recursive size and change time propagation
+func (n *Node) EnablePropagation() (err error) {
+	nodePath := n.InternalPath()
+	if err := xattrs.Set(nodePath, xattrs.PropagationAttr, "1"); err != nil {
+		return errors.Wrap(err, "Decomposedfs: could not set extended attribute")
+	}
+	return nil
+}
+
+// EnablePropagation enables recursive size and change time propagation
+func (n *Node) SetReference(targetURI *url.URL) (err error) {
+	nodePath := n.InternalPath()
+	if err := xattrs.Set(nodePath, xattrs.ReferenceAttr, targetURI.String()); err != nil {
+		// the reference could not be set - that would result in an lost reference?
+		return errors.Wrapf(err, "Decomposedfs: error setting the target %s on the reference file %s",
+			targetURI.String(),
+			nodePath,
+		)
 	}
 	return nil
 }

--- a/pkg/storage/utils/decomposedfs/node/node_test.go
+++ b/pkg/storage/utils/decomposedfs/node/node_test.go
@@ -86,10 +86,10 @@ var _ = Describe("Node", func() {
 			n, err := env.Lookup.NodeFromResource(env.Ctx, ref)
 			Expect(err).ToNot(HaveOccurred())
 
-			blobsize := 239485734
+			blobsize := uint64(239485734)
 			n.Name = "TestName"
 			n.BlobID = "TestBlobID"
-			n.Blobsize = int64(blobsize)
+			n.Blobsize = blobsize
 
 			err = n.WriteAllNodeMetadata()
 			Expect(err).ToNot(HaveOccurred())
@@ -97,7 +97,7 @@ var _ = Describe("Node", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(n2.Name).To(Equal("TestName"))
 			Expect(n2.BlobID).To(Equal("TestBlobID"))
-			Expect(n2.Blobsize).To(Equal(int64(blobsize)))
+			Expect(n2.Blobsize).To(Equal(blobsize))
 		})
 	})
 

--- a/pkg/storage/utils/decomposedfs/revisions.go
+++ b/pkg/storage/utils/decomposedfs/revisions.go
@@ -78,9 +78,12 @@ func (fs *Decomposedfs) ListRevisions(ctx context.Context, ref *provider.Referen
 					Key:   n.ID + node.RevisionIDDelimiter + parts[1],
 					Mtime: uint64(mtime.Unix()),
 				}
-				blobSize, err := node.ReadBlobSizeAttr(items[i])
+				// TODO add revision property to node
+				// TODO add trash property to node with time and key
+				revisionNode := node.New(n.SpaceID, rev.Key, n.ParentID, n.Name, 0, "", n.Owner(), fs.lu)
+				blobSize, err := revisionNode.GetBlobSize()
 				if err != nil {
-					return nil, errors.Wrapf(err, "error reading blobsize xattr")
+					return nil, errors.Wrapf(err, "error reading blobsize")
 				}
 				rev.Size = uint64(blobSize)
 				etag, err := node.CalculateEtag(np, mtime)

--- a/pkg/storage/utils/decomposedfs/spaces.go
+++ b/pkg/storage/utils/decomposedfs/spaces.go
@@ -638,7 +638,7 @@ func (fs *Decomposedfs) DeleteStorageSpace(ctx context.Context, req *provider.De
 		return err
 	}
 
-	st, err := n.SpaceRoot.GetMetadata(xattrs.SpaceTypeAttr)
+	st, err := n.SpaceRoot.GetSpaceType()
 	if err != nil {
 		return errtypes.InternalError(fmt.Sprintf("space %s does not have a spacetype, possible corrupt decompsedfs", n.ID))
 	}
@@ -666,7 +666,7 @@ func (fs *Decomposedfs) DeleteStorageSpace(ctx context.Context, req *provider.De
 			return errtypes.NewErrtypeFromStatus(status.NewInvalidArg(ctx, "can't purge enabled space"))
 		}
 
-		spaceType, err := n.GetMetadata(xattrs.SpaceTypeAttr)
+		spaceType, err := n.GetSpaceType()
 		if err != nil {
 			return err
 		}
@@ -770,7 +770,7 @@ func (fs *Decomposedfs) storageSpaceFromNode(ctx context.Context, n *node.Node, 
 	var err error
 	// TODO apply more filters
 	var sname string
-	if sname, err = n.SpaceRoot.GetMetadata(xattrs.SpaceNameAttr); err != nil {
+	if sname, err = n.SpaceRoot.GetSpaceName(); err != nil {
 		// FIXME: Is that a severe problem?
 		appctx.GetLogger(ctx).Debug().Err(err).Msg("space does not have a name attribute")
 	}
@@ -834,7 +834,7 @@ func (fs *Decomposedfs) storageSpaceFromNode(ctx context.Context, n *node.Node, 
 		// Mtime is set either as node.tmtime or as fi.mtime below
 	}
 
-	if space.SpaceType, err = n.SpaceRoot.GetMetadata(xattrs.SpaceTypeAttr); err != nil {
+	if space.SpaceType, err = n.SpaceRoot.GetSpaceType(); err != nil {
 		appctx.GetLogger(ctx).Debug().Err(err).Msg("space does not have a type attribute")
 	}
 

--- a/pkg/storage/utils/decomposedfs/spaces.go
+++ b/pkg/storage/utils/decomposedfs/spaces.go
@@ -139,7 +139,7 @@ func (fs *Decomposedfs) CreateStorageSpace(ctx context.Context, req *provider.Cr
 		metadata[xattrs.SpaceAliasAttr] = alias
 	}
 
-	if err := xattrs.SetMultiple(root.InternalPath(), metadata); err != nil {
+	if err := root.SetMultiple(metadata); err != nil {
 		return nil, err
 	}
 
@@ -597,7 +597,7 @@ func (fs *Decomposedfs) UpdateStorageSpace(ctx context.Context, req *provider.Up
 		}
 	}
 
-	err = xattrs.SetMultiple(node.InternalPath(), metadata)
+	err = node.SetMultiple(metadata)
 	if err != nil {
 		return nil, err
 	}
@@ -877,7 +877,7 @@ func (fs *Decomposedfs) storageSpaceFromNode(ctx context.Context, n *node.Node, 
 		Value:   []byte(etag),
 	}
 
-	spaceAttributes, err := xattrs.All(n.InternalPath())
+	spaceAttributes, err := n.GetAllMetadata()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/storage/utils/decomposedfs/testhelpers/helpers.go
+++ b/pkg/storage/utils/decomposedfs/testhelpers/helpers.go
@@ -24,10 +24,8 @@ import (
 	"path/filepath"
 
 	"github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/lookup"
-	"github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/xattrs"
 	"github.com/cs3org/reva/v2/pkg/storagespace"
 	"github.com/google/uuid"
-	"github.com/pkg/xattr"
 	"github.com/stretchr/testify/mock"
 
 	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
@@ -73,9 +71,9 @@ const (
 // NewTestEnv prepares a test environment on disk
 // The storage contains some directories and a file:
 //
-//  /dir1/
-//  /dir1/file1
-//  /dir1/subdir1/
+//	/dir1/
+//	/dir1/file1
+//	/dir1/subdir1/
 //
 // The default config can be overridden by providing the strings to override
 // via map as a parameter
@@ -262,7 +260,7 @@ func (t *TestEnv) CreateTestStorageSpace(typ string, quota *providerv1beta1.Quot
 	if err != nil {
 		return nil, err
 	}
-	if err = xattr.Set(h.InternalPath(), xattrs.SpaceNameAttr, []byte("username")); err != nil {
+	if err = h.SetSpaceName("username"); err != nil {
 		return nil, err
 	}
 

--- a/pkg/storage/utils/decomposedfs/testhelpers/helpers.go
+++ b/pkg/storage/utils/decomposedfs/testhelpers/helpers.go
@@ -196,7 +196,7 @@ func (t *TestEnv) CreateTestDir(name string, parentRef *providerv1beta1.Referenc
 }
 
 // CreateTestFile creates a new file and its metadata and returns a corresponding Node
-func (t *TestEnv) CreateTestFile(name, blobID, parentID, spaceID string, blobSize int64) (*node.Node, error) {
+func (t *TestEnv) CreateTestFile(name, blobID, parentID, spaceID string, blobSize uint64) (*node.Node, error) {
 	// Create n in dir1
 	n := node.New(
 		spaceID,

--- a/pkg/storage/utils/decomposedfs/tree/migrations.go
+++ b/pkg/storage/utils/decomposedfs/tree/migrations.go
@@ -24,6 +24,8 @@ import (
 	"path/filepath"
 
 	"github.com/cs3org/reva/v2/pkg/logger"
+	"github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/node"
+	"github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/xattrs"
 )
 
 /**
@@ -120,4 +122,10 @@ func (t *Tree) migration0002SpaceTypes() error {
 		}
 	}
 	return nil
+}
+
+// isRootNode checks if a node is a space root
+func isRootNode(nodePath string) bool {
+	attr, err := xattrs.Get(nodePath, xattrs.ParentidAttr)
+	return err == nil && attr == node.RootID
 }

--- a/pkg/storage/utils/decomposedfs/tree/tree.go
+++ b/pkg/storage/utils/decomposedfs/tree/tree.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	iofs "io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -269,7 +268,7 @@ func (t *Tree) TouchFile(ctx context.Context, n *node.Node) error {
 			return errors.Wrap(err, "Decomposedfs: could not remove symlink child entry")
 		}
 	}
-	if errors.Is(err, iofs.ErrNotExist) || link != "../"+n.ID {
+	if errors.Is(err, fs.ErrNotExist) || link != "../"+n.ID {
 		relativeNodePath := filepath.Join("../../../../../", lookup.Pathify(n.ID, 4, 2))
 		if err = os.Symlink(relativeNodePath, childNameLink); err != nil {
 			return errors.Wrap(err, "Decomposedfs: could not symlink child entry")

--- a/pkg/storage/utils/decomposedfs/tree/tree.go
+++ b/pkg/storage/utils/decomposedfs/tree/tree.go
@@ -468,7 +468,7 @@ func (t *Tree) Delete(ctx context.Context, n *node.Node) (err error) {
 
 	// set origin location in metadata
 	nodePath := n.InternalPath()
-	if err := n.SetMetadata(xattrs.TrashOriginAttr, origin); err != nil {
+	if err := n.SetTrashOrigin(origin); err != nil {
 		return err
 	}
 
@@ -478,7 +478,7 @@ func (t *Tree) Delete(ctx context.Context, n *node.Node) (err error) {
 	trashLink := filepath.Join(t.root, "spaces", lookup.Pathify(n.SpaceRoot.ID, 1, 2), "trash", lookup.Pathify(n.ID, 4, 2))
 	if err := os.MkdirAll(filepath.Dir(trashLink), 0700); err != nil {
 		// Roll back changes
-		_ = n.RemoveMetadata(xattrs.TrashOriginAttr)
+		_ = n.RemoveTrashOrigin()
 		return err
 	}
 
@@ -491,7 +491,7 @@ func (t *Tree) Delete(ctx context.Context, n *node.Node) (err error) {
 	err = os.Symlink("../../../../../nodes/"+lookup.Pathify(n.ID, 4, 2)+node.TrashIDDelimiter+deletionTime, trashLink)
 	if err != nil {
 		// Roll back changes
-		_ = n.RemoveMetadata(xattrs.TrashOriginAttr)
+		_ = n.RemoveTrashOrigin()
 		return
 	}
 
@@ -504,7 +504,7 @@ func (t *Tree) Delete(ctx context.Context, n *node.Node) (err error) {
 		// To roll back changes
 		// TODO remove symlink
 		// Roll back changes
-		_ = n.RemoveMetadata(xattrs.TrashOriginAttr)
+		_ = n.RemoveTrashOrigin()
 		return
 	}
 
@@ -519,7 +519,7 @@ func (t *Tree) Delete(ctx context.Context, n *node.Node) (err error) {
 		// TODO revert the rename
 		// TODO remove symlink
 		// Roll back changes
-		_ = n.RemoveMetadata(xattrs.TrashOriginAttr)
+		_ = n.RemoveTrashOrigin()
 		return
 	}
 
@@ -578,14 +578,14 @@ func (t *Tree) RestoreRecycleItemFunc(ctx context.Context, spaceid, key, trashPa
 
 		targetNode.Exists = true
 		// update name attribute
-		if err := recycleNode.SetMetadata(xattrs.NameAttr, targetNode.Name); err != nil {
-			return errors.Wrap(err, "Decomposedfs: could not set name attribute")
+		if err := recycleNode.SetName(targetNode.Name); err != nil {
+			return err
 		}
 
 		// set ParentidAttr to restorePath's node parent id
 		if trashPath != "" {
-			if err := recycleNode.SetMetadata(xattrs.ParentidAttr, targetNode.ParentID); err != nil {
-				return errors.Wrap(err, "Decomposedfs: could not set name attribute")
+			if err := recycleNode.SetParentID(targetNode.ParentID); err != nil {
+				return err
 			}
 		}
 

--- a/pkg/storage/utils/decomposedfs/upload_test.go
+++ b/pkg/storage/utils/decomposedfs/upload_test.go
@@ -22,7 +22,6 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"io/ioutil"
 	"os"
 
 	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
@@ -236,13 +235,13 @@ var _ = Describe("File uploads", func() {
 					Return(nil).
 					Run(func(args mock.Arguments) {
 						reader := args.Get(1).(io.Reader)
-						data, err := ioutil.ReadAll(reader)
+						data, err := io.ReadAll(reader)
 
 						Expect(err).ToNot(HaveOccurred())
 						Expect(data).To(Equal([]byte("0123456789")))
 					})
 
-				_, err = fs.Upload(ctx, uploadRef, ioutil.NopCloser(bytes.NewReader(fileContent)), nil)
+				_, err = fs.Upload(ctx, uploadRef, io.NopCloser(bytes.NewReader(fileContent)), nil)
 
 				Expect(err).ToNot(HaveOccurred())
 				bs.AssertCalled(GinkgoT(), "Upload", mock.Anything, mock.Anything, mock.Anything)
@@ -274,13 +273,13 @@ var _ = Describe("File uploads", func() {
 					Return(nil).
 					Run(func(args mock.Arguments) {
 						reader := args.Get(1).(io.Reader)
-						data, err := ioutil.ReadAll(reader)
+						data, err := io.ReadAll(reader)
 
 						Expect(err).ToNot(HaveOccurred())
 						Expect(data).To(Equal([]byte("")))
 					})
 
-				_, err = fs.Upload(ctx, uploadRef, ioutil.NopCloser(bytes.NewReader(fileContent)), nil)
+				_, err = fs.Upload(ctx, uploadRef, io.NopCloser(bytes.NewReader(fileContent)), nil)
 
 				Expect(err).ToNot(HaveOccurred())
 				bs.AssertCalled(GinkgoT(), "Upload", mock.Anything, mock.Anything, mock.Anything)
@@ -300,7 +299,7 @@ var _ = Describe("File uploads", func() {
 				)
 
 				uploadRef := &provider.Reference{Path: "/some-non-existent-upload-reference"}
-				_, err := fs.Upload(ctx, uploadRef, ioutil.NopCloser(bytes.NewReader(fileContent)), nil)
+				_, err := fs.Upload(ctx, uploadRef, io.NopCloser(bytes.NewReader(fileContent)), nil)
 
 				Expect(err).To(HaveOccurred())
 

--- a/pkg/storage/utils/decomposedfs/xattrs/xattrs.go
+++ b/pkg/storage/utils/decomposedfs/xattrs/xattrs.go
@@ -214,6 +214,9 @@ func Remove(filePath string, key string) (err error) {
 // the changes are protected with an file lock
 // If the file lock can not be acquired the function returns a
 // lock error.
+// TODO we should split the metadata keys into an xattr prefix "user.oc." and the actual keys
+//
+//	then SetMultiple should use an internal set method which then prefixes the canonical metadata
 func SetMultiple(filePath string, attribs map[string]string) (err error) {
 
 	// h, err := lockedfile.OpenFile(filePath, os.O_WRONLY, 0) // 0? Open File only workn for files ... but we want to lock dirs ... or symlinks

--- a/pkg/storage/utils/decomposedfs/xattrs/xattrs.go
+++ b/pkg/storage/utils/decomposedfs/xattrs/xattrs.go
@@ -20,9 +20,7 @@ package xattrs
 
 import (
 	"strconv"
-	"strings"
 
-	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	"github.com/cs3org/reva/v2/pkg/storage/utils/filelocks"
 	"github.com/gofrs/flock"
 	"github.com/pkg/errors"
@@ -101,24 +99,6 @@ const (
 	UserAcePrefix  string = "u:"
 	GroupAcePrefix string = "g:"
 )
-
-// ReferenceFromAttr returns a CS3 reference from xattr of a node.
-// Supported formats are: "cs3:storageid/nodeid"
-func ReferenceFromAttr(b []byte) (*provider.Reference, error) {
-	return refFromCS3(b)
-}
-
-// refFromCS3 creates a CS3 reference from a set of bytes. This method should remain private
-// and only be called after validation because it can potentially panic.
-func refFromCS3(b []byte) (*provider.Reference, error) {
-	parts := string(b[4:])
-	return &provider.Reference{
-		ResourceId: &provider.ResourceId{
-			StorageId: strings.Split(parts, "/")[0],
-			OpaqueId:  strings.Split(parts, "/")[1],
-		},
-	}, nil
-}
 
 // CopyMetadata copies all extended attributes from source to target.
 // The optional filter function can be used to filter by attribute name, e.g. by checking a prefix


### PR DESCRIPTION
Decomposedfs can now store metadata in JSON
- [ ] refactor all xattr access into node specific methods
- [ ] introduce MetadataStore interface and pass it down to Node instances
- [ ] move xattr access to MetadataStore implementation
- [ ] make sure tests still work
- [ ] implement new JSON backed Metadata store