### PR TITLE
[tests-only]Check for issue not mentioned to a test in expected to failure in reva-edge

### DIFF
--- a/tests/acceptance/expected-failures-on-EOS-storage.md
+++ b/tests/acceptance/expected-failures-on-EOS-storage.md
@@ -63,8 +63,6 @@
 - [apiWebdavProperties1/getQuota.feature:62](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/getQuota.feature#L62)
 - [apiWebdavProperties1/getQuota.feature:77](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/getQuota.feature#L77)
 - [apiWebdavProperties1/getQuota.feature:78](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/getQuota.feature#L78)
-
-### [There is no such thing like a "super-user"](https://github.com/owncloud/ocis/issues/1319)
 ### [no command equivalent to occ](https://github.com/owncloud/ocis/issues/1317)
 - [apiMain/status.feature:5](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiMain/status.feature#L5)
 
@@ -91,7 +89,6 @@
 ### [users can access each-others data using the new webdav API](https://github.com/owncloud/ocis/issues/1347)
 - [apiAuthWebDav/webDavPUTAuth.feature:40](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiAuthWebDav/webDavPUTAuth.feature#L40)
 
-### [Default capabilities for normal user not same as in oC-core](https://github.com/owncloud/ocis/issues/1285)
 ### [Difference in response content of status.php and default capabilities](https://github.com/owncloud/ocis/issues/1286)
 - [apiCapabilities/capabilitiesWithNormalUser.feature:11](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiCapabilities/capabilitiesWithNormalUser.feature#L11)
 
@@ -203,26 +200,17 @@
 - [apiSharees/sharees.feature:560](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharees/sharees.feature#L560)
 - [apiSharees/sharees.feature:561](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharees/sharees.feature#L561)
 
-### Accepting a share returns empty response
-- [apiShareManagement/acceptSharesToSharesFolder.feature:15](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareManagement/acceptSharesToSharesFolder.feature#L15)
-- [apiShareManagement/acceptSharesToSharesFolder.feature:22](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareManagement/acceptSharesToSharesFolder.feature#L22)
-- [apiShareManagement/acceptSharesToSharesFolder.feature:30](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareManagement/acceptSharesToSharesFolder.feature#L30)
-- [apiShareManagement/acceptSharesToSharesFolder.feature:52](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareManagement/acceptSharesToSharesFolder.feature#L52)
-
 ### [After accepting a share data in the received file cannot be downloaded](https://github.com/owncloud/product/issues/208)
 - [apiShareManagement/acceptSharesToSharesFolder.feature:15](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareManagement/acceptSharesToSharesFolder.feature#L15)
 
 ### [Response is empty when accepting a share](https://github.com/owncloud/product/issues/207)
 - [apiShareManagement/acceptSharesToSharesFolder.feature:30](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareManagement/acceptSharesToSharesFolder.feature#L30)
 - [apiShareManagement/acceptSharesToSharesFolder.feature:52](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareManagement/acceptSharesToSharesFolder.feature#L52)
+- [apiShareManagement/acceptSharesToSharesFolder.feature:15](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareManagement/acceptSharesToSharesFolder.feature#L15)
+- [apiShareManagement/acceptSharesToSharesFolder.feature:22](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareManagement/acceptSharesToSharesFolder.feature#L22)
+- [apiShareManagement/acceptSharesToSharesFolder.feature:30](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareManagement/acceptSharesToSharesFolder.feature#L30)
+- [apiShareManagement/acceptSharesToSharesFolder.feature:52](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareManagement/acceptSharesToSharesFolder.feature#L52)
 
-### [groups endpoint does not exist](https://github.com/owncloud/ocis-reva/issues/34)
-### [Sharing seems to work but does not work](https://github.com/owncloud/ocis/issues/1303)
-### [Listing shares via ocs API does not show path for parent folders](https://github.com/owncloud/ocis/issues/1231)
-### [Fields missing in delete share OCS response](https://github.com/owncloud/ocis-reva/issues/356)
-### [file_target in share response](https://github.com/owncloud/product/issues/203)
-### [Shares not deleted when user is deleted](hhttps://github.com/owncloud/ocis/issues/1226)
-### [EOS no displayname owner when creating share](https://github.com/owncloud/ocis/issues/1270)
 ### [EOS mime-type is not set correctly when sharing](https://github.com/owncloud/ocis/issues/1271)
 - [apiShareToSharesManagementBasic/createShareToSharesFolder.feature:36](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareToSharesManagementBasic/createShareToSharesFolder.feature#L36)
 - [apiShareToSharesManagementBasic/createShareToSharesFolder.feature:37](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareToSharesManagementBasic/createShareToSharesFolder.feature#L37)
@@ -314,7 +302,6 @@
 - [apiShareOperations/gettingShares.feature:34](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareOperations/gettingShares.feature#L34)
 - [apiShareOperations/gettingShares.feature:35](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareOperations/gettingShares.feature#L35)
 
-### [Delete shares from user when user is deleted](hhttps://github.com/owncloud/ocis/issues/1226)
 ### [no displayname_owner shown when creating a share](https://github.com/owncloud/ocis/issues/1270)
 ### [when sharing a file mime-type field is set to application/octet-stream](https://github.com/owncloud/ocis/issues/1271)
 - [apiShareOperations/gettingShares.feature:124](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareOperations/gettingShares.feature#L124)
@@ -334,7 +321,6 @@
 - [apiShareOperations/getWebDAVSharePermissions.feature:134](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareOperations/getWebDAVSharePermissions.feature#L134)
 - [apiShareOperations/getWebDAVSharePermissions.feature:135](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareOperations/getWebDAVSharePermissions.feature#L135)
 
-### [Split old public API webdav tests from new public webdav tests](https://github.com/owncloud/ocis-reva/issues/282)
 ### [Public link enforce permissions](https://github.com/owncloud/ocis/issues/1269)
 - [apiSharePublicLink1/accessToPublicLinkShare.feature:10](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/accessToPublicLinkShare.feature#L10)
 - [apiSharePublicLink1/accessToPublicLinkShare.feature:20](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink1/accessToPublicLinkShare.feature#L20)
@@ -429,8 +415,6 @@
 
 ### [copying a folder within a public link folder to folder with same name as an already existing file overwrites the parent file](https://github.com/owncloud/ocis/issues/1232)
 - [apiSharePublicLink2/copyFromPublicLink.feature:59](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/copyFromPublicLink.feature#L59)
-
-### https://github.com/owncloud/ocis/issues/1232
 - [apiSharePublicLink2/copyFromPublicLink.feature:86](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/copyFromPublicLink.feature#L86)
 
 ### [copying a file from within a public link folder to "/" overwrites the parent folder](https://github.com/owncloud/ocis/issues/1230)
@@ -481,7 +465,6 @@
 ### [Upload-only shares must not overwrite but create a separate file](https://github.com/owncloud/ocis/issues/1267)
 - [apiSharePublicLink2/uploadToPublicLinkShare.feature:262](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink2/uploadToPublicLinkShare.feature#L262)
 
-### [Propfind to trashbin endpoint requires UUID](https://github.com/owncloud/product/issues/179)
 ### [File deletion using dav gives unique string in filename in the trashbin](https://github.com/owncloud/product/issues/178)
 - [apiTrashbin/trashbinDelete.feature:30](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiTrashbin/trashbinDelete.feature#L30)
 - [apiTrashbin/trashbinDelete.feature:31](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiTrashbin/trashbinDelete.feature#L31)
@@ -549,7 +532,6 @@
 - [apiTrashbin/trashbinRestore.feature:343](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiTrashbin/trashbinRestore.feature#L343)
 - [apiTrashbin/trashbinRestore.feature:344](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiTrashbin/trashbinRestore.feature#L344)
 
-### [uploading with old-chunking does not work](https://github.com/owncloud/ocis/issues/1343)
 ### [remote.php/dav/uploads endpoint does not exist](https://github.com/owncloud/ocis/issues/1321)
 - [apiWebdavUpload2/uploadFileUsingNewChunking.feature:12](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUpload2/uploadFileUsingNewChunking.feature#L12)
 - [apiWebdavUpload2/uploadFileUsingNewChunking.feature:29](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUpload2/uploadFileUsingNewChunking.feature#L29)
@@ -825,7 +807,6 @@ Not everything needs to be implemented for ocis. While the oc10 testsuite covers
 * _The `OC-LazyOps` header is [no longer supported by the client](https://github.com/owncloud/client/pull/8398), implmenting this is not necessary for a first production release. We plan to have an uploed state machine to visualize the state of a file, see https://github.com/owncloud/ocis/issues/214_
 * _Blacklisted ignored files are no longer required because ocis can handle `.htaccess` files without security implications introduced by serving user provided files with apache._
 
-### [uploading with old-chunking does not work](https://github.com/owncloud/ocis/issues/1343)
 ### [remote.php/dav/uploads endpoint does not exist](https://github.com/owncloud/ocis/issues/1321)
 - [apiWebdavUpload1/uploadFileAsyncUsingNewChunking.feature:14](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUpload1/uploadFileAsyncUsingNewChunking.feature#L14)
 - [apiWebdavUpload1/uploadFileAsyncUsingNewChunking.feature:31](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUpload1/uploadFileAsyncUsingNewChunking.feature#L31)

--- a/tests/acceptance/expected-failures-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-on-OCIS-storage.md
@@ -150,7 +150,7 @@ File and sync features in a shared scenario
 - [apiSharees/sharees.feature:430](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharees/sharees.feature#L430)
 - [apiSharees/sharees.feature:431](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharees/sharees.feature#L431)
 
-#### User cannot create a folder named Share
+#### [accepting matching name shared resources from different users/groups sets no serial identifiers on the resource name for the receiver](https://github.com/owncloud/ocis/issues/4289)
 - [apiShareManagementToShares/acceptShares.feature:366](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareManagementToShares/acceptShares.feature#L366)
 - [apiShareManagementToShares/acceptShares.feature:402](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareManagementToShares/acceptShares.feature#L402)
 
@@ -260,7 +260,6 @@ _requires a [CS3 user provisioning api that can update the quota for a user](htt
 - [apiTrashbin/trashbinSharingToShares.feature:212](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiTrashbin/trashbinSharingToShares.feature#L212)
 - [apiTrashbin/trashbinSharingToShares.feature:236](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiTrashbin/trashbinSharingToShares.feature#L236)
 
-#### [Scoped links](https://github.com/owncloud/ocis/issues/2809)
 #### [oc:privatelink property not returned in webdav responses](https://github.com/owncloud/product/issues/262)
 - [apiWebdavProperties2/getFileProperties.feature:306](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties2/getFileProperties.feature#L306)
 - [apiWebdavProperties2/getFileProperties.feature:307](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties2/getFileProperties.feature#L307)
@@ -420,8 +419,6 @@ _requires a [CS3 user provisioning api that can update the quota for a user](htt
 - [apiShareCreateSpecialToShares2/createShareWithDisabledUser.feature:20](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareCreateSpecialToShares2/createShareWithDisabledUser.feature#L20)
 - [apiShareCreateSpecialToShares2/createShareWithDisabledUser.feature:23](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareCreateSpecialToShares2/createShareWithDisabledUser.feature#L23)
 
-
-#### [Share additional info](https://github.com/owncloud/ocis/issues/1253)
 #### [Edit user share response has an "name" field](https://github.com/owncloud/ocis/issues/1225)
 - [apiShareUpdateToShares/updateShare.feature:288](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareUpdateToShares/updateShare.feature#L288)
 - [apiShareUpdateToShares/updateShare.feature:289](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareUpdateToShares/updateShare.feature#L289)
@@ -484,7 +481,6 @@ _ocdav: api compatibility, return correct status code_
 - [apiAuthWebDav/webDavSpecialURLs.feature:163](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiAuthWebDav/webDavSpecialURLs.feature#L163)
 - [apiAuthWebDav/webDavSpecialURLs.feature:174](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiAuthWebDav/webDavSpecialURLs.feature#L174)
 
-#### [Default capabilities for normal user not same as in oC-core](https://github.com/owncloud/ocis/issues/1285)
 #### [Difference in response content of status.php and default capabilities](https://github.com/owncloud/ocis/issues/1286)
 - [apiCapabilities/capabilitiesWithNormalUser.feature:11](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiCapabilities/capabilitiesWithNormalUser.feature#L11) Scenario: getting default capabilities with normal user
 
@@ -698,7 +694,7 @@ Not everything needs to be implemented for ocis. While the oc10 testsuite covers
 - [apiWebdavUpload1/uploadFileToBlacklistedName.feature:72](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUpload1/uploadFileToBlacklistedName.feature#L72)
 - [apiWebdavUpload1/uploadFileToBlacklistedName.feature:77](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUpload1/uploadFileToBlacklistedName.feature#L77)
 
-#### moving a share from the /Shares jail to a user home is no longer supported.
+#### [file_target of a auto-renamed file is not correct directly after sharing](https://github.com/owncloud/core/issues/32322)
 - [apiShareManagementToShares/mergeShare.feature:105](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareManagementToShares/mergeShare.feature#L105)
 
 ### To triage
@@ -814,7 +810,7 @@ moving outside of the Shares folder gives 501 Not Implemented.
 - [apiVersions/fileVersionAuthor.feature:180](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiVersions/fileVersionAuthor.feature#L180)
 - [apiVersions/fileVersionAuthor.feature:223](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiVersions/fileVersionAuthor.feature#L223)
 
-### [Allow public link sharing only for certain groups feature not implemented]
+### [Allow public link sharing only for certain groups feature not implemented](https://github.com/owncloud/ocis/issues/4623)
 - [apiSharePublicLink3/allowGroupToCreatePublicLinks.feature:35](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink3/allowGroupToCreatePublicLinks.feature#L35)
 - [apiSharePublicLink3/allowGroupToCreatePublicLinks.feature:91](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink3/allowGroupToCreatePublicLinks.feature#L91)
 

--- a/tests/acceptance/expected-failures-on-S3NG-storage.md
+++ b/tests/acceptance/expected-failures-on-S3NG-storage.md
@@ -162,7 +162,7 @@ File and sync features in a shared scenario
 - [apiSharees/sharees.feature:430](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharees/sharees.feature#L430)
 - [apiSharees/sharees.feature:431](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharees/sharees.feature#L431)
 
-#### User cannot create a folder named Share
+#### [accepting matching name shared resources from different users/groups sets no serial identifiers on the resource name for the receiver](https://github.com/owncloud/ocis/issues/4289)
 - [apiShareManagementToShares/acceptShares.feature:366](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareManagementToShares/acceptShares.feature#L366)
 - [apiShareManagementToShares/acceptShares.feature:402](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareManagementToShares/acceptShares.feature#L402)
 
@@ -270,7 +270,6 @@ _requires a [CS3 user provisioning api that can update the quota for a user](htt
 - [apiTrashbin/trashbinSharingToShares.feature:212](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiTrashbin/trashbinSharingToShares.feature#L212)
 - [apiTrashbin/trashbinSharingToShares.feature:236](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiTrashbin/trashbinSharingToShares.feature#L236)
 
-#### [Scoped links](https://github.com/owncloud/ocis/issues/2809)
 #### [oc:privatelink property not returned in webdav responses](https://github.com/owncloud/product/issues/262)
 - [apiWebdavProperties2/getFileProperties.feature:306](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties2/getFileProperties.feature#L306)
 - [apiWebdavProperties2/getFileProperties.feature:307](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties2/getFileProperties.feature#L307)
@@ -301,7 +300,7 @@ _requires a [CS3 user provisioning api that can update the quota for a user](htt
 #### [restoring an older version of a shared file deletes the share](https://github.com/owncloud/ocis/issues/765)
 - [apiShareManagementToShares/acceptShares.feature:588](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareManagementToShares/acceptShares.feature#L588)
 
-####[not possible to move file into a received folder](https://github.com/owncloud/ocis/issues/764)
+#### [not possible to move file into a received folder](https://github.com/owncloud/ocis/issues/764)
 - [apiVersions/fileVersionsSharingToShares.feature:220](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiVersions/fileVersionsSharingToShares.feature#L220)
 - [apiVersions/fileVersionsSharingToShares.feature:221](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiVersions/fileVersionsSharingToShares.feature#L221)
 
@@ -433,8 +432,6 @@ _requires a [CS3 user provisioning api that can update the quota for a user](htt
 - [apiShareCreateSpecialToShares2/createShareWithDisabledUser.feature:20](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareCreateSpecialToShares2/createShareWithDisabledUser.feature#L20)
 - [apiShareCreateSpecialToShares2/createShareWithDisabledUser.feature:23](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareCreateSpecialToShares2/createShareWithDisabledUser.feature#L23)
 
-
-#### [Share additional info](https://github.com/owncloud/ocis/issues/1253)
 #### [Edit user share response has an "name" field](https://github.com/owncloud/ocis/issues/1225)
 - [apiShareUpdateToShares/updateShare.feature:288](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareUpdateToShares/updateShare.feature#L288)
 - [apiShareUpdateToShares/updateShare.feature:289](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareUpdateToShares/updateShare.feature#L289)
@@ -497,7 +494,6 @@ _ocdav: api compatibility, return correct status code_
 - [apiAuthWebDav/webDavSpecialURLs.feature:163](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiAuthWebDav/webDavSpecialURLs.feature#L163)
 - [apiAuthWebDav/webDavSpecialURLs.feature:174](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiAuthWebDav/webDavSpecialURLs.feature#L174)
 
-#### [Default capabilities for normal user not same as in oC-core](https://github.com/owncloud/ocis/issues/1285)
 #### [Difference in response content of status.php and default capabilities](https://github.com/owncloud/ocis/issues/1286)
 - [apiCapabilities/capabilitiesWithNormalUser.feature:11](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiCapabilities/capabilitiesWithNormalUser.feature#L11) Scenario: getting default capabilities with normal user
 
@@ -533,7 +529,7 @@ _ocdav: api compatibility, return correct status code_
 - [apiWebdavOperations/search.feature:265](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L265)
 - [apiWebdavOperations/search.feature:270](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavOperations/search.feature#L270)
 
-And other missing implementation of favorites
+#### [Support for favorites](https://github.com/owncloud/ocis/issues/1228)
 - [apiFavorites/favorites.feature:182](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiFavorites/favorites.feature#L182)
 - [apiFavorites/favorites.feature:183](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiFavorites/favorites.feature#L183)
 - [apiFavorites/favorites.feature:215](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiFavorites/favorites.feature#L215)
@@ -717,7 +713,7 @@ Not everything needs to be implemented for ocis. While the oc10 testsuite covers
 - [apiWebdavUpload1/uploadFileToBlacklistedName.feature:72](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUpload1/uploadFileToBlacklistedName.feature#L72)
 - [apiWebdavUpload1/uploadFileToBlacklistedName.feature:77](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavUpload1/uploadFileToBlacklistedName.feature#L77)
 
-#### moving a share from the /Shares jail to a user home is no longer supported.
+#### [file_target of a auto-renamed file is not correct directly after sharing](https://github.com/owncloud/core/issues/32322)
 - [apiShareManagementToShares/mergeShare.feature:105](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareManagementToShares/mergeShare.feature#L105)
 
 ### To triage
@@ -818,7 +814,7 @@ _ocs: api compatibility, return correct status code_
 - [apiWebdavProperties1/copyFile.feature:439](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/copyFile.feature#L439)
 - [apiWebdavProperties1/copyFile.feature:444](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/copyFile.feature#L444)
 
-### [Allow public link sharing only for certain groups feature not implemented]
+### [Allow public link sharing only for certain groups feature not implemented](https://github.com/owncloud/ocis/issues/4623)
 - [apiSharePublicLink3/allowGroupToCreatePublicLinks.feature:35](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink3/allowGroupToCreatePublicLinks.feature#L35)
 - [apiSharePublicLink3/allowGroupToCreatePublicLinks.feature:91](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiSharePublicLink3/allowGroupToCreatePublicLinks.feature#L91)
 


### PR DESCRIPTION
### Description
- Cleans up issues that has no failed related tests on expected to failure file (most of them are closed)
- Put issue to the failed tests if missing
- clean up description

### Part of 
https://github.com/owncloud/QA/issues/716