### PR TITLE
Reduce default cache sizes for smaller memory footprint

### DIFF
--- a/changelog/unreleased/fix-default-cachesizes.md
+++ b/changelog/unreleased/fix-default-cachesizes.md
@@ -1,0 +1,9 @@
+Bugfix: Reduced default cache sizes for smaller memory footprint
+
+We reduced the default cachesizes of the auth interceptors and the share
+cache. The default of 1 Million cache entries was way too high and caused
+a high memory usage upon startup. Config options to set custom cache size
+where added.
+
+https://github.com/owncloud/ocis/issues/3267
+https://github.com/owncloud/ocis/issues/4628

--- a/internal/http/interceptors/auth/auth.go
+++ b/internal/http/interceptors/auth/auth.go
@@ -71,6 +71,7 @@ type config struct {
 	TokenManagers          map[string]map[string]interface{} `mapstructure:"token_managers"`
 	TokenWriter            string                            `mapstructure:"token_writer"`
 	TokenWriters           map[string]map[string]interface{} `mapstructure:"token_writers"`
+	UserGroupsCacheSize    int                               `mapstructure:"usergroups_cache_size"`
 }
 
 func parseConfig(m map[string]interface{}) (*config, error) {
@@ -112,7 +113,10 @@ func New(m map[string]interface{}, unprotected []string, tp trace.TracerProvider
 		conf.CredentialsByUserAgent = map[string]string{}
 	}
 
-	userGroupsCache = gcache.New(1000000).LFU().Build()
+	if conf.UserGroupsCacheSize == 0 {
+		conf.UserGroupsCacheSize = 5000
+	}
+	userGroupsCache = gcache.New(conf.UserGroupsCacheSize).LFU().Build()
 
 	credChain := map[string]auth.CredentialStrategy{}
 	for i, key := range conf.CredentialChain {

--- a/pkg/share/cache/memory/memory.go
+++ b/pkg/share/cache/memory/memory.go
@@ -48,7 +48,7 @@ func New(m map[string]interface{}) (cache.ResourceInfoCache, error) {
 		return nil, errors.Wrap(err, "error decoding conf")
 	}
 	if c.CacheSize == 0 {
-		c.CacheSize = 1000000
+		c.CacheSize = 10000
 	}
 
 	return &manager{


### PR DESCRIPTION
We reduced the default cachesizes of the auth interceptors and the share cache. The default of 1 Million cache entries was way too high and caused a high memory usage upon startup. Config options to set custom cache size were added.

https://github.com/owncloud/ocis/issues/4628