### PR TITLE
[tests-only] Don't panic when extracting refs

### DIFF
--- a/internal/grpc/interceptors/auth/scope.go
+++ b/internal/grpc/interceptors/auth/scope.go
@@ -440,8 +440,15 @@ func extractShareRef(req interface{}) (*collaboration.ShareReference, bool) {
 }
 
 func getRefKey(ref *provider.Reference) string {
-	if ref.Path != "" {
+	if ref.GetPath() != "" {
 		return ref.Path
 	}
-	return storagespace.FormatResourceID(*ref.ResourceId)
+
+	if ref.GetResourceId() != nil {
+		return storagespace.FormatResourceID(*ref.ResourceId)
+	}
+
+	// on malicious request both path and rid could be empty
+	// we still should not panic
+	return ""
 }


### PR DESCRIPTION
Monitoring experimental logs showed that gateway service is sometimes panicing in auth interceptor. For some reason both path and rid are empty. Event though this is obviously not a proper request, gateway should still not panic when getting faulty requests.