### PR TITLE
align more OCS error responses with oc10

### DIFF
--- a/changelog/unreleased/polish-ocs-errors.md
+++ b/changelog/unreleased/polish-ocs-errors.md
@@ -1,0 +1,6 @@
+Bugfix: Polish OCS error responses
+
+We aligned more OCS error responses with oc10
+
+https://github.com/cs3org/reva/pull/3279
+https://github.com/owncloud/ocis/issues/1799

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/shares.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/shares.go
@@ -227,11 +227,9 @@ func (h *Handler) CreateShare(w http.ResponseWriter, r *http.Request) {
 	if statRes.Status.Code != rpc.Code_CODE_OK {
 		switch statRes.Status.Code {
 		case rpc.Code_CODE_NOT_FOUND:
-			response.WriteOCSError(w, r, http.StatusNotFound, "Not found", nil)
-			w.WriteHeader(http.StatusNotFound)
+			response.WriteOCSData(w, r, response.MetaPathNotFound, nil, nil)
 		case rpc.Code_CODE_PERMISSION_DENIED:
 			response.WriteOCSError(w, r, http.StatusNotFound, "No share permission", nil)
-			w.WriteHeader(http.StatusForbidden)
 		default:
 			sublog.Error().Interface("status", statRes.Status).Msg("CreateShare: stat failed")
 			w.WriteHeader(http.StatusInternalServerError)

--- a/internal/http/services/owncloud/ocs/response/response.go
+++ b/internal/http/services/owncloud/ocs/response/response.go
@@ -112,6 +112,15 @@ type Meta struct {
 // MetaOK is the default ok response
 var MetaOK = Meta{Status: "ok", StatusCode: 100, Message: "OK"}
 
+// MetaFailure is a failure response with code 101
+var MetaFailure = Meta{Status: "", StatusCode: 101, Message: "Failure"}
+
+// MetaInvalidInput is an error response with code 102
+var MetaInvalidInput = Meta{Status: "", StatusCode: 102, Message: "Invalid Input"}
+
+// MetaForbidden is an error response with code 104
+var MetaForbidden = Meta{Status: "", StatusCode: 104, Message: "Forbidden"}
+
 // MetaBadRequest is used for unknown errors
 var MetaBadRequest = Meta{Status: "error", StatusCode: 400, Message: "Bad Request"}
 
@@ -124,8 +133,20 @@ var MetaUnauthorized = Meta{Status: "error", StatusCode: 997, Message: "Unauthor
 // MetaNotFound is returned when trying to access not existing resources
 var MetaNotFound = Meta{Status: "error", StatusCode: 998, Message: "Not Found"}
 
+// MetaPathNotFound is returned when trying to share not existing resources
+var MetaPathNotFound = Meta{Status: "failure", StatusCode: 404, Message: MessagePathNotFound}
+
 // MetaUnknownError is used for unknown errors
 var MetaUnknownError = Meta{Status: "error", StatusCode: 999, Message: "Unknown Error"}
+
+// MessageUserNotFound is  used when a user can not be found
+var MessageUserNotFound = "The requested user could not be found"
+
+// MessageGroupNotFound is used when a group can not be found
+var MessageGroupNotFound = "The requested group could not be found"
+
+// MessagePathNotFound is used when a file or folder can not be found
+var MessagePathNotFound = "Wrong path, file/folder doesn't exist"
 
 // WriteOCSSuccess handles writing successful ocs response data
 func WriteOCSSuccess(w http.ResponseWriter, r *http.Request, d interface{}) {


### PR DESCRIPTION
We aligned more OCS error responses with oc10

see https://github.com/owncloud/ocis/issues/1799

a `curl -X POST -u admin:admin https://cloud.ocis.test/ocs/v1.php/apps/files_sharing/api/v1/shares -d shareType=3 -d path=nonExisting -v -k` now returns
```
< HTTP/2 200 
< content-type: text/xml; charset=utf-8
< date: Tue, 27 Sep 2022 15:34:43 GMT
< ocs-api-version: 1
< vary: Origin
< content-length: 175
< 
<?xml version="1.0" encoding="UTF-8"?>
* Connection #0 to host cloud.ocis.test left intact
<ocs><meta><status>failure</status><statuscode>404</statuscode><message>Wrong path, file/folder doesn&#39;t exist</message></meta></ocs>
```