### PR TITLE
better user names in wopi apps

### DIFF
--- a/changelog/unreleased/better-usernames.md
+++ b/changelog/unreleased/better-usernames.md
@@ -1,0 +1,5 @@
+Bugfix: Use Displayname in wopi apps
+
+We now use the users display name in wopi apps.
+
+https://github.com/cs3org/reva/pull/3282

--- a/pkg/app/provider/wopi/wopi.go
+++ b/pkg/app/provider/wopi/wopi.go
@@ -155,7 +155,7 @@ func (p *wopiProvider) GetAppURL(ctx context.Context, resource *provider.Resourc
 		}
 
 		if !isPublicShare {
-			q.Add("username", u.Username)
+			q.Add("username", u.DisplayName)
 		}
 	}
 


### PR DESCRIPTION
# Description

Use better usernames in WOPI apps.

- Display Name for authenticated users
- Don't set the owner's userid when editing a publicshare, that could lead to wrong assumtions