### PR TITLE
Return OCS forbidden error when a share already exists

### DIFF
--- a/changelog/unreleased/forbidden-on-reshare.md
+++ b/changelog/unreleased/forbidden-on-reshare.md
@@ -1,0 +1,6 @@
+Bugfix: Return OCS forbidden error when a share already exists
+
+We now return OCS 104 / HTTP 403 errors when a user tries to reshare a file with a recipient that already has access to a resource.
+
+https://github.com/cs3org/reva/pull/3287
+https://github.com/owncloud/ocis/issues/4630

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/shares.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/shares.go
@@ -1398,6 +1398,12 @@ func (h *Handler) createCs3Share(ctx context.Context, w http.ResponseWriter, r *
 				Message: "not found",
 				Error:   nil,
 			}
+		case rpc.Code_CODE_ALREADY_EXISTS:
+			return nil, &ocsError{
+				Code:    response.MetaForbidden.StatusCode,
+				Message: response.MessageShareExists,
+				Error:   nil,
+			}
 		case rpc.Code_CODE_INVALID_ARGUMENT:
 			return nil, &ocsError{
 				Code:    response.MetaBadRequest.StatusCode,

--- a/internal/http/services/owncloud/ocs/response/response.go
+++ b/internal/http/services/owncloud/ocs/response/response.go
@@ -124,6 +124,9 @@ var MetaForbidden = Meta{Status: "", StatusCode: 104, Message: "Forbidden"}
 // MetaBadRequest is used for unknown errors
 var MetaBadRequest = Meta{Status: "error", StatusCode: 400, Message: "Bad Request"}
 
+// MetaPathNotFound is returned when trying to share not existing resources
+var MetaPathNotFound = Meta{Status: "failure", StatusCode: 404, Message: MessagePathNotFound}
+
 // MetaServerError is returned on server errors
 var MetaServerError = Meta{Status: "error", StatusCode: 996, Message: "Server Error"}
 
@@ -132,9 +135,6 @@ var MetaUnauthorized = Meta{Status: "error", StatusCode: 997, Message: "Unauthor
 
 // MetaNotFound is returned when trying to access not existing resources
 var MetaNotFound = Meta{Status: "error", StatusCode: 998, Message: "Not Found"}
-
-// MetaPathNotFound is returned when trying to share not existing resources
-var MetaPathNotFound = Meta{Status: "failure", StatusCode: 404, Message: MessagePathNotFound}
 
 // MetaUnknownError is used for unknown errors
 var MetaUnknownError = Meta{Status: "error", StatusCode: 999, Message: "Unknown Error"}
@@ -147,6 +147,9 @@ var MessageGroupNotFound = "The requested group could not be found"
 
 // MessagePathNotFound is used when a file or folder can not be found
 var MessagePathNotFound = "Wrong path, file/folder doesn't exist"
+
+// MessageShareExists is used when a user tries to create a new share for the same user
+var MessageShareExists = "A share for the recipient already exists"
 
 // WriteOCSSuccess handles writing successful ocs response data
 func WriteOCSSuccess(w http.ResponseWriter, r *http.Request, d interface{}) {
@@ -240,9 +243,11 @@ func OcsV2StatusCodes(meta Meta) int {
 		return http.StatusInternalServerError
 	case MetaUnauthorized.StatusCode:
 		return http.StatusUnauthorized
-	case 100:
+	case MetaOK.StatusCode:
 		meta.StatusCode = http.StatusOK
 		return http.StatusOK
+	case MetaForbidden.StatusCode:
+		return http.StatusForbidden
 	}
 	// any 2xx, 4xx and 5xx will be used as is
 	if sc >= 200 && sc < 600 {

--- a/pkg/share/manager/jsoncs3/jsoncs3.go
+++ b/pkg/share/manager/jsoncs3/jsoncs3.go
@@ -217,7 +217,7 @@ func (m *Manager) Share(ctx context.Context, md *provider.ResourceInfo, g *colla
 
 	// check if share already exists.
 	key := &collaboration.ShareKey{
-		//Owner:      md.Owner, owner not longer matters as it belongs to the space
+		//Owner:      md.Owner, owner no longer matters as it belongs to the space
 		ResourceId: md.Id,
 		Grantee:    g.Grantee,
 	}


### PR DESCRIPTION
We now return OCS 104 / HTTP 403 errors when a user tries to reshare a file with a recipient that already has access to a resource.

see https://github.com/owncloud/ocis/issues/4630

Signed-off-by: Jörn Friedrich Dreyer <jfd@butonic.de>