### PR TITLE
make date expiry parsing use end of day

### DIFF
--- a/changelog/unreleased/expiry-parsing-date-only-fix.md
+++ b/changelog/unreleased/expiry-parsing-date-only-fix.md
@@ -1,0 +1,5 @@
+Bugfix: Make date only expiry dates valid for the whole day
+
+When an expiry date like `2022-09-30` is parsed, we now make it valid for the whole day, effectively becoming `2022-09-30 23:59:59`
+
+https://github.com/cs3org/reva/pull/3298

--- a/internal/http/services/owncloud/ocs/conversions/main.go
+++ b/internal/http/services/owncloud/ocs/conversions/main.go
@@ -322,14 +322,18 @@ func timestampToExpiration(t *types.Timestamp) string {
 	return time.Unix(int64(t.Seconds), int64(t.Nanos)).UTC().Format("2006-01-02 15:05:05")
 }
 
-// ParseTimestamp tries to parses the ocs expiry into a CS3 Timestamp
+// ParseTimestamp tries to parse the ocs expiry into a CS3 Timestamp
 func ParseTimestamp(timestampString string) (*types.Timestamp, error) {
 	parsedTime, err := time.Parse("2006-01-02T15:04:05Z0700", timestampString)
 	if err != nil {
 		parsedTime, err = time.Parse("2006-01-02", timestampString)
+		if err == nil {
+			// the link needs to be valid for the whole day
+			parsedTime.Add(23*time.Hour + 59*time.Minute + 59*time.Second)
+		}
 	}
 	if err != nil {
-		return nil, fmt.Errorf("datetime format invalid: %v", timestampString)
+		return nil, fmt.Errorf("datetime format invalid: %v, %s", timestampString, err.Error())
 	}
 	final := parsedTime.UnixNano()
 

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/public.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/public.go
@@ -143,8 +143,8 @@ func (h *Handler) createPublicLinkShare(w http.ResponseWriter, r *http.Request, 
 			expireTime, err := conversions.ParseTimestamp(expireTimeString[0])
 			if err != nil {
 				return nil, &ocsError{
-					Code:    response.MetaServerError.StatusCode,
-					Message: "invalid datetime format",
+					Code:    response.MetaBadRequest.StatusCode,
+					Message: err.Error(),
 					Error:   err,
 				}
 			}


### PR DESCRIPTION
When an expiry date like `2022-09-30` is parsed, we now make it valid for the whole day, effectively becoming `2022-09-30 23:59:59`

Fixes https://github.com/owncloud/ocis/issues/4446