### PR TITLE
Backport from edge: added support for language locales in apps

### DIFF
--- a/changelog/unreleased/lang-supp-in-app.md
+++ b/changelog/unreleased/lang-supp-in-app.md
@@ -1,0 +1,10 @@
+Enhancement: added support for configuring language locales in apps
+
+This is a partial backport from edge: we introduce a language option
+in the appprovider, which if set is passed as appropriate parameter
+to the external apps in order to force a given localization. In particular,
+for Microsoft Office 365 the DC_LLCC option is set as well.
+The default behavior is unset, where apps try and resolve the
+localization from the browser headers.
+
+https://github.com/cs3org/reva/pull/3303

--- a/examples/storage-references/gateway.toml
+++ b/examples/storage-references/gateway.toml
@@ -46,6 +46,7 @@ mime_types = [
 
 [grpc.services.appprovider]
 mime_types = ["text/plain"]
+language = "en-GB"
 
 [http.services.datagateway]
 [http.services.prometheus]

--- a/internal/grpc/services/appprovider/appprovider.go
+++ b/internal/grpc/services/appprovider/appprovider.go
@@ -58,6 +58,7 @@ type config struct {
 	GatewaySvc     string                            `mapstructure:"gatewaysvc"`
 	MimeTypes      []string                          `mapstructure:"mime_types"`
 	Priority       uint64                            `mapstructure:"priority"`
+	Language       string                            `mapstructure:"language"`
 }
 
 func (c *config) init() {
@@ -170,7 +171,7 @@ func getProvider(c *config) (app.Provider, error) {
 }
 
 func (s *service) OpenInApp(ctx context.Context, req *providerpb.OpenInAppRequest) (*providerpb.OpenInAppResponse, error) {
-	appURL, err := s.provider.GetAppURL(ctx, req.ResourceInfo, req.ViewMode, req.AccessToken)
+	appURL, err := s.provider.GetAppURL(ctx, req.ResourceInfo, req.ViewMode, req.AccessToken, s.conf.Language)
 	if err != nil {
 		res := &providerpb.OpenInAppResponse{
 			Status: status.NewInternal(ctx, errors.New("appprovider: error calling GetAppURL"), err.Error()),

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -40,6 +40,6 @@ type Registry interface {
 // Provider is the interface that application providers implement
 // for interacting with external apps that serve the requested resource.
 type Provider interface {
-	GetAppURL(ctx context.Context, resource *provider.ResourceInfo, viewMode appprovider.OpenInAppRequest_ViewMode, token string) (*appprovider.OpenInAppURL, error)
+	GetAppURL(ctx context.Context, resource *provider.ResourceInfo, viewMode appprovider.OpenInAppRequest_ViewMode, token, language string) (*appprovider.OpenInAppURL, error)
 	GetAppProviderInfo(ctx context.Context) (*registry.ProviderInfo, error)
 }

--- a/pkg/app/provider/demo/demo.go
+++ b/pkg/app/provider/demo/demo.go
@@ -38,8 +38,8 @@ type demoProvider struct {
 	iframeUIProvider string
 }
 
-func (p *demoProvider) GetAppURL(ctx context.Context, resource *provider.ResourceInfo, viewMode appprovider.OpenInAppRequest_ViewMode, token string) (*appprovider.OpenInAppURL, error) {
-	url := fmt.Sprintf("<iframe src=%s/open/%s?view-mode=%s&access-token=%s />", p.iframeUIProvider, resource.Id.StorageId+":"+resource.Id.OpaqueId, viewMode.String(), token)
+func (p *demoProvider) GetAppURL(ctx context.Context, resource *provider.ResourceInfo, viewMode appprovider.OpenInAppRequest_ViewMode, token, language string) (*appprovider.OpenInAppURL, error) {
+	url := fmt.Sprintf("<iframe src=%s/open/%s?view-mode=%s&access-token=%s&lang=%s />", p.iframeUIProvider, resource.Id.StorageId+":"+resource.Id.OpaqueId, viewMode.String(), token, language)
 	return &appprovider.OpenInAppURL{
 		AppUrl: url,
 		Method: "GET",

--- a/pkg/app/provider/wopi/wopi.go
+++ b/pkg/app/provider/wopi/wopi.go
@@ -125,7 +125,7 @@ func New(m map[string]interface{}) (app.Provider, error) {
 	}, nil
 }
 
-func (p *wopiProvider) GetAppURL(ctx context.Context, resource *provider.ResourceInfo, viewMode appprovider.OpenInAppRequest_ViewMode, token string) (*appprovider.OpenInAppURL, error) {
+func (p *wopiProvider) GetAppURL(ctx context.Context, resource *provider.ResourceInfo, viewMode appprovider.OpenInAppRequest_ViewMode, token, language string) (*appprovider.OpenInAppURL, error) {
 	log := appctx.GetLogger(ctx)
 
 	ext := path.Ext(resource.Path)
@@ -237,6 +237,19 @@ func (p *wopiProvider) GetAppURL(ctx context.Context, resource *provider.Resourc
 	}
 
 	appFullURL := result["app-url"].(string)
+
+	if language != "" {
+		url, err := url.Parse(appFullURL)
+		if err != nil {
+			return nil, err
+		}
+		urlQuery := url.Query()
+		urlQuery.Set("ui", language)   // OnlyOffice + Office365
+		urlQuery.Set("lang", language) // Collabora
+		urlQuery.Set("rs", language)   // Office365, https://learn.microsoft.com/en-us/microsoft-365/cloud-storage-partner-program/online/discovery#dc_llcc
+		url.RawQuery = urlQuery.Encode()
+		appFullURL = url.String()
+	}
 
 	// Depending on whether wopi server returned any form parameters or not,
 	// we decide whether the request method is POST or GET

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -348,6 +348,8 @@ func GetViewMode(viewMode string) gateway.OpenInAppRequest_ViewMode {
 		return gateway.OpenInAppRequest_VIEW_MODE_READ_ONLY
 	case "write":
 		return gateway.OpenInAppRequest_VIEW_MODE_READ_WRITE
+	case "preview":
+		return gateway.OpenInAppRequest_VIEW_MODE_PREVIEW
 	default:
 		return gateway.OpenInAppRequest_VIEW_MODE_INVALID
 	}


### PR DESCRIPTION
The goal here is to backport the minimal logic from `edge` to support different locales in WOPI apps, and drive this by configuration rather than by query parameters.

In addition, the `DC_LLCC` parameter should be used for Office 365 to compensate issues with incorrect dates computations depending on the locale:

https://learn.microsoft.com/en-us/microsoft-365/cloud-storage-partner-program/online/discovery#dc_llcc
