### PR TITLE
Add description to public links + internal public links

### DIFF
--- a/changelog/unreleased/publiclink-description.md
+++ b/changelog/unreleased/publiclink-description.md
@@ -1,0 +1,3 @@
+Enhancement: Add description to public link
+
+https://github.com/cs3org/reva/pull/3305

--- a/cmd/reva/public-share-create.go
+++ b/cmd/reva/public-share-create.go
@@ -35,9 +35,10 @@ func publicShareCreateCommand() *command {
 	cmd.Description = func() string { return "create a public share" }
 	cmd.Usage = func() string { return "Usage: public-share-create [-flags] <path>" }
 	rol := cmd.String("rol", "viewer", "the permission for the share (viewer or editor)")
+	description := cmd.String("description", "", "the description for the share")
 
 	cmd.ResetFlags = func() {
-		*rol = "viewer"
+		*rol, *description = "viewer", ""
 	}
 
 	cmd.Action = func(w ...io.Writer) error {
@@ -78,6 +79,7 @@ func publicShareCreateCommand() *command {
 		shareRequest := &link.CreatePublicShareRequest{
 			ResourceInfo: res.Info,
 			Grant:        grant,
+			Description:  *description,
 		}
 
 		shareRes, err := client.CreatePublicShare(ctx, shareRequest)
@@ -91,11 +93,11 @@ func publicShareCreateCommand() *command {
 
 		t := table.NewWriter()
 		t.SetOutputMirror(os.Stdout)
-		t.AppendHeader(table.Row{"#", "Owner.Idp", "Owner.OpaqueId", "ResourceId", "Permissions", "Token", "Expiration", "Created", "Updated"})
+		t.AppendHeader(table.Row{"#", "Owner.Idp", "Owner.OpaqueId", "ResourceId", "Permissions", "Token", "Expiration", "Created", "Updated", "Description"})
 
 		s := shareRes.Share
 		t.AppendRows([]table.Row{
-			{s.Id.OpaqueId, s.Owner.Idp, s.Owner.OpaqueId, s.ResourceId.String(), s.Permissions.String(), s.Token, s.Expiration.String(), time.Unix(int64(s.Ctime.Seconds), 0), time.Unix(int64(s.Mtime.Seconds), 0)},
+			{s.Id.OpaqueId, s.Owner.Idp, s.Owner.OpaqueId, s.ResourceId.String(), s.Permissions.String(), s.Token, s.Expiration.String(), time.Unix(int64(s.Ctime.Seconds), 0), time.Unix(int64(s.Mtime.Seconds), 0), s.Description},
 		})
 		t.Render()
 

--- a/cmd/reva/public-share-create.go
+++ b/cmd/reva/public-share-create.go
@@ -36,9 +36,10 @@ func publicShareCreateCommand() *command {
 	cmd.Usage = func() string { return "Usage: public-share-create [-flags] <path>" }
 	rol := cmd.String("rol", "viewer", "the permission for the share (viewer or editor)")
 	description := cmd.String("description", "", "the description for the share")
+	internal := cmd.Bool("internal", false, "mark the public share as internal")
 
 	cmd.ResetFlags = func() {
-		*rol, *description = "viewer", ""
+		*rol, *description, *internal = "viewer", "", false
 	}
 
 	cmd.Action = func(w ...io.Writer) error {
@@ -80,6 +81,7 @@ func publicShareCreateCommand() *command {
 			ResourceInfo: res.Info,
 			Grant:        grant,
 			Description:  *description,
+			Internal:     *internal,
 		}
 
 		shareRes, err := client.CreatePublicShare(ctx, shareRequest)

--- a/cmd/reva/public-share-list.go
+++ b/cmd/reva/public-share-list.go
@@ -76,11 +76,11 @@ func publicShareListCommand() *command {
 		if len(w) == 0 {
 			t := table.NewWriter()
 			t.SetOutputMirror(os.Stdout)
-			t.AppendHeader(table.Row{"#", "Owner.Idp", "Owner.OpaqueId", "ResourceId", "Permissions", "Token", "Expiration", "Created", "Updated"})
+			t.AppendHeader(table.Row{"#", "Owner.Idp", "Owner.OpaqueId", "ResourceId", "Permissions", "Token", "Expiration", "Created", "Updated", "Description"})
 
 			for _, s := range shareRes.Share {
 				t.AppendRows([]table.Row{
-					{s.Id.OpaqueId, s.Owner.Idp, s.Owner.OpaqueId, s.ResourceId.String(), s.Permissions.String(), s.Token, s.Expiration.String(), time.Unix(int64(s.Ctime.Seconds), 0), time.Unix(int64(s.Mtime.Seconds), 0)},
+					{s.Id.OpaqueId, s.Owner.Idp, s.Owner.OpaqueId, s.ResourceId.String(), s.Permissions.String(), s.Token, s.Expiration.String(), time.Unix(int64(s.Ctime.Seconds), 0), time.Unix(int64(s.Mtime.Seconds), 0), s.Description},
 				})
 			}
 			t.Render()

--- a/cmd/reva/public-share-update.go
+++ b/cmd/reva/public-share-update.go
@@ -32,9 +32,10 @@ func publicShareUpdateCommand() *command {
 	cmd.Description = func() string { return "update a public share" }
 	cmd.Usage = func() string { return "Usage: public-share-update [-flags] <share_id>" }
 	rol := cmd.String("rol", "viewer", "the permission for the share (viewer or editor)")
+	description := cmd.String("description", "", "the description for the share")
 
 	cmd.ResetFlags = func() {
-		*rol = "viewer"
+		*rol, *description = "viewer", ""
 	}
 	cmd.Action = func(w ...io.Writer) error {
 		if cmd.NArg() < 1 {
@@ -59,7 +60,9 @@ func publicShareUpdateCommand() *command {
 			return err
 		}
 
-		shareRequest := &link.UpdatePublicShareRequest{
+		var updates []*link.UpdatePublicShareRequest
+
+		updates = append(updates, &link.UpdatePublicShareRequest{
 			Ref: &link.PublicShareReference{
 				Spec: &link.PublicShareReference_Id{
 					Id: &link.PublicShareId{
@@ -75,15 +78,33 @@ func publicShareUpdateCommand() *command {
 					},
 				},
 			},
+		})
+
+		if *description != "" {
+			updates = append(updates, &link.UpdatePublicShareRequest{
+				Ref: &link.PublicShareReference{
+					Spec: &link.PublicShareReference_Id{
+						Id: &link.PublicShareId{
+							OpaqueId: id,
+						},
+					},
+				},
+				Update: &link.UpdatePublicShareRequest_Update{
+					Type:        link.UpdatePublicShareRequest_Update_TYPE_DESCRIPTION,
+					Description: *description,
+				},
+			})
 		}
 
-		shareRes, err := shareClient.UpdatePublicShare(ctx, shareRequest)
-		if err != nil {
-			return err
-		}
+		for _, u := range updates {
+			shareRes, err := shareClient.UpdatePublicShare(ctx, u)
+			if err != nil {
+				return err
+			}
 
-		if shareRes.Status.Code != rpc.Code_CODE_OK {
-			return formatError(shareRes.Status)
+			if shareRes.Status.Code != rpc.Code_CODE_OK {
+				return formatError(shareRes.Status)
+			}
 		}
 
 		fmt.Println("OK")

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/cheggaaa/pb v1.0.29
 	github.com/coreos/go-oidc v2.2.1+incompatible
 	github.com/cs3org/cato v0.0.0-20200828125504-e418fc54dd5e
-	github.com/cs3org/go-cs3apis v0.0.0-20220929122709-ec9bb8a96f95
+	github.com/cs3org/go-cs3apis v0.0.0-20220930140901-5777bc1ccfaa
 	github.com/cubewise-code/go-mime v0.0.0-20200519001935-8c5762b177d8
 	github.com/dgraph-io/ristretto v0.1.0
 	github.com/eventials/go-tus v0.0.0-20200718001131-45c7ec8f5d59

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/cheggaaa/pb v1.0.29
 	github.com/coreos/go-oidc v2.2.1+incompatible
 	github.com/cs3org/cato v0.0.0-20200828125504-e418fc54dd5e
-	github.com/cs3org/go-cs3apis v0.0.0-20220930140901-5777bc1ccfaa
+	github.com/cs3org/go-cs3apis v0.0.0-20221004162747-f20ee4756d90
 	github.com/cubewise-code/go-mime v0.0.0-20200519001935-8c5762b177d8
 	github.com/dgraph-io/ristretto v0.1.0
 	github.com/eventials/go-tus v0.0.0-20200718001131-45c7ec8f5d59
@@ -86,7 +86,6 @@ require (
 go 1.16
 
 replace (
-	github.com/cs3org/go-cs3apis => github.com/gmgigi96/go-cs3apis v0.0.0-20221004074314-b2292f6a794c
 	github.com/eventials/go-tus => github.com/andrewmostello/go-tus v0.0.0-20200314041820-904a9904af9a
 	github.com/oleiade/reflections => github.com/oleiade/reflections v1.0.1
 )

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/cheggaaa/pb v1.0.29
 	github.com/coreos/go-oidc v2.2.1+incompatible
 	github.com/cs3org/cato v0.0.0-20200828125504-e418fc54dd5e
-	github.com/cs3org/go-cs3apis v0.0.0-20220719130120-361e9f987d64
+	github.com/cs3org/go-cs3apis v0.0.0-20220929122709-ec9bb8a96f95
 	github.com/cubewise-code/go-mime v0.0.0-20200519001935-8c5762b177d8
 	github.com/dgraph-io/ristretto v0.1.0
 	github.com/eventials/go-tus v0.0.0-20200718001131-45c7ec8f5d59
@@ -86,7 +86,6 @@ require (
 go 1.16
 
 replace (
-	github.com/cs3org/go-cs3apis => github.com/gmgigi96/go-cs3apis v0.0.0-20220929122901-2b86325082cd
 	github.com/eventials/go-tus => github.com/andrewmostello/go-tus v0.0.0-20200314041820-904a9904af9a
 	github.com/oleiade/reflections => github.com/oleiade/reflections v1.0.1
 )

--- a/go.mod
+++ b/go.mod
@@ -86,6 +86,7 @@ require (
 go 1.16
 
 replace (
+	github.com/cs3org/go-cs3apis => github.com/gmgigi96/go-cs3apis v0.0.0-20221004074314-b2292f6a794c
 	github.com/eventials/go-tus => github.com/andrewmostello/go-tus v0.0.0-20200314041820-904a9904af9a
 	github.com/oleiade/reflections => github.com/oleiade/reflections v1.0.1
 )

--- a/go.mod
+++ b/go.mod
@@ -86,6 +86,7 @@ require (
 go 1.16
 
 replace (
+	github.com/cs3org/go-cs3apis => github.com/gmgigi96/go-cs3apis v0.0.0-20220929122901-2b86325082cd
 	github.com/eventials/go-tus => github.com/andrewmostello/go-tus v0.0.0-20200314041820-904a9904af9a
 	github.com/oleiade/reflections => github.com/oleiade/reflections v1.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -224,10 +224,8 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/cs3org/cato v0.0.0-20200828125504-e418fc54dd5e h1:tqSPWQeueWTKnJVMJffz4pz0o1WuQxJ28+5x5JgaHD8=
 github.com/cs3org/cato v0.0.0-20200828125504-e418fc54dd5e/go.mod h1:XJEZ3/EQuI3BXTp/6DUzFr850vlxq11I6satRtz0YQ4=
-github.com/cs3org/go-cs3apis v0.0.0-20220719130120-361e9f987d64 h1:cFnankJOCWndnOns4sKRG7yzH61ammK2Am6rEGWCK40=
-github.com/cs3org/go-cs3apis v0.0.0-20220719130120-361e9f987d64/go.mod h1:UXha4TguuB52H14EMoSsCqDj7k8a/t7g4gVP+bgY5LY=
-github.com/cs3org/go-cs3apis v0.0.0-20220929122709-ec9bb8a96f95 h1:mcYS2I7nu60kEjSjiE5eDqwMOAjCV9H4Zs8t9mLcaf0=
-github.com/cs3org/go-cs3apis v0.0.0-20220929122709-ec9bb8a96f95/go.mod h1:UXha4TguuB52H14EMoSsCqDj7k8a/t7g4gVP+bgY5LY=
+github.com/cs3org/go-cs3apis v0.0.0-20220930140901-5777bc1ccfaa h1:MDbQLEHxlgEB9Xca1NKMqKR4c1r5S94SoP5hEkWLPC8=
+github.com/cs3org/go-cs3apis v0.0.0-20220930140901-5777bc1ccfaa/go.mod h1:UXha4TguuB52H14EMoSsCqDj7k8a/t7g4gVP+bgY5LY=
 github.com/cubewise-code/go-mime v0.0.0-20200519001935-8c5762b177d8 h1:Z9lwXumT5ACSmJ7WGnFl+OMLLjpz5uR2fyz7dC255FI=
 github.com/cubewise-code/go-mime v0.0.0-20200519001935-8c5762b177d8/go.mod h1:4abs/jPXcmJzYoYGF91JF9Uq9s/KL5n1jvFDix8KcqY=
 github.com/cyberdelia/templates v0.0.0-20141128023046-ca7fffd4298c/go.mod h1:GyV+0YP4qX0UQ7r2MoYZ+AvYDp12OF5yg4q8rGnyNh4=

--- a/go.sum
+++ b/go.sum
@@ -224,6 +224,10 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/cs3org/cato v0.0.0-20200828125504-e418fc54dd5e h1:tqSPWQeueWTKnJVMJffz4pz0o1WuQxJ28+5x5JgaHD8=
 github.com/cs3org/cato v0.0.0-20200828125504-e418fc54dd5e/go.mod h1:XJEZ3/EQuI3BXTp/6DUzFr850vlxq11I6satRtz0YQ4=
+github.com/cs3org/go-cs3apis v0.0.0-20220719130120-361e9f987d64 h1:cFnankJOCWndnOns4sKRG7yzH61ammK2Am6rEGWCK40=
+github.com/cs3org/go-cs3apis v0.0.0-20220719130120-361e9f987d64/go.mod h1:UXha4TguuB52H14EMoSsCqDj7k8a/t7g4gVP+bgY5LY=
+github.com/cs3org/go-cs3apis v0.0.0-20220929122709-ec9bb8a96f95 h1:mcYS2I7nu60kEjSjiE5eDqwMOAjCV9H4Zs8t9mLcaf0=
+github.com/cs3org/go-cs3apis v0.0.0-20220929122709-ec9bb8a96f95/go.mod h1:UXha4TguuB52H14EMoSsCqDj7k8a/t7g4gVP+bgY5LY=
 github.com/cubewise-code/go-mime v0.0.0-20200519001935-8c5762b177d8 h1:Z9lwXumT5ACSmJ7WGnFl+OMLLjpz5uR2fyz7dC255FI=
 github.com/cubewise-code/go-mime v0.0.0-20200519001935-8c5762b177d8/go.mod h1:4abs/jPXcmJzYoYGF91JF9Uq9s/KL5n1jvFDix8KcqY=
 github.com/cyberdelia/templates v0.0.0-20141128023046-ca7fffd4298c/go.mod h1:GyV+0YP4qX0UQ7r2MoYZ+AvYDp12OF5yg4q8rGnyNh4=
@@ -281,8 +285,6 @@ github.com/gdexlab/go-render v1.0.1/go.mod h1:wRi5nW2qfjiGj4mPukH4UV0IknS1cHD4Vg
 github.com/getkin/kin-openapi v0.13.0/go.mod h1:WGRs2ZMM1Q8LR1QBEwUxC6RJEfaBcD0s+pcEVXFuAjw=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gliderlabs/ssh v0.2.2/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
-github.com/gmgigi96/go-cs3apis v0.0.0-20220929122901-2b86325082cd h1:5MaxAL044yyi1VRzTg3HbTqnjTM1z8mkv7zYdmAHgCU=
-github.com/gmgigi96/go-cs3apis v0.0.0-20220929122901-2b86325082cd/go.mod h1:UXha4TguuB52H14EMoSsCqDj7k8a/t7g4gVP+bgY5LY=
 github.com/go-acme/lego/v4 v4.4.0/go.mod h1:l3+tFUFZb590dWcqhWZegynUthtaHJbG2fevUpoOOE0=
 github.com/go-asn1-ber/asn1-ber v1.5.4 h1:vXT6d/FNDiELJnLb6hGNa309LMsrCoYFvpwHDF0+Y1A=
 github.com/go-asn1-ber/asn1-ber v1.5.4/go.mod h1:hEBeB/ic+5LoWskz+yKT7vGhhPYkProFKoKdwZRWMe0=

--- a/go.sum
+++ b/go.sum
@@ -224,10 +224,6 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/cs3org/cato v0.0.0-20200828125504-e418fc54dd5e h1:tqSPWQeueWTKnJVMJffz4pz0o1WuQxJ28+5x5JgaHD8=
 github.com/cs3org/cato v0.0.0-20200828125504-e418fc54dd5e/go.mod h1:XJEZ3/EQuI3BXTp/6DUzFr850vlxq11I6satRtz0YQ4=
-github.com/cs3org/go-cs3apis v0.0.0-20220330081745-2ad58f5932b9 h1:SuPu5Mc2mpz+J059XML+cMd0i5FZR4t/kROS3SaIsnU=
-github.com/cs3org/go-cs3apis v0.0.0-20220330081745-2ad58f5932b9/go.mod h1:UXha4TguuB52H14EMoSsCqDj7k8a/t7g4gVP+bgY5LY=
-github.com/cs3org/go-cs3apis v0.0.0-20220719130120-361e9f987d64 h1:cFnankJOCWndnOns4sKRG7yzH61ammK2Am6rEGWCK40=
-github.com/cs3org/go-cs3apis v0.0.0-20220719130120-361e9f987d64/go.mod h1:UXha4TguuB52H14EMoSsCqDj7k8a/t7g4gVP+bgY5LY=
 github.com/cubewise-code/go-mime v0.0.0-20200519001935-8c5762b177d8 h1:Z9lwXumT5ACSmJ7WGnFl+OMLLjpz5uR2fyz7dC255FI=
 github.com/cubewise-code/go-mime v0.0.0-20200519001935-8c5762b177d8/go.mod h1:4abs/jPXcmJzYoYGF91JF9Uq9s/KL5n1jvFDix8KcqY=
 github.com/cyberdelia/templates v0.0.0-20141128023046-ca7fffd4298c/go.mod h1:GyV+0YP4qX0UQ7r2MoYZ+AvYDp12OF5yg4q8rGnyNh4=
@@ -285,6 +281,8 @@ github.com/gdexlab/go-render v1.0.1/go.mod h1:wRi5nW2qfjiGj4mPukH4UV0IknS1cHD4Vg
 github.com/getkin/kin-openapi v0.13.0/go.mod h1:WGRs2ZMM1Q8LR1QBEwUxC6RJEfaBcD0s+pcEVXFuAjw=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gliderlabs/ssh v0.2.2/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
+github.com/gmgigi96/go-cs3apis v0.0.0-20220929122901-2b86325082cd h1:5MaxAL044yyi1VRzTg3HbTqnjTM1z8mkv7zYdmAHgCU=
+github.com/gmgigi96/go-cs3apis v0.0.0-20220929122901-2b86325082cd/go.mod h1:UXha4TguuB52H14EMoSsCqDj7k8a/t7g4gVP+bgY5LY=
 github.com/go-acme/lego/v4 v4.4.0/go.mod h1:l3+tFUFZb590dWcqhWZegynUthtaHJbG2fevUpoOOE0=
 github.com/go-asn1-ber/asn1-ber v1.5.4 h1:vXT6d/FNDiELJnLb6hGNa309LMsrCoYFvpwHDF0+Y1A=
 github.com/go-asn1-ber/asn1-ber v1.5.4/go.mod h1:hEBeB/ic+5LoWskz+yKT7vGhhPYkProFKoKdwZRWMe0=

--- a/go.sum
+++ b/go.sum
@@ -224,8 +224,6 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/cs3org/cato v0.0.0-20200828125504-e418fc54dd5e h1:tqSPWQeueWTKnJVMJffz4pz0o1WuQxJ28+5x5JgaHD8=
 github.com/cs3org/cato v0.0.0-20200828125504-e418fc54dd5e/go.mod h1:XJEZ3/EQuI3BXTp/6DUzFr850vlxq11I6satRtz0YQ4=
-github.com/cs3org/go-cs3apis v0.0.0-20220930140901-5777bc1ccfaa h1:MDbQLEHxlgEB9Xca1NKMqKR4c1r5S94SoP5hEkWLPC8=
-github.com/cs3org/go-cs3apis v0.0.0-20220930140901-5777bc1ccfaa/go.mod h1:UXha4TguuB52H14EMoSsCqDj7k8a/t7g4gVP+bgY5LY=
 github.com/cubewise-code/go-mime v0.0.0-20200519001935-8c5762b177d8 h1:Z9lwXumT5ACSmJ7WGnFl+OMLLjpz5uR2fyz7dC255FI=
 github.com/cubewise-code/go-mime v0.0.0-20200519001935-8c5762b177d8/go.mod h1:4abs/jPXcmJzYoYGF91JF9Uq9s/KL5n1jvFDix8KcqY=
 github.com/cyberdelia/templates v0.0.0-20141128023046-ca7fffd4298c/go.mod h1:GyV+0YP4qX0UQ7r2MoYZ+AvYDp12OF5yg4q8rGnyNh4=
@@ -283,6 +281,8 @@ github.com/gdexlab/go-render v1.0.1/go.mod h1:wRi5nW2qfjiGj4mPukH4UV0IknS1cHD4Vg
 github.com/getkin/kin-openapi v0.13.0/go.mod h1:WGRs2ZMM1Q8LR1QBEwUxC6RJEfaBcD0s+pcEVXFuAjw=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gliderlabs/ssh v0.2.2/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
+github.com/gmgigi96/go-cs3apis v0.0.0-20221004074314-b2292f6a794c h1:mC9jwnDK3weg0S3md2euO0iIvlD33JE/MsFQGaZ/zX0=
+github.com/gmgigi96/go-cs3apis v0.0.0-20221004074314-b2292f6a794c/go.mod h1:UXha4TguuB52H14EMoSsCqDj7k8a/t7g4gVP+bgY5LY=
 github.com/go-acme/lego/v4 v4.4.0/go.mod h1:l3+tFUFZb590dWcqhWZegynUthtaHJbG2fevUpoOOE0=
 github.com/go-asn1-ber/asn1-ber v1.5.4 h1:vXT6d/FNDiELJnLb6hGNa309LMsrCoYFvpwHDF0+Y1A=
 github.com/go-asn1-ber/asn1-ber v1.5.4/go.mod h1:hEBeB/ic+5LoWskz+yKT7vGhhPYkProFKoKdwZRWMe0=

--- a/go.sum
+++ b/go.sum
@@ -224,6 +224,8 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/cs3org/cato v0.0.0-20200828125504-e418fc54dd5e h1:tqSPWQeueWTKnJVMJffz4pz0o1WuQxJ28+5x5JgaHD8=
 github.com/cs3org/cato v0.0.0-20200828125504-e418fc54dd5e/go.mod h1:XJEZ3/EQuI3BXTp/6DUzFr850vlxq11I6satRtz0YQ4=
+github.com/cs3org/go-cs3apis v0.0.0-20221004162747-f20ee4756d90 h1:zYg2UzwpChLgXktwt7MJEMv46GQPtluifRnynkSw80Y=
+github.com/cs3org/go-cs3apis v0.0.0-20221004162747-f20ee4756d90/go.mod h1:UXha4TguuB52H14EMoSsCqDj7k8a/t7g4gVP+bgY5LY=
 github.com/cubewise-code/go-mime v0.0.0-20200519001935-8c5762b177d8 h1:Z9lwXumT5ACSmJ7WGnFl+OMLLjpz5uR2fyz7dC255FI=
 github.com/cubewise-code/go-mime v0.0.0-20200519001935-8c5762b177d8/go.mod h1:4abs/jPXcmJzYoYGF91JF9Uq9s/KL5n1jvFDix8KcqY=
 github.com/cyberdelia/templates v0.0.0-20141128023046-ca7fffd4298c/go.mod h1:GyV+0YP4qX0UQ7r2MoYZ+AvYDp12OF5yg4q8rGnyNh4=

--- a/internal/grpc/services/publicshareprovider/publicshareprovider.go
+++ b/internal/grpc/services/publicshareprovider/publicshareprovider.go
@@ -146,7 +146,7 @@ func (s *service) CreatePublicShare(ctx context.Context, req *link.CreatePublicS
 		log.Error().Msg("error getting user from context")
 	}
 
-	share, err := s.sm.CreatePublicShare(ctx, u, req.ResourceInfo, req.Grant)
+	share, err := s.sm.CreatePublicShare(ctx, u, req.ResourceInfo, req.Grant, req.Description)
 	if err != nil {
 		log.Debug().Err(err).Str("createShare", "shares").Msg("error connecting to storage provider")
 	}

--- a/internal/grpc/services/publicshareprovider/publicshareprovider.go
+++ b/internal/grpc/services/publicshareprovider/publicshareprovider.go
@@ -146,7 +146,7 @@ func (s *service) CreatePublicShare(ctx context.Context, req *link.CreatePublicS
 		log.Error().Msg("error getting user from context")
 	}
 
-	share, err := s.sm.CreatePublicShare(ctx, u, req.ResourceInfo, req.Grant, req.Description)
+	share, err := s.sm.CreatePublicShare(ctx, u, req.ResourceInfo, req.Grant, req.Description, req.Internal)
 	if err != nil {
 		log.Debug().Err(err).Str("createShare", "shares").Msg("error connecting to storage provider")
 	}

--- a/internal/http/services/owncloud/ocs/conversions/main.go
+++ b/internal/http/services/owncloud/ocs/conversions/main.go
@@ -145,6 +145,8 @@ type ShareData struct {
 	// PasswordProtected represents a public share is password protected
 	// PasswordProtected bool `json:"password_protected,omitempty" xml:"password_protected,omitempty"`
 	Quicklink bool `json:"quicklink,omitempty" xml:"quicklink,omitempty"`
+	// Description of the public share
+	Description string `json:"description" xml:"description"`
 }
 
 // ShareeData holds share recipient search results
@@ -217,6 +219,7 @@ func PublicShare2ShareData(share *link.PublicShare, r *http.Request, publicURL s
 		UIDOwner:     LocalUserIDToString(share.Creator),
 		UIDFileOwner: LocalUserIDToString(share.Owner),
 		Quicklink:    share.Quicklink,
+		Description:  share.Description,
 	}
 	if share.Id != nil {
 		sd.ID = share.Id.OpaqueId

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/public.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/public.go
@@ -118,6 +118,7 @@ func (h *Handler) createPublicLinkShare(w http.ResponseWriter, r *http.Request, 
 			},
 			Password: r.FormValue("password"),
 		},
+		Description: r.FormValue("description"),
 	}
 
 	expireTimeString, ok := r.Form["expireDate"]
@@ -137,9 +138,8 @@ func (h *Handler) createPublicLinkShare(w http.ResponseWriter, r *http.Request, 
 	// set displayname and password protected as arbitrary metadata
 	req.ResourceInfo.ArbitraryMetadata = &provider.ArbitraryMetadata{
 		Metadata: map[string]string{
-			"name":        r.FormValue("name"),
-			"quicklink":   r.FormValue("quicklink"),
-			"description": r.FormValue("description"),
+			"name":      r.FormValue("name"),
+			"quicklink": r.FormValue("quicklink"),
 			// "password": r.FormValue("password"),
 		},
 	}

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/public.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/public.go
@@ -110,6 +110,8 @@ func (h *Handler) createPublicLinkShare(w http.ResponseWriter, r *http.Request, 
 		newPermissions = conversions.RoleFromOCSPermissions(permissions).CS3ResourcePermissions()
 	}
 
+	internal, _ := strconv.ParseBool(r.FormValue("internal"))
+
 	req := link.CreatePublicShareRequest{
 		ResourceInfo: statInfo,
 		Grant: &link.Grant{
@@ -119,6 +121,7 @@ func (h *Handler) createPublicLinkShare(w http.ResponseWriter, r *http.Request, 
 			Password: r.FormValue("password"),
 		},
 		Description: r.FormValue("description"),
+		Internal:    internal,
 	}
 
 	expireTimeString, ok := r.Form["expireDate"]

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/public.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/public.go
@@ -137,8 +137,9 @@ func (h *Handler) createPublicLinkShare(w http.ResponseWriter, r *http.Request, 
 	// set displayname and password protected as arbitrary metadata
 	req.ResourceInfo.ArbitraryMetadata = &provider.ArbitraryMetadata{
 		Metadata: map[string]string{
-			"name":      r.FormValue("name"),
-			"quicklink": r.FormValue("quicklink"),
+			"name":        r.FormValue("name"),
+			"quicklink":   r.FormValue("quicklink"),
+			"description": r.FormValue("description"),
 			// "password": r.FormValue("password"),
 		},
 	}
@@ -356,6 +357,17 @@ func (h *Handler) updatePublicShare(w http.ResponseWriter, r *http.Request, shar
 			Grant: &link.Grant{
 				Password: newPassword[0],
 			},
+		})
+	}
+
+	// Description
+	description, ok := r.Form["description"]
+	if ok {
+		updatesFound = true
+		logger.Info().Str("shares", "update").Msg("description updated")
+		updates = append(updates, &link.UpdatePublicShareRequest_Update{
+			Type:        link.UpdatePublicShareRequest_Update_TYPE_DESCRIPTION,
+			Description: description[0],
 		})
 	}
 

--- a/pkg/cbox/publicshare/sql/sql.go
+++ b/pkg/cbox/publicshare/sql/sql.go
@@ -143,6 +143,11 @@ func (m *manager) CreatePublicShare(ctx context.Context, u *user.User, rInfo *pr
 		Seconds: uint64(now),
 	}
 
+	description, ok := rInfo.ArbitraryMetadata.Metadata["description"]
+	if !ok {
+		description = ""
+	}
+
 	creator := conversions.FormatUserID(u.Id)
 	owner := conversions.FormatUserID(rInfo.Owner)
 	permissions := conversions.SharePermToInt(g.Permissions.Permissions)
@@ -156,8 +161,8 @@ func (m *manager) CreatePublicShare(ctx context.Context, u *user.User, rInfo *pr
 		fileSource = 0
 	}
 
-	query := "insert into oc_share set share_type=?,uid_owner=?,uid_initiator=?,item_type=?,fileid_prefix=?,item_source=?,file_source=?,permissions=?,stime=?,token=?,share_name=?,quicklink=?"
-	params := []interface{}{publicShareType, owner, creator, itemType, prefix, itemSource, fileSource, permissions, now, tkn, displayName, quicklink}
+	query := "insert into oc_share set share_type=?,uid_owner=?,uid_initiator=?,item_type=?,fileid_prefix=?,item_source=?,file_source=?,permissions=?,stime=?,token=?,share_name=?,quicklink=?,description=?"
+	params := []interface{}{publicShareType, owner, creator, itemType, prefix, itemSource, fileSource, permissions, now, tkn, displayName, quicklink, description}
 
 	var passwordProtected bool
 	password := g.Password
@@ -206,6 +211,7 @@ func (m *manager) CreatePublicShare(ctx context.Context, u *user.User, rInfo *pr
 		Expiration:        g.Expiration,
 		DisplayName:       displayName,
 		Quicklink:         quicklink,
+		Description:       description,
 	}, nil
 }
 
@@ -234,6 +240,8 @@ func (m *manager) UpdatePublicShare(ctx context.Context, u *user.User, req *link
 			}
 			paramsMap["share_with"] = h
 		}
+	case link.UpdatePublicShareRequest_Update_TYPE_DESCRIPTION:
+		paramsMap["description"] = req.Update.GetDescription()
 	default:
 		return nil, fmt.Errorf("invalid update type: %v", req.GetUpdate().GetType())
 	}
@@ -267,8 +275,8 @@ func (m *manager) UpdatePublicShare(ctx context.Context, u *user.User, req *link
 
 func (m *manager) getByToken(ctx context.Context, token string, u *user.User) (*link.PublicShare, string, error) {
 	s := conversions.DBShare{Token: token}
-	query := "select coalesce(uid_owner, '') as uid_owner, coalesce(uid_initiator, '') as uid_initiator, coalesce(share_with, '') as share_with, coalesce(fileid_prefix, '') as fileid_prefix, coalesce(item_source, '') as item_source, coalesce(item_type, '') as item_type, coalesce(expiration, '') as expiration, coalesce(share_name, '') as share_name, id, stime, permissions, quicklink FROM oc_share WHERE (orphan = 0 or orphan IS NULL) AND share_type=? AND token=?"
-	if err := m.db.QueryRow(query, publicShareType, token).Scan(&s.UIDOwner, &s.UIDInitiator, &s.ShareWith, &s.Prefix, &s.ItemSource, &s.ItemType, &s.Expiration, &s.ShareName, &s.ID, &s.STime, &s.Permissions, &s.Quicklink); err != nil {
+	query := "select coalesce(uid_owner, '') as uid_owner, coalesce(uid_initiator, '') as uid_initiator, coalesce(share_with, '') as share_with, coalesce(fileid_prefix, '') as fileid_prefix, coalesce(item_source, '') as item_source, coalesce(item_type, '') as item_type, coalesce(expiration, '') as expiration, coalesce(share_name, '') as share_name, id, stime, permissions, quicklink, description FROM oc_share WHERE (orphan = 0 or orphan IS NULL) AND share_type=? AND token=?"
+	if err := m.db.QueryRow(query, publicShareType, token).Scan(&s.UIDOwner, &s.UIDInitiator, &s.ShareWith, &s.Prefix, &s.ItemSource, &s.ItemType, &s.Expiration, &s.ShareName, &s.ID, &s.STime, &s.Permissions, &s.Quicklink, &s.Description); err != nil {
 		if err == sql.ErrNoRows {
 			return nil, "", errtypes.NotFound(token)
 		}
@@ -280,8 +288,8 @@ func (m *manager) getByToken(ctx context.Context, token string, u *user.User) (*
 func (m *manager) getByID(ctx context.Context, id *link.PublicShareId, u *user.User) (*link.PublicShare, string, error) {
 	uid := conversions.FormatUserID(u.Id)
 	s := conversions.DBShare{ID: id.OpaqueId}
-	query := "select coalesce(uid_owner, '') as uid_owner, coalesce(uid_initiator, '') as uid_initiator, coalesce(share_with, '') as share_with, coalesce(fileid_prefix, '') as fileid_prefix, coalesce(item_source, '') as item_source, coalesce(item_type, '') as item_type, coalesce(token,'') as token, coalesce(expiration, '') as expiration, coalesce(share_name, '') as share_name, stime, permissions, quicklink FROM oc_share WHERE (orphan = 0 or orphan IS NULL) AND share_type=? AND id=? AND (uid_owner=? OR uid_initiator=?)"
-	if err := m.db.QueryRow(query, publicShareType, id.OpaqueId, uid, uid).Scan(&s.UIDOwner, &s.UIDInitiator, &s.ShareWith, &s.Prefix, &s.ItemSource, &s.ItemType, &s.Token, &s.Expiration, &s.ShareName, &s.STime, &s.Permissions, &s.Quicklink); err != nil {
+	query := "select coalesce(uid_owner, '') as uid_owner, coalesce(uid_initiator, '') as uid_initiator, coalesce(share_with, '') as share_with, coalesce(fileid_prefix, '') as fileid_prefix, coalesce(item_source, '') as item_source, coalesce(item_type, '') as item_type, coalesce(token,'') as token, coalesce(expiration, '') as expiration, coalesce(share_name, '') as share_name, stime, permissions, quicklink, description FROM oc_share WHERE (orphan = 0 or orphan IS NULL) AND share_type=? AND id=? AND (uid_owner=? OR uid_initiator=?)"
+	if err := m.db.QueryRow(query, publicShareType, id.OpaqueId, uid, uid).Scan(&s.UIDOwner, &s.UIDInitiator, &s.ShareWith, &s.Prefix, &s.ItemSource, &s.ItemType, &s.Token, &s.Expiration, &s.ShareName, &s.STime, &s.Permissions, &s.Quicklink, &s.Description); err != nil {
 		if err == sql.ErrNoRows {
 			return nil, "", errtypes.NotFound(id.OpaqueId)
 		}
@@ -324,7 +332,7 @@ func (m *manager) GetPublicShare(ctx context.Context, u *user.User, ref *link.Pu
 }
 
 func (m *manager) ListPublicShares(ctx context.Context, u *user.User, filters []*link.ListPublicSharesRequest_Filter, md *provider.ResourceInfo, sign bool) ([]*link.PublicShare, error) {
-	query := "select coalesce(uid_owner, '') as uid_owner, coalesce(uid_initiator, '') as uid_initiator, coalesce(share_with, '') as share_with, coalesce(fileid_prefix, '') as fileid_prefix, coalesce(item_source, '') as item_source, coalesce(item_type, '') as item_type, coalesce(token,'') as token, coalesce(expiration, '') as expiration, coalesce(share_name, '') as share_name, id, stime, permissions, quicklink FROM oc_share WHERE (orphan = 0 or orphan IS NULL) AND (share_type=?)"
+	query := "select coalesce(uid_owner, '') as uid_owner, coalesce(uid_initiator, '') as uid_initiator, coalesce(share_with, '') as share_with, coalesce(fileid_prefix, '') as fileid_prefix, coalesce(item_source, '') as item_source, coalesce(item_type, '') as item_type, coalesce(token,'') as token, coalesce(expiration, '') as expiration, coalesce(share_name, '') as share_name, id, stime, permissions, quicklink, description FROM oc_share WHERE (orphan = 0 or orphan IS NULL) AND (share_type=?)"
 	var resourceFilters, ownerFilters, creatorFilters string
 	var resourceParams, ownerParams, creatorParams []interface{}
 	params := []interface{}{publicShareType}
@@ -382,7 +390,7 @@ func (m *manager) ListPublicShares(ctx context.Context, u *user.User, filters []
 	var s conversions.DBShare
 	shares := []*link.PublicShare{}
 	for rows.Next() {
-		if err := rows.Scan(&s.UIDOwner, &s.UIDInitiator, &s.ShareWith, &s.Prefix, &s.ItemSource, &s.ItemType, &s.Token, &s.Expiration, &s.ShareName, &s.ID, &s.STime, &s.Permissions, &s.Quicklink); err != nil {
+		if err := rows.Scan(&s.UIDOwner, &s.UIDInitiator, &s.ShareWith, &s.Prefix, &s.ItemSource, &s.ItemType, &s.Token, &s.Expiration, &s.ShareName, &s.ID, &s.STime, &s.Permissions, &s.Quicklink, &s.Description); err != nil {
 			continue
 		}
 		cs3Share := conversions.ConvertToCS3PublicShare(s)
@@ -441,8 +449,8 @@ func (m *manager) RevokePublicShare(ctx context.Context, u *user.User, ref *link
 
 func (m *manager) GetPublicShareByToken(ctx context.Context, token string, auth *link.PublicShareAuthentication, sign bool) (*link.PublicShare, error) {
 	s := conversions.DBShare{Token: token}
-	query := "select coalesce(uid_owner, '') as uid_owner, coalesce(uid_initiator, '') as uid_initiator, coalesce(share_with, '') as share_with, coalesce(fileid_prefix, '') as fileid_prefix, coalesce(item_source, '') as item_source, coalesce(item_type, '') as item_type, coalesce(expiration, '') as expiration, coalesce(share_name, '') as share_name, id, stime, permissions, quicklink FROM oc_share WHERE share_type=? AND token=?"
-	if err := m.db.QueryRow(query, publicShareType, token).Scan(&s.UIDOwner, &s.UIDInitiator, &s.ShareWith, &s.Prefix, &s.ItemSource, &s.ItemType, &s.Expiration, &s.ShareName, &s.ID, &s.STime, &s.Permissions, &s.Quicklink); err != nil {
+	query := "select coalesce(uid_owner, '') as uid_owner, coalesce(uid_initiator, '') as uid_initiator, coalesce(share_with, '') as share_with, coalesce(fileid_prefix, '') as fileid_prefix, coalesce(item_source, '') as item_source, coalesce(item_type, '') as item_type, coalesce(expiration, '') as expiration, coalesce(share_name, '') as share_name, id, stime, permissions, quicklink, description FROM oc_share WHERE share_type=? AND token=?"
+	if err := m.db.QueryRow(query, publicShareType, token).Scan(&s.UIDOwner, &s.UIDInitiator, &s.ShareWith, &s.Prefix, &s.ItemSource, &s.ItemType, &s.Expiration, &s.ShareName, &s.ID, &s.STime, &s.Permissions, &s.Quicklink, &s.Description); err != nil {
 		if err == sql.ErrNoRows {
 			return nil, errtypes.NotFound(token)
 		}

--- a/pkg/cbox/publicshare/sql/sql.go
+++ b/pkg/cbox/publicshare/sql/sql.go
@@ -144,7 +144,7 @@ func New(m map[string]interface{}) (publicshare.Manager, error) {
 
 func hiddenTagsQuery(hiddenTags []string) (string, []interface{}) {
 	query := ""
-	for _ = range hiddenTags {
+	for range hiddenTags {
 		query += "?,"
 	}
 	if query != "" {

--- a/pkg/cbox/publicshare/sql/sql.go
+++ b/pkg/cbox/publicshare/sql/sql.go
@@ -358,12 +358,11 @@ func (m *manager) GetPublicShare(ctx context.Context, u *user.User, ref *link.Pu
 	return s, nil
 }
 
-func (m *manager) filterHiddenTagsQuery(query string, params []interface{}) (string, []interface{}) {
+func (m *manager) filterHiddenTagsQuery(query *string, params *[]interface{}) {
 	if len(m.hiddenTags.params) != 0 {
-		query = query + m.hiddenTags.query
-		params = append(params, m.hiddenTags.params...)
+		*query += m.hiddenTags.query
+		*params = append(*params, m.hiddenTags.params...)
 	}
-	return query, params
 }
 
 func (m *manager) ListPublicShares(ctx context.Context, u *user.User, filters []*link.ListPublicSharesRequest_Filter, md *provider.ResourceInfo, sign bool) ([]*link.PublicShare, error) {
@@ -416,7 +415,7 @@ func (m *manager) ListPublicShares(ctx context.Context, u *user.User, filters []
 		query = fmt.Sprintf("%s AND (%s)", query, uidOwnersQuery)
 	}
 
-	query, params = m.filterHiddenTagsQuery(query, params)
+	m.filterHiddenTagsQuery(&query, &params)
 
 	rows, err := m.db.Query(query, params...)
 	if err != nil {

--- a/pkg/cbox/publicshare/sql/sql.go
+++ b/pkg/cbox/publicshare/sql/sql.go
@@ -160,7 +160,7 @@ func hiddenTagsQuery(hiddenTags []string) (string, []interface{}) {
 	return query, params
 }
 
-func (m *manager) CreatePublicShare(ctx context.Context, u *user.User, rInfo *provider.ResourceInfo, g *link.Grant) (*link.PublicShare, error) {
+func (m *manager) CreatePublicShare(ctx context.Context, u *user.User, rInfo *provider.ResourceInfo, g *link.Grant, description string) (*link.PublicShare, error) {
 
 	tkn := utils.RandString(15)
 	now := time.Now().Unix()
@@ -173,11 +173,6 @@ func (m *manager) CreatePublicShare(ctx context.Context, u *user.User, rInfo *pr
 	}
 	createdAt := &typespb.Timestamp{
 		Seconds: uint64(now),
-	}
-
-	description, ok := rInfo.ArbitraryMetadata.Metadata["description"]
-	if !ok {
-		description = ""
 	}
 
 	creator := conversions.FormatUserID(u.Id)

--- a/pkg/cbox/utils/conversions.go
+++ b/pkg/cbox/utils/conversions.go
@@ -49,6 +49,7 @@ type DBShare struct {
 	FileTarget   string
 	State        int
 	Quicklink    bool
+	Description  string
 }
 
 // FormatGrantee formats a CS3API grantee to a string
@@ -252,5 +253,6 @@ func ConvertToCS3PublicShare(s DBShare) *link.PublicShare {
 		Ctime:             ts,
 		Mtime:             ts,
 		Quicklink:         s.Quicklink,
+		Description:       s.Description,
 	}
 }

--- a/pkg/publicshare/manager/json/json.go
+++ b/pkg/publicshare/manager/json/json.go
@@ -140,7 +140,7 @@ func (m *manager) startJanitorRun() {
 }
 
 // CreatePublicShare adds a new entry to manager.shares
-func (m *manager) CreatePublicShare(ctx context.Context, u *user.User, rInfo *provider.ResourceInfo, g *link.Grant, description string) (*link.PublicShare, error) {
+func (m *manager) CreatePublicShare(ctx context.Context, u *user.User, rInfo *provider.ResourceInfo, g *link.Grant, description string, internal bool) (*link.PublicShare, error) {
 	id := &link.PublicShareId{
 		OpaqueId: utils.RandString(15),
 	}

--- a/pkg/publicshare/manager/json/json.go
+++ b/pkg/publicshare/manager/json/json.go
@@ -140,7 +140,7 @@ func (m *manager) startJanitorRun() {
 }
 
 // CreatePublicShare adds a new entry to manager.shares
-func (m *manager) CreatePublicShare(ctx context.Context, u *user.User, rInfo *provider.ResourceInfo, g *link.Grant) (*link.PublicShare, error) {
+func (m *manager) CreatePublicShare(ctx context.Context, u *user.User, rInfo *provider.ResourceInfo, g *link.Grant, description string) (*link.PublicShare, error) {
 	id := &link.PublicShareId{
 		OpaqueId: utils.RandString(15),
 	}
@@ -181,6 +181,7 @@ func (m *manager) CreatePublicShare(ctx context.Context, u *user.User, rInfo *pr
 		PasswordProtected: passwordProtected,
 		Expiration:        g.Expiration,
 		DisplayName:       displayName,
+		Description:       description,
 	}
 
 	ps := &publicShare{

--- a/pkg/publicshare/manager/memory/memory.go
+++ b/pkg/publicshare/manager/memory/memory.go
@@ -58,7 +58,7 @@ var (
 )
 
 // CreatePublicShare adds a new entry to manager.shares
-func (m *manager) CreatePublicShare(ctx context.Context, u *user.User, rInfo *provider.ResourceInfo, g *link.Grant, description string) (*link.PublicShare, error) {
+func (m *manager) CreatePublicShare(ctx context.Context, u *user.User, rInfo *provider.ResourceInfo, g *link.Grant, description string, internal bool) (*link.PublicShare, error) {
 	id := &link.PublicShareId{
 		OpaqueId: randString(15),
 	}

--- a/pkg/publicshare/manager/memory/memory.go
+++ b/pkg/publicshare/manager/memory/memory.go
@@ -58,7 +58,7 @@ var (
 )
 
 // CreatePublicShare adds a new entry to manager.shares
-func (m *manager) CreatePublicShare(ctx context.Context, u *user.User, rInfo *provider.ResourceInfo, g *link.Grant) (*link.PublicShare, error) {
+func (m *manager) CreatePublicShare(ctx context.Context, u *user.User, rInfo *provider.ResourceInfo, g *link.Grant, description string) (*link.PublicShare, error) {
 	id := &link.PublicShareId{
 		OpaqueId: randString(15),
 	}
@@ -97,6 +97,7 @@ func (m *manager) CreatePublicShare(ctx context.Context, u *user.User, rInfo *pr
 		PasswordProtected: passwordProtected,
 		Expiration:        g.Expiration,
 		DisplayName:       displayName,
+		Description:       description,
 	}
 
 	m.shares.Store(s.Token, &s)

--- a/pkg/publicshare/publicshare.go
+++ b/pkg/publicshare/publicshare.go
@@ -35,7 +35,7 @@ import (
 
 // Manager manipulates public shares.
 type Manager interface {
-	CreatePublicShare(ctx context.Context, u *user.User, md *provider.ResourceInfo, g *link.Grant) (*link.PublicShare, error)
+	CreatePublicShare(ctx context.Context, u *user.User, md *provider.ResourceInfo, g *link.Grant, description string) (*link.PublicShare, error)
 	UpdatePublicShare(ctx context.Context, u *user.User, req *link.UpdatePublicShareRequest, g *link.Grant) (*link.PublicShare, error)
 	GetPublicShare(ctx context.Context, u *user.User, ref *link.PublicShareReference, sign bool) (*link.PublicShare, error)
 	ListPublicShares(ctx context.Context, u *user.User, filters []*link.ListPublicSharesRequest_Filter, md *provider.ResourceInfo, sign bool) ([]*link.PublicShare, error)

--- a/pkg/publicshare/publicshare.go
+++ b/pkg/publicshare/publicshare.go
@@ -35,7 +35,7 @@ import (
 
 // Manager manipulates public shares.
 type Manager interface {
-	CreatePublicShare(ctx context.Context, u *user.User, md *provider.ResourceInfo, g *link.Grant, description string) (*link.PublicShare, error)
+	CreatePublicShare(ctx context.Context, u *user.User, md *provider.ResourceInfo, g *link.Grant, description string, internal bool) (*link.PublicShare, error)
 	UpdatePublicShare(ctx context.Context, u *user.User, req *link.UpdatePublicShareRequest, g *link.Grant) (*link.PublicShare, error)
 	GetPublicShare(ctx context.Context, u *user.User, ref *link.PublicShareReference, sign bool) (*link.PublicShare, error)
 	ListPublicShares(ctx context.Context, u *user.User, filters []*link.ListPublicSharesRequest_Filter, md *provider.ResourceInfo, sign bool) ([]*link.PublicShare, error)


### PR DESCRIPTION
This PR adds the possibility to set a description to a public link, allowing an user to describe the usefulness of the public link.
It also adds an option to set the public links for internal usage (for example for being using by apps). When a public link is internal, this will not be exposed in the list of public links.