### PR TITLE
rewind to the start of the lock file

### DIFF
--- a/changelog/unreleased/refresh-lock-fix.md
+++ b/changelog/unreleased/refresh-lock-fix.md
@@ -1,0 +1,5 @@
+Bugfix: Refresh lock in decomposedFS needs to overwrite
+
+We fixed a bug in the refresh lock operation in the DecomposedFS. The new lock was appended but needs to overwrite the existing one.
+
+https://github.com/cs3org/reva/pull/3307

--- a/pkg/storage/utils/decomposedfs/node/locks.go
+++ b/pkg/storage/utils/decomposedfs/node/locks.go
@@ -190,6 +190,11 @@ func (n *Node) RefreshLock(ctx context.Context, lock *provider.Lock, existingLoc
 		return err
 	}
 
+	// Rewind to the beginning of the file before writing a refreshed lock
+	_, err = f.Seek(0, 0)
+	if err != nil {
+		return errors.Wrap(err, "could not seek to the beginning of the lock file")
+	}
 	if err := json.NewEncoder(f).Encode(lock); err != nil {
 		return errors.Wrap(err, "Decomposedfs: could not write lock file")
 	}

--- a/pkg/storage/utils/decomposedfs/node/locks_test.go
+++ b/pkg/storage/utils/decomposedfs/node/locks_test.go
@@ -214,6 +214,13 @@ var _ = Describe("Node locks", func() {
 				err := n.RefreshLock(env.Ctx, newLock, "")
 				Expect(err).ToNot(HaveOccurred())
 			})
+
+			It("refreshes the lock and unlocks with the new lock", func() {
+				err := n.RefreshLock(env.Ctx, newLock, lockByUser.LockId)
+				Expect(err).ToNot(HaveOccurred())
+				err = n.Unlock(env.Ctx, newLock)
+				Expect(err).ToNot(HaveOccurred())
+			})
 		})
 
 		Describe("Unlock", func() {
@@ -328,6 +335,13 @@ var _ = Describe("Node locks", func() {
 
 			It("refreshes the lock", func() {
 				err := n.RefreshLock(env.Ctx, newLock, "")
+				Expect(err).ToNot(HaveOccurred())
+			})
+			It("refreshes the lock and unlocks it with the new lock", func() {
+				newLock.LockId = "somethingnew"
+				err := n.RefreshLock(env.Ctx, newLock, lockByApp.LockId)
+				Expect(err).ToNot(HaveOccurred())
+				err = n.Unlock(env.Ctx, newLock)
 				Expect(err).ToNot(HaveOccurred())
 			})
 		})


### PR DESCRIPTION
# Description

Refresh lock in decomposedFS needs to overwrite.

We fixed a bug in the refresh lock operation in the DecomposedFS. The new lock was appended but needs to overwrite the existing one.