### PR TITLE
Add parent id to resourceInfo for web navigation

### DIFF
--- a/changelog/unreleased/add-parent-id-dav-ocs.md
+++ b/changelog/unreleased/add-parent-id-dav-ocs.md
@@ -1,0 +1,5 @@
+Enhancement: Add the parentID to the ocs and dav responses
+
+We added the parent resourceID to the OCS and WebDav responses to enable navigation by ID in the web client.
+
+https://github.com/cs3org/reva/pull/3320

--- a/internal/grpc/services/storageprovider/storageprovider.go
+++ b/internal/grpc/services/storageprovider/storageprovider.go
@@ -701,6 +701,11 @@ func (s *service) Stat(ctx context.Context, req *provider.StatRequest) (*provide
 		md.Id.StorageId = s.conf.MountID
 	}
 
+	// The storage driver might set the mount ID by itself, in which case skip this step
+	if md.ParentId != nil && md.ParentId.GetStorageId() == "" {
+		md.ParentId.StorageId = s.conf.MountID
+	}
+
 	return &provider.StatResponse{
 		Status: status.NewOK(ctx),
 		Info:   md,
@@ -764,6 +769,9 @@ func (s *service) ListContainer(ctx context.Context, req *provider.ListContainer
 
 	for _, i := range res.Infos {
 		s.addMissingStorageProviderID(i.Id, nil)
+		if i.ParentId != nil {
+			s.addMissingStorageProviderID(i.ParentId, nil)
+		}
 	}
 	return res, nil
 }

--- a/internal/http/services/owncloud/ocdav/propfind/propfind.go
+++ b/internal/http/services/owncloud/ocdav/propfind/propfind.go
@@ -1004,6 +1004,12 @@ func mdToPropResponse(ctx context.Context, pf *XML, md *provider.ResourceInfo, p
 			)
 		}
 
+		if md.ParentId != nil {
+			appendToOK(prop.Escaped("oc:file-parent", storagespace.FormatResourceID(*md.ParentId)))
+		} else {
+			appendToNotFound(prop.NotFound("oc:file-parent"))
+		}
+
 		// we need to add the shareid if possible - the only way to extract it here is to parse it from the path
 		if ref, err := storagespace.ParseReference(strings.TrimPrefix(md.Path, "/")); err == nil && ref.GetResourceId().GetSpaceId() == utils.ShareStorageSpaceID {
 			appendToOK(prop.Raw("oc:shareid", ref.GetResourceId().GetOpaqueId()))
@@ -1118,6 +1124,12 @@ func mdToPropResponse(ctx context.Context, pf *XML, md *provider.ResourceInfo, p
 						appendToOK(prop.Escaped("oc:id", storagespace.FormatResourceID(*md.Id)))
 					} else {
 						appendToNotFound(prop.NotFound("oc:id"))
+					}
+				case "file-parent":
+					if md.ParentId != nil {
+						appendToOK(prop.Escaped("oc:file-parent", storagespace.FormatResourceID(*md.ParentId)))
+					} else {
+						appendToNotFound(prop.NotFound("oc:file-parent"))
 					}
 				case "spaceid":
 					if md.Id != nil {

--- a/internal/http/services/owncloud/ocdav/propfind/propfind_test.go
+++ b/internal/http/services/owncloud/ocdav/propfind/propfind_test.go
@@ -180,99 +180,112 @@ var _ = Describe("Propfind", func() {
 		mockListContainer(&sprovider.Reference{ResourceId: &sprovider.ResourceId{StorageId: "provider-1", SpaceId: "foospace", OpaqueId: "root"}, Path: "."},
 			[]*sprovider.ResourceInfo{
 				{
-					Type: sprovider.ResourceType_RESOURCE_TYPE_FILE,
-					Id:   &sprovider.ResourceId{StorageId: "provider-1", SpaceId: "foospace", OpaqueId: "bar"},
-					Path: "bar",
-					Size: 100,
+					Type:     sprovider.ResourceType_RESOURCE_TYPE_FILE,
+					Id:       &sprovider.ResourceId{StorageId: "provider-1", SpaceId: "foospace", OpaqueId: "bar"},
+					Path:     "bar",
+					Size:     100,
+					ParentId: &sprovider.ResourceId{StorageId: "provider-1", SpaceId: "foospace", OpaqueId: "foospace"},
 				},
 				{
-					Type: sprovider.ResourceType_RESOURCE_TYPE_FILE,
-					Id:   &sprovider.ResourceId{StorageId: "provider-1", SpaceId: "foospace", OpaqueId: "baz"},
-					Path: "baz",
-					Size: 1,
+					Type:     sprovider.ResourceType_RESOURCE_TYPE_FILE,
+					Id:       &sprovider.ResourceId{StorageId: "provider-1", SpaceId: "foospace", OpaqueId: "baz"},
+					Path:     "baz",
+					Size:     1,
+					ParentId: &sprovider.ResourceId{StorageId: "provider-1", SpaceId: "foospace", OpaqueId: "foospace"},
 				},
 				{
-					Type: sprovider.ResourceType_RESOURCE_TYPE_CONTAINER,
-					Id:   &sprovider.ResourceId{StorageId: "provider-1", SpaceId: "foospace", OpaqueId: "dir"},
-					Path: "dir",
-					Size: 30,
+					Type:     sprovider.ResourceType_RESOURCE_TYPE_CONTAINER,
+					Id:       &sprovider.ResourceId{StorageId: "provider-1", SpaceId: "foospace", OpaqueId: "dir"},
+					Path:     "dir",
+					Size:     30,
+					ParentId: &sprovider.ResourceId{StorageId: "provider-1", SpaceId: "foospace", OpaqueId: "foospace"},
 				},
 			})
 		mockStat(&sprovider.Reference{ResourceId: &sprovider.ResourceId{StorageId: "provider-1", SpaceId: "foospace", OpaqueId: "root"}, Path: "./bar"},
 			&sprovider.ResourceInfo{
-				Id:   &sprovider.ResourceId{StorageId: "provider-1", SpaceId: "foospace", OpaqueId: "bar"},
-				Type: sprovider.ResourceType_RESOURCE_TYPE_FILE,
-				Path: "./bar",
-				Size: uint64(100),
+				Id:       &sprovider.ResourceId{StorageId: "provider-1", SpaceId: "foospace", OpaqueId: "bar"},
+				Type:     sprovider.ResourceType_RESOURCE_TYPE_FILE,
+				Path:     "./bar",
+				Size:     uint64(100),
+				ParentId: &sprovider.ResourceId{StorageId: "provider-1", SpaceId: "foospace", OpaqueId: "foospace"},
 			})
 		mockStat(&sprovider.Reference{ResourceId: &sprovider.ResourceId{StorageId: "provider-1", SpaceId: "foospace", OpaqueId: "bar"}, Path: "."},
 			&sprovider.ResourceInfo{
-				Id:   &sprovider.ResourceId{StorageId: "provider-1", SpaceId: "foospace", OpaqueId: "bar"},
-				Type: sprovider.ResourceType_RESOURCE_TYPE_FILE,
-				Path: "./bar",
-				Size: uint64(100),
+				Id:       &sprovider.ResourceId{StorageId: "provider-1", SpaceId: "foospace", OpaqueId: "bar"},
+				Type:     sprovider.ResourceType_RESOURCE_TYPE_FILE,
+				Path:     "./bar",
+				Size:     uint64(100),
+				ParentId: &sprovider.ResourceId{StorageId: "provider-1", SpaceId: "foospace", OpaqueId: "foospace"},
 			})
 		mockStat(&sprovider.Reference{ResourceId: &sprovider.ResourceId{StorageId: "provider-1", SpaceId: "foospace", OpaqueId: "root"}, Path: "./baz"},
 			&sprovider.ResourceInfo{
-				Id:   &sprovider.ResourceId{StorageId: "provider-1", SpaceId: "foospace", OpaqueId: "baz"},
-				Type: sprovider.ResourceType_RESOURCE_TYPE_FILE,
-				Path: "./baz",
-				Size: uint64(1),
+				Id:       &sprovider.ResourceId{StorageId: "provider-1", SpaceId: "foospace", OpaqueId: "baz"},
+				Type:     sprovider.ResourceType_RESOURCE_TYPE_FILE,
+				Path:     "./baz",
+				Size:     uint64(1),
+				ParentId: &sprovider.ResourceId{StorageId: "provider-1", SpaceId: "foospace", OpaqueId: "foospace"},
 			})
 		mockStat(&sprovider.Reference{ResourceId: &sprovider.ResourceId{StorageId: "provider-1", SpaceId: "foospace", OpaqueId: "baz"}, Path: "."},
 			&sprovider.ResourceInfo{
-				Id:   &sprovider.ResourceId{StorageId: "provider-1", SpaceId: "foospace", OpaqueId: "baz"},
-				Type: sprovider.ResourceType_RESOURCE_TYPE_FILE,
-				Path: "./baz",
-				Size: uint64(1),
+				Id:       &sprovider.ResourceId{StorageId: "provider-1", SpaceId: "foospace", OpaqueId: "baz"},
+				Type:     sprovider.ResourceType_RESOURCE_TYPE_FILE,
+				Path:     "./baz",
+				Size:     uint64(1),
+				ParentId: &sprovider.ResourceId{StorageId: "provider-1", SpaceId: "foospace", OpaqueId: "foospace"},
 			})
 		mockStat(&sprovider.Reference{ResourceId: &sprovider.ResourceId{StorageId: "provider-1", SpaceId: "foospace", OpaqueId: "root"}, Path: "./dir"},
 			&sprovider.ResourceInfo{
-				Id:   &sprovider.ResourceId{StorageId: "provider-1", SpaceId: "foospace", OpaqueId: "dir"},
-				Type: sprovider.ResourceType_RESOURCE_TYPE_CONTAINER,
-				Path: "./dir",
-				Size: uint64(30),
+				Id:       &sprovider.ResourceId{StorageId: "provider-1", SpaceId: "foospace", OpaqueId: "dir"},
+				Type:     sprovider.ResourceType_RESOURCE_TYPE_CONTAINER,
+				Path:     "./dir",
+				Size:     uint64(30),
+				ParentId: &sprovider.ResourceId{StorageId: "provider-1", SpaceId: "foospace", OpaqueId: "foospace"},
 			})
 		mockStat(&sprovider.Reference{ResourceId: &sprovider.ResourceId{StorageId: "provider-1", SpaceId: "foospace", OpaqueId: "root"}, Path: "./dir&dir"},
 			&sprovider.ResourceInfo{
-				Id:   &sprovider.ResourceId{StorageId: "provider-1", SpaceId: "foospace", OpaqueId: "dir"},
-				Type: sprovider.ResourceType_RESOURCE_TYPE_CONTAINER,
-				Path: "./dir&dir",
-				Name: "dir&dir",
-				Size: uint64(30),
+				Id:       &sprovider.ResourceId{StorageId: "provider-1", SpaceId: "foospace", OpaqueId: "dir"},
+				Type:     sprovider.ResourceType_RESOURCE_TYPE_CONTAINER,
+				Path:     "./dir&dir",
+				Name:     "dir&dir",
+				Size:     uint64(30),
+				ParentId: &sprovider.ResourceId{StorageId: "provider-1", SpaceId: "foospace", OpaqueId: "foospace"},
 			})
 		mockStat(&sprovider.Reference{ResourceId: &sprovider.ResourceId{StorageId: "provider-1", SpaceId: "foospace", OpaqueId: "dir"}, Path: "."},
 			&sprovider.ResourceInfo{
-				Id:   &sprovider.ResourceId{StorageId: "provider-1", SpaceId: "foospace", OpaqueId: "dir"},
-				Type: sprovider.ResourceType_RESOURCE_TYPE_CONTAINER,
-				Path: "./dir",
-				Size: uint64(30),
+				Id:       &sprovider.ResourceId{StorageId: "provider-1", SpaceId: "foospace", OpaqueId: "dir"},
+				Type:     sprovider.ResourceType_RESOURCE_TYPE_CONTAINER,
+				Path:     "./dir",
+				Size:     uint64(30),
+				ParentId: &sprovider.ResourceId{StorageId: "provider-1", SpaceId: "foospace", OpaqueId: "foospace"},
 			})
 		mockListContainer(&sprovider.Reference{ResourceId: &sprovider.ResourceId{StorageId: "provider-1", SpaceId: "foospace", OpaqueId: "root"}, Path: "./dir"},
 			[]*sprovider.ResourceInfo{
 				{
-					Id:   &sprovider.ResourceId{StorageId: "provider-1", SpaceId: "foospace", OpaqueId: "direntry"},
-					Type: sprovider.ResourceType_RESOURCE_TYPE_FILE,
-					Path: "entry",
-					Size: 30,
+					Id:       &sprovider.ResourceId{StorageId: "provider-1", SpaceId: "foospace", OpaqueId: "direntry"},
+					Type:     sprovider.ResourceType_RESOURCE_TYPE_FILE,
+					Path:     "entry",
+					Size:     30,
+					ParentId: &sprovider.ResourceId{StorageId: "provider-1", SpaceId: "foospace", OpaqueId: "foospace"},
 				},
 			})
 		mockListContainer(&sprovider.Reference{ResourceId: &sprovider.ResourceId{StorageId: "provider-1", SpaceId: "foospace", OpaqueId: "root"}, Path: "./dir&dir"},
 			[]*sprovider.ResourceInfo{
 				{
-					Id:   &sprovider.ResourceId{StorageId: "provider-1", SpaceId: "foospace", OpaqueId: "direntry"},
-					Type: sprovider.ResourceType_RESOURCE_TYPE_FILE,
-					Path: "entry",
-					Size: 30,
+					Id:       &sprovider.ResourceId{StorageId: "provider-1", SpaceId: "foospace", OpaqueId: "direntry"},
+					Type:     sprovider.ResourceType_RESOURCE_TYPE_FILE,
+					Path:     "entry",
+					Size:     30,
+					ParentId: &sprovider.ResourceId{StorageId: "provider-1", SpaceId: "foospace", OpaqueId: "foospace"},
 				},
 			})
 		mockListContainer(&sprovider.Reference{ResourceId: &sprovider.ResourceId{StorageId: "provider-1", SpaceId: "foospace", OpaqueId: "dir"}, Path: "."},
 			[]*sprovider.ResourceInfo{
 				{
-					Id:   &sprovider.ResourceId{StorageId: "provider-1", SpaceId: "foospace", OpaqueId: "direntry"},
-					Type: sprovider.ResourceType_RESOURCE_TYPE_FILE,
-					Path: "entry",
-					Size: 30,
+					Id:       &sprovider.ResourceId{StorageId: "provider-1", SpaceId: "foospace", OpaqueId: "direntry"},
+					Type:     sprovider.ResourceType_RESOURCE_TYPE_FILE,
+					Path:     "entry",
+					Size:     30,
+					ParentId: &sprovider.ResourceId{StorageId: "provider-1", SpaceId: "foospace", OpaqueId: "foospace"},
 				},
 			})
 
@@ -289,10 +302,11 @@ var _ = Describe("Propfind", func() {
 		mockListContainer(&sprovider.Reference{ResourceId: &sprovider.ResourceId{StorageId: "provider-1", SpaceId: "fooquxspace", OpaqueId: "root"}, Path: "."},
 			[]*sprovider.ResourceInfo{
 				{
-					Id:   &sprovider.ResourceId{StorageId: "provider-1", SpaceId: "fooquxspace", OpaqueId: "quux"},
-					Type: sprovider.ResourceType_RESOURCE_TYPE_FILE,
-					Path: "./quux",
-					Size: 1000,
+					Id:       &sprovider.ResourceId{StorageId: "provider-1", SpaceId: "fooquxspace", OpaqueId: "quux"},
+					Type:     sprovider.ResourceType_RESOURCE_TYPE_FILE,
+					Path:     "./quux",
+					Size:     1000,
+					ParentId: &sprovider.ResourceId{StorageId: "provider-1", SpaceId: "fooquxspace", OpaqueId: "fooquxspace"},
 				},
 			})
 
@@ -335,10 +349,11 @@ var _ = Describe("Propfind", func() {
 		mockListContainer(&sprovider.Reference{ResourceId: &sprovider.ResourceId{StorageId: "provider-1", SpaceId: "fooDirShareSpace", OpaqueId: "shareddir"}, Path: "."},
 			[]*sprovider.ResourceInfo{
 				{
-					Id:   &sprovider.ResourceId{StorageId: "provider-1", SpaceId: "fooDirShareSpace", OpaqueId: "shareddirsomething"},
-					Type: sprovider.ResourceType_RESOURCE_TYPE_FILE,
-					Path: "something",
-					Size: 1500,
+					Id:       &sprovider.ResourceId{StorageId: "provider-1", SpaceId: "fooDirShareSpace", OpaqueId: "shareddirsomething"},
+					Type:     sprovider.ResourceType_RESOURCE_TYPE_FILE,
+					Path:     "something",
+					Size:     1500,
+					ParentId: &sprovider.ResourceId{StorageId: "provider-1", SpaceId: "fooDirShareSpace", OpaqueId: "fooDirShareSpace"},
 				},
 			})
 
@@ -767,14 +782,17 @@ var _ = Describe("Propfind", func() {
 			bar := res.Responses[1]
 			Expect(bar.Href).To(Equal("http:/127.0.0.1:3000/" + spaceIDUrl + "/bar"))
 			Expect(string(bar.Propstat[0].Prop[0].InnerXML)).To(ContainSubstring("<d:getcontentlength>100</d:getcontentlength>"))
+			Expect(string(bar.Propstat[0].Prop[0].InnerXML)).To(ContainSubstring("<oc:file-parent>provider-1$foospace!foospace</oc:file-parent>"))
 
 			baz := res.Responses[2]
 			Expect(baz.Href).To(Equal("http:/127.0.0.1:3000/" + spaceIDUrl + "/baz"))
 			Expect(string(baz.Propstat[0].Prop[0].InnerXML)).To(ContainSubstring("<d:getcontentlength>1</d:getcontentlength>"))
+			Expect(string(baz.Propstat[0].Prop[0].InnerXML)).To(ContainSubstring("<oc:file-parent>provider-1$foospace!foospace</oc:file-parent>"))
 
 			dir := res.Responses[3]
 			Expect(dir.Href).To(Equal("http:/127.0.0.1:3000/" + spaceIDUrl + "/dir/"))
 			Expect(string(dir.Propstat[0].Prop[0].InnerXML)).To(ContainSubstring("<oc:size>30</oc:size>"))
+			Expect(string(dir.Propstat[0].Prop[0].InnerXML)).To(ContainSubstring("<oc:file-parent>provider-1$foospace!foospace</oc:file-parent>"))
 		})
 
 		It("stats a file", func() {


### PR DESCRIPTION
# Description

We added the parent resourceID to the OCS and WebDav responses to enable navigation by ID in the web client.

## Related issue

https://github.com/owncloud/ocis/issues/4727