### PR TITLE
fix base url for file public links

### DIFF
--- a/changelog/unreleased/fix-public-link-baseurl.md
+++ b/changelog/unreleased/fix-public-link-baseurl.md
@@ -1,0 +1,6 @@
+Bugfix: correct base URL for download URL and href when listing file public links
+
+We now build the correct base URL when listing file public links.
+
+https://github.com/cs3org/reva/pull/3324
+https://github.com/owncloud/ocis/issues/4758


### PR DESCRIPTION
We now build the correct base URL when listing file public links.

necessary for https://github.com/owncloud/ocis/issues/4758