### PR TITLE
fix malformed uid string in getter

### DIFF
--- a/changelog/unreleased/fix-malformed-uid-string.md
+++ b/changelog/unreleased/fix-malformed-uid-string.md
@@ -1,0 +1,9 @@
+Bugfix: Fix malformed uid string in cache
+
+The rediscache returns a uid in the format of `<tablename>uid:<someuid>` in the getter
+this results in issues when trying to delete the key from the cache store, because
+the Delete function will prepend the table name to the string which will not be resolvable in redis
+(e.g. `<tablename><tablename>uid:<somuid>`)
+
+https://github.com/cs3org/reva/pull/3338
+https://github.com/owncloud/ocis/issues/4772

--- a/pkg/storage/cache/cache.go
+++ b/pkg/storage/cache/cache.go
@@ -198,7 +198,14 @@ func (cache cacheStore) List(opts ...microstore.ListOption) ([]string, error) {
 		microstore.ListFrom(cache.database, cache.table),
 	}
 	o = append(o, opts...)
-	return cache.s.List(o...)
+	keys, err := cache.s.List(o...)
+	if err != nil {
+		return nil, err
+	}
+	for i, key := range keys {
+		keys[i] = strings.TrimPrefix(key, cache.table)
+	}
+	return keys, nil
 }
 
 // Delete deletes the given key on the configured database and table of the underlying store


### PR DESCRIPTION
The rediscache returns a uid in the format of `<tablename>uid:<someuid>` in the getter
this results in issues when trying to delete the key from the cache store, because
the Delete function will prepend the table name to the string which will not be resolvable in redis
(e.g. `<tablename><tablename>uid:<somuid>`)

refs https://github.com/owncloud/ocis/issues/4772