### PR TITLE
Fix space owner or manager

### DIFF
--- a/changelog/unreleased/add-spaceowner-to-events.md
+++ b/changelog/unreleased/add-spaceowner-to-events.md
@@ -4,3 +4,4 @@ We added a SpaceOwner field to some of the events which can be used by
 consumers to gain access to the affected space.
 
 https://github.com/cs3org/reva/pull/3340
+https://github.com/cs3org/reva/pull/3350

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/cheggaaa/pb v1.0.29
 	github.com/coreos/go-oidc v2.2.1+incompatible
 	github.com/cs3org/cato v0.0.0-20200828125504-e418fc54dd5e
-	github.com/cs3org/go-cs3apis v0.0.0-20221005085457-19ea8088a512
+	github.com/cs3org/go-cs3apis v0.0.0-20221012090518-ef2996678965
 	github.com/cubewise-code/go-mime v0.0.0-20200519001935-8c5762b177d8
 	github.com/dgraph-io/ristretto v0.1.0
 	github.com/emvi/iso-639-1 v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -195,6 +195,8 @@ github.com/cs3org/go-cs3apis v0.0.0-20220929083235-bb0b1a236d6c h1:b+YTmOGlf43mn
 github.com/cs3org/go-cs3apis v0.0.0-20220929083235-bb0b1a236d6c/go.mod h1:UXha4TguuB52H14EMoSsCqDj7k8a/t7g4gVP+bgY5LY=
 github.com/cs3org/go-cs3apis v0.0.0-20221005085457-19ea8088a512 h1:xTvaIsLu1ezoWOJKnV0ehgiowkOiEhMaylaI1lD/Axw=
 github.com/cs3org/go-cs3apis v0.0.0-20221005085457-19ea8088a512/go.mod h1:UXha4TguuB52H14EMoSsCqDj7k8a/t7g4gVP+bgY5LY=
+github.com/cs3org/go-cs3apis v0.0.0-20221012090518-ef2996678965 h1:y4n2j68LLnvac+zw/al8MfPgO5aQiIwLmHM/JzYN8AM=
+github.com/cs3org/go-cs3apis v0.0.0-20221012090518-ef2996678965/go.mod h1:UXha4TguuB52H14EMoSsCqDj7k8a/t7g4gVP+bgY5LY=
 github.com/cubewise-code/go-mime v0.0.0-20200519001935-8c5762b177d8 h1:Z9lwXumT5ACSmJ7WGnFl+OMLLjpz5uR2fyz7dC255FI=
 github.com/cubewise-code/go-mime v0.0.0-20200519001935-8c5762b177d8/go.mod h1:4abs/jPXcmJzYoYGF91JF9Uq9s/KL5n1jvFDix8KcqY=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/pkg/storage/utils/decomposedfs/node/node.go
+++ b/pkg/storage/utils/decomposedfs/node/node.go
@@ -184,8 +184,9 @@ func (n *Node) WriteOwner(owner *userpb.UserId) error {
 // SpaceOwnerOrManager returns the space owner of the space. If no owner is set
 // one of the space managers is returned instead.
 func (n *Node) SpaceOwnerOrManager(ctx context.Context) *userpb.UserId {
-	if n.Owner() != nil {
-		return n.Owner()
+	owner := n.Owner()
+	if owner != nil && owner.Type != userpb.UserType_USER_TYPE_SPACE_OWNER {
+		return owner
 	}
 
 	// We don't have an owner set. Find a manager instead.

--- a/pkg/storage/utils/decomposedfs/spaces.go
+++ b/pkg/storage/utils/decomposedfs/spaces.go
@@ -104,7 +104,7 @@ func (fs *Decomposedfs) CreateStorageSpace(ctx context.Context, req *provider.Cr
 	if req.GetOwner() != nil && req.GetOwner().GetId() != nil {
 		owner = req.GetOwner().GetId()
 	} else {
-		owner = &userv1beta1.UserId{OpaqueId: spaceID, Type: 8}
+		owner = &userv1beta1.UserId{OpaqueId: spaceID, Type: userv1beta1.UserType_USER_TYPE_SPACE_OWNER}
 	}
 	if err := root.WriteOwner(owner); err != nil {
 		return nil, err


### PR DESCRIPTION
Do not return `USER_TYPE_SPACE_OWNER` users when looking for space owners. Those are internal users which aren't suitable for all use cases. Fall back to another space manager in this case.