### PR TITLE
[tests-only] Bump core commit id to latest `reva-master`

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The test runner source for API tests
-CORE_COMMITID=65806c107fc679c4c70cd3c4e7dddefe2516dade
+CORE_COMMITID=899e9b85389bbb22f6b8c81ee7ada0e5cc1f70a4
 CORE_BRANCH=master


### PR DESCRIPTION
Part of https://github.com/owncloud/QA/issues/767