### PR TITLE
[tests-only] bump core commit id to latest `reva-edge`

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The test runner source for API tests
-CORE_COMMITID=6aa9948841ce4f4b4068bbbf08cfae158b2f6bab
+CORE_COMMITID=65ad24535fb095c2aa26bdfa3103dd59ff6499b3
 CORE_BRANCH=master


### PR DESCRIPTION
Part of https://github.com/owncloud/QA/issues/767