### PR TITLE
[tests-only] Return 500 on faulty propfinds

### DIFF
--- a/internal/http/services/owncloud/ocdav/propfind/propfind.go
+++ b/internal/http/services/owncloud/ocdav/propfind/propfind.go
@@ -695,6 +695,7 @@ func (p *Handler) getSpaceResourceInfos(ctx context.Context, w http.ResponseWrit
 
 	if res.Status.Code != rpc.Code_CODE_OK {
 		log.Debug().Interface("status", res.Status).Msg("List Container not ok, skipping")
+		w.WriteHeader(http.StatusInternalServerError)
 		return nil, false
 	}
 	for _, info := range res.Infos {

--- a/pkg/storage/utils/decomposedfs/decomposedfs.go
+++ b/pkg/storage/utils/decomposedfs/decomposedfs.go
@@ -865,10 +865,13 @@ func (fs *Decomposedfs) ListFolder(ctx context.Context, ref *provider.Reference,
 		// add this childs permissions
 		pset := n.PermissionSet(ctx)
 		node.AddPermissions(&np, &pset)
-		if ri, err := children[i].AsResourceInfo(ctx, &np, mdKeys, fieldMask, utils.IsRelativeReference(ref)); err == nil {
-			finfos = append(finfos, ri)
+		ri, err := children[i].AsResourceInfo(ctx, &np, mdKeys, fieldMask, utils.IsRelativeReference(ref))
+		if err != nil {
+			return nil, errtypes.InternalError(err.Error())
 		}
+		finfos = append(finfos, ri)
 	}
+
 	return
 }
 


### PR DESCRIPTION
fixes propfinds returning 200 even it they are not complete. For real. I promise. :crossed_fingers: 