### PR TITLE
Fix some possible race conditions

### DIFF
--- a/changelog/unreleased/fix-racecond.md
+++ b/changelog/unreleased/fix-racecond.md
@@ -1,0 +1,6 @@
+Bugfix: Fix possible race conditions
+
+We fixed two potential race condition when initializing the shared config
+structure and when setting up caches for the http authentication interceptors.
+
+https://github.com/cs3org/reva/pull/3377

--- a/pkg/sharedconf/sharedconf.go
+++ b/pkg/sharedconf/sharedconf.go
@@ -21,11 +21,15 @@ package sharedconf
 import (
 	"fmt"
 	"os"
+	"sync"
 
 	"github.com/mitchellh/mapstructure"
 )
 
-var sharedConf = &conf{}
+var (
+	sharedConf     = &conf{}
+	sharedConfOnce sync.Once
+)
 
 // ClientOptions represent additional options (e.g. tls settings) for the grpc clients
 type ClientOptions struct {
@@ -43,32 +47,35 @@ type conf struct {
 
 // Decode decodes the configuration.
 func Decode(v interface{}) error {
-	if err := mapstructure.Decode(v, sharedConf); err != nil {
-		return err
-	}
+	var err error
 
-	// add some defaults
-	if sharedConf.GatewaySVC == "" {
-		sharedConf.GatewaySVC = "0.0.0.0:19000"
-	}
-
-	// this is the default address we use for the data gateway HTTP service
-	if sharedConf.DataGateway == "" {
-		host, err := os.Hostname()
-		if err != nil || host == "" {
-			sharedConf.DataGateway = "http://0.0.0.0:19001/datagateway"
-		} else {
-			sharedConf.DataGateway = fmt.Sprintf("http://%s:19001/datagateway", host)
+	sharedConfOnce.Do(func() {
+		if err = mapstructure.Decode(v, sharedConf); err != nil {
+			return
 		}
-	}
+		// add some defaults
+		if sharedConf.GatewaySVC == "" {
+			sharedConf.GatewaySVC = "0.0.0.0:19000"
+		}
 
-	// TODO(labkode): would be cool to autogenerate one secret and print
-	// it on init time.
-	if sharedConf.JWTSecret == "" {
-		sharedConf.JWTSecret = "changemeplease"
-	}
+		// this is the default address we use for the data gateway HTTP service
+		if sharedConf.DataGateway == "" {
+			host, err := os.Hostname()
+			if err != nil || host == "" {
+				sharedConf.DataGateway = "http://0.0.0.0:19001/datagateway"
+			} else {
+				sharedConf.DataGateway = fmt.Sprintf("http://%s:19001/datagateway", host)
+			}
+		}
 
-	return nil
+		// TODO(labkode): would be cool to autogenerate one secret and print
+		// it on init time.
+		if sharedConf.JWTSecret == "" {
+			sharedConf.JWTSecret = "changemeplease"
+		}
+	})
+
+	return err
 }
 
 // GetJWTSecret returns the package level configured jwt secret if not overwritten.
@@ -103,4 +110,10 @@ func SkipUserGroupsInToken() bool {
 // GRPCClientOptions returns the global grpc client options
 func GRPCClientOptions() ClientOptions {
 	return sharedConf.GRPCClientOptions
+}
+
+// this is used by the tests
+func resetOnce() {
+	sharedConf = &conf{}
+	sharedConfOnce = sync.Once{}
 }

--- a/pkg/sharedconf/sharedconf_test.go
+++ b/pkg/sharedconf/sharedconf_test.go
@@ -47,6 +47,7 @@ func Test(t *testing.T) {
 		"jwt_secret": "dummy",
 	}
 
+	resetOnce()
 	err = Decode(conf)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
When launching multiple reva instance for a single process we need to make sure that the sharedconfig global variable is initialized exactly once. Otherwise we might run into race conditions. Similarly make sure to initialize the user cache for the auth interceptor exactly once.