### PR TITLE
Block users

### DIFF
--- a/changelog/unreleased/blocked-users.md
+++ b/changelog/unreleased/blocked-users.md
@@ -1,0 +1,6 @@
+Enhancement: Block users
+
+Allows an operator to set a list of users that
+are banned for every operation in reva.
+
+https://github.com/cs3org/reva/pull/3402

--- a/internal/grpc/interceptors/auth/auth.go
+++ b/internal/grpc/interceptors/auth/auth.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cs3org/reva/pkg/sharedconf"
 	"github.com/cs3org/reva/pkg/token"
 	tokenmgr "github.com/cs3org/reva/pkg/token/manager/registry"
+	"github.com/cs3org/reva/pkg/user"
 	"github.com/cs3org/reva/pkg/utils"
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
@@ -50,6 +51,7 @@ type config struct {
 	TokenManager  string                            `mapstructure:"token_manager"`
 	TokenManagers map[string]map[string]interface{} `mapstructure:"token_managers"`
 	GatewayAddr   string                            `mapstructure:"gateway_addr"`
+	blockedUsers  []string
 }
 
 func parseConfig(m map[string]interface{}) (*config, error) {
@@ -58,6 +60,7 @@ func parseConfig(m map[string]interface{}) (*config, error) {
 		err = errors.Wrap(err, "auth: error decoding conf")
 		return nil, err
 	}
+	c.blockedUsers = sharedconf.GetBlockedUsers()
 	return c, nil
 }
 
@@ -69,6 +72,8 @@ func NewUnary(m map[string]interface{}, unprotected []string) (grpc.UnaryServerI
 		err = errors.Wrap(err, "auth: error parsing config")
 		return nil, err
 	}
+
+	blockedUsers := user.NewBlockedUsersSet(conf.blockedUsers)
 
 	if conf.TokenManager == "" {
 		conf.TokenManager = "jwt"
@@ -100,6 +105,9 @@ func NewUnary(m map[string]interface{}, unprotected []string) (grpc.UnaryServerI
 			if ok {
 				u, err := dismantleToken(ctx, tkn, req, tokenManager, conf.GatewayAddr, true)
 				if err == nil {
+					if blockedUsers.IsBlocked(u.Username) {
+						return nil, status.Errorf(codes.PermissionDenied, "user %s blocked", u.Username)
+					}
 					ctx = ctxpkg.ContextSetUser(ctx, u)
 				}
 			}
@@ -118,6 +126,10 @@ func NewUnary(m map[string]interface{}, unprotected []string) (grpc.UnaryServerI
 		if err != nil {
 			log.Warn().Err(err).Msg("access token is invalid")
 			return nil, status.Errorf(codes.PermissionDenied, "auth: core access token is invalid")
+		}
+
+		if blockedUsers.IsBlocked(u.Username) {
+			return nil, status.Errorf(codes.PermissionDenied, "user %s blocked", u.Username)
 		}
 
 		ctx = ctxpkg.ContextSetUser(ctx, u)

--- a/pkg/sharedconf/sharedconf.go
+++ b/pkg/sharedconf/sharedconf.go
@@ -28,10 +28,11 @@ import (
 var sharedConf = &conf{}
 
 type conf struct {
-	JWTSecret             string `mapstructure:"jwt_secret"`
-	GatewaySVC            string `mapstructure:"gatewaysvc"`
-	DataGateway           string `mapstructure:"datagateway"`
-	SkipUserGroupsInToken bool   `mapstructure:"skip_user_groups_in_token"`
+	JWTSecret             string   `mapstructure:"jwt_secret"`
+	GatewaySVC            string   `mapstructure:"gatewaysvc"`
+	DataGateway           string   `mapstructure:"datagateway"`
+	SkipUserGroupsInToken bool     `mapstructure:"skip_user_groups_in_token"`
+	BlockedUsers          []string `mapstructure:"blocked_users"`
 }
 
 // Decode decodes the configuration.
@@ -91,4 +92,8 @@ func GetDataGateway(val string) string {
 // SkipUserGroupsInToken returns whether to skip encoding user groups in the access tokens.
 func SkipUserGroupsInToken() bool {
 	return sharedConf.SkipUserGroupsInToken
+}
+
+func GetBlockedUsers() []string {
+	return sharedConf.BlockedUsers
 }

--- a/pkg/sharedconf/sharedconf.go
+++ b/pkg/sharedconf/sharedconf.go
@@ -94,6 +94,7 @@ func SkipUserGroupsInToken() bool {
 	return sharedConf.SkipUserGroupsInToken
 }
 
+// GetBlockedUsers returns a list of blocked users
 func GetBlockedUsers() []string {
 	return sharedConf.BlockedUsers
 }

--- a/pkg/user/blocked.go
+++ b/pkg/user/blocked.go
@@ -1,0 +1,37 @@
+// Copyright 2018-2022 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package user
+
+// BlockedUsers is a set containing all the blocked users
+type BlockedUsers map[string]struct{}
+
+// NewBlockedUsersSet creates a new set of blocked users from a list
+func NewBlockedUsersSet(users []string) BlockedUsers {
+	s := make(map[string]struct{})
+	for _, u := range users {
+		s[u] = struct{}{}
+	}
+	return s
+}
+
+// IsBlocked returns true if the user is blocked
+func (b BlockedUsers) IsBlocked(user string) bool {
+	_, ok := b[user]
+	return ok
+}


### PR DESCRIPTION
This PR allows an operator to set a list of users (username) that are banned for every operation in reva.
This requires that every service is restarted to get the new list if a user is added!

Example:
Given the storage-references example.
Add in gateway.toml:
```
[shared]
blocked_users = ["einstein"]
```

```
$ cmd/reva/reva -host localhost:19000 -insecure
reva-cli v1.19.0-124-ga4ffa8aa (rev-a4ffa8aa)
Please use `exit` or `Ctrl-D` to exit this program.
>> login basic
username: einstein
password: error: code=CODE_PERMISSION_DENIED msg="user is blocked" support_trace="ac860997b02743ef52b9d5bdab4311d0"
```

Even with a valid token:
```
>> whoami
rpc error: code = PermissionDenied desc = user einstein blocked
```