### PR TITLE
[tests-only] Max acquire lock cycles

### DIFF
--- a/pkg/storage/utils/decomposedfs/decomposedfs.go
+++ b/pkg/storage/utils/decomposedfs/decomposedfs.go
@@ -56,6 +56,7 @@ import (
 	"github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/tree"
 	"github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/upload"
 	"github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/xattrs"
+	"github.com/cs3org/reva/v2/pkg/storage/utils/filelocks"
 	"github.com/cs3org/reva/v2/pkg/storage/utils/templates"
 	"github.com/cs3org/reva/v2/pkg/storagespace"
 	"github.com/cs3org/reva/v2/pkg/utils"
@@ -143,6 +144,11 @@ func New(o *options.Options, lu *lookup.Lookup, p PermissionsChecker, tp Tree, p
 	if err != nil {
 		log.Error().Err(err).Msg("could not setup tree")
 		return nil, errors.Wrap(err, "could not setup tree")
+	}
+
+	// Fixme: temporary workaround to make MaxAcquireLockCycles configurable.
+	if o.MaxAcquireLockCycles != 0 {
+		filelocks.MaxAcquireLockCycles = o.MaxAcquireLockCycles
 	}
 
 	var ev events.Stream

--- a/pkg/storage/utils/decomposedfs/options/options.go
+++ b/pkg/storage/utils/decomposedfs/options/options.go
@@ -59,6 +59,8 @@ type Options struct {
 	Tokens TokenOptions `mapstructure:"tokens"`
 
 	StatCache CacheOptions `mapstructure:"statcache"`
+
+	MaxAcquireLockCycles int `mapstructure:"max_acquire_lock_cycles"`
 }
 
 // EventOptions are the configurable options for events

--- a/pkg/storage/utils/filelocks/filelocks.go
+++ b/pkg/storage/utils/filelocks/filelocks.go
@@ -28,7 +28,11 @@ import (
 	"github.com/gofrs/flock"
 )
 
-var _localLocks sync.Map
+var (
+	_localLocks sync.Map
+	// MaxAcquireLockCycles defines how often the system tries to acquire a lock before failing.
+	MaxAcquireLockCycles = 25
+)
 
 // getMutexedFlock returns a new Flock struct for the given file.
 // If there is already one in the local store, it returns nil.
@@ -70,7 +74,7 @@ func acquireLock(file string, write bool) (*flock.Flock, error) {
 	}
 
 	var flock *flock.Flock
-	for i := 1; i <= 10; i++ {
+	for i := 1; i <= MaxAcquireLockCycles; i++ {
 		if flock = getMutexedFlock(n); flock != nil {
 			break
 		}


### PR DESCRIPTION
When acquiring a file lock the code tries to wait for a certain amount of time before it fails. In Some cases the fixed waiting time can be too short.

For example when uploading a whole bunch of files into the same folder, the etag propagation updates the destination folder many times which fails in some cases.

slightly changed version of https://github.com/cs3org/reva/pull/3423