### PR TITLE
add missing error check in decomposedfs

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -313,16 +313,6 @@ def coverage():
                     "make test",
                 ],
             },
-            {
-                "name": "codacy",
-                "image": "plugins/codacy:1",
-                "pull": "always",
-                "settings": {
-                    "token": {
-                        "from_secret": "codacy_token",
-                    },
-                },
-            },
         ],
         "depends_on": ["changelog"],
     }

--- a/changelog/unreleased/decomposedfs-check-error.md
+++ b/changelog/unreleased/decomposedfs-check-error.md
@@ -1,0 +1,6 @@
+Bugfix: add missing error check in decomposedfs
+
+During space creation the decomposedfs now checks for errors when trying to read the root node. This prevents a panic by no longer calling InternalPath on the node.
+
+https://github.com/cs3org/reva/pull/3430
+https://github.com/owncloud/ocis/issues/4961

--- a/pkg/storage/utils/decomposedfs/spaces.go
+++ b/pkg/storage/utils/decomposedfs/spaces.go
@@ -83,11 +83,12 @@ func (fs *Decomposedfs) CreateStorageSpace(ctx context.Context, req *provider.Cr
 	}
 
 	root, err := node.ReadNode(ctx, fs.lu, spaceID, spaceID, true) // will fall into `Exists` case below
-	if err == nil && root.Exists {
+	switch {
+	case err != nil:
+		return nil, err
+	case root.Exists:
 		return nil, errtypes.AlreadyExists("decomposedfs: spaces: space already exists")
-	}
-
-	if !fs.canCreateSpace(ctx, spaceID) {
+	case !fs.canCreateSpace(ctx, spaceID):
 		return nil, errtypes.PermissionDenied(spaceID)
 	}
 


### PR DESCRIPTION
During space creation the decomposedfs now checks for errors when trying to read the root node. This prevents a panic by no longer calling InternalPath on the node.

Seen in the stacktrace of https://github.com/owncloud/ocis/issues/4961