### PR TITLE
[tests-only] increase max lock cycles in tests

### DIFF
--- a/pkg/storage/utils/filelocks/filelocks.go
+++ b/pkg/storage/utils/filelocks/filelocks.go
@@ -86,7 +86,7 @@ func acquireLock(file string, write bool) (*flock.Flock, error) {
 	}
 
 	var flock *flock.Flock
-	for i := 1; i <= 10; i++ {
+	for i := 1; i <= _lockCyclesValue; i++ {
 		if flock = getMutexedFlock(n); flock != nil {
 			break
 		}

--- a/pkg/storage/utils/filelocks/filelocks_test.go
+++ b/pkg/storage/utils/filelocks/filelocks_test.go
@@ -31,20 +31,25 @@ func TestAcquireWriteLock(t *testing.T) {
 	file, fin, _ := filelocks.FileFactory()
 	defer fin()
 
+	filelocks.SetMaxLockCycles(90)
+
 	var wg sync.WaitGroup
 	for i := 0; i < 10; i++ {
 		wg.Add(1)
 		go func() {
+			defer wg.Done()
+
 			l, err := filelocks.AcquireWriteLock(file)
 			assert.Nil(t, err)
 			require.NotNil(t, l)
+
+			defer func() {
+				err = filelocks.ReleaseLock(l)
+				assert.Nil(t, err)
+			}()
+
 			assert.Equal(t, true, l.Locked())
 			assert.Equal(t, false, l.RLocked())
-
-			err = filelocks.ReleaseLock(l)
-			assert.Nil(t, err)
-
-			wg.Done()
 		}()
 	}
 
@@ -55,20 +60,26 @@ func TestAcquireReadLock(t *testing.T) {
 	file, fin, _ := filelocks.FileFactory()
 	defer fin()
 
+	filelocks.SetMaxLockCycles(90)
+
 	var wg sync.WaitGroup
 	for i := 0; i < 10; i++ {
 		wg.Add(1)
 		go func() {
+			defer wg.Done()
+
 			l, err := filelocks.AcquireReadLock(file)
 			assert.Nil(t, err)
 			require.NotNil(t, l)
+
+			defer func() {
+				err = filelocks.ReleaseLock(l)
+				assert.Nil(t, err)
+			}()
+
 			assert.Equal(t, false, l.Locked())
 			assert.Equal(t, true, l.RLocked())
 
-			err = filelocks.ReleaseLock(l)
-			assert.Nil(t, err)
-
-			wg.Done()
 		}()
 	}
 


### PR DESCRIPTION
we've introduced flaky tests in https://github.com/cs3org/reva/pull/3429, see https://github.com/cs3org/reva/pull/3431#issuecomment-1302725305 for more detail.

This PR increases the value and fixes the issue.