### PR TITLE
Sanitize xattr values in eos

### DIFF
--- a/changelog/unreleased/sanitize-eos-xattr-values.md
+++ b/changelog/unreleased/sanitize-eos-xattr-values.md
@@ -1,0 +1,3 @@
+Enhancement: Sanitize non-utf8 characters in xattr values in EOS
+
+https://github.com/cs3org/reva/pull/3438

--- a/pkg/eosclient/eosbinary/eosbinary.go
+++ b/pkg/eosclient/eosbinary/eosbinary.go
@@ -1074,7 +1074,7 @@ func (c *Client) parseFileInfo(ctx context.Context, raw string, parseFavoriteKey
 					previousXAttr = strings.Replace(previousXAttr, "user.", "", 1)
 				}
 			case partsByEqual[0] == "xattrv":
-				attrs[previousXAttr] = partsByEqual[1]
+				attrs[previousXAttr] = strings.ToValidUTF8(partsByEqual[1], "")
 				previousXAttr = ""
 			default:
 				kv[partsByEqual[0]] = partsByEqual[1]


### PR DESCRIPTION
Sanitize values in EOS xattrs that can contains non-utf8 characters that make the marshaling of the grpc response of List folder crashing