### PR TITLE
simplify gateway client usage

### DIFF
--- a/changelog/unreleased/dav-unit-tests.md
+++ b/changelog/unreleased/dav-unit-tests.md
@@ -4,3 +4,4 @@ We added unit tests to cover more ocdav handlers:
 -   delete
 
 https://github.com/cs3org/reva/pull/3441
+https://github.com/cs3org/reva/pull/3443

--- a/internal/http/services/owncloud/ocdav/delete.go
+++ b/internal/http/services/owncloud/ocdav/delete.go
@@ -40,13 +40,7 @@ func (s *svc) handlePathDelete(w http.ResponseWriter, r *http.Request, ns string
 
 	fn := path.Join(ns, r.URL.Path)
 
-	client, err := s.getClient()
-	if err != nil {
-		span.RecordError(err)
-		return http.StatusInternalServerError, err
-	}
-
-	space, rpcStatus, err := spacelookup.LookUpStorageSpaceForPath(ctx, client, fn)
+	space, rpcStatus, err := spacelookup.LookUpStorageSpaceForPath(ctx, s.gwClient, fn)
 	switch {
 	case err != nil:
 		span.RecordError(err)
@@ -74,13 +68,7 @@ func (s *svc) handleDelete(ctx context.Context, w http.ResponseWriter, r *http.R
 		return http.StatusBadRequest, errtypes.BadRequest("invalid if header")
 	}
 
-	client, err := s.getClient()
-	if err != nil {
-		span.RecordError(err)
-		return http.StatusInternalServerError, err
-	}
-
-	res, err := client.Delete(ctx, req)
+	res, err := s.gwClient.Delete(ctx, req)
 	switch {
 	case err != nil:
 		span.RecordError(err)
@@ -98,7 +86,7 @@ func (s *svc) handleDelete(ctx context.Context, w http.ResponseWriter, r *http.R
 			status = http.StatusLocked
 		}
 		// check if user has access to resource
-		sRes, err := client.Stat(ctx, &provider.StatRequest{Ref: ref})
+		sRes, err := s.gwClient.Stat(ctx, &provider.StatRequest{Ref: ref})
 		if err != nil {
 			span.RecordError(err)
 			return http.StatusInternalServerError, err

--- a/internal/http/services/owncloud/ocdav/head.go
+++ b/internal/http/services/owncloud/ocdav/head.go
@@ -47,14 +47,8 @@ func (s *svc) handlePathHead(w http.ResponseWriter, r *http.Request, ns string) 
 	fn := path.Join(ns, r.URL.Path)
 
 	sublog := appctx.GetLogger(ctx).With().Str("path", fn).Logger()
-	client, err := s.getClient()
-	if err != nil {
-		sublog.Error().Err(err).Msg("error getting grpc client")
-		w.WriteHeader(http.StatusInternalServerError)
-		return
-	}
 
-	space, status, err := spacelookup.LookUpStorageSpaceForPath(ctx, client, fn)
+	space, status, err := spacelookup.LookUpStorageSpaceForPath(ctx, s.gwClient, fn)
 	if err != nil {
 		sublog.Error().Err(err).Str("path", fn).Msg("failed to look up storage space")
 		w.WriteHeader(http.StatusInternalServerError)
@@ -69,15 +63,9 @@ func (s *svc) handlePathHead(w http.ResponseWriter, r *http.Request, ns string) 
 }
 
 func (s *svc) handleHead(ctx context.Context, w http.ResponseWriter, r *http.Request, ref *provider.Reference, log zerolog.Logger) {
-	client, err := s.getClient()
-	if err != nil {
-		log.Error().Err(err).Msg("error getting grpc client")
-		w.WriteHeader(http.StatusInternalServerError)
-		return
-	}
 
 	req := &provider.StatRequest{Ref: ref}
-	res, err := client.Stat(ctx, req)
+	res, err := s.gwClient.Stat(ctx, req)
 	if err != nil {
 		log.Error().Err(err).Msg("error sending grpc stat request")
 		w.WriteHeader(http.StatusInternalServerError)

--- a/internal/http/services/owncloud/ocdav/locks.go
+++ b/internal/http/services/owncloud/ocdav/locks.go
@@ -387,13 +387,8 @@ func (s *svc) handleLock(w http.ResponseWriter, r *http.Request, ns string) (ret
 
 	fn := path.Join(ns, r.URL.Path) // TODO do we still need to jail if we query the registry about the spaces?
 
-	client, err := s.getClient()
-	if err != nil {
-		return http.StatusInternalServerError, err
-	}
-
 	// TODO instead of using a string namespace ns pass in the space with the request?
-	ref, cs3Status, err := spacelookup.LookupReferenceForPath(ctx, client, fn)
+	ref, cs3Status, err := spacelookup.LookupReferenceForPath(ctx, s.gwClient, fn)
 	if err != nil {
 		return http.StatusInternalServerError, err
 	}
@@ -570,13 +565,8 @@ func (s *svc) handleUnlock(w http.ResponseWriter, r *http.Request, ns string) (s
 
 	fn := path.Join(ns, r.URL.Path) // TODO do we still need to jail if we query the registry about the spaces?
 
-	client, err := s.getClient()
-	if err != nil {
-		return http.StatusInternalServerError, err
-	}
-
 	// TODO instead of using a string namespace ns pass in the space with the request?
-	ref, cs3Status, err := spacelookup.LookupReferenceForPath(ctx, client, fn)
+	ref, cs3Status, err := spacelookup.LookupReferenceForPath(ctx, s.gwClient, fn)
 	if err != nil {
 		return http.StatusInternalServerError, err
 	}

--- a/internal/http/services/owncloud/ocdav/meta.go
+++ b/internal/http/services/owncloud/ocdav/meta.go
@@ -96,12 +96,6 @@ func (h *MetaHandler) handlePathForUser(w http.ResponseWriter, r *http.Request, 
 	id := storagespace.FormatResourceID(*rid)
 	sublog := appctx.GetLogger(ctx).With().Str("path", r.URL.Path).Str("resourceid", id).Logger()
 	sublog.Info().Msg("calling get path for user")
-	client, err := s.getClient()
-	if err != nil {
-		sublog.Error().Err(err).Msg("error getting grpc client")
-		w.WriteHeader(http.StatusInternalServerError)
-		return
-	}
 
 	pf, status, err := propfind.ReadPropfind(r.Body)
 	if err != nil {
@@ -117,7 +111,7 @@ func (h *MetaHandler) handlePathForUser(w http.ResponseWriter, r *http.Request, 
 	}
 
 	pathReq := &provider.GetPathRequest{ResourceId: rid}
-	pathRes, err := client.GetPath(ctx, pathReq)
+	pathRes, err := s.gwClient.GetPath(ctx, pathReq)
 	if err != nil {
 		sublog.Error().Err(err).Msg("could not send GetPath grpc request: transport error")
 		w.WriteHeader(http.StatusInternalServerError)

--- a/internal/http/services/owncloud/ocdav/put.go
+++ b/internal/http/services/owncloud/ocdav/put.go
@@ -111,13 +111,7 @@ func (s *svc) handlePathPut(w http.ResponseWriter, r *http.Request, ns string) {
 	fn := path.Join(ns, r.URL.Path)
 
 	sublog := appctx.GetLogger(ctx).With().Str("path", fn).Logger()
-	client, err := s.getClient()
-	if err != nil {
-		sublog.Error().Err(err).Msg("error getting grpc client")
-		w.WriteHeader(http.StatusInternalServerError)
-		return
-	}
-	space, status, err := spacelookup.LookUpStorageSpaceForPath(ctx, client, fn)
+	space, status, err := spacelookup.LookUpStorageSpaceForPath(ctx, s.gwClient, fn)
 	if err != nil {
 		sublog.Error().Err(err).Str("path", fn).Msg("failed to look up storage space")
 		w.WriteHeader(http.StatusInternalServerError)
@@ -140,13 +134,6 @@ func (s *svc) handlePut(ctx context.Context, w http.ResponseWriter, r *http.Requ
 	length, err := getContentLength(w, r)
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
-		return
-	}
-
-	client, err := s.getClient()
-	if err != nil {
-		log.Error().Err(err).Msg("error getting grpc client")
-		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 
@@ -206,7 +193,7 @@ func (s *svc) handlePut(ctx context.Context, w http.ResponseWriter, r *http.Requ
 	}
 
 	// where to upload the file?
-	uRes, err := client.InitiateFileUpload(ctx, uReq)
+	uRes, err := s.gwClient.InitiateFileUpload(ctx, uReq)
 	if err != nil {
 		log.Error().Err(err).Msg("error initiating file upload")
 		w.WriteHeader(http.StatusInternalServerError)
@@ -219,7 +206,7 @@ func (s *svc) handlePut(ctx context.Context, w http.ResponseWriter, r *http.Requ
 			status := http.StatusForbidden
 			m := uRes.Status.Message
 			// check if user has access to parent
-			sRes, err := client.Stat(ctx, &provider.StatRequest{Ref: &provider.Reference{
+			sRes, err := s.gwClient.Stat(ctx, &provider.StatRequest{Ref: &provider.Reference{
 				ResourceId: ref.ResourceId,
 				Path:       utils.MakeRelativePath(path.Dir(ref.Path)),
 			}})

--- a/internal/http/services/owncloud/ocdav/report.go
+++ b/internal/http/services/owncloud/ocdav/report.go
@@ -64,14 +64,6 @@ func (s *svc) handleReport(w http.ResponseWriter, r *http.Request, ns string) {
 }
 
 func (s *svc) doSearchFiles(w http.ResponseWriter, r *http.Request, sf *reportSearchFiles) {
-	ctx := r.Context()
-	log := appctx.GetLogger(ctx)
-	_, err := s.getClient()
-	if err != nil {
-		log.Error().Err(err).Msg("error getting grpc client")
-		w.WriteHeader(http.StatusInternalServerError)
-		return
-	}
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -89,16 +81,9 @@ func (s *svc) doFilterFiles(w http.ResponseWriter, r *http.Request, ff *reportFi
 			return
 		}
 
-		client, err := s.getClient()
-		if err != nil {
-			log.Error().Err(err).Msg("error getting gateway client")
-			w.WriteHeader(http.StatusInternalServerError)
-			return
-		}
-
 		infos := make([]*provider.ResourceInfo, 0, len(favorites))
 		for i := range favorites {
-			statRes, err := client.Stat(ctx, &providerv1beta1.StatRequest{Ref: &providerv1beta1.Reference{ResourceId: favorites[i]}})
+			statRes, err := s.gwClient.Stat(ctx, &providerv1beta1.StatRequest{Ref: &providerv1beta1.Reference{ResourceId: favorites[i]}})
 			if err != nil {
 				log.Error().Err(err).Msg("error getting resource info")
 				continue

--- a/internal/http/services/owncloud/ocdav/tpc.go
+++ b/internal/http/services/owncloud/ocdav/tpc.go
@@ -134,18 +134,10 @@ func (s *svc) handleTPCPull(ctx context.Context, w http.ResponseWriter, r *http.
 	}
 	sublog.Debug().Bool("overwrite", overwrite).Msg("TPC Pull")
 
-	// get Gateway client
-	client, err := s.getClient()
-	if err != nil {
-		sublog.Error().Err(err).Msg("error getting grpc client")
-		w.WriteHeader(http.StatusInternalServerError)
-		return
-	}
-
 	// check if destination exists
 	ref := &provider.Reference{Path: dst}
 	dstStatReq := &provider.StatRequest{Ref: ref}
-	dstStatRes, err := client.Stat(ctx, dstStatReq)
+	dstStatRes, err := s.gwClient.Stat(ctx, dstStatReq)
 	if err != nil {
 		sublog.Error().Err(err).Msg("error sending grpc stat request")
 		w.WriteHeader(http.StatusInternalServerError)
@@ -161,7 +153,7 @@ func (s *svc) handleTPCPull(ctx context.Context, w http.ResponseWriter, r *http.
 		return
 	}
 
-	err = s.performHTTPPull(ctx, client, r, w, ns)
+	err = s.performHTTPPull(ctx, s.gwClient, r, w, ns)
 	if err != nil {
 		sublog.Error().Err(err).Msg("error performing TPC Pull")
 		return
@@ -295,17 +287,9 @@ func (s *svc) handleTPCPush(ctx context.Context, w http.ResponseWriter, r *http.
 
 	sublog.Debug().Bool("overwrite", overwrite).Msg("TPC Push")
 
-	// get Gateway client
-	client, err := s.getClient()
-	if err != nil {
-		sublog.Error().Err(err).Msg("error getting grpc client")
-		w.WriteHeader(http.StatusInternalServerError)
-		return
-	}
-
 	ref := &provider.Reference{Path: src}
 	srcStatReq := &provider.StatRequest{Ref: ref}
-	srcStatRes, err := client.Stat(ctx, srcStatReq)
+	srcStatRes, err := s.gwClient.Stat(ctx, srcStatReq)
 	if err != nil {
 		sublog.Error().Err(err).Msg("error sending grpc stat request")
 		w.WriteHeader(http.StatusInternalServerError)
@@ -321,7 +305,7 @@ func (s *svc) handleTPCPush(ctx context.Context, w http.ResponseWriter, r *http.
 		return
 	}
 
-	err = s.performHTTPPush(ctx, client, r, w, srcStatRes.Info, ns)
+	err = s.performHTTPPush(ctx, s.gwClient, r, w, srcStatRes.Info, ns)
 	if err != nil {
 		sublog.Error().Err(err).Msg("error performing TPC Push")
 		return

--- a/internal/http/services/owncloud/ocdav/tus.go
+++ b/internal/http/services/owncloud/ocdav/tus.go
@@ -117,18 +117,10 @@ func (s *svc) handleTusPost(ctx context.Context, w http.ResponseWriter, r *http.
 
 	// TODO check Expect: 100-continue
 
-	// check if destination exists or is a file
-	client, err := s.getClient()
-	if err != nil {
-		log.Error().Err(err).Msg("error getting grpc client")
-		w.WriteHeader(http.StatusInternalServerError)
-		return
-	}
-
 	sReq := &provider.StatRequest{
 		Ref: ref,
 	}
-	sRes, err := client.Stat(ctx, sReq)
+	sRes, err := s.gwClient.Stat(ctx, sReq)
 	if err != nil {
 		log.Error().Err(err).Msg("error sending grpc stat request")
 		w.WriteHeader(http.StatusInternalServerError)
@@ -166,7 +158,7 @@ func (s *svc) handleTusPost(ctx context.Context, w http.ResponseWriter, r *http.
 		return
 	}
 	if uploadLength == 0 {
-		tfRes, err := client.TouchFile(ctx, &provider.TouchFileRequest{
+		tfRes, err := s.gwClient.TouchFile(ctx, &provider.TouchFileRequest{
 			Ref: ref,
 		})
 		if err != nil {
@@ -204,7 +196,7 @@ func (s *svc) handleTusPost(ctx context.Context, w http.ResponseWriter, r *http.
 		},
 	}
 
-	uRes, err := client.InitiateFileUpload(ctx, uReq)
+	uRes, err := s.gwClient.InitiateFileUpload(ctx, uReq)
 	if err != nil {
 		log.Error().Err(err).Msg("error initiating file upload")
 		w.WriteHeader(http.StatusInternalServerError)
@@ -285,7 +277,7 @@ func (s *svc) handleTusPost(ctx context.Context, w http.ResponseWriter, r *http.
 		if length == 0 || httpRes.Header.Get(net.HeaderUploadOffset) == r.Header.Get(net.HeaderUploadLength) {
 			// get uploaded file metadata
 
-			sRes, err := client.Stat(ctx, sReq)
+			sRes, err := s.gwClient.Stat(ctx, sReq)
 			if err != nil {
 				log.Error().Err(err).Msg("error sending grpc stat request")
 				w.WriteHeader(http.StatusInternalServerError)

--- a/internal/http/services/owncloud/ocdav/versions.go
+++ b/internal/http/services/owncloud/ocdav/versions.go
@@ -122,15 +122,8 @@ func (h *VersionsHandler) doListVersions(w http.ResponseWriter, r *http.Request,
 		return
 	}
 
-	client, err := s.getClient()
-	if err != nil {
-		sublog.Error().Err(err).Msg("error getting grpc client")
-		w.WriteHeader(http.StatusInternalServerError)
-		return
-	}
-
 	ref := &provider.Reference{ResourceId: rid}
-	res, err := client.Stat(ctx, &provider.StatRequest{Ref: ref})
+	res, err := s.gwClient.Stat(ctx, &provider.StatRequest{Ref: ref})
 	if err != nil {
 		sublog.Error().Err(err).Msg("error sending a grpc stat request")
 		w.WriteHeader(http.StatusInternalServerError)
@@ -149,7 +142,7 @@ func (h *VersionsHandler) doListVersions(w http.ResponseWriter, r *http.Request,
 
 	info := res.Info
 
-	lvRes, err := client.ListFileVersions(ctx, &provider.ListFileVersionsRequest{Ref: ref})
+	lvRes, err := s.gwClient.ListFileVersions(ctx, &provider.ListFileVersionsRequest{Ref: ref})
 	if err != nil {
 		sublog.Error().Err(err).Msg("error sending list container grpc request")
 		w.WriteHeader(http.StatusInternalServerError)
@@ -221,19 +214,12 @@ func (h *VersionsHandler) doRestore(w http.ResponseWriter, r *http.Request, s *s
 
 	sublog := appctx.GetLogger(ctx).With().Interface("resourceid", rid).Str("key", key).Logger()
 
-	client, err := s.getClient()
-	if err != nil {
-		sublog.Error().Err(err).Msg("error getting grpc client")
-		w.WriteHeader(http.StatusInternalServerError)
-		return
-	}
-
 	req := &provider.RestoreFileVersionRequest{
 		Ref: &provider.Reference{ResourceId: rid},
 		Key: key,
 	}
 
-	res, err := client.RestoreFileVersion(ctx, req)
+	res, err := s.gwClient.RestoreFileVersion(ctx, req)
 	if err != nil {
 		sublog.Error().Err(err).Msg("error sending a grpc restore version request")
 		w.WriteHeader(http.StatusInternalServerError)


### PR DESCRIPTION
Since ocdav only fetches a gateway client once on startup we no longer need to check the error case whenever we call getClient() and can actually use the client of the service. Deleting all these unused error checks brings ocdav coverage from 9.8% to 10.1%

part of https://github.com/owncloud/ocis/issues/5022