### PR TITLE
add ocdav delete error case unit tests

### DIFF
--- a/changelog/unreleased/dav-unit-tests.md
+++ b/changelog/unreleased/dav-unit-tests.md
@@ -5,3 +5,4 @@ We added unit tests to cover more ocdav handlers:
 
 https://github.com/cs3org/reva/pull/3441
 https://github.com/cs3org/reva/pull/3443
+https://github.com/cs3org/reva/pull/3445

--- a/internal/http/services/owncloud/ocdav/delete.go
+++ b/internal/http/services/owncloud/ocdav/delete.go
@@ -76,7 +76,8 @@ func (s *svc) handleDelete(ctx context.Context, w http.ResponseWriter, r *http.R
 	case res.Status.Code == rpc.Code_CODE_OK:
 		return http.StatusNoContent, nil
 	case res.Status.Code == rpc.Code_CODE_NOT_FOUND:
-		return http.StatusNotFound, errtypes.NotFound("Resource not found") // mimic the oc10 error message
+		//lint:ignore ST1005 mimic the exact oc10 error message
+		return http.StatusNotFound, fmt.Errorf("Resource not found")
 	case res.Status.Code == rpc.Code_CODE_PERMISSION_DENIED:
 		status = http.StatusForbidden
 		if lockID := utils.ReadPlainFromOpaque(res.Opaque, "lockid"); lockID != "" {
@@ -95,10 +96,10 @@ func (s *svc) handleDelete(ctx context.Context, w http.ResponseWriter, r *http.R
 			// return not found error so we do not leak existence of a file
 			// TODO hide permission failed for users without access in every kind of request
 			// TODO should this be done in the driver?
-			return http.StatusNotFound, errtypes.NotFound("Resource not found") // mimic the oc10 error message
+			//lint:ignore ST1005 mimic the exact oc10 error message
+			return http.StatusNotFound, fmt.Errorf("Resource not found")
 		}
-		// TODO path might be empty or relative...
-		return status, fmt.Errorf("permission denied to delete %v", ref.Path)
+		return status, fmt.Errorf("") // mimic the oc10 error messages which have an empty message in this case
 	case res.Status.Code == rpc.Code_CODE_INTERNAL && res.Status.Message == "can't delete mount path":
 		// 405 must generate an Allow header
 		w.Header().Set("Allow", "PROPFIND, MOVE, COPY, POST, PROPPATCH, HEAD, GET, OPTIONS, LOCK, UNLOCK, REPORT, SEARCH, PUT")
@@ -121,7 +122,7 @@ func (s *svc) handleSpacesDelete(w http.ResponseWriter, r *http.Request, spaceID
 	// we get a relative reference coming from the space root
 	// so if the path is "empty" we a referencing the space
 	if ref.GetPath() == "." {
-		return http.StatusForbidden, errtypes.PermissionDenied("deleting spaces via dav is not allowed")
+		return http.StatusMethodNotAllowed, fmt.Errorf("deleting spaces via dav is not allowed")
 	}
 
 	return s.handleDelete(ctx, w, r, &ref)

--- a/internal/http/services/owncloud/ocdav/delete.go
+++ b/internal/http/services/owncloud/ocdav/delete.go
@@ -20,7 +20,7 @@ package ocdav
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"net/http"
 	"path"
 
@@ -77,7 +77,7 @@ func (s *svc) handleDelete(ctx context.Context, w http.ResponseWriter, r *http.R
 		return http.StatusNoContent, nil
 	case res.Status.Code == rpc.Code_CODE_NOT_FOUND:
 		//lint:ignore ST1005 mimic the exact oc10 error message
-		return http.StatusNotFound, fmt.Errorf("Resource not found")
+		return http.StatusNotFound, errors.New("Resource not found")
 	case res.Status.Code == rpc.Code_CODE_PERMISSION_DENIED:
 		status = http.StatusForbidden
 		if lockID := utils.ReadPlainFromOpaque(res.Opaque, "lockid"); lockID != "" {
@@ -97,9 +97,9 @@ func (s *svc) handleDelete(ctx context.Context, w http.ResponseWriter, r *http.R
 			// TODO hide permission failed for users without access in every kind of request
 			// TODO should this be done in the driver?
 			//lint:ignore ST1005 mimic the exact oc10 error message
-			return http.StatusNotFound, fmt.Errorf("Resource not found")
+			return http.StatusNotFound, errors.New("Resource not found")
 		}
-		return status, fmt.Errorf("") // mimic the oc10 error messages which have an empty message in this case
+		return status, errors.New("") // mimic the oc10 error messages which have an empty message in this case
 	case res.Status.Code == rpc.Code_CODE_INTERNAL && res.Status.Message == "can't delete mount path":
 		// 405 must generate an Allow header
 		w.Header().Set("Allow", "PROPFIND, MOVE, COPY, POST, PROPPATCH, HEAD, GET, OPTIONS, LOCK, UNLOCK, REPORT, SEARCH, PUT")
@@ -122,7 +122,7 @@ func (s *svc) handleSpacesDelete(w http.ResponseWriter, r *http.Request, spaceID
 	// we get a relative reference coming from the space root
 	// so if the path is "empty" we a referencing the space
 	if ref.GetPath() == "." {
-		return http.StatusMethodNotAllowed, fmt.Errorf("deleting spaces via dav is not allowed")
+		return http.StatusMethodNotAllowed, errors.New("deleting spaces via dav is not allowed")
 	}
 
 	return s.handleDelete(ctx, w, r, &ref)

--- a/internal/http/services/owncloud/ocdav/ocdav_blackbox_test.go
+++ b/internal/http/services/owncloud/ocdav/ocdav_blackbox_test.go
@@ -19,6 +19,7 @@ package ocdav_test
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -125,7 +126,131 @@ var _ = Describe("ocdav", func() {
 		})
 	})
 
-	Context("When a default space is used", func() {
+	// listing spaces is a precondition for path based requests, what if listing spaces currently is broken?
+	Context("bad requests", func() {
+
+		It("to the /dav/spaces endpoint root return a method not allowed status ", func() {
+			rr := httptest.NewRecorder()
+			req, err := http.NewRequest("DELETE", "/dav/spaces", strings.NewReader(""))
+			Expect(err).ToNot(HaveOccurred())
+			req = req.WithContext(ctx)
+
+			handler.Handler().ServeHTTP(rr, req)
+			Expect(rr).To(HaveHTTPStatus(http.StatusMethodNotAllowed))
+		})
+		It("when deleting a space at the /dav/spaces endpoint return method not allowed status", func() {
+			rr := httptest.NewRecorder()
+			req, err := http.NewRequest("DELETE", "/dav/spaces/trytodeleteme", strings.NewReader(""))
+			Expect(err).ToNot(HaveOccurred())
+			req = req.WithContext(ctx)
+
+			handler.Handler().ServeHTTP(rr, req)
+			Expect(rr).To(HaveHTTPStatus(http.StatusMethodNotAllowed))
+			Expect(rr).To(HaveHTTPBody("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<d:error xmlns:d=\"DAV\" xmlns:s=\"http://sabredav.org/ns\"><s:exception>Sabre\\DAV\\Exception\\MethodNotAllowed</s:exception><s:message>deleting spaces via dav is not allowed</s:message></d:error>"), "Body must have a sabredav exception")
+		})
+		It("with invalid if header return bad request status", func() {
+			rr := httptest.NewRecorder()
+			req, err := http.NewRequest("DELETE", "/dav/spaces/somespace/foo", strings.NewReader(""))
+			req.Header.Set("If", "invalid")
+			Expect(err).ToNot(HaveOccurred())
+			req = req.WithContext(ctx)
+
+			handler.Handler().ServeHTTP(rr, req)
+			Expect(rr).To(HaveHTTPStatus(http.StatusBadRequest))
+		})
+
+	})
+
+	// listing spaces is a precondition for path based requests, what if listing spaces currently is broken?
+	Context("When listing spaces fails with an error", func() {
+
+		DescribeTable("HandleDelete",
+			func(endpoint string, expectedPathPrefix string, expectedStatus int, expectBody bool) {
+
+				client.On("ListStorageSpaces", mock.Anything, mock.MatchedBy(func(req *cs3storageprovider.ListStorageSpacesRequest) bool {
+					p := string(req.Opaque.Map["path"].Value)
+					return p == "/" || strings.HasPrefix(p, expectedPathPrefix)
+				})).Return(nil, fmt.Errorf("unexpected io error"))
+
+				// the spaces endpoint omits the list storage spaces call, it directly executes the delete call
+				client.On("Delete", mock.Anything, mock.MatchedBy(func(req *cs3storageprovider.DeleteRequest) bool {
+					return utils.ResourceEqual(req.Ref, &cs3storageprovider.Reference{
+						ResourceId: userspace.Root,
+						Path:       "./foo",
+					})
+				})).Return(&cs3storageprovider.DeleteResponse{
+					Status: status.NewOK(ctx),
+				}, nil)
+
+				rr := httptest.NewRecorder()
+				req, err := http.NewRequest("DELETE", endpoint+"/foo", strings.NewReader(""))
+				Expect(err).ToNot(HaveOccurred())
+				req = req.WithContext(ctx)
+
+				handler.Handler().ServeHTTP(rr, req)
+				Expect(rr).To(HaveHTTPStatus(expectedStatus))
+				if expectBody {
+					Expect(rr).To(HaveHTTPBody("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<d:error xmlns:d=\"DAV\" xmlns:s=\"http://sabredav.org/ns\"><s:exception></s:exception><s:message>unexpected io error</s:message></d:error>"), "Body must have a sabredav exception")
+				} else {
+					Expect(rr).To(HaveHTTPBody(""), "Body must be empty")
+				}
+
+			},
+			Entry("at the /webdav endpoint", "/webdav", "/users", http.StatusInternalServerError, true),
+			Entry("at the /dav/files endpoint", "/dav/files/username", "/users/username", http.StatusInternalServerError, true),
+			Entry("at the /dav/spaces endpoint", "/dav/spaces/provider-1$userspace!root", "/users/username", http.StatusNoContent, false),
+			Entry("at the /dav/public-files endpoint for a file", "/dav/public-files/tokenforfile", "", http.StatusMethodNotAllowed, false),
+			Entry("at the /dav/public-files endpoint for a folder", "/dav/public-files/tokenforfolder", "/public/tokenforfolder", http.StatusInternalServerError, true),
+		)
+
+	})
+
+	Context("When calls fail with an error", func() {
+
+		DescribeTable("HandleDelete",
+			func(endpoint string, expectedPathPrefix string, expectedPath string, expectedStatus int, expectBody bool) {
+
+				client.On("ListStorageSpaces", mock.Anything, mock.MatchedBy(func(req *cs3storageprovider.ListStorageSpacesRequest) bool {
+					p := string(req.Opaque.Map["path"].Value)
+					return p == "/" || strings.HasPrefix(p, expectedPathPrefix)
+				})).Return(&cs3storageprovider.ListStorageSpacesResponse{
+					Status:        status.NewOK(ctx),
+					StorageSpaces: []*cs3storageprovider.StorageSpace{userspace},
+				}, nil)
+
+				ref := cs3storageprovider.Reference{
+					ResourceId: userspace.Root,
+					Path:       expectedPath,
+				}
+
+				client.On("Delete", mock.Anything, mock.MatchedBy(func(req *cs3storageprovider.DeleteRequest) bool {
+					return utils.ResourceEqual(req.Ref, &ref)
+				})).Return(nil, fmt.Errorf("unexpected io error"))
+
+				rr := httptest.NewRecorder()
+				req, err := http.NewRequest("DELETE", endpoint+"/foo", strings.NewReader(""))
+				Expect(err).ToNot(HaveOccurred())
+				req = req.WithContext(ctx)
+
+				handler.Handler().ServeHTTP(rr, req)
+				Expect(rr).To(HaveHTTPStatus(expectedStatus))
+				if expectBody {
+					Expect(rr).To(HaveHTTPBody("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<d:error xmlns:d=\"DAV\" xmlns:s=\"http://sabredav.org/ns\"><s:exception></s:exception><s:message>unexpected io error</s:message></d:error>"), "Body must have a sabredav exception")
+				} else {
+					Expect(rr).To(HaveHTTPBody(""), "Body must be empty")
+				}
+
+			},
+			Entry("at the /webdav endpoint", "/webdav", "/users", "./foo", http.StatusInternalServerError, true),
+			Entry("at the /dav/files endpoint", "/dav/files/username", "/users/username", "./foo", http.StatusInternalServerError, true),
+			Entry("at the /dav/spaces endpoint", "/dav/spaces/provider-1$userspace!root", "/users/username", "./foo", http.StatusInternalServerError, true),
+			Entry("at the /dav/public-files endpoint for a file", "/dav/public-files/tokenforfile", "", "", http.StatusMethodNotAllowed, false),
+			Entry("at the /dav/public-files endpoint for a folder", "/dav/public-files/tokenforfolder", "/public/tokenforfolder", ".", http.StatusInternalServerError, true),
+		)
+
+	})
+
+	Context("When calls return ok", func() {
 
 		DescribeTable("HandleDelete",
 			func(endpoint string, expectedPathPrefix string, expectedPath string, expectedStatus int) {
@@ -165,5 +290,205 @@ var _ = Describe("ocdav", func() {
 			Entry("at the /dav/public-files endpoint for a file", "/dav/public-files/tokenforfile", "", "", http.StatusMethodNotAllowed),
 			Entry("at the /dav/public-files endpoint for a folder", "/dav/public-files/tokenforfolder", "/public/tokenforfolder", ".", http.StatusNoContent),
 		)
+
 	})
+
+	Context("When the resource is not found", func() {
+
+		DescribeTable("HandleDelete",
+			func(endpoint string, expectedPathPrefix string, expectedPath string, expectedStatus int, expectBody bool) {
+
+				client.On("ListStorageSpaces", mock.Anything, mock.MatchedBy(func(req *cs3storageprovider.ListStorageSpacesRequest) bool {
+					p := string(req.Opaque.Map["path"].Value)
+					return p == "/" || strings.HasPrefix(p, expectedPathPrefix)
+				})).Return(&cs3storageprovider.ListStorageSpacesResponse{
+					Status:        status.NewOK(ctx),
+					StorageSpaces: []*cs3storageprovider.StorageSpace{userspace},
+				}, nil)
+
+				ref := cs3storageprovider.Reference{
+					ResourceId: userspace.Root,
+					Path:       expectedPath,
+				}
+
+				client.On("Delete", mock.Anything, mock.MatchedBy(func(req *cs3storageprovider.DeleteRequest) bool {
+					return utils.ResourceEqual(req.Ref, &ref)
+				})).Return(&cs3storageprovider.DeleteResponse{
+					Status: status.NewNotFound(ctx, "not found"),
+				}, nil)
+
+				rr := httptest.NewRecorder()
+				req, err := http.NewRequest("DELETE", endpoint+"/foo", strings.NewReader(""))
+				Expect(err).ToNot(HaveOccurred())
+				req = req.WithContext(ctx)
+
+				handler.Handler().ServeHTTP(rr, req)
+				Expect(rr).To(HaveHTTPStatus(expectedStatus))
+				if expectBody {
+					Expect(rr).To(HaveHTTPBody("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<d:error xmlns:d=\"DAV\" xmlns:s=\"http://sabredav.org/ns\"><s:exception>Sabre\\DAV\\Exception\\NotFound</s:exception><s:message>Resource not found</s:message></d:error>"), "Body must have a not found sabredav exception")
+				} else {
+					Expect(rr).To(HaveHTTPBody(""), "Body must be empty")
+				}
+			},
+			Entry("at the /webdav endpoint", "/webdav", "/users", "./foo", http.StatusNotFound, true),
+			Entry("at the /dav/files endpoint", "/dav/files/username", "/users/username", "./foo", http.StatusNotFound, true),
+			Entry("at the /dav/spaces endpoint", "/dav/spaces/provider-1$userspace!root", "/users/username", "./foo", http.StatusNotFound, true),
+			Entry("at the /dav/public-files endpoint for a file", "/dav/public-files/tokenforfile", "", "", http.StatusMethodNotAllowed, false),
+			Entry("at the /dav/public-files endpoint for a folder", "/dav/public-files/tokenforfolder", "/public/tokenforfolder", ".", http.StatusNotFound, true),
+		)
+
+	})
+
+	Context("When the operation is forbidden", func() {
+
+		DescribeTable("HandleDelete",
+			func(endpoint string, expectedPathPrefix string, expectedPath string, locked, userHasAccess bool, expectedStatus int, expectBody bool) {
+
+				client.On("ListStorageSpaces", mock.Anything, mock.MatchedBy(func(req *cs3storageprovider.ListStorageSpacesRequest) bool {
+					p := string(req.Opaque.Map["path"].Value)
+					return p == "/" || strings.HasPrefix(p, expectedPathPrefix)
+				})).Return(&cs3storageprovider.ListStorageSpacesResponse{
+					Status:        status.NewOK(ctx),
+					StorageSpaces: []*cs3storageprovider.StorageSpace{userspace},
+				}, nil)
+
+				ref := cs3storageprovider.Reference{
+					ResourceId: userspace.Root,
+					Path:       expectedPath,
+				}
+
+				if locked {
+					client.On("Delete", mock.Anything, mock.MatchedBy(func(req *cs3storageprovider.DeleteRequest) bool {
+						return utils.ResourceEqual(req.Ref, &ref)
+					})).Return(&cs3storageprovider.DeleteResponse{
+						Opaque: &typesv1beta1.Opaque{Map: map[string]*typesv1beta1.OpaqueEntry{
+							"lockid": {Decoder: "plain", Value: []byte("somelockid")},
+						}},
+						Status: status.NewPermissionDenied(ctx, fmt.Errorf("permission denied error"), "permission denied message"),
+					}, nil)
+				} else {
+					client.On("Delete", mock.Anything, mock.MatchedBy(func(req *cs3storageprovider.DeleteRequest) bool {
+						return utils.ResourceEqual(req.Ref, &ref)
+					})).Return(&cs3storageprovider.DeleteResponse{
+						Status: status.NewPermissionDenied(ctx, fmt.Errorf("permission denied error"), "permission denied message"),
+					}, nil)
+				}
+
+				// we check if the user has access
+				// TODO make configurable
+				if userHasAccess {
+					client.On("Stat", mock.Anything, mock.MatchedBy(func(req *cs3storageprovider.StatRequest) bool {
+						return utils.ResourceEqual(req.Ref, &ref)
+					})).Return(&cs3storageprovider.StatResponse{
+						Status: status.NewOK(ctx),
+						Info: &cs3storageprovider.ResourceInfo{
+							Type: cs3storageprovider.ResourceType_RESOURCE_TYPE_CONTAINER,
+						},
+					}, nil)
+				} else {
+					client.On("Stat", mock.Anything, mock.MatchedBy(func(req *cs3storageprovider.StatRequest) bool {
+						return utils.ResourceEqual(req.Ref, &ref)
+					})).Return(&cs3storageprovider.StatResponse{
+						Status: status.NewPermissionDenied(ctx, fmt.Errorf("permission denied error"), "permission denied message"),
+					}, nil)
+				}
+
+				rr := httptest.NewRecorder()
+				req, err := http.NewRequest("DELETE", endpoint+"/foo", strings.NewReader(""))
+				Expect(err).ToNot(HaveOccurred())
+				req = req.WithContext(ctx)
+
+				handler.Handler().ServeHTTP(rr, req)
+				Expect(rr).To(HaveHTTPStatus(expectedStatus))
+				if expectBody {
+					if userHasAccess {
+						if locked {
+							Expect(rr).To(HaveHTTPBody("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<d:error xmlns:d=\"DAV\" xmlns:s=\"http://sabredav.org/ns\"><s:exception>Sabre\\DAV\\Exception\\Locked</s:exception><s:message></s:message></d:error>"), "Body must have a locked sabredav exception")
+							Expect(rr).To(HaveHTTPHeaderWithValue("Lock-Token", "<somelockid>"))
+						} else {
+							Expect(rr).To(HaveHTTPBody("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<d:error xmlns:d=\"DAV\" xmlns:s=\"http://sabredav.org/ns\"><s:exception>Sabre\\DAV\\Exception\\Forbidden</s:exception><s:message></s:message></d:error>"), "Body must have a forbidden sabredav exception")
+						}
+					} else {
+						Expect(rr).To(HaveHTTPBody("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<d:error xmlns:d=\"DAV\" xmlns:s=\"http://sabredav.org/ns\"><s:exception>Sabre\\DAV\\Exception\\NotFound</s:exception><s:message>Resource not found</s:message></d:error>"), "Body must have a not found sabredav exception")
+					}
+				} else {
+					Expect(rr).To(HaveHTTPBody(""), "Body must be empty")
+				}
+			},
+
+			// without lock
+
+			// when user has access he should see forbidden status
+			Entry("at the /webdav endpoint", "/webdav", "/users", "./foo", false, true, http.StatusForbidden, true),
+			Entry("at the /dav/files endpoint", "/dav/files/username", "/users/username", "./foo", false, true, http.StatusForbidden, true),
+			Entry("at the /dav/spaces endpoint", "/dav/spaces/provider-1$userspace!root", "/users/username", "./foo", false, true, http.StatusForbidden, true),
+			Entry("at the /dav/public-files endpoint for a file", "/dav/public-files/tokenforfile", "", "", false, true, http.StatusMethodNotAllowed, false),
+			Entry("at the /dav/public-files endpoint for a folder", "/dav/public-files/tokenforfolder", "/public/tokenforfolder", ".", false, true, http.StatusForbidden, true),
+			// when user does not have access he should get not found status
+			Entry("at the /webdav endpoint", "/webdav", "/users", "./foo", false, false, http.StatusNotFound, true),
+			Entry("at the /dav/files endpoint", "/dav/files/username", "/users/username", "./foo", false, false, http.StatusNotFound, true),
+			Entry("at the /dav/spaces endpoint", "/dav/spaces/provider-1$userspace!root", "/users/username", "./foo", false, false, http.StatusNotFound, true),
+			Entry("at the /dav/public-files endpoint for a file", "/dav/public-files/tokenforfile", "", "", false, false, http.StatusMethodNotAllowed, false),
+			Entry("at the /dav/public-files endpoint for a folder", "/dav/public-files/tokenforfolder", "/public/tokenforfolder", ".", false, false, http.StatusNotFound, true),
+
+			// With lock
+
+			// when user has access he should see forbidden status
+			Entry("at the /webdav endpoint", "/webdav", "/users", "./foo", true, true, http.StatusLocked, true),
+			Entry("at the /dav/files endpoint", "/dav/files/username", "/users/username", "./foo", true, true, http.StatusLocked, true),
+			Entry("at the /dav/spaces endpoint", "/dav/spaces/provider-1$userspace!root", "/users/username", "./foo", true, true, http.StatusLocked, true),
+			Entry("at the /dav/public-files endpoint for a file", "/dav/public-files/tokenforfile", "", "", true, true, http.StatusMethodNotAllowed, false),
+			Entry("at the /dav/public-files endpoint for a folder", "/dav/public-files/tokenforfolder", "/public/tokenforfolder", ".", true, true, http.StatusLocked, true),
+			// when user does not have access he should get not found status
+			Entry("at the /webdav endpoint", "/webdav", "/users", "./foo", true, false, http.StatusNotFound, true),
+			Entry("at the /dav/files endpoint", "/dav/files/username", "/users/username", "./foo", true, false, http.StatusNotFound, true),
+			Entry("at the /dav/spaces endpoint", "/dav/spaces/provider-1$userspace!root", "/users/username", "./foo", true, false, http.StatusNotFound, true),
+			Entry("at the /dav/public-files endpoint for a file", "/dav/public-files/tokenforfile", "", "", true, false, http.StatusMethodNotAllowed, false),
+			Entry("at the /dav/public-files endpoint for a folder", "/dav/public-files/tokenforfolder", "/public/tokenforfolder", ".", true, false, http.StatusNotFound, true),
+		)
+
+	})
+	// listing spaces is a precondition for path based requests, what if listing spaces currently is broken?
+	Context("locks are forwarded", func() {
+
+		DescribeTable("HandleDelete",
+			func(endpoint string, expectedPathPrefix string, expectedPath string, expectedStatus int, expectBody bool) {
+
+				client.On("ListStorageSpaces", mock.Anything, mock.MatchedBy(func(req *cs3storageprovider.ListStorageSpacesRequest) bool {
+					p := string(req.Opaque.Map["path"].Value)
+					return p == "/" || strings.HasPrefix(p, expectedPathPrefix)
+				})).Return(&cs3storageprovider.ListStorageSpacesResponse{
+					Status:        status.NewOK(ctx),
+					StorageSpaces: []*cs3storageprovider.StorageSpace{userspace},
+				}, nil)
+
+				ref := cs3storageprovider.Reference{
+					ResourceId: userspace.Root,
+					Path:       expectedPath,
+				}
+
+				client.On("Delete", mock.Anything, mock.MatchedBy(func(req *cs3storageprovider.DeleteRequest) bool {
+					Expect(utils.ReadPlainFromOpaque(req.Opaque, "lockid")).To(Equal("urn:uuid:181d4fae-7d8c-11d0-a765-00a0c91e6bf2"))
+					return utils.ResourceEqual(req.Ref, &ref)
+				})).Return(&cs3storageprovider.DeleteResponse{
+					Status: status.NewOK(ctx),
+				}, nil)
+
+				rr := httptest.NewRecorder()
+				req, err := http.NewRequest("DELETE", endpoint+"/foo", strings.NewReader(""))
+				req.Header.Set("If", "(<urn:uuid:181d4fae-7d8c-11d0-a765-00a0c91e6bf2>)")
+				Expect(err).ToNot(HaveOccurred())
+				req = req.WithContext(ctx)
+
+				handler.Handler().ServeHTTP(rr, req)
+				Expect(rr).To(HaveHTTPStatus(expectedStatus))
+			},
+			Entry("at the /webdav endpoint", "/webdav", "/users", "./foo", http.StatusNoContent, true),
+			Entry("at the /dav/files endpoint", "/dav/files/username", "/users/username", "./foo", http.StatusNoContent, true),
+			Entry("at the /dav/spaces endpoint", "/dav/spaces/provider-1$userspace!root", "/users/username", "./foo", http.StatusNoContent, true),
+			Entry("at the /dav/public-files endpoint for a file", "/dav/public-files/tokenforfile", "", "", http.StatusMethodNotAllowed, false),
+			Entry("at the /dav/public-files endpoint for a folder", "/dav/public-files/tokenforfolder", "/public/tokenforfolder", ".", http.StatusNoContent, true),
+		)
+	})
+
 })


### PR DESCRIPTION
we now cover error cases in the ocdav delete handler in unit tests. increases coverage from 10.1% to 11.0%

part of https://github.com/owncloud/ocis/issues/5009