### PR TITLE
Dont leak info on UpdateSpace

### DIFF
--- a/changelog/unreleased/dont-leak-spaces.md
+++ b/changelog/unreleased/dont-leak-spaces.md
@@ -1,0 +1,7 @@
+Bugfix: Don't leak space information on update drive
+
+There were some problems with the `UpdateDrive` func in decomposedfs when it is called without permission
+-   When calling with empty request it would leak the complete drive info
+-   When calling with non-empty request it would leak the drive name
+
+https://github.com/cs3org/reva/pull/3447

--- a/pkg/storage/utils/decomposedfs/spaces_test.go
+++ b/pkg/storage/utils/decomposedfs/spaces_test.go
@@ -373,7 +373,7 @@ var _ = Describe("Spaces", func() {
 					},
 				)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(updateResp.Status.Code, rpcv1beta1.Code_CODE_PERMISSION_DENIED)
+				Expect(updateResp.Status.Code).To(Equal(rpcv1beta1.Code_CODE_NOT_FOUND))
 			})
 		})
 	})


### PR DESCRIPTION
There were some problems with the `UpdateDrive` func in decomposedfs when it is called without permission
-  When calling with empty request it would leak the complete drive info
-  When calling with non-empty request it would leak the drive name

Fixes https://github.com/owncloud/ocis/issues/5030
