### PR TITLE
Fix access to spaces shared via public link

### DIFF
--- a/changelog/unreleased/fix-space-public-links.md
+++ b/changelog/unreleased/fix-space-public-links.md
@@ -1,0 +1,6 @@
+Bugfix: Fix access to spaces shared via public link
+
+We fixed a problem where downloading archives from spaces which were shared via
+public links was not possible.
+
+https://github.com/cs3org/reva/pull/3452


### PR DESCRIPTION
This PR fixes a problem where downloading archives from spaces which were shared via public links was not possible.

Fixes https://github.com/owncloud/ocis/issues/5027