### PR TITLE
[tests-only]Bump CORE latest commit

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The test runner source for API tests
-CORE_COMMITID=1eed08f1229136ac5cd7ef3ae2ccd2821a113129
+CORE_COMMITID=7296d4f3544a0de278d8d2eee7388b6c44160724
 CORE_BRANCH=master


### PR DESCRIPTION
### Description

Bump core latest commit ID to `reva-edge`

### Related Issue:
https://github.com/owncloud/QA/issues/772