### PR TITLE
Set oc fileid header

### DIFF
--- a/changelog/unreleased/set-oc-fileid-header.md
+++ b/changelog/unreleased/set-oc-fileid-header.md
@@ -1,0 +1,6 @@
+Bugfix: Set the Oc-Fileid header when copying items
+
+We added the Oc-Fileid header in the COPY response for compatibility reasons.
+
+https://github.com/cs3org/reva/pull/3458
+https://github.com/owncloud/ocis/issues/5039

--- a/internal/http/services/owncloud/ocdav/copy.go
+++ b/internal/http/services/owncloud/ocdav/copy.go
@@ -279,6 +279,9 @@ func (s *svc) executePathCopy(ctx context.Context, client gateway.GatewayAPIClie
 			return err
 		}
 
+		if fileid := httpUploadRes.Header.Get(net.HeaderOCFileID); fileid != "" {
+			w.Header().Set(net.HeaderOCFileID, fileid)
+		}
 	}
 	return nil
 }
@@ -467,6 +470,10 @@ func (s *svc) executeSpacesCopy(ctx context.Context, w http.ResponseWriter, clie
 		defer httpUploadRes.Body.Close()
 		if httpUploadRes.StatusCode != http.StatusOK {
 			return err
+		}
+
+		if fileid := httpUploadRes.Header.Get(net.HeaderOCFileID); fileid != "" {
+			w.Header().Set(net.HeaderOCFileID, fileid)
 		}
 	}
 	return nil


### PR DESCRIPTION
This PR adds the Oc-Fileid header in the COPY response for compatibility reasons.

Fixes https://github.com/owncloud/ocis/issues/5039