### PR TITLE
Decomposedfs readdir including stat

### DIFF
--- a/changelog/unreleased/decomposedfs-readdir-including-stat.md
+++ b/changelog/unreleased/decomposedfs-readdir-including-stat.md
@@ -1,0 +1,6 @@
+Enhancement: more efficient tree size calculation in decomposedfs
+
+We now fetch the stat info of all children using `Readdir` instead of `Readdirnames` and subsequent `Stat` calls. While it does not remove the tree size aggregation penalty during uploads it does help in large directories.
+
+https://github.com/cs3org/reva/pull/3468
+https://github.com/owncloud/ocis/issues/5061

--- a/pkg/storage/utils/decomposedfs/tree/tree.go
+++ b/pkg/storage/utils/decomposedfs/tree/tree.go
@@ -819,14 +819,13 @@ func calculateTreeSize(ctx context.Context, nodePath string) (uint64, error) {
 	}
 	defer f.Close()
 
-	names, err := f.Readdirnames(0)
+	finfos, err := f.Readdir(0)
 	if err != nil {
-		appctx.GetLogger(ctx).Error().Err(err).Str("nodepath", nodePath).Msg("could not read dirnames")
+		appctx.GetLogger(ctx).Error().Err(err).Str("nodepath", nodePath).Msg("could not read dir")
 		return 0, err
 	}
-	for i := range names {
-		cPath := filepath.Join(nodePath, names[i])
-		info, err := os.Stat(cPath)
+	for _, info := range finfos {
+		cPath := filepath.Join(nodePath, info.Name())
 		if err != nil {
 			appctx.GetLogger(ctx).Error().Err(err).Str("childpath", cPath).Msg("could not stat child entry")
 			continue // continue after an error


### PR DESCRIPTION
We now fetch the stat info of all children using `Readdir` instead of `Readdirnames` and subsequent `Stat` calls. While it does not remove the tree size aggregation penalty during uploads it does help in large directories.

see https://github.com/owncloud/ocis/issues/5061