### PR TITLE
Decomposedfs propagate diff

### DIFF
--- a/changelog/unreleased/decomposedfs-finish-upload-rewrite.md
+++ b/changelog/unreleased/decomposedfs-finish-upload-rewrite.md
@@ -1,0 +1,5 @@
+Bugfix: decomposedfs make finish upload atomic
+
+We rewrote the finish upload code to use a write lock when creating and updating node metadata. This prevents some cornercases and allows us to calculate the size diff atomically.
+
+https://github.com/cs3org/reva/pull/3473

--- a/changelog/unreleased/decomposedfs-finish-upload-rewrite.md
+++ b/changelog/unreleased/decomposedfs-finish-upload-rewrite.md
@@ -1,5 +1,5 @@
-Bugfix: decomposedfs make finish upload atomic
+Bugfix: decomposedfs fix revision download
 
-We rewrote the finish upload code to use a write lock when creating and updating node metadata. This prevents some cornercases and allows us to calculate the size diff atomically.
+We rewrote the finish upload code to use a write lock when creating and updating node metadata. This prevents some cornercases, allows us to calculate the size diff atomically and fixes downloading revisions.
 
 https://github.com/cs3org/reva/pull/3473

--- a/changelog/unreleased/decomposedfs-finish-upload-rewrite.md
+++ b/changelog/unreleased/decomposedfs-finish-upload-rewrite.md
@@ -3,3 +3,5 @@ Bugfix: decomposedfs fix revision download
 We rewrote the finish upload code to use a write lock when creating and updating node metadata. This prevents some cornercases, allows us to calculate the size diff atomically and fixes downloading revisions.
 
 https://github.com/cs3org/reva/pull/3473
+https://github.com/owncloud/ocis/issues/765
+https://github.com/owncloud/ocis/issues/3868

--- a/changelog/unreleased/decomposedfs-propagate-sizediff.md
+++ b/changelog/unreleased/decomposedfs-propagate-sizediff.md
@@ -1,0 +1,6 @@
+Bugfix: decomposedfs propagate sizediff
+
+We now propagate the size diff instead of calculating the treesize. This fixes the slower upload speeds in large folders.
+
+https://github.com/cs3org/reva/pull/3482
+https://github.com/owncloud/ocis/issues/5061

--- a/internal/http/services/owncloud/ocdav/meta.go
+++ b/internal/http/services/owncloud/ocdav/meta.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"net/http"
 	"path"
+	"strings"
 
 	rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
@@ -69,6 +70,15 @@ func (h *MetaHandler) Handler(s *svc) http.Handler {
 			b, err := errors.Marshal(http.StatusBadRequest, m, "")
 			errors.HandleWebdavError(logger, w, b, err)
 			return
+		}
+		if did.StorageId == "" && did.OpaqueId == "" && strings.Count(id, ":") >= 2 {
+			logger := appctx.GetLogger(r.Context())
+			logger.Warn().Str("id", id).Msg("detected invalid : separted resourceid id, trying to split it ... but fix the client that made the request")
+			// try splitting with :
+			parts := strings.SplitN(id, ":", 3)
+			did.StorageId = parts[0]
+			did.SpaceId = parts[1]
+			did.OpaqueId = parts[2]
 		}
 
 		var head string

--- a/internal/http/services/owncloud/ocdav/meta.go
+++ b/internal/http/services/owncloud/ocdav/meta.go
@@ -73,7 +73,7 @@ func (h *MetaHandler) Handler(s *svc) http.Handler {
 		}
 		if did.StorageId == "" && did.OpaqueId == "" && strings.Count(id, ":") >= 2 {
 			logger := appctx.GetLogger(r.Context())
-			logger.Warn().Str("id", id).Msg("detected invalid : separted resourceid id, trying to split it ... but fix the client that made the request")
+			logger.Warn().Str("id", id).Msg("detected invalid : separated resourceid id, trying to split it ... but fix the client that made the request")
 			// try splitting with :
 			parts := strings.SplitN(id, ":", 3)
 			did.StorageId = parts[0]

--- a/pkg/storage/utils/decomposedfs/decomposedfs.go
+++ b/pkg/storage/utils/decomposedfs/decomposedfs.go
@@ -30,6 +30,7 @@ import (
 	"path"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"syscall"
 
 	cs3permissions "github.com/cs3org/go-cs3apis/cs3/permissions/v1beta1"
@@ -591,6 +592,12 @@ func (fs *Decomposedfs) Delete(ctx context.Context, ref *provider.Reference) (er
 
 // Download returns a reader to the specified resource
 func (fs *Decomposedfs) Download(ctx context.Context, ref *provider.Reference) (io.ReadCloser, error) {
+	// check if we are trying to download a revision
+	// TODO the CS3 api should allow initiating a revision download
+	if ref.ResourceId != nil && strings.Contains(ref.ResourceId.OpaqueId, node.RevisionIDDelimiter) {
+		return fs.DownloadRevision(ctx, ref, ref.ResourceId.OpaqueId)
+	}
+
 	node, err := fs.lu.NodeFromResource(ctx, ref)
 	if err != nil {
 		return nil, errors.Wrap(err, "Decomposedfs: error resolving ref")

--- a/pkg/storage/utils/decomposedfs/decomposedfs.go
+++ b/pkg/storage/utils/decomposedfs/decomposedfs.go
@@ -88,7 +88,7 @@ type Tree interface {
 	ReadBlob(node *node.Node) (io.ReadCloser, error)
 	DeleteBlob(node *node.Node) error
 
-	Propagate(ctx context.Context, node *node.Node) (err error)
+	Propagate(ctx context.Context, node *node.Node, sizeDiff int64) (err error)
 }
 
 // Decomposedfs provides the base for decomposed filesystem implementations

--- a/pkg/storage/utils/decomposedfs/grants.go
+++ b/pkg/storage/utils/decomposedfs/grants.go
@@ -220,7 +220,7 @@ func (fs *Decomposedfs) RemoveGrant(ctx context.Context, ref *provider.Reference
 		}
 	}
 
-	return fs.tp.Propagate(ctx, node)
+	return fs.tp.Propagate(ctx, node, 0)
 }
 
 // UpdateGrant updates a grant on a resource
@@ -321,7 +321,7 @@ func (fs *Decomposedfs) storeGrant(ctx context.Context, n *node.Node, g *provide
 		return err
 	}
 
-	return fs.tp.Propagate(ctx, n)
+	return fs.tp.Propagate(ctx, n, 0)
 }
 
 // extractACEsFromAttrs reads ACEs in the list of attrs from the node

--- a/pkg/storage/utils/decomposedfs/metadata.go
+++ b/pkg/storage/utils/decomposedfs/metadata.go
@@ -117,7 +117,7 @@ func (fs *Decomposedfs) SetArbitraryMetadata(ctx context.Context, ref *provider.
 
 	switch len(errs) {
 	case 0:
-		return fs.tp.Propagate(ctx, n)
+		return fs.tp.Propagate(ctx, n, 0)
 	case 1:
 		// TODO Propagate if anything changed
 		return errs[0]
@@ -207,7 +207,7 @@ func (fs *Decomposedfs) UnsetArbitraryMetadata(ctx context.Context, ref *provide
 	}
 	switch len(errs) {
 	case 0:
-		return fs.tp.Propagate(ctx, n)
+		return fs.tp.Propagate(ctx, n, 0)
 	case 1:
 		// TODO Propagate if anything changed
 		return errs[0]

--- a/pkg/storage/utils/decomposedfs/metadata.go
+++ b/pkg/storage/utils/decomposedfs/metadata.go
@@ -73,8 +73,7 @@ func (fs *Decomposedfs) SetArbitraryMetadata(ctx context.Context, ref *provider.
 	if md.Metadata != nil {
 		if val, ok := md.Metadata["mtime"]; ok {
 			delete(md.Metadata, "mtime")
-			err := n.SetMtime(ctx, val)
-			if err != nil {
+			if err := n.SetMtimeString(val); err != nil {
 				errs = append(errs, errors.Wrap(err, "could not set mtime"))
 			}
 		}
@@ -85,8 +84,7 @@ func (fs *Decomposedfs) SetArbitraryMetadata(ctx context.Context, ref *provider.
 		// TODO unset when folder is updated or add timestamp to etag?
 		if val, ok := md.Metadata["etag"]; ok {
 			delete(md.Metadata, "etag")
-			err := n.SetEtag(ctx, val)
-			if err != nil {
+			if err := n.SetEtag(ctx, val); err != nil {
 				errs = append(errs, errors.Wrap(err, "could not set etag"))
 			}
 		}

--- a/pkg/storage/utils/decomposedfs/node/node.go
+++ b/pkg/storage/utils/decomposedfs/node/node.go
@@ -929,6 +929,15 @@ func (n *Node) SetTreeSize(ts uint64) (err error) {
 	return n.SetXattr(xattrs.TreesizeAttr, strconv.FormatUint(ts, 10))
 }
 
+// GetBlobSize reads the blobsize from the extended attributes
+func (n *Node) GetBlobSize() (treesize uint64, err error) {
+	var b string
+	if b, err = n.Xattr(xattrs.TreesizeAttr); err != nil {
+		return
+	}
+	return strconv.ParseUint(b, 10, 64)
+}
+
 // SetChecksum writes the checksum with the given checksum type to the extended attributes
 func (n *Node) SetChecksum(csType string, h hash.Hash) (err error) {
 	return n.SetXattr(xattrs.ChecksumPrefix+csType, string(h.Sum(nil)))

--- a/pkg/storage/utils/decomposedfs/node/node_test.go
+++ b/pkg/storage/utils/decomposedfs/node/node_test.go
@@ -89,10 +89,10 @@ var _ = Describe("Node", func() {
 			n, err := env.Lookup.NodeFromResource(env.Ctx, ref)
 			Expect(err).ToNot(HaveOccurred())
 
-			blobsize := 239485734
+			blobsize := int64(239485734)
 			n.Name = "TestName"
 			n.BlobID = "TestBlobID"
-			n.Blobsize = int64(blobsize)
+			n.Blobsize = blobsize
 
 			err = n.WriteAllNodeMetadata()
 			Expect(err).ToNot(HaveOccurred())

--- a/pkg/storage/utils/decomposedfs/node/node_test.go
+++ b/pkg/storage/utils/decomposedfs/node/node_test.go
@@ -100,7 +100,7 @@ var _ = Describe("Node", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(n2.Name).To(Equal("TestName"))
 			Expect(n2.BlobID).To(Equal("TestBlobID"))
-			Expect(n2.Blobsize).To(Equal(int64(blobsize)))
+			Expect(n2.Blobsize).To(Equal(blobsize))
 		})
 	})
 

--- a/pkg/storage/utils/decomposedfs/node/permissions.go
+++ b/pkg/storage/utils/decomposedfs/node/permissions.go
@@ -20,10 +20,12 @@ package node
 
 import (
 	"context"
+	"strings"
 
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	"github.com/cs3org/reva/v2/pkg/appctx"
 	ctxpkg "github.com/cs3org/reva/v2/pkg/ctx"
+	"github.com/cs3org/reva/v2/pkg/errtypes"
 	"github.com/cs3org/reva/v2/pkg/utils"
 	"github.com/pkg/errors"
 )
@@ -89,6 +91,16 @@ func (p *Permissions) AssemblePermissions(ctx context.Context, n *Node) (ap prov
 	u, ok := ctxpkg.ContextGetUser(ctx)
 	if !ok {
 		return NoPermissions(), nil
+	}
+
+	if strings.Contains(n.ID, RevisionIDDelimiter) {
+		// verify revision key format
+		kp := strings.SplitN(n.ID, RevisionIDDelimiter, 2)
+		if len(kp) != 2 {
+			return NoPermissions(), errtypes.NotFound(n.ID)
+		}
+		// use the actual node for the permission assembly
+		n.ID = kp[0]
 	}
 
 	// check if the current user is the owner

--- a/pkg/storage/utils/decomposedfs/node/permissions.go
+++ b/pkg/storage/utils/decomposedfs/node/permissions.go
@@ -93,6 +93,7 @@ func (p *Permissions) AssemblePermissions(ctx context.Context, n *Node) (ap prov
 		return NoPermissions(), nil
 	}
 
+	// are we reading a revision?
 	if strings.Contains(n.ID, RevisionIDDelimiter) {
 		// verify revision key format
 		kp := strings.SplitN(n.ID, RevisionIDDelimiter, 2)

--- a/pkg/storage/utils/decomposedfs/node/xattrs.go
+++ b/pkg/storage/utils/decomposedfs/node/xattrs.go
@@ -93,5 +93,6 @@ func (n *Node) Xattr(key string) (string, error) {
 	if val, ok := n.xattrsCache[key]; ok {
 		return val, nil
 	}
-	return "", xattr.ENOATTR
+	// wrap the error as xattr does
+	return "", &xattr.Error{Op: "xattr.get", Path: n.InternalPath(), Name: key, Err: xattr.ENOATTR}
 }

--- a/pkg/storage/utils/decomposedfs/node/xattrs.go
+++ b/pkg/storage/utils/decomposedfs/node/xattrs.go
@@ -56,6 +56,15 @@ func (n *Node) SetXattr(key, val string) (err error) {
 	return xattrs.Set(n.InternalPath(), key, val)
 }
 
+// SetXattr sets an extended attribute on the write-through cache/node
+func (n *Node) SetXattrWithLock(key, val string, fileLock *flock.Flock) (err error) {
+	if n.xattrsCache != nil {
+		n.xattrsCache[key] = val
+	}
+
+	return xattrs.SetWithLock(n.InternalPath(), key, val, fileLock)
+}
+
 // RemoveXattr removes an extended attribute from the write-through cache/node
 func (n *Node) RemoveXattr(key string) error {
 	if n.xattrsCache != nil {

--- a/pkg/storage/utils/decomposedfs/node/xattrs.go
+++ b/pkg/storage/utils/decomposedfs/node/xattrs.go
@@ -20,6 +20,7 @@ package node
 
 import (
 	"github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/xattrs"
+	"github.com/gofrs/flock"
 	"github.com/pkg/xattr"
 )
 
@@ -32,6 +33,18 @@ func (n *Node) SetXattrs(attribs map[string]string) (err error) {
 	}
 
 	return xattrs.SetMultiple(n.InternalPath(), attribs)
+}
+
+// SetXattrsWithLock sets multiple extended attributes on the write-through cache/node with a given lock
+func (n *Node) SetXattrsWithLock(attribs map[string]string, fileLock *flock.Flock) (err error) {
+	// TODO what if writing the lock fails?
+	if n.xattrsCache != nil {
+		for k, v := range attribs {
+			n.xattrsCache[k] = v
+		}
+	}
+
+	return xattrs.SetMultipleWithLock(n.InternalPath(), attribs, fileLock)
 }
 
 // SetXattr sets an extended attribute on the write-through cache/node

--- a/pkg/storage/utils/decomposedfs/revisions.go
+++ b/pkg/storage/utils/decomposedfs/revisions.go
@@ -126,7 +126,7 @@ func (fs *Decomposedfs) DownloadRevision(ctx context.Context, ref *provider.Refe
 	switch {
 	case err != nil:
 		return nil, errtypes.InternalError(err.Error())
-	case !rp.ListFileVersions || !rp.RestoreFileVersion || !rp.InitiateFileDownload: // TODO add explicit permission in the CS3 api?
+	case !rp.ListFileVersions || !rp.InitiateFileDownload: // TODO add explicit permission in the CS3 api?
 		f, _ := storagespace.FormatReference(ref)
 		if rp.Stat {
 			return nil, errtypes.PermissionDenied(f)

--- a/pkg/storage/utils/decomposedfs/revisions.go
+++ b/pkg/storage/utils/decomposedfs/revisions.go
@@ -245,7 +245,14 @@ func (fs *Decomposedfs) RestoreRevision(ctx context.Context, ref *provider.Refer
 			return errtypes.InternalError("failed to change mtime of version node")
 		}
 
-		return fs.tp.Propagate(ctx, n)
+		currentSize := n.Blobsize
+		revisionSize, err := xattrs.GetInt64(revisionPath, xattrs.BlobsizeAttr)
+		if err != nil {
+			return errtypes.InternalError("failed to read blob size xattr from version node")
+		}
+		sizeDiff := revisionSize - currentSize
+
+		return fs.tp.Propagate(ctx, n, sizeDiff)
 	}
 
 	log.Error().Err(err).Interface("ref", ref).Str("originalnode", kp[0]).Str("revisionKey", revisionKey).Msg("original node does not exist")

--- a/pkg/storage/utils/decomposedfs/revisions.go
+++ b/pkg/storage/utils/decomposedfs/revisions.go
@@ -234,6 +234,11 @@ func (fs *Decomposedfs) RestoreRevision(ctx context.Context, ref *provider.Refer
 			return errtypes.InternalError("failed to copy blob xattrs to version node")
 		}
 
+		// drop old revision
+		if err := os.Remove(revisionPath); err != nil {
+			log.Warn().Err(err).Interface("ref", ref).Str("originalnode", kp[0]).Str("revisionKey", revisionKey).Msg("could not delete old revision, continuing")
+		}
+
 		// explicitly update mtime of node as writing xattrs does not change mtime
 		now := time.Now()
 		if err := os.Chtimes(nodePath, now, now); err != nil {

--- a/pkg/storage/utils/decomposedfs/revisions.go
+++ b/pkg/storage/utils/decomposedfs/revisions.go
@@ -135,6 +135,9 @@ func (fs *Decomposedfs) DownloadRevision(ctx context.Context, ref *provider.Refe
 
 	contentPath := fs.lu.InternalPath(spaceID, revisionKey)
 
+	// FIXME this will always be an empty file ... actuallyd DownloadRevision is never called ... the CS3 api has no way to initiate a file revision download
+	// it all just magically works by accident ... and only partly ...
+	// see also https://github.com/cs3org/reva/issues/1813
 	r, err := os.Open(contentPath)
 	if err != nil {
 		if errors.Is(err, iofs.ErrNotExist) {

--- a/pkg/storage/utils/decomposedfs/tree/tree.go
+++ b/pkg/storage/utils/decomposedfs/tree/tree.go
@@ -757,7 +757,7 @@ func (t *Tree) Propagate(ctx context.Context, n *node.Node) (err error) {
 				}
 			}
 
-			if err := n.UnsetTempEtag(); !xattrs.IsAttrUnset(err) {
+			if err := n.UnsetTempEtag(); err != nil && !xattrs.IsAttrUnset(err) {
 				sublog.Error().Err(err).Msg("could not remove temporary etag attribute")
 			}
 		}

--- a/pkg/storage/utils/decomposedfs/tree/tree.go
+++ b/pkg/storage/utils/decomposedfs/tree/tree.go
@@ -808,7 +808,7 @@ func (t *Tree) Propagate(ctx context.Context, n *node.Node, sizeDiff int64) (err
 				if sizeDiff > 0 {
 					newSize = treeSize + uint64(sizeDiff)
 				} else {
-					newSize = treeSize - uint64(sizeDiff)
+					newSize = treeSize - uint64(-sizeDiff)
 				}
 			}
 

--- a/pkg/storage/utils/decomposedfs/tree/tree.go
+++ b/pkg/storage/utils/decomposedfs/tree/tree.go
@@ -37,6 +37,7 @@ import (
 	"github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/lookup"
 	"github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/node"
 	"github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/xattrs"
+	"github.com/cs3org/reva/v2/pkg/storage/utils/filelocks"
 	"github.com/cs3org/reva/v2/pkg/utils"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
@@ -282,7 +283,7 @@ func (t *Tree) TouchFile(ctx context.Context, n *node.Node) error {
 		}
 	}
 
-	return t.Propagate(ctx, n)
+	return t.Propagate(ctx, n, 0)
 }
 
 // CreateDir creates a new directory entry in the tree
@@ -318,7 +319,7 @@ func (t *Tree) CreateDir(ctx context.Context, n *node.Node) (err error) {
 		}
 		return errtypes.AlreadyExists(err.Error())
 	}
-	return t.Propagate(ctx, n)
+	return t.Propagate(ctx, n, 0)
 }
 
 // Move replaces the target with the source
@@ -363,7 +364,7 @@ func (t *Tree) Move(ctx context.Context, oldNode *node.Node, newNode *node.Node)
 			return errors.Wrap(err, "Decomposedfs: could not set name attribute")
 		}
 
-		return t.Propagate(ctx, newNode)
+		return t.Propagate(ctx, newNode, 0)
 	}
 
 	// we are moving the node to a new parent, any target has been removed
@@ -386,15 +387,27 @@ func (t *Tree) Move(ctx context.Context, oldNode *node.Node, newNode *node.Node)
 		return errors.Wrap(err, "Decomposedfs: could not set name attribute")
 	}
 
+	// the size diff is the current treesize or blobsize of the old/source node
+	var sizeDiff int64
+	if oldNode.IsDir() {
+		treeSize, err := oldNode.GetTreeSize()
+		if err != nil {
+			return err
+		}
+		sizeDiff = int64(treeSize)
+	} else {
+		sizeDiff = oldNode.Blobsize
+	}
+
 	// TODO inefficient because we might update several nodes twice, only propagate unchanged nodes?
 	// collect in a list, then only stat each node once
 	// also do this in a go routine ... webdav should check the etag async
 
-	err = t.Propagate(ctx, oldNode)
+	err = t.Propagate(ctx, oldNode, -sizeDiff)
 	if err != nil {
 		return errors.Wrap(err, "Decomposedfs: Move: could not propagate old node")
 	}
-	err = t.Propagate(ctx, newNode)
+	err = t.Propagate(ctx, newNode, sizeDiff)
 	if err != nil {
 		return errors.Wrap(err, "Decomposedfs: Move: could not propagate new node")
 	}
@@ -523,7 +536,7 @@ func (t *Tree) Delete(ctx context.Context, n *node.Node) (err error) {
 		return
 	}
 
-	return t.Propagate(ctx, n)
+	return t.Propagate(ctx, n, n.Blobsize)
 }
 
 // RestoreRecycleItemFunc returns a node and a function to restore it from the trash.
@@ -593,7 +606,7 @@ func (t *Tree) RestoreRecycleItemFunc(ctx context.Context, spaceid, key, trashPa
 		if err = os.Remove(trashItem); err != nil {
 			log.Error().Err(err).Str("trashItem", trashItem).Msg("error deleting trash item")
 		}
-		return t.Propagate(ctx, targetNode)
+		return t.Propagate(ctx, targetNode, targetNode.Blobsize)
 	}
 	return recycleNode, parent, fn, nil
 }
@@ -691,7 +704,7 @@ func (t *Tree) removeNode(path string, n *node.Node) error {
 }
 
 // Propagate propagates changes to the root of the tree
-func (t *Tree) Propagate(ctx context.Context, n *node.Node) (err error) {
+func (t *Tree) Propagate(ctx context.Context, n *node.Node, sizeDiff int64) (err error) {
 	sublog := appctx.GetLogger(ctx).With().Str("spaceid", n.SpaceID).Str("nodeid", n.ID).Logger()
 	if !t.treeTimeAccounting && !t.treeSizeAccounting {
 		// no propagation enabled
@@ -763,44 +776,56 @@ func (t *Tree) Propagate(ctx context.Context, n *node.Node) (err error) {
 		}
 
 		// size accounting
-		if t.treeSizeAccounting {
-			// update the treesize if it differs from the current size
-			updateTreeSize := false
-
-			var treeSize, calculatedTreeSize uint64
-			calculatedTreeSize, err = calculateTreeSize(ctx, n.InternalPath())
+		if t.treeSizeAccounting && sizeDiff != 0 {
+			// lock node before reading treesize
+			nodeLock, err := filelocks.AcquireWriteLock(n.InternalPath())
 			if err != nil {
-				continue
+				return err
 			}
-
-			treeSize, err = n.GetTreeSize()
-			switch {
-			case err != nil:
-				// missing attribute, or invalid format, overwrite
-				sublog.Debug().Err(err).Msg("could not read treesize attribute, overwriting")
-				updateTreeSize = true
-			case treeSize != calculatedTreeSize:
-				sublog.Debug().
-					Uint64("treesize", treeSize).
-					Uint64("calculatedTreeSize", calculatedTreeSize).
-					Msg("parent treesize is different then calculated treesize, updating")
-				updateTreeSize = true
-			default:
-				sublog.Debug().
-					Uint64("treesize", treeSize).
-					Uint64("calculatedTreeSize", calculatedTreeSize).
-					Msg("parent size matches calculated size, not updating")
-			}
-
-			if updateTreeSize {
-				// update the tree time of the parent node
-				if err = n.SetTreeSize(calculatedTreeSize); err != nil {
-					sublog.Error().Err(err).Uint64("calculatedTreeSize", calculatedTreeSize).Msg("could not update treesize of parent node")
-				} else {
-					sublog.Debug().Uint64("calculatedTreeSize", calculatedTreeSize).Msg("updated treesize of parent node")
+			// always unlock node
+			releaseLock := func() {
+				// ReleaseLock returns nil if already unlocked
+				if err := filelocks.ReleaseLock(nodeLock); err != nil {
+					sublog.Err(err).Msg("Decomposedfs: could not unlock parent node")
 				}
 			}
+			defer releaseLock()
+
+			var newSize uint64
+
+			// read treesize
+			treeSize, err := n.GetTreeSize()
+			switch {
+			case xattrs.IsAttrUnset(err):
+				// fallback to calculating the treesize
+				newSize, err = calculateTreeSize(ctx, n.InternalPath())
+				if err != nil {
+					return err
+				}
+			case err != nil:
+				return err
+			default:
+				if sizeDiff > 0 {
+					newSize = treeSize + uint64(sizeDiff)
+				} else {
+					newSize = treeSize - uint64(sizeDiff)
+				}
+			}
+
+			// update the tree time of the node
+			if err = n.SetXattrWithLock(xattrs.TreesizeAttr, strconv.FormatUint(newSize, 10), nodeLock); err != nil {
+				return err
+			}
+
+			// Release node lock early, returns nil if already unlocked
+			err = filelocks.ReleaseLock(nodeLock)
+			if err != nil {
+				return errtypes.InternalError(err.Error())
+			}
+
+			sublog.Debug().Uint64("newSize", newSize).Msg("updated treesize of parent node")
 		}
+
 	}
 	if err != nil {
 		sublog.Error().Err(err).Msg("error propagating")
@@ -855,7 +880,6 @@ func calculateTreeSize(ctx context.Context, nodePath string) (uint64, error) {
 		}
 	}
 	return size, err
-
 }
 
 // WriteBlob writes a blob to the blobstore

--- a/pkg/storage/utils/decomposedfs/tree/tree.go
+++ b/pkg/storage/utils/decomposedfs/tree/tree.go
@@ -692,7 +692,7 @@ func (t *Tree) removeNode(path string, n *node.Node) error {
 
 // Propagate propagates changes to the root of the tree
 func (t *Tree) Propagate(ctx context.Context, n *node.Node) (err error) {
-	sublog := appctx.GetLogger(ctx).With().Interface("node", n).Logger()
+	sublog := appctx.GetLogger(ctx).With().Str("spaceid", n.SpaceID).Str("nodeid", n.ID).Logger()
 	if !t.treeTimeAccounting && !t.treeSizeAccounting {
 		// no propagation enabled
 		sublog.Debug().Msg("propagation disabled")
@@ -713,7 +713,7 @@ func (t *Tree) Propagate(ctx context.Context, n *node.Node) (err error) {
 			break
 		}
 
-		sublog = sublog.With().Interface("node", n).Logger()
+		sublog = sublog.With().Str("spaceid", n.SpaceID).Str("nodeid", n.ID).Logger()
 
 		// TODO none, sync and async?
 		if !n.HasPropagation() {
@@ -757,7 +757,7 @@ func (t *Tree) Propagate(ctx context.Context, n *node.Node) (err error) {
 				}
 			}
 
-			if err := n.UnsetTempEtag(); err != nil {
+			if err := n.UnsetTempEtag(); !xattrs.IsAttrUnset(err) {
 				sublog.Error().Err(err).Msg("could not remove temporary etag attribute")
 			}
 		}

--- a/pkg/storage/utils/decomposedfs/tree/tree_test.go
+++ b/pkg/storage/utils/decomposedfs/tree/tree_test.go
@@ -308,7 +308,7 @@ var _ = Describe("Tree", func() {
 				riBefore, err := dir.AsResourceInfo(env.Ctx, &perms, []string{}, []string{}, false)
 				Expect(err).ToNot(HaveOccurred())
 
-				err = env.Tree.Propagate(env.Ctx, file)
+				err = env.Tree.Propagate(env.Ctx, file, 0)
 				Expect(err).ToNot(HaveOccurred())
 
 				dir, err := env.Lookup.NodeFromID(env.Ctx, &provider.ResourceId{
@@ -328,7 +328,7 @@ var _ = Describe("Tree", func() {
 				file, err := env.CreateTestFile("file1", "", dir.ID, dir.SpaceID, 1)
 				Expect(err).ToNot(HaveOccurred())
 
-				err = env.Tree.Propagate(env.Ctx, file)
+				err = env.Tree.Propagate(env.Ctx, file, 1)
 				Expect(err).ToNot(HaveOccurred())
 
 				dir, err := env.Lookup.NodeFromID(env.Ctx, &provider.ResourceId{
@@ -348,7 +348,7 @@ var _ = Describe("Tree", func() {
 				file2, err := env.CreateTestFile("file2", "", dir.ID, dir.SpaceID, 100)
 				Expect(err).ToNot(HaveOccurred())
 
-				err = env.Tree.Propagate(env.Ctx, file2)
+				err = env.Tree.Propagate(env.Ctx, file2, 101)
 				Expect(err).ToNot(HaveOccurred())
 
 				dir, err := env.Lookup.NodeFromID(env.Ctx, &provider.ResourceId{
@@ -371,7 +371,7 @@ var _ = Describe("Tree", func() {
 				file, err := env.CreateTestFile("file1", "", dir.ID, dir.SpaceID, 1)
 				Expect(err).ToNot(HaveOccurred())
 
-				err = env.Tree.Propagate(env.Ctx, file)
+				err = env.Tree.Propagate(env.Ctx, file, 1)
 				Expect(err).ToNot(HaveOccurred())
 
 				dir, err := env.Lookup.NodeFromID(env.Ctx, &provider.ResourceId{
@@ -391,7 +391,7 @@ var _ = Describe("Tree", func() {
 				err = subdir.SetTreeSize(uint64(200))
 				Expect(err).ToNot(HaveOccurred())
 
-				err = env.Tree.Propagate(env.Ctx, subdir)
+				err = env.Tree.Propagate(env.Ctx, subdir, 0)
 				Expect(err).ToNot(HaveOccurred())
 
 				dir, err := env.Lookup.NodeFromID(env.Ctx, &provider.ResourceId{
@@ -412,7 +412,7 @@ var _ = Describe("Tree", func() {
 				Expect(err).ToNot(HaveOccurred())
 				err = otherdir.SetTreeSize(uint64(100000))
 				Expect(err).ToNot(HaveOccurred())
-				err = env.Tree.Propagate(env.Ctx, otherdir)
+				err = env.Tree.Propagate(env.Ctx, otherdir, 100000)
 				Expect(err).ToNot(HaveOccurred())
 
 				dir, err = env.Lookup.NodeFromID(env.Ctx, &provider.ResourceId{

--- a/pkg/storage/utils/decomposedfs/upload.go
+++ b/pkg/storage/utils/decomposedfs/upload.go
@@ -48,11 +48,11 @@ import (
 	"github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/lookup"
 	"github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/node"
 	"github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/xattrs"
+	"github.com/cs3org/reva/v2/pkg/storage/utils/filelocks"
 	"github.com/cs3org/reva/v2/pkg/storagespace"
 	"github.com/cs3org/reva/v2/pkg/utils"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
-	"github.com/rs/zerolog"
 )
 
 var defaultFilePerm = os.FileMode(0664)
@@ -566,6 +566,20 @@ func (upload *fileUpload) writeInfo() error {
 }
 
 // FinishUpload finishes an upload and moves the file to the internal destination
+//
+// # upload steps
+// check if match header to fail early
+// copy blob
+// lock metadata node
+// check if match header again as safeguard
+// read metadata
+// create version node with current metadata
+// update node metadata with new blobid etc
+// remember size diff
+// unlock metadata
+// propagate size diff and new etag
+// - propagation can happen outside the metadata lock because diff calculation happens inside the lock and the order in which diffs are applied to the parent is irrelvevant
+// - propagation needs to propagate the diff
 func (upload *fileUpload) FinishUpload(ctx context.Context) (err error) {
 
 	// ensure cleanup
@@ -599,18 +613,18 @@ func (upload *fileUpload) FinishUpload(ctx context.Context) (err error) {
 	}
 
 	overwrite := n.ID != ""
-	var oldSize uint64
+	var oldSize int64
 	if overwrite {
 		// read size from existing node
 		old, _ := node.ReadNode(ctx, upload.fs.lu, spaceID, n.ID, false)
-		oldSize = uint64(old.Blobsize)
+		oldSize = old.Blobsize
 	} else {
 		// create new fileid
 		n.ID = uuid.New().String()
 		upload.info.Storage["NodeId"] = n.ID
 	}
 
-	if _, err = node.CheckQuota(n.SpaceRoot, overwrite, oldSize, uint64(fi.Size())); err != nil {
+	if _, err = node.CheckQuota(n.SpaceRoot, overwrite, uint64(oldSize), uint64(fi.Size())); err != nil {
 		return err
 	}
 
@@ -618,6 +632,8 @@ func (upload *fileUpload) FinishUpload(ctx context.Context) (err error) {
 	sublog := appctx.GetLogger(upload.ctx).
 		With().
 		Interface("info", upload.info).
+		Str("spaceid", spaceID).
+		Str("nodeid", n.ID).
 		Str("binPath", upload.binPath).
 		Str("targetPath", targetPath).
 		Logger()
@@ -669,8 +685,9 @@ func (upload *fileUpload) FinishUpload(ctx context.Context) (err error) {
 
 	// defer writing the checksums until the node is in place
 
-	// if target exists create new version
-	versionsPath := ""
+	// upload steps
+	// check if match header to fail early
+
 	if fi, err = os.Stat(targetPath); err == nil {
 		// When the if-match header was set we need to check if the
 		// etag still matches before finishing the upload.
@@ -684,24 +701,10 @@ func (upload *fileUpload) FinishUpload(ctx context.Context) (err error) {
 				return errtypes.Aborted("etag mismatch")
 			}
 		}
-
-		// FIXME move versioning to blobs ... no need to copy all the metadata! well ... it does if we want to version metadata...
-		// versions are stored alongside the actual file, so a rename can be efficient and does not cross storage / partition boundaries
-		versionsPath = upload.fs.lu.InternalPath(spaceID, n.ID+node.RevisionIDDelimiter+fi.ModTime().UTC().Format(time.RFC3339Nano))
-
-		// This move drops all metadata!!! We copy it below with CopyMetadata
-		// FIXME the node must remain the same. otherwise we might restore share metadata
-		if err = os.Rename(targetPath, versionsPath); err != nil {
-			sublog.Err(err).
-				Str("binPath", upload.binPath).
-				Str("versionsPath", versionsPath).
-				Msg("Decomposedfs: could not create version")
-			return
-		}
-
 	}
 
-	// upload the data to the blobstore
+	// copy blob
+
 	file, err := os.Open(upload.binPath)
 	if err != nil {
 		return err
@@ -712,25 +715,72 @@ func (upload *fileUpload) FinishUpload(ctx context.Context) (err error) {
 		return errors.Wrap(err, "failed to upload file to blostore")
 	}
 
-	// now truncate the upload (the payload stays in the blobstore) and move it to the target path
-	// TODO put uploads on the same underlying storage as the destination dir?
-	// TODO trigger a workflow as the final rename might eg involve antivirus scanning
-	if err = os.Truncate(upload.binPath, 0); err != nil {
-		sublog.Err(err).
-			Msg("Decomposedfs: could not truncate")
-		return
+	// prepare discarding the blob if something changed while writing it
+	discardBlob := func() {
+		err = upload.fs.tp.DeleteBlob(n)
+		if err != nil {
+			sublog.Err(err).Str("blobid", n.BlobID).Msg("Decomposedfs: failed to discard blob in blostore")
+		}
 	}
-	if err := os.MkdirAll(filepath.Dir(targetPath), 0700); err != nil {
-		sublog.Warn().Err(err).Msg("Decomposedfs: could not create node dir, trying to write file anyway")
+
+	// lock metadata node
+	lock, err := filelocks.AcquireWriteLock(targetPath)
+	if err != nil {
+		return errtypes.InternalError(err.Error())
 	}
-	if err = os.Rename(upload.binPath, targetPath); err != nil {
-		sublog.Error().Err(err).Msg("Decomposedfs: could not rename")
-		return
+
+	// check if match header again as safequard
+	versionsPath := ""
+	if fi, err = os.Stat(targetPath); err == nil {
+		// When the if-match header was set we need to check if the
+		// etag still matches before finishing the upload.
+		if ifMatch, ok := upload.info.MetaData["if-match"]; ok {
+			var targetEtag string
+			targetEtag, err = node.CalculateEtag(n.ID, fi.ModTime())
+			if err != nil {
+				discardBlob()
+				return errtypes.InternalError(err.Error())
+			}
+			if ifMatch != targetEtag {
+				discardBlob()
+				return errtypes.Aborted("etag mismatch")
+			}
+		}
+
+		// FIXME move versioning to blobs ... no need to copy all the metadata! well ... it does if we want to version metadata...
+		// versions are stored alongside the actual file, so a rename can be efficient and does not cross storage / partition boundaries
+		versionsPath = upload.fs.lu.InternalPath(spaceID, n.ID+node.RevisionIDDelimiter+fi.ModTime().UTC().Format(time.RFC3339Nano))
 	}
+
+	// read metadata
+
+	// attributes that will change
+	attrs := map[string]string{
+		xattrs.BlobIDAttr:   n.BlobID,
+		xattrs.BlobsizeAttr: strconv.FormatInt(n.Blobsize, 10),
+
+		// update checksums
+		xattrs.ChecksumPrefix + "sha1":        string(sha1h.Sum(nil)),
+		xattrs.ChecksumPrefix + "md5":         string(md5h.Sum(nil)),
+		xattrs.ChecksumPrefix + "shadler32a1": string(adler32h.Sum(nil)),
+	}
+
+	// create version node with current metadata
+
+	// if file already exists
 	if versionsPath != "" {
-		// copy grant and arbitrary metadata
+		// touch version node
+		file, err := os.Create(versionsPath)
+		if err != nil {
+			discardBlob()
+			sublog.Err(err).Str("version", versionsPath).Msg("could not create version")
+			return errtypes.InternalError("could not create version")
+		}
+		file.Close()
+
+		// copy grant and arbitrary metadata to version node
 		// FIXME ... now restoring an older revision might bring back a grant that was removed!
-		err = xattrs.CopyMetadata(versionsPath, targetPath, func(attributeName string) bool {
+		err = xattrs.CopyMetadataWithSourceLock(targetPath, versionsPath, func(attributeName string) bool {
 			return true
 			// TODO determine all attributes that must be copied, currently we just copy all and overwrite changed properties
 			/*
@@ -739,21 +789,66 @@ func (upload *fileUpload) FinishUpload(ctx context.Context) (err error) {
 					strings.HasPrefix(attributeName, xattrs.FavPrefix) || // for favorites
 					strings.HasPrefix(attributeName, xattrs.SpaceNameAttr) || // for a shared file
 			*/
-		})
+		}, lock)
 		if err != nil {
-			sublog.Info().Err(err).Msg("Decomposedfs: failed to copy xattrs")
+			discardBlob()
+			sublog.Err(err).Str("version", versionsPath).Msg("failed to copy xattrs to version node")
+			return errtypes.InternalError("failed to copy xattrs to version node")
+		}
+
+		// we MUST bypass any cache here as we have to calculate the size diff atomically
+		oldSize, err = node.ReadBlobSizeAttr(targetPath)
+		if err != nil {
+			discardBlob()
+			sublog.Err(err).Str("version", versionsPath).Msg("failed to copy xattrs to version node")
+			return errtypes.InternalError("failed to copy xattrs to version node")
+		}
+
+	} else {
+		// create dir to node
+		if err := os.MkdirAll(filepath.Dir(targetPath), 0700); err != nil {
+			discardBlob()
+			sublog.Err(err).Msg("could not create node dir")
+			return errtypes.InternalError("could not create node dir")
+		}
+		// touch metadata node
+		file, err := os.Create(targetPath)
+		if err != nil {
+			discardBlob()
+			sublog.Err(err).Msg("could not create metadata node")
+			return errtypes.InternalError("could not create version")
+		}
+		file.Close()
+
+		// basic node metadata
+		attrs[xattrs.ParentidAttr] = n.ParentID
+		attrs[xattrs.NameAttr] = n.Name
+		oldSize = 0
+	}
+
+	// update node metadata with new blobid etc
+	err = n.SetXattrsWithLock(attrs, lock)
+	if err != nil {
+		discardBlob()
+		return errors.Wrap(err, "Decomposedfs: could not write metadata")
+	}
+
+	// use set arbitrary metadata?
+	if upload.info.MetaData["mtime"] != "" {
+		err := n.SetMtime(ctx, upload.info.MetaData["mtime"])
+		if err != nil {
+			sublog.Err(err).Interface("info", upload.info).Msg("Decomposedfs: could not set mtime metadata")
+			return err
 		}
 	}
 
-	// now try write all checksums
-	tryWritingChecksum(&sublog, n, "sha1", sha1h)
-	tryWritingChecksum(&sublog, n, "md5", md5h)
-	tryWritingChecksum(&sublog, n, "adler32", adler32h)
+	// remember size diff
+	//sizeDiff := oldSize - n.Blobsize
 
-	// who will become the owner?  the owner of the parent actually ... not the currently logged in user
-	err = n.WriteAllNodeMetadata()
+	// unlock metadata
+	err = filelocks.ReleaseLock(lock)
 	if err != nil {
-		return errors.Wrap(err, "Decomposedfs: could not write metadata")
+		return errtypes.InternalError(err.Error())
 	}
 
 	// link child name to parent if it is new
@@ -778,23 +873,6 @@ func (upload *fileUpload) FinishUpload(ctx context.Context) (err error) {
 		}
 	}
 
-	// only delete the upload if it was successfully written to the storage
-	if err = os.Remove(upload.infoPath); err != nil {
-		if !errors.Is(err, iofs.ErrNotExist) {
-			sublog.Err(err).Msg("Decomposedfs: could not delete upload info")
-			return
-		}
-	}
-	// use set arbitrary metadata?
-	if upload.info.MetaData["mtime"] != "" {
-		err := n.SetMtime(ctx, upload.info.MetaData["mtime"])
-		if err != nil {
-			sublog.Err(err).Interface("info", upload.info).Msg("Decomposedfs: could not set mtime metadata")
-			return err
-		}
-
-	}
-
 	// fill metadata with current mtime
 	if fi, err = os.Stat(targetPath); err == nil {
 		upload.info.MetaData["mtime"] = fmt.Sprintf("%d.%d", fi.ModTime().Unix(), fi.ModTime().Nanosecond())
@@ -803,6 +881,11 @@ func (upload *fileUpload) FinishUpload(ctx context.Context) (err error) {
 
 	n.Exists = true
 
+	// propagate size diff and new etag
+	//   propagation can happen outside the metadata lock because diff calculation happens inside the lock and the order in which diffs are applied to the parent is irrelvevant
+	//   propagation needs to propagate the diff
+
+	//return upload.fs.tp.Propagate(upload.ctx, n, sizeDiff)
 	return upload.fs.tp.Propagate(upload.ctx, n)
 }
 
@@ -812,15 +895,6 @@ func (upload *fileUpload) checkHash(expected string, h hash.Hash) error {
 		return errtypes.ChecksumMismatch(fmt.Sprintf("invalid checksum: expected %s got %x", upload.info.MetaData["checksum"], h.Sum(nil)))
 	}
 	return nil
-}
-func tryWritingChecksum(log *zerolog.Logger, n *node.Node, algo string, h hash.Hash) {
-	if err := n.SetChecksum(algo, h); err != nil {
-		log.Err(err).
-			Str("csType", algo).
-			Bytes("hash", h.Sum(nil)).
-			Msg("Decomposedfs: could not write checksum")
-		// this is not critical, the bytes are there so we will continue
-	}
 }
 
 func (upload *fileUpload) discardChunk() {

--- a/pkg/storage/utils/decomposedfs/upload.go
+++ b/pkg/storage/utils/decomposedfs/upload.go
@@ -918,7 +918,7 @@ func (upload *fileUpload) FinishUpload(ctx context.Context) (err error) {
 	//   propagation can happen outside the metadata lock because diff calculation happens inside the lock and the order in which diffs are applied to the parent is irrelvevant
 	//   propagation needs to propagate the diff
 
-	//return upload.fs.tp.Propagate(upload.ctx, n, sizeDiff)
+	// return upload.fs.tp.Propagate(upload.ctx, n, sizeDiff)
 	sublog.Debug().Int64("sizediff", sizeDiff).Msg("Decomposedfs: propagating size diff")
 	return upload.fs.tp.Propagate(upload.ctx, n)
 }

--- a/pkg/storage/utils/decomposedfs/upload.go
+++ b/pkg/storage/utils/decomposedfs/upload.go
@@ -854,9 +854,9 @@ func (upload *fileUpload) FinishUpload(ctx context.Context) (err error) {
 
 	// link child name to parent if it is new
 	childNameLink := filepath.Join(n.ParentInternalPath(), n.Name)
+	relativeNodePath := filepath.Join("../../../../../", lookup.Pathify(n.ID, 4, 2))
 	var link string
 	link, err = os.Readlink(childNameLink)
-	relativeNodePath := filepath.Join("../../../../../", lookup.Pathify(n.ID, 4, 2))
 	if err == nil && link != relativeNodePath {
 		sublog.Err(err).
 			Interface("node", n).
@@ -868,7 +868,7 @@ func (upload *fileUpload) FinishUpload(ctx context.Context) (err error) {
 			return errors.Wrap(err, "Decomposedfs: could not remove symlink child entry")
 		}
 	}
-	if errors.Is(err, iofs.ErrNotExist) || link != "../"+n.ID {
+	if errors.Is(err, iofs.ErrNotExist) || link != relativeNodePath {
 		if err = os.Symlink(relativeNodePath, childNameLink); err != nil {
 			return errors.Wrap(err, "Decomposedfs: could not symlink child entry")
 		}

--- a/pkg/storage/utils/decomposedfs/upload.go
+++ b/pkg/storage/utils/decomposedfs/upload.go
@@ -908,11 +908,8 @@ func (upload *fileUpload) FinishUpload(ctx context.Context) (err error) {
 
 	// propagate size diff and new etag
 	//   propagation can happen outside the metadata lock because diff calculation happens inside the lock and the order in which diffs are applied to the parent is irrelvevant
-	//   propagation needs to propagate the diff
-
-	// return upload.fs.tp.Propagate(upload.ctx, n, sizeDiff)
 	sublog.Debug().Int64("sizediff", sizeDiff).Msg("Decomposedfs: propagating size diff")
-	return upload.fs.tp.Propagate(upload.ctx, n)
+	return upload.fs.tp.Propagate(upload.ctx, n, sizeDiff)
 }
 
 func (upload *fileUpload) checkHash(expected string, h hash.Hash) error {

--- a/pkg/storage/utils/decomposedfs/upload.go
+++ b/pkg/storage/utils/decomposedfs/upload.go
@@ -794,15 +794,17 @@ func (upload *fileUpload) FinishUpload(ctx context.Context) (err error) {
 			sublog.Err(err).Str("version", versionsPath).Msg("could not create version node")
 			return errtypes.InternalError("could not create version node")
 		}
-		file.Close()
 		fi, err := file.Stat()
 		if err != nil {
+			file.Close()
 			discardBlob()
 			sublog.Err(err).Str("version", versionsPath).Msg("could not stat version node")
 			return errtypes.InternalError("could not stat version node")
 		}
 		newMtime = fi.ModTime()
+		file.Close()
 
+		// FIXME the copying might not be necessary when we are leaving the node in place since we only need the blobsize and the blobid in the extended attributes for a revision
 		// copy grant and arbitrary metadata to version node
 		// FIXME ... now restoring an older revision might bring back a grant that was removed!
 		err = xattrs.CopyMetadataWithSourceLock(targetPath, versionsPath, func(attributeName string) bool {

--- a/pkg/storage/utils/decomposedfs/upload.go
+++ b/pkg/storage/utils/decomposedfs/upload.go
@@ -723,8 +723,7 @@ func (upload *fileUpload) FinishUpload(ctx context.Context) (err error) {
 
 	// prepare discarding the blob if something changed while writing it
 	discardBlob := func() {
-		err = upload.fs.tp.DeleteBlob(n)
-		if err != nil {
+		if err := upload.fs.tp.DeleteBlob(n); err != nil {
 			sublog.Err(err).Str("blobid", n.BlobID).Msg("Decomposedfs: failed to discard blob in blostore")
 		}
 	}

--- a/pkg/storage/utils/decomposedfs/upload.go
+++ b/pkg/storage/utils/decomposedfs/upload.go
@@ -777,9 +777,9 @@ func (upload *fileUpload) FinishUpload(ctx context.Context) (err error) {
 		xattrs.BlobsizeAttr: strconv.FormatInt(n.Blobsize, 10),
 
 		// update checksums
-		xattrs.ChecksumPrefix + "sha1":        string(sha1h.Sum(nil)),
-		xattrs.ChecksumPrefix + "md5":         string(md5h.Sum(nil)),
-		xattrs.ChecksumPrefix + "shadler32a1": string(adler32h.Sum(nil)),
+		xattrs.ChecksumPrefix + "sha1":    string(sha1h.Sum(nil)),
+		xattrs.ChecksumPrefix + "md5":     string(md5h.Sum(nil)),
+		xattrs.ChecksumPrefix + "adler32": string(adler32h.Sum(nil)),
 	}
 
 	// create version node with current metadata

--- a/pkg/storage/utils/decomposedfs/upload.go
+++ b/pkg/storage/utils/decomposedfs/upload.go
@@ -804,18 +804,11 @@ func (upload *fileUpload) FinishUpload(ctx context.Context) (err error) {
 		newMtime = fi.ModTime()
 		file.Close()
 
-		// FIXME the copying might not be necessary when we are leaving the node in place since we only need the blobsize and the blobid in the extended attributes for a revision
-		// copy grant and arbitrary metadata to version node
-		// FIXME ... now restoring an older revision might bring back a grant that was removed!
+		// copy blob metadata to version node
 		err = xattrs.CopyMetadataWithSourceLock(targetPath, versionsPath, func(attributeName string) bool {
-			return true
-			// TODO determine all attributes that must be copied, currently we just copy all and overwrite changed properties
-			/*
-				return strings.HasPrefix(attributeName, xattrs.GrantPrefix) || // for grants
-					strings.HasPrefix(attributeName, xattrs.MetadataPrefix) || // for arbitrary metadata
-					strings.HasPrefix(attributeName, xattrs.FavPrefix) || // for favorites
-					strings.HasPrefix(attributeName, xattrs.SpaceNameAttr) || // for a shared file
-			*/
+			return strings.HasPrefix(attributeName, xattrs.ChecksumPrefix) || // for checksums
+				attributeName == xattrs.BlobIDAttr ||
+				attributeName == xattrs.BlobsizeAttr
 		}, lock)
 		if err != nil {
 			discardBlob()

--- a/pkg/storage/utils/decomposedfs/upload.go
+++ b/pkg/storage/utils/decomposedfs/upload.go
@@ -718,13 +718,13 @@ func (upload *fileUpload) FinishUpload(ctx context.Context) (err error) {
 	defer file.Close()
 	err = upload.fs.tp.WriteBlob(n, file)
 	if err != nil {
-		return errors.Wrap(err, "failed to upload file to blostore")
+		return errors.Wrap(err, "failed to upload file to blobstore")
 	}
 
 	// prepare discarding the blob if something changed while writing it
 	discardBlob := func() {
 		if err := upload.fs.tp.DeleteBlob(n); err != nil {
-			sublog.Err(err).Str("blobid", n.BlobID).Msg("Decomposedfs: failed to discard blob in blostore")
+			sublog.Err(err).Str("blobid", n.BlobID).Msg("Decomposedfs: failed to discard blob in blobstore")
 		}
 	}
 
@@ -761,7 +761,6 @@ func (upload *fileUpload) FinishUpload(ctx context.Context) (err error) {
 			}
 		}
 
-		// FIXME move versioning to blobs ... no need to copy all the metadata! well ... it does if we want to version metadata...
 		// versions are stored alongside the actual file, so a rename can be efficient and does not cross storage / partition boundaries
 		versionsPath = upload.fs.lu.InternalPath(spaceID, n.ID+node.RevisionIDDelimiter+fi.ModTime().UTC().Format(time.RFC3339Nano))
 

--- a/pkg/storage/utils/decomposedfs/upload.go
+++ b/pkg/storage/utils/decomposedfs/upload.go
@@ -806,14 +806,14 @@ func (upload *fileUpload) FinishUpload(ctx context.Context) (err error) {
 
 		// copy blob metadata to version node
 		err = xattrs.CopyMetadataWithSourceLock(targetPath, versionsPath, func(attributeName string) bool {
-			return strings.HasPrefix(attributeName, xattrs.ChecksumPrefix) || // for checksums
+			return strings.HasPrefix(attributeName, xattrs.ChecksumPrefix) ||
 				attributeName == xattrs.BlobIDAttr ||
 				attributeName == xattrs.BlobsizeAttr
 		}, lock)
 		if err != nil {
 			discardBlob()
 			sublog.Err(err).Str("version", versionsPath).Msg("failed to copy xattrs to version node")
-			return errtypes.InternalError("failed to copy xattrs to version node")
+			return errtypes.InternalError("failed to copy blob xattrs to version node")
 		}
 
 		// keep mtime from previous version

--- a/pkg/storage/utils/filelocks/filelocks.go
+++ b/pkg/storage/utils/filelocks/filelocks.go
@@ -85,10 +85,6 @@ func acquireLock(file string, write bool) (*flock.Flock, error) {
 		return nil, ErrPathEmpty
 	}
 
-	if _, err = os.Stat(file); err != nil {
-		return nil, err
-	}
-
 	var flock *flock.Flock
 	for i := 1; i <= _lockCyclesValue; i++ {
 		if flock = getMutexedFlock(n); flock != nil {

--- a/tests/acceptance/expected-failures-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-on-OCIS-storage.md
@@ -284,10 +284,6 @@ _requires a [CS3 user provisioning api that can update the quota for a user](htt
 -   [apiWebdavMove2/moveShareOnOcis.feature:169](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavMove2/moveShareOnOcis.feature#L169)
 -   [apiWebdavMove2/moveShareOnOcis.feature:170](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavMove2/moveShareOnOcis.feature#L170)
 
-
-#### [restoring an older version of a shared file deletes the share](https://github.com/owncloud/ocis/issues/765)
--   [apiShareManagementToShares/acceptShares.feature:579](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareManagementToShares/acceptShares.feature#L579)
-
 #### [Expiration date for shares is not implemented](https://github.com/owncloud/ocis/issues/1250)
 #### Expiration date of user shares
 -   [apiShareCreateSpecialToShares1/createShareExpirationDate.feature:52](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareCreateSpecialToShares1/createShareExpirationDate.feature#L52)

--- a/tests/acceptance/expected-failures-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-on-OCIS-storage.md
@@ -784,9 +784,6 @@ moving outside of the Shares folder gives 501 Not Implemented.
 -   [apiWebdavProperties1/copyFile.feature:437](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/copyFile.feature#L437)
 -   [apiWebdavProperties1/copyFile.feature:442](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavProperties1/copyFile.feature#L442)
 
-#### [Downloading the older version of shared file gives 404](https://github.com/owncloud/ocis/issues/3868)
--   [apiVersions/fileVersionsSharingToShares.feature:306](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiVersions/fileVersionsSharingToShares.feature#L306)
-
 #### [file versions do not report the version author](https://github.com/owncloud/ocis/issues/2914)
 -   [apiVersions/fileVersionAuthor.feature:14](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiVersions/fileVersionAuthor.feature#L14)
 -   [apiVersions/fileVersionAuthor.feature:37](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiVersions/fileVersionAuthor.feature#L37)

--- a/tests/acceptance/expected-failures-on-S3NG-storage.md
+++ b/tests/acceptance/expected-failures-on-S3NG-storage.md
@@ -9,9 +9,6 @@ Basic file management like up and download, move, copy, properties, quota, trash
 -   [apiTrashbin/trashbinFilesFolders.feature:318](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature#L318)
 -   [apiTrashbin/trashbinFilesFolders.feature:323](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature#L323)
 
-#### [Downloading the older version of shared file gives 404](https://github.com/owncloud/ocis/issues/3868)
--   [apiVersions/fileVersionsSharingToShares.feature:306](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiVersions/fileVersionsSharingToShares.feature#L306)
-
 #### [file versions do not report the version author](https://github.com/owncloud/ocis/issues/2914)
 -   [apiVersions/fileVersionAuthor.feature:14](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiVersions/fileVersionAuthor.feature#L14)
 -   [apiVersions/fileVersionAuthor.feature:37](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiVersions/fileVersionAuthor.feature#L37)

--- a/tests/acceptance/expected-failures-on-S3NG-storage.md
+++ b/tests/acceptance/expected-failures-on-S3NG-storage.md
@@ -293,9 +293,6 @@ _requires a [CS3 user provisioning api that can update the quota for a user](htt
 -   [apiWebdavMove2/moveShareOnOcis.feature:169](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavMove2/moveShareOnOcis.feature#L169)
 -   [apiWebdavMove2/moveShareOnOcis.feature:170](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiWebdavMove2/moveShareOnOcis.feature#L170)
 
-#### [restoring an older version of a shared file deletes the share](https://github.com/owncloud/ocis/issues/765)
--   [apiShareManagementToShares/acceptShares.feature:579](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareManagementToShares/acceptShares.feature#L579)
-
 #### [Expiration date for shares is not implemented](https://github.com/owncloud/ocis/issues/1250)
 #### Expiration date of user shares
 -   [apiShareCreateSpecialToShares1/createShareExpirationDate.feature:52](https://github.com/owncloud/core/blob/master/tests/acceptance/features/apiShareCreateSpecialToShares1/createShareExpirationDate.feature#L52)


### PR DESCRIPTION
We now propagate the size diff instead of calculating the treesize. This fixes the slower upload speeds in large folders.

fixes https://github.com/owncloud/ocis/issues/5061

requires https://github.com/cs3org/reva/pull/3473