### PR TITLE
EOS default (available) quota set to 1T

### DIFF
--- a/changelog/unreleased/eos-default-quota-fix.md
+++ b/changelog/unreleased/eos-default-quota-fix.md
@@ -1,0 +1,6 @@
+Bugfix: Fixes the DefaultQuotaBytes in EOS
+
+We were setting the default logical quota to 1T, resulting 
+on only 500GB available to the user.
+
+https://github.com/cs3org/reva/pull/3492

--- a/pkg/storage/utils/eosfs/eosfs.go
+++ b/pkg/storage/utils/eosfs/eosfs.go
@@ -100,7 +100,7 @@ func (c *Config) init() {
 	}
 
 	if c.DefaultQuotaBytes == 0 {
-		c.DefaultQuotaBytes = 1000000000000 // 1 TB
+		c.DefaultQuotaBytes = 2000000000000 // 1 TB logical
 	}
 	if c.DefaultQuotaFiles == 0 {
 		c.DefaultQuotaFiles = 1000000 // 1 Million


### PR DESCRIPTION
Up until now, we were creating user homes with 500.00GB by default, rather than the intended policy of 1TB.

```
eos quota ls -u test1mgt

┏━> Quota Node: /eos/user/
┌──────────┬──────────┬──────────┬──────────┬──────────┬──────────┬──────────┬──────────┬──────────┬──────────┐
│user      │used bytes│logi bytes│used files│aval bytes│aval logib│aval files│ filled[%]│vol-status│ino-status│
└──────────┴──────────┴──────────┴──────────┴──────────┴──────────┴──────────┴──────────┴──────────┴──────────┘
 test1mgt          0 B        0 B          0    1.00 TB  500.00 GB     1.00 M     0.00 %         ok         ok
┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
```