### PR TITLE
appproviders: pass query parameters in /app/open as Opaque

### DIFF
--- a/changelog/unreleased/apps-opaque.md
+++ b/changelog/unreleased/apps-opaque.md
@@ -1,0 +1,6 @@
+Enhancement: appproviders: pass other query parameters as Opaque
+
+This allows to send any other HTTP query parameter passed to /app/open
+to the underlying appprovider drivers via GRPC
+
+https://github.com/cs3org/reva/pull/3502

--- a/internal/grpc/services/appprovider/appprovider.go
+++ b/internal/grpc/services/appprovider/appprovider.go
@@ -212,7 +212,7 @@ func getProvider(c *config) (app.Provider, error) {
 }
 
 func (s *service) OpenInApp(ctx context.Context, req *providerpb.OpenInAppRequest) (*providerpb.OpenInAppResponse, error) {
-	appURL, err := s.provider.GetAppURL(ctx, req.ResourceInfo, req.ViewMode, req.AccessToken, s.conf.Language)
+	appURL, err := s.provider.GetAppURL(ctx, req.ResourceInfo, req.ViewMode, req.AccessToken, req.Opaque.Map, s.conf.Language)
 	if err != nil {
 		res := &providerpb.OpenInAppResponse{
 			Status: status.NewInternal(ctx, errors.New("appprovider: error calling GetAppURL"), err.Error()),

--- a/internal/grpc/services/gateway/appprovider.go
+++ b/internal/grpc/services/gateway/appprovider.go
@@ -95,7 +95,7 @@ func (s *svc) OpenInApp(ctx context.Context, req *gateway.OpenInAppRequest) (*pr
 		}
 		if uri.Scheme == "webdav" {
 			insecure, skipVerify := getGRPCConfig(req.Opaque)
-			return s.openFederatedShares(ctx, fileInfo.Target, req.ViewMode, req.App, insecure, skipVerify, resChild)
+			return s.openFederatedShares(ctx, fileInfo.Target, req, insecure, skipVerify, resChild)
 		}
 
 		res, err := s.Stat(ctx, &storageprovider.StatRequest{
@@ -114,10 +114,10 @@ func (s *svc) OpenInApp(ctx context.Context, req *gateway.OpenInAppRequest) (*pr
 		}
 		fileInfo = res.Info
 	}
-	return s.openLocalResources(ctx, fileInfo, req.ViewMode, req.App)
+	return s.openLocalResources(ctx, fileInfo, req)
 }
 
-func (s *svc) openFederatedShares(ctx context.Context, targetURL string, vm gateway.OpenInAppRequest_ViewMode, app string,
+func (s *svc) openFederatedShares(ctx context.Context, targetURL string, req *gateway.OpenInAppRequest,
 	insecure, skipVerify bool, nameQueries ...string) (*providerpb.OpenInAppResponse, error) {
 	log := appctx.GetLogger(ctx)
 	targetURL, err := appendNameQuery(targetURL, nameQueries...)
@@ -132,8 +132,9 @@ func (s *svc) openFederatedShares(ctx context.Context, targetURL string, vm gate
 	ref := &storageprovider.Reference{Path: ep.filePath}
 	appProviderReq := &gateway.OpenInAppRequest{
 		Ref:      ref,
-		ViewMode: vm,
-		App:      app,
+		ViewMode: req.ViewMode,
+		App:      req.App,
+		Opaque:   req.Opaque,
 	}
 
 	meshProvider, err := s.GetInfoByDomain(ctx, &ocmprovider.GetInfoByDomainRequest{
@@ -168,8 +169,7 @@ func (s *svc) openFederatedShares(ctx context.Context, targetURL string, vm gate
 	return res, nil
 }
 
-func (s *svc) openLocalResources(ctx context.Context, ri *storageprovider.ResourceInfo,
-	vm gateway.OpenInAppRequest_ViewMode, app string) (*providerpb.OpenInAppResponse, error) {
+func (s *svc) openLocalResources(ctx context.Context, ri *storageprovider.ResourceInfo, req *gateway.OpenInAppRequest) (*providerpb.OpenInAppResponse, error) {
 	accessToken, ok := ctxpkg.ContextGetToken(ctx)
 	if !ok || accessToken == "" {
 		return &providerpb.OpenInAppResponse{
@@ -177,7 +177,7 @@ func (s *svc) openLocalResources(ctx context.Context, ri *storageprovider.Resour
 		}, nil
 	}
 
-	provider, err := s.findAppProvider(ctx, ri, app)
+	provider, err := s.findAppProvider(ctx, ri, req.App)
 	if err != nil {
 		err = errors.Wrap(err, "gateway: error calling findAppProvider")
 		if _, ok := err.(errtypes.IsNotFound); ok {
@@ -195,8 +195,9 @@ func (s *svc) openLocalResources(ctx context.Context, ri *storageprovider.Resour
 
 	appProviderReq := &providerpb.OpenInAppRequest{
 		ResourceInfo: ri,
-		ViewMode:     providerpb.OpenInAppRequest_ViewMode(vm),
+		ViewMode:     providerpb.OpenInAppRequest_ViewMode(req.ViewMode),
 		AccessToken:  accessToken,
+		Opaque:       req.Opaque,
 	}
 
 	res, err := appProviderClient.OpenInApp(ctx, appProviderReq)

--- a/internal/http/services/appprovider/appprovider.go
+++ b/internal/http/services/appprovider/appprovider.go
@@ -378,10 +378,21 @@ func (s *svc) handleOpen(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	opaqueMap := make(map[string]*typespb.OpaqueEntry)
+	for k, v := range r.Form {
+		if k != "file_id" && k != "view_mode" && k != "app_name" {
+			opaqueMap[k] = &typespb.OpaqueEntry{
+				Decoder: "plain",
+				Value:   []byte(v[0]),
+			}
+		}
+	}
+
 	openReq := gateway.OpenInAppRequest{
 		Ref:      fileRef,
 		ViewMode: viewMode,
 		App:      r.Form.Get("app_name"),
+		Opaque:   &typespb.Opaque{Map: opaqueMap},
 	}
 	openRes, err := client.OpenInApp(ctx, &openReq)
 	if err != nil {

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -24,6 +24,7 @@ import (
 	appprovider "github.com/cs3org/go-cs3apis/cs3/app/provider/v1beta1"
 	registry "github.com/cs3org/go-cs3apis/cs3/app/registry/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+	typespb "github.com/cs3org/go-cs3apis/cs3/types/v1beta1"
 )
 
 // Registry is the interface that application registries implement
@@ -40,6 +41,6 @@ type Registry interface {
 // Provider is the interface that application providers implement
 // for interacting with external apps that serve the requested resource.
 type Provider interface {
-	GetAppURL(ctx context.Context, resource *provider.ResourceInfo, viewMode appprovider.OpenInAppRequest_ViewMode, token, language string) (*appprovider.OpenInAppURL, error)
+	GetAppURL(ctx context.Context, resource *provider.ResourceInfo, viewMode appprovider.OpenInAppRequest_ViewMode, token string, opaqueMap map[string]*typespb.OpaqueEntry, language string) (*appprovider.OpenInAppURL, error)
 	GetAppProviderInfo(ctx context.Context) (*registry.ProviderInfo, error)
 }

--- a/pkg/app/provider/demo/demo.go
+++ b/pkg/app/provider/demo/demo.go
@@ -26,6 +26,7 @@ import (
 	appprovider "github.com/cs3org/go-cs3apis/cs3/app/provider/v1beta1"
 	appregistry "github.com/cs3org/go-cs3apis/cs3/app/registry/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+	typespb "github.com/cs3org/go-cs3apis/cs3/types/v1beta1"
 	"github.com/cs3org/reva/pkg/app"
 	"github.com/cs3org/reva/pkg/app/provider/registry"
 	"github.com/mitchellh/mapstructure"
@@ -39,7 +40,7 @@ type demoProvider struct {
 	iframeUIProvider string
 }
 
-func (p *demoProvider) GetAppURL(ctx context.Context, resource *provider.ResourceInfo, viewMode appprovider.OpenInAppRequest_ViewMode, token, language string) (*appprovider.OpenInAppURL, error) {
+func (p *demoProvider) GetAppURL(ctx context.Context, resource *provider.ResourceInfo, viewMode appprovider.OpenInAppRequest_ViewMode, token string, opaqueMap map[string]*typespb.OpaqueEntry, language string) (*appprovider.OpenInAppURL, error) {
 	url := fmt.Sprintf("<iframe src=%s/open/%s?view-mode=%s&access-token=%s&lang=%s />", p.iframeUIProvider, resource.Id.StorageId+":"+resource.Id.OpaqueId, viewMode.String(), token, language)
 	return &appprovider.OpenInAppURL{
 		AppUrl: url,

--- a/pkg/app/provider/wopi/wopi.go
+++ b/pkg/app/provider/wopi/wopi.go
@@ -37,6 +37,7 @@ import (
 	appregistry "github.com/cs3org/go-cs3apis/cs3/app/registry/v1beta1"
 	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+	typespb "github.com/cs3org/go-cs3apis/cs3/types/v1beta1"
 	"github.com/cs3org/reva/pkg/app"
 	"github.com/cs3org/reva/pkg/app/provider/registry"
 	"github.com/cs3org/reva/pkg/appctx"
@@ -118,7 +119,7 @@ func New(m map[string]interface{}) (app.Provider, error) {
 	}, nil
 }
 
-func (p *wopiProvider) GetAppURL(ctx context.Context, resource *provider.ResourceInfo, viewMode appprovider.OpenInAppRequest_ViewMode, token, language string) (*appprovider.OpenInAppURL, error) {
+func (p *wopiProvider) GetAppURL(ctx context.Context, resource *provider.ResourceInfo, viewMode appprovider.OpenInAppRequest_ViewMode, token string, opaqueMap map[string]*typespb.OpaqueEntry, language string) (*appprovider.OpenInAppURL, error) {
 	log := appctx.GetLogger(ctx)
 
 	ext := path.Ext(resource.Path)
@@ -185,6 +186,11 @@ func (p *wopiProvider) GetAppURL(ctx context.Context, resource *provider.Resourc
 
 	if p.conf.AppIntURL != "" {
 		q.Add("appinturl", p.conf.AppIntURL)
+	}
+
+	if _, ok := opaqueMap["forcelock"]; ok {
+		// this is to work around an issue with Microsoft Office, cf. cs3org/wopiserver#106
+		q.Add("forcelock", "1")
 	}
 
 	httpReq.URL.RawQuery = q.Encode()


### PR DESCRIPTION
This allows to send any other HTTP query parameter passed to `/app/open` all the way to the underlying appprovider drivers via GRPC