### PR TITLE
Fix refresh lock method for cephfs storage driver

### DIFF
--- a/changelog/unreleased/refresh-lock-cephfs.md
+++ b/changelog/unreleased/refresh-lock-cephfs.md
@@ -1,0 +1,3 @@
+Bugfix: Fix RefreshLock method for cephfs storage driver
+
+https://github.com/cs3org/reva/pull/3504

--- a/pkg/storage/fs/cephfs/cephfs.go
+++ b/pkg/storage/fs/cephfs/cephfs.go
@@ -625,7 +625,7 @@ func (fs *cephfs) GetLock(ctx context.Context, ref *provider.Reference) (*provid
 	return nil, errtypes.NotSupported("unimplemented")
 }
 
-func (fs *cephfs) RefreshLock(ctx context.Context, ref *provider.Reference, lock *provider.Lock) error {
+func (fs *cephfs) RefreshLock(ctx context.Context, ref *provider.Reference, lock *provider.Lock, existingLockID string) error {
 	return errtypes.NotSupported("unimplemented")
 }
 


### PR DESCRIPTION
The build for reva including the ceph storage was failing becase the driver was not implementing the correct storage.FS interface, for the missing parameter in RefreshLock method.

This PR fixes this.