### PR TITLE
Get user preferred language

### DIFF
--- a/changelog/unreleased/get-user-language.md
+++ b/changelog/unreleased/get-user-language.md
@@ -1,0 +1,9 @@
+Enhancement: Get user preferred language
+
+The only way for an OCIS web user to change language
+was to set it into the browser settings.
+In the ocs user info response, a field `language` is added,
+to change their language in the UI, regardless of the
+browser settings.
+
+https://github.com/cs3org/reva/pull/3507

--- a/internal/http/services/owncloud/ocs/handlers/cloud/user/user.go
+++ b/internal/http/services/owncloud/ocs/handlers/cloud/user/user.go
@@ -43,7 +43,6 @@ func (h *Handler) Init(c *config.Config) {
 }
 
 const (
-	defaultLanguage   = "en"
 	languageNamespace = "core"
 	languageKey       = "lang"
 )
@@ -71,7 +70,7 @@ func (h *Handler) GetSelf(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) getLanguage(ctx context.Context) string {
 	gw, err := pool.GetGatewayServiceClient(pool.Endpoint(h.gatewayAddr))
 	if err != nil {
-		return defaultLanguage
+		return ""
 	}
 	res, err := gw.GetKey(ctx, &preferences.GetKeyRequest{
 		Key: &preferences.PreferenceKey{
@@ -80,7 +79,7 @@ func (h *Handler) getLanguage(ctx context.Context) string {
 		},
 	})
 	if err != nil || res.Status.Code != rpc.Code_CODE_OK {
-		return defaultLanguage
+		return ""
 	}
 	return res.GetVal()
 }
@@ -92,5 +91,5 @@ type User struct {
 	DisplayName string `json:"display-name" xml:"display-name"`
 	Email       string `json:"email" xml:"email"`
 	UserType    string `json:"user-type" xml:"user-type"`
-	Language    string `json:"language" xml:"language"`
+	Language    string `json:"language,omitempty" xml:"language,omitempty"`
 }

--- a/internal/http/services/owncloud/ocs/ocs.go
+++ b/internal/http/services/owncloud/ocs/ocs.go
@@ -95,6 +95,7 @@ func (s *svc) routerInit() error {
 	shareesHandler := new(sharees.Handler)
 	capabilitiesHandler.Init(s.c)
 	usersHandler.Init(s.c)
+	userHandler.Init(s.c)
 	configHandler.Init(s.c)
 	sharesHandler.Init(s.c)
 	shareesHandler.Init(s.c)


### PR DESCRIPTION
This PR adds in the `/ocs/v{1|2}.php/cloud/user` response a language field, used by OCIS web to override the default browser setting language.