### PR TITLE
Allow an user to set a preferred language

### DIFF
--- a/changelog/unreleased/set-user-language.md
+++ b/changelog/unreleased/set-user-language.md
@@ -1,0 +1,3 @@
+Enhancement: Allow an user to set a preferred language
+
+https://github.com/cs3org/reva/pull/3508

--- a/internal/http/services/owncloud/ocs/config/config.go
+++ b/internal/http/services/owncloud/ocs/config/config.go
@@ -42,6 +42,7 @@ type Config struct {
 	ResourceInfoCacheTTL     int                               `mapstructure:"resource_info_cache_ttl"`
 	ResourceInfoCacheDrivers map[string]map[string]interface{} `mapstructure:"resource_info_caches"`
 	UserIdentifierCacheTTL   int                               `mapstructure:"user_identifier_cache_ttl"`
+	AllowedLanguages         []string                          `mapstructure:"allowed_languages"`
 }
 
 // Init sets sane defaults.

--- a/internal/http/services/owncloud/ocs/handlers/cloud/user/user.go
+++ b/internal/http/services/owncloud/ocs/handlers/cloud/user/user.go
@@ -115,7 +115,6 @@ func (h *Handler) UpdateSelf(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-
 }
 
 func (h *Handler) updateLanguage(ctx context.Context, lang string) error {

--- a/internal/http/services/owncloud/ocs/handlers/cloud/user/user.go
+++ b/internal/http/services/owncloud/ocs/handlers/cloud/user/user.go
@@ -95,6 +95,7 @@ type updateSelfRequest struct {
 	Language string `json:"language"`
 }
 
+// UpdateSelf handles PATCH requests on /cloud/user.
 func (h *Handler) UpdateSelf(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 

--- a/internal/http/services/owncloud/ocs/ocs.go
+++ b/internal/http/services/owncloud/ocs/ocs.go
@@ -134,6 +134,7 @@ func (s *svc) routerInit() error {
 		r.Route("/cloud", func(r chi.Router) {
 			r.Get("/capabilities", capabilitiesHandler.GetCapabilities)
 			r.Get("/user", userHandler.GetSelf)
+			r.Patch("/user", userHandler.UpdateSelf)
 			r.Route("/users", func(r chi.Router) {
 				r.Get("/{userid}", usersHandler.GetUsers)
 				r.Get("/{userid}/groups", usersHandler.GetGroups)


### PR DESCRIPTION
This PR adds an endpoint that a user can use to set their preferred language:

```
 curl -X PATCH https://xxxx/ocs/v1.php/cloud/user -d '{"language":"it"}'-v -u xxxx
```
