### PR TITLE
Fix expired authenticated public link error code

### DIFF
--- a/changelog/unreleased/fix-authenticated-expired-publiclinks.md
+++ b/changelog/unreleased/fix-authenticated-expired-publiclinks.md
@@ -1,0 +1,8 @@
+Bugfix: Fix expired authenticated public link error code
+
+On an expired authenticated public link, the error returned
+was 401 unauthorized, behaving differently from
+a not-authenticated one, that returns 404 not found.
+This has been fixed, returning 404 not found.
+
+https://github.com/cs3org/reva/pull/3528

--- a/pkg/cbox/publicshare/sql/sql.go
+++ b/pkg/cbox/publicshare/sql/sql.go
@@ -449,6 +449,12 @@ func (m *manager) GetPublicShareByToken(ctx context.Context, token string, auth 
 		return nil, err
 	}
 	cs3Share := conversions.ConvertToCS3PublicShare(s)
+	if expired(cs3Share) {
+		if err := m.cleanupExpiredShares(); err != nil {
+			return nil, err
+		}
+		return nil, errtypes.NotFound(token)
+	}
 	if s.ShareWith != "" {
 		if !authenticate(cs3Share, s.ShareWith, auth) {
 			// if check := checkPasswordHash(auth.Password, s.ShareWith); !check {
@@ -460,13 +466,6 @@ func (m *manager) GetPublicShareByToken(ctx context.Context, token string, auth 
 				return nil, err
 			}
 		}
-	}
-
-	if expired(cs3Share) {
-		if err := m.cleanupExpiredShares(); err != nil {
-			return nil, err
-		}
-		return nil, errtypes.NotFound(token)
 	}
 
 	return cs3Share, nil


### PR DESCRIPTION
On an expired authenticated public link, the error returned from server was 401 unauthorized, behaving differently from a not-authenticated one, that returns 404 not found. This has been fixed in this PR, aligning the first case with the second.