### PR TITLE
Fix nil node on err

### DIFF
--- a/changelog/unreleased/fix-nil-node-on-error.md
+++ b/changelog/unreleased/fix-nil-node-on-error.md
@@ -1,0 +1,3 @@
+Bugfix: prevent panic in decomposed node when returning an error
+
+https://github.com/cs3org/reva/pull/3534

--- a/pkg/storage/utils/decomposedfs/node/node.go
+++ b/pkg/storage/utils/decomposedfs/node/node.go
@@ -238,7 +238,10 @@ func ReadNode(ctx context.Context, lu PathLookup, spaceID, nodeID string, canLis
 
 	// append back revision to nodeid, even when returning a not existing node
 	defer func() {
-		n.ID += revisionSuffix
+		// when returning errors n is nil
+		if n != nil {
+			n.ID += revisionSuffix
+		}
 	}()
 
 	nodePath := n.InternalPath()


### PR DESCRIPTION
When returning `nil, err`, `n` is set to nil causing a panic in `n.ID += revisionSuffix`.