### PR TITLE
Fix #3550: OCM share fails for json driver

### DIFF
--- a/changelog/unreleased/fix-3550.md
+++ b/changelog/unreleased/fix-3550.md
@@ -1,4 +1,4 @@
-Fix: Fixes implementation omission of #3526
+Bugfix: Fixes implementation omission of #3526
 
 In #3526 a new value format of the owner parameter of the ocm share request was introduced.
 This change was not implemented in the json driver. This change fixes that.

--- a/changelog/unreleased/fix-3550.md
+++ b/changelog/unreleased/fix-3550.md
@@ -1,0 +1,5 @@
+Fix: Fixes implementation omission of #3526
+
+In #3526 a new value format of the owner parameter of the ocm share request was introduced.
+This change was not implemented in the json driver. This change fixes that.
+

--- a/changelog/unreleased/fix-3550.md
+++ b/changelog/unreleased/fix-3550.md
@@ -3,3 +3,4 @@ Fix: Fixes implementation omission of #3526
 In #3526 a new value format of the owner parameter of the ocm share request was introduced.
 This change was not implemented in the json driver. This change fixes that.
 
+https://github.com/cs3org/reva/pull/3551

--- a/pkg/ocm/share/manager/json/json.go
+++ b/pkg/ocm/share/manager/json/json.go
@@ -268,9 +268,9 @@ func (m *mgr) Share(ctx context.Context, md *provider.ResourceId, g *ocm.ShareGr
 			"shareWith":    g.Grantee.GetUserId().OpaqueId,
 			"name":         name,
 			"providerId":   fmt.Sprintf("%s:%s", md.StorageId, md.OpaqueId),
-			"owner":        userID.OpaqueId,
+			"owner":        fmt.Sprintf("%s@%s", userID.OpaqueId, userID.Idp),
 			"protocol":     protocol,
-			"meshProvider": userID.Idp, // FIXME: move this into the 'owner' string?
+			"meshProvider": userID.Idp,
 		}
 		err = sender.Send(ctx, requestBodyMap, pi)
 		if err != nil {


### PR DESCRIPTION
Fixes implementation omission in ocm share json driver in https://github.com/cs3org/reva/pull/3526