### PR TITLE
[tests-only] Bump core commit id to latest `reva-master`

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The test runner source for API tests
-CORE_COMMITID=156adf5eb80eac9c70bd36f1fe3f8067ba543b92
+CORE_COMMITID=374a2a3d42a89ccb3caec6329c5f2a85214608f0
 CORE_BRANCH=master


### PR DESCRIPTION
Bump core commit id to latest.
Part of https://github.com/owncloud/QA/issues/785