### PR TITLE
[tests-only] Bump core commit id to latest `reva-master`

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,3 @@
 # The test runner source for API tests
-CORE_COMMITID=3a79d3860b0a1eb26a46c434bd1331d873c65aa7
+CORE_COMMITID=a890932216b9450d7cc7446dda7163fc8f999eab
 CORE_BRANCH=master


### PR DESCRIPTION
Bump core commit id to latest.
Part of https://github.com/owncloud/QA/issues/791