### PR TITLE
Resource info fallback to manager

### DIFF
--- a/changelog/unreleased/fix-node-owner-or-manager.md
+++ b/changelog/unreleased/fix-node-owner-or-manager.md
@@ -1,0 +1,8 @@
+Bugfix: Node owner or manager
+
+DecomposedFS resource info returned the `node.owner` as owner, that is fine in the case of a `personal space`.
+But if the current space is a `project space`, the space uuid is used as an owner which makes it impossible to authenticate it.
+
+This is fixed now and the resourceInfo owner returns the owner where it exists and falls back to the first available manager if not.
+
+https://github.com/cs3org/reva/pull/3583

--- a/pkg/storage/utils/decomposedfs/node/node.go
+++ b/pkg/storage/utils/decomposedfs/node/node.go
@@ -660,7 +660,7 @@ func (n *Node) AsResourceInfo(ctx context.Context, rp *provider.ResourcePermissi
 		Size:          uint64(n.Blobsize),
 		Target:        target,
 		PermissionSet: rp,
-		Owner:         n.Owner(),
+		Owner:         n.SpaceOwnerOrManager(ctx),
 		ParentId:      parentID,
 		Name:          n.Name,
 	}


### PR DESCRIPTION
DecomposedFS resource info returned the `node.owner` as owner, that is fine in the case of a `personal space`.
But if the current space is a `project space`, the space uuid is used as an owner which makes it impossible to authenticate it.

This is fixed now and the resourceInfo owner returns the owner where it exists and falls back to the first available manager if not.