### PR TITLE
[full-ci] [tests-only] Add APITESTS_REPO_GIT_URL env variable to .drone.env

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,4 @@
 # The test runner source for API tests
 APITESTS_COMMITID=6357a703181b368e2109f720e0785a11222eed88
 APITESTS_BRANCH=master
+APITESTS_REPO_GIT_URL=https://github.com/owncloud/ocis.git

--- a/.drone.star
+++ b/.drone.star
@@ -41,7 +41,7 @@ def cloneApiTestReposStep():
         "commands": [
             "source /drone/src/.drone.env",
             "git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing",
-            "git clone -b $APITESTS_BRANCH --single-branch --no-tags https://github.com/owncloud/ocis.git /drone/src/tmp/testrunner",
+            "git clone -b $APITESTS_BRANCH --single-branch --no-tags $APITESTS_REPO_GIT_URL /drone/src/tmp/testrunner",
             "cd /drone/src/tmp/testrunner",
             "git checkout $APITESTS_COMMITID",
         ],


### PR DESCRIPTION
I think that it will be clearer to specify the upstream repo that has the API test code and features/scenarios in `.drone.env`

That will make it more obvious to maintainers that the `APITESTS_COMMITID` and `APITESTS_BRANCH` must be a commit id and a branch from the `owncloud/ocis` repo.