### PR TITLE
[tests-only] acceptance tests run.sh no longer needs --remote

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -178,7 +178,7 @@ BEHAT_BIN=vendor-bin/behat/vendor/bin/behat
 CORE_BEHAT_YML=$(PATH_TO_APITESTS)/tests/acceptance/config/behat-core.yml
 
 test-acceptance-api: vendor-bin/behat/vendor
-	BEHAT_BIN=$(BEHAT_BIN) $(PATH_TO_APITESTS)/tests/acceptance/run.sh --remote --type api
+	BEHAT_BIN=$(BEHAT_BIN) $(PATH_TO_APITESTS)/tests/acceptance/run.sh --type api
 
 test-acceptance-core-api: vendor-bin/behat/vendor
 	BEHAT_BIN=$(BEHAT_BIN) BEHAT_YML=$(CORE_BEHAT_YML) $(PATH_TO_APITESTS)/tests/acceptance/run.sh --type core-api


### PR DESCRIPTION
Apply this change the same as we are doing in master branch https://github.com/cs3org/reva/pull/3592/commits/a01e04312046b4875a916f69900d95500d9708f3

See comment in PR #3592 
https://github.com/cs3org/reva/pull/3592#issuecomment-1376828555