### PR TITLE
Cache CreateStorageSpace calls for personal spaces

### DIFF
--- a/changelog/unreleased/cache-create-home.md
+++ b/changelog/unreleased/cache-create-home.md
@@ -1,0 +1,5 @@
+Bugfix: Cache CreateHome calls
+
+We restored the caching of CreateHome calls getting rid of a lot of internal calls.
+
+https://github.com/cs3org/reva/pull/3596

--- a/internal/grpc/services/gateway/gateway.go
+++ b/internal/grpc/services/gateway/gateway.go
@@ -131,12 +131,13 @@ func (c *config) init() {
 }
 
 type svc struct {
-	c               *config
-	dataGatewayURL  url.URL
-	tokenmgr        token.Manager
-	statCache       cache.StatCache
-	providerCache   cache.ProviderCache
-	createHomeCache cache.CreateHomeCache
+	c                        *config
+	dataGatewayURL           url.URL
+	tokenmgr                 token.Manager
+	statCache                cache.StatCache
+	providerCache            cache.ProviderCache
+	createHomeCache          cache.CreateHomeCache
+	createPersonalSpaceCache cache.CreatePersonalSpaceCache
 }
 
 // New creates a new gateway svc that acts as a proxy for any grpc operation.
@@ -162,12 +163,13 @@ func New(m map[string]interface{}, ss *grpc.Server) (rgrpc.Service, error) {
 	}
 
 	s := &svc{
-		c:               c,
-		dataGatewayURL:  *u,
-		tokenmgr:        tokenManager,
-		statCache:       cache.GetStatCache(c.CacheStore, c.CacheNodes, c.CacheDatabase, "stat", time.Duration(c.StatCacheTTL)*time.Second),
-		providerCache:   cache.GetProviderCache(c.CacheStore, c.CacheNodes, c.CacheDatabase, "provider", time.Duration(c.ProviderCacheTTL)*time.Second),
-		createHomeCache: cache.GetCreateHomeCache(c.CacheStore, c.CacheNodes, c.CacheDatabase, "createHome", time.Duration(c.CreateHomeCacheTTL)*time.Second),
+		c:                        c,
+		dataGatewayURL:           *u,
+		tokenmgr:                 tokenManager,
+		statCache:                cache.GetStatCache(c.CacheStore, c.CacheNodes, c.CacheDatabase, "stat", time.Duration(c.StatCacheTTL)*time.Second),
+		providerCache:            cache.GetProviderCache(c.CacheStore, c.CacheNodes, c.CacheDatabase, "provider", time.Duration(c.ProviderCacheTTL)*time.Second),
+		createHomeCache:          cache.GetCreateHomeCache(c.CacheStore, c.CacheNodes, c.CacheDatabase, "createHome", time.Duration(c.CreateHomeCacheTTL)*time.Second),
+		createPersonalSpaceCache: cache.GetCreatePersonalSpaceCache(c.CacheStore, c.CacheNodes, c.CacheDatabase, "createPersonalSpace", time.Duration(c.CreateHomeCacheTTL)*time.Second),
 	}
 
 	return s, nil

--- a/internal/grpc/services/gateway/storageprovider.go
+++ b/internal/grpc/services/gateway/storageprovider.go
@@ -1090,9 +1090,10 @@ func (s *svc) getStorageProviderClient(_ context.Context, p *registry.ProviderIn
 	}
 
 	return &cachedAPIClient{
-		c:               c,
-		statCache:       s.statCache,
-		createHomeCache: s.createHomeCache,
+		c:                        c,
+		statCache:                s.statCache,
+		createHomeCache:          s.createHomeCache,
+		createPersonalSpaceCache: s.createPersonalSpaceCache,
 	}, nil
 }
 

--- a/pkg/storage/cache/createpersonalspace.go
+++ b/pkg/storage/cache/createpersonalspace.go
@@ -1,0 +1,45 @@
+// Copyright 2018-2023 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package cache
+
+import (
+	"time"
+
+	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
+)
+
+// CreatePersonalSpaceCache can invalidate all create home related cache entries
+type createPersonalSpaceCache struct {
+	cacheStore
+}
+
+// NewCreatePersonalSpaceCache creates a new CreatePersonalSpaceCache
+func NewCreatePersonalSpaceCache(store string, nodes []string, database, table string, ttl time.Duration) CreatePersonalSpaceCache {
+	c := &createPersonalSpaceCache{}
+	c.s = getStore(store, nodes, database, table, ttl)
+	c.database = database
+	c.table = table
+	c.ttl = ttl
+
+	return c
+}
+
+func (c createPersonalSpaceCache) GetKey(userID *userpb.UserId) string {
+	return userID.GetOpaqueId()
+}


### PR DESCRIPTION
This PR restores the caching behavior for the `CreateHome` calls. 
In the past `CreateHome` requests to the gateway triggered `CreateHome` calls on the storage provider and those calls are cached.
With the move to spaces `CreateHome` calls to the gateway are translated to `CreateStorageSpace` calls to the storageprovider though and those calls haven't been cached until now.

