### PR TITLE
Pass Estream to StorageProviders

### DIFF
--- a/changelog/unreleased/pass-estream-to-storageproviders.md
+++ b/changelog/unreleased/pass-estream-to-storageproviders.md
@@ -1,0 +1,5 @@
+Enhancement: Pass estream to Storage Providers
+
+Similar to the data providers we now pass the stream to the `New` func. This will reduce connections from storage providers to nats.
+
+https://github.com/cs3org/reva/pull/3598

--- a/pkg/cbox/storage/eoshomewrapper/eoshomewrapper.go
+++ b/pkg/cbox/storage/eoshomewrapper/eoshomewrapper.go
@@ -27,6 +27,7 @@ import (
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	ctxpkg "github.com/cs3org/reva/v2/pkg/ctx"
 	"github.com/cs3org/reva/v2/pkg/errtypes"
+	"github.com/cs3org/reva/v2/pkg/events"
 	"github.com/cs3org/reva/v2/pkg/storage"
 	"github.com/cs3org/reva/v2/pkg/storage/fs/registry"
 	"github.com/cs3org/reva/v2/pkg/storage/utils/eosfs"
@@ -65,7 +66,7 @@ func parseConfig(m map[string]interface{}) (*eosfs.Config, string, error) {
 
 // New returns an implementation of the storage.FS interface that forms a wrapper
 // around separate connections to EOS.
-func New(m map[string]interface{}) (storage.FS, error) {
+func New(m map[string]interface{}, _ events.Stream) (storage.FS, error) {
 	c, t, err := parseConfig(m)
 	if err != nil {
 		return nil, err

--- a/pkg/cbox/storage/eoswrapper/eoswrapper.go
+++ b/pkg/cbox/storage/eoswrapper/eoswrapper.go
@@ -30,6 +30,7 @@ import (
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	ctxpkg "github.com/cs3org/reva/v2/pkg/ctx"
 	"github.com/cs3org/reva/v2/pkg/errtypes"
+	"github.com/cs3org/reva/v2/pkg/events"
 	"github.com/cs3org/reva/v2/pkg/storage"
 	"github.com/cs3org/reva/v2/pkg/storage/fs/registry"
 	"github.com/cs3org/reva/v2/pkg/storage/utils/eosfs"
@@ -85,7 +86,7 @@ func parseConfig(m map[string]interface{}) (*eosfs.Config, string, error) {
 
 // New returns an implementation of the storage.FS interface that forms a wrapper
 // around separate connections to EOS.
-func New(m map[string]interface{}) (storage.FS, error) {
+func New(m map[string]interface{}, _ events.Stream) (storage.FS, error) {
 	c, t, err := parseConfig(m)
 	if err != nil {
 		return nil, err

--- a/pkg/storage/fs/cephfs/cephfs.go
+++ b/pkg/storage/fs/cephfs/cephfs.go
@@ -35,6 +35,7 @@ import (
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	"github.com/cs3org/reva/v2/pkg/appctx"
 	"github.com/cs3org/reva/v2/pkg/errtypes"
+	"github.com/cs3org/reva/v2/pkg/events"
 	"github.com/cs3org/reva/v2/pkg/storage"
 	"github.com/cs3org/reva/v2/pkg/storage/fs/registry"
 	"github.com/mitchellh/mapstructure"
@@ -64,7 +65,7 @@ func init() {
 
 // New returns an implementation to of the storage.FS interface that talk to
 // a ceph filesystem.
-func New(m map[string]interface{}) (fs storage.FS, err error) {
+func New(m map[string]interface{}, _ events.Stream) (fs storage.FS, err error) {
 	c := &Options{}
 	if err = mapstructure.Decode(m, c); err != nil {
 		return nil, errors.Wrap(err, "error decoding conf")

--- a/pkg/storage/fs/cephfs/unsupported.go
+++ b/pkg/storage/fs/cephfs/unsupported.go
@@ -24,6 +24,7 @@ package cephfs
 import (
 	"github.com/pkg/errors"
 
+	"github.com/cs3org/reva/v2/pkg/events"
 	"github.com/cs3org/reva/v2/pkg/storage"
 	"github.com/cs3org/reva/v2/pkg/storage/fs/registry"
 )
@@ -34,6 +35,6 @@ func init() {
 
 // New returns an implementation to of the storage.FS interface that talk to
 // a ceph filesystem.
-func New(m map[string]interface{}) (storage.FS, error) {
+func New(m map[string]interface{}, _ events.Stream) (storage.FS, error) {
 	return nil, errors.New("cephfs: revad was compiled without CephFS support")
 }

--- a/pkg/storage/fs/eos/eos.go
+++ b/pkg/storage/fs/eos/eos.go
@@ -19,6 +19,7 @@
 package eos
 
 import (
+	"github.com/cs3org/reva/v2/pkg/events"
 	"github.com/cs3org/reva/v2/pkg/storage"
 	"github.com/cs3org/reva/v2/pkg/storage/fs/registry"
 	"github.com/cs3org/reva/v2/pkg/storage/utils/eosfs"
@@ -46,7 +47,7 @@ func parseConfig(m map[string]interface{}) (*eosfs.Config, error) {
 }
 
 // New returns a new implementation of the storage.FS interface that connects to EOS.
-func New(m map[string]interface{}) (storage.FS, error) {
+func New(m map[string]interface{}, _ events.Stream) (storage.FS, error) {
 	c, err := parseConfig(m)
 	if err != nil {
 		return nil, err

--- a/pkg/storage/fs/eosgrpc/eosgrpc.go
+++ b/pkg/storage/fs/eosgrpc/eosgrpc.go
@@ -19,6 +19,7 @@
 package eosgrpc
 
 import (
+	"github.com/cs3org/reva/v2/pkg/events"
 	"github.com/cs3org/reva/v2/pkg/storage"
 	"github.com/cs3org/reva/v2/pkg/storage/fs/registry"
 	"github.com/cs3org/reva/v2/pkg/storage/utils/eosfs"
@@ -46,7 +47,7 @@ func parseConfig(m map[string]interface{}) (*eosfs.Config, error) {
 }
 
 // New returns a new implementation of the storage.FS interface that connects to EOS.
-func New(m map[string]interface{}) (storage.FS, error) {
+func New(m map[string]interface{}, _ events.Stream) (storage.FS, error) {
 	c, err := parseConfig(m)
 	if err != nil {
 		return nil, err

--- a/pkg/storage/fs/eosgrpchome/eosgrpchome.go
+++ b/pkg/storage/fs/eosgrpchome/eosgrpchome.go
@@ -19,6 +19,7 @@
 package eosgrpchome
 
 import (
+	"github.com/cs3org/reva/v2/pkg/events"
 	"github.com/cs3org/reva/v2/pkg/storage"
 	"github.com/cs3org/reva/v2/pkg/storage/fs/registry"
 	"github.com/cs3org/reva/v2/pkg/storage/utils/eosfs"
@@ -46,7 +47,7 @@ func parseConfig(m map[string]interface{}) (*eosfs.Config, error) {
 }
 
 // New returns a new implementation of the storage.FS interface that connects to EOS.
-func New(m map[string]interface{}) (storage.FS, error) {
+func New(m map[string]interface{}, _ events.Stream) (storage.FS, error) {
 	c, err := parseConfig(m)
 	if err != nil {
 		return nil, err

--- a/pkg/storage/fs/eoshome/eoshome.go
+++ b/pkg/storage/fs/eoshome/eoshome.go
@@ -19,6 +19,7 @@
 package eoshome
 
 import (
+	"github.com/cs3org/reva/v2/pkg/events"
 	"github.com/cs3org/reva/v2/pkg/storage"
 	"github.com/cs3org/reva/v2/pkg/storage/fs/registry"
 	"github.com/cs3org/reva/v2/pkg/storage/utils/eosfs"
@@ -46,7 +47,7 @@ func parseConfig(m map[string]interface{}) (*eosfs.Config, error) {
 }
 
 // New returns a new implementation of the storage.FS interface that connects to EOS.
-func New(m map[string]interface{}) (storage.FS, error) {
+func New(m map[string]interface{}, _ events.Stream) (storage.FS, error) {
 	c, err := parseConfig(m)
 	if err != nil {
 		return nil, err

--- a/pkg/storage/fs/local/local.go
+++ b/pkg/storage/fs/local/local.go
@@ -19,6 +19,7 @@
 package local
 
 import (
+	"github.com/cs3org/reva/v2/pkg/events"
 	"github.com/cs3org/reva/v2/pkg/storage"
 	"github.com/cs3org/reva/v2/pkg/storage/fs/registry"
 	"github.com/cs3org/reva/v2/pkg/storage/utils/localfs"
@@ -48,7 +49,7 @@ func parseConfig(m map[string]interface{}) (*config, error) {
 
 // New returns an implementation to of the storage.FS interface that talks to
 // a local filesystem with user homes disabled.
-func New(m map[string]interface{}) (storage.FS, error) {
+func New(m map[string]interface{}, _ events.Stream) (storage.FS, error) {
 	c, err := parseConfig(m)
 	if err != nil {
 		return nil, err

--- a/pkg/storage/fs/localhome/localhome.go
+++ b/pkg/storage/fs/localhome/localhome.go
@@ -19,6 +19,7 @@
 package localhome
 
 import (
+	"github.com/cs3org/reva/v2/pkg/events"
 	"github.com/cs3org/reva/v2/pkg/storage"
 	"github.com/cs3org/reva/v2/pkg/storage/fs/registry"
 	"github.com/cs3org/reva/v2/pkg/storage/utils/localfs"
@@ -47,7 +48,7 @@ func parseConfig(m map[string]interface{}) (*config, error) {
 
 // New returns an implementation to of the storage.FS interface that talks to
 // a local filesystem with user homes.
-func New(m map[string]interface{}) (storage.FS, error) {
+func New(m map[string]interface{}, _ events.Stream) (storage.FS, error) {
 	c, err := parseConfig(m)
 	if err != nil {
 		return nil, err

--- a/pkg/storage/fs/nextcloud/nextcloud.go
+++ b/pkg/storage/fs/nextcloud/nextcloud.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cs3org/reva/v2/pkg/appctx"
 	ctxpkg "github.com/cs3org/reva/v2/pkg/ctx"
 	"github.com/cs3org/reva/v2/pkg/errtypes"
+	"github.com/cs3org/reva/v2/pkg/events"
 	"github.com/cs3org/reva/v2/pkg/storage"
 	"github.com/cs3org/reva/v2/pkg/storage/fs/registry"
 	"github.com/mitchellh/mapstructure"
@@ -68,7 +69,7 @@ func parseConfig(m map[string]interface{}) (*StorageDriverConfig, error) {
 
 // New returns an implementation to of the storage.FS interface that talks to
 // a Nextcloud instance over http.
-func New(m map[string]interface{}) (storage.FS, error) {
+func New(m map[string]interface{}, _ events.Stream) (storage.FS, error) {
 	conf, err := parseConfig(m)
 	if err != nil {
 		return nil, err

--- a/pkg/storage/fs/nextcloud/nextcloud_test.go
+++ b/pkg/storage/fs/nextcloud/nextcloud_test.go
@@ -118,7 +118,7 @@ var _ = Describe("Nextcloud", func() {
 
 	Describe("New", func() {
 		It("returns a new instance", func() {
-			_, err := nextcloud.New(options)
+			_, err := nextcloud.New(options, nil)
 			Expect(err).ToNot(HaveOccurred())
 		})
 	})

--- a/pkg/storage/fs/ocis/ocis.go
+++ b/pkg/storage/fs/ocis/ocis.go
@@ -21,6 +21,7 @@ package ocis
 import (
 	"path"
 
+	"github.com/cs3org/reva/v2/pkg/events"
 	"github.com/cs3org/reva/v2/pkg/storage"
 	"github.com/cs3org/reva/v2/pkg/storage/fs/ocis/blobstore"
 	"github.com/cs3org/reva/v2/pkg/storage/fs/registry"
@@ -34,7 +35,7 @@ func init() {
 
 // New returns an implementation to of the storage.FS interface that talk to
 // a local filesystem.
-func New(m map[string]interface{}) (storage.FS, error) {
+func New(m map[string]interface{}, stream events.Stream) (storage.FS, error) {
 	o, err := options.New(m)
 	if err != nil {
 		return nil, err
@@ -45,5 +46,5 @@ func New(m map[string]interface{}) (storage.FS, error) {
 		return nil, err
 	}
 
-	return decomposedfs.NewDefault(m, bs)
+	return decomposedfs.NewDefault(m, bs, stream)
 }

--- a/pkg/storage/fs/ocis/ocis_test.go
+++ b/pkg/storage/fs/ocis/ocis_test.go
@@ -53,7 +53,7 @@ var _ = Describe("Ocis", func() {
 
 	Describe("New", func() {
 		It("returns a new instance", func() {
-			_, err := ocis.New(options)
+			_, err := ocis.New(options, nil)
 			Expect(err).ToNot(HaveOccurred())
 		})
 	})

--- a/pkg/storage/fs/owncloudsql/owncloudsql.go
+++ b/pkg/storage/fs/owncloudsql/owncloudsql.go
@@ -44,6 +44,7 @@ import (
 	"github.com/cs3org/reva/v2/pkg/appctx"
 	ctxpkg "github.com/cs3org/reva/v2/pkg/ctx"
 	"github.com/cs3org/reva/v2/pkg/errtypes"
+	"github.com/cs3org/reva/v2/pkg/events"
 	"github.com/cs3org/reva/v2/pkg/logger"
 	"github.com/cs3org/reva/v2/pkg/mime"
 	"github.com/cs3org/reva/v2/pkg/rgrpc/todo/pool"
@@ -150,7 +151,7 @@ func (c *config) init(m map[string]interface{}) {
 
 // New returns an implementation to of the storage.FS interface that talk to
 // a local filesystem.
-func New(m map[string]interface{}) (storage.FS, error) {
+func New(m map[string]interface{}, _ events.Stream) (storage.FS, error) {
 	c, err := parseConfig(m)
 	if err != nil {
 		return nil, err

--- a/pkg/storage/fs/registry/registry.go
+++ b/pkg/storage/fs/registry/registry.go
@@ -18,11 +18,14 @@
 
 package registry
 
-import "github.com/cs3org/reva/v2/pkg/storage"
+import (
+	"github.com/cs3org/reva/v2/pkg/events"
+	"github.com/cs3org/reva/v2/pkg/storage"
+)
 
 // NewFunc is the function that storage implementations
 // should register at init time.
-type NewFunc func(map[string]interface{}) (storage.FS, error)
+type NewFunc func(map[string]interface{}, events.Stream) (storage.FS, error)
 
 // NewFuncs is a map containing all the registered storage backends.
 var NewFuncs = map[string]NewFunc{}

--- a/pkg/storage/fs/s3/s3.go
+++ b/pkg/storage/fs/s3/s3.go
@@ -38,6 +38,7 @@ import (
 	types "github.com/cs3org/go-cs3apis/cs3/types/v1beta1"
 	"github.com/cs3org/reva/v2/pkg/appctx"
 	"github.com/cs3org/reva/v2/pkg/errtypes"
+	"github.com/cs3org/reva/v2/pkg/events"
 	"github.com/cs3org/reva/v2/pkg/mime"
 	"github.com/cs3org/reva/v2/pkg/storage"
 	"github.com/cs3org/reva/v2/pkg/storage/fs/registry"
@@ -69,7 +70,7 @@ func parseConfig(m map[string]interface{}) (*config, error) {
 
 // New returns an implementation to of the storage.FS interface that talk to
 // a s3 api.
-func New(m map[string]interface{}) (storage.FS, error) {
+func New(m map[string]interface{}, _ events.Stream) (storage.FS, error) {
 	c, err := parseConfig(m)
 	if err != nil {
 		return nil, err

--- a/pkg/storage/fs/s3ng/s3ng.go
+++ b/pkg/storage/fs/s3ng/s3ng.go
@@ -21,6 +21,7 @@ package s3ng
 import (
 	"fmt"
 
+	"github.com/cs3org/reva/v2/pkg/events"
 	"github.com/cs3org/reva/v2/pkg/storage"
 	"github.com/cs3org/reva/v2/pkg/storage/fs/registry"
 	"github.com/cs3org/reva/v2/pkg/storage/fs/s3ng/blobstore"
@@ -33,7 +34,7 @@ func init() {
 
 // New returns an implementation to of the storage.FS interface that talk to
 // a local filesystem.
-func New(m map[string]interface{}) (storage.FS, error) {
+func New(m map[string]interface{}, stream events.Stream) (storage.FS, error) {
 	o, err := parseConfig(m)
 	if err != nil {
 		return nil, err
@@ -48,5 +49,5 @@ func New(m map[string]interface{}) (storage.FS, error) {
 		return nil, err
 	}
 
-	return decomposedfs.NewDefault(m, bs)
+	return decomposedfs.NewDefault(m, bs, stream)
 }

--- a/pkg/storage/fs/s3ng/s3ng_test.go
+++ b/pkg/storage/fs/s3ng/s3ng_test.go
@@ -58,12 +58,12 @@ var _ = Describe("S3ng", func() {
 
 	Describe("New", func() {
 		It("fails on missing s3 configuration", func() {
-			_, err := s3ng.New(map[string]interface{}{})
+			_, err := s3ng.New(map[string]interface{}{}, nil)
 			Expect(err).To(MatchError("S3 configuration incomplete"))
 		})
 
 		It("works with complete configuration", func() {
-			_, err := s3ng.New(options)
+			_, err := s3ng.New(options, nil)
 			Expect(err).ToNot(HaveOccurred())
 		})
 	})

--- a/pkg/storage/utils/decomposedfs/decomposedfs_test.go
+++ b/pkg/storage/utils/decomposedfs/decomposedfs_test.go
@@ -59,7 +59,7 @@ var _ = Describe("Decomposed", func() {
 			bs := &treemocks.Blobstore{}
 			_, err := decomposedfs.NewDefault(map[string]interface{}{
 				"root": env.Root,
-			}, bs)
+			}, bs, nil)
 			Expect(err).ToNot(HaveOccurred())
 		})
 	})

--- a/tests/integration/grpc/gateway_storageprovider_test.go
+++ b/tests/integration/grpc/gateway_storageprovider_test.go
@@ -182,7 +182,7 @@ var _ = Describe("gateway", func() {
 				"enable_home":         true,
 				"treesize_accounting": true,
 				"treetime_accounting": true,
-			})
+			}, nil)
 			Expect(err).ToNot(HaveOccurred())
 			res, err := shard1Fs.CreateStorageSpace(ctx, &storagep.CreateStorageSpaceRequest{
 				Type:  "project",
@@ -209,7 +209,7 @@ var _ = Describe("gateway", func() {
 				"enable_home":         true,
 				"treesize_accounting": true,
 				"treetime_accounting": true,
-			})
+			}, nil)
 			Expect(err).ToNot(HaveOccurred())
 			res, err = shard2Fs.CreateStorageSpace(ctx, &storagep.CreateStorageSpaceRequest{
 				Type:  "project",
@@ -370,7 +370,7 @@ var _ = Describe("gateway", func() {
 				"enable_home":         true,
 				"treesize_accounting": true,
 				"treetime_accounting": true,
-			})
+			}, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			r, err := serviceClient.CreateHome(ctx, &storagep.CreateHomeRequest{})
@@ -396,7 +396,7 @@ var _ = Describe("gateway", func() {
 				"enable_home":         true,
 				"treesize_accounting": true,
 				"treetime_accounting": true,
-			})
+			}, nil)
 			Expect(err).ToNot(HaveOccurred())
 			res, err := serviceClient.CreateStorageSpace(ctx, &storagep.CreateStorageSpaceRequest{
 				Type:  "project",

--- a/tests/integration/grpc/storageprovider_test.go
+++ b/tests/integration/grpc/storageprovider_test.go
@@ -28,6 +28,7 @@ import (
 	storagep "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	"github.com/cs3org/reva/v2/pkg/auth/scope"
 	ctxpkg "github.com/cs3org/reva/v2/pkg/ctx"
+	"github.com/cs3org/reva/v2/pkg/events"
 	"github.com/cs3org/reva/v2/pkg/rgrpc/todo/pool"
 	"github.com/cs3org/reva/v2/pkg/storage"
 	"github.com/cs3org/reva/v2/pkg/storage/fs/nextcloud"
@@ -55,7 +56,7 @@ func ref(provider string, path string) *storagep.Reference {
 
 func createFS(provider string, revads map[string]*Revad) (storage.FS, error) {
 	conf := make(map[string]interface{})
-	var f func(map[string]interface{}) (storage.FS, error)
+	var f func(map[string]interface{}, events.Stream) (storage.FS, error)
 	switch provider {
 	case "ocis":
 		conf["root"] = revads["storage"].StorageRoot
@@ -66,7 +67,7 @@ func createFS(provider string, revads map[string]*Revad) (storage.FS, error) {
 		conf["mock_http"] = true
 		f = nextcloud.New
 	}
-	return f(conf)
+	return f(conf, nil)
 }
 
 // This test suite tests the gprc storageprovider interface using different


### PR DESCRIPTION
Passes an `events.Stream` to storage providers instead of configuring it there

Supposed to fix https://github.com/owncloud/ocis/issues/5381
