### PR TITLE
Allow SpaceMembershipGroup

### DIFF
--- a/changelog/unreleased/space-group-member-sharetype.md
+++ b/changelog/unreleased/space-group-member-sharetype.md
@@ -1,0 +1,5 @@
+Enhancement: Allow a new ShareType `SpaceMembershipGroup`
+
+Added a new sharetype for groups that are members of spaces
+
+https://github.com/cs3org/reva/pull/3620

--- a/internal/http/services/owncloud/ocs/conversions/main.go
+++ b/internal/http/services/owncloud/ocs/conversions/main.go
@@ -52,8 +52,11 @@ const (
 	// ShareTypeFederatedCloudShare represents a federated share
 	ShareTypeFederatedCloudShare ShareType = 6
 
-	// ShareTypeSpaceMembership represents an action regarding space members
-	ShareTypeSpaceMembership ShareType = 7
+	// ShareTypeSpaceMembershipUser represents an action regarding user type space members
+	ShareTypeSpaceMembershipUser ShareType = 7
+
+	// ShareTypeSpaceMembershipGroup represents an action regarding group type space members
+	ShareTypeSpaceMembershipGroup ShareType = 8
 
 	// ShareWithUserTypeUser represents a normal user
 	ShareWithUserTypeUser ShareWithUserType = 0

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/shares.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/shares.go
@@ -309,7 +309,7 @@ func (h *Handler) CreateShare(w http.ResponseWriter, r *http.Request) {
 		if role, val, err := h.extractPermissions(reqRole, reqPermissions, statRes.Info, conversions.NewViewerRole()); err == nil {
 			h.createFederatedCloudShare(w, r, statRes.Info, role, val)
 		}
-	case int(conversions.ShareTypeSpaceMembership):
+	case int(conversions.ShareTypeSpaceMembershipUser), int(conversions.ShareTypeSpaceMembershipGroup):
 		switch reqRole {
 		// Note: we convert viewer and editor roles to spaceviewer and spaceditor to keep backwards compatibility
 		// we can remove this switch when this behaviour is no longer wanted.


### PR DESCRIPTION
Allows to set `SpaceMembershipGroup` (`8`) to be used as sharetype when creating shares

fixes https://github.com/owncloud/ocis/issues/5454
