### PR TITLE
Copy p.Services to pi.Services in mentix

### DIFF
--- a/pkg/ocm/provider/authorizer/mentix/mentix.go
+++ b/pkg/ocm/provider/authorizer/mentix/mentix.go
@@ -177,6 +177,7 @@ func (a *authorizer) IsProviderAllowed(ctx context.Context, pi *ocmprovider.Prov
 		for _, p := range providers {
 			if p.Domain == normalizedDomain {
 				providerAuthorized = true
+				pi.Services = p.Services
 				break
 			}
 		}

--- a/pkg/ocm/share/manager/nextcloud/nextcloud.go
+++ b/pkg/ocm/share/manager/nextcloud/nextcloud.go
@@ -157,6 +157,9 @@ func NewShareManager(c *ShareManagerConfig) (*Manager, error) {
 		if len(c.EndPoint) == 0 {
 			return nil, errors.New("Please specify 'endpoint' in '[grpc.services.ocmshareprovider.drivers.nextcloud]' and  '[grpc.services.ocmcore.drivers.nextcloud]'")
 		}
+		if len(c.WebDAVHost) == 0 {
+			return nil, errors.New("Please specify 'webdav_host' in '[grpc.services.ocmshareprovider.drivers.nextcloud]' and  '[grpc.services.ocmcore.drivers.nextcloud]'")
+		}
 		client = &http.Client{}
 	}
 


### PR DESCRIPTION
When testing Reva with Mentix in the ScienceMesh, I found that without this, the services struct is missing and an error is thrown.