### PR TITLE
[tests-only] Removed unused make target, bump ocis commit id

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,3 +1,4 @@
 # The test runner source for API tests
-APITESTS_COMMITID=6357a703181b368e2109f720e0785a11222eed88
+APITESTS_COMMITID=6c0a5baec09e7f0716c55f58d7263d6943e95f89
 APITESTS_BRANCH=master
+APITESTS_REPO_GIT_URL=https://github.com/owncloud/ocis.git

--- a/.drone.env
+++ b/.drone.env
@@ -1,4 +1,4 @@
 # The test runner source for API tests
-APITESTS_COMMITID=6c0a5baec09e7f0716c55f58d7263d6943e95f89
+APITESTS_COMMITID=770fc74a14d2150c51c088e6966434faef8b5557
 APITESTS_BRANCH=master
 APITESTS_REPO_GIT_URL=https://github.com/owncloud/ocis.git

--- a/.drone.star
+++ b/.drone.star
@@ -20,7 +20,7 @@ def cloneApiTestReposStep():
         "commands": [
             "source /drone/src/.drone.env",
             "git clone -b master --depth=1 https://github.com/owncloud/testing.git /drone/src/tmp/testing",
-            "git clone -b $APITESTS_BRANCH --single-branch --no-tags https://github.com/owncloud/ocis.git /drone/src/tmp/testrunner",
+            "git clone -b $APITESTS_BRANCH --single-branch --no-tags $APITESTS_REPO_GIT_URL /drone/src/tmp/testrunner",
             "cd /drone/src/tmp/testrunner",
             "git checkout $APITESTS_COMMITID",
         ],
@@ -174,7 +174,7 @@ def ocisIntegrationTests(parallelRuns, skipExceptParts = []):
                         "image": OC_CI_PHP,
                         "commands": [
                             "cd /drone/src/tmp/testrunner",
-                            "make test-acceptance-core-api",
+                            "make test-acceptance-from-core-api",
                         ],
                         "environment": {
                             "TEST_SERVER_URL": "http://revad-services:20080",
@@ -248,7 +248,7 @@ def s3ngIntegrationTests(parallelRuns, skipExceptParts = []):
                         "image": OC_CI_PHP,
                         "commands": [
                             "cd /drone/src/tmp/testrunner",
-                            "make test-acceptance-core-api",
+                            "make test-acceptance-from-core-api",
                         ],
                         "environment": {
                             "TEST_SERVER_URL": "http://revad-services:20080",

--- a/Makefile
+++ b/Makefile
@@ -141,11 +141,5 @@ clean: toolchain-clean
 dist: gen-doc
 	go run tools/create-artifacts/main.go -version ${VERSION} -commit ${GIT_COMMIT} -goversion ${GO_VERSION}
 
-# behat config file for core api tests
-CORE_BEHAT_YML=$(PATH_TO_APITESTS)/tests/acceptance/config/behat-core.yml
-
 test-acceptance-api:
 	$(PATH_TO_APITESTS)/tests/acceptance/run.sh --type api
-
-test-acceptance-core-api:
-	BEHAT_YML=$(CORE_BEHAT_YML) $(PATH_TO_APITESTS)/tests/acceptance/run.sh --type core-api

--- a/README.md
+++ b/README.md
@@ -134,9 +134,9 @@ This will require some PHP-related tools to run, for instance on Ubuntu you will
     ../../../cmd/revad/revad -c ldap-users.toml
     ```
 
-3.  clone ownCloud 10
+3.  clone ownCloud Infinite Scale `OCIS`
     ```
-    git clone https://github.com/owncloud/core.git ./testrunner
+    git clone https://github.com/owncloud/ocis.git ./testrunner
     ```
 
 4.  to run the correct version of the testsuite check out the commit id from the `.drone.env` file
@@ -158,7 +158,7 @@ This will require some PHP-related tools to run, for instance on Ubuntu you will
     TEST_REVA='true' \
     BEHAT_FILTER_TAGS='~@notToImplementOnOCIS&&~@toImplementOnOCIS&&~comments-app-required&&~@federation-app-required&&~@notifications-app-required&&~systemtags-app-required&&~@provisioning_api-app-required&&~@preview-extension-required&&~@local_storage&&~@skipOnOcis-OCIS-Storage&&~@skipOnOcis' \
     EXPECTED_FAILURES_FILE=../reva/tests/acceptance/expected-failures-on-OCIS-storage.md \
-    make test-acceptance-api
+    make test-acceptance-from-core-api
     ```
 
     This will run all tests that are relevant to reva.

--- a/tests/acceptance/expected-failures-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-on-OCIS-storage.md
@@ -312,16 +312,11 @@ _requires a [CS3 user provisioning api that can update the quota for a user](htt
 - [coreApiWebdavMove2/moveFile.feature:288](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiWebdavMove2/moveFile.feature#L288)
 
 #### [OCIS-storage overwriting a file as share receiver, does not create a new file version for the sharer](https://github.com/owncloud/ocis/issues/766) //todo
-- [coreApiVersions/fileVersionsSharingToShares.feature:33](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersionsSharingToShares.feature#L33)
+- [coreApiVersions/fileVersions.feature:291](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersions.feature#L291)
 
 #### [restoring an older version of a shared file deletes the share](https://github.com/owncloud/ocis/issues/765)
 - [coreApiShareManagementToShares/acceptShares.feature:532](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiShareManagementToShares/acceptShares.feature#L532)
-- [coreApiVersions/fileVersionsSharingToShares.feature:44](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersionsSharingToShares.feature#L44)
-
-#### [not possible to move file into a received folder](https://github.com/owncloud/ocis/issues/764)
-
-- [coreApiVersions/fileVersionsSharingToShares.feature:220](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersionsSharingToShares.feature#L220)
-- [coreApiVersions/fileVersionsSharingToShares.feature:221](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersionsSharingToShares.feature#L221)
+- [coreApiVersions/fileVersions.feature:302](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersions.feature#L302)
 
 #### [Expiration date for shares is not implemented](https://github.com/owncloud/ocis/issues/1250)
 #### Expiration date of user shares
@@ -497,14 +492,14 @@ _requires a [CS3 user provisioning api that can update the quota for a user](htt
 - [coreApiShareUpdateToShares/updateShare.feature:282](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiShareUpdateToShares/updateShare.feature#L282)
 
 #### [user can access version metadata of a received share before accepting it](https://github.com/owncloud/ocis/issues/760)
-- [coreApiVersions/fileVersionsSharingToShares.feature:283](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersionsSharingToShares.feature#L283)
+- [coreApiVersions/fileVersions.feature:487](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersions.feature#L487)
 
 #### [Share lists deleted user as 'user'](https://github.com/owncloud/ocis/issues/903)
 - [coreApiShareManagementBasicToShares/createShareToSharesFolder.feature:682](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiShareManagementBasicToShares/createShareToSharesFolder.feature#L682)
 - [coreApiShareManagementBasicToShares/createShareToSharesFolder.feature:683](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiShareManagementBasicToShares/createShareToSharesFolder.feature#L683)
 
 #### [OCIS-storage overwriting a file as share receiver, does not create a new file version for the sharer](https://github.com/owncloud/ocis/issues/766)
-- [coreApiVersions/fileVersionsSharingToShares.feature:295](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersionsSharingToShares.feature#L295) //todo
+- [coreApiVersions/fileVersions.feature:499](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersions.feature#L499) //todo
 
 #### [deleting a share with wrong authentication returns OCS status 996 / HTTP 500](https://github.com/owncloud/ocis/issues/1229)
 - [coreApiShareManagementBasicToShares/deleteShareFromShares.feature:226](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiShareManagementBasicToShares/deleteShareFromShares.feature#L226)
@@ -779,20 +774,24 @@ _ocs: api compatibility, return correct status code_
 - [coreApiWebdavProperties1/copyFile.feature:437](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiWebdavProperties1/copyFile.feature#L437)
 
 #### [Downloading the older version of shared file gives 404](https://github.com/owncloud/ocis/issues/3868)
-- [coreApiVersions/fileVersions.feature:443](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersions.feature#L443)
-- [coreApiVersions/fileVersions.feature:461](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersions.feature#L461)
-- [coreApiVersions/fileVersionsSharingToShares.feature:306](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersionsSharingToShares.feature#L306)
+- [coreApiVersions/fileVersions.feature:160](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersions.feature#L160)
+- [coreApiVersions/fileVersions.feature:178](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersions.feature#L178)
+- [coreApiVersions/fileVersions.feature:510](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersions.feature#L510)
 
 #### [file versions do not report the version author](https://github.com/owncloud/ocis/issues/2914)
-- [coreApiVersions/fileVersionAuthor.feature:14](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersionAuthor.feature#L14)
-- [coreApiVersions/fileVersionAuthor.feature:37](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersionAuthor.feature#L37)
-- [coreApiVersions/fileVersionAuthor.feature:58](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersionAuthor.feature#L58)
-- [coreApiVersions/fileVersionAuthor.feature:78](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersionAuthor.feature#L78)
-- [coreApiVersions/fileVersionAuthor.feature:104](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersionAuthor.feature#L104)
-- [coreApiVersions/fileVersionAuthor.feature:129](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersionAuthor.feature#L129)
-- [coreApiVersions/fileVersionAuthor.feature:154](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersionAuthor.feature#L154)
-- [coreApiVersions/fileVersionAuthor.feature:180](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersionAuthor.feature#L180)
+- [coreApiVersions/fileVersionAuthor.feature:13](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersionAuthor.feature#L13)
+- [coreApiVersions/fileVersionAuthor.feature:44](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersionAuthor.feature#L44)
+- [coreApiVersions/fileVersionAuthor.feature:71](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersionAuthor.feature#L71)
+- [coreApiVersions/fileVersionAuthor.feature:97](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersionAuthor.feature#L97)
+- [coreApiVersions/fileVersionAuthor.feature:130](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersionAuthor.feature#L130)
+- [coreApiVersions/fileVersionAuthor.feature:157](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersionAuthor.feature#L157)
+- [coreApiVersions/fileVersionAuthor.feature:188](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersionAuthor.feature#L188)
 - [coreApiVersions/fileVersionAuthor.feature:223](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersionAuthor.feature#L223)
+- [coreApiVersions/fileVersionAuthor.feature:275](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersionAuthor.feature#L275)
+- [coreApiVersions/fileVersionAuthor.feature:324](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersionAuthor.feature#L324)
+- [coreApiVersions/fileVersionAuthor.feature:345](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersionAuthor.feature#L345)
+- [coreApiVersions/fileVersionAuthor.feature:365](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersionAuthor.feature#L365)
+- [coreApiVersions/fileVersionAuthor.feature:390](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersionAuthor.feature#L390)
 
 #### [Allow public link sharing only for certain groups feature not implemented](https://github.com/owncloud/ocis/issues/4623)
 - [coreApiSharePublicLink3/allowGroupToCreatePublicLinks.feature:35](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiSharePublicLink3/allowGroupToCreatePublicLinks.feature#L35)
@@ -834,12 +833,6 @@ _ocs: api compatibility, return correct status code_
 - [coreApiWebdavMove2/moveFileToBlacklistedName.feature:36](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiWebdavMove2/moveFileToBlacklistedName.feature#L36)
 - [coreApiWebdavMove2/moveFileToBlacklistedName.feature:74](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiWebdavMove2/moveFileToBlacklistedName.feature#L74)
 - [coreApiWebdavMove2/moveFileToBlacklistedName.feature:75](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiWebdavMove2/moveFileToBlacklistedName.feature#L75)
-
-
-#### [could not create system tag](https://github.com/owncloud/ocis/issues/3092)
-- [coreApiWebdavOperations/search.feature:274](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiWebdavOperations/search.feature#L274)
-- [coreApiWebdavOperations/search.feature:291](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiWebdavOperations/search.feature#L291)
-- [coreApiWebdavOperations/search.feature:317](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiWebdavOperations/search.feature#L317)
 
 #### [resource path is included in the returned error message](https://github.com/owncloud/ocis/issues/3344)
 - [coreApiWebdavProperties2/getFileProperties.feature:324](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiWebdavProperties2/getFileProperties.feature#L324)
@@ -953,17 +946,17 @@ _ocs: api compatibility, return correct status code_
 - [coreApiWebdavEtagPropagation2/restoreFromTrash.feature:71](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiWebdavEtagPropagation2/restoreFromTrash.feature#L71)
 - [coreApiWebdavEtagPropagation2/restoreFromTrash.feature:93](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiWebdavEtagPropagation2/restoreFromTrash.feature#L93)
 - [coreApiWebdavEtagPropagation2/restoreFromTrash.feature:94](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiWebdavEtagPropagation2/restoreFromTrash.feature#L94)
-- [coreApiVersions/fileVersions.feature:520](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersions.feature#L520)
+- [coreApiVersions/fileVersions.feature:237](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersions.feature#L237)
 
 #### [`meta` requests have empty responses with master branch](https://github.com/cs3org/reva/issues/2897)
-- [coreApiVersions/fileVersions.feature:480](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersions.feature#L480)
-- [coreApiVersions/fileVersions.feature:486](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersions.feature#L486)
-- [coreApiVersions/fileVersions.feature:493](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersions.feature#L493)
-- [coreApiVersions/fileVersions.feature:501](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersions.feature#L501)
-- [coreApiVersions/fileVersions.feature:514](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersions.feature#L514)
-- [coreApiVersions/fileVersions.feature:515](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersions.feature#L515)
-- [coreApiVersions/fileVersions.feature:516](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersions.feature#L516)
-- [coreApiVersions/fileVersions.feature:517](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersions.feature#L517)
+- [coreApiVersions/fileVersions.feature:197](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersions.feature#L197)
+- [coreApiVersions/fileVersions.feature:203](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersions.feature#L203)
+- [coreApiVersions/fileVersions.feature:210](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersions.feature#L210)
+- [coreApiVersions/fileVersions.feature:218](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersions.feature#L218)
+- [coreApiVersions/fileVersions.feature:231](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersions.feature#L231)
+- [coreApiVersions/fileVersions.feature:232](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersions.feature#L232)
+- [coreApiVersions/fileVersions.feature:233](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersions.feature#L233)
+- [coreApiVersions/fileVersions.feature:234](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersions.feature#L234)
 
 #### [WebDAV MOVE with body returns 400 rather than 415](https://github.com/cs3org/reva/issues/3119)
 
@@ -991,6 +984,12 @@ _ocs: api compatibility, return correct status code_
 The problem has been fixed in reva edge branch but not in reva master
 - [coreApiWebdavOperations/propfind.feature:78](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiWebdavOperations/propfind.feature#L78)
 - [coreApiWebdavOperations/propfind.feature:90](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiWebdavOperations/propfind.feature#L90)
+
+#### [Updating the role of a public link to internal gives returns 400]
+- [coreApiSharePublicLink3/updatePublicLinkShare.feature:628](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiSharePublicLink3/updatePublicLinkShare.feature#L628)
+- [coreApiSharePublicLink3/updatePublicLinkShare.feature:629](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiSharePublicLink3/updatePublicLinkShare.feature#L629)
+- [coreApiSharePublicLink3/updatePublicLinkShare.feature:630](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiSharePublicLink3/updatePublicLinkShare.feature#L630)
+- [coreApiSharePublicLink3/updatePublicLinkShare.feature:631](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiSharePublicLink3/updatePublicLinkShare.feature#L631)
 
 Note: always have an empty line at the end of this file.
 The bash script that processes this file may not process a scenario reference on the last line.

--- a/tests/acceptance/expected-failures-on-S3NG-storage.md
+++ b/tests/acceptance/expected-failures-on-S3NG-storage.md
@@ -8,20 +8,24 @@ Basic file management like up and download, move, copy, properties, quota, trash
 - [coreApiTrashbin/trashbinFilesFolders.feature:318](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiTrashbin/trashbinFilesFolders.feature#L318)
 
 ### [Downloading the older version of shared file gives 404](https://github.com/owncloud/ocis/issues/3868)
-- [coreApiVersions/fileVersions.feature:443](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersions.feature#L443)
-- [coreApiVersions/fileVersions.feature:461](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersions.feature#L461)
-- [coreApiVersions/fileVersionsSharingToShares.feature:306](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersionsSharingToShares.feature#L306)
+- [coreApiVersions/fileVersions.feature:160](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersions.feature#L160)
+- [coreApiVersions/fileVersions.feature:178](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersions.feature#L178)
+- [coreApiVersions/fileVersions.feature:510](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersions.feature#L510)
 
 #### [file versions do not report the version author](https://github.com/owncloud/ocis/issues/2914)
-- [coreApiVersions/fileVersionAuthor.feature:14](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersionAuthor.feature#L14)
-- [coreApiVersions/fileVersionAuthor.feature:37](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersionAuthor.feature#L37)
-- [coreApiVersions/fileVersionAuthor.feature:58](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersionAuthor.feature#L58)
-- [coreApiVersions/fileVersionAuthor.feature:78](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersionAuthor.feature#L78)
-- [coreApiVersions/fileVersionAuthor.feature:104](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersionAuthor.feature#L104)
-- [coreApiVersions/fileVersionAuthor.feature:129](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersionAuthor.feature#L129)
-- [coreApiVersions/fileVersionAuthor.feature:154](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersionAuthor.feature#L154)
-- [coreApiVersions/fileVersionAuthor.feature:180](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersionAuthor.feature#L180)
+- [coreApiVersions/fileVersionAuthor.feature:13](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersionAuthor.feature#L13)
+- [coreApiVersions/fileVersionAuthor.feature:44](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersionAuthor.feature#L44)
+- [coreApiVersions/fileVersionAuthor.feature:71](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersionAuthor.feature#L71)
+- [coreApiVersions/fileVersionAuthor.feature:97](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersionAuthor.feature#L97)
+- [coreApiVersions/fileVersionAuthor.feature:130](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersionAuthor.feature#L130)
+- [coreApiVersions/fileVersionAuthor.feature:157](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersionAuthor.feature#L157)
+- [coreApiVersions/fileVersionAuthor.feature:188](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersionAuthor.feature#L188)
 - [coreApiVersions/fileVersionAuthor.feature:223](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersionAuthor.feature#L223)
+- [coreApiVersions/fileVersionAuthor.feature:275](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersionAuthor.feature#L275)
+- [coreApiVersions/fileVersionAuthor.feature:324](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersionAuthor.feature#L324)
+- [coreApiVersions/fileVersionAuthor.feature:345](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersionAuthor.feature#L345)
+- [coreApiVersions/fileVersionAuthor.feature:365](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersionAuthor.feature#L365)
+- [coreApiVersions/fileVersionAuthor.feature:390](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersionAuthor.feature#L390)
 
 #### [Getting information about a folder overwritten by a file gives 500 error instead of 404](https://github.com/owncloud/ocis/issues/1239)
 - [coreApiWebdavProperties1/copyFile.feature:274](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiWebdavProperties1/copyFile.feature#L274)
@@ -327,15 +331,11 @@ _requires a [CS3 user provisioning api that can update the quota for a user](htt
 - [coreApiWebdavMove2/moveFile.feature:288](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiWebdavMove2/moveFile.feature#L288)
 
 #### [OCIS-storage overwriting a file as share receiver, does not create a new file version for the sharer](https://github.com/owncloud/ocis/issues/766) //todo
-- [coreApiVersions/fileVersionsSharingToShares.feature:33](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersionsSharingToShares.feature#L33)
+- [coreApiVersions/fileVersions.feature:291](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersions.feature#L291)
 
 #### [restoring an older version of a shared file deletes the share](https://github.com/owncloud/ocis/issues/765)
 - [coreApiShareManagementToShares/acceptShares.feature:532](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiShareManagementToShares/acceptShares.feature#L532)
-- [coreApiVersions/fileVersionsSharingToShares.feature:44](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersionsSharingToShares.feature#L44)
-
-####[not possible to move file into a received folder](https://github.com/owncloud/ocis/issues/764)
-- [coreApiVersions/fileVersionsSharingToShares.feature:220](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersionsSharingToShares.feature#L220)
-- [coreApiVersions/fileVersionsSharingToShares.feature:221](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersionsSharingToShares.feature#L221)
+- [coreApiVersions/fileVersions.feature:302](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersions.feature#L302)
 
 #### [Expiration date for shares is not implemented](https://github.com/owncloud/ocis/issues/1250)
 #### Expiration date of user shares
@@ -511,14 +511,14 @@ _requires a [CS3 user provisioning api that can update the quota for a user](htt
 - [coreApiShareUpdateToShares/updateShare.feature:282](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiShareUpdateToShares/updateShare.feature#L282)
 
 #### [user can access version metadata of a received share before accepting it](https://github.com/owncloud/ocis/issues/760)
-- [coreApiVersions/fileVersionsSharingToShares.feature:283](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersionsSharingToShares.feature#L283)
+- [coreApiVersions/fileVersions.feature:487](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersions.feature#L487)
 
 #### [Share lists deleted user as 'user'](https://github.com/owncloud/ocis/issues/903)
 - [coreApiShareManagementBasicToShares/createShareToSharesFolder.feature:682](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiShareManagementBasicToShares/createShareToSharesFolder.feature#L682)
 - [coreApiShareManagementBasicToShares/createShareToSharesFolder.feature:683](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiShareManagementBasicToShares/createShareToSharesFolder.feature#L683)
 
 #### [OCIS-storage overwriting a file as share receiver, does not create a new file version for the sharer](https://github.com/owncloud/ocis/issues/766) //todo
-- [coreApiVersions/fileVersionsSharingToShares.feature:295](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersionsSharingToShares.feature#L295)
+- [coreApiVersions/fileVersions.feature:499](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersions.feature#L499)
 
 #### [deleting a share with wrong authentication returns OCS status 996 / HTTP 500](https://github.com/owncloud/ocis/issues/1229)
 - [coreApiShareManagementBasicToShares/deleteShareFromShares.feature:226](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiShareManagementBasicToShares/deleteShareFromShares.feature#L226)
@@ -835,11 +835,6 @@ _ocs: api compatibility, return correct status code_
 - [coreApiWebdavMove2/moveFileToBlacklistedName.feature:74](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiWebdavMove2/moveFileToBlacklistedName.feature#L74)
 - [coreApiWebdavMove2/moveFileToBlacklistedName.feature:75](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiWebdavMove2/moveFileToBlacklistedName.feature#L75)
 
-#### [could not create system tag](https://github.com/owncloud/ocis/issues/3092)
-- [coreApiWebdavOperations/search.feature:274](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiWebdavOperations/search.feature#L274)
-- [coreApiWebdavOperations/search.feature:291](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiWebdavOperations/search.feature#L291)
-- [coreApiWebdavOperations/search.feature:317](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiWebdavOperations/search.feature#L317)
-
 #### [resource path is included in the returned error message](https://github.com/owncloud/ocis/issues/3344)
 - [coreApiWebdavProperties2/getFileProperties.feature:324](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiWebdavProperties2/getFileProperties.feature#L324)
 
@@ -952,17 +947,17 @@ _ocs: api compatibility, return correct status code_
 - [coreApiWebdavEtagPropagation2/restoreFromTrash.feature:71](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiWebdavEtagPropagation2/restoreFromTrash.feature#L71)
 - [coreApiWebdavEtagPropagation2/restoreFromTrash.feature:93](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiWebdavEtagPropagation2/restoreFromTrash.feature#L93)
 - [coreApiWebdavEtagPropagation2/restoreFromTrash.feature:94](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiWebdavEtagPropagation2/restoreFromTrash.feature#L94)
-- [coreApiVersions/fileVersions.feature:520](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersions.feature#L520)
+- [coreApiVersions/fileVersions.feature:237](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersions.feature#L237)
 
 #### [`meta` requests have empty responses with master branch](https://github.com/cs3org/reva/issues/2897)
-- [coreApiVersions/fileVersions.feature:480](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersions.feature#L480)
-- [coreApiVersions/fileVersions.feature:486](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersions.feature#L486)
-- [coreApiVersions/fileVersions.feature:493](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersions.feature#L493)
-- [coreApiVersions/fileVersions.feature:501](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersions.feature#L501)
-- [coreApiVersions/fileVersions.feature:514](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersions.feature#L514)
-- [coreApiVersions/fileVersions.feature:515](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersions.feature#L515)
-- [coreApiVersions/fileVersions.feature:516](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersions.feature#L516)
-- [coreApiVersions/fileVersions.feature:517](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersions.feature#L517)
+- [coreApiVersions/fileVersions.feature:197](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersions.feature#L197)
+- [coreApiVersions/fileVersions.feature:203](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersions.feature#L203)
+- [coreApiVersions/fileVersions.feature:210](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersions.feature#L210)
+- [coreApiVersions/fileVersions.feature:218](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersions.feature#L218)
+- [coreApiVersions/fileVersions.feature:231](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersions.feature#L231)
+- [coreApiVersions/fileVersions.feature:232](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersions.feature#L232)
+- [coreApiVersions/fileVersions.feature:233](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersions.feature#L233)
+- [coreApiVersions/fileVersions.feature:234](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiVersions/fileVersions.feature#L234)
 
 #### [WebDAV MOVE with body returns 400 rather than 415](https://github.com/cs3org/reva/issues/3119)
 
@@ -990,6 +985,12 @@ _ocs: api compatibility, return correct status code_
 The problem has been fixed in reva edge branch but not in reva master
 - [coreApiWebdavOperations/propfind.feature:78](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiWebdavOperations/propfind.feature#L78)
 - [coreApiWebdavOperations/propfind.feature:90](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiWebdavOperations/propfind.feature#L90)
+
+#### [Updating the role of a public link to internal gives returns 400]
+- [coreApiSharePublicLink3/updatePublicLinkShare.feature:628](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiSharePublicLink3/updatePublicLinkShare.feature#L628)
+- [coreApiSharePublicLink3/updatePublicLinkShare.feature:629](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiSharePublicLink3/updatePublicLinkShare.feature#L629)
+- [coreApiSharePublicLink3/updatePublicLinkShare.feature:630](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiSharePublicLink3/updatePublicLinkShare.feature#L630)
+- [coreApiSharePublicLink3/updatePublicLinkShare.feature:631](https://github.com/owncloud/core/blob/master/tests/acceptance/features/coreApiSharePublicLink3/updatePublicLinkShare.feature#L631)
 
 Note: always have an empty line at the end of this file.
 The bash script that processes this file may not process a scenario reference on the last line.


### PR DESCRIPTION
This PR removes the unused make target from Makefile, same as (https://github.com/cs3org/reva/pull/3622),
added APITESTS_REPO_GIT_URL env variable to .drone.env (https://github.com/cs3org/reva/pull/3593),
bump ocis commit id to latest
Fix https://github.com/owncloud/ocis/issues/5450
Part of https://github.com/owncloud/QA/issues/795