### PR TITLE
Dont share versions

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,4 +1,4 @@
 # The test runner source for API tests
-APITESTS_COMMITID=f4ae082265c54013f28e7facb892d6fdc943e827
+APITESTS_COMMITID=2cd625777122e292c92b30bc0ec0c6f4fc29a178
 APITESTS_BRANCH=dont-share-versions
 APITESTS_REPO_GIT_URL=https://github.com/owncloud/ocis.git

--- a/.drone.env
+++ b/.drone.env
@@ -1,4 +1,4 @@
 # The test runner source for API tests
-APITESTS_COMMITID=76cc388e4546d4e588515c6c7d624829a674163a
-APITESTS_BRANCH=master
+APITESTS_COMMITID=f4ae082265c54013f28e7facb892d6fdc943e827
+APITESTS_BRANCH=dont-share-versions
 APITESTS_REPO_GIT_URL=https://github.com/owncloud/ocis.git

--- a/changelog/unreleased/hide-file-versions-shares.md
+++ b/changelog/unreleased/hide-file-versions-shares.md
@@ -1,0 +1,5 @@
+Change: Hide file versions for share receivers
+
+We needed to change the visibility of file versions and hide them to share receivers. Space Editors can still see and restore file versions.
+
+https://github.com/cs3org/reva/pull/3641

--- a/internal/http/services/owncloud/ocdav/versions.go
+++ b/internal/http/services/owncloud/ocdav/versions.go
@@ -149,6 +149,12 @@ func (h *VersionsHandler) doListVersions(w http.ResponseWriter, r *http.Request,
 		return
 	}
 	if lvRes.Status.Code != rpc.Code_CODE_OK {
+		if lvRes.Status.Code == rpc.Code_CODE_PERMISSION_DENIED {
+			w.WriteHeader(http.StatusForbidden)
+			b, err := errors.Marshal(http.StatusForbidden, "You have no permission to list file versions on this resource", "")
+			errors.HandleWebdavError(&sublog, w, b, err)
+			return
+		}
 		errors.HandleErrorStatus(&sublog, w, lvRes.Status)
 		return
 	}
@@ -226,6 +232,12 @@ func (h *VersionsHandler) doRestore(w http.ResponseWriter, r *http.Request, s *s
 		return
 	}
 	if res.Status.Code != rpc.Code_CODE_OK {
+		if res.Status.Code == rpc.Code_CODE_PERMISSION_DENIED {
+			w.WriteHeader(http.StatusForbidden)
+			b, err := errors.Marshal(http.StatusForbidden, "You have no permission to restore versions on this resource", "")
+			errors.HandleWebdavError(&sublog, w, b, err)
+			return
+		}
 		errors.HandleErrorStatus(&sublog, w, res.Status)
 		return
 	}

--- a/internal/http/services/owncloud/ocs/conversions/role.go
+++ b/internal/http/services/owncloud/ocs/conversions/role.go
@@ -184,7 +184,6 @@ func NewViewerRole() *Role {
 			GetQuota:             true,
 			InitiateFileDownload: true,
 			ListContainer:        true,
-			ListFileVersions:     true,
 			ListRecycle:          true,
 			Stat:                 true,
 		},
@@ -201,7 +200,6 @@ func NewSpaceViewerRole() *Role {
 			GetQuota:             true,
 			InitiateFileDownload: true,
 			ListContainer:        true,
-			ListFileVersions:     true,
 			ListGrants:           true,
 			ListRecycle:          true,
 			Stat:                 true,
@@ -223,11 +221,9 @@ func NewEditorRole() *Role {
 			InitiateFileDownload: true,
 			InitiateFileUpload:   true,
 			ListContainer:        true,
-			ListFileVersions:     true,
 			ListRecycle:          true,
 			Move:                 true,
 			PurgeRecycle:         true,
-			RestoreFileVersion:   true,
 			RestoreRecycleItem:   true,
 			Stat:                 true,
 		},
@@ -270,11 +266,9 @@ func NewFileEditorRole() *Role {
 			InitiateFileDownload: true,
 			ListGrants:           true,
 			ListContainer:        true,
-			ListFileVersions:     true,
 			ListRecycle:          true,
 			Stat:                 true,
 			InitiateFileUpload:   true,
-			RestoreFileVersion:   true,
 			RestoreRecycleItem:   true,
 		},
 		ocsPermissions: PermissionRead | PermissionWrite,
@@ -374,7 +368,7 @@ func NewLegacyRoleFromOCSPermissions(p Permissions) *Role {
 	if p.Contain(PermissionRead) {
 		r.cS3ResourcePermissions.ListContainer = true
 		// r.cS3ResourcePermissions.ListGrants = true
-		r.cS3ResourcePermissions.ListFileVersions = true
+		// r.cS3ResourcePermissions.ListFileVersions = true
 		r.cS3ResourcePermissions.ListRecycle = true
 		r.cS3ResourcePermissions.Stat = true
 		r.cS3ResourcePermissions.GetPath = true
@@ -383,7 +377,7 @@ func NewLegacyRoleFromOCSPermissions(p Permissions) *Role {
 	}
 	if p.Contain(PermissionWrite) {
 		r.cS3ResourcePermissions.InitiateFileUpload = true
-		r.cS3ResourcePermissions.RestoreFileVersion = true
+		// r.cS3ResourcePermissions.RestoreFileVersion = true
 		r.cS3ResourcePermissions.RestoreRecycleItem = true
 	}
 	if p.Contain(PermissionCreate) {
@@ -429,7 +423,7 @@ func RoleFromResourcePermissions(rp *provider.ResourcePermissions, islink bool) 
 		return r
 	}
 	if rp.ListContainer &&
-		rp.ListFileVersions &&
+		// rp.ListFileVersions &&
 		rp.ListRecycle &&
 		rp.Stat &&
 		rp.GetPath &&
@@ -438,7 +432,7 @@ func RoleFromResourcePermissions(rp *provider.ResourcePermissions, islink bool) 
 		r.ocsPermissions |= PermissionRead
 	}
 	if rp.InitiateFileUpload &&
-		rp.RestoreFileVersion &&
+		// rp.RestoreFileVersion &&
 		rp.RestoreRecycleItem {
 		r.ocsPermissions |= PermissionWrite
 	}

--- a/internal/http/services/owncloud/ocs/conversions/role.go
+++ b/internal/http/services/owncloud/ocs/conversions/role.go
@@ -368,7 +368,6 @@ func NewLegacyRoleFromOCSPermissions(p Permissions) *Role {
 	if p.Contain(PermissionRead) {
 		r.cS3ResourcePermissions.ListContainer = true
 		// r.cS3ResourcePermissions.ListGrants = true
-		// r.cS3ResourcePermissions.ListFileVersions = true
 		r.cS3ResourcePermissions.ListRecycle = true
 		r.cS3ResourcePermissions.Stat = true
 		r.cS3ResourcePermissions.GetPath = true
@@ -377,7 +376,6 @@ func NewLegacyRoleFromOCSPermissions(p Permissions) *Role {
 	}
 	if p.Contain(PermissionWrite) {
 		r.cS3ResourcePermissions.InitiateFileUpload = true
-		// r.cS3ResourcePermissions.RestoreFileVersion = true
 		r.cS3ResourcePermissions.RestoreRecycleItem = true
 	}
 	if p.Contain(PermissionCreate) {
@@ -423,7 +421,6 @@ func RoleFromResourcePermissions(rp *provider.ResourcePermissions, islink bool) 
 		return r
 	}
 	if rp.ListContainer &&
-		// rp.ListFileVersions &&
 		rp.ListRecycle &&
 		rp.Stat &&
 		rp.GetPath &&
@@ -432,7 +429,6 @@ func RoleFromResourcePermissions(rp *provider.ResourcePermissions, islink bool) 
 		r.ocsPermissions |= PermissionRead
 	}
 	if rp.InitiateFileUpload &&
-		// rp.RestoreFileVersion &&
 		rp.RestoreRecycleItem {
 		r.ocsPermissions |= PermissionWrite
 	}

--- a/tests/acceptance/expected-failures-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-on-OCIS-storage.md
@@ -325,9 +325,6 @@ _requires a [CS3 user provisioning api that can update the quota for a user](htt
 -   [coreApiShareUpdateToShares/updateShare.feature:241](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareUpdateToShares/updateShare.feature#L241)
 -   [coreApiShareUpdateToShares/updateShare.feature:242](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareUpdateToShares/updateShare.feature#L242)
 
-#### [user can access version metadata of a received share before accepting it](https://github.com/owncloud/ocis/issues/760)
--   [coreApiVersions/fileVersions.feature:487](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiVersions/fileVersions.feature#L487)
-
 #### [Share lists deleted user as 'user'](https://github.com/owncloud/ocis/issues/903)
 -   [coreApiShareManagementBasicToShares/createShareToSharesFolder.feature:676](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareManagementBasicToShares/createShareToSharesFolder.feature#L676)
 -   [coreApiShareManagementBasicToShares/createShareToSharesFolder.feature:677](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareManagementBasicToShares/createShareToSharesFolder.feature#L677)

--- a/tests/acceptance/expected-failures-on-S3NG-storage.md
+++ b/tests/acceptance/expected-failures-on-S3NG-storage.md
@@ -333,9 +333,6 @@ _requires a [CS3 user provisioning api that can update the quota for a user](htt
 -   [coreApiShareUpdateToShares/updateShare.feature:241](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareUpdateToShares/updateShare.feature#L241)
 -   [coreApiShareUpdateToShares/updateShare.feature:242](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareUpdateToShares/updateShare.feature#L242)
 
-#### [user can access version metadata of a received share before accepting it](https://github.com/owncloud/ocis/issues/760)
--   [coreApiVersions/fileVersions.feature:487](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiVersions/fileVersions.feature#L487)
-
 #### [Share lists deleted user as 'user'](https://github.com/owncloud/ocis/issues/903)
 -   [coreApiShareManagementBasicToShares/createShareToSharesFolder.feature:676](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareManagementBasicToShares/createShareToSharesFolder.feature#L676)
 -   [coreApiShareManagementBasicToShares/createShareToSharesFolder.feature:677](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiShareManagementBasicToShares/createShareToSharesFolder.feature#L677)


### PR DESCRIPTION
# Description

Hide file versions for share receivers

We needed to change the visibility of file versions and hide them to share receivers. Space Editors can still see and restore file versions.
