### PR TITLE
FreeBSD xattr support

### DIFF
--- a/changelog/unreleased/freebsd-xattr-support.md
+++ b/changelog/unreleased/freebsd-xattr-support.md
@@ -1,0 +1,5 @@
+Bugfix: FreeBSD xattr support
+
+We now properly handle FreeBSD xattr namespaces by leaving out the `user.` prefix. FreeBSD adds that automatically.
+
+https://github.com/cs3org/reva/pull/3650

--- a/pkg/storage/utils/decomposedfs/xattrs/xattrs.go
+++ b/pkg/storage/utils/decomposedfs/xattrs/xattrs.go
@@ -38,7 +38,6 @@ import (
 // collisions with other apps We are going to introduce a sub namespace
 // "user.ocis."
 const (
-	OcisPrefix    string = "user.ocis."
 	ParentidAttr  string = OcisPrefix + "parentid"
 	OwnerIDAttr   string = OcisPrefix + "owner.id"
 	OwnerIDPAttr  string = OcisPrefix + "owner.idp"

--- a/pkg/storage/utils/decomposedfs/xattrs/xattrs.go
+++ b/pkg/storage/utils/decomposedfs/xattrs/xattrs.go
@@ -36,7 +36,7 @@ import (
 // A non root user can only manipulate the user. namespace, which is what
 // we will use to store ownCloud specific metadata. To prevent name
 // collisions with other apps We are going to introduce a sub namespace
-// "user.ocis."
+// "user.ocis." in the xattrs_prefix*.go files.
 const (
 	ParentidAttr  string = OcisPrefix + "parentid"
 	OwnerIDAttr   string = OcisPrefix + "owner.id"

--- a/pkg/storage/utils/decomposedfs/xattrs/xattrs_prefix.go
+++ b/pkg/storage/utils/decomposedfs/xattrs/xattrs_prefix.go
@@ -1,7 +1,7 @@
 //go:build !freebsd
+
 package xattrs
 
 const (
-       OcisPrefix    string = "user.ocis."
+	OcisPrefix string = "user.ocis."
 )
-

--- a/pkg/storage/utils/decomposedfs/xattrs/xattrs_prefix.go
+++ b/pkg/storage/utils/decomposedfs/xattrs/xattrs_prefix.go
@@ -1,0 +1,7 @@
+//go:build !freebsd
+package xattrs
+
+const (
+       OcisPrefix    string = "user.ocis."
+)
+

--- a/pkg/storage/utils/decomposedfs/xattrs/xattrs_prefix.go
+++ b/pkg/storage/utils/decomposedfs/xattrs/xattrs_prefix.go
@@ -2,6 +2,10 @@
 
 package xattrs
 
+// The default namespace for ocis. As non root users can only manipulate
+// the user. namespace, which is what is used to store ownCloud specific
+// metadata. To prevent name collisions with other apps, we are going to
+// introduce a sub namespace "user.ocis."
 const (
 	OcisPrefix string = "user.ocis."
 )

--- a/pkg/storage/utils/decomposedfs/xattrs/xattrs_prefix_freebsd.go
+++ b/pkg/storage/utils/decomposedfs/xattrs/xattrs_prefix_freebsd.go
@@ -1,0 +1,10 @@
+//go:build freebsd
+package xattrs
+
+// On FreeBSD the `user` namespace is implied through a separate syscall argument
+// and will fail with invalid argument when you try to start an xattr name with user. or system.
+// For that reason we drop the user. prefix for FreeBSD specifically
+const (
+  OcisPrefix    string = "ocis."
+)
+

--- a/pkg/storage/utils/decomposedfs/xattrs/xattrs_prefix_freebsd.go
+++ b/pkg/storage/utils/decomposedfs/xattrs/xattrs_prefix_freebsd.go
@@ -1,10 +1,10 @@
 //go:build freebsd
+
 package xattrs
 
 // On FreeBSD the `user` namespace is implied through a separate syscall argument
 // and will fail with invalid argument when you try to start an xattr name with user. or system.
-// For that reason we drop the user. prefix for FreeBSD specifically
+// For that reason we drop the superfluous user. prefix for FreeBSD specifically.
 const (
-  OcisPrefix    string = "ocis."
+	OcisPrefix string = "ocis."
 )
-


### PR DESCRIPTION
Since #3559, reva compiles perfectly fine on FreeBSD, but runs into problems with the `xattr` on FreeBSD:

`Failed to set all xattrs: xattr.Set   user.ocis.blobsize: invalid argument`

This MR adds support for FreeBSD's xattr namespaces. On Linux, every namespace is accessible, but in FreeBSD (and in FreeBSD jails) this is not the case: the `user` part of the namespace is the only namespace writable, and is the implied namespace. 

Setting a namespace manually, i.e. `user.ocis` will have the system refuse to use said namespace. Omitting the `user.` part of the namespace on FreeBSD solves this bug. The complete namespace will still be `user.ocis`, as FreeBSD prepends this part automatically.

Many thanks to @BlackNovaTech for help with the debugging.