### PR TITLE
remove expired spaces grants on access

### DIFF
--- a/changelog/unreleased/space-member-expiration.md
+++ b/changelog/unreleased/space-member-expiration.md
@@ -2,4 +2,5 @@ Enhancement: Add expiration date to space memberships
 
 Added an optional expiration date to space memberships to restrict the access in time. 
 
+https://github.com/cs3org/reva/pull/3655
 https://github.com/cs3org/reva/pull/3628

--- a/pkg/storage/utils/decomposedfs/spaces.go
+++ b/pkg/storage/utils/decomposedfs/spaces.go
@@ -723,10 +723,25 @@ func (fs *Decomposedfs) storageSpaceFromNode(ctx context.Context, n *node.Node, 
 			continue
 		}
 
-		grantMap[id] = g.Permissions
 		if g.Expiration != nil {
+			// We are doing this check here because we want to remove expired grants "on access".
+			// This way we don't have to have a cron job checking the grants in regular intervals.
+			// The tradeof obviously is that this code is here.
+			if isGrantExpired(g) {
+				err := fs.RemoveGrant(ctx, &provider.Reference{
+					ResourceId: &provider.ResourceId{
+						SpaceId:  n.SpaceRoot.SpaceID,
+						OpaqueId: n.ID},
+				}, g)
+				appctx.GetLogger(ctx).Error().Err(err).
+					Str("space", n.SpaceRoot.ID).
+					Str("grantee", id).
+					Msg("failed to remove expired space grant")
+				continue
+			}
 			grantExpiration[id] = g.Expiration
 		}
+		grantMap[id] = g.Permissions
 	}
 
 	grantMapJSON, err := json.Marshal(grantMap)
@@ -880,4 +895,11 @@ func mapHasKey(checkMap map[string]string, keys ...string) bool {
 		}
 	}
 	return false
+}
+
+func isGrantExpired(g *provider.Grant) bool {
+	if g.Expiration == nil {
+		return false
+	}
+	return time.Now().After(time.Unix(int64(g.Expiration.Seconds), int64(g.Expiration.Nanos)))
 }


### PR DESCRIPTION
When I implement the spaces membership expiration I forgot to actually check the expiration and remove expired grants.
This adds these missing bits. 

/cc @ScharfViktor when this was merged and reva was updated in oCIS then your tests should work.