### PR TITLE
Quota

### DIFF
--- a/changelog/unreleased/quota.md
+++ b/changelog/unreleased/quota.md
@@ -1,0 +1,6 @@
+Enhancement: add global max quota option and quota for CreateHome
+
+Added a global max quota option to limit how much quota can be assigned to spaces.
+Added a quota parameter to CreateHome. This is a prerequisite for setting a default quota per usertypes.
+
+https://github.com/cs3org/reva/pull/3671

--- a/internal/grpc/services/gateway/storageprovider.go
+++ b/internal/grpc/services/gateway/storageprovider.go
@@ -24,6 +24,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -111,10 +112,24 @@ func (s *svc) CreateHome(ctx context.Context, req *provider.CreateHomeRequest) (
 		}, nil
 
 	}
+	quotaStr := utils.ReadPlainFromOpaque(req.Opaque, "quota")
+	var quota *provider.Quota
+	if quotaStr != "" {
+		q, err := strconv.ParseUint(quotaStr, 10, 64)
+		if err != nil {
+			return &provider.CreateHomeResponse{
+				Status: status.NewInvalid(ctx, fmt.Sprintf("can't parse quotaStr: %s", quotaStr)),
+			}, nil
+		}
+		quota = &provider.Quota{
+			QuotaMaxBytes: q,
+		}
+	}
 	createReq := &provider.CreateStorageSpaceRequest{
 		Type:  "personal",
 		Owner: u,
 		Name:  u.DisplayName,
+		Quota: quota,
 	}
 
 	// send the user id as the space id, makes debugging easier

--- a/pkg/storage/utils/decomposedfs/options/options.go
+++ b/pkg/storage/utils/decomposedfs/options/options.go
@@ -67,6 +67,8 @@ type Options struct {
 
 	MaxAcquireLockCycles    int `mapstructure:"max_acquire_lock_cycles"`
 	LockCycleDurationFactor int `mapstructure:"lock_cycle_duration_factor"`
+
+	MaxQuota uint64 `mapstructure:"max_quota"`
 }
 
 // EventOptions are the configurable options for events


### PR DESCRIPTION
- Added a global max quota option to limit how much quota can be assigned to spaces.
- Added a quota parameter to CreateHome. This is a prerequisite for setting a default quota per usertypes.