### PR TITLE
Cleanup unused configs in OCM HTTP service

### DIFF
--- a/changelog/unreleased/ocm-config-cleanup.md
+++ b/changelog/unreleased/ocm-config-cleanup.md
@@ -1,0 +1,3 @@
+Enhancement: Cleanup unused configs in OCM HTTP service
+
+https://github.com/cs3org/reva/pull/3675

--- a/internal/http/services/ocmd/invites.go
+++ b/internal/http/services/ocmd/invites.go
@@ -33,14 +33,11 @@ import (
 	"github.com/cs3org/reva/internal/http/services/reqres"
 	"github.com/cs3org/reva/pkg/appctx"
 	"github.com/cs3org/reva/pkg/rgrpc/todo/pool"
-	"github.com/cs3org/reva/pkg/smtpclient"
 	"github.com/cs3org/reva/pkg/utils"
 )
 
 type invitesHandler struct {
-	smtpCredentials  *smtpclient.SMTPCredentials
-	gatewayClient    gateway.GatewayAPIClient
-	meshDirectoryURL string
+	gatewayClient gateway.GatewayAPIClient
 }
 
 func (h *invitesHandler) init(c *config) error {
@@ -49,10 +46,6 @@ func (h *invitesHandler) init(c *config) error {
 	if err != nil {
 		return err
 	}
-	if c.SMTPCredentials != nil {
-		h.smtpCredentials = smtpclient.NewSMTPCredentials(c.SMTPCredentials)
-	}
-	h.meshDirectoryURL = c.MeshDirectoryURL
 	return nil
 }
 

--- a/internal/http/services/ocmd/ocm.go
+++ b/internal/http/services/ocmd/ocm.go
@@ -24,7 +24,6 @@ import (
 	"github.com/cs3org/reva/pkg/appctx"
 	"github.com/cs3org/reva/pkg/rhttp/global"
 	"github.com/cs3org/reva/pkg/sharedconf"
-	"github.com/cs3org/reva/pkg/smtpclient"
 	"github.com/go-chi/chi/v5"
 	"github.com/mitchellh/mapstructure"
 	"github.com/rs/zerolog"
@@ -35,13 +34,10 @@ func init() {
 }
 
 type config struct {
-	SMTPCredentials            *smtpclient.SMTPCredentials `mapstructure:"smtp_credentials"`
-	Prefix                     string                      `mapstructure:"prefix"`
-	Host                       string                      `mapstructure:"host"`
-	GatewaySvc                 string                      `mapstructure:"gatewaysvc"`
-	MeshDirectoryURL           string                      `mapstructure:"mesh_directory_url"`
-	Config                     configData                  `mapstructure:"config"`
-	ExposeRecipientDisplayName bool                        `mapstructure:"expose_recipient_display_name"`
+	Prefix                     string     `mapstructure:"prefix"`
+	GatewaySvc                 string     `mapstructure:"gatewaysvc"`
+	Config                     configData `mapstructure:"config"`
+	ExposeRecipientDisplayName bool       `mapstructure:"expose_recipient_display_name"`
 }
 
 func (c *config) init() {


### PR DESCRIPTION
Some config variables were not used. This PR removes them.