### PR TITLE
[WIP] Use rename in blob upload

### DIFF
--- a/pkg/storage/fs/ocis/blobstore/blobstore.go
+++ b/pkg/storage/fs/ocis/blobstore/blobstore.go
@@ -50,20 +50,10 @@ func New(root string) (*Blobstore, error) {
 // Upload stores some data in the blobstore under the given key
 func (bs *Blobstore) Upload(node *node.Node, source string) error {
 
-	// ensure parent path exists
-	if err := os.MkdirAll(filepath.Dir(bs.path(node)), 0700); err != nil {
-		return errors.Wrap(err, "Decomposedfs: oCIS blobstore: error creating parent folders for blob")
-	}
-
-	// check that destination is not a directory, that makes Rename fail
 	dest := bs.path(node)
-	di, err := os.Stat(dest)
-	if err != nil && !os.IsNotExist(err) {
-		return errors.Wrap(err, "Decomposedfs: Could not stat dest file, yet exists")
-	}
-
-	if di != nil && di.IsDir() {
-		return errors.New("Decomposedfs: Upload to directory misses dest file name")
+	// ensure parent path exists
+	if err := os.MkdirAll(filepath.Dir(dest), 0700); err != nil {
+		return errors.Wrap(err, "Decomposedfs: oCIS blobstore: error creating parent folders for blob")
 	}
 
 	if err := os.Rename(source, dest); err == nil {

--- a/pkg/storage/fs/s3ng/blobstore/blobstore.go
+++ b/pkg/storage/fs/s3ng/blobstore/blobstore.go
@@ -64,19 +64,23 @@ func New(endpoint, region, bucket, accessKey, secretKey string) (*Blobstore, err
 }
 
 // Upload stores some data in the blobstore under the given key
-func (bs *Blobstore) Upload(node *node.Node, reader io.Reader) error {
+func (bs *Blobstore) Upload(node *node.Node, source string) error {
 	size := int64(-1)
-	if file, ok := reader.(*os.File); ok {
-		info, err := file.Stat()
-		if err != nil {
-			return errors.Wrapf(err, "could not determine file size for object '%s'", bs.path(node))
-		}
-		size = info.Size()
-	}
-
-	_, err := bs.client.PutObject(context.Background(), bs.bucket, bs.path(node), reader, size, minio.PutObjectOptions{ContentType: "application/octet-stream"})
-
+	reader, err := os.Open(source)
 	if err != nil {
+		return errors.Wrap(err, "can not open source file to upload")
+	}
+	defer reader.Close()
+
+	info, err := os.Stat(source)
+	if err != nil {
+		return errors.Wrapf(err, "could not determine file size for object '%s'", bs.path(node))
+	}
+	size = info.Size()
+
+	_, err2 := bs.client.PutObject(context.Background(), bs.bucket, bs.path(node), reader, size, minio.PutObjectOptions{ContentType: "application/octet-stream"})
+
+	if err2 != nil {
 		return errors.Wrapf(err, "could not store object '%s' into bucket '%s'", bs.path(node), bs.bucket)
 	}
 	return nil

--- a/pkg/storage/utils/decomposedfs/decomposedfs.go
+++ b/pkg/storage/utils/decomposedfs/decomposedfs.go
@@ -78,7 +78,7 @@ type Tree interface {
 	RestoreRecycleItemFunc(ctx context.Context, spaceid, key, trashPath string, target *node.Node) (*node.Node, *node.Node, func() error, error)
 	PurgeRecycleItemFunc(ctx context.Context, spaceid, key, purgePath string) (*node.Node, func() error, error)
 
-	WriteBlob(node *node.Node, reader io.Reader) error
+	WriteBlob(node *node.Node, source string) error
 	ReadBlob(node *node.Node) (io.ReadCloser, error)
 	DeleteBlob(node *node.Node) error
 

--- a/pkg/storage/utils/decomposedfs/mocks/Tree.go
+++ b/pkg/storage/utils/decomposedfs/mocks/Tree.go
@@ -22,7 +22,7 @@ package mocks
 
 import (
 	context "context"
-
+	"os"
 	fs "io/fs"
 
 	io "io"
@@ -278,7 +278,13 @@ func (_m *Tree) TouchFile(ctx context.Context, _a1 *node.Node) error {
 }
 
 // WriteBlob provides a mock function with given fields: _a0, reader
-func (_m *Tree) WriteBlob(_a0 *node.Node, reader io.Reader) error {
+func (_m *Tree) WriteBlob(_a0 *node.Node, source string) error {
+	
+	reader, err := os.Open(source)
+	if err != nil {
+		return err
+	}
+	defer reader.Close()
 	ret := _m.Called(_a0, reader)
 
 	var r0 error

--- a/pkg/storage/utils/decomposedfs/tree/mocks/Blobstore.go
+++ b/pkg/storage/utils/decomposedfs/tree/mocks/Blobstore.go
@@ -70,7 +70,7 @@ func (_m *Blobstore) Download(_a0 *node.Node) (io.ReadCloser, error) {
 }
 
 // Upload provides a mock function with given fields: _a0, reader
-func (_m *Blobstore) Upload(_a0 *node.Node, reader io.Reader) error {
+func (_m *Blobstore) Upload(_a0 *node.Node, source string) error {
 	ret := _m.Called(_a0, reader)
 
 	var r0 error

--- a/pkg/storage/utils/decomposedfs/tree/mocks/Blobstore.go
+++ b/pkg/storage/utils/decomposedfs/tree/mocks/Blobstore.go
@@ -22,7 +22,7 @@ package mocks
 
 import (
 	io "io"
-
+	"os"
 	node "github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/node"
 	mock "github.com/stretchr/testify/mock"
 )
@@ -71,6 +71,12 @@ func (_m *Blobstore) Download(_a0 *node.Node) (io.ReadCloser, error) {
 
 // Upload provides a mock function with given fields: _a0, reader
 func (_m *Blobstore) Upload(_a0 *node.Node, source string) error {
+
+	reader, err := os.Open(source)
+	if err != nil {
+		return err
+	}
+
 	ret := _m.Called(_a0, reader)
 
 	var r0 error

--- a/pkg/storage/utils/decomposedfs/tree/tree.go
+++ b/pkg/storage/utils/decomposedfs/tree/tree.go
@@ -51,7 +51,7 @@ import (
 
 // Blobstore defines an interface for storing blobs in a blobstore
 type Blobstore interface {
-	Upload(node *node.Node, reader io.Reader) error
+	Upload(node *node.Node, source string) error
 	Download(node *node.Node) (io.ReadCloser, error)
 	Delete(node *node.Node) error
 }
@@ -931,8 +931,8 @@ func calculateTreeSize(ctx context.Context, childrenPath string) (uint64, error)
 }
 
 // WriteBlob writes a blob to the blobstore
-func (t *Tree) WriteBlob(node *node.Node, reader io.Reader) error {
-	return t.blobstore.Upload(node, reader)
+func (t *Tree) WriteBlob(node *node.Node, source string) error {
+	return t.blobstore.Upload(node, source)
 }
 
 // ReadBlob reads a blob from the blobstore

--- a/pkg/storage/utils/decomposedfs/upload/upload.go
+++ b/pkg/storage/utils/decomposedfs/upload/upload.go
@@ -65,7 +65,7 @@ type Tree interface {
 	RestoreRecycleItemFunc(ctx context.Context, spaceid, key, trashPath string, target *node.Node) (*node.Node, *node.Node, func() error, error)
 	PurgeRecycleItemFunc(ctx context.Context, spaceid, key, purgePath string) (*node.Node, func() error, error)
 
-	WriteBlob(node *node.Node, reader io.Reader) error
+	WriteBlob(node *node.Node, binPath string) error
 	ReadBlob(node *node.Node) (io.ReadCloser, error)
 	DeleteBlob(node *node.Node) error
 
@@ -336,13 +336,8 @@ func (upload *Upload) Finalize() (err error) {
 	}
 
 	// upload the data to the blobstore
-	file, err := os.Open(upload.binPath)
-	if err != nil {
-		return err
-	}
-	defer file.Close()
 
-	if err := upload.tp.WriteBlob(n, file); err != nil {
+	if err := upload.tp.WriteBlob(n, upload.binPath); err != nil {
 		return errors.Wrap(err, "failed to upload file to blostore")
 	}
 


### PR DESCRIPTION
Use rename instead of copy data again for the cost of an less clean interface of BlobStore. @aduffeck 