### PR TITLE
add a max quota value to the spaces capabilities

### DIFF
--- a/changelog/unreleased/quota.md
+++ b/changelog/unreleased/quota.md
@@ -1,6 +1,8 @@
 Enhancement: add global max quota option and quota for CreateHome
 
 Added a global max quota option to limit how much quota can be assigned to spaces.
+Added a max quota value in the spacescapabilities.
 Added a quota parameter to CreateHome. This is a prerequisite for setting a default quota per usertypes.
 
+https://github.com/cs3org/reva/pull/3678
 https://github.com/cs3org/reva/pull/3671

--- a/internal/http/services/owncloud/ocs/data/capabilities.go
+++ b/internal/http/services/owncloud/ocs/data/capabilities.go
@@ -66,6 +66,7 @@ type Spaces struct {
 	Enabled   bool   `json:"enabled" xml:"enabled" mapstructure:"enabled"`
 	Projects  bool   `json:"projects" xml:"projects" mapstructure:"projects"`
 	ShareJail bool   `json:"share_jail" xml:"share_jail" mapstructure:"share_jail"`
+	MaxQuota  uint64 `json:"max_quota" xml:"max_quota" mapstructure:"max_quota"`
 }
 
 // CapabilitiesCore holds webdav config


### PR DESCRIPTION
The capability value will be used by clients to determine the maximum allowed quota.