### PR TITLE
add correct etag to empty shares jail in propfind responses

### DIFF
--- a/changelog/unreleased/shares-propfind-etag.md
+++ b/changelog/unreleased/shares-propfind-etag.md
@@ -1,0 +1,6 @@
+Bugfix: fix etag of "empty" shares jail
+
+Added the correct etag for an empty shares jail in PROPFIND responses.
+
+https://github.com/cs3org/reva/pull/3681
+https://github.com/owncloud/ocis/issues/5591

--- a/internal/grpc/services/sharesstorageprovider/sharesstorageprovider.go
+++ b/internal/grpc/services/sharesstorageprovider/sharesstorageprovider.go
@@ -652,7 +652,7 @@ func (s *service) Stat(ctx context.Context, req *provider.StatRequest) (*provide
 		}
 		earliestShare := findEarliestShare(receivedShares, shareMd)
 		var mtime *typesv1beta1.Timestamp
-		var etag string
+		etag := _defaultSharesJailEtag
 		if earliestShare != nil {
 			if info, ok := shareMd[earliestShare.GetId().GetOpaqueId()]; ok {
 				mtime = info.Mtime


### PR DESCRIPTION
Added the correct etag for an empty shares jail in PROPFIND responses.

Fixes: https://github.com/owncloud/ocis/issues/5591