### PR TITLE
set max quota as space quota

### DIFF
--- a/changelog/unreleased/quota.md
+++ b/changelog/unreleased/quota.md
@@ -4,5 +4,6 @@ Added a global max quota option to limit how much quota can be assigned to space
 Added a max quota value in the spacescapabilities.
 Added a quota parameter to CreateHome. This is a prerequisite for setting a default quota per usertypes.
 
+https://github.com/cs3org/reva/pull/3682
 https://github.com/cs3org/reva/pull/3678
 https://github.com/cs3org/reva/pull/3671

--- a/pkg/storage/utils/decomposedfs/spaces.go
+++ b/pkg/storage/utils/decomposedfs/spaces.go
@@ -145,6 +145,10 @@ func (fs *Decomposedfs) CreateStorageSpace(ctx context.Context, req *provider.Cr
 			return nil, errtypes.BadRequest("decompsedFS: requested quota is higher than allowed")
 		}
 		metadata[prefixes.QuotaAttr] = strconv.FormatUint(q.QuotaMaxBytes, 10)
+	} else if fs.o.MaxQuota != quotaUnrestricted {
+		// If no quota was requested but a max quota was set then the the storage space has a quota
+		// of max quota.
+		metadata[prefixes.QuotaAttr] = strconv.FormatUint(fs.o.MaxQuota, 10)
 	}
 
 	if description != "" {


### PR DESCRIPTION
When CreateStorageSpace is called without a quota but a max quota was set then the space can at most have max quota.