### PR TITLE
Add FileID Header on COPY

### DIFF
--- a/changelog/unreleased/fileid-on-copy.md
+++ b/changelog/unreleased/fileid-on-copy.md
@@ -1,0 +1,6 @@
+Bugfix: Send fileid on copy
+
+When copying a folder oc-fileid header would not be added (unlinke when copying files)
+this is fixed now.
+
+https://github.com/cs3org/reva/pull/3685


### PR DESCRIPTION
When copying a folder oc-fileid header would not be added (unlinke when copying files)

fixes https://github.com/owncloud/ocis/issues/5039
