### PR TITLE
Return no users when user disabled.

### DIFF
--- a/changelog/unreleased/disabled-users.md
+++ b/changelog/unreleased/disabled-users.md
@@ -1,0 +1,5 @@
+Enhancement: User disabling functionality
+
+Check if users are enabled or disabled
+
+https://github.com/cs3org/reva/pull/3686

--- a/pkg/user/manager/ldap/ldap.go
+++ b/pkg/user/manager/ldap/ldap.go
@@ -148,6 +148,10 @@ func (m *manager) GetUserByClaim(ctx context.Context, claim, value string, skipF
 		return nil, err
 	}
 
+	if m.c.LDAPIdentity.IsLDAPUserInDisabledGroup(log, m.ldapClient, userEntry) {
+		return nil, errtypes.NotFound("user is locally disabled")
+	}
+
 	if skipFetchingGroups {
 		return u, nil
 	}

--- a/pkg/utils/ldap/identity.go
+++ b/pkg/utils/ldap/identity.go
@@ -155,6 +155,22 @@ func (i *Identity) Setup() error {
 		return fmt.Errorf("error configuring group substring filter type: %w", err)
 	}
 
+	dm := i.User.DisableMechanism
+	if dm == "" || dm == "none" || dm == "attribute" || dm == "group" {
+		if dm == "attribute" || dm == "group" {
+			if i.User.EnabledProperty == "" {
+				return fmt.Errorf("error configuring disable mechanism, enabled property not set")
+			}
+		}
+		if dm == "group" {
+			if i.Group.LocalDisabledDN == "" {
+				return fmt.Errorf("error configuring disable mechanism, disabled group DN not set")
+			}
+		}
+	} else {
+		return fmt.Errorf("invalid disable mechanism setting: %s", dm)
+	}
+
 	return nil
 }
 

--- a/pkg/utils/ldap/identity.go
+++ b/pkg/utils/ldap/identity.go
@@ -155,20 +155,18 @@ func (i *Identity) Setup() error {
 		return fmt.Errorf("error configuring group substring filter type: %w", err)
 	}
 
-	dm := i.User.DisableMechanism
-	if dm == "" || dm == "none" || dm == "attribute" || dm == "group" {
-		if dm == "attribute" || dm == "group" {
-			if i.User.EnabledProperty == "" {
-				return fmt.Errorf("error configuring disable mechanism, enabled property not set")
-			}
+	switch i.User.DisableMechanism {
+	case "group":
+		if i.Group.LocalDisabledDN == "" {
+			return fmt.Errorf("error configuring disable mechanism, disabled group DN not set")
 		}
-		if dm == "group" {
-			if i.Group.LocalDisabledDN == "" {
-				return fmt.Errorf("error configuring disable mechanism, disabled group DN not set")
-			}
+	case "attribute":
+		if i.User.EnabledProperty == "" {
+			return fmt.Errorf("error configuring disable mechanism, enabled property not set")
 		}
-	} else {
-		return fmt.Errorf("invalid disable mechanism setting: %s", dm)
+	case "", "none":
+	default:
+		return fmt.Errorf("invalid disable mechanism setting: %s", i.User.DisableMechanism)
 	}
 
 	return nil
@@ -527,7 +525,7 @@ func (i *Identity) getUserAttributeFilter(attribute, value string) (string, erro
 }
 
 func (i *Identity) disabledFilter() string {
-	if i.User.DisableMechanism == "attribute" || i.User.DisableMechanism == "group" {
+	if i.User.DisableMechanism == "attribute" {
 		return fmt.Sprintf("(!(%s=FALSE)))", i.User.EnabledProperty)
 	}
 	return ""


### PR DESCRIPTION
This alters the `GetUserByClaim` method to return not found if the user is disabled, via either the property, or the local group way.