### PR TITLE
Return 425 on ocdav GET

### DIFF
--- a/changelog/unreleased/fix-425-get.md
+++ b/changelog/unreleased/fix-425-get.md
@@ -1,0 +1,5 @@
+Bugfix: Return 425 on GET
+
+On ocdav GET endpoint the server will now return `425` instead `500` when the file is being processed
+
+https://github.com/cs3org/reva/pull/3688

--- a/internal/http/services/owncloud/ocdav/get.go
+++ b/internal/http/services/owncloud/ocdav/get.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cs3org/reva/v2/internal/http/services/owncloud/ocdav/spacelookup"
 	"github.com/cs3org/reva/v2/pkg/appctx"
 	"github.com/cs3org/reva/v2/pkg/rhttp"
+	"github.com/cs3org/reva/v2/pkg/utils"
 	"github.com/rs/zerolog"
 )
 
@@ -75,6 +76,11 @@ func (s *svc) handleGet(ctx context.Context, w http.ResponseWriter, r *http.Requ
 	if sRes.Info.Type != provider.ResourceType_RESOURCE_TYPE_FILE {
 		w.Header().Set("Content-Length", "0")
 		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	if status := utils.ReadPlainFromOpaque(sRes.GetInfo().GetOpaque(), "status"); status == "processing" {
+		w.WriteHeader(http.StatusTooEarly)
 		return
 	}
 


### PR DESCRIPTION
Returns now `425` when GETting files that are being processed.

Fixes https://github.com/owncloud/ocis/issues/5326
