### PR TITLE
Create and list OCM shares in OCS layer

### DIFF
--- a/changelog/unreleased/ocm-create-list-shares-ocs.md
+++ b/changelog/unreleased/ocm-create-list-shares-ocs.md
@@ -1,0 +1,3 @@
+Enhancement: Create and list OCM shares in OCS layer
+
+https://github.com/cs3org/reva/pull/3692

--- a/go.mod
+++ b/go.mod
@@ -53,7 +53,7 @@ require (
 	github.com/sciencemesh/meshdirectory-web v1.0.4
 	github.com/sethvargo/go-password v0.2.0
 	github.com/stretchr/testify v1.8.1
-	github.com/studio-b12/gowebdav v0.0.0-20210917133250-a3a86976a1df
+	github.com/studio-b12/gowebdav v0.0.0-20230203202212-3282f94193f2
 	github.com/thanhpk/randstr v1.0.4
 	github.com/tus/tusd v1.10.0
 	github.com/wk8/go-ordered-map v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -1120,6 +1120,8 @@ github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKs
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/studio-b12/gowebdav v0.0.0-20210917133250-a3a86976a1df h1:C+J/LwTqP8gRPt1MdSzBNZP0OYuDm5wsmDKgwpLjYzo=
 github.com/studio-b12/gowebdav v0.0.0-20210917133250-a3a86976a1df/go.mod h1:gCcfDlA1Y7GqOaeEKw5l9dOGx1VLdc/HuQSlQAaZ30s=
+github.com/studio-b12/gowebdav v0.0.0-20230203202212-3282f94193f2 h1:VsBj3UD2xyAOu7kJw6O/2jjG2UXLFoBzihqDU9Ofg9M=
+github.com/studio-b12/gowebdav v0.0.0-20230203202212-3282f94193f2/go.mod h1:bHA7t77X/QFExdeAnDzK6vKM34kEZAcE1OX4MfiwjkE=
 github.com/stvp/go-udp-testing v0.0.0-20201019212854-469649b16807/go.mod h1:7jxmlfBCDBXRzr0eAQJ48XC1hBu1np4CS5+cHEYfwpc=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpPAyBWyWuQ=

--- a/internal/grpc/services/ocmcore/ocmcore.go
+++ b/internal/grpc/services/ocmcore/ocmcore.go
@@ -21,10 +21,12 @@ package ocmcore
 import (
 	"context"
 	"fmt"
+	"time"
 
 	ocmcore "github.com/cs3org/go-cs3apis/cs3/ocm/core/v1beta1"
 	ocm "github.com/cs3org/go-cs3apis/cs3/sharing/ocm/v1beta1"
 	providerpb "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+	typesv1beta1 "github.com/cs3org/go-cs3apis/cs3/types/v1beta1"
 	"github.com/cs3org/reva/pkg/errtypes"
 	"github.com/cs3org/reva/pkg/ocm/share"
 	"github.com/cs3org/reva/pkg/ocm/share/repository/registry"
@@ -110,6 +112,10 @@ func (s *service) CreateOCMCoreShare(ctx context.Context, req *ocmcore.CreateOCM
 		return nil, errtypes.NotSupported("share type not supported")
 	}
 
+	now := &typesv1beta1.Timestamp{
+		Seconds: uint64(time.Now().Unix()),
+	}
+
 	share, err := s.repo.StoreReceivedShare(ctx, &ocm.ReceivedShare{
 		ResourceId: &providerpb.ResourceId{
 			OpaqueId: req.ResourceId,
@@ -126,6 +132,8 @@ func (s *service) CreateOCMCoreShare(ctx context.Context, req *ocmcore.CreateOCM
 		Owner:        req.Owner,
 		Creator:      req.Sender,
 		Protocols:    req.Protocols,
+		Ctime:        now,
+		Mtime:        now,
 		Expiration:   req.Expiration,
 		State:        ocm.ShareState_SHARE_STATE_PENDING,
 	})

--- a/internal/grpc/services/ocminvitemanager/ocminvitemanager.go
+++ b/internal/grpc/services/ocminvitemanager/ocminvitemanager.go
@@ -51,6 +51,7 @@ type config struct {
 	OCMClientTimeout  int                               `mapstructure:"ocm_timeout"`
 	OCMClientInsecure bool                              `mapstructure:"ocm_insecure"`
 	GatewaySVC        string                            `mapstructure:"gateway_svc"`
+	ProviderDomain    string                            `mapstructure:"provider_domain" docs:"The same domain registered in the provider authorizer"`
 
 	tokenExpiration time.Duration
 }
@@ -174,7 +175,7 @@ func (s *service) ForwardInvite(ctx context.Context, req *invitepb.ForwardInvite
 
 	remoteUser, err := s.ocmClient.InviteAccepted(ctx, ocmEndpoint, &client.InviteAcceptedRequest{
 		Token:             req.InviteToken.GetToken(),
-		RecipientProvider: user.GetId().GetIdp(),
+		RecipientProvider: s.conf.ProviderDomain,
 		UserID:            user.GetId().GetOpaqueId(),
 		Email:             user.GetMail(),
 		Name:              user.GetDisplayName(),

--- a/internal/http/services/owncloud/ocs/config/config.go
+++ b/internal/http/services/owncloud/ocs/config/config.go
@@ -44,6 +44,7 @@ type Config struct {
 	UserIdentifierCacheTTL   int                               `mapstructure:"user_identifier_cache_ttl"`
 	AllowedLanguages         []string                          `mapstructure:"allowed_languages"`
 	OCMMountPoint            string                            `mapstructure:"ocm_mount_point"`
+	ListOCMShares            bool                              `mapstructure:"list_ocm_shares"`
 }
 
 // Init sets sane defaults.

--- a/internal/http/services/owncloud/ocs/config/config.go
+++ b/internal/http/services/owncloud/ocs/config/config.go
@@ -43,6 +43,7 @@ type Config struct {
 	ResourceInfoCacheDrivers map[string]map[string]interface{} `mapstructure:"resource_info_caches"`
 	UserIdentifierCacheTTL   int                               `mapstructure:"user_identifier_cache_ttl"`
 	AllowedLanguages         []string                          `mapstructure:"allowed_languages"`
+	OCMMountPoint            string                            `mapstructure:"ocm_mount_point"`
 }
 
 // Init sets sane defaults.

--- a/internal/http/services/owncloud/ocs/conversions/main.go
+++ b/internal/http/services/owncloud/ocs/conversions/main.go
@@ -34,6 +34,7 @@ import (
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	types "github.com/cs3org/go-cs3apis/cs3/types/v1beta1"
 	"github.com/cs3org/reva/pkg/errtypes"
+	"github.com/cs3org/reva/pkg/mime"
 	"github.com/cs3org/reva/pkg/publicshare"
 	publicsharemgr "github.com/cs3org/reva/pkg/publicshare/manager/registry"
 	"github.com/cs3org/reva/pkg/user"
@@ -272,6 +273,7 @@ func ReceivedOCMShare2ShareData(share *ocm.ReceivedShare, path string) (*ShareDa
 		Permissions:  RoleFromResourcePermissions(webdav.Permissions.Permissions).OCSPermissions(),
 		ShareType:    ShareTypeFederatedCloudShare,
 		Path:         path,
+		MimeType:     mime.Detect(share.ResourceType == provider.ResourceType_RESOURCE_TYPE_CONTAINER, share.Name),
 		ItemType:     ResourceType(share.ResourceType).String(),
 		ItemSource:   path,
 		STime:        share.Ctime.Seconds,

--- a/internal/http/services/owncloud/ocs/conversions/main.go
+++ b/internal/http/services/owncloud/ocs/conversions/main.go
@@ -273,6 +273,7 @@ func ReceivedOCMShare2ShareData(share *ocm.ReceivedShare, path string) (*ShareDa
 		Permissions:  RoleFromResourcePermissions(webdav.Permissions.Permissions).OCSPermissions(),
 		ShareType:    ShareTypeFederatedCloudShare,
 		Path:         path,
+		FileTarget:   path,
 		MimeType:     mime.Detect(share.ResourceType == provider.ResourceType_RESOURCE_TYPE_CONTAINER, share.Name),
 		ItemType:     ResourceType(share.ResourceType).String(),
 		ItemSource:   path,

--- a/internal/http/services/owncloud/ocs/conversions/main.go
+++ b/internal/http/services/owncloud/ocs/conversions/main.go
@@ -264,18 +264,22 @@ func ReceivedOCMShare2ShareData(share *ocm.ReceivedShare, path string) (*ShareDa
 		return nil, errtypes.InternalError("webdav endpoint not in share")
 	}
 
-	return &ShareData{
+	s := &ShareData{
 		ID:           share.Id.OpaqueId,
 		UIDOwner:     formatRemoteUser(share.Creator),
 		UIDFileOwner: formatRemoteUser(share.Owner),
 		ShareWith:    share.Grantee.GetUserId().OpaqueId,
 		Permissions:  RoleFromResourcePermissions(webdav.Permissions.Permissions).OCSPermissions(),
 		ShareType:    ShareTypeFederatedCloudShare,
-		Expiration:   timestampToExpiration(share.Expiration),
 		Path:         path,
 		STime:        share.Ctime.Seconds,
 		Name:         share.Name,
-	}, nil
+	}
+
+	if share.Expiration != nil {
+		s.Expiration = timestampToExpiration(share.Expiration)
+	}
+	return s, nil
 }
 
 func webdavAMInfo(methods []*ocm.AccessMethod) (*ocm.WebDAVAccessMethod, bool) {

--- a/internal/http/services/owncloud/ocs/conversions/main.go
+++ b/internal/http/services/owncloud/ocs/conversions/main.go
@@ -272,6 +272,8 @@ func ReceivedOCMShare2ShareData(share *ocm.ReceivedShare, path string) (*ShareDa
 		Permissions:  RoleFromResourcePermissions(webdav.Permissions.Permissions).OCSPermissions(),
 		ShareType:    ShareTypeFederatedCloudShare,
 		Path:         path,
+		ItemType:     ResourceType(share.ResourceType).String(),
+		ItemSource:   path,
 		STime:        share.Ctime.Seconds,
 		Name:         share.Name,
 	}

--- a/internal/http/services/owncloud/ocs/conversions/main.go
+++ b/internal/http/services/owncloud/ocs/conversions/main.go
@@ -175,6 +175,7 @@ type MatchData struct {
 type MatchValueData struct {
 	ShareType               int    `json:"shareType" xml:"shareType"`
 	ShareWith               string `json:"shareWith" xml:"shareWith"`
+	ShareWithProvider       string `json:"shareWithProvider" xml:"shareWithProvider"`
 	ShareWithAdditionalInfo string `json:"shareWithAdditionalInfo" xml:"shareWithAdditionalInfo"`
 }
 

--- a/internal/http/services/owncloud/ocs/conversions/main.go
+++ b/internal/http/services/owncloud/ocs/conversions/main.go
@@ -259,6 +259,7 @@ func webdavInfo(protocols []*ocm.Protocol) (*ocm.WebDAVProtocol, bool) {
 	return nil, false
 }
 
+// ReceivedOCMShare2ShareData converts a cs3 ocm received share into a share data model.
 func ReceivedOCMShare2ShareData(share *ocm.ReceivedShare, path string) (*ShareData, error) {
 	webdav, ok := webdavInfo(share.Protocols)
 	if !ok {
@@ -296,6 +297,7 @@ func webdavAMInfo(methods []*ocm.AccessMethod) (*ocm.WebDAVAccessMethod, bool) {
 	return nil, false
 }
 
+// OCMShare2ShareData converts a cs3 ocm share into a share data model.
 func OCMShare2ShareData(share *ocm.Share) (*ShareData, error) {
 	webdav, ok := webdavAMInfo(share.AccessMethods)
 	if !ok {

--- a/internal/http/services/owncloud/ocs/conversions/main.go
+++ b/internal/http/services/owncloud/ocs/conversions/main.go
@@ -297,18 +297,22 @@ func OCMShare2ShareData(share *ocm.Share) (*ShareData, error) {
 		return nil, errtypes.InternalError("webdav endpoint not in share")
 	}
 
-	return &ShareData{
+	s := &ShareData{
 		ID:           share.Id.OpaqueId,
 		UIDOwner:     share.Creator.OpaqueId,
 		UIDFileOwner: share.Owner.OpaqueId,
+		ShareWith:    formatRemoteUser(share.Grantee.GetUserId()),
+		Permissions:  RoleFromResourcePermissions(webdav.Permissions).OCSPermissions(),
+		ShareType:    ShareTypeFederatedCloudShare,
+		STime:        share.Ctime.Seconds,
+		Name:         share.Name,
+	}
 
-		ShareWith:   formatRemoteUser(share.Grantee.GetUserId()),
-		Permissions: RoleFromResourcePermissions(webdav.Permissions).OCSPermissions(),
-		ShareType:   ShareTypeFederatedCloudShare,
-		Expiration:  timestampToExpiration(share.Expiration),
-		STime:       share.Ctime.Seconds,
-		Name:        share.Name,
-	}, nil
+	if share.Expiration != nil {
+		s.Expiration = timestampToExpiration(share.Expiration)
+	}
+
+	return s, nil
 }
 
 // LocalUserIDToString transforms a cs3api user id into an ocs data model without domain name

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/sharees/sharees.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/sharees/sharees.go
@@ -99,12 +99,18 @@ func (h *Handler) FindSharees(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) userAsMatch(u *userpb.User) *conversions.MatchData {
+	shareWith := u.Username
+	if shareWith == "" {
+		shareWith = u.Id.OpaqueId
+	}
+
 	return &conversions.MatchData{
 		Label: u.DisplayName,
 		Value: &conversions.MatchValueData{
 			ShareType: int(conversions.ShareTypeUser),
 			// api compatibility with oc10: always use the username
-			ShareWith:               u.Username,
+			ShareWith:               shareWith,
+			ShareWithProvider:       u.Id.Idp,
 			ShareWithAdditionalInfo: h.getAdditionalInfoAttribute(u),
 		},
 	}

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/sharees/sharees.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/sharees/sharees.go
@@ -104,10 +104,15 @@ func (h *Handler) userAsMatch(u *userpb.User) *conversions.MatchData {
 		shareWith = u.Id.OpaqueId
 	}
 
+	shareType := conversions.ShareTypeUser
+	if u.Id.Type == userpb.UserType_USER_TYPE_FEDERATED {
+		shareType = conversions.ShareTypeFederatedCloudShare
+	}
+
 	return &conversions.MatchData{
 		Label: u.DisplayName,
 		Value: &conversions.MatchValueData{
-			ShareType: int(conversions.ShareTypeUser),
+			ShareType: int(shareType),
 			// api compatibility with oc10: always use the username
 			ShareWith:               shareWith,
 			ShareWithProvider:       u.Id.Idp,

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/remote.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/remote.go
@@ -186,18 +186,18 @@ func (h *Handler) ocmLocalMount(share *ocm.ReceivedShare) string {
 
 func (h *Handler) mapUserIdsFederatedShare(ctx context.Context, gw gatewayv1beta1.GatewayAPIClient, sd *conversions.ShareData) {
 	if sd.ShareWith != "" {
-		user := h.mustGetIdentifiers(ctx, gw, sd.ShareWith, false)
+		user := h.mustGetRemoteUser(ctx, gw, sd.ShareWith)
 		sd.ShareWith = user.Username
 		sd.ShareWithDisplayname = user.DisplayName
 	}
 
 	if sd.UIDOwner != "" {
-		user := h.mustGetRemoteUser(ctx, gw, sd.UIDOwner)
+		user := h.mustGetIdentifiers(ctx, gw, sd.UIDOwner, false)
 		sd.DisplaynameOwner = user.DisplayName
 	}
 
 	if sd.UIDFileOwner != "" {
-		user := h.mustGetRemoteUser(ctx, gw, sd.UIDFileOwner)
+		user := h.mustGetIdentifiers(ctx, gw, sd.UIDFileOwner, false)
 		sd.DisplaynameFileOwner = user.DisplayName
 	}
 }

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/remote.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/remote.go
@@ -19,98 +19,99 @@
 package shares
 
 import (
+	"context"
 	"net/http"
+	"path/filepath"
+	"strings"
 
+	providerv1beta1 "github.com/cs3org/go-cs3apis/cs3/app/provider/v1beta1"
+	gatewayv1beta1 "github.com/cs3org/go-cs3apis/cs3/gateway/v1beta1"
+	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
+	invitepb "github.com/cs3org/go-cs3apis/cs3/ocm/invite/v1beta1"
+	providerpb "github.com/cs3org/go-cs3apis/cs3/ocm/provider/v1beta1"
+	rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
 	ocm "github.com/cs3org/go-cs3apis/cs3/sharing/ocm/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	"github.com/cs3org/reva/internal/http/services/owncloud/ocs/conversions"
 	"github.com/cs3org/reva/internal/http/services/owncloud/ocs/response"
+	"github.com/cs3org/reva/pkg/ocm/share"
 	"github.com/cs3org/reva/pkg/rgrpc/todo/pool"
 	"github.com/go-chi/chi/v5"
 )
 
-func (h *Handler) createFederatedCloudShare(w http.ResponseWriter, r *http.Request, statInfo *provider.ResourceInfo, role *conversions.Role, roleVal []byte) {
-	// ctx := r.Context()
+func (h *Handler) createFederatedCloudShare(w http.ResponseWriter, r *http.Request, resource *provider.ResourceInfo, role *conversions.Role, roleVal []byte) {
+	ctx := r.Context()
 
-	// c, err := pool.GetGatewayServiceClient(pool.Endpoint(h.gatewayAddr))
-	// if err != nil {
-	// 	response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "error getting grpc gateway client", err)
-	// 	return
-	// }
+	c, err := pool.GetGatewayServiceClient(pool.Endpoint(h.gatewayAddr))
+	if err != nil {
+		response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "error getting grpc gateway client", err)
+		return
+	}
 
-	// shareWithUser, shareWithProvider := r.FormValue("shareWithUser"), r.FormValue("shareWithProvider")
-	// if shareWithUser == "" || shareWithProvider == "" {
-	// 	response.WriteOCSError(w, r, response.MetaBadRequest.StatusCode, "missing shareWith parameters", nil)
-	// 	return
-	// }
+	shareWithUser, shareWithProvider := r.FormValue("shareWithUser"), r.FormValue("shareWithProvider")
+	if shareWithUser == "" || shareWithProvider == "" {
+		response.WriteOCSError(w, r, response.MetaBadRequest.StatusCode, "missing shareWith parameters", nil)
+		return
+	}
 
-	// providerInfoResp, err := c.GetInfoByDomain(ctx, &ocmprovider.GetInfoByDomainRequest{
-	// 	Domain: shareWithProvider,
-	// })
-	// if err != nil {
-	// 	response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "error sending a grpc get invite by domain info request", err)
-	// 	return
-	// }
+	providerInfoResp, err := c.GetInfoByDomain(ctx, &providerpb.GetInfoByDomainRequest{
+		Domain: shareWithProvider,
+	})
+	if err != nil {
+		response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "error sending a grpc get invite by domain info request", err)
+		return
+	}
 
-	// remoteUserRes, err := c.GetAcceptedUser(ctx, &invitepb.GetAcceptedUserRequest{
-	// 	RemoteUserId: &userpb.UserId{OpaqueId: shareWithUser, Idp: shareWithProvider, Type: userpb.UserType_USER_TYPE_PRIMARY},
-	// })
-	// if err != nil {
-	// 	response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "error searching recipient", err)
-	// 	return
-	// }
-	// if remoteUserRes.Status.Code != rpc.Code_CODE_OK {
-	// 	response.WriteOCSError(w, r, response.MetaNotFound.StatusCode, "user not found", err)
-	// 	return
-	// }
+	remoteUserRes, err := c.GetAcceptedUser(ctx, &invitepb.GetAcceptedUserRequest{
+		RemoteUserId: &userpb.UserId{OpaqueId: shareWithUser, Idp: shareWithProvider, Type: userpb.UserType_USER_TYPE_FEDERATED},
+	})
+	if err != nil {
+		response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "error searching recipient", err)
+		return
+	}
+	if remoteUserRes.Status.Code != rpc.Code_CODE_OK {
+		response.WriteOCSError(w, r, response.MetaNotFound.StatusCode, "user not found", err)
+		return
+	}
 
-	// createShareReq := &ocm.CreateOCMShareRequest{
-	// 	Opaque: &types.Opaque{
-	// 		Map: map[string]*types.OpaqueEntry{
-	// 			/* TODO extend the spec with role names?
-	// 			"role": {
-	// 				Decoder: "plain",
-	// 				Value:   []byte(role.Name),
-	// 			},
-	// 			*/
-	// 			"permissions": {
-	// 				Decoder: "plain",
-	// 				Value:   []byte(strconv.Itoa(int(role.OCSPermissions()))),
-	// 			},
-	// 			"name": {
-	// 				Decoder: "plain",
-	// 				Value:   []byte(statInfo.Path),
-	// 			},
-	// 		},
-	// 	},
-	// 	ResourceId: statInfo.Id,
-	// 	Grant: &ocm.ShareGrant{
-	// 		Grantee: &provider.Grantee{
-	// 			Type: provider.GranteeType_GRANTEE_TYPE_USER,
-	// 			Id:   &provider.Grantee_UserId{UserId: remoteUserRes.RemoteUser.GetId()},
-	// 		},
-	// 		Permissions: &ocm.SharePermissions{
-	// 			Permissions: role.CS3ResourcePermissions(),
-	// 		},
-	// 	},
-	// 	RecipientMeshProvider: providerInfoResp.ProviderInfo,
-	// }
+	createShareResponse, err := c.CreateOCMShare(ctx, &ocm.CreateOCMShareRequest{
+		ResourceId: resource.Id,
+		Grantee: &provider.Grantee{
+			Type: provider.GranteeType_GRANTEE_TYPE_USER,
+			Id: &provider.Grantee_UserId{
+				UserId: remoteUserRes.RemoteUser.Id,
+			},
+		},
+		RecipientMeshProvider: providerInfoResp.ProviderInfo,
+		AccessMethods: []*ocm.AccessMethod{
+			share.NewWebDavAccessMethod(role.CS3ResourcePermissions()),
+			share.NewWebappAccessMethod(getViewModeFromRole(role)),
+		},
+	})
+	if err != nil {
+		response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "error sending a grpc create ocm share request", err)
+		return
+	}
+	if createShareResponse.Status.Code != rpc.Code_CODE_OK {
+		if createShareResponse.Status.Code == rpc.Code_CODE_NOT_FOUND {
+			response.WriteOCSError(w, r, response.MetaNotFound.StatusCode, "not found", nil)
+			return
+		}
+		response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "grpc create ocm share request failed", err)
+		return
+	}
 
-	// createShareResponse, err := c.CreateOCMShare(ctx, createShareReq)
-	// if err != nil {
-	// 	response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "error sending a grpc create ocm share request", err)
-	// 	return
-	// }
-	// if createShareResponse.Status.Code != rpc.Code_CODE_OK {
-	// 	if createShareResponse.Status.Code == rpc.Code_CODE_NOT_FOUND {
-	// 		response.WriteOCSError(w, r, response.MetaNotFound.StatusCode, "not found", nil)
-	// 		return
-	// 	}
-	// 	response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "grpc create ocm share request failed", err)
-	// 	return
-	// }
+	response.WriteOCSSuccess(w, r, "OCM Share created")
+}
 
-	// response.WriteOCSSuccess(w, r, "OCM Share created")
+func getViewModeFromRole(role *conversions.Role) providerv1beta1.ViewMode {
+	switch role.Name {
+	case conversions.RoleViewer:
+		return providerv1beta1.ViewMode_VIEW_MODE_READ_ONLY
+	case conversions.RoleEditor:
+		return providerv1beta1.ViewMode_VIEW_MODE_READ_WRITE
+	}
+	return providerv1beta1.ViewMode_VIEW_MODE_INVALID
 }
 
 // GetFederatedShare handles GET requests on /apps/files_sharing/api/v1/shares/remote_shares/{shareid}.
@@ -152,23 +153,100 @@ func (h *Handler) GetFederatedShare(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) ListFederatedShares(w http.ResponseWriter, r *http.Request) {
 	// TODO Implement pagination.
 	// TODO Implement response with HAL schemating
-	ctx := r.Context()
+}
 
-	gatewayClient, err := pool.GetGatewayServiceClient(pool.Endpoint(h.gatewayAddr))
+func (h *Handler) listReceivedFederatedShares(ctx context.Context, gw gatewayv1beta1.GatewayAPIClient) ([]*conversions.ShareData, error) {
+	listRes, err := gw.ListReceivedOCMShares(ctx, &ocm.ListReceivedOCMSharesRequest{})
 	if err != nil {
-		response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "error getting grpc gateway client", err)
-		return
+		return nil, err
 	}
 
-	listOCMSharesResponse, err := gatewayClient.ListOCMShares(ctx, &ocm.ListOCMSharesRequest{})
+	shares := []*conversions.ShareData{}
+	for _, s := range listRes.Shares {
+		sd, err := conversions.ReceivedOCMShare2ShareData(s, h.ocmLocalMount(s))
+		if err != nil {
+			continue
+		}
+		h.mapUserIdsFederatedShare(ctx, gw, sd)
+		shares = append(shares, sd)
+	}
+	return shares, nil
+}
+
+func (h *Handler) ocmLocalMount(share *ocm.ReceivedShare) string {
+	return filepath.Join("/", h.ocmMountPoint, share.Id.OpaqueId)
+}
+
+func (h *Handler) mapUserIdsFederatedShare(ctx context.Context, gw gatewayv1beta1.GatewayAPIClient, sd *conversions.ShareData) {
+	if sd.ShareWith != "" {
+		user := h.mustGetIdentifiers(ctx, gw, sd.ShareWith, false)
+		sd.ShareWith = user.Username
+		sd.ShareWithDisplayname = user.DisplayName
+	}
+
+	if sd.UIDOwner != "" {
+		user := h.mustGetRemoteUser(ctx, gw, sd.UIDOwner)
+		sd.DisplaynameOwner = user.DisplayName
+	}
+
+	if sd.UIDFileOwner != "" {
+		user := h.mustGetRemoteUser(ctx, gw, sd.UIDFileOwner)
+		sd.DisplaynameFileOwner = user.DisplayName
+	}
+}
+
+func (h *Handler) mustGetRemoteUser(ctx context.Context, gw gatewayv1beta1.GatewayAPIClient, id string) *userIdentifiers {
+	s := strings.SplitN(id, "@", 2)
+	opaqueID, idp := s[0], s[1]
+	userRes, err := gw.GetAcceptedUser(ctx, &invitepb.GetAcceptedUserRequest{
+		RemoteUserId: &userpb.UserId{
+			Idp:      idp,
+			OpaqueId: opaqueID,
+		},
+	})
 	if err != nil {
-		response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "error sending a grpc list ocm share request", err)
-		return
+		return &userIdentifiers{}
+	}
+	if userRes.Status.Code != rpc.Code_CODE_OK {
+		return &userIdentifiers{}
 	}
 
-	shares := listOCMSharesResponse.GetShares()
-	if shares == nil {
-		shares = make([]*ocm.Share, 0)
+	user := userRes.RemoteUser
+	return &userIdentifiers{
+		DisplayName: user.DisplayName,
+		Username:    user.Username,
+		Mail:        user.Mail,
 	}
-	response.WriteOCSSuccess(w, r, shares)
+}
+
+func (h *Handler) listOutcomingFederatedShares(ctx context.Context, gw gatewayv1beta1.GatewayAPIClient) ([]*conversions.ShareData, error) {
+	listRes, err := gw.ListOCMShares(ctx, &ocm.ListOCMSharesRequest{})
+	if err != nil {
+		return nil, err
+	}
+
+	shares := []*conversions.ShareData{}
+	for _, s := range listRes.Shares {
+		sd, err := conversions.OCMShare2ShareData(s)
+		if err != nil {
+			continue
+		}
+		h.mapUserIdsFederatedShare(ctx, gw, sd)
+
+		info, status, err := h.getResourceInfoByID(ctx, gw, s.ResourceId)
+		if err != nil {
+			return nil, err
+		}
+
+		if status.Code != rpc.Code_CODE_OK {
+			return nil, err
+		}
+
+		err = h.addFileInfo(ctx, sd, info)
+		if err != nil {
+			return nil, err
+		}
+		shares = append(shares, sd)
+	}
+	return shares, nil
 }

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/remote.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/remote.go
@@ -37,6 +37,7 @@ import (
 	"github.com/cs3org/reva/pkg/ocm/share"
 	"github.com/cs3org/reva/pkg/rgrpc/todo/pool"
 	"github.com/go-chi/chi/v5"
+	"github.com/pkg/errors"
 )
 
 func (h *Handler) createFederatedCloudShare(w http.ResponseWriter, r *http.Request, resource *provider.ResourceInfo, role *conversions.Role, roleVal []byte) {
@@ -59,6 +60,12 @@ func (h *Handler) createFederatedCloudShare(w http.ResponseWriter, r *http.Reque
 	})
 	if err != nil {
 		response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "error sending a grpc get invite by domain info request", err)
+		return
+	}
+
+	if providerInfoResp.Status.Code != rpc.Code_CODE_OK {
+		// return proper error
+		response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "error from provider info response", errors.New(providerInfoResp.Status.Message))
 		return
 	}
 

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/remote.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/remote.go
@@ -174,7 +174,7 @@ func (h *Handler) listReceivedFederatedShares(ctx context.Context, gw gatewayv1b
 		if err != nil {
 			continue
 		}
-		h.mapUserIdsFederatedShare(ctx, gw, sd)
+		h.mapUserIdsReceivedFederatedShare(ctx, gw, sd)
 		shares = append(shares, sd)
 	}
 	return shares, nil
@@ -182,6 +182,24 @@ func (h *Handler) listReceivedFederatedShares(ctx context.Context, gw gatewayv1b
 
 func (h *Handler) ocmLocalMount(share *ocm.ReceivedShare) string {
 	return filepath.Join("/", h.ocmMountPoint, share.Id.OpaqueId)
+}
+
+func (h *Handler) mapUserIdsReceivedFederatedShare(ctx context.Context, gw gatewayv1beta1.GatewayAPIClient, sd *conversions.ShareData) {
+	if sd.ShareWith != "" {
+		user := h.mustGetIdentifiers(ctx, gw, sd.ShareWith, false)
+		sd.ShareWith = user.Username
+		sd.ShareWithDisplayname = user.DisplayName
+	}
+
+	if sd.UIDOwner != "" {
+		user := h.mustGetRemoteUser(ctx, gw, sd.UIDOwner)
+		sd.DisplaynameOwner = user.DisplayName
+	}
+
+	if sd.UIDFileOwner != "" {
+		user := h.mustGetRemoteUser(ctx, gw, sd.UIDFileOwner)
+		sd.DisplaynameFileOwner = user.DisplayName
+	}
 }
 
 func (h *Handler) mapUserIdsFederatedShare(ctx context.Context, gw gatewayv1beta1.GatewayAPIClient, sd *conversions.ShareData) {

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/user.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/user.go
@@ -214,13 +214,15 @@ func (h *Handler) listUserShares(r *http.Request, filters []*collaboration.Filte
 			ocsDataPayload = append(ocsDataPayload, data)
 		}
 
-		// include the ocm shares
-		ocmShares, err := h.listOutcomingFederatedShares(ctx, client)
-		if err != nil {
-			return nil, nil, err
+		if h.listOCMShares {
+			// include the ocm shares
+			ocmShares, err := h.listOutcomingFederatedShares(ctx, client)
+			if err != nil {
+				return nil, nil, err
+			}
+			ocsDataPayload = append(ocsDataPayload, ocmShares...)
 		}
 
-		ocsDataPayload = append(ocsDataPayload, ocmShares...)
 	}
 
 	return ocsDataPayload, nil, nil

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/user.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/user.go
@@ -222,7 +222,6 @@ func (h *Handler) listUserShares(r *http.Request, filters []*collaboration.Filte
 			}
 			ocsDataPayload = append(ocsDataPayload, ocmShares...)
 		}
-
 	}
 
 	return ocsDataPayload, nil, nil

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/user.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/user.go
@@ -213,6 +213,14 @@ func (h *Handler) listUserShares(r *http.Request, filters []*collaboration.Filte
 			log.Debug().Interface("share", s).Interface("info", info).Interface("shareData", data).Msg("mapped")
 			ocsDataPayload = append(ocsDataPayload, data)
 		}
+
+		// include the ocm shares
+		ocmShares, err := h.listOutcomingFederatedShares(ctx, client)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		ocsDataPayload = append(ocsDataPayload, ocmShares...)
 	}
 
 	return ocsDataPayload, nil, nil

--- a/pkg/ocm/share/repository/sql/conversions.go
+++ b/pkg/ocm/share/repository/sql/conversions.go
@@ -19,6 +19,7 @@
 package sql
 
 import (
+	"database/sql"
 	"strconv"
 	"strings"
 
@@ -157,7 +158,7 @@ type dbReceivedShare struct {
 	Initiator  string
 	Ctime      int
 	Mtime      int
-	Expiration int
+	Expiration sql.NullInt64
 	Type       ShareType
 	State      ShareState
 }
@@ -258,9 +259,9 @@ func convertToCS3OCMReceivedShare(s *dbReceivedShare, p []*ocm.Protocol) *ocm.Re
 		State:        convertToCS3OCMShareState(s.State),
 		Protocols:    p,
 	}
-	if s.Expiration != 0 {
+	if s.Expiration.Valid {
 		share.Expiration = &types.Timestamp{
-			Seconds: uint64(s.Expiration),
+			Seconds: uint64(s.Expiration.Int64),
 		}
 	}
 	return share

--- a/pkg/ocm/share/repository/sql/conversions.go
+++ b/pkg/ocm/share/repository/sql/conversions.go
@@ -136,7 +136,7 @@ type dbShare struct {
 	Initiator  string
 	Ctime      int
 	Mtime      int
-	Expiration int
+	Expiration sql.NullInt64
 	ShareType  ShareType
 }
 
@@ -220,9 +220,9 @@ func convertToCS3OCMShare(s *dbShare, am []*ocm.AccessMethod) *ocm.Share {
 		ShareType:     ocm.ShareType_SHARE_TYPE_USER,
 		AccessMethods: am,
 	}
-	if s.Expiration != 0 {
+	if s.Expiration.Valid {
 		share.Expiration = &types.Timestamp{
-			Seconds: uint64(s.Expiration),
+			Seconds: uint64(s.Expiration.Int64),
 		}
 	}
 	return share

--- a/pkg/ocm/share/repository/sql/init.sql
+++ b/pkg/ocm/share/repository/sql/init.sql
@@ -62,7 +62,7 @@ CREATE TABLE IF NOT EXISTS ocm_received_share_protocols (
 CREATE TABLE IF NOT EXISTS ocm_protocol_webdav (
     ocm_protocol_id INTEGER NOT NULL PRIMARY KEY,
     uri VARCHAR(255) NOT NULL,
-    shared_secret VARCHAR(255) NOT NULL,
+    shared_secret TEXT NOT NULL,
     permissions INTEGER NOT NULL,
     FOREIGN KEY (ocm_protocol_id) REFERENCES ocm_received_share_protocols(id) ON DELETE CASCADE
 );

--- a/pkg/ocm/share/repository/sql/sql.go
+++ b/pkg/ocm/share/repository/sql/sql.go
@@ -117,7 +117,7 @@ func storeTransferAccessMethod(tx *sql.Tx, shareID int64, _ *ocm.AccessMethod_Tr
 }
 
 func storeAccessMethod(tx *sql.Tx, shareID int64, t AccessMethod) (int64, error) {
-	query := "INSERT INTO ocm_shares_access_method SET ocm_share_id=?, type=?"
+	query := "INSERT INTO ocm_shares_access_methods SET ocm_share_id=?, type=?"
 	params := []any{shareID, int(t)}
 
 	res, err := tx.Exec(query, params...)
@@ -259,7 +259,7 @@ func (m *mgr) getByKey(ctx context.Context, user *userpb.User, key *ocm.ShareKey
 }
 
 func (m *mgr) getAccessMethods(ctx context.Context, id int) ([]*ocm.AccessMethod, error) {
-	query := "SELECT m.type, dav.permissions, app.view_mode FROM ocm_shares_access_method as m LEFT JOIN ocm_access_method_webdav as dav ON m.id=dav.ocm_access_method_id LEFT JOIN ocm_access_method_webapp as app ON m.id=app.ocm_access_method_id WHERE m.ocm_share_id=?"
+	query := "SELECT m.type, dav.permissions, app.view_mode FROM ocm_shares_access_methods as m LEFT JOIN ocm_access_method_webdav as dav ON m.id=dav.ocm_access_method_id LEFT JOIN ocm_access_method_webapp as app ON m.id=app.ocm_access_method_id WHERE m.ocm_share_id=?"
 
 	var methods []*ocm.AccessMethod
 	rows, err := m.db.QueryContext(ctx, query, id)
@@ -415,7 +415,7 @@ func (m *mgr) getAccessMethodsIds(ctx context.Context, ids []any) (map[string][]
 		return methods, nil
 	}
 
-	query := "SELECT m.ocm_share_id, m.type, dav.permissions, app.view_mode FROM ocm_shares_access_method as m LEFT JOIN ocm_access_method_webdav as dav ON m.id=dav.ocm_access_method_id LEFT JOIN ocm_access_method_webapp as app ON m.id=app.ocm_access_method_id WHERE m.ocm_share_id IN "
+	query := "SELECT m.ocm_share_id, m.type, dav.permissions, app.view_mode FROM ocm_shares_access_methods as m LEFT JOIN ocm_access_method_webdav as dav ON m.id=dav.ocm_access_method_id LEFT JOIN ocm_access_method_webapp as app ON m.id=app.ocm_access_method_id WHERE m.ocm_share_id IN "
 	in := strings.Repeat("?,", len(ids))
 	query += "(" + in[:len(in)-1] + ")"
 

--- a/pkg/ocm/share/repository/sql/sql.go
+++ b/pkg/ocm/share/repository/sql/sql.go
@@ -99,7 +99,7 @@ func storeWebDAVAccessMethod(tx *sql.Tx, shareID int64, o *ocm.AccessMethod_Webd
 }
 
 func storeWebappAccessMethod(tx *sql.Tx, shareID int64, o *ocm.AccessMethod_WebappOptions) error {
-	amID, err := storeAccessMethod(tx, shareID, WebDAVAccessMethod)
+	amID, err := storeAccessMethod(tx, shareID, WebappAccessMethod)
 	if err != nil {
 		return err
 	}

--- a/pkg/ocm/share/repository/sql/sql_test.go
+++ b/pkg/ocm/share/repository/sql/sql_test.go
@@ -47,7 +47,7 @@ var (
 	port                 = 3306
 	m                    sync.Mutex // for increasing the port
 	ocmShareTable        = "ocm_shares"
-	ocmAccessMethodTable = "ocm_shares_access_method"
+	ocmAccessMethodTable = "ocm_shares_access_methods"
 	ocmAMWebDAVTable     = "ocm_access_method_webdav"
 	ocmAMWebappTable     = "ocm_access_method_webapp"
 
@@ -128,7 +128,7 @@ func createShareTables(ctx *sql.Context, initData []*ocm.Share) map[string]*memo
 	}, ""))
 	tables[ocmShareTable] = tableShares
 
-	// ocm_shares_access_method table
+	// ocm_shares_access_methods table
 	var fkAccessMethods memory.ForeignKeyCollection
 	fkAccessMethods.AddFK(sql.ForeignKeyConstraint{
 		Columns:       []string{"ocm_share_id"},

--- a/pkg/ocm/share/repository/sql/sql_test.go
+++ b/pkg/ocm/share/repository/sql/sql_test.go
@@ -1060,13 +1060,17 @@ func TestStoreShare(t *testing.T) {
 				ShareType:  ocm.ShareType_SHARE_TYPE_USER,
 				AccessMethods: []*ocm.AccessMethod{
 					share.NewWebDavAccessMethod(conversions.NewViewerRole().CS3ResourcePermissions()),
+					share.NewWebappAccessMethod(appprovider.ViewMode_VIEW_MODE_READ_ONLY),
 				},
 			},
 			expected: storeShareExpected{
-				shares:        []sql.Row{{int64(1), "qwerty", "storage", "resource-id1", "file-name", "richard@cesnet", "einstein", "marie", uint64(1670859468), uint64(1670859468), nil, int8(0)}},
-				accessmethods: []sql.Row{{int64(1), int64(1), int8(0)}},
-				webdav:        []sql.Row{{int64(1), int64(1)}},
-				webapp:        []sql.Row{},
+				shares: []sql.Row{{int64(1), "qwerty", "storage", "resource-id1", "file-name", "richard@cesnet", "einstein", "marie", uint64(1670859468), uint64(1670859468), nil, int8(0)}},
+				accessmethods: []sql.Row{
+					{int64(1), int64(1), int8(0)},
+					{int64(2), int64(1), int8(1)},
+				},
+				webdav: []sql.Row{{int64(1), int64(1)}},
+				webapp: []sql.Row{{int64(2), int8(2)}},
 			},
 		},
 		{

--- a/pkg/ocm/share/repository/sql/sql_test.go
+++ b/pkg/ocm/share/repository/sql/sql_test.go
@@ -349,6 +349,7 @@ func TestGetShare(t *testing.T) {
 				Ctime:         &typesv1beta1.Timestamp{Seconds: 1670859468},
 				Mtime:         &typesv1beta1.Timestamp{Seconds: 1670859468},
 				ShareType:     ocm.ShareType_SHARE_TYPE_USER,
+				Expiration:    &typesv1beta1.Timestamp{},
 				AccessMethods: []*ocm.AccessMethod{share.NewWebDavAccessMethod(conversions.NewEditorRole().CS3ResourcePermissions())},
 			},
 		},
@@ -390,6 +391,7 @@ func TestGetShare(t *testing.T) {
 				Ctime:         &typesv1beta1.Timestamp{Seconds: 1670859468},
 				Mtime:         &typesv1beta1.Timestamp{Seconds: 1670859468},
 				ShareType:     ocm.ShareType_SHARE_TYPE_USER,
+				Expiration:    &typesv1beta1.Timestamp{},
 				AccessMethods: []*ocm.AccessMethod{share.NewWebDavAccessMethod(conversions.NewEditorRole().CS3ResourcePermissions())},
 			},
 		},
@@ -485,6 +487,7 @@ func TestGetShare(t *testing.T) {
 				Ctime:      &typesv1beta1.Timestamp{Seconds: 1670859468},
 				Mtime:      &typesv1beta1.Timestamp{Seconds: 1670859468},
 				ShareType:  ocm.ShareType_SHARE_TYPE_USER,
+				Expiration: &typesv1beta1.Timestamp{},
 				AccessMethods: []*ocm.AccessMethod{
 					share.NewWebDavAccessMethod(conversions.NewEditorRole().CS3ResourcePermissions()),
 					share.NewWebappAccessMethod(appprovider.ViewMode_VIEW_MODE_READ_ONLY),
@@ -526,6 +529,7 @@ func TestGetShare(t *testing.T) {
 				Ctime:      &typesv1beta1.Timestamp{Seconds: 1670859468},
 				Mtime:      &typesv1beta1.Timestamp{Seconds: 1670859468},
 				ShareType:  ocm.ShareType_SHARE_TYPE_USER,
+				Expiration: &typesv1beta1.Timestamp{},
 				AccessMethods: []*ocm.AccessMethod{
 					share.NewWebDavAccessMethod(conversions.NewEditorRole().CS3ResourcePermissions()),
 					share.NewWebappAccessMethod(appprovider.ViewMode_VIEW_MODE_READ_ONLY),
@@ -617,6 +621,7 @@ func TestListShares(t *testing.T) {
 					Ctime:      &typesv1beta1.Timestamp{Seconds: 1670859468},
 					Mtime:      &typesv1beta1.Timestamp{Seconds: 1670859468},
 					ShareType:  ocm.ShareType_SHARE_TYPE_USER,
+					Expiration: &typesv1beta1.Timestamp{},
 					AccessMethods: []*ocm.AccessMethod{
 						share.NewWebDavAccessMethod(conversions.NewEditorRole().CS3ResourcePermissions()),
 						share.NewWebappAccessMethod(appprovider.ViewMode_VIEW_MODE_READ_ONLY),
@@ -675,6 +680,7 @@ func TestListShares(t *testing.T) {
 					Ctime:      &typesv1beta1.Timestamp{Seconds: 1670859468},
 					Mtime:      &typesv1beta1.Timestamp{Seconds: 1670859468},
 					ShareType:  ocm.ShareType_SHARE_TYPE_USER,
+					Expiration: &typesv1beta1.Timestamp{},
 					AccessMethods: []*ocm.AccessMethod{
 						share.NewWebDavAccessMethod(conversions.NewEditorRole().CS3ResourcePermissions()),
 						share.NewWebappAccessMethod(appprovider.ViewMode_VIEW_MODE_READ_ONLY),
@@ -691,6 +697,7 @@ func TestListShares(t *testing.T) {
 					Creator:    &userpb.UserId{OpaqueId: "einstein"},
 					Ctime:      &typesv1beta1.Timestamp{Seconds: 1670859468},
 					Mtime:      &typesv1beta1.Timestamp{Seconds: 1670859468},
+					Expiration: &typesv1beta1.Timestamp{},
 					ShareType:  ocm.ShareType_SHARE_TYPE_USER,
 					AccessMethods: []*ocm.AccessMethod{
 						share.NewWebDavAccessMethod(conversions.NewViewerRole().CS3ResourcePermissions()),
@@ -748,6 +755,7 @@ func TestListShares(t *testing.T) {
 					Ctime:      &typesv1beta1.Timestamp{Seconds: 1670859468},
 					Mtime:      &typesv1beta1.Timestamp{Seconds: 1670859468},
 					ShareType:  ocm.ShareType_SHARE_TYPE_USER,
+					Expiration: &typesv1beta1.Timestamp{},
 					AccessMethods: []*ocm.AccessMethod{
 						share.NewWebDavAccessMethod(conversions.NewViewerRole().CS3ResourcePermissions()),
 					},
@@ -811,6 +819,7 @@ func TestListShares(t *testing.T) {
 					Ctime:      &typesv1beta1.Timestamp{Seconds: 1670859468},
 					Mtime:      &typesv1beta1.Timestamp{Seconds: 1670859468},
 					ShareType:  ocm.ShareType_SHARE_TYPE_USER,
+					Expiration: &typesv1beta1.Timestamp{},
 					AccessMethods: []*ocm.AccessMethod{
 						share.NewWebDavAccessMethod(conversions.NewViewerRole().CS3ResourcePermissions()),
 					},
@@ -942,6 +951,7 @@ func TestListShares(t *testing.T) {
 					Ctime:      &typesv1beta1.Timestamp{Seconds: 1670859468},
 					Mtime:      &typesv1beta1.Timestamp{Seconds: 1670859468},
 					ShareType:  ocm.ShareType_SHARE_TYPE_USER,
+					Expiration: &typesv1beta1.Timestamp{},
 					AccessMethods: []*ocm.AccessMethod{
 						share.NewWebDavAccessMethod(conversions.NewEditorRole().CS3ResourcePermissions()),
 						share.NewWebappAccessMethod(appprovider.ViewMode_VIEW_MODE_READ_ONLY),
@@ -959,6 +969,7 @@ func TestListShares(t *testing.T) {
 					Ctime:      &typesv1beta1.Timestamp{Seconds: 1670859468},
 					Mtime:      &typesv1beta1.Timestamp{Seconds: 1670859468},
 					ShareType:  ocm.ShareType_SHARE_TYPE_USER,
+					Expiration: &typesv1beta1.Timestamp{},
 					AccessMethods: []*ocm.AccessMethod{
 						share.NewWebDavAccessMethod(conversions.NewViewerRole().CS3ResourcePermissions()),
 					},
@@ -1242,6 +1253,7 @@ func TestGetReceivedShare(t *testing.T) {
 				ShareType:    ocm.ShareType_SHARE_TYPE_USER,
 				State:        ocm.ShareState_SHARE_STATE_ACCEPTED,
 				ResourceType: providerv1beta1.ResourceType_RESOURCE_TYPE_CONTAINER,
+				Expiration:   &typesv1beta1.Timestamp{},
 				Protocols: []*ocm.Protocol{
 					share.NewWebDAVProtocol("webdav+https//cernbox.cern.ch/dav/ocm/1", "secret", &ocm.SharePermissions{
 						Permissions: conversions.NewEditorRole().CS3ResourcePermissions(),
@@ -1293,6 +1305,7 @@ func TestGetReceivedShare(t *testing.T) {
 				ShareType:    ocm.ShareType_SHARE_TYPE_USER,
 				State:        ocm.ShareState_SHARE_STATE_ACCEPTED,
 				ResourceType: providerv1beta1.ResourceType_RESOURCE_TYPE_FILE,
+				Expiration:   &typesv1beta1.Timestamp{},
 				Protocols: []*ocm.Protocol{
 					share.NewWebDAVProtocol("webdav+https//cernbox.cern.ch/dav/ocm/1", "secret", &ocm.SharePermissions{
 						Permissions: conversions.NewEditorRole().CS3ResourcePermissions(),
@@ -1398,6 +1411,7 @@ func TestGetReceivedShare(t *testing.T) {
 				ShareType:    ocm.ShareType_SHARE_TYPE_USER,
 				State:        ocm.ShareState_SHARE_STATE_ACCEPTED,
 				ResourceType: providerv1beta1.ResourceType_RESOURCE_TYPE_FILE,
+				Expiration:   &typesv1beta1.Timestamp{},
 				Protocols: []*ocm.Protocol{
 					share.NewWebDAVProtocol("webdav+https//cernbox.cern.ch/dav/ocm/1", "secret", &ocm.SharePermissions{
 						Permissions: conversions.NewEditorRole().CS3ResourcePermissions(),
@@ -1492,6 +1506,7 @@ func TestListReceviedShares(t *testing.T) {
 					ShareType:    ocm.ShareType_SHARE_TYPE_USER,
 					State:        ocm.ShareState_SHARE_STATE_ACCEPTED,
 					ResourceType: providerv1beta1.ResourceType_RESOURCE_TYPE_CONTAINER,
+					Expiration:   &typesv1beta1.Timestamp{},
 					Protocols: []*ocm.Protocol{
 						share.NewWebDAVProtocol("webdav+https//cernbox.cern.ch/dav/ocm/1", "secret", &ocm.SharePermissions{
 							Permissions: conversions.NewEditorRole().CS3ResourcePermissions(),
@@ -1556,6 +1571,7 @@ func TestListReceviedShares(t *testing.T) {
 					ShareType:    ocm.ShareType_SHARE_TYPE_USER,
 					State:        ocm.ShareState_SHARE_STATE_ACCEPTED,
 					ResourceType: providerv1beta1.ResourceType_RESOURCE_TYPE_FILE,
+					Expiration:   &typesv1beta1.Timestamp{},
 					Protocols: []*ocm.Protocol{
 						share.NewWebDAVProtocol("webdav+https//cernbox.cern.ch/dav/ocm/1", "secret", &ocm.SharePermissions{
 							Permissions: conversions.NewEditorRole().CS3ResourcePermissions(),
@@ -1576,6 +1592,7 @@ func TestListReceviedShares(t *testing.T) {
 					ShareType:    ocm.ShareType_SHARE_TYPE_USER,
 					State:        ocm.ShareState_SHARE_STATE_ACCEPTED,
 					ResourceType: providerv1beta1.ResourceType_RESOURCE_TYPE_CONTAINER,
+					Expiration:   &typesv1beta1.Timestamp{},
 					Protocols: []*ocm.Protocol{
 						share.NewWebappProtocol("https://cernbox.cern.ch/ocm/54321"),
 					},
@@ -1636,6 +1653,7 @@ func TestListReceviedShares(t *testing.T) {
 					ShareType:    ocm.ShareType_SHARE_TYPE_USER,
 					State:        ocm.ShareState_SHARE_STATE_ACCEPTED,
 					ResourceType: providerv1beta1.ResourceType_RESOURCE_TYPE_CONTAINER,
+					Expiration:   &typesv1beta1.Timestamp{},
 					Protocols: []*ocm.Protocol{
 						share.NewWebDAVProtocol("webdav+https//cernbox.cern.ch/dav/ocm/1", "secret", &ocm.SharePermissions{
 							Permissions: conversions.NewEditorRole().CS3ResourcePermissions(),

--- a/pkg/ocm/storage/ocm.go
+++ b/pkg/ocm/storage/ocm.go
@@ -254,6 +254,9 @@ func (d *driver) GetMD(ctx context.Context, ref *provider.Reference, _ []string)
 
 	info, err := client.Stat(rel)
 	if err != nil {
+		if gowebdav.IsErrNotFound(err) {
+			return nil, errtypes.NotFound(ref.GetPath())
+		}
 		return nil, err
 	}
 

--- a/pkg/ocm/storage/ocm.go
+++ b/pkg/ocm/storage/ocm.go
@@ -156,6 +156,11 @@ func (d *driver) webdavClient(ctx context.Context, ref *provider.Reference) (*go
 		return nil, nil, "", err
 	}
 
+	endpoint, err = url.PathUnescape(endpoint)
+	if err != nil {
+		return nil, nil, "", err
+	}
+
 	// FIXME: it's still not clear from the OCM APIs how to use the shared secret
 	// will use as a token in the bearer authentication as this is the reva implementation
 	c := gowebdav.NewClient(endpoint, "", "")

--- a/tests/integration/grpc/fixtures/ocm-server-cernbox-grpc.toml
+++ b/tests/integration/grpc/fixtures/ocm-server-cernbox-grpc.toml
@@ -1,3 +1,6 @@
+[log]
+mode = "json"
+
 [shared]
 gatewaysvc = "{{grpc_address}}"
 
@@ -18,6 +21,7 @@ basic = "{{grpc_address}}"
 
 [grpc.services.ocminvitemanager]
 driver = "json"
+provider_domain = "cernbox.cern.ch"
 
 [grpc.services.ocminvitemanager.drivers.json]
 file = "{{invite_token_file}}"

--- a/tests/integration/grpc/fixtures/ocm-server-cernbox-http.toml
+++ b/tests/integration/grpc/fixtures/ocm-server-cernbox-http.toml
@@ -1,3 +1,6 @@
+[log]
+mode = "json"
+
 [shared]
 gatewaysvc = "{{cernboxgw_address}}"
 

--- a/tests/integration/grpc/fixtures/ocm-server-cesnet-grpc.toml
+++ b/tests/integration/grpc/fixtures/ocm-server-cesnet-grpc.toml
@@ -1,3 +1,6 @@
+[log]
+mode = "json"
+
 [shared]
 gatewaysvc = "{{grpc_address}}"
 
@@ -18,6 +21,7 @@ basic = "{{grpc_address}}"
 
 [grpc.services.ocminvitemanager]
 driver = "json"
+provider_domain = "cesnet.cz"
 
 [grpc.services.ocminvitemanager.drivers.json]
 file = "{{invite_token_file}}"

--- a/tests/integration/grpc/fixtures/ocm-server-cesnet-http.toml
+++ b/tests/integration/grpc/fixtures/ocm-server-cesnet-http.toml
@@ -1,3 +1,6 @@
+[log]
+mode = "json"
+
 [shared]
 gatewaysvc = "{{cesnetgw_address}}"
 


### PR DESCRIPTION
This PR adds the support of OCM shares in the OCS layer, allowing a client to create, listing the created shares and the received shares transparently.