### PR TITLE
enforce the publiclink.create permission

### DIFF
--- a/changelog/unreleased/public-link-permission.md
+++ b/changelog/unreleased/public-link-permission.md
@@ -1,0 +1,5 @@
+Enhancement: Enforce the PublicLink.Write permission
+
+Added checks for the "PublicLink.Write" permission when creating or updating public links.
+
+https://github.com/cs3org/reva/pull/3693

--- a/pkg/permission/manager/demo/demo.go
+++ b/pkg/permission/manager/demo/demo.go
@@ -42,6 +42,8 @@ func (m manager) CheckPermission(perm string, subject string, ref *provider.Refe
 		// TODO Users can only create their own personal space
 		// TODO guest accounts cannot create spaces
 		return true
+	case permission.WritePublicLink:
+		return true
 	case permission.ListAllSpaces:
 		// TODO introduce an admin role to allow listing all spaces
 		return false

--- a/pkg/permission/permission.go
+++ b/pkg/permission/permission.go
@@ -27,6 +27,8 @@ const (
 	ListAllSpaces string = "list-all-spaces"
 	// CreateSpace is the hardcoded name for the create space permission
 	CreateSpace string = "create-space"
+	// WritePublicLink is the hardcoded name for the PublicLink.Write permission
+	WritePublicLink string = "PublicLink.Write"
 )
 
 // Manager defines the interface for the permission service driver


### PR DESCRIPTION
Added checks for the "publiclink.create" permission when creating or updating public links.