### PR TITLE
[tests-only] Unmark processing correctly

### DIFF
--- a/internal/grpc/services/gateway/storageprovidercache.go
+++ b/internal/grpc/services/gateway/storageprovidercache.go
@@ -112,6 +112,8 @@ func (c *cachedAPIClient) Stat(ctx context.Context, in *provider.StatRequest, op
 		// we do not know when to invalidate them
 		// FIXME: find a way to cache/invalidate them too
 		return resp, nil
+	case utils.ReadPlainFromOpaque(resp.GetInfo().GetOpaque(), "status") == "processing":
+		return resp, nil
 	default:
 		return resp, c.statCache.PushToCache(key, resp)
 	}

--- a/pkg/storage/utils/decomposedfs/decomposedfs.go
+++ b/pkg/storage/utils/decomposedfs/decomposedfs.go
@@ -231,10 +231,10 @@ func (fs *Decomposedfs) Postprocessing(ch <-chan events.Event) {
 				}
 			}
 
+			upload.Cleanup(up, failed, keepUpload)
+
 			// remove cache entry in gateway
 			fs.cache.RemoveStat(ev.ExecutingUser.GetId(), &provider.ResourceId{SpaceId: n.SpaceID, OpaqueId: n.ID})
-
-			upload.Cleanup(up, failed, keepUpload)
 
 			if err := events.Publish(
 				fs.stream,

--- a/pkg/storage/utils/decomposedfs/node/node.go
+++ b/pkg/storage/utils/decomposedfs/node/node.go
@@ -1216,7 +1216,7 @@ func (n *Node) UnmarkProcessing(uploadID string) error {
 		// file started another postprocessing later - do not remove
 		return nil
 	}
-	return n.RemoveXattr(prefixes.StatusPrefix)
+	return n.SetXattr(prefixes.StatusPrefix, "")
 }
 
 // IsProcessing returns true if the node is currently being processed


### PR DESCRIPTION
Uses `SetXattr` instead `RemoveXattr` to remove processing status
