### PR TITLE
Fix caching

### DIFF
--- a/changelog/unreleased/fix-caching.md
+++ b/changelog/unreleased/fix-caching.md
@@ -1,0 +1,5 @@
+Bugfix: Fix caching
+
+Do not cache files that are in processing.
+
+https://github.com/cs3org/reva/pull/3700

--- a/internal/grpc/services/gateway/storageprovidercache.go
+++ b/internal/grpc/services/gateway/storageprovidercache.go
@@ -112,6 +112,8 @@ func (c *cachedAPIClient) Stat(ctx context.Context, in *provider.StatRequest, op
 		// we do not know when to invalidate them
 		// FIXME: find a way to cache/invalidate them too
 		return resp, nil
+	case utils.ReadPlainFromOpaque(resp.GetInfo().GetOpaque(), "status") == "processing":
+		return resp, nil
 	default:
 		return resp, c.statCache.PushToCache(key, resp)
 	}

--- a/pkg/storage/utils/decomposedfs/decomposedfs.go
+++ b/pkg/storage/utils/decomposedfs/decomposedfs.go
@@ -231,10 +231,10 @@ func (fs *Decomposedfs) Postprocessing(ch <-chan events.Event) {
 				}
 			}
 
+			upload.Cleanup(up, failed, keepUpload)
+
 			// remove cache entry in gateway
 			fs.cache.RemoveStat(ev.ExecutingUser.GetId(), &provider.ResourceId{SpaceId: n.SpaceID, OpaqueId: n.ID})
-
-			upload.Cleanup(up, failed, keepUpload)
 
 			if err := events.Publish(
 				fs.stream,


### PR DESCRIPTION
Do not cache files that are in processing. This can cause problems when cache invalidation and get request are executed at the same time
