### PR TITLE
Docker: bump alpine base image to `v3.17` 

### DIFF
--- a/changelog/unreleased/security-update-docker-base.md
+++ b/changelog/unreleased/security-update-docker-base.md
@@ -1,0 +1,6 @@
+Enhancement: Bump reva(d) base image to alpine 3.17
+
+Prevents several vulnerabilities from the base image itself:
+  https://artifacthub.io/packages/helm/cs3org/revad?modal=security-report
+
+https://github.com/cs3org/reva/pull/3703

--- a/docker/Dockerfile.reva
+++ b/docker/Dockerfile.reva
@@ -16,7 +16,7 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
-FROM golang:alpine3.16 as builder
+FROM golang:alpine3.17 as builder
 
 RUN apk --no-cache add \
   ca-certificates \

--- a/docker/Dockerfile.revad
+++ b/docker/Dockerfile.revad
@@ -16,7 +16,7 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
-FROM golang:alpine3.16 as builder
+FROM golang:alpine3.17 as builder
 
 WORKDIR /home/reva
 COPY . .

--- a/docker/Dockerfile.revad-eos
+++ b/docker/Dockerfile.revad-eos
@@ -16,7 +16,7 @@
 # granted to it by virtue of its status as an Intergovernmental Organization
 # or submit itself to any jurisdiction.
 
-FROM golang:alpine3.16 as builder
+FROM golang:alpine3.17 as builder
 
 WORKDIR /home/reva
 COPY . .


### PR DESCRIPTION
Prevents the following CVEs as reported in ArtifactHub: https://artifacthub.io/packages/helm/cs3org/revad?modal=security-report

- CVE-2022-4450
- CVE-2023-0215
- CVE-2022-4450
- CVE-2023-0215
- CVE-2023-0286
- CVE-2023-0286
- CVE-2022-4304
- CVE-2022-4304
