### PR TITLE
Fix error handling in DeleteStorage space

### DIFF
--- a/changelog/unreleased/fix-del-space.md
+++ b/changelog/unreleased/fix-del-space.md
@@ -1,0 +1,6 @@
+Bugfix: Fix error when try to delete space without permission
+
+When a user without the correct permission tries to delete a storage space,
+return a PermissionDenied error instead of an Internal Error.
+
+https://github.com/cs3org/reva/pull/3710


### PR DESCRIPTION
Return a permission denied error when the user is not able to list the to be delete space.