### PR TITLE
respect the max quota when updating the space quota

### DIFF
--- a/changelog/unreleased/quota.md
+++ b/changelog/unreleased/quota.md
@@ -4,6 +4,7 @@ Added a global max quota option to limit how much quota can be assigned to space
 Added a max quota value in the spacescapabilities.
 Added a quota parameter to CreateHome. This is a prerequisite for setting a default quota per usertypes.
 
+https://github.com/cs3org/reva/pull/3714
 https://github.com/cs3org/reva/pull/3682
 https://github.com/cs3org/reva/pull/3678
 https://github.com/cs3org/reva/pull/3671

--- a/pkg/storage/utils/decomposedfs/spaces.go
+++ b/pkg/storage/utils/decomposedfs/spaces.go
@@ -444,6 +444,9 @@ func (fs *Decomposedfs) UpdateStorageSpace(ctx context.Context, req *provider.Up
 			return &provider.UpdateStorageSpaceResponse{
 				Status: &v1beta11.Status{Code: v1beta11.Code_CODE_INVALID_ARGUMENT, Message: "decompsedFS: requested quota is higher than allowed"},
 			}, nil
+		} else if fs.o.MaxQuota != quotaUnrestricted && space.Quota.QuotaMaxBytes == quotaUnrestricted {
+			// If the caller wants to unrestrict the space we give it the maximum allowed quota.
+			space.Quota.QuotaMaxBytes = fs.o.MaxQuota
 		}
 		metadata[prefixes.QuotaAttr] = strconv.FormatUint(space.Quota.QuotaMaxBytes, 10)
 	}


### PR DESCRIPTION
When the space quota should be updated to '0' i.e. unlimited and a global max quota was configured we only give the space the max quota amount instead of unlimited storage.