### PR TITLE
properly enforce the password on writeable public links

### DIFF
--- a/changelog/unreleased/public-link-password.md
+++ b/changelog/unreleased/public-link-password.md
@@ -2,4 +2,5 @@ Enhancement: Add config option to enforce passwords on public links
 
 Added a new config option to enforce passwords on public links with "Uploader, Editor, Contributor" roles.
 
+https://github.com/cs3org/reva/pull/3716
 https://github.com/cs3org/reva/pull/3698

--- a/pkg/publicshare/manager/json/json_test.go
+++ b/pkg/publicshare/manager/json/json_test.go
@@ -190,7 +190,7 @@ var _ = Describe("Json", func() {
 			persistence := cs3.New(storage)
 			Expect(persistence.Init(context.Background())).To(Succeed())
 
-			m, err = json.New("https://localhost:9200", 11, 60, false, persistence)
+			m, err = json.New("https://localhost:9200", 11, 60, false, persistence, false)
 			Expect(err).ToNot(HaveOccurred())
 
 			ctx = ctxpkg.ContextSetUser(context.Background(), user1)
@@ -228,7 +228,7 @@ var _ = Describe("Json", func() {
 				p := cs3.New(storage)
 				Expect(p.Init(context.Background())).To(Succeed())
 
-				m, err = json.New("https://localhost:9200", 11, 60, false, p)
+				m, err = json.New("https://localhost:9200", 11, 60, false, p, false)
 				Expect(err).ToNot(HaveOccurred())
 
 				ps, err := m.ListPublicShares(ctx, user1, []*link.ListPublicSharesRequest_Filter{}, false)

--- a/pkg/publicshare/publicshare.go
+++ b/pkg/publicshare/publicshare.go
@@ -24,6 +24,7 @@ import (
 	"crypto/sha256"
 	"crypto/sha512"
 	"encoding/hex"
+	"errors"
 	"time"
 
 	user "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
@@ -38,6 +39,11 @@ const (
 	// StorageIDFilterType defines a new filter type for storage id.
 	// TODO: Remove this once the filter type is in the CS3 API.
 	StorageIDFilterType link.ListPublicSharesRequest_Filter_Type = 4
+)
+
+var (
+	// ErrShareNeedsPassword is an error which is returned when a public share must have a password.
+	ErrShareNeedsPassword = errors.New("the public share needs to have a password")
 )
 
 // Manager manipulates public shares.
@@ -213,8 +219,8 @@ func IsCreatedByUser(share link.PublicShare, user *user.User) bool {
 }
 
 // IsWriteable checks if the grant for a publicshare allows writes or uploads.
-func IsWriteable(g *link.Grant) bool {
-	p := g.Permissions.Permissions
-	return p.CreateContainer || p.Delete || p.InitiateFileUpload ||
-		p.Move || p.AddGrant || p.PurgeRecycle || p.RestoreFileVersion || p.RestoreRecycleItem
+func IsWriteable(perm *link.PublicSharePermissions) bool {
+	p := perm.GetPermissions()
+	return p != nil && (p.CreateContainer || p.Delete || p.InitiateFileUpload ||
+		p.Move || p.AddGrant || p.PurgeRecycle || p.RestoreFileVersion || p.RestoreRecycleItem)
 }


### PR DESCRIPTION
@ScharfViktor found some bugs in the first implementation of this feature.
This PR fixes these issues and properly handles share creation and updates.