### PR TITLE
Improve performance of decomposedfs

### DIFF
--- a/pkg/storage/utils/decomposedfs/decomposedfs.go
+++ b/pkg/storage/utils/decomposedfs/decomposedfs.go
@@ -194,7 +194,7 @@ func (fs *Decomposedfs) Postprocessing(ch <-chan events.Event) {
 				keepUpload bool
 			)
 
-			n, err := node.ReadNode(ctx, fs.lu, up.Info.Storage["SpaceRoot"], up.Info.Storage["NodeId"], false)
+			n, err := node.ReadNode(ctx, fs.lu, up.Info.Storage["SpaceRoot"], up.Info.Storage["NodeId"], false, nil, true)
 			if err != nil {
 				log.Error().Err(err).Str("uploadID", ev.UploadID).Msg("could not read node")
 				continue
@@ -219,7 +219,7 @@ func (fs *Decomposedfs) Postprocessing(ch <-chan events.Event) {
 			}
 
 			now := time.Now()
-			if p, err := node.ReadNode(ctx, fs.lu, up.Info.Storage["SpaceRoot"], n.ParentID, false); err != nil {
+			if p, err := node.ReadNode(ctx, fs.lu, up.Info.Storage["SpaceRoot"], n.ParentID, false, nil, true); err != nil {
 				log.Error().Err(err).Str("uploadID", ev.UploadID).Msg("could not read parent")
 			} else {
 				// update parent tmtime to propagate etag change

--- a/pkg/storage/utils/decomposedfs/lookup/lookup.go
+++ b/pkg/storage/utils/decomposedfs/lookup/lookup.go
@@ -143,7 +143,7 @@ func (lu *Lookup) NodeFromID(ctx context.Context, id *provider.ResourceId) (n *n
 		// The Resource references the root of a space
 		return lu.NodeFromSpaceID(ctx, id)
 	}
-	return node.ReadNode(ctx, lu, id.SpaceId, id.OpaqueId, false)
+	return node.ReadNode(ctx, lu, id.SpaceId, id.OpaqueId, false, nil, false)
 }
 
 // Pathify segments the beginning of a string into depth segments of width length
@@ -164,7 +164,7 @@ func Pathify(id string, depth, width int) string {
 
 // NodeFromSpaceID converts a resource id without an opaque id into a Node
 func (lu *Lookup) NodeFromSpaceID(ctx context.Context, id *provider.ResourceId) (n *node.Node, err error) {
-	node, err := node.ReadNode(ctx, lu, id.SpaceId, id.OpaqueId, false)
+	node, err := node.ReadNode(ctx, lu, id.SpaceId, id.OpaqueId, false, nil, false)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/storage/utils/decomposedfs/node/node.go
+++ b/pkg/storage/utils/decomposedfs/node/node.go
@@ -658,14 +658,6 @@ func (n *Node) AsResourceInfo(ctx context.Context, rp *provider.ResourcePermissi
 		}
 	}
 
-	var parentID *provider.ResourceId
-	if p, err := n.Parent(); err == nil {
-		parentID = &provider.ResourceId{
-			SpaceId:  p.SpaceID,
-			OpaqueId: p.ID,
-		}
-	}
-
 	ri = &provider.ResourceInfo{
 		Id:            id,
 		Path:          fn,
@@ -675,8 +667,11 @@ func (n *Node) AsResourceInfo(ctx context.Context, rp *provider.ResourcePermissi
 		Target:        target,
 		PermissionSet: rp,
 		Owner:         n.Owner(),
-		ParentId:      parentID,
-		Name:          n.Name,
+		ParentId: &provider.ResourceId{
+			SpaceId:  n.SpaceID,
+			OpaqueId: n.ParentID,
+		},
+		Name: n.Name,
 	}
 
 	if n.IsProcessing() {

--- a/pkg/storage/utils/decomposedfs/node/node_test.go
+++ b/pkg/storage/utils/decomposedfs/node/node_test.go
@@ -74,7 +74,7 @@ var _ = Describe("Node", func() {
 			})
 			Expect(err).ToNot(HaveOccurred())
 
-			n, err := node.ReadNode(env.Ctx, env.Lookup, lookupNode.SpaceID, lookupNode.ID, false)
+			n, err := node.ReadNode(env.Ctx, env.Lookup, lookupNode.SpaceID, lookupNode.ID, false, nil, false)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(n.BlobID).To(Equal("file1-blobid"))
 		})
@@ -327,7 +327,7 @@ var _ = Describe("Node", func() {
 			})
 			Expect(err).ToNot(HaveOccurred())
 			// checking that the path "subpath" is denied properly
-			subfolder, err = node.ReadNode(env.Ctx, env.Lookup, subfolder.SpaceID, subfolder.ID, false)
+			subfolder, err = node.ReadNode(env.Ctx, env.Lookup, subfolder.SpaceID, subfolder.ID, false, nil, false)
 			Expect(err).ToNot(HaveOccurred())
 			subfolderActual, denied := subfolder.PermissionSet(env.Ctx)
 			subfolderExpected := ocsconv.NewDeniedRole().CS3ResourcePermissions()

--- a/pkg/storage/utils/decomposedfs/revisions.go
+++ b/pkg/storage/utils/decomposedfs/revisions.go
@@ -124,7 +124,7 @@ func (fs *Decomposedfs) DownloadRevision(ctx context.Context, ref *provider.Refe
 
 	spaceID := ref.ResourceId.SpaceId
 	// check if the node is available and has not been deleted
-	n, err := node.ReadNode(ctx, fs.lu, spaceID, kp[0], false)
+	n, err := node.ReadNode(ctx, fs.lu, spaceID, kp[0], false, nil, false)
 	if err != nil {
 		return nil, err
 	}
@@ -178,7 +178,7 @@ func (fs *Decomposedfs) RestoreRevision(ctx context.Context, ref *provider.Refer
 
 	spaceID := ref.ResourceId.SpaceId
 	// check if the node is available and has not been deleted
-	n, err := node.ReadNode(ctx, fs.lu, spaceID, kp[0], false)
+	n, err := node.ReadNode(ctx, fs.lu, spaceID, kp[0], false, nil, false)
 	if err != nil {
 		return err
 	}
@@ -315,7 +315,7 @@ func (fs *Decomposedfs) getRevisionNode(ctx context.Context, ref *provider.Refer
 
 	spaceID := ref.ResourceId.SpaceId
 	// check if the node is available and has not been deleted
-	n, err := node.ReadNode(ctx, fs.lu, spaceID, kp[0], false)
+	n, err := node.ReadNode(ctx, fs.lu, spaceID, kp[0], false, nil, false)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/storage/utils/decomposedfs/spaces.go
+++ b/pkg/storage/utils/decomposedfs/spaces.go
@@ -83,7 +83,7 @@ func (fs *Decomposedfs) CreateStorageSpace(ctx context.Context, req *provider.Cr
 		alias = templates.WithSpacePropertiesAndUser(u, req.Type, req.Name, fs.o.PersonalSpaceAliasTemplate)
 	}
 
-	root, err := node.ReadNode(ctx, fs.lu, spaceID, spaceID, true) // will fall into `Exists` case below
+	root, err := node.ReadNode(ctx, fs.lu, spaceID, spaceID, true, nil, false) // will fall into `Exists` case below
 	switch {
 	case err != nil:
 		return nil, err
@@ -268,7 +268,7 @@ func (fs *Decomposedfs) ListStorageSpaces(ctx context.Context, filter []*provide
 
 	if spaceID != spaceIDAny && nodeID != spaceIDAny {
 		// try directly reading the node
-		n, err := node.ReadNode(ctx, fs.lu, spaceID, nodeID, true) // permission to read disabled space is checked later
+		n, err := node.ReadNode(ctx, fs.lu, spaceID, nodeID, true, nil, false) // permission to read disabled space is checked later
 		if err != nil {
 			appctx.GetLogger(ctx).Error().Err(err).Str("id", nodeID).Msg("could not read node")
 			return nil, err
@@ -356,7 +356,7 @@ func (fs *Decomposedfs) ListStorageSpaces(ctx context.Context, filter []*provide
 			continue
 		}
 
-		n, err := node.ReadNode(ctx, fs.lu, spaceID, nodeID, true)
+		n, err := node.ReadNode(ctx, fs.lu, spaceID, nodeID, true, nil, true)
 		if err != nil {
 			appctx.GetLogger(ctx).Error().Err(err).Str("id", nodeID).Msg("could not read node, skipping")
 			continue
@@ -396,7 +396,7 @@ func (fs *Decomposedfs) ListStorageSpaces(ctx context.Context, filter []*provide
 	// if there are no matches (or they happened to be spaces for the owner) and the node is a child return a space
 	if len(matches) <= numShares && nodeID != spaceID {
 		// try node id
-		n, err := node.ReadNode(ctx, fs.lu, spaceID, nodeID, true) // permission to read disabled space is checked in storageSpaceFromNode
+		n, err := node.ReadNode(ctx, fs.lu, spaceID, nodeID, true, nil, false) // permission to read disabled space is checked in storageSpaceFromNode
 		if err != nil {
 			return nil, err
 		}
@@ -484,7 +484,7 @@ func (fs *Decomposedfs) UpdateStorageSpace(ctx context.Context, req *provider.Up
 	}
 
 	// check which permissions are needed
-	spaceNode, err := node.ReadNode(ctx, fs.lu, spaceID, spaceID, true)
+	spaceNode, err := node.ReadNode(ctx, fs.lu, spaceID, spaceID, true, nil, false)
 	if err != nil {
 		return nil, err
 	}
@@ -573,7 +573,7 @@ func (fs *Decomposedfs) DeleteStorageSpace(ctx context.Context, req *provider.De
 		return err
 	}
 
-	n, err := node.ReadNode(ctx, fs.lu, spaceID, spaceID, true) // permission to read disabled space is checked later
+	n, err := node.ReadNode(ctx, fs.lu, spaceID, spaceID, true, nil, false) // permission to read disabled space is checked later
 	if err != nil {
 		return err
 	}

--- a/pkg/storage/utils/decomposedfs/testhelpers/helpers.go
+++ b/pkg/storage/utils/decomposedfs/testhelpers/helpers.go
@@ -273,7 +273,7 @@ func (t *TestEnv) CreateTestStorageSpace(typ string, quota *providerv1beta1.Quot
 	if err != nil {
 		return nil, err
 	}
-	h, err := node.ReadNode(t.Ctx, t.Lookup, sid.SpaceId, sid.OpaqueId, false)
+	h, err := node.ReadNode(t.Ctx, t.Lookup, sid.SpaceId, sid.OpaqueId, false, nil, false)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/storage/utils/decomposedfs/tree/tree.go
+++ b/pkg/storage/utils/decomposedfs/tree/tree.go
@@ -985,7 +985,7 @@ func (t *Tree) readRecycleItem(ctx context.Context, spaceID, key, path string) (
 	nodeID = strings.ReplaceAll(nodeID, "/", "")
 
 	recycleNode = node.New(spaceID, nodeID, "", "", 0, "", provider.ResourceType_RESOURCE_TYPE_INVALID, nil, t.lookup)
-	recycleNode.SpaceRoot, err = node.ReadNode(ctx, t.lookup, spaceID, spaceID, false)
+	recycleNode.SpaceRoot, err = node.ReadNode(ctx, t.lookup, spaceID, spaceID, false, nil, false)
 	if err != nil {
 		return
 	}

--- a/pkg/storage/utils/decomposedfs/upload/processing.go
+++ b/pkg/storage/utils/decomposedfs/upload/processing.go
@@ -256,7 +256,7 @@ func CreateNodeForUpload(upload *Upload, initAttrs node.Attributes) (*node.Node,
 		nil,
 		upload.lu,
 	)
-	n.SpaceRoot, err = node.ReadNode(upload.Ctx, upload.lu, spaceID, spaceID, false)
+	n.SpaceRoot, err = node.ReadNode(upload.Ctx, upload.lu, spaceID, spaceID, false, nil, false)
 	if err != nil {
 		return nil, err
 	}
@@ -372,7 +372,7 @@ func initNewNode(upload *Upload, n *node.Node, fsize uint64) (*lockedfile.File, 
 }
 
 func updateExistingNode(upload *Upload, n *node.Node, spaceID string, fsize uint64) (*lockedfile.File, error) {
-	old, _ := node.ReadNode(upload.Ctx, upload.lu, spaceID, n.ID, false)
+	old, _ := node.ReadNode(upload.Ctx, upload.lu, spaceID, n.ID, false, nil, false)
 	if _, err := node.CheckQuota(n.SpaceRoot, true, uint64(old.Blobsize), fsize); err != nil {
 		return nil, err
 	}

--- a/pkg/storage/utils/decomposedfs/upload/upload.go
+++ b/pkg/storage/utils/decomposedfs/upload/upload.go
@@ -327,7 +327,7 @@ func (upload *Upload) Finalize() (err error) {
 	n := upload.Node
 	if n == nil {
 		var err error
-		n, err = node.ReadNode(upload.Ctx, upload.lu, upload.Info.Storage["SpaceRoot"], upload.Info.Storage["NodeId"], false)
+		n, err = node.ReadNode(upload.Ctx, upload.lu, upload.Info.Storage["SpaceRoot"], upload.Info.Storage["NodeId"], false, nil, false)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This PR improves the performance of the decomposedfs using the following measures:
- Reuse exisiting space and parent information when iterating over a list of child entries
- Do not resolve the parent node just to transform the parent id
- Gather and transform the child information concurrently