### PR TITLE
Limit the number of concurrent goroutines for listing directories

### DIFF
--- a/changelog/unreleased/limit-concurrency.md
+++ b/changelog/unreleased/limit-concurrency.md
@@ -1,0 +1,5 @@
+Enhancement: Limit concurrency in decomposedfs
+
+The number of concurrent goroutines used for listing directories in decomposedfs are now limited to a configurable number.
+
+https://github.com/cs3org/reva/pull/3740

--- a/pkg/storage/utils/decomposedfs/decomposedfs.go
+++ b/pkg/storage/utils/decomposedfs/decomposedfs.go
@@ -833,7 +833,7 @@ func (fs *Decomposedfs) ListFolder(ctx context.Context, ref *provider.Reference,
 
 	// Wait for things to settle down, then close results chan
 	go func() {
-		g.Wait()
+		_ = g.Wait() // error is checked later
 		close(results)
 	}()
 

--- a/pkg/storage/utils/decomposedfs/decomposedfs.go
+++ b/pkg/storage/utils/decomposedfs/decomposedfs.go
@@ -115,7 +115,7 @@ func NewDefault(m map[string]interface{}, bs tree.Blobstore, es events.Stream) (
 		return nil, fmt.Errorf("unknown metadata backend %s, only 'messagepack' or 'xattrs' (default) supported", o.MetadataBackend)
 	}
 
-	tp := tree.New(o.Root, o.TreeTimeAccounting, o.TreeSizeAccounting, lu, bs)
+	tp := tree.New(lu, bs, o)
 
 	permissionsClient, err := pool.GetPermissionsClient(o.PermissionsSVC, pool.WithTLSMode(o.PermTLSMode))
 	if err != nil {
@@ -782,29 +782,69 @@ func (fs *Decomposedfs) ListFolder(ctx context.Context, ref *provider.Reference,
 		return nil, errtypes.NotFound(f)
 	}
 
-	var children []*node.Node
-	children, err = fs.tp.ListFolder(ctx, n)
+	children, err := fs.tp.ListFolder(ctx, n)
 	if err != nil {
 		return nil, err
 	}
-	finfos := make([]*provider.ResourceInfo, len(children))
-	eg, ctx := errgroup.WithContext(ctx)
-	for i := range children {
-		pos := i
-		eg.Go(func() error {
-			np := rp
-			// add this childs permissions
-			pset, _ := n.PermissionSet(ctx)
-			node.AddPermissions(&np, &pset)
-			ri, err := children[pos].AsResourceInfo(ctx, &np, mdKeys, fieldMask, utils.IsRelativeReference(ref))
-			if err != nil {
-				return errtypes.InternalError(err.Error())
+
+	numWorkers := fs.o.MaxConcurrency
+	if len(children) < numWorkers {
+		numWorkers = len(children)
+	}
+	work := make(chan *node.Node, len(children))
+	results := make(chan *provider.ResourceInfo, len(children))
+
+	g, ctx := errgroup.WithContext(ctx)
+
+	// Distribute work
+	g.Go(func() error {
+		defer close(work)
+		for _, child := range children {
+			select {
+			case work <- child:
+			case <-ctx.Done():
+				return ctx.Err()
 			}
-			finfos[pos] = ri
+		}
+		return nil
+	})
+
+	// Spawn workers that'll concurrently work the queue
+	for i := 0; i < numWorkers; i++ {
+		g.Go(func() error {
+			for child := range work {
+				np := rp
+				// add this childs permissions
+				pset, _ := n.PermissionSet(ctx)
+				node.AddPermissions(&np, &pset)
+				ri, err := child.AsResourceInfo(ctx, &np, mdKeys, fieldMask, utils.IsRelativeReference(ref))
+				if err != nil {
+					return errtypes.InternalError(err.Error())
+				}
+				select {
+				case results <- ri:
+				case <-ctx.Done():
+					return ctx.Err()
+				}
+			}
 			return nil
 		})
 	}
-	if err := eg.Wait(); err != nil {
+
+	// Wait for things to settle down, then close results chan
+	go func() {
+		g.Wait()
+		close(results)
+	}()
+
+	finfos := make([]*provider.ResourceInfo, len(children))
+	i := 0
+	for fi := range results {
+		finfos[i] = fi
+		i++
+	}
+
+	if err := g.Wait(); err != nil {
 		return nil, err
 	}
 

--- a/pkg/storage/utils/decomposedfs/options/options.go
+++ b/pkg/storage/utils/decomposedfs/options/options.go
@@ -68,6 +68,7 @@ type Options struct {
 
 	MaxAcquireLockCycles    int `mapstructure:"max_acquire_lock_cycles"`
 	LockCycleDurationFactor int `mapstructure:"lock_cycle_duration_factor"`
+	MaxConcurrency          int `mapstructure:"max_concurrency"`
 
 	MaxQuota uint64 `mapstructure:"max_quota"`
 }
@@ -138,6 +139,10 @@ func New(m map[string]interface{}) (*Options, error) {
 		if o.PermTLSMode, err = pool.StringToTLSMode(sharedOpt.TLSMode); err != nil {
 			return nil, err
 		}
+	}
+
+	if o.MaxConcurrency <= 0 {
+		o.MaxConcurrency = 100
 	}
 
 	return o, nil

--- a/pkg/storage/utils/decomposedfs/testhelpers/helpers.go
+++ b/pkg/storage/utils/decomposedfs/testhelpers/helpers.go
@@ -156,7 +156,7 @@ func NewTestEnv(config map[string]interface{}) (*TestEnv, error) {
 	permissions := &mocks.PermissionsChecker{}
 	cs3permissionsclient := &mocks.CS3PermissionsClient{}
 	bs := &treemocks.Blobstore{}
-	tree := tree.New(o.Root, true, true, lu, bs)
+	tree := tree.New(lu, bs, o)
 	fs, err := decomposedfs.New(o, lu, decomposedfs.NewPermissions(permissions, cs3permissionsclient), tree, nil)
 	if err != nil {
 		return nil, err

--- a/pkg/storage/utils/decomposedfs/tree/tree.go
+++ b/pkg/storage/utils/decomposedfs/tree/tree.go
@@ -379,7 +379,7 @@ func (t *Tree) ListFolder(ctx context.Context, n *node.Node) ([]*node.Node, erro
 	}
 	// Wait for things to settle down, then close results chan
 	go func() {
-		g.Wait()
+		_ = g.Wait() // error is checked later
 		close(results)
 	}()
 

--- a/pkg/storage/utils/decomposedfs/upload_async_test.go
+++ b/pkg/storage/utils/decomposedfs/upload_async_test.go
@@ -105,7 +105,7 @@ var _ = Describe("Async file uploads", Ordered, func() {
 
 		// setup fs
 		pub, con = make(chan interface{}), make(chan interface{})
-		tree := tree.New(o.Root, true, true, lu, bs)
+		tree := tree.New(lu, bs, o)
 		fs, err = New(o, lu, NewPermissions(permissions, cs3permissionsclient), tree, stream.Chan{pub, con})
 		Expect(err).ToNot(HaveOccurred())
 

--- a/pkg/storage/utils/decomposedfs/upload_test.go
+++ b/pkg/storage/utils/decomposedfs/upload_test.go
@@ -119,7 +119,7 @@ var _ = Describe("File uploads", func() {
 			AddGrant: true,
 		}, nil).Times(1)
 		var err error
-		tree := tree.New(o.Root, true, true, lu, bs)
+		tree := tree.New(lu, bs, o)
 		fs, err = decomposedfs.New(o, lu, decomposedfs.NewPermissions(permissions, cs3permissionsclient), tree, nil)
 		Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
The number of goroutines used for listing directories is now limited to configurable number.