### PR TITLE
Use webdav protocol when creating ocm reference.

### DIFF
--- a/changelog/unreleased/fix-createocmreference.md
+++ b/changelog/unreleased/fix-createocmreference.md
@@ -1,0 +1,3 @@
+Bugfix: Fix createOCMReference - correct the protocol
+
+https://github.com/cs3org/reva/pull/3743

--- a/internal/grpc/services/gateway/ocmshareprovider.go
+++ b/internal/grpc/services/gateway/ocmshareprovider.go
@@ -422,10 +422,19 @@ func getTransferProtocol(share *ocm.ReceivedShare) (*ocm.TransferProtocol, bool)
 	return nil, false
 }
 
+func getWebDAVProtocol(share *ocm.ReceivedShare) (*ocm.WebDAVProtocol, bool) {
+	for _, p := range share.Protocols {
+		if d, ok := p.Term.(*ocm.Protocol_WebdavOptions); ok {
+			return d.WebdavOptions, true
+		}
+	}
+	return nil, false
+}
+
 func (s *svc) createOCMReference(ctx context.Context, share *ocm.ReceivedShare) (*rpc.Status, error) {
 	log := appctx.GetLogger(ctx)
 
-	d, _ := getTransferProtocol(share)
+	d, _ := getWebDAVProtocol(share)
 
 	homeRes, err := s.GetHome(ctx, &provider.GetHomeRequest{})
 	if err != nil {


### PR DESCRIPTION
This fixes the 'd.SharedSecret undefined' issue of https://github.com/cs3org/reva/issues/3677