### PR TITLE
Add UserTypeProperty to get user type from ldap user entry

### DIFF
--- a/changelog/unreleased/add-ldap-usertype-attribute.md
+++ b/changelog/unreleased/add-ldap-usertype-attribute.md
@@ -1,0 +1,5 @@
+Enhancement: Add LDAP user type attribute
+
+Adding an LDAP attribute so that we can distinguish between member and guest users.
+
+https://github.com/cs3org/reva/pull/3744

--- a/pkg/auth/manager/ldap/ldap.go
+++ b/pkg/auth/manager/ldap/ldap.go
@@ -144,7 +144,7 @@ func (am *mgr) Authenticate(ctx context.Context, clientID, clientSecret string) 
 	userID := &user.UserId{
 		Idp:      am.c.Idp,
 		OpaqueId: uid,
-		Type:     user.UserType_USER_TYPE_PRIMARY, // TODO: assign the appropriate user type
+		Type:     am.c.LDAPIdentity.GetUserType(userEntry),
 	}
 	gwc, err := pool.GetGatewayServiceClient(am.c.GatewaySvc)
 	if err != nil {

--- a/pkg/user/manager/ldap/ldap.go
+++ b/pkg/user/manager/ldap/ldap.go
@@ -261,6 +261,6 @@ func (m *manager) ldapEntryToUserID(entry *ldap.Entry) (*userpb.UserId, error) {
 	return &userpb.UserId{
 		Idp:      m.c.Idp,
 		OpaqueId: uid,
-		Type:     userpb.UserType_USER_TYPE_PRIMARY,
+		Type:     m.c.LDAPIdentity.GetUserType(entry),
 	}, nil
 }

--- a/pkg/utils/ldap/identity.go
+++ b/pkg/utils/ldap/identity.go
@@ -693,7 +693,7 @@ func (i *Identity) getGroupAttributeFilter(attribute, value string) (string, err
 	), nil
 }
 
-// GetUserType is used to set the proper UserType from ldap entry string
+// GetUserType is used to get the proper UserType from ldap entry string
 func (i *Identity) GetUserType(userEntry *ldap.Entry) identityUser.UserType {
 	userTypeString := userEntry.GetEqualFoldAttributeValue(i.User.UserTypeProperty)
 	switch strings.ToLower(userTypeString) {


### PR DESCRIPTION
Adding an LDAP attribute UserTypeProperty to be able to distinguish between member and guest users.