### PR TITLE
change language code validation

### DIFF
--- a/changelog/unreleased/fix-app-provider-lang.md
+++ b/changelog/unreleased/fix-app-provider-lang.md
@@ -1,0 +1,6 @@
+Bugfix: Fix app provider language validation
+
+This changes the validation to only look at the first part (tag) of the language code and ignore the second part (sub-tag).
+
+
+https://github.com/cs3org/reva/pull/3755

--- a/internal/http/services/appprovider/appprovider.go
+++ b/internal/http/services/appprovider/appprovider.go
@@ -366,8 +366,9 @@ func (s *svc) handleOpen(openMode int) http.HandlerFunc {
 		}
 
 		lang := r.Form.Get("lang")
-		if lang != "" && !iso6391.ValidCode(lang) {
-			writeError(w, r, appErrorInvalidParameter, "lang parameter does not contain a valid ISO 639-1 language code", nil)
+		parts := strings.Split(lang, "_")
+		if lang != "" && !iso6391.ValidCode(parts[0]) {
+			writeError(w, r, appErrorInvalidParameter, "lang parameter does not contain a valid ISO 639-1 language code in the language tag", nil)
 			return
 		}
 


### PR DESCRIPTION
Bugfix: Fix app provider language validation

This changes the validation to only look at the first part (tag) of the language code and ignore the second part (sub-tag).