### PR TITLE
Support OCM v1.0 schema

### DIFF
--- a/changelog/unreleased/ocm-reconcile.md
+++ b/changelog/unreleased/ocm-reconcile.md
@@ -1,0 +1,14 @@
+Enhancement: Support OCM v1.0 schema
+
+Following cs3org/cs3apis#206, we add the fields to ensure
+backwards compatibility with OCM v1.0. However, if the
+`protocol.options` undocumented object is not empty, we bail
+out for now. Supporting interoperability with OCM v1.0
+implementations (notably Nextcloud 25) may come in the future
+if the undocumented options are fully reverse engineered. This
+is reflected in the unit tests as well.
+
+Also, added viewMode to webapp protocol options (cs3org/cs3apis#207)
+and adapted all SQL code and unit tests.
+
+https://github.com/cs3org/reva/pull/3757

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/cheggaaa/pb v1.0.29
 	github.com/coreos/go-oidc v2.2.1+incompatible
 	github.com/cs3org/cato v0.0.0-20200828125504-e418fc54dd5e
-	github.com/cs3org/go-cs3apis v0.0.0-20230228180528-ee4e51c97a49
+	github.com/cs3org/go-cs3apis v0.0.0-20230331073620-011a5b8a3115
 	github.com/dgraph-io/ristretto v0.1.1
 	github.com/dolthub/go-mysql-server v0.14.0
 	github.com/eventials/go-tus v0.0.0-20200718001131-45c7ec8f5d59

--- a/go.sum
+++ b/go.sum
@@ -305,8 +305,8 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/cs3org/cato v0.0.0-20200828125504-e418fc54dd5e h1:tqSPWQeueWTKnJVMJffz4pz0o1WuQxJ28+5x5JgaHD8=
 github.com/cs3org/cato v0.0.0-20200828125504-e418fc54dd5e/go.mod h1:XJEZ3/EQuI3BXTp/6DUzFr850vlxq11I6satRtz0YQ4=
-github.com/cs3org/go-cs3apis v0.0.0-20230228180528-ee4e51c97a49 h1:CG65qpsSttrPAqdK19kaZaAiRadZ5xNFVrKoIjICBBM=
-github.com/cs3org/go-cs3apis v0.0.0-20230228180528-ee4e51c97a49/go.mod h1:UXha4TguuB52H14EMoSsCqDj7k8a/t7g4gVP+bgY5LY=
+github.com/cs3org/go-cs3apis v0.0.0-20230331073620-011a5b8a3115 h1:WR5sDbfsHZZViXKB0036V2hobzZSxew1MomrSk1kWyI=
+github.com/cs3org/go-cs3apis v0.0.0-20230331073620-011a5b8a3115/go.mod h1:UXha4TguuB52H14EMoSsCqDj7k8a/t7g4gVP+bgY5LY=
 github.com/cyberdelia/templates v0.0.0-20141128023046-ca7fffd4298c/go.mod h1:GyV+0YP4qX0UQ7r2MoYZ+AvYDp12OF5yg4q8rGnyNh4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/internal/http/services/ocmd/protocols.go
+++ b/internal/http/services/ocmd/protocols.go
@@ -80,7 +80,7 @@ type Webapp struct {
 
 // ToOCMProtocol convert the protocol to a ocm Protocol struct.
 func (w *Webapp) ToOCMProtocol() *ocm.Protocol {
-	return ocmshare.NewWebappProtocol(w.URITemplate, utils.GetAPViewMode(w.ViewMode))
+	return ocmshare.NewWebappProtocol(w.URITemplate, utils.GetAppViewMode(w.ViewMode))
 }
 
 // Datatx contains the parameters for the Datatx protocol.

--- a/internal/http/services/ocmd/protocols.go
+++ b/internal/http/services/ocmd/protocols.go
@@ -20,6 +20,7 @@ package ocmd
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"reflect"
 	"strings"
@@ -27,6 +28,7 @@ import (
 	ocm "github.com/cs3org/go-cs3apis/cs3/sharing/ocm/v1beta1"
 	providerv1beta1 "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	ocmshare "github.com/cs3org/reva/pkg/ocm/share"
+	utils "github.com/cs3org/reva/pkg/utils"
 )
 
 // Protocols is the list of protocols.
@@ -73,11 +75,12 @@ func (w *WebDAV) ToOCMProtocol() *ocm.Protocol {
 // Webapp contains the parameters for the Webapp protocol.
 type Webapp struct {
 	URITemplate string `json:"uriTemplate" validate:"required"`
+	ViewMode    string `json:"viewMode" validate:"required,dive,required,oneof=view read write"`
 }
 
 // ToOCMProtocol convert the protocol to a ocm Protocol struct.
 func (w *Webapp) ToOCMProtocol() *ocm.Protocol {
-	return ocmshare.NewWebappProtocol(w.URITemplate)
+	return ocmshare.NewWebappProtocol(w.URITemplate, utils.GetAPViewMode(w.ViewMode))
 }
 
 // Datatx contains the parameters for the Datatx protocol.
@@ -109,11 +112,22 @@ func (p *Protocols) UnmarshalJSON(data []byte) error {
 
 	for name, d := range prot {
 		var res Protocol
+
+		// we do not support the OCM v1.0 properties for now, therefore just skip or bail out
+		if name == "name" {
+			continue
+		}
+		if name == "options" {
+			var opt map[string]any
+			if err := json.Unmarshal(d, &opt); err != nil || len(opt) > 0 {
+				return fmt.Errorf("protocol options not supported: %s", string(d))
+			}
+			continue
+		}
 		ctype, ok := protocolImpl[name]
 		if !ok {
 			return fmt.Errorf("protocol %s not recognised", name)
 		}
-
 		res = reflect.New(ctype).Interface().(Protocol)
 		if err := json.Unmarshal(d, &res); err != nil {
 			return err
@@ -126,10 +140,16 @@ func (p *Protocols) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON implements the Marshaler interface.
 func (p Protocols) MarshalJSON() ([]byte, error) {
-	d := make(map[string]Protocol)
+	if len(p) == 0 {
+		return nil, errors.New("no protocol defined")
+	}
+	d := make(map[string]any)
 	for _, prot := range p {
 		d[getProtocolName(prot)] = prot
 	}
+	// fill in the OCM v1.0 properties
+	d["name"] = "multi"
+	d["options"] = map[string]any{}
 	return json.Marshal(d)
 }
 

--- a/internal/http/services/ocmd/shares.go
+++ b/internal/http/services/ocmd/shares.go
@@ -71,7 +71,7 @@ type createShareRequest struct {
 	ShareType         string    `json:"shareType" validate:"required,oneof=user group"` // recipient share type (user or group)
 	ResourceType      string    `json:"resourceType" validate:"required,oneof=file folder"`
 	Expiration        uint64    `json:"expiration"`
-	Protocols         Protocols `json:"protocols" validate:"required"`
+	Protocols         Protocols `json:"protocol" validate:"required"`
 }
 
 // CreateShare sends all the informations to the consumer needed to start

--- a/pkg/ocm/client/client.go
+++ b/pkg/ocm/client/client.go
@@ -166,7 +166,7 @@ type NewShareRequest struct {
 	ShareType         string         `json:"shareType"`
 	Expiration        uint64         `json:"expiration"`
 	ResourceType      string         `json:"resourceType"`
-	Protocols         ocmd.Protocols `json:"protocols"`
+	Protocols         ocmd.Protocols `json:"protocol"`
 }
 
 func (r *NewShareRequest) toJSON() (io.Reader, error) {
@@ -183,7 +183,7 @@ type NewShareResponse struct {
 }
 
 // NewShare creates a new share.
-// https://github.com/cs3org/OCM-API/blob/223285aa4d828ed85c361c7382efd08c42b5e719/spec.yaml
+// https://github.com/cs3org/OCM-API/blob/develop/spec.yaml
 func (c *OCMClient) NewShare(ctx context.Context, endpoint string, r *NewShareRequest) (*NewShareResponse, error) {
 	url, err := url.JoinPath(endpoint, "shares")
 	if err != nil {

--- a/pkg/ocm/share/repository/sql/conversions.go
+++ b/pkg/ocm/share/repository/sql/conversions.go
@@ -23,7 +23,7 @@ import (
 	"strconv"
 	"strings"
 
-	providerv1beta1 "github.com/cs3org/go-cs3apis/cs3/app/provider/v1beta1"
+	appprovider "github.com/cs3org/go-cs3apis/cs3/app/provider/v1beta1"
 	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	ocm "github.com/cs3org/go-cs3apis/cs3/sharing/ocm/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
@@ -78,8 +78,8 @@ const (
 const (
 	// WebDAVProtocol is the WebDav protocol.
 	WebDAVProtocol Protocol = iota
-	// WebappProtcol is the Webapp protocol.
-	WebappProtcol
+	// WebappProtocol is the Webapp protocol.
+	WebappProtocol
 	// TransferProtocol is the Transfer protocol.
 	TransferProtocol
 )
@@ -171,6 +171,7 @@ type dbProtocol struct {
 	WebDAVSharedSecret   *string
 	WebDavPermissions    *int
 	WebappURITemplate    *string
+	WebappViewMode       *int
 	TransferSourceURI    *string
 	TransferSharedSecret *string
 	TransferSize         *int
@@ -272,7 +273,7 @@ func convertToCS3AccessMethod(m *dbAccessMethod) *ocm.AccessMethod {
 	case WebDAVAccessMethod:
 		return share.NewWebDavAccessMethod(conversions.RoleFromOCSPermissions(conversions.Permissions(*m.WebDAVPermissions)).CS3ResourcePermissions())
 	case WebappAccessMethod:
-		return share.NewWebappAccessMethod(providerv1beta1.ViewMode(*m.WebAppViewMode))
+		return share.NewWebappAccessMethod(appprovider.ViewMode(*m.WebAppViewMode))
 	case TransferAccessMethod:
 		return share.NewTransferAccessMethod()
 	}
@@ -285,8 +286,8 @@ func convertToCS3Protocol(p *dbProtocol) *ocm.Protocol {
 		return share.NewWebDAVProtocol(*p.WebDAVURI, *p.WebDAVSharedSecret, &ocm.SharePermissions{
 			Permissions: conversions.RoleFromOCSPermissions(conversions.Permissions(*p.WebDavPermissions)).CS3ResourcePermissions(),
 		})
-	case WebappProtcol:
-		return share.NewWebappProtocol(*p.WebappURITemplate)
+	case WebappProtocol:
+		return share.NewWebappProtocol(*p.WebappURITemplate, appprovider.ViewMode(*p.WebappViewMode))
 	case TransferProtocol:
 		return share.NewTransferProtocol(*p.TransferSourceURI, *p.TransferSharedSecret, uint64(*p.TransferSize))
 	}

--- a/pkg/ocm/share/repository/sql/init.sql
+++ b/pkg/ocm/share/repository/sql/init.sql
@@ -70,6 +70,7 @@ CREATE TABLE IF NOT EXISTS ocm_protocol_webdav (
 CREATE TABLE IF NOT EXISTS ocm_protocol_webapp (
     ocm_protocol_id INTEGER NOT NULL PRIMARY KEY,
     uri_template VARCHAR(255) NOT NULL,
+    view_mode INTEGER NOT NULL,
     FOREIGN KEY (ocm_protocol_id) REFERENCES ocm_received_share_protocols(id) ON DELETE CASCADE
 );
 

--- a/pkg/ocm/share/utils.go
+++ b/pkg/ocm/share/utils.go
@@ -38,11 +38,12 @@ func NewWebDAVProtocol(uri, shareSecred string, perms *ocm.SharePermissions) *oc
 }
 
 // NewWebappProtocol is an abstraction for creating a Webapp protocol.
-func NewWebappProtocol(uriTemplate string) *ocm.Protocol {
+func NewWebappProtocol(uriTemplate string, viewMode appprovider.ViewMode) *ocm.Protocol {
 	return &ocm.Protocol{
 		Term: &ocm.Protocol_WebappOptions{
 			WebappOptions: &ocm.WebappProtocol{
 				UriTemplate: uriTemplate,
+				ViewMode:    viewMode,
 			},
 		},
 	}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -357,8 +357,8 @@ func GetViewMode(viewMode string) gateway.OpenInAppRequest_ViewMode {
 	}
 }
 
-// GetAPViewMode converts a human-readable string to a appprovider view mode for opening a resource in an app.
-func GetAPViewMode(viewMode string) appprovider.ViewMode {
+// GetAppViewMode converts a human-readable string to an appprovider view mode for opening a resource in an app.
+func GetAppViewMode(viewMode string) appprovider.ViewMode {
 	switch viewMode {
 	case "view":
 		return appprovider.ViewMode_VIEW_MODE_VIEW_ONLY

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -31,6 +31,7 @@ import (
 	"strings"
 	"time"
 
+	appprovider "github.com/cs3org/go-cs3apis/cs3/app/provider/v1beta1"
 	gateway "github.com/cs3org/go-cs3apis/cs3/gateway/v1beta1"
 	grouppb "github.com/cs3org/go-cs3apis/cs3/identity/group/v1beta1"
 	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
@@ -353,6 +354,22 @@ func GetViewMode(viewMode string) gateway.OpenInAppRequest_ViewMode {
 		return gateway.OpenInAppRequest_VIEW_MODE_PREVIEW
 	default:
 		return gateway.OpenInAppRequest_VIEW_MODE_INVALID
+	}
+}
+
+// GetAPViewMode converts a human-readable string to a appprovider view mode for opening a resource in an app.
+func GetAPViewMode(viewMode string) appprovider.ViewMode {
+	switch viewMode {
+	case "view":
+		return appprovider.ViewMode_VIEW_MODE_VIEW_ONLY
+	case "read":
+		return appprovider.ViewMode_VIEW_MODE_READ_ONLY
+	case "write":
+		return appprovider.ViewMode_VIEW_MODE_READ_WRITE
+	case "preview":
+		return appprovider.ViewMode_VIEW_MODE_PREVIEW
+	default:
+		return appprovider.ViewMode_VIEW_MODE_INVALID
 	}
 }
 


### PR DESCRIPTION
Following https://github.com/cs3org/cs3apis/pull/206, we add the fields to ensure backwards compatibility with OCM v1.0.

However, if we receive a request where the `protocol.options` undocumented object is not empty, we bail out for now. Also, we always send out an empty `protocol.options`, and use the newly defined properties that (will) come with OCM v1.1. This is reflected in the unit tests as well.

Supporting interoperability with existing OCM v1.0 implementations (notably Nextcloud 25) may come in the future once the undocumented options are fully reverse engineered.

Also added `viewMode` to the webapp protocol and adapted the SQL layer.
