### PR TITLE
check for password during update public link

### DIFF
--- a/changelog/unreleased/fix-public-pw.md
+++ b/changelog/unreleased/fix-public-pw.md
@@ -1,0 +1,5 @@
+Bugfix: Fix public links with enforced password
+
+Fix the public link update operation in the case that a password is enforced.
+
+https://github.com/cs3org/reva/pull/3758

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/public.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/public.go
@@ -389,6 +389,7 @@ func (h *Handler) updatePublicShare(w http.ResponseWriter, r *http.Request, shar
 				Type: link.UpdatePublicShareRequest_Update_TYPE_PERMISSIONS,
 				Grant: &link.Grant{
 					Permissions: publicSharePermissions,
+					Password:    r.FormValue("password"),
 				},
 			})
 		}


### PR DESCRIPTION
Bugfix: Fix public links with enforced password

Fix the public link update operation in the case that a password is enforced.