### PR TITLE
Set correct share type when listing shares

### DIFF
--- a/changelog/unreleased/set_correct_share_type_when_listing_shares.md
+++ b/changelog/unreleased/set_correct_share_type_when_listing_shares.md
@@ -1,0 +1,5 @@
+Enhancement: Set correct share type when listing shares
+
+This fixes so that we can differentiate between guest/member users for shares.
+
+https://github.com/cs3org/reva/pull/3759

--- a/internal/http/services/owncloud/ocs/conversions/main.go
+++ b/internal/http/services/owncloud/ocs/conversions/main.go
@@ -43,9 +43,6 @@ const (
 	// ShareTypeUser refers to user shares
 	ShareTypeUser ShareType = 0
 
-	// ShareTypeGuestUser refers to guest user shares
-	ShareTypeGuestUser ShareType = 4
-
 	// ShareTypePublicLink refers to public link shares
 	ShareTypePublicLink ShareType = 3
 
@@ -218,6 +215,7 @@ type MatchValueData struct {
 	ShareType               int    `json:"shareType" xml:"shareType"`
 	ShareWith               string `json:"shareWith" xml:"shareWith"`
 	ShareWithAdditionalInfo string `json:"shareWithAdditionalInfo" xml:"shareWithAdditionalInfo"`
+	UserType                int    `json:"userType" xml:"userType"`
 }
 
 // CS3Share2ShareData converts a cs3api user share into shareData data model

--- a/internal/http/services/owncloud/ocs/conversions/main.go
+++ b/internal/http/services/owncloud/ocs/conversions/main.go
@@ -43,6 +43,9 @@ const (
 	// ShareTypeUser refers to user shares
 	ShareTypeUser ShareType = 0
 
+	// ShareTypeGuestUser refers to guest user shares
+	ShareTypeGuestUser ShareType = 4
+
 	// ShareTypePublicLink refers to public link shares
 	ShareTypePublicLink ShareType = 3
 
@@ -229,7 +232,8 @@ func CS3Share2ShareData(ctx context.Context, share *collaboration.Share) (*Share
 	if share.Grantee.Type == provider.GranteeType_GRANTEE_TYPE_USER {
 		sd.ShareType = ShareTypeUser
 		sd.ShareWith = LocalUserIDToString(share.Grantee.GetUserId())
-		if share.GetGrantee().GetUserId().GetType() == userpb.UserType_USER_TYPE_LIGHTWEIGHT {
+		shareType := share.GetGrantee().GetUserId().GetType()
+		if shareType == userpb.UserType_USER_TYPE_LIGHTWEIGHT || shareType == userpb.UserType_USER_TYPE_GUEST {
 			sd.ShareWithUserType = ShareWithUserTypeGuest
 		} else {
 			sd.ShareWithUserType = ShareWithUserTypeUser

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/sharees/sharees.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/sharees/sharees.go
@@ -100,15 +100,17 @@ func (h *Handler) FindSharees(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) userAsMatch(u *userpb.User) *conversions.MatchData {
-	shareType := conversions.ShareTypeUser
-	if u.Id.Type == userpb.UserType_USER_TYPE_GUEST {
-		shareType = conversions.ShareTypeGuestUser
+	var ocsUserType int
+	if u.Id.Type == userpb.UserType_USER_TYPE_GUEST || u.Id.Type == userpb.UserType_USER_TYPE_LIGHTWEIGHT {
+		ocsUserType = 1
 	}
 
 	return &conversions.MatchData{
 		Label: u.DisplayName,
 		Value: &conversions.MatchValueData{
-			ShareType: int(shareType),
+			ShareType: int(conversions.ShareTypeUser),
+			// api compatibility with oc10: mark guest users in share invite dialogue
+			UserType: ocsUserType,
 			// api compatibility with oc10: always use the username
 			ShareWith:               u.Username,
 			ShareWithAdditionalInfo: h.getAdditionalInfoAttribute(u),

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/sharees/sharees.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/sharees/sharees.go
@@ -100,10 +100,15 @@ func (h *Handler) FindSharees(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) userAsMatch(u *userpb.User) *conversions.MatchData {
+	shareType := conversions.ShareTypeUser
+	if u.Id.Type == userpb.UserType_USER_TYPE_GUEST {
+		shareType = conversions.ShareTypeGuestUser
+	}
+
 	return &conversions.MatchData{
 		Label: u.DisplayName,
 		Value: &conversions.MatchValueData{
-			ShareType: int(conversions.ShareTypeUser),
+			ShareType: int(shareType),
 			// api compatibility with oc10: always use the username
 			ShareWith:               u.Username,
 			ShareWithAdditionalInfo: h.getAdditionalInfoAttribute(u),


### PR DESCRIPTION
This fixes so that we can differentiate between guest/member users for shares.

# Description

## List Shares

When listing shares on a file/folder with a GET on the following endpoint: /ocs/v1.php/apps/files_sharing/api/v1/shares the entities in the response have a shareType of 0 for all users, no matter if they are guests or not at the time of the request (already implemented like that). However, we need an additional attribute share_with_user_type for the shares where the user represented by the share_with* attributes is a guest (value 1) or not a guest (value 0) at the time of the request. The reason for this additional attribute instead of a shareType 0 vs 4 is that we don't want the need to migrate shares when a guest user becomes a non-guest or vice versa.

## List sharees (share candidates)

when searching for potential sharees on a file/folder with a GET on the following endpoint:
/ocs/v2.php/apps/files_sharing/api/v1/sharees?search=ein the entities in the response have a shareType and a userType. shareType needs to be 0 and userType needs to be 1 for users that are guests at the time of the request. We pulled that out of [demo.owncloud.com](http://demo.owncloud.com/)

@Excds @kobergj FYI
