### PR TITLE
Download file revisions

### DIFF
--- a/changelog/unreleased/download-file-revisions.md
+++ b/changelog/unreleased/download-file-revisions.md
@@ -1,0 +1,8 @@
+Enhancement: Download file revisions
+
+Currently it is only possible to restore a file version,
+replacing the actual file with the selected version.
+This allows an user to download a version file,
+without touching/replacing the last version of the file
+
+https://github.com/cs3org/reva/pull/3766

--- a/internal/http/services/archiver/manager/archiver.go
+++ b/internal/http/services/archiver/manager/archiver.go
@@ -168,7 +168,7 @@ func (a *Archiver) CreateTar(ctx context.Context, dst io.Writer) error {
 			}
 
 			if !isDir {
-				err = a.downloader.Download(ctx, path, w)
+				err = a.downloader.Download(ctx, path, "", w)
 				if err != nil {
 					return err
 				}
@@ -239,7 +239,7 @@ func (a *Archiver) CreateZip(ctx context.Context, dst io.Writer) error {
 			}
 
 			if !isDir {
-				err = a.downloader.Download(ctx, path, dst)
+				err = a.downloader.Download(ctx, path, "", dst)
 				if err != nil {
 					return err
 				}

--- a/internal/http/services/datagateway/datagateway.go
+++ b/internal/http/services/datagateway/datagateway.go
@@ -52,7 +52,8 @@ func init() {
 // transferClaims are custom claims for a JWT token to be used between the metadata and data gateways.
 type transferClaims struct {
 	jwt.StandardClaims
-	Target string `json:"target"`
+	Target     string `json:"target"`
+	VersionKey string `json:"version_key,omitempty"`
 }
 type config struct {
 	Prefix               string `mapstructure:"prefix"`
@@ -191,6 +192,12 @@ func (s *svc) doHead(w http.ResponseWriter, r *http.Request) {
 	}
 	httpReq.Header = r.Header
 
+	if claims.VersionKey != "" {
+		q := httpReq.URL.Query()
+		q.Add("version_key", claims.VersionKey)
+		httpReq.URL.RawQuery = q.Encode()
+	}
+
 	httpRes, err := httpClient.Do(httpReq)
 	if err != nil {
 		log.Error().Err(err).Msg("error doing HEAD request to data service")
@@ -236,6 +243,12 @@ func (s *svc) doGet(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	httpReq.Header = r.Header
+
+	if claims.VersionKey != "" {
+		q := httpReq.URL.Query()
+		q.Add("version_key", claims.VersionKey)
+		httpReq.URL.RawQuery = q.Encode()
+	}
 
 	httpRes, err := httpClient.Do(httpReq)
 	if err != nil {

--- a/internal/http/services/owncloud/ocdav/versions.go
+++ b/internal/http/services/owncloud/ocdav/versions.go
@@ -253,8 +253,7 @@ func (h *VersionsHandler) doDownload(w http.ResponseWriter, r *http.Request, s *
 	w.Header().Set("Content-Transfer-Encoding", "binary")
 
 	down := downloader.NewDownloader(client)
-	down.Download(ctx, resStat.Info.Path, key, w)
-	if err != nil {
+	if err := down.Download(ctx, resStat.Info.Path, key, w); err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}

--- a/pkg/storage/utils/downloader/mock/downloader_mock.go
+++ b/pkg/storage/utils/downloader/mock/downloader_mock.go
@@ -36,7 +36,7 @@ func NewDownloader() downloader.Downloader {
 }
 
 // Download copies the content of a local file into the dst Writer.
-func (m *mockDownloader) Download(ctx context.Context, path string, dst io.Writer) error {
+func (m *mockDownloader) Download(ctx context.Context, path, _ string, dst io.Writer) error {
 	f, err := os.Open(path)
 	if err != nil {
 		return err


### PR DESCRIPTION
For now it's only possible to restore a file revision. This means the the actual file is replaced with the revision.
This PR expand this functionality, allowing a user to download the revision, without touching/replacing the last version of the file.