### PR TITLE
ldap: Fix binary UUID handling in GetUserGroups

### DIFF
--- a/changelog/unreleased/fix-ldap-usergroups-binary-uuid.md
+++ b/changelog/unreleased/fix-ldap-usergroups-binary-uuid.md
@@ -1,0 +1,6 @@
+Bugfix: decode binary UUID when looking up a users group memberships
+
+The LDAP backend for the users service didn't correctly decode binary UUIDs
+when looking up a user's group memberships.
+
+https://github.com/cs3org/reva/pull/3767

--- a/pkg/utils/ldap/identity.go
+++ b/pkg/utils/ldap/identity.go
@@ -358,7 +358,19 @@ func (i *Identity) GetLDAPUserGroups(log *zerolog.Logger, lc ldap.Client, userEn
 		// FIXME this makes the users groups use the cn, not an immutable id
 		// FIXME 1. use the memberof or members attribute of a user to get the groups
 		// FIXME 2. ook up the id for each group
-		groups = append(groups, entry.GetEqualFoldAttributeValue(i.Group.Schema.ID))
+		var groupID string
+		if i.Group.Schema.IDIsOctetString {
+			raw := entry.GetEqualFoldRawAttributeValue(i.Group.Schema.ID)
+			value, err := uuid.FromBytes(raw)
+			if err != nil {
+				return nil, err
+			}
+			groupID = value.String()
+		} else {
+			groupID = entry.GetEqualFoldAttributeValue(i.Group.Schema.ID)
+		}
+
+		groups = append(groups, groupID)
 	}
 	return groups, nil
 }


### PR DESCRIPTION
The LDAP backend for the users service didn't correctly decode binary UUIDs when looking up a user's group memberships.