### PR TITLE
Fix capabilities for files sharing

### DIFF
--- a/changelog/unreleased/deny-default-reshare-capabilities copy.md
+++ b/changelog/unreleased/deny-default-reshare-capabilities copy.md
@@ -1,0 +1,7 @@
+Bugfix: Fix files sharing capabilities
+
+A bug was preventing setting some capabilities
+(ResharingDefault and DenyAccess) for files sharing
+from the configuration file
+
+https://github.com/cs3org/reva/pull/3771

--- a/internal/http/services/owncloud/ocs/data/capabilities.go
+++ b/internal/http/services/owncloud/ocs/data/capabilities.go
@@ -148,9 +148,9 @@ type CapabilitiesDav struct {
 // CapabilitiesFilesSharing TODO document.
 type CapabilitiesFilesSharing struct {
 	APIEnabled                    ocsBool                                  `json:"api_enabled" xml:"api_enabled" mapstructure:"api_enabled"`
-	Resharing                     ocsBool                                  `json:"resharing" xml:"resharing"`
-	ResharingDefault              ocsBool                                  `json:"resharing_default" xml:"resharing_default"`
-	DenyAccess                    ocsBool                                  `json:"deny_access" xml:"deny_access"`
+	Resharing                     ocsBool                                  `json:"resharing" xml:"resharing" mapstructure:"resharing"`
+	ResharingDefault              ocsBool                                  `json:"resharing_default" xml:"resharing_default" mapstructure:"resharing_default"`
+	DenyAccess                    ocsBool                                  `json:"deny_access" xml:"deny_access" mapstructure:"deny_access"`
 	GroupSharing                  ocsBool                                  `json:"group_sharing" xml:"group_sharing" mapstructure:"group_sharing"`
 	AutoAcceptShare               ocsBool                                  `json:"auto_accept_share" xml:"auto_accept_share" mapstructure:"auto_accept_share"`
 	ShareWithGroupMembersOnly     ocsBool                                  `json:"share_with_group_members_only" xml:"share_with_group_members_only" mapstructure:"share_with_group_members_only"`


### PR DESCRIPTION
A bug was preventing setting some capabilities (ResharingDefault and DenyAccess) for files sharing from the configuration file. This PR fixes this issue.