### PR TITLE
Fix #3774

### DIFF
--- a/pkg/ocm/client/client.go
+++ b/pkg/ocm/client/client.go
@@ -214,7 +214,7 @@ func (c *OCMClient) NewShare(ctx context.Context, endpoint string, r *NewShareRe
 	// defer resp.Body.Close()
 	// body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		log.Debug().Msgf("OCM response from: %d; could not read body")
+		log.Debug().Msgf("OCM response from: %d; could not read body", resp.StatusCode)
 	}
 	log.Debug().Msgf("OCM response from: %d %s", resp.StatusCode, respBody)
 

--- a/pkg/ocm/client/client.go
+++ b/pkg/ocm/client/client.go
@@ -214,9 +214,9 @@ func (c *OCMClient) NewShare(ctx context.Context, endpoint string, r *NewShareRe
 	// defer resp.Body.Close()
 	// body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		log.Debug().Msgf("OCM response from: %d; could not read body", resp.StatusCode)
+		log.Debug().Msgf("OCM response from %s: %d; could not read body", url, resp.StatusCode)
 	}
-	log.Debug().Msgf("OCM response from: %d %s", resp.StatusCode, respBody)
+	log.Debug().Msgf("OCM response from %s: %d %s", url, resp.StatusCode, respBody)
 
 	return c.parseNewShareResponse(resp)
 }


### PR DESCRIPTION
Add debug logs for the OCM /shares call.
Note that this does not resolve the problem for the other calls that this client makes, such as invitations and notifications.