### PR TITLE
Resolve Makefile error on Ubuntu

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+# force makefile to use bash instead of sh.
+SHELL := /usr/bin/env bash
+
 .PHONY: all
 all: revad reva test-go lint gen-doc
 

--- a/changelog/unreleased/fix-makefile.md
+++ b/changelog/unreleased/fix-makefile.md
@@ -3,5 +3,5 @@ Bugfix: Fix Makefile error on Ubuntu
 I've fixed Makefile using sh which is defaulted to dash in ubuntu, dash doesn't support
 `[[ ... ]]` syntax and Makefile would throw `/bin/sh: 1: [[: not found` errors.
 
-https://github.com/cs3org/reva/issues/3773
 https://github.com/cs3org/reva/pull/3780
+https://github.com/cs3org/reva/issues/3773

--- a/changelog/unreleased/fix-makefile.md
+++ b/changelog/unreleased/fix-makefile.md
@@ -1,0 +1,7 @@
+Bugfix: Fix Makefile error on Ubuntu
+
+I've fixed Makefile using sh which is defaulted to dash in ubuntu, dash doesn't support
+`[[ ... ]]` syntax and Makefile would throw `/bin/sh: 1: [[: not found` errors.
+
+https://github.com/cs3org/reva/issues/3773
+https://github.com/cs3org/reva/pull/3780


### PR DESCRIPTION
Makefile will be using bash as it's shell instead of sh which is defaulted to dash in Ubuntu and doesn't support `[[` syntax.

Fixes #3773