### PR TITLE
Fix listing directory for a read-only shares for EOS storage driver

### DIFF
--- a/changelog/unreleased/fix-create-version-folder-on-list-eos.md
+++ b/changelog/unreleased/fix-create-version-folder-on-list-eos.md
@@ -1,0 +1,9 @@
+Bugfix: Fix listing directory for a read-only shares for EOS storage driver
+
+In a read-only share, while listing a folder, for resources
+not having a version folder, the returned resource id was wrongly
+the one of the original file, instead of the version folder.
+This behavior has been fixed, where the version folder is always
+created on behalf of the resource owner.
+
+https://github.com/cs3org/reva/pull/3786


### PR DESCRIPTION
In a read-only share, while listing a folder, for resources not having a version folder, the returned resource id was wrongly the one of the original file, instead of the version folder. This was causing problems for example in the open in app.
Even if the driver was trying to create a version folder, this was done on behalf of the recipient, which does not have enough permissions to create a resource in the folder.

This behavior has been fixed in this PR, where the version folder is always created on behalf of the resource owner, fixing the issue.