### PR TITLE
eosbinary: fix application flag

### DIFF
--- a/changelog/unreleased/fix-eosbinary-app.md
+++ b/changelog/unreleased/fix-eosbinary-app.md
@@ -1,0 +1,3 @@
+Bugfix: Fix application flag for EOS binary
+
+https://github.com/cs3org/reva/pull/3787

--- a/pkg/eosclient/eosbinary/eosbinary.go
+++ b/pkg/eosclient/eosbinary/eosbinary.go
@@ -238,10 +238,10 @@ func (c *Client) executeEOS(ctx context.Context, cmdArgs []string, auth eosclien
 		cmd.Env = append(cmd.Env, "KRB5CCNAME=FILE:/dev/null") // do not try to use krb
 	}
 
-	cmd.Args = append(cmd.Args, cmdArgs...)
-
 	// add application label
 	cmd.Args = append(cmd.Args, "-a", "reva_eosclient::meta")
+
+	cmd.Args = append(cmd.Args, cmdArgs...)
 
 	span := trace.SpanFromContext(ctx)
 	cmd.Args = append(cmd.Args, "--comment", span.SpanContext().TraceID().String())


### PR DESCRIPTION
The EOS binary does not accept the application tag at the end, it needs to be set just after the role flag.