### PR TITLE
fix: Handle error when user fetch fails in REST user manager

### DIFF
--- a/changelog/unreleased/handle-error-rest-user-manager.md
+++ b/changelog/unreleased/handle-error-rest-user-manager.md
@@ -1,0 +1,7 @@
+Bugfix: Handle error when user fetch fails in REST user manager
+
+The current implementation of the REST user manager does not handle errors that occur when fetching user data from the remote server. As a result, if the fetch fails, errors are not returned, and the user manager continues to operate as if the fetch was successful.
+
+This PR adds error handling for cases when the fetch fails. Specifically, the **`fetchAllUserAccounts`** function now returns an error if the fetch operation fails, and this error is propagated up to the caller.
+
+https://github.com/cs3org/reva/pull/3790

--- a/changelog/unreleased/handle-error-rest-user-manager.md
+++ b/changelog/unreleased/handle-error-rest-user-manager.md
@@ -1,5 +1,7 @@
 Bugfix: Handle error when user fetch fails in REST user manager
 
+## Description
+
 The current implementation of the REST user manager does not handle errors that occur when fetching user data from the remote server. As a result, if the fetch fails, errors are not returned, and the user manager continues to operate as if the fetch was successful.
 
 This PR adds error handling for cases when the fetch fails. Specifically, the **`fetchAllUserAccounts`** function now returns an error if the fetch operation fails, and this error is propagated up to the caller.

--- a/pkg/cbox/user/rest/rest.go
+++ b/pkg/cbox/user/rest/rest.go
@@ -133,7 +133,11 @@ func (m *manager) Configure(ml map[string]interface{}) error {
 
 	// Since we're starting a subroutine which would take some time to execute,
 	// we can't wait to see if it works before returning the user.Manager object
-	return m.fetchAllUsers()
+	err = m.fetchAllUsers()
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 func (m *manager) fetchAllUsers() error {

--- a/pkg/cbox/user/rest/rest.go
+++ b/pkg/cbox/user/rest/rest.go
@@ -133,24 +133,45 @@ func (m *manager) Configure(ml map[string]interface{}) error {
 
 	// Since we're starting a subroutine which would take some time to execute,
 	// we can't wait to see if it works before returning the user.Manager object
-	// TODO: return err if the fetch fails
-	go m.fetchAllUsers()
+	if err := m.fetchAllUsers(); err != nil {
+		return err
+	}
 	return nil
 }
 
-func (m *manager) fetchAllUsers() {
-	_ = m.fetchAllUserAccounts()
-	ticker := time.NewTicker(time.Duration(m.conf.UserFetchInterval) * time.Second)
-	work := make(chan os.Signal, 1)
-	signal.Notify(work, syscall.SIGHUP, syscall.SIGINT, syscall.SIGQUIT)
+func (m *manager) fetchAllUsers() error {
+	errCh := make(chan error, 1)
 
-	for {
-		select {
-		case <-work:
+	go func() {
+		defer close(errCh)
+
+		if err := m.fetchAllUserAccounts(); err != nil {
+			errCh <- err
 			return
-		case <-ticker.C:
-			_ = m.fetchAllUserAccounts()
 		}
+
+		ticker := time.NewTicker(time.Duration(m.conf.UserFetchInterval) * time.Second)
+		work := make(chan os.Signal, 1)
+		signal.Notify(work, syscall.SIGHUP, syscall.SIGINT, syscall.SIGQUIT)
+
+		for {
+			select {
+			case <-work:
+				return
+			case <-ticker.C:
+				if err := m.fetchAllUserAccounts(); err != nil {
+					errCh <- err
+					return
+				}
+			}
+		}
+	}()
+
+	select {
+	case err := <-errCh:
+		return err
+	default:
+		return nil
 	}
 }
 

--- a/pkg/cbox/user/rest/rest.go
+++ b/pkg/cbox/user/rest/rest.go
@@ -133,10 +133,7 @@ func (m *manager) Configure(ml map[string]interface{}) error {
 
 	// Since we're starting a subroutine which would take some time to execute,
 	// we can't wait to see if it works before returning the user.Manager object
-	if err := m.fetchAllUsers(); err != nil {
-		return err
-	}
-	return nil
+	return m.fetchAllUsers()
 }
 
 func (m *manager) fetchAllUsers() error {


### PR DESCRIPTION
## Description

The current implementation of the REST user manager does not handle errors that occur when fetching user data from the remote server. As a result, if the fetch fails, errors are not returned, and the user manager continues to operate as if the fetch was successful.

This PR adds error handling for cases when the fetch fails. Specifically, the **`fetchAllUserAccounts`** function now returns an error if the fetch operation fails, and this error is propagated up to the caller.