### PR TITLE
Add prometheus metrics for active transfers.

### DIFF
--- a/changelog/unreleased/add-dl-ul-metrics.md
+++ b/changelog/unreleased/add-dl-ul-metrics.md
@@ -1,0 +1,6 @@
+Enhancement: Add a prometheus gauge to keep track of active uploads and downloads.
+
+This adds a prometheus gauge to keep track of active uploads and downloads. 
+These can be used to monitor the activity of any service that embeds reva and prometheus.
+
+https://github.com/cs3org/reva/pull/3792

--- a/changelog/unreleased/add-dl-ul-metrics.md
+++ b/changelog/unreleased/add-dl-ul-metrics.md
@@ -1,6 +1,5 @@
-Enhancement: Add a prometheus gauge to keep track of active uploads and downloads.
+Enhancement: Add a prometheus gauge to keep track of active uploads and downloads
 
 This adds a prometheus gauge to keep track of active uploads and downloads. 
-These can be used to monitor the activity of any service that embeds reva and prometheus.
 
 https://github.com/cs3org/reva/pull/3792

--- a/pkg/rhttp/datatx/manager/simple/simple.go
+++ b/pkg/rhttp/datatx/manager/simple/simple.go
@@ -24,8 +24,6 @@ import (
 
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 
 	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
@@ -35,23 +33,12 @@ import (
 	"github.com/cs3org/reva/v2/pkg/events"
 	"github.com/cs3org/reva/v2/pkg/rhttp/datatx"
 	"github.com/cs3org/reva/v2/pkg/rhttp/datatx/manager/registry"
+	"github.com/cs3org/reva/v2/pkg/rhttp/datatx/metrics"
 	"github.com/cs3org/reva/v2/pkg/rhttp/datatx/utils/download"
 	"github.com/cs3org/reva/v2/pkg/storage"
 	"github.com/cs3org/reva/v2/pkg/storage/cache"
 	"github.com/cs3org/reva/v2/pkg/storagespace"
 	"github.com/cs3org/reva/v2/pkg/utils"
-)
-
-// Keep track of active uploads/downloads.
-var (
-	downloadsActive = promauto.NewGauge(prometheus.GaugeOpts{
-		Name: "reva_download_active",
-		Help: "Number of active downloads",
-	})
-	uploadsActive = promauto.NewGauge(prometheus.GaugeOpts{
-		Name: "reva_upload_active",
-		Help: "Number of active uploads",
-	})
 )
 
 func init() {
@@ -101,15 +88,17 @@ func (m *manager) Handler(fs storage.FS) (http.Handler, error) {
 
 		switch r.Method {
 		case "GET", "HEAD":
-			downloadsActive.Add(1)
-			defer func() {
-				downloadsActive.Sub(1)
-			}()
+			if r.Method == "GET" {
+				metrics.DownloadsActive.Add(1)
+				defer func() {
+					metrics.DownloadsActive.Sub(1)
+				}()
+			}
 			download.GetOrHeadFile(w, r, fs, "")
 		case "PUT":
-			uploadsActive.Add(1)
+			metrics.UploadsActive.Add(1)
 			defer func() {
-				uploadsActive.Sub(1)
+				metrics.UploadsActive.Sub(1)
 			}()
 			fn := r.URL.Path
 			defer r.Body.Close()

--- a/pkg/rhttp/datatx/manager/tus/tus.go
+++ b/pkg/rhttp/datatx/manager/tus/tus.go
@@ -36,6 +36,7 @@ import (
 	"github.com/cs3org/reva/v2/pkg/events"
 	"github.com/cs3org/reva/v2/pkg/rhttp/datatx"
 	"github.com/cs3org/reva/v2/pkg/rhttp/datatx/manager/registry"
+	"github.com/cs3org/reva/v2/pkg/rhttp/datatx/metrics"
 	"github.com/cs3org/reva/v2/pkg/storage"
 	"github.com/cs3org/reva/v2/pkg/storage/cache"
 	"github.com/cs3org/reva/v2/pkg/utils"
@@ -144,6 +145,10 @@ func (m *manager) Handler(fs storage.FS) (http.Handler, error) {
 
 		switch method {
 		case "POST":
+			metrics.UploadsActive.Add(1)
+			defer func() {
+				metrics.UploadsActive.Sub(1)
+			}()
 			// set etag, mtime and file id
 			handler.PostFile(w, r)
 		case "HEAD":
@@ -155,6 +160,10 @@ func (m *manager) Handler(fs storage.FS) (http.Handler, error) {
 		case "DELETE":
 			handler.DelFile(w, r)
 		case "GET":
+			metrics.DownloadsActive.Add(1)
+			defer func() {
+				metrics.DownloadsActive.Sub(1)
+			}()
 			// NOTE: this is breaking change - allthought it does not seem to be used
 			// We can make a switch here depending on some header value if that is needed
 			// download.GetOrHeadFile(w, r, fs, "")

--- a/pkg/rhttp/datatx/manager/tus/tus.go
+++ b/pkg/rhttp/datatx/manager/tus/tus.go
@@ -154,6 +154,10 @@ func (m *manager) Handler(fs storage.FS) (http.Handler, error) {
 		case "HEAD":
 			handler.HeadFile(w, r)
 		case "PATCH":
+			metrics.UploadsActive.Add(1)
+			defer func() {
+				metrics.UploadsActive.Sub(1)
+			}()
 			// set etag, mtime and file id
 			setExpiresHeader(fs, w, r)
 			handler.PatchFile(w, r)

--- a/pkg/rhttp/datatx/metrics/metrics.go
+++ b/pkg/rhttp/datatx/metrics/metrics.go
@@ -1,0 +1,20 @@
+// Package metrics provides prometheus metrics for the data managers..
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	// DownloadsActive is the number of active downloads
+	DownloadsActive = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "reva_download_active",
+		Help: "Number of active downloads",
+	})
+	// UploadsActive is the number of active uploads
+	UploadsActive = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "reva_upload_active",
+		Help: "Number of active uploads",
+	})
+)

--- a/pkg/rhttp/datatx/utils/download/download.go
+++ b/pkg/rhttp/datatx/utils/download/download.go
@@ -36,6 +36,8 @@ import (
 	"github.com/cs3org/reva/v2/pkg/storage"
 	"github.com/cs3org/reva/v2/pkg/storagespace"
 	"github.com/cs3org/reva/v2/pkg/utils"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/rs/zerolog"
 )
 
@@ -213,7 +215,6 @@ func GetOrHeadFile(w http.ResponseWriter, r *http.Request, fs storage.FS, spaceI
 			sublog.Error().Int64("copied", c).Int64("size", sendSize).Msg("copied vs size mismatch")
 		}
 	}
-
 }
 
 func handleError(w http.ResponseWriter, log *zerolog.Logger, err error, action string) {

--- a/pkg/rhttp/datatx/utils/download/download.go
+++ b/pkg/rhttp/datatx/utils/download/download.go
@@ -36,8 +36,6 @@ import (
 	"github.com/cs3org/reva/v2/pkg/storage"
 	"github.com/cs3org/reva/v2/pkg/storagespace"
 	"github.com/cs3org/reva/v2/pkg/utils"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/rs/zerolog"
 )
 


### PR DESCRIPTION
This PR adds simple gauges for active uploads and downloads. These
can then be picked up by the prometheus handler.