### PR TITLE
Fix unshare for EOS storage driver

### DIFF
--- a/changelog/unreleased/fix-unshare-eos.md
+++ b/changelog/unreleased/fix-unshare-eos.md
@@ -1,0 +1,9 @@
+Bugfix: Fix unshare for EOS storage driver
+
+In the EOS storage driver, the remove acl operation was a no-op.
+After removing a share, the recipient of the share was still able
+to operate on the shared resource.
+Now this has been fixed, removing correctly the ACL from the shared
+resource.
+
+https://github.com/cs3org/reva/pull/3794

--- a/pkg/eosclient/eosbinary/eosbinary.go
+++ b/pkg/eosclient/eosbinary/eosbinary.go
@@ -314,6 +314,7 @@ func (c *Client) RemoveACL(ctx context.Context, auth, rootAuth eosclient.Authori
 		return err
 	}
 
+	a.Permissions = ""
 	sysACL := a.CitrineSerialize()
 	args := []string{"acl", "--sys"}
 	if finfo.IsDir {


### PR DESCRIPTION
In the EOS storage driver, the remove acl operation was a no-op. The consequence of this was that after removing a share, the recipient of the share was still able to operate on the shared resource.
Now this has been fixed in this PR.