### PR TITLE
Cache resolved links

### DIFF
--- a/changelog/unreleased/cache-node-ids.md
+++ b/changelog/unreleased/cache-node-ids.md
@@ -1,0 +1,5 @@
+Enhancement: Cache node ids
+
+decomposedfs now keeps an in-memory cache for node ids, sparing a lot of ReadLink calls.
+
+https://github.com/cs3org/reva/pull/3801


### PR DESCRIPTION
decomposedfs now keeps an in-memory cache for node ids, sparing a lot of ReadLink calls. The cache is currently limited to 1M entries, this number can be made configurable in the future if needed.

stats from testing (warm cache):
```
List the space root with 24 files and 2 subdirs:
Before:                                             After
+-----------+------------------+-------+            +-----------+------------------+-------+
| Function  | last 5 second(s) | total |            | Function  | last 5 second(s) | total |
+-----------+------------------+-------+            +-----------+------------------+-------+
| Chtimes   |                0 |    10 |            | Chtimes   |                0 |    10 |
| Create    |                0 |     5 |            | Create    |                0 |     5 |
| Open      |                1 |    33 |            | Open      |                1 |    34 |
| OpenFile  |                0 |     0 |            | OpenFile  |                0 |     0 |
| Lstat     |               25 |   112 |            | Lstat     |               25 |   137 |
| MkdirAll  |                0 |    23 |            | MkdirAll  |                0 |    23 |
| ReadFile  |                0 |     5 |            | ReadFile  |                0 |     5 |
| Readlink  |               27 |   156 |            | Readlink  |                1 |   131 |
| Rename    |                0 |     0 |            | Rename    |                0 |     0 |
| Remove    |                0 |    20 |            | Remove    |                0 |    20 |
| RemoveAll |                0 |     0 |            | RemoveAll |                0 |     0 |
| Stat      |                0 |    77 |            | Stat      |                0 |    39 |
| Symlink   |                0 |    15 |            | Symlink   |                0 |    15 |
| WriteFile |                0 |     0 |            | WriteFile |                0 |     0 |
+-----------+------------------+-------+            +-----------+------------------+-------+
```