### PR TITLE
[tests-only][full-ci]Bump ocis commit on reva edge

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,4 +1,4 @@
 # The test runner source for API tests
-APITESTS_COMMITID=26c9f889e79611c05be078723ea253dbef486538
+APITESTS_COMMITID=0b04edd0d84593ab94fbd74e5a7eac2672b98b55
 APITESTS_BRANCH=master
 APITESTS_REPO_GIT_URL=https://github.com/owncloud/ocis.git


### PR DESCRIPTION
### Description
Bump latest ocis commit id to reva edge.

### Part of:
https://github.com/owncloud/QA/issues/806