### PR TITLE
Make Filename Validation Configurable

### DIFF
--- a/changelog/unreleased/name-validation.md
+++ b/changelog/unreleased/name-validation.md
@@ -1,0 +1,5 @@
+Enhancement: Name Validation
+
+Make name validation in ocdav configurable and add a new validation: max lenght
+
+https://github.com/cs3org/reva/pull/3807

--- a/internal/http/services/owncloud/ocdav/copy.go
+++ b/internal/http/services/owncloud/ocdav/copy.go
@@ -87,19 +87,18 @@ func (s *svc) handlePathCopy(w http.ResponseWriter, r *http.Request, ns string) 
 		return
 	}
 
-	for _, r := range nameRules {
-		if !r.Test(src) {
-			w.WriteHeader(http.StatusBadRequest)
-			b, err := errors.Marshal(http.StatusBadRequest, "source failed naming rules", "")
-			errors.HandleWebdavError(appctx.GetLogger(ctx), w, b, err)
-			return
-		}
-		if !r.Test(dst) {
-			w.WriteHeader(http.StatusBadRequest)
-			b, err := errors.Marshal(http.StatusBadRequest, "destination failed naming rules", "")
-			errors.HandleWebdavError(appctx.GetLogger(ctx), w, b, err)
-			return
-		}
+	if err := ValidateName(src, s.nameValidators); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		b, err := errors.Marshal(http.StatusBadRequest, "source failed naming rules", "")
+		errors.HandleWebdavError(appctx.GetLogger(ctx), w, b, err)
+		return
+	}
+
+	if err := ValidateName(dst, s.nameValidators); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		b, err := errors.Marshal(http.StatusBadRequest, "destination failed naming rules", "")
+		errors.HandleWebdavError(appctx.GetLogger(ctx), w, b, err)
+		return
 	}
 
 	dst = path.Join(ns, dst)

--- a/internal/http/services/owncloud/ocdav/mkcol.go
+++ b/internal/http/services/owncloud/ocdav/mkcol.go
@@ -40,10 +40,8 @@ func (s *svc) handlePathMkcol(w http.ResponseWriter, r *http.Request, ns string)
 	defer span.End()
 
 	fn := path.Join(ns, r.URL.Path)
-	for _, r := range nameRules {
-		if !r.Test(fn) {
-			return http.StatusBadRequest, fmt.Errorf("invalid name rule")
-		}
+	if err := ValidateName(fn, s.nameValidators); err != nil {
+		return http.StatusBadRequest, err
 	}
 	sublog := appctx.GetLogger(ctx).With().Str("path", fn).Logger()
 

--- a/internal/http/services/owncloud/ocdav/move.go
+++ b/internal/http/services/owncloud/ocdav/move.go
@@ -60,19 +60,18 @@ func (s *svc) handlePathMove(w http.ResponseWriter, r *http.Request, ns string) 
 		return
 	}
 
-	for _, r := range nameRules {
-		if !r.Test(srcPath) {
-			w.WriteHeader(http.StatusBadRequest)
-			b, err := errors.Marshal(http.StatusBadRequest, "source failed naming rules", "")
-			errors.HandleWebdavError(appctx.GetLogger(ctx), w, b, err)
-			return
-		}
-		if !r.Test(dstPath) {
-			w.WriteHeader(http.StatusBadRequest)
-			b, err := errors.Marshal(http.StatusBadRequest, "destination naming rules", "")
-			errors.HandleWebdavError(appctx.GetLogger(ctx), w, b, err)
-			return
-		}
+	if err := ValidateName(srcPath, s.nameValidators); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		b, err := errors.Marshal(http.StatusBadRequest, "source failed naming rules", "")
+		errors.HandleWebdavError(appctx.GetLogger(ctx), w, b, err)
+		return
+	}
+
+	if err := ValidateName(dstPath, s.nameValidators); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		b, err := errors.Marshal(http.StatusBadRequest, "destination naming rules", "")
+		errors.HandleWebdavError(appctx.GetLogger(ctx), w, b, err)
+		return
 	}
 
 	dstPath = path.Join(ns, dstPath)

--- a/internal/http/services/owncloud/ocdav/ocdav.go
+++ b/internal/http/services/owncloud/ocdav/ocdav.go
@@ -55,31 +55,6 @@ import (
 // name is the Tracer name used to identify this instrumentation library.
 const tracerName = "ocdav"
 
-var (
-	nameRules = [...]nameRule{
-		nameNotEmpty{},
-		nameDoesNotContain{chars: "\f\r\n\\"},
-	}
-)
-
-type nameRule interface {
-	Test(name string) bool
-}
-
-type nameNotEmpty struct{}
-
-func (r nameNotEmpty) Test(name string) bool {
-	return len(strings.TrimSpace(name)) > 0
-}
-
-type nameDoesNotContain struct {
-	chars string
-}
-
-func (r nameDoesNotContain) Test(name string) bool {
-	return !strings.ContainsAny(name, r.chars)
-}
-
 func init() {
 	global.Register("ocdav", New)
 }
@@ -113,7 +88,15 @@ type Config struct {
 	ProductName            string                            `mapstructure:"product_name"`
 	ProductVersion         string                            `mapstructure:"product_version"`
 
+	NameValidation NameValidation `mapstructure:"validation"`
+
 	MachineAuthAPIKey string `mapstructure:"machine_auth_apikey"`
+}
+
+// NameValidation is the validation configuration for file and folder names
+type NameValidation struct {
+	InvalidChars []string `mapstructure:"invalid_chars"`
+	MaxLength    int      `mapstructure:"max_length"`
 }
 
 func (c *Config) init() {
@@ -147,6 +130,14 @@ func (c *Config) init() {
 	if c.Edition == "" {
 		c.Edition = "community"
 	}
+
+	if c.NameValidation.InvalidChars == nil {
+		c.NameValidation.InvalidChars = []string{"\f", "\r", "\n", "\\"}
+	}
+
+	if c.NameValidation.MaxLength == 0 {
+		c.NameValidation.MaxLength = 255
+	}
 }
 
 type svc struct {
@@ -160,6 +151,7 @@ type svc struct {
 	LockSystem          LockSystem
 	userIdentifierCache *ttlcache.Cache
 	tracerProvider      trace.TracerProvider
+	nameValidators      []Validator
 }
 
 func (s *svc) Config() *Config {
@@ -217,6 +209,7 @@ func NewWith(conf *Config, fm favorite.Manager, ls LockSystem, _ *zerolog.Logger
 		LockSystem:          ls,
 		userIdentifierCache: ttlcache.NewCache(),
 		tracerProvider:      tp,
+		nameValidators:      ValidatorsFromConfig(conf),
 	}
 	_ = s.userIdentifierCache.SetTTL(60 * time.Second)
 

--- a/internal/http/services/owncloud/ocdav/ocdav.go
+++ b/internal/http/services/owncloud/ocdav/ocdav.go
@@ -196,6 +196,9 @@ func New(m map[string]interface{}, log *zerolog.Logger) (global.Service, error) 
 
 // NewWith returns a new ocdav service
 func NewWith(conf *Config, fm favorite.Manager, ls LockSystem, _ *zerolog.Logger, tp trace.TracerProvider, gwc gateway.GatewayAPIClient) (global.Service, error) {
+	// be safe - init the conf again
+	conf.init()
+
 	s := &svc{
 		c:             conf,
 		webDavHandler: new(WebDavHandler),

--- a/internal/http/services/owncloud/ocdav/ocdav_blackbox_test.go
+++ b/internal/http/services/owncloud/ocdav/ocdav_blackbox_test.go
@@ -137,10 +137,15 @@ var _ = Describe("ocdav", func() {
 		ctx = ctxpkg.ContextSetUser(context.Background(), user)
 		client = &mocks.GatewayAPIClient{}
 
-		handler, err = ocdav.NewWith(&ocdav.Config{
+		cfg := &ocdav.Config{
 			FilesNamespace:  "/users/{{.Username}}",
 			WebdavNamespace: "/users/{{.Username}}",
-		}, nil, ocdav.NewCS3LS(client), nil, trace.NewNoopTracerProvider(), client)
+			NameValidation: ocdav.NameValidation{
+				MaxLength:    255,
+				InvalidChars: []string{"\f", "\r", "\n", "\\"},
+			},
+		}
+		handler, err = ocdav.NewWith(cfg, nil, ocdav.NewCS3LS(client), nil, trace.NewNoopTracerProvider(), client)
 		Expect(err).ToNot(HaveOccurred())
 
 		userspace = &cs3storageprovider.StorageSpace{

--- a/internal/http/services/owncloud/ocdav/put.go
+++ b/internal/http/services/owncloud/ocdav/put.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"net/http"
 	"path"
+	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -136,6 +137,14 @@ func (s *svc) handlePut(ctx context.Context, w http.ResponseWriter, r *http.Requ
 	length, err := getContentLength(w, r)
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	fn := filepath.Base(ref.Path)
+	if err := ValidateName(fn, s.nameValidators); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		b, err := errors.Marshal(http.StatusBadRequest, err.Error(), "")
+		errors.HandleWebdavError(&log, w, b, err)
 		return
 	}
 

--- a/internal/http/services/owncloud/ocdav/tus.go
+++ b/internal/http/services/owncloud/ocdav/tus.go
@@ -50,11 +50,9 @@ func (s *svc) handlePathTusPost(w http.ResponseWriter, r *http.Request, ns strin
 
 	// read filename from metadata
 	meta := tusd.ParseMetadataHeader(r.Header.Get(net.HeaderUploadMetadata))
-	for _, r := range nameRules {
-		if !r.Test(meta["filename"]) {
-			w.WriteHeader(http.StatusPreconditionFailed)
-			return
-		}
+	if err := ValidateName(meta["filename"], s.nameValidators); err != nil {
+		w.WriteHeader(http.StatusPreconditionFailed)
+		return
 	}
 
 	// append filename to current dir
@@ -76,11 +74,9 @@ func (s *svc) handleSpacesTusPost(w http.ResponseWriter, r *http.Request, spaceI
 
 	// read filename from metadata
 	meta := tusd.ParseMetadataHeader(r.Header.Get(net.HeaderUploadMetadata))
-	for _, r := range nameRules {
-		if !r.Test(meta["filename"]) {
-			w.WriteHeader(http.StatusPreconditionFailed)
-			return
-		}
+	if err := ValidateName(meta["filename"], s.nameValidators); err != nil {
+		w.WriteHeader(http.StatusPreconditionFailed)
+		return
 	}
 
 	sublog := appctx.GetLogger(ctx).With().Str("spaceid", spaceID).Str("path", r.URL.Path).Logger()

--- a/internal/http/services/owncloud/ocdav/validation.go
+++ b/internal/http/services/owncloud/ocdav/validation.go
@@ -27,7 +27,7 @@ func ValidatorsFromConfig(c *Config) []Validator {
 func ValidateName(name string, validators []Validator) error {
 	for _, v := range validators {
 		if err := v(name); err != nil {
-			return err
+			return fmt.Errorf("name validation failed: %w", err)
 		}
 	}
 	return nil

--- a/internal/http/services/owncloud/ocdav/validation.go
+++ b/internal/http/services/owncloud/ocdav/validation.go
@@ -1,0 +1,63 @@
+package ocdav
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// Validator validates strings
+type Validator func(string) error
+
+// ValidatorsFromConfig returns the configured Validators
+func ValidatorsFromConfig(c *Config) []Validator {
+	// we always want to exclude empty names
+	vals := []Validator{notEmpty()}
+
+	// forbidden characters
+	vals = append(vals, doesNotContain(c.NameValidation.InvalidChars))
+
+	// max length
+	vals = append(vals, isShorterThan(c.NameValidation.MaxLength))
+
+	return vals
+}
+
+// ValidateName will validate a file or folder name, returning an error when it is not accepted
+func ValidateName(name string, validators []Validator) error {
+	for _, v := range validators {
+		if err := v(name); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func notEmpty() Validator {
+	return func(s string) error {
+		if strings.TrimSpace(s) == "" {
+			return errors.New("must not be empty")
+		}
+		return nil
+	}
+}
+
+func doesNotContain(bad []string) Validator {
+	return func(s string) error {
+		for _, b := range bad {
+			if strings.Contains(s, b) {
+				return fmt.Errorf("must not contain %s", b)
+			}
+		}
+		return nil
+	}
+}
+
+func isShorterThan(maxLength int) Validator {
+	return func(s string) error {
+		if len(s) > maxLength {
+			return fmt.Errorf("must be shorter than %d", maxLength)
+		}
+		return nil
+	}
+}

--- a/pkg/micro/ocdav/option.go
+++ b/pkg/micro/ocdav/option.go
@@ -307,3 +307,17 @@ func AllowedHeaders(val []string) Option {
 		o.AllowedHeaders = val
 	}
 }
+
+// ItemNameInvalidChars provides a function to set forbidden characters in file or folder names
+func ItemNameInvalidChars(chars []string) Option {
+	return func(o *Options) {
+		o.config.NameValidation.InvalidChars = chars
+	}
+}
+
+// ItemNameMaxLength provides a function to set the maximum length of a file or folder name
+func ItemNameMaxLength(i int) Option {
+	return func(o *Options) {
+		o.config.NameValidation.MaxLength = i
+	}
+}


### PR DESCRIPTION
# Revamp ocdav file/folder naming validation

- Makes validation option `invalid chars` configurable and also adds a new one: `max lenght`
- Refactors naming validation in ocdav
