### PR TITLE
pass down context for tracing

### DIFF
--- a/changelog/unreleased/trace-syscalls.md
+++ b/changelog/unreleased/trace-syscalls.md
@@ -1,0 +1,6 @@
+Enhancement: Trace decomposedfs syscalls
+
+To investigate performance characteristics of the underlying storage when the system is under load we wrapped the related syscalls in decomposedfs with trace spans.
+
+https://github.com/cs3org/reva/pull/3809
+

--- a/internal/grpc/services/gateway/gateway.go
+++ b/internal/grpc/services/gateway/gateway.go
@@ -191,10 +191,10 @@ func New(m map[string]interface{}, ss *grpc.Server) (rgrpc.Service, error) {
 		c:                        c,
 		dataGatewayURL:           *u,
 		tokenmgr:                 tokenManager,
-		statCache:                cache.GetStatCache(c.StatCacheStore, c.StatCacheNodes, c.StatCacheDatabase, "stat", time.Duration(c.StatCacheTTL)*time.Second, c.StatCacheSize),
-		providerCache:            cache.GetProviderCache(c.ProviderCacheStore, c.ProviderCacheNodes, c.ProviderCacheDatabase, "provider", time.Duration(c.ProviderCacheTTL)*time.Second, c.ProviderCacheSize),
-		createHomeCache:          cache.GetCreateHomeCache(c.CreateHomeCacheStore, c.CreateHomeCacheNodes, c.CreateHomeCacheDatabase, "createHome", time.Duration(c.CreateHomeCacheTTL)*time.Second, c.CreateHomeCacheSize),
-		createPersonalSpaceCache: cache.GetCreatePersonalSpaceCache(c.CreateHomeCacheStore, c.CreateHomeCacheNodes, c.CreateHomeCacheDatabase, "createPersonalSpace", time.Duration(c.CreateHomeCacheTTL)*time.Second, c.CreateHomeCacheSize),
+		statCache:                cache.GetStatCache(c.StatCacheStore, c.StatCacheNodes, c.StatCacheDatabase, "stat:", time.Duration(c.StatCacheTTL)*time.Second, c.StatCacheSize),
+		providerCache:            cache.GetProviderCache(c.ProviderCacheStore, c.ProviderCacheNodes, c.ProviderCacheDatabase, "provider:", time.Duration(c.ProviderCacheTTL)*time.Second, c.ProviderCacheSize),
+		createHomeCache:          cache.GetCreateHomeCache(c.CreateHomeCacheStore, c.CreateHomeCacheNodes, c.CreateHomeCacheDatabase, "createHome:", time.Duration(c.CreateHomeCacheTTL)*time.Second, c.CreateHomeCacheSize),
+		createPersonalSpaceCache: cache.GetCreatePersonalSpaceCache(c.CreateHomeCacheStore, c.CreateHomeCacheNodes, c.CreateHomeCacheDatabase, "createPersonalSpace:", time.Duration(c.CreateHomeCacheTTL)*time.Second, c.CreateHomeCacheSize),
 	}
 
 	return s, nil

--- a/internal/grpc/services/gateway/gateway.go
+++ b/internal/grpc/services/gateway/gateway.go
@@ -191,10 +191,10 @@ func New(m map[string]interface{}, ss *grpc.Server) (rgrpc.Service, error) {
 		c:                        c,
 		dataGatewayURL:           *u,
 		tokenmgr:                 tokenManager,
-		statCache:                cache.GetStatCache(c.StatCacheStore, c.StatCacheNodes, c.StatCacheDatabase, "stat:", time.Duration(c.StatCacheTTL)*time.Second, c.StatCacheSize),
-		providerCache:            cache.GetProviderCache(c.ProviderCacheStore, c.ProviderCacheNodes, c.ProviderCacheDatabase, "provider:", time.Duration(c.ProviderCacheTTL)*time.Second, c.ProviderCacheSize),
-		createHomeCache:          cache.GetCreateHomeCache(c.CreateHomeCacheStore, c.CreateHomeCacheNodes, c.CreateHomeCacheDatabase, "createHome:", time.Duration(c.CreateHomeCacheTTL)*time.Second, c.CreateHomeCacheSize),
-		createPersonalSpaceCache: cache.GetCreatePersonalSpaceCache(c.CreateHomeCacheStore, c.CreateHomeCacheNodes, c.CreateHomeCacheDatabase, "createPersonalSpace:", time.Duration(c.CreateHomeCacheTTL)*time.Second, c.CreateHomeCacheSize),
+		statCache:                cache.GetStatCache(c.StatCacheStore, c.StatCacheNodes, c.StatCacheDatabase, "stat", time.Duration(c.StatCacheTTL)*time.Second, c.StatCacheSize),
+		providerCache:            cache.GetProviderCache(c.ProviderCacheStore, c.ProviderCacheNodes, c.ProviderCacheDatabase, "provider", time.Duration(c.ProviderCacheTTL)*time.Second, c.ProviderCacheSize),
+		createHomeCache:          cache.GetCreateHomeCache(c.CreateHomeCacheStore, c.CreateHomeCacheNodes, c.CreateHomeCacheDatabase, "createHome", time.Duration(c.CreateHomeCacheTTL)*time.Second, c.CreateHomeCacheSize),
+		createPersonalSpaceCache: cache.GetCreatePersonalSpaceCache(c.CreateHomeCacheStore, c.CreateHomeCacheNodes, c.CreateHomeCacheDatabase, "createPersonalSpace", time.Duration(c.CreateHomeCacheTTL)*time.Second, c.CreateHomeCacheSize),
 	}
 
 	return s, nil

--- a/internal/grpc/services/gateway/publicshareprovider.go
+++ b/internal/grpc/services/gateway/publicshareprovider.go
@@ -45,7 +45,7 @@ func (s *svc) CreatePublicShare(ctx context.Context, req *link.CreatePublicShare
 	}
 
 	if res.GetShare() != nil {
-		s.statCache.RemoveStat(ctxpkg.ContextMustGetUser(ctx).GetId(), res.Share.ResourceId)
+		s.statCache.RemoveStatContext(ctx, ctxpkg.ContextMustGetUser(ctx).GetId(), res.Share.ResourceId)
 	}
 	return res, nil
 }
@@ -63,7 +63,7 @@ func (s *svc) RemovePublicShare(ctx context.Context, req *link.RemovePublicShare
 		return nil, err
 	}
 	// TODO: How to find out the resourceId? -> get public share first, then delete
-	s.statCache.RemoveStat(ctxpkg.ContextMustGetUser(ctx).GetId(), nil)
+	s.statCache.RemoveStatContext(ctx, ctxpkg.ContextMustGetUser(ctx).GetId(), nil)
 	return res, nil
 }
 
@@ -142,7 +142,7 @@ func (s *svc) UpdatePublicShare(ctx context.Context, req *link.UpdatePublicShare
 		return nil, errors.Wrap(err, "error updating share")
 	}
 	if res.GetShare() != nil {
-		s.statCache.RemoveStat(
+		s.statCache.RemoveStatContext(ctx,
 			&userprovider.UserId{
 				OpaqueId: res.Share.Owner.GetOpaqueId(),
 			},

--- a/internal/grpc/services/gateway/storageprovider.go
+++ b/internal/grpc/services/gateway/storageprovider.go
@@ -326,7 +326,7 @@ func (s *svc) UpdateStorageSpace(ctx context.Context, req *provider.UpdateStorag
 
 	if res.Status.Code == rpc.Code_CODE_OK {
 		id := res.StorageSpace.Root
-		s.statCache.RemoveStat(ctxpkg.ContextMustGetUser(ctx).GetId(), id)
+		s.statCache.RemoveStatContext(ctx, ctxpkg.ContextMustGetUser(ctx).GetId(), id)
 		s.providerCache.RemoveListStorageProviders(id)
 	}
 	return res, nil
@@ -363,7 +363,7 @@ func (s *svc) DeleteStorageSpace(ctx context.Context, req *provider.DeleteStorag
 	}
 
 	id := &provider.ResourceId{OpaqueId: req.Id.OpaqueId}
-	s.statCache.RemoveStat(ctxpkg.ContextMustGetUser(ctx).GetId(), id)
+	s.statCache.RemoveStatContext(ctx, ctxpkg.ContextMustGetUser(ctx).GetId(), id)
 	s.providerCache.RemoveListStorageProviders(id)
 
 	if dsRes.Status.Code != rpc.Code_CODE_OK {
@@ -608,7 +608,7 @@ func (s *svc) InitiateFileUpload(ctx context.Context, req *provider.InitiateFile
 		}
 	}
 
-	s.statCache.RemoveStat(ctxpkg.ContextMustGetUser(ctx).GetId(), req.Ref.ResourceId)
+	s.statCache.RemoveStatContext(ctx, ctxpkg.ContextMustGetUser(ctx).GetId(), req.Ref.ResourceId)
 	return &gateway.InitiateFileUploadResponse{
 		Opaque:    storageRes.Opaque,
 		Status:    storageRes.Status,
@@ -645,7 +645,7 @@ func (s *svc) CreateContainer(ctx context.Context, req *provider.CreateContainer
 		}, nil
 	}
 
-	s.statCache.RemoveStat(ctxpkg.ContextMustGetUser(ctx).GetId(), req.Ref.ResourceId)
+	s.statCache.RemoveStatContext(ctx, ctxpkg.ContextMustGetUser(ctx).GetId(), req.Ref.ResourceId)
 	return res, nil
 }
 
@@ -688,7 +688,7 @@ func (s *svc) Delete(ctx context.Context, req *provider.DeleteRequest) (*provide
 		}, nil
 	}
 
-	s.statCache.RemoveStat(ctxpkg.ContextMustGetUser(ctx).GetId(), req.Ref.ResourceId)
+	s.statCache.RemoveStatContext(ctx, ctxpkg.ContextMustGetUser(ctx).GetId(), req.Ref.ResourceId)
 	return res, nil
 }
 
@@ -715,8 +715,8 @@ func (s *svc) Move(ctx context.Context, req *provider.MoveRequest) (*provider.Mo
 
 	req.Source = sref
 	req.Destination = dref
-	s.statCache.RemoveStat(ctxpkg.ContextMustGetUser(ctx).GetId(), req.Source.ResourceId)
-	s.statCache.RemoveStat(ctxpkg.ContextMustGetUser(ctx).GetId(), req.Destination.ResourceId)
+	s.statCache.RemoveStatContext(ctx, ctxpkg.ContextMustGetUser(ctx).GetId(), req.Source.ResourceId)
+	s.statCache.RemoveStatContext(ctx, ctxpkg.ContextMustGetUser(ctx).GetId(), req.Destination.ResourceId)
 	return c.Move(ctx, req)
 }
 
@@ -739,7 +739,7 @@ func (s *svc) SetArbitraryMetadata(ctx context.Context, req *provider.SetArbitra
 		return nil, errors.Wrap(err, "gateway: error calling SetArbitraryMetadata")
 	}
 
-	s.statCache.RemoveStat(ctxpkg.ContextMustGetUser(ctx).GetId(), req.Ref.ResourceId)
+	s.statCache.RemoveStatContext(ctx, ctxpkg.ContextMustGetUser(ctx).GetId(), req.Ref.ResourceId)
 	return res, nil
 }
 
@@ -761,7 +761,7 @@ func (s *svc) UnsetArbitraryMetadata(ctx context.Context, req *provider.UnsetArb
 		}
 		return nil, errors.Wrap(err, "gateway: error calling UnsetArbitraryMetadata")
 	}
-	s.statCache.RemoveStat(ctxpkg.ContextMustGetUser(ctx).GetId(), req.Ref.ResourceId)
+	s.statCache.RemoveStatContext(ctx, ctxpkg.ContextMustGetUser(ctx).GetId(), req.Ref.ResourceId)
 
 	return res, nil
 }
@@ -785,7 +785,7 @@ func (s *svc) SetLock(ctx context.Context, req *provider.SetLockRequest) (*provi
 		return nil, errors.Wrap(err, "gateway: error calling SetLock")
 	}
 
-	s.statCache.RemoveStat(ctxpkg.ContextMustGetUser(ctx).GetId(), req.Ref.ResourceId)
+	s.statCache.RemoveStatContext(ctx, ctxpkg.ContextMustGetUser(ctx).GetId(), req.Ref.ResourceId)
 	return res, nil
 }
 
@@ -826,7 +826,7 @@ func (s *svc) RefreshLock(ctx context.Context, req *provider.RefreshLockRequest)
 		return nil, errors.Wrap(err, "gateway: error calling RefreshLock")
 	}
 
-	s.statCache.RemoveStat(ctxpkg.ContextMustGetUser(ctx).GetId(), req.Ref.ResourceId)
+	s.statCache.RemoveStatContext(ctx, ctxpkg.ContextMustGetUser(ctx).GetId(), req.Ref.ResourceId)
 	return res, nil
 }
 
@@ -847,7 +847,7 @@ func (s *svc) Unlock(ctx context.Context, req *provider.UnlockRequest) (*provide
 		return nil, errors.Wrap(err, "gateway: error calling Unlock")
 	}
 
-	s.statCache.RemoveStat(ctxpkg.ContextMustGetUser(ctx).GetId(), req.Ref.ResourceId)
+	s.statCache.RemoveStatContext(ctx, ctxpkg.ContextMustGetUser(ctx).GetId(), req.Ref.ResourceId)
 	return res, nil
 }
 
@@ -927,7 +927,7 @@ func (s *svc) RestoreFileVersion(ctx context.Context, req *provider.RestoreFileV
 		}, nil
 	}
 
-	s.statCache.RemoveStat(ctxpkg.ContextMustGetUser(ctx).GetId(), req.Ref.ResourceId)
+	s.statCache.RemoveStatContext(ctx, ctxpkg.ContextMustGetUser(ctx).GetId(), req.Ref.ResourceId)
 	return res, nil
 }
 
@@ -983,7 +983,7 @@ func (s *svc) RestoreRecycleItem(ctx context.Context, req *provider.RestoreRecyc
 		}, nil
 	}
 
-	s.statCache.RemoveStat(ctxpkg.ContextMustGetUser(ctx).GetId(), req.Ref.ResourceId)
+	s.statCache.RemoveStatContext(ctx, ctxpkg.ContextMustGetUser(ctx).GetId(), req.Ref.ResourceId)
 	return res, nil
 }
 
@@ -1006,7 +1006,7 @@ func (s *svc) PurgeRecycle(ctx context.Context, req *provider.PurgeRecycleReques
 		}, nil
 	}
 
-	s.statCache.RemoveStat(ctxpkg.ContextMustGetUser(ctx).GetId(), req.Ref.ResourceId)
+	s.statCache.RemoveStatContext(ctx, ctxpkg.ContextMustGetUser(ctx).GetId(), req.Ref.ResourceId)
 	return res, nil
 }
 

--- a/internal/grpc/services/gateway/usershareprovider.go
+++ b/internal/grpc/services/gateway/usershareprovider.go
@@ -130,7 +130,7 @@ func (s *svc) UpdateShare(ctx context.Context, req *collaboration.UpdateShareReq
 		}
 	}
 
-	s.statCache.RemoveStat(ctxpkg.ContextMustGetUser(ctx).GetId(), res.Share.ResourceId)
+	s.statCache.RemoveStatContext(ctx, ctxpkg.ContextMustGetUser(ctx).GetId(), res.Share.ResourceId)
 	return res, nil
 }
 
@@ -213,7 +213,7 @@ func (s *svc) UpdateReceivedShare(ctx context.Context, req *collaboration.Update
 		}, nil
 	}
 
-	s.statCache.RemoveStat(ctxpkg.ContextMustGetUser(ctx).GetId(), req.Share.Share.ResourceId)
+	s.statCache.RemoveStatContext(ctx, ctxpkg.ContextMustGetUser(ctx).GetId(), req.Share.Share.ResourceId)
 	return c.UpdateReceivedShare(ctx, req)
 	/*
 		    TODO: Leftover from master merge. Do we need this?
@@ -504,7 +504,7 @@ func (s *svc) addShare(ctx context.Context, req *collaboration.CreateShareReques
 
 		switch status.Code {
 		case rpc.Code_CODE_OK:
-			s.statCache.RemoveStat(ctxpkg.ContextMustGetUser(ctx).GetId(), req.ResourceInfo.Id)
+			s.statCache.RemoveStatContext(ctx, ctxpkg.ContextMustGetUser(ctx).GetId(), req.ResourceInfo.Id)
 		case rpc.Code_CODE_UNIMPLEMENTED:
 			appctx.GetLogger(ctx).Debug().Interface("status", status).Interface("req", req).Msg("storing grants not supported, ignoring")
 			rollBackFn(status)
@@ -548,7 +548,7 @@ func (s *svc) addSpaceShare(ctx context.Context, req *collaboration.CreateShareR
 
 	switch st.Code {
 	case rpc.Code_CODE_OK:
-		s.statCache.RemoveStat(ctxpkg.ContextMustGetUser(ctx).GetId(), req.ResourceInfo.Id)
+		s.statCache.RemoveStatContext(ctx, ctxpkg.ContextMustGetUser(ctx).GetId(), req.ResourceInfo.Id)
 		s.providerCache.RemoveListStorageProviders(req.ResourceInfo.Id)
 	case rpc.Code_CODE_UNIMPLEMENTED:
 		appctx.GetLogger(ctx).Debug().Interface("status", st).Interface("req", req).Msg("storing grants not supported, ignoring")
@@ -618,7 +618,7 @@ func (s *svc) removeShare(ctx context.Context, req *collaboration.RemoveShareReq
 		}
 	}
 
-	s.statCache.RemoveStat(ctxpkg.ContextMustGetUser(ctx).GetId(), share.ResourceId)
+	s.statCache.RemoveStatContext(ctx, ctxpkg.ContextMustGetUser(ctx).GetId(), share.ResourceId)
 	return res, nil
 }
 
@@ -651,7 +651,7 @@ func (s *svc) removeSpaceShare(ctx context.Context, ref *provider.ResourceId, gr
 			Status: removeGrantStatus,
 		}, err
 	}
-	s.statCache.RemoveStat(ctxpkg.ContextMustGetUser(ctx).GetId(), ref)
+	s.statCache.RemoveStatContext(ctx, ctxpkg.ContextMustGetUser(ctx).GetId(), ref)
 	s.providerCache.RemoveListStorageProviders(ref)
 	return &collaboration.RemoveShareResponse{Status: status.NewOK(ctx)}, nil
 }

--- a/pkg/rhttp/datatx/datatx.go
+++ b/pkg/rhttp/datatx/datatx.go
@@ -21,6 +21,7 @@
 package datatx
 
 import (
+	"context"
 	"net/http"
 
 	userv1beta1 "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
@@ -55,5 +56,5 @@ func EmitFileUploadedEvent(spaceOwnerOrManager, executant *userv1beta1.UserId, r
 
 // InvalidateCache is a helper function which invalidates the stat cache
 func InvalidateCache(owner *userv1beta1.UserId, ref *provider.Reference, statCache cache.StatCache) {
-	statCache.RemoveStat(owner, ref.GetResourceId())
+	statCache.RemoveStatContext(context.TODO(), owner, ref.GetResourceId())
 }

--- a/pkg/storage/cache/cache.go
+++ b/pkg/storage/cache/cache.go
@@ -19,6 +19,7 @@
 package cache
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"sync"
@@ -67,6 +68,7 @@ type Cache interface {
 type StatCache interface {
 	Cache
 	RemoveStat(userID *userpb.UserId, res *provider.ResourceId)
+	RemoveStatContext(ctx context.Context, userID *userpb.UserId, res *provider.ResourceId)
 	GetKey(userID *userpb.UserId, ref *provider.Reference, metaDataKeys, fieldMaskPaths []string) string
 }
 

--- a/pkg/storage/cache/filemetadata.go
+++ b/pkg/storage/cache/filemetadata.go
@@ -39,5 +39,5 @@ func NewFileMetadataCache(store string, nodes []string, database, table string, 
 
 // RemoveMetadata removes a reference from the metadata cache
 func (c *fileMetadataCache) RemoveMetadata(path string) error {
-	return c.Delete(path)
+	return c.s.Delete(path)
 }

--- a/pkg/storage/cache/filemetadata.go
+++ b/pkg/storage/cache/filemetadata.go
@@ -39,5 +39,5 @@ func NewFileMetadataCache(store string, nodes []string, database, table string, 
 
 // RemoveMetadata removes a reference from the metadata cache
 func (c *fileMetadataCache) RemoveMetadata(path string) error {
-	return c.s.Delete(path)
+	return c.Delete(path)
 }

--- a/pkg/storage/cache/stat.go
+++ b/pkg/storage/cache/stat.go
@@ -19,6 +19,7 @@
 package cache
 
 import (
+	"context"
 	"strings"
 	"sync"
 	"time"
@@ -26,7 +27,13 @@ import (
 	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	"go-micro.dev/v4/store"
+	"go.opentelemetry.io/otel/attribute"
+	semconv "go.opentelemetry.io/otel/semconv/v1.10.0"
+	"go.opentelemetry.io/otel/trace"
 )
+
+// name is the Tracer name used to identify this instrumentation library.
+const tracerName = "cache"
 
 // NewStatCache creates a new StatCache
 func NewStatCache(store string, nodes []string, database, table string, ttl time.Duration, size int) StatCache {
@@ -42,12 +49,23 @@ type statCache struct {
 	cacheStore
 }
 
-// RemoveStat removes a reference from the stat cache
-func (c statCache) RemoveStat(userID *userpb.UserId, res *provider.ResourceId) {
+func (c statCache) RemoveStatContext(ctx context.Context, userID *userpb.UserId, res *provider.ResourceId) {
+
+	span := trace.SpanFromContext(ctx)
+	tp := span.TracerProvider()
+	_, span = tp.Tracer(tracerName).Start(ctx, "RemoveStatContext")
+	defer span.End()
+
+	span.SetAttributes(semconv.EnduserIDKey.String(userID.GetOpaqueId()))
+
 	uid := "uid:" + userID.GetOpaqueId()
 	sid := ""
 	oid := ""
 	if res != nil {
+		span.SetAttributes(
+			attribute.String("space.id", res.SpaceId),
+			attribute.String("node.id", res.OpaqueId),
+		)
 		sid = "sid:" + res.SpaceId
 		oid = "oid:" + res.OpaqueId
 	}
@@ -73,6 +91,12 @@ func (c statCache) RemoveStat(userID *userpb.UserId, res *provider.ResourceId) {
 	}
 
 	wg.Wait()
+
+}
+
+// RemoveStatContext(ctx,  removes a reference from the stat cache
+func (c statCache) RemoveStat(userID *userpb.UserId, res *provider.ResourceId) {
+	c.RemoveStatContext(context.Background(), userID, res)
 }
 
 // generates a user specific key pointing to ref - used for statcache

--- a/pkg/storage/cache/stat.go
+++ b/pkg/storage/cache/stat.go
@@ -27,13 +27,17 @@ import (
 	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	"go-micro.dev/v4/store"
+	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	semconv "go.opentelemetry.io/otel/semconv/v1.10.0"
 	"go.opentelemetry.io/otel/trace"
 )
 
-// name is the Tracer name used to identify this instrumentation library.
-const tracerName = "cache"
+var tracer trace.Tracer
+
+func init() {
+	tracer = otel.Tracer("github.com/cs3org/reva/pkg/storage/utils/decomposedfs/lookup")
+}
 
 // NewStatCache creates a new StatCache
 func NewStatCache(store string, nodes []string, database, table string, ttl time.Duration, size int) StatCache {
@@ -50,9 +54,7 @@ type statCache struct {
 }
 
 func (c statCache) RemoveStatContext(ctx context.Context, userID *userpb.UserId, res *provider.ResourceId) {
-	span := trace.SpanFromContext(ctx)
-	tp := span.TracerProvider()
-	_, span = tp.Tracer(tracerName).Start(ctx, "RemoveStatContext")
+	_, span := tracer.Start(ctx, "RemoveStatContext")
 	defer span.End()
 
 	span.SetAttributes(semconv.EnduserIDKey.String(userID.GetOpaqueId()))

--- a/pkg/storage/cache/stat.go
+++ b/pkg/storage/cache/stat.go
@@ -50,7 +50,6 @@ type statCache struct {
 }
 
 func (c statCache) RemoveStatContext(ctx context.Context, userID *userpb.UserId, res *provider.ResourceId) {
-
 	span := trace.SpanFromContext(ctx)
 	tp := span.TracerProvider()
 	_, span = tp.Tracer(tracerName).Start(ctx, "RemoveStatContext")
@@ -61,6 +60,7 @@ func (c statCache) RemoveStatContext(ctx context.Context, userID *userpb.UserId,
 	uid := "uid:" + userID.GetOpaqueId()
 	sid := ""
 	oid := ""
+
 	if res != nil {
 		span.SetAttributes(
 			attribute.String("space.id", res.SpaceId),
@@ -91,7 +91,6 @@ func (c statCache) RemoveStatContext(ctx context.Context, userID *userpb.UserId,
 	}
 
 	wg.Wait()
-
 }
 
 // RemoveStatContext(ctx,  removes a reference from the stat cache

--- a/pkg/storage/utils/decomposedfs/decomposedfs.go
+++ b/pkg/storage/utils/decomposedfs/decomposedfs.go
@@ -256,7 +256,7 @@ func (fs *Decomposedfs) Postprocessing(ch <-chan events.Event) {
 			upload.Cleanup(up, failed, keepUpload)
 
 			// remove cache entry in gateway
-			fs.cache.RemoveStat(ev.ExecutingUser.GetId(), &provider.ResourceId{SpaceId: n.SpaceID, OpaqueId: n.ID})
+			fs.cache.RemoveStatContext(ctx, ev.ExecutingUser.GetId(), &provider.ResourceId{SpaceId: n.SpaceID, OpaqueId: n.ID})
 
 			if err := events.Publish(
 				fs.stream,
@@ -331,7 +331,7 @@ func (fs *Decomposedfs) Postprocessing(ch <-chan events.Event) {
 						}
 
 						// remove cache entry in gateway
-						fs.cache.RemoveStat(ev.ExecutingUser.GetId(), &provider.ResourceId{SpaceId: n.SpaceID, OpaqueId: n.ID})
+						fs.cache.RemoveStatContext(ctx, ev.ExecutingUser.GetId(), &provider.ResourceId{SpaceId: n.SpaceID, OpaqueId: n.ID})
 						continue
 					}
 
@@ -369,7 +369,7 @@ func (fs *Decomposedfs) Postprocessing(ch <-chan events.Event) {
 					}
 
 					// remove cache entry in gateway
-					fs.cache.RemoveStat(ev.ExecutingUser.GetId(), &provider.ResourceId{SpaceId: n.SpaceID, OpaqueId: n.ID})
+					fs.cache.RemoveStatContext(ctx, ev.ExecutingUser.GetId(), &provider.ResourceId{SpaceId: n.SpaceID, OpaqueId: n.ID})
 					continue
 				}
 				*/
@@ -396,7 +396,7 @@ func (fs *Decomposedfs) Postprocessing(ch <-chan events.Event) {
 			}
 
 			// remove cache entry in gateway
-			fs.cache.RemoveStat(ev.ExecutingUser.GetId(), &provider.ResourceId{SpaceId: n.SpaceID, OpaqueId: n.ID})
+			fs.cache.RemoveStatContext(ctx, ev.ExecutingUser.GetId(), &provider.ResourceId{SpaceId: n.SpaceID, OpaqueId: n.ID})
 		default:
 			log.Error().Interface("event", ev).Msg("Unknown event")
 		}
@@ -557,6 +557,9 @@ func (fs *Decomposedfs) GetPathByID(ctx context.Context, id *provider.ResourceId
 
 // CreateDir creates the specified directory
 func (fs *Decomposedfs) CreateDir(ctx context.Context, ref *provider.Reference) (err error) {
+	ctx, span := appctx.GetTracerProvider(ctx).Tracer(tracerName).Start(ctx, "CreateDir")
+	defer span.End()
+
 	name := path.Base(ref.Path)
 	if name == "" || name == "." || name == "/" {
 		return errtypes.BadRequest("Invalid path: " + ref.Path)

--- a/pkg/storage/utils/decomposedfs/grants.go
+++ b/pkg/storage/utils/decomposedfs/grants.go
@@ -135,7 +135,7 @@ func (fs *Decomposedfs) ListGrants(ctx context.Context, ref *provider.Reference)
 	}
 	log := appctx.GetLogger(ctx)
 	var attrs node.Attributes
-	if attrs, err = grantNode.Xattrs(); err != nil {
+	if attrs, err = grantNode.Xattrs(ctx); err != nil {
 		log.Error().Err(err).Msg("error listing attributes")
 		return nil, err
 	}
@@ -208,7 +208,7 @@ func (fs *Decomposedfs) RemoveGrant(ctx context.Context, ref *provider.Reference
 		attr = prefixes.GrantUserAcePrefix + g.Grantee.GetUserId().OpaqueId
 	}
 
-	if err = grantNode.RemoveXattr(attr); err != nil {
+	if err = grantNode.RemoveXattr(ctx, attr); err != nil {
 		return err
 	}
 
@@ -326,7 +326,7 @@ func (fs *Decomposedfs) storeGrant(ctx context.Context, n *node.Node, g *provide
 	// set the grant
 	e := ace.FromGrant(g)
 	principal, value := e.Marshal()
-	if err := n.SetXattr(prefixes.GrantPrefix+principal, value); err != nil {
+	if err := n.SetXattr(ctx, prefixes.GrantPrefix+principal, value); err != nil {
 		appctx.GetLogger(ctx).Error().Err(err).
 			Str("principal", principal).Msg("Could not set grant for principal")
 		return err

--- a/pkg/storage/utils/decomposedfs/grants_test.go
+++ b/pkg/storage/utils/decomposedfs/grants_test.go
@@ -138,7 +138,7 @@ var _ = Describe("Grants", func() {
 					Path:       "/dir1",
 				})
 				Expect(err).ToNot(HaveOccurred())
-				attr, err := n.XattrString(prefixes.GrantUserAcePrefix + grant.Grantee.GetUserId().OpaqueId)
+				attr, err := n.XattrString(env.Ctx, prefixes.GrantUserAcePrefix+grant.Grantee.GetUserId().OpaqueId)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(attr).To(Equal(fmt.Sprintf("\x00t=A:f=:p=rw:c=%s:e=0\n", o.GetOpaqueId()))) // NOTE: this tests ace package
 			})

--- a/pkg/storage/utils/decomposedfs/lookup/lookup.go
+++ b/pkg/storage/utils/decomposedfs/lookup/lookup.go
@@ -36,6 +36,9 @@ import (
 	"github.com/rogpeppe/go-internal/lockedfile"
 )
 
+// name is the Tracer name used to identify this instrumentation library.
+const tracerName = "decomposedfs.lookup"
+
 // Lookup implements transformations from filepath to node and back
 type Lookup struct {
 	Options *options.Options
@@ -108,6 +111,9 @@ func (lu *Lookup) TypeFromPath(path string) provider.ResourceType {
 
 // NodeFromResource takes in a request path or request id and converts it to a Node
 func (lu *Lookup) NodeFromResource(ctx context.Context, ref *provider.Reference) (*node.Node, error) {
+	ctx, span := appctx.GetTracerProvider(ctx).Tracer(tracerName).Start(ctx, "NodeFromResource")
+	defer span.End()
+
 	if ref.ResourceId != nil {
 		// check if a storage space reference is used
 		// currently, the decomposed fs uses the root node id as the space id

--- a/pkg/storage/utils/decomposedfs/lookup/lookup.go
+++ b/pkg/storage/utils/decomposedfs/lookup/lookup.go
@@ -60,8 +60,8 @@ func (lu *Lookup) MetadataBackend() metadata.Backend {
 }
 
 // ReadBlobSizeAttr reads the blobsize from the xattrs
-func (lu *Lookup) ReadBlobSizeAttr(path string) (int64, error) {
-	blobSize, err := lu.metadataBackend.GetInt64(path, prefixes.BlobsizeAttr)
+func (lu *Lookup) ReadBlobSizeAttr(ctx context.Context, path string) (int64, error) {
+	blobSize, err := lu.metadataBackend.GetInt64(ctx, path, prefixes.BlobsizeAttr)
 	if err != nil {
 		return 0, errors.Wrapf(err, "error reading blobsize xattr")
 	}
@@ -69,8 +69,8 @@ func (lu *Lookup) ReadBlobSizeAttr(path string) (int64, error) {
 }
 
 // ReadBlobIDAttr reads the blobsize from the xattrs
-func (lu *Lookup) ReadBlobIDAttr(path string) (string, error) {
-	attr, err := lu.metadataBackend.Get(path, prefixes.BlobIDAttr)
+func (lu *Lookup) ReadBlobIDAttr(ctx context.Context, path string) (string, error) {
+	attr, err := lu.metadataBackend.Get(ctx, path, prefixes.BlobIDAttr)
 	if err != nil {
 		return "", errors.Wrapf(err, "error reading blobid xattr")
 	}
@@ -78,9 +78,9 @@ func (lu *Lookup) ReadBlobIDAttr(path string) (string, error) {
 }
 
 // TypeFromPath returns the type of the node at the given path
-func (lu *Lookup) TypeFromPath(path string) provider.ResourceType {
+func (lu *Lookup) TypeFromPath(ctx context.Context, path string) provider.ResourceType {
 	// Try to read from xattrs
-	typeAttr, err := lu.metadataBackend.GetInt64(path, prefixes.TypeAttr)
+	typeAttr, err := lu.metadataBackend.GetInt64(ctx, path, prefixes.TypeAttr)
 	if err == nil {
 		return provider.ResourceType(int32(typeAttr))
 	}
@@ -94,7 +94,7 @@ func (lu *Lookup) TypeFromPath(path string) provider.ResourceType {
 
 	switch {
 	case fi.IsDir():
-		if _, err = lu.metadataBackend.Get(path, prefixes.ReferenceAttr); err == nil {
+		if _, err = lu.metadataBackend.Get(ctx, path, prefixes.ReferenceAttr); err == nil {
 			t = provider.ResourceType_RESOURCE_TYPE_REFERENCE
 		} else {
 			t = provider.ResourceType_RESOURCE_TYPE_CONTAINER
@@ -142,6 +142,8 @@ func (lu *Lookup) NodeFromResource(ctx context.Context, ref *provider.Reference)
 
 // NodeFromID returns the internal path for the id
 func (lu *Lookup) NodeFromID(ctx context.Context, id *provider.ResourceId) (n *node.Node, err error) {
+	ctx, span := appctx.GetTracerProvider(ctx).Tracer(tracerName).Start(ctx, "NodeFromID")
+	defer span.End()
 	if id == nil {
 		return nil, fmt.Errorf("invalid resource id %+v", id)
 	}
@@ -184,7 +186,7 @@ func (lu *Lookup) Path(ctx context.Context, n *node.Node, hasPermission node.Per
 	root := n.SpaceRoot
 	for n.ID != root.ID {
 		p = filepath.Join(n.Name, p)
-		if n, err = n.Parent(); err != nil {
+		if n, err = n.Parent(ctx); err != nil {
 			appctx.GetLogger(ctx).
 				Error().Err(err).
 				Str("path", p).
@@ -213,7 +215,7 @@ func (lu *Lookup) WalkPath(ctx context.Context, r *node.Node, p string, followRe
 		}
 
 		if followReferences {
-			if attrBytes, err := r.Xattr(prefixes.ReferenceAttr); err == nil {
+			if attrBytes, err := r.Xattr(ctx, prefixes.ReferenceAttr); err == nil {
 				realNodeID := attrBytes
 				ref, err := refFromCS3(realNodeID)
 				if err != nil {
@@ -226,7 +228,7 @@ func (lu *Lookup) WalkPath(ctx context.Context, r *node.Node, p string, followRe
 				}
 			}
 		}
-		if r.IsSpaceRoot() {
+		if r.IsSpaceRoot(ctx) {
 			r.SpaceRoot = r
 		}
 
@@ -274,7 +276,7 @@ func refFromCS3(b []byte) (*provider.Reference, error) {
 // The optional filter function can be used to filter by attribute name, e.g. by checking a prefix
 // For the source file, a shared lock is acquired.
 // NOTE: target resource will be write locked!
-func (lu *Lookup) CopyMetadata(src, target string, filter func(attributeName string) bool) (err error) {
+func (lu *Lookup) CopyMetadata(ctx context.Context, src, target string, filter func(attributeName string) bool) (err error) {
 	// Acquire a read log on the source node
 	// write lock existing node before reading treesize or tree time
 	f, err := lockedfile.Open(lu.MetadataBackend().MetadataPath(src))
@@ -294,14 +296,14 @@ func (lu *Lookup) CopyMetadata(src, target string, filter func(attributeName str
 		}
 	}()
 
-	return lu.CopyMetadataWithSourceLock(src, target, filter, f)
+	return lu.CopyMetadataWithSourceLock(ctx, src, target, filter, f)
 }
 
 // CopyMetadataWithSourceLock copies all extended attributes from source to target.
 // The optional filter function can be used to filter by attribute name, e.g. by checking a prefix
 // For the source file, a matching lockedfile is required.
 // NOTE: target resource will be write locked!
-func (lu *Lookup) CopyMetadataWithSourceLock(sourcePath, targetPath string, filter func(attributeName string) bool, lockedSource *lockedfile.File) (err error) {
+func (lu *Lookup) CopyMetadataWithSourceLock(ctx context.Context, sourcePath, targetPath string, filter func(attributeName string) bool, lockedSource *lockedfile.File) (err error) {
 	switch {
 	case lockedSource == nil:
 		return errors.New("no lock provided")
@@ -309,7 +311,7 @@ func (lu *Lookup) CopyMetadataWithSourceLock(sourcePath, targetPath string, filt
 		return errors.New("lockpath does not match filepath")
 	}
 
-	attrs, err := lu.metadataBackend.AllWithLockedSource(sourcePath, lockedSource)
+	attrs, err := lu.metadataBackend.AllWithLockedSource(ctx, sourcePath, lockedSource)
 	if err != nil {
 		return err
 	}
@@ -321,7 +323,7 @@ func (lu *Lookup) CopyMetadataWithSourceLock(sourcePath, targetPath string, filt
 		}
 	}
 
-	return lu.MetadataBackend().SetMultiple(targetPath, newAttrs, true)
+	return lu.MetadataBackend().SetMultiple(ctx, targetPath, newAttrs, true)
 }
 
 // DetectBackendOnDisk returns the name of the metadata backend being used on disk

--- a/pkg/storage/utils/decomposedfs/lookup/lookup.go
+++ b/pkg/storage/utils/decomposedfs/lookup/lookup.go
@@ -34,10 +34,15 @@ import (
 	"github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/options"
 	"github.com/pkg/errors"
 	"github.com/rogpeppe/go-internal/lockedfile"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/trace"
 )
 
-// name is the Tracer name used to identify this instrumentation library.
-const tracerName = "decomposedfs.lookup"
+var tracer trace.Tracer
+
+func init() {
+	tracer = otel.Tracer("github.com/cs3org/reva/pkg/storage/utils/decomposedfs/lookup")
+}
 
 // Lookup implements transformations from filepath to node and back
 type Lookup struct {
@@ -111,7 +116,7 @@ func (lu *Lookup) TypeFromPath(ctx context.Context, path string) provider.Resour
 
 // NodeFromResource takes in a request path or request id and converts it to a Node
 func (lu *Lookup) NodeFromResource(ctx context.Context, ref *provider.Reference) (*node.Node, error) {
-	ctx, span := appctx.GetTracerProvider(ctx).Tracer(tracerName).Start(ctx, "NodeFromResource")
+	ctx, span := tracer.Start(ctx, "NodeFromResource")
 	defer span.End()
 
 	if ref.ResourceId != nil {
@@ -142,7 +147,7 @@ func (lu *Lookup) NodeFromResource(ctx context.Context, ref *provider.Reference)
 
 // NodeFromID returns the internal path for the id
 func (lu *Lookup) NodeFromID(ctx context.Context, id *provider.ResourceId) (n *node.Node, err error) {
-	ctx, span := appctx.GetTracerProvider(ctx).Tracer(tracerName).Start(ctx, "NodeFromID")
+	ctx, span := tracer.Start(ctx, "NodeFromID")
 	defer span.End()
 	if id == nil {
 		return nil, fmt.Errorf("invalid resource id %+v", id)

--- a/pkg/storage/utils/decomposedfs/metadata.go
+++ b/pkg/storage/utils/decomposedfs/metadata.go
@@ -93,7 +93,7 @@ func (fs *Decomposedfs) SetArbitraryMetadata(ctx context.Context, ref *provider.
 			delete(md.Metadata, node.FavoriteKey)
 			if u, ok := ctxpkg.ContextGetUser(ctx); ok {
 				if uid := u.GetId(); uid != nil {
-					if err := n.SetFavorite(uid, val); err != nil {
+					if err := n.SetFavorite(ctx, uid, val); err != nil {
 						sublog.Error().Err(err).
 							Interface("user", u).
 							Msg("could not set favorite flag")
@@ -111,7 +111,7 @@ func (fs *Decomposedfs) SetArbitraryMetadata(ctx context.Context, ref *provider.
 	}
 	for k, v := range md.Metadata {
 		attrName := prefixes.MetadataPrefix + k
-		if err = n.SetXattrString(attrName, v); err != nil {
+		if err = n.SetXattrString(ctx, attrName, v); err != nil {
 			errs = append(errs, errors.Wrap(err, "Decomposedfs: could not set metadata attribute "+attrName+" to "+k))
 		}
 	}
@@ -184,7 +184,7 @@ func (fs *Decomposedfs) UnsetArbitraryMetadata(ctx context.Context, ref *provide
 				continue
 			}
 			fa := fmt.Sprintf("%s:%s:%s@%s", prefixes.FavPrefix, utils.UserTypeToString(uid.GetType()), uid.GetOpaqueId(), uid.GetIdp())
-			if err := n.RemoveXattr(fa); err != nil {
+			if err := n.RemoveXattr(ctx, fa); err != nil {
 				if metadata.IsAttrUnset(err) {
 					continue // already gone, ignore
 				}
@@ -195,7 +195,7 @@ func (fs *Decomposedfs) UnsetArbitraryMetadata(ctx context.Context, ref *provide
 				errs = append(errs, errors.Wrap(err, "could not unset favorite flag"))
 			}
 		default:
-			if err = n.RemoveXattr(prefixes.MetadataPrefix + k); err != nil {
+			if err = n.RemoveXattr(ctx, prefixes.MetadataPrefix+k); err != nil {
 				if metadata.IsAttrUnset(err) {
 					continue // already gone, ignore
 				}

--- a/pkg/storage/utils/decomposedfs/metadata/messagepack_backend.go
+++ b/pkg/storage/utils/decomposedfs/metadata/messagepack_backend.go
@@ -241,7 +241,9 @@ func (b MessagePackBackend) loadAttributes(ctx context.Context, path string, sou
 				// some of the caller rely on ENOTEXISTS to be returned when the
 				// actual file (not the metafile) does not exist in order to
 				// determine whether a node exists or not -> stat the actual node
+				_, subspan := appctx.GetTracerProvider(ctx).Tracer(tracerName).Start(ctx, "os.Stat")
 				_, err := os.Stat(path)
+				subspan.End()
 				if err != nil {
 					return nil, err
 				}
@@ -251,7 +253,7 @@ func (b MessagePackBackend) loadAttributes(ctx context.Context, path string, sou
 		defer source.(*lockedfile.File).Close()
 	}
 
-	ctx, subspan := appctx.GetTracerProvider(ctx).Tracer(tracerName).Start(ctx, "io.ReadAll")
+	_, subspan := appctx.GetTracerProvider(ctx).Tracer(tracerName).Start(ctx, "io.ReadAll")
 	msgBytes, err := io.ReadAll(source)
 	subspan.End()
 	if err != nil {

--- a/pkg/storage/utils/decomposedfs/metadata/messagepack_backend.go
+++ b/pkg/storage/utils/decomposedfs/metadata/messagepack_backend.go
@@ -53,7 +53,7 @@ type readWriteCloseSeekTruncater interface {
 func NewMessagePackBackend(rootPath string, o cache.Config) MessagePackBackend {
 	return MessagePackBackend{
 		rootPath:  filepath.Clean(rootPath),
-		metaCache: cache.GetFileMetadataCache(o.Store, o.Nodes, o.Database, "filemetadata", time.Duration(o.TTL)*time.Second, o.Size),
+		metaCache: cache.GetFileMetadataCache(o.Store, o.Nodes, o.Database, "filemetadata:", time.Duration(o.TTL)*time.Second, o.Size),
 	}
 }
 

--- a/pkg/storage/utils/decomposedfs/metadata/metadata.go
+++ b/pkg/storage/utils/decomposedfs/metadata/metadata.go
@@ -19,6 +19,7 @@
 package metadata
 
 import (
+	"context"
 	"errors"
 	"io"
 )
@@ -36,6 +37,7 @@ type Backend interface {
 	List(path string) (attribs []string, err error)
 	Set(path, key string, val []byte) error
 	SetMultiple(path string, attribs map[string][]byte, acquireLock bool) error
+	SetMultipleWithContext(ctx context.Context, path string, attribs map[string][]byte, acquireLock bool) error
 	Remove(path, key string) error
 
 	Purge(path string) error
@@ -67,6 +69,11 @@ func (NullBackend) List(path string) ([]string, error) { return nil, errUnconfig
 
 // Set sets one attribute for the given path
 func (NullBackend) Set(path string, key string, val []byte) error { return errUnconfiguredError }
+
+// SetMultipleWithContext sets a set of attribute for the given path
+func (NullBackend) SetMultipleWithContext(ctx context.Context, path string, attribs map[string][]byte, acquireLock bool) error {
+	return errUnconfiguredError
+}
 
 // SetMultiple sets a set of attribute for the given path
 func (NullBackend) SetMultiple(path string, attribs map[string][]byte, acquireLock bool) error {

--- a/pkg/storage/utils/decomposedfs/metadata/metadata.go
+++ b/pkg/storage/utils/decomposedfs/metadata/metadata.go
@@ -30,22 +30,21 @@ var errUnconfiguredError = errors.New("no metadata backend configured. Bailing o
 type Backend interface {
 	Name() string
 
-	All(path string) (map[string][]byte, error)
-	Get(path, key string) ([]byte, error)
+	All(ctx context.Context, path string) (map[string][]byte, error)
+	Get(ctx context.Context, path, key string) ([]byte, error)
 
-	GetInt64(path, key string) (int64, error)
-	List(path string) (attribs []string, err error)
-	Set(path, key string, val []byte) error
-	SetMultiple(path string, attribs map[string][]byte, acquireLock bool) error
-	SetMultipleWithContext(ctx context.Context, path string, attribs map[string][]byte, acquireLock bool) error
-	Remove(path, key string) error
+	GetInt64(ctx context.Context, path, key string) (int64, error)
+	List(ctx context.Context, path string) (attribs []string, err error)
+	Set(ctx context.Context, path, key string, val []byte) error
+	SetMultiple(ctx context.Context, path string, attribs map[string][]byte, acquireLock bool) error
+	Remove(ctx context.Context, path, key string) error
 
 	Purge(path string) error
 	Rename(oldPath, newPath string) error
 	IsMetaFile(path string) bool
 	MetadataPath(path string) string
 
-	AllWithLockedSource(path string, source io.Reader) (map[string][]byte, error)
+	AllWithLockedSource(ctx context.Context, path string, source io.Reader) (map[string][]byte, error)
 }
 
 // NullBackend is the default stub backend, used to enforce the configuration of a proper backend
@@ -55,33 +54,40 @@ type NullBackend struct{}
 func (NullBackend) Name() string { return "null" }
 
 // All reads all extended attributes for a node
-func (NullBackend) All(path string) (map[string][]byte, error) { return nil, errUnconfiguredError }
+func (NullBackend) All(ctx context.Context, path string) (map[string][]byte, error) {
+	return nil, errUnconfiguredError
+}
 
 // Get an extended attribute value for the given key
-func (NullBackend) Get(path, key string) ([]byte, error) { return []byte{}, errUnconfiguredError }
+func (NullBackend) Get(ctx context.Context, path, key string) ([]byte, error) {
+	return []byte{}, errUnconfiguredError
+}
 
 // GetInt64 reads a string as int64 from the xattrs
-func (NullBackend) GetInt64(path, key string) (int64, error) { return 0, errUnconfiguredError }
+func (NullBackend) GetInt64(ctx context.Context, path, key string) (int64, error) {
+	return 0, errUnconfiguredError
+}
 
 // List retrieves a list of names of extended attributes associated with the
 // given path in the file system.
-func (NullBackend) List(path string) ([]string, error) { return nil, errUnconfiguredError }
+func (NullBackend) List(ctx context.Context, path string) ([]string, error) {
+	return nil, errUnconfiguredError
+}
 
 // Set sets one attribute for the given path
-func (NullBackend) Set(path string, key string, val []byte) error { return errUnconfiguredError }
-
-// SetMultipleWithContext sets a set of attribute for the given path
-func (NullBackend) SetMultipleWithContext(ctx context.Context, path string, attribs map[string][]byte, acquireLock bool) error {
+func (NullBackend) Set(ctx context.Context, path string, key string, val []byte) error {
 	return errUnconfiguredError
 }
 
 // SetMultiple sets a set of attribute for the given path
-func (NullBackend) SetMultiple(path string, attribs map[string][]byte, acquireLock bool) error {
+func (NullBackend) SetMultiple(ctx context.Context, path string, attribs map[string][]byte, acquireLock bool) error {
 	return errUnconfiguredError
 }
 
 // Remove removes an extended attribute key
-func (NullBackend) Remove(path string, key string) error { return errUnconfiguredError }
+func (NullBackend) Remove(ctx context.Context, path string, key string) error {
+	return errUnconfiguredError
+}
 
 // IsMetaFile returns whether the given path represents a meta file
 func (NullBackend) IsMetaFile(path string) bool { return false }
@@ -97,6 +103,6 @@ func (NullBackend) MetadataPath(path string) string { return "" }
 
 // AllWithLockedSource reads all extended attributes from the given reader
 // The path argument is used for storing the data in the cache
-func (NullBackend) AllWithLockedSource(path string, source io.Reader) (map[string][]byte, error) {
+func (NullBackend) AllWithLockedSource(ctx context.Context, path string, source io.Reader) (map[string][]byte, error) {
 	return nil, errUnconfiguredError
 }

--- a/pkg/storage/utils/decomposedfs/metadata/metadata.go
+++ b/pkg/storage/utils/decomposedfs/metadata/metadata.go
@@ -22,7 +22,16 @@ import (
 	"context"
 	"errors"
 	"io"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/trace"
 )
+
+var tracer trace.Tracer
+
+func init() {
+	tracer = otel.Tracer("github.com/cs3org/reva/pkg/storage/utils/decomposedfs/metadata")
+}
 
 var errUnconfiguredError = errors.New("no metadata backend configured. Bailing out")
 

--- a/pkg/storage/utils/decomposedfs/metadata/metadata_test.go
+++ b/pkg/storage/utils/decomposedfs/metadata/metadata_test.go
@@ -19,6 +19,7 @@
 package metadata_test
 
 import (
+	"context"
 	"os"
 	"path"
 
@@ -66,43 +67,43 @@ var _ = Describe("Backend", func() {
 		Describe("Set", func() {
 			It("sets an attribute", func() {
 				data := []byte(`bar\`)
-				err := backend.Set(file, "foo", data)
+				err := backend.Set(context.Background(), file, "foo", data)
 				Expect(err).ToNot(HaveOccurred())
 
-				readData, err := backend.Get(file, "foo")
+				readData, err := backend.Get(context.Background(), file, "foo")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(readData).To(Equal(data))
 			})
 
 			It("handles funny strings", func() {
 				data := []byte(`bar\`)
-				err := backend.Set(file, "foo", data)
+				err := backend.Set(context.Background(), file, "foo", data)
 				Expect(err).ToNot(HaveOccurred())
 
-				readData, err := backend.Get(file, "foo")
+				readData, err := backend.Get(context.Background(), file, "foo")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(readData).To(Equal(data))
 			})
 
 			It("updates an attribute", func() {
-				err := backend.Set(file, "foo", []byte("bar"))
+				err := backend.Set(context.Background(), file, "foo", []byte("bar"))
 				Expect(err).ToNot(HaveOccurred())
-				err = backend.Set(file, "foo", []byte("baz"))
+				err = backend.Set(context.Background(), file, "foo", []byte("baz"))
 				Expect(err).ToNot(HaveOccurred())
 
-				readData, err := backend.Get(file, "foo")
+				readData, err := backend.Get(context.Background(), file, "foo")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(readData).To(Equal([]byte("baz")))
 			})
 
 			It("sets an empty attribute", func() {
-				_, err := backend.Get(file, "foo")
+				_, err := backend.Get(context.Background(), file, "foo")
 				Expect(err).To(HaveOccurred())
 
-				err = backend.Set(file, "foo", []byte{})
+				err = backend.Set(context.Background(), file, "foo", []byte{})
 				Expect(err).ToNot(HaveOccurred())
 
-				v, err := backend.Get(file, "foo")
+				v, err := backend.Get(context.Background(), file, "foo")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(v).To(Equal([]byte{}))
 			})
@@ -111,23 +112,23 @@ var _ = Describe("Backend", func() {
 		Describe("SetMultiple", func() {
 			It("sets attributes", func() {
 				data := map[string][]byte{"foo": []byte("bar"), "baz": []byte("qux")}
-				err := backend.SetMultiple(file, data, true)
+				err := backend.SetMultiple(context.Background(), file, data, true)
 				Expect(err).ToNot(HaveOccurred())
 
-				readData, err := backend.All(file)
+				readData, err := backend.All(context.Background(), file)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(readData).To(Equal(data))
 			})
 
 			It("updates an attribute", func() {
-				err := backend.Set(file, "foo", []byte("something"))
+				err := backend.Set(context.Background(), file, "foo", []byte("something"))
 
 				data := map[string][]byte{"foo": []byte("bar"), "baz": []byte("qux")}
 				Expect(err).ToNot(HaveOccurred())
-				err = backend.SetMultiple(file, data, true)
+				err = backend.SetMultiple(context.Background(), file, data, true)
 				Expect(err).ToNot(HaveOccurred())
 
-				readData, err := backend.All(file)
+				readData, err := backend.All(context.Background(), file)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(readData).To(Equal(data))
 			})
@@ -136,10 +137,10 @@ var _ = Describe("Backend", func() {
 		Describe("All", func() {
 			It("returns the entries", func() {
 				data := map[string][]byte{"foo": []byte("123"), "bar": []byte("baz")}
-				err := backend.SetMultiple(file, data, true)
+				err := backend.SetMultiple(context.Background(), file, data, true)
 				Expect(err).ToNot(HaveOccurred())
 
-				v, err := backend.All(file)
+				v, err := backend.All(context.Background(), file)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(len(v)).To(Equal(2))
 				Expect(v["foo"]).To(Equal([]byte("123")))
@@ -147,7 +148,7 @@ var _ = Describe("Backend", func() {
 			})
 
 			It("returns an empty map", func() {
-				v, err := backend.All(file)
+				v, err := backend.All(context.Background(), file)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(v).To(Equal(map[string][]byte{}))
 			})
@@ -156,16 +157,16 @@ var _ = Describe("Backend", func() {
 		Describe("List", func() {
 			It("returns the entries", func() {
 				data := map[string][]byte{"foo": []byte("123"), "bar": []byte("baz")}
-				err := backend.SetMultiple(file, data, true)
+				err := backend.SetMultiple(context.Background(), file, data, true)
 				Expect(err).ToNot(HaveOccurred())
 
-				v, err := backend.List(file)
+				v, err := backend.List(context.Background(), file)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(v).To(ConsistOf("foo", "bar"))
 			})
 
 			It("returns an empty list", func() {
-				v, err := backend.List(file)
+				v, err := backend.List(context.Background(), file)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(v).To(Equal([]string{}))
 			})
@@ -174,16 +175,16 @@ var _ = Describe("Backend", func() {
 		Describe("Get", func() {
 			It("returns the attribute", func() {
 				data := map[string][]byte{"foo": []byte("bar")}
-				err := backend.SetMultiple(file, data, true)
+				err := backend.SetMultiple(context.Background(), file, data, true)
 				Expect(err).ToNot(HaveOccurred())
 
-				v, err := backend.Get(file, "foo")
+				v, err := backend.Get(context.Background(), file, "foo")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(v).To(Equal([]byte("bar")))
 			})
 
 			It("returns an error on unknown attributes", func() {
-				_, err := backend.Get(file, "foo")
+				_, err := backend.Get(context.Background(), file, "foo")
 				Expect(err).To(HaveOccurred())
 			})
 		})
@@ -191,16 +192,16 @@ var _ = Describe("Backend", func() {
 		Describe("GetInt64", func() {
 			It("returns the attribute", func() {
 				data := map[string][]byte{"foo": []byte("123")}
-				err := backend.SetMultiple(file, data, true)
+				err := backend.SetMultiple(context.Background(), file, data, true)
 				Expect(err).ToNot(HaveOccurred())
 
-				v, err := backend.GetInt64(file, "foo")
+				v, err := backend.GetInt64(context.Background(), file, "foo")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(v).To(Equal(int64(123)))
 			})
 
 			It("returns an error on unknown attributes", func() {
-				_, err := backend.GetInt64(file, "foo")
+				_, err := backend.GetInt64(context.Background(), file, "foo")
 				Expect(err).To(HaveOccurred())
 			})
 		})
@@ -208,17 +209,17 @@ var _ = Describe("Backend", func() {
 		Describe("Remove", func() {
 			It("deletes an attribute", func() {
 				data := map[string][]byte{"foo": []byte("bar")}
-				err := backend.SetMultiple(file, data, true)
+				err := backend.SetMultiple(context.Background(), file, data, true)
 				Expect(err).ToNot(HaveOccurred())
 
-				v, err := backend.Get(file, "foo")
+				v, err := backend.Get(context.Background(), file, "foo")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(v).To(Equal([]byte("bar")))
 
-				err = backend.Remove(file, "foo")
+				err = backend.Remove(context.Background(), file, "foo")
 				Expect(err).ToNot(HaveOccurred())
 
-				_, err = backend.Get(file, "foo")
+				_, err = backend.Get(context.Background(), file, "foo")
 				Expect(err).To(HaveOccurred())
 			})
 		})

--- a/pkg/storage/utils/decomposedfs/metadata/xattrs_backend.go
+++ b/pkg/storage/utils/decomposedfs/metadata/xattrs_backend.go
@@ -19,6 +19,7 @@
 package metadata
 
 import (
+	"context"
 	"io"
 	"os"
 	"path/filepath"
@@ -110,8 +111,12 @@ func (b XattrsBackend) Set(path string, key string, val []byte) (err error) {
 	return b.SetMultiple(path, map[string][]byte{key: val}, true)
 }
 
+func (b XattrsBackend) SetMultiple(path string, attribs map[string][]byte, acquireLock bool) (err error) {
+	return b.SetMultipleWithContext(context.Background(), path, attribs, acquireLock)
+}
+
 // SetMultiple sets a set of attribute for the given path
-func (XattrsBackend) SetMultiple(path string, attribs map[string][]byte, acquireLock bool) (err error) {
+func (XattrsBackend) SetMultipleWithContext(ctx context.Context, path string, attribs map[string][]byte, acquireLock bool) (err error) {
 	if acquireLock {
 		err := os.MkdirAll(filepath.Dir(path), 0600)
 		if err != nil {

--- a/pkg/storage/utils/decomposedfs/migrator/0001_create_spaces_directory_structure.go
+++ b/pkg/storage/utils/decomposedfs/migrator/0001_create_spaces_directory_structure.go
@@ -19,6 +19,7 @@
 package migrator
 
 import (
+	"context"
 	"errors"
 	"os"
 	"path/filepath"
@@ -48,7 +49,7 @@ func (m *Migrator) Migration0001() (Result, error) {
 		for _, n := range nodes {
 			nodePath := filepath.Join(nodesPath, n.Name())
 
-			attr, err := m.lu.MetadataBackend().Get(nodePath, prefixes.ParentidAttr)
+			attr, err := m.lu.MetadataBackend().Get(context.Background(), nodePath, prefixes.ParentidAttr)
 			if err == nil && string(attr) == node.RootID {
 				if err := m.moveNode(n.Name(), n.Name()); err != nil {
 					m.log.Error().Err(err).

--- a/pkg/storage/utils/decomposedfs/migrator/0003_switch_to_messagepack_metadata.go
+++ b/pkg/storage/utils/decomposedfs/migrator/0003_switch_to_messagepack_metadata.go
@@ -19,6 +19,7 @@
 package migrator
 
 import (
+	"context"
 	"errors"
 	"io/fs"
 	"os"
@@ -74,7 +75,7 @@ func (m *Migrator) Migration0003() (Result, error) {
 				return nil
 			}
 
-			attribs, err := xattrs.All(path)
+			attribs, err := xattrs.All(context.Background(), path)
 			if err != nil {
 				m.log.Error().Err(err).Str("path", path).Msg("error converting file")
 				return err
@@ -83,14 +84,14 @@ func (m *Migrator) Migration0003() (Result, error) {
 				return nil
 			}
 
-			err = mpk.SetMultiple(path, attribs, false)
+			err = mpk.SetMultiple(context.Background(), path, attribs, false)
 			if err != nil {
 				m.log.Error().Err(err).Str("path", path).Msg("error setting attributes")
 				return err
 			}
 
 			for k := range attribs {
-				err = xattrs.Remove(path, k)
+				err = xattrs.Remove(context.Background(), path, k)
 				if err != nil {
 					m.log.Debug().Err(err).Str("path", path).Msg("error removing xattr")
 				}

--- a/pkg/storage/utils/decomposedfs/migrator/migrator_test.go
+++ b/pkg/storage/utils/decomposedfs/migrator/migrator_test.go
@@ -1,6 +1,7 @@
 package migrator_test
 
 import (
+	"context"
 	"io"
 	"os"
 
@@ -101,7 +102,7 @@ var _ = Describe("Migrator", func() {
 
 				_, err = os.Stat(path + ".mpk")
 				Expect(err).ToNot(HaveOccurred())
-				nameAttr, err = backend.Get(path, prefixes.NameAttr)
+				nameAttr, err = backend.Get(context.Background(), path, prefixes.NameAttr)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(string(nameAttr)).To(Equal("file1"))
 			})

--- a/pkg/storage/utils/decomposedfs/node/locks.go
+++ b/pkg/storage/utils/decomposedfs/node/locks.go
@@ -255,7 +255,7 @@ func (n *Node) Unlock(ctx context.Context, lock *provider.Lock) error {
 
 // CheckLock compares the context lock with the node lock
 func (n *Node) CheckLock(ctx context.Context) error {
-	ctx, span := appctx.GetTracerProvider(ctx).Tracer(tracerName).Start(ctx, "CheckLock")
+	ctx, span := tracer.Start(ctx, "CheckLock")
 	defer span.End()
 	contextLock, _ := ctxpkg.ContextGetLockID(ctx)
 	diskLock, _ := n.ReadLock(ctx, false)

--- a/pkg/storage/utils/decomposedfs/node/locks.go
+++ b/pkg/storage/utils/decomposedfs/node/locks.go
@@ -255,6 +255,8 @@ func (n *Node) Unlock(ctx context.Context, lock *provider.Lock) error {
 
 // CheckLock compares the context lock with the node lock
 func (n *Node) CheckLock(ctx context.Context) error {
+	ctx, span := appctx.GetTracerProvider(ctx).Tracer(tracerName).Start(ctx, "CheckLock")
+	defer span.End()
 	contextLock, _ := ctxpkg.ContextGetLockID(ctx)
 	diskLock, _ := n.ReadLock(ctx, false)
 	if diskLock != nil {

--- a/pkg/storage/utils/decomposedfs/node/node.go
+++ b/pkg/storage/utils/decomposedfs/node/node.go
@@ -48,10 +48,15 @@ import (
 	"github.com/cs3org/reva/v2/pkg/utils"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/trace"
 )
 
-// name is the Tracer name used to identify this instrumentation library.
-const tracerName = "decomposedfs.node"
+var tracer trace.Tracer
+
+func init() {
+	tracer = otel.Tracer("github.com/cs3org/reva/pkg/storage/utils/decomposedfs/node")
+}
 
 // Define keys and values used in the node metadata
 const (
@@ -209,7 +214,7 @@ func (n *Node) SpaceOwnerOrManager(ctx context.Context) *userpb.UserId {
 
 // ReadNode creates a new instance from an id and checks if it exists
 func ReadNode(ctx context.Context, lu PathLookup, spaceID, nodeID string, canListDisabledSpace bool, spaceRoot *Node, skipParentCheck bool) (*Node, error) {
-	ctx, span := appctx.GetTracerProvider(ctx).Tracer(tracerName).Start(ctx, "ReadNode")
+	ctx, span := tracer.Start(ctx, "ReadNode")
 	defer span.End()
 	var err error
 
@@ -347,7 +352,7 @@ func readChildNodeFromLink(path string) (string, error) {
 
 // Child returns the child node with the given name
 func (n *Node) Child(ctx context.Context, name string) (*Node, error) {
-	ctx, span := appctx.GetTracerProvider(ctx).Tracer(tracerName).Start(ctx, "Child")
+	ctx, span := tracer.Start(ctx, "Child")
 	defer span.End()
 
 	spaceID := n.SpaceID
@@ -927,7 +932,7 @@ func (n *Node) IsDisabled(ctx context.Context) bool {
 
 // GetTreeSize reads the treesize from the extended attributes
 func (n *Node) GetTreeSize(ctx context.Context) (treesize uint64, err error) {
-	ctx, span := appctx.GetTracerProvider(ctx).Tracer(tracerName).Start(ctx, "GetTreeSize")
+	ctx, span := tracer.Start(ctx, "GetTreeSize")
 	defer span.End()
 	s, err := n.XattrUint64(ctx, prefixes.TreesizeAttr)
 	if err != nil {

--- a/pkg/storage/utils/decomposedfs/node/node.go
+++ b/pkg/storage/utils/decomposedfs/node/node.go
@@ -100,8 +100,8 @@ type PathLookup interface {
 	InternalPath(spaceID, nodeID string) string
 	Path(ctx context.Context, n *Node, hasPermission PermissionFunc) (path string, err error)
 	MetadataBackend() metadata.Backend
-	ReadBlobSizeAttr(path string) (int64, error)
-	ReadBlobIDAttr(path string) (string, error)
+	ReadBlobSizeAttr(ctx context.Context, path string) (int64, error)
+	ReadBlobIDAttr(ctx context.Context, path string) (string, error)
 }
 
 // New returns a new instance of Node
@@ -123,7 +123,7 @@ func New(spaceID, id, parentID, name string, blobsize int64, blobID string, t pr
 }
 
 // Type returns the node's resource type
-func (n *Node) Type() provider.ResourceType {
+func (n *Node) Type(ctx context.Context) provider.ResourceType {
 	if n.nodeType != nil {
 		return *n.nodeType
 	}
@@ -131,7 +131,7 @@ func (n *Node) Type() provider.ResourceType {
 	t := provider.ResourceType_RESOURCE_TYPE_INVALID
 
 	// Try to read from xattrs
-	typeAttr, err := n.XattrInt32(prefixes.TypeAttr)
+	typeAttr, err := n.XattrInt32(ctx, prefixes.TypeAttr)
 	if err == nil {
 		t = provider.ResourceType(typeAttr)
 		n.nodeType = &t
@@ -146,7 +146,7 @@ func (n *Node) Type() provider.ResourceType {
 
 	switch {
 	case fi.IsDir():
-		if _, err = n.Xattr(prefixes.ReferenceAttr); err == nil {
+		if _, err = n.Xattr(ctx, prefixes.ReferenceAttr); err == nil {
 			t = provider.ResourceType_RESOURCE_TYPE_REFERENCE
 		} else {
 			t = provider.ResourceType_RESOURCE_TYPE_CONTAINER
@@ -168,12 +168,12 @@ func (n *Node) SetType(t provider.ResourceType) {
 }
 
 // NodeMetadata writes the Node metadata to disk and allows passing additional attributes
-func (n *Node) NodeMetadata() Attributes {
+func (n *Node) NodeMetadata(ctx context.Context) Attributes {
 	attribs := Attributes{}
-	attribs.SetInt64(prefixes.TypeAttr, int64(n.Type()))
+	attribs.SetInt64(prefixes.TypeAttr, int64(n.Type(ctx)))
 	attribs.SetString(prefixes.ParentidAttr, n.ParentID)
 	attribs.SetString(prefixes.NameAttr, n.Name)
-	if n.Type() == provider.ResourceType_RESOURCE_TYPE_FILE {
+	if n.Type(ctx) == provider.ResourceType_RESOURCE_TYPE_FILE {
 		attribs.SetString(prefixes.BlobIDAttr, n.BlobID)
 		attribs.SetInt64(prefixes.BlobsizeAttr, n.Blobsize)
 	}
@@ -209,6 +209,8 @@ func (n *Node) SpaceOwnerOrManager(ctx context.Context) *userpb.UserId {
 
 // ReadNode creates a new instance from an id and checks if it exists
 func ReadNode(ctx context.Context, lu PathLookup, spaceID, nodeID string, canListDisabledSpace bool, spaceRoot *Node, skipParentCheck bool) (*Node, error) {
+	ctx, span := appctx.GetTracerProvider(ctx).Tracer(tracerName).Start(ctx, "ReadNode")
+	defer span.End()
 	var err error
 
 	if spaceRoot == nil {
@@ -219,7 +221,7 @@ func ReadNode(ctx context.Context, lu PathLookup, spaceID, nodeID string, canLis
 			ID:      spaceID,
 		}
 		spaceRoot.SpaceRoot = spaceRoot
-		spaceRoot.owner, err = spaceRoot.readOwner()
+		spaceRoot.owner, err = spaceRoot.readOwner(ctx)
 		switch {
 		case metadata.IsNotExist(err):
 			return spaceRoot, nil // swallow not found, the node defaults to exists = false
@@ -229,14 +231,14 @@ func ReadNode(ctx context.Context, lu PathLookup, spaceID, nodeID string, canLis
 		spaceRoot.Exists = true
 
 		// lookup name in extended attributes
-		spaceRoot.Name, err = spaceRoot.XattrString(prefixes.NameAttr)
+		spaceRoot.Name, err = spaceRoot.XattrString(ctx, prefixes.NameAttr)
 		if err != nil {
 			return nil, err
 		}
 	}
 
 	// TODO ReadNode should not check permissions
-	if !canListDisabledSpace && spaceRoot.IsDisabled() {
+	if !canListDisabledSpace && spaceRoot.IsDisabled(ctx) {
 		// no permission = not found
 		return nil, errtypes.NotFound(spaceID)
 	}
@@ -279,7 +281,7 @@ func ReadNode(ctx context.Context, lu PathLookup, spaceID, nodeID string, canLis
 		}
 	}()
 
-	attrs, err := n.Xattrs()
+	attrs, err := n.Xattrs(ctx)
 	switch {
 	case metadata.IsNotExist(err):
 		return n, nil // swallow not found, the node defaults to exists = false
@@ -308,13 +310,13 @@ func ReadNode(ctx context.Context, lu PathLookup, spaceID, nodeID string, canLis
 			n.Blobsize = blobSize
 		}
 	} else {
-		n.BlobID, err = lu.ReadBlobIDAttr(nodePath + revisionSuffix)
+		n.BlobID, err = lu.ReadBlobIDAttr(ctx, nodePath+revisionSuffix)
 		if err != nil {
 			return nil, err
 		}
 
 		// Lookup blobsize
-		n.Blobsize, err = lu.ReadBlobSizeAttr(nodePath + revisionSuffix)
+		n.Blobsize, err = lu.ReadBlobSizeAttr(ctx, nodePath+revisionSuffix)
 		if err != nil {
 			return nil, err
 		}
@@ -381,7 +383,7 @@ func (n *Node) Child(ctx context.Context, name string) (*Node, error) {
 }
 
 // ParentWithReader returns the parent node
-func (n *Node) ParentWithReader(r io.Reader) (*Node, error) {
+func (n *Node) ParentWithReader(ctx context.Context, r io.Reader) (*Node, error) {
 	if n.ParentID == "" {
 		return nil, fmt.Errorf("decomposedfs: root has no parent")
 	}
@@ -393,7 +395,7 @@ func (n *Node) ParentWithReader(r io.Reader) (*Node, error) {
 	}
 
 	// fill metadata cache using the reader
-	attrs, err := p.XattrsWithReader(r)
+	attrs, err := p.XattrsWithReader(ctx, r)
 	switch {
 	case metadata.IsNotExist(err):
 		return p, nil // swallow not found, the node defaults to exists = false
@@ -409,8 +411,8 @@ func (n *Node) ParentWithReader(r io.Reader) (*Node, error) {
 }
 
 // Parent returns the parent node
-func (n *Node) Parent() (p *Node, err error) {
-	return n.ParentWithReader(nil)
+func (n *Node) Parent(ctx context.Context) (p *Node, err error) {
+	return n.ParentWithReader(ctx, nil)
 }
 
 // Owner returns the space owner
@@ -420,14 +422,14 @@ func (n *Node) Owner() *userpb.UserId {
 
 // readOwner reads the owner from the extended attributes of the space root
 // in case either owner id or owner idp are unset we return an error and an empty owner object
-func (n *Node) readOwner() (*userpb.UserId, error) {
+func (n *Node) readOwner(ctx context.Context) (*userpb.UserId, error) {
 	owner := &userpb.UserId{}
 
 	// lookup parent id in extended attributes
 	var attr string
 	var err error
 	// lookup ID in extended attributes
-	attr, err = n.SpaceRoot.XattrString(prefixes.OwnerIDAttr)
+	attr, err = n.SpaceRoot.XattrString(ctx, prefixes.OwnerIDAttr)
 	switch {
 	case err == nil:
 		owner.OpaqueId = attr
@@ -438,7 +440,7 @@ func (n *Node) readOwner() (*userpb.UserId, error) {
 	}
 
 	// lookup IDP in extended attributes
-	attr, err = n.SpaceRoot.XattrString(prefixes.OwnerIDPAttr)
+	attr, err = n.SpaceRoot.XattrString(ctx, prefixes.OwnerIDPAttr)
 	switch {
 	case err == nil:
 		owner.Idp = attr
@@ -449,7 +451,7 @@ func (n *Node) readOwner() (*userpb.UserId, error) {
 	}
 
 	// lookup type in extended attributes
-	attr, err = n.SpaceRoot.XattrString(prefixes.OwnerTypeAttr)
+	attr, err = n.SpaceRoot.XattrString(ctx, prefixes.OwnerTypeAttr)
 	switch {
 	case err == nil:
 		owner.Type = utils.UserTypeMap(attr)
@@ -544,7 +546,7 @@ func (n *Node) SetMtime(mtime time.Time) error {
 func (n *Node) SetEtag(ctx context.Context, val string) (err error) {
 	sublog := appctx.GetLogger(ctx).With().Interface("node", n).Logger()
 	var tmTime time.Time
-	if tmTime, err = n.GetTMTime(); err != nil {
+	if tmTime, err = n.GetTMTime(ctx); err != nil {
 		return
 	}
 	var etag string
@@ -561,7 +563,7 @@ func (n *Node) SetEtag(ctx context.Context, val string) (err error) {
 		return nil
 	}
 	// etag is only valid until the calculated etag changes, is part of propagation
-	return n.SetXattrString(prefixes.TmpEtagAttr, val)
+	return n.SetXattrString(ctx, prefixes.TmpEtagAttr, val)
 }
 
 // SetFavorite sets the favorite for the current user
@@ -581,15 +583,15 @@ func (n *Node) SetEtag(ctx context.Context, val string) (err error) {
 // 5. app? = a:<aid>: for apps?
 // obviously this only is secure when the u/s/g/a namespaces are not accessible by users in the filesystem
 // public tags can be mapped to extended attributes
-func (n *Node) SetFavorite(uid *userpb.UserId, val string) error {
+func (n *Node) SetFavorite(ctx context.Context, uid *userpb.UserId, val string) error {
 	// the favorite flag is specific to the user, so we need to incorporate the userid
 	fa := fmt.Sprintf("%s:%s:%s@%s", prefixes.FavPrefix, utils.UserTypeToString(uid.GetType()), uid.GetOpaqueId(), uid.GetIdp())
-	return n.SetXattrString(fa, val)
+	return n.SetXattrString(ctx, fa, val)
 }
 
 // IsDir returns true if the node is a directory
-func (n *Node) IsDir() bool {
-	attr, _ := n.XattrInt32(prefixes.TypeAttr)
+func (n *Node) IsDir(ctx context.Context) bool {
+	attr, _ := n.XattrInt32(ctx, prefixes.TypeAttr)
 	return attr == int32(provider.ResourceType_RESOURCE_TYPE_CONTAINER)
 }
 
@@ -598,17 +600,17 @@ func (n *Node) AsResourceInfo(ctx context.Context, rp *provider.ResourcePermissi
 	sublog := appctx.GetLogger(ctx).With().Interface("node", n.ID).Logger()
 
 	var fn string
-	nodeType := n.Type()
+	nodeType := n.Type(ctx)
 
 	var target string
 	if nodeType == provider.ResourceType_RESOURCE_TYPE_REFERENCE {
-		target, _ = n.XattrString(prefixes.ReferenceAttr)
+		target, _ = n.XattrString(ctx, prefixes.ReferenceAttr)
 	}
 
 	id := &provider.ResourceId{SpaceId: n.SpaceID, OpaqueId: n.ID}
 
 	switch {
-	case n.IsSpaceRoot():
+	case n.IsSpaceRoot(ctx):
 		fn = "." // space roots do not have a path as they are referencing themselves
 	case returnBasename:
 		fn = n.Name
@@ -635,12 +637,12 @@ func (n *Node) AsResourceInfo(ctx context.Context, rp *provider.ResourcePermissi
 		Name: n.Name,
 	}
 
-	if n.IsProcessing() {
+	if n.IsProcessing(ctx) {
 		ri.Opaque = utils.AppendPlainToOpaque(ri.Opaque, "status", "processing")
 	}
 
 	if nodeType == provider.ResourceType_RESOURCE_TYPE_CONTAINER {
-		ts, err := n.GetTreeSize()
+		ts, err := n.GetTreeSize(ctx)
 		if err == nil {
 			ri.Size = ts
 		} else {
@@ -652,12 +654,12 @@ func (n *Node) AsResourceInfo(ctx context.Context, rp *provider.ResourcePermissi
 	// TODO make etag of files use fileid and checksum
 
 	var tmTime time.Time
-	if tmTime, err = n.GetTMTime(); err != nil {
+	if tmTime, err = n.GetTMTime(ctx); err != nil {
 		sublog.Debug().Err(err).Msg("could not get tmtime")
 	}
 
 	// use temporary etag if it is set
-	if b, err := n.XattrString(prefixes.TmpEtagAttr); err == nil && b != "" {
+	if b, err := n.XattrString(ctx, prefixes.TmpEtagAttr); err == nil && b != "" {
 		ri.Etag = fmt.Sprintf(`"%x"`, b)
 	} else if ri.Etag, err = calculateEtag(n.ID, tmTime); err != nil {
 		sublog.Debug().Err(err).Msg("could not calculate etag")
@@ -700,7 +702,7 @@ func (n *Node) AsResourceInfo(ctx context.Context, rp *provider.ResourcePermissi
 			// the favorite flag is specific to the user, so we need to incorporate the userid
 			if uid := u.GetId(); uid != nil {
 				fa := fmt.Sprintf("%s:%s:%s@%s", prefixes.FavPrefix, utils.UserTypeToString(uid.GetType()), uid.GetOpaqueId(), uid.GetIdp())
-				if val, err := n.XattrString(fa); err == nil {
+				if val, err := n.XattrString(ctx, fa); err == nil {
 					sublog.Debug().
 						Str("favorite", fa).
 						Msg("found favorite flag")
@@ -762,7 +764,7 @@ func (n *Node) AsResourceInfo(ctx context.Context, rp *provider.ResourcePermissi
 	}
 
 	// only read the requested metadata attributes
-	attrs, err := n.Xattrs()
+	attrs, err := n.Xattrs(ctx)
 	if err != nil {
 		sublog.Error().Err(err).Msg("error getting list of extended attributes")
 	} else {
@@ -784,7 +786,7 @@ func (n *Node) AsResourceInfo(ctx context.Context, rp *provider.ResourcePermissi
 	}
 
 	// add virusscan information
-	if scanned, _, date := n.ScanData(); scanned {
+	if scanned, _, date := n.ScanData(ctx); scanned {
 		ri.Opaque = utils.AppendPlainToOpaque(ri.Opaque, "scantime", date.Format(time.RFC3339Nano))
 	}
 
@@ -796,7 +798,7 @@ func (n *Node) AsResourceInfo(ctx context.Context, rp *provider.ResourcePermissi
 }
 
 func (n *Node) readChecksumIntoResourceChecksum(ctx context.Context, algo string, ri *provider.ResourceInfo) {
-	v, err := n.Xattr(prefixes.ChecksumPrefix + algo)
+	v, err := n.Xattr(ctx, prefixes.ChecksumPrefix+algo)
 	switch {
 	case err == nil:
 		ri.Checksum = &provider.ResourceChecksum{
@@ -811,7 +813,7 @@ func (n *Node) readChecksumIntoResourceChecksum(ctx context.Context, algo string
 }
 
 func (n *Node) readChecksumIntoOpaque(ctx context.Context, algo string, ri *provider.ResourceInfo) {
-	v, err := n.Xattr(prefixes.ChecksumPrefix + algo)
+	v, err := n.Xattr(ctx, prefixes.ChecksumPrefix+algo)
 	switch {
 	case err == nil:
 		if ri.Opaque == nil {
@@ -832,7 +834,7 @@ func (n *Node) readChecksumIntoOpaque(ctx context.Context, algo string, ri *prov
 
 // quota is always stored on the root node
 func (n *Node) readQuotaIntoOpaque(ctx context.Context, ri *provider.ResourceInfo) {
-	v, err := n.XattrString(prefixes.QuotaAttr)
+	v, err := n.XattrString(ctx, prefixes.QuotaAttr)
 	switch {
 	case err == nil:
 		// make sure we have a proper signed int
@@ -861,16 +863,16 @@ func (n *Node) readQuotaIntoOpaque(ctx context.Context, ri *provider.ResourceInf
 }
 
 // HasPropagation checks if the propagation attribute exists and is set to "1"
-func (n *Node) HasPropagation() (propagation bool) {
-	if b, err := n.XattrString(prefixes.PropagationAttr); err == nil {
+func (n *Node) HasPropagation(ctx context.Context) (propagation bool) {
+	if b, err := n.XattrString(ctx, prefixes.PropagationAttr); err == nil {
 		return b == "1"
 	}
 	return false
 }
 
 // GetTMTime reads the tmtime from the extended attributes, falling back to GetMTime()
-func (n *Node) GetTMTime() (time.Time, error) {
-	b, err := n.XattrString(prefixes.TreeMTimeAttr)
+func (n *Node) GetTMTime(ctx context.Context) (time.Time, error) {
+	b, err := n.XattrString(ctx, prefixes.TreeMTimeAttr)
 	if err == nil {
 		return time.Parse(time.RFC3339Nano, b)
 	}
@@ -889,16 +891,16 @@ func (n *Node) GetMTime() (time.Time, error) {
 }
 
 // SetTMTime writes the UTC tmtime to the extended attributes or removes the attribute if nil is passed
-func (n *Node) SetTMTime(t *time.Time) (err error) {
+func (n *Node) SetTMTime(ctx context.Context, t *time.Time) (err error) {
 	if t == nil {
-		return n.RemoveXattr(prefixes.TreeMTimeAttr)
+		return n.RemoveXattr(ctx, prefixes.TreeMTimeAttr)
 	}
-	return n.SetXattrString(prefixes.TreeMTimeAttr, t.UTC().Format(time.RFC3339Nano))
+	return n.SetXattrString(ctx, prefixes.TreeMTimeAttr, t.UTC().Format(time.RFC3339Nano))
 }
 
 // GetDTime reads the dtime from the extended attributes
-func (n *Node) GetDTime() (tmTime time.Time, err error) {
-	b, err := n.XattrString(prefixes.DTimeAttr)
+func (n *Node) GetDTime(ctx context.Context) (tmTime time.Time, err error) {
+	b, err := n.XattrString(ctx, prefixes.DTimeAttr)
 	if err != nil {
 		return time.Time{}, err
 	}
@@ -906,25 +908,27 @@ func (n *Node) GetDTime() (tmTime time.Time, err error) {
 }
 
 // SetDTime writes the UTC dtime to the extended attributes or removes the attribute if nil is passed
-func (n *Node) SetDTime(t *time.Time) (err error) {
+func (n *Node) SetDTime(ctx context.Context, t *time.Time) (err error) {
 	if t == nil {
-		return n.RemoveXattr(prefixes.DTimeAttr)
+		return n.RemoveXattr(ctx, prefixes.DTimeAttr)
 	}
-	return n.SetXattrString(prefixes.DTimeAttr, t.UTC().Format(time.RFC3339Nano))
+	return n.SetXattrString(ctx, prefixes.DTimeAttr, t.UTC().Format(time.RFC3339Nano))
 }
 
 // IsDisabled returns true when the node has a dmtime attribute set
 // only used to check if a space is disabled
 // FIXME confusing with the trash logic
-func (n *Node) IsDisabled() bool {
-	if _, err := n.GetDTime(); err == nil {
+func (n *Node) IsDisabled(ctx context.Context) bool {
+	if _, err := n.GetDTime(ctx); err == nil {
 		return true
 	}
 	return false
 }
 
 // GetTreeSize reads the treesize from the extended attributes
-func (n *Node) GetTreeSize() (treesize uint64, err error) {
+func (n *Node) GetTreeSize(ctx context.Context) (treesize uint64, err error) {
+	ctx, span := appctx.GetTracerProvider(ctx).Tracer(tracerName).Start(ctx, "GetTreeSize")
+	defer span.End()
 	s, err := n.XattrUint64(prefixes.TreesizeAttr)
 	if err != nil {
 		return 0, err
@@ -933,13 +937,13 @@ func (n *Node) GetTreeSize() (treesize uint64, err error) {
 }
 
 // SetTreeSize writes the treesize to the extended attributes
-func (n *Node) SetTreeSize(ts uint64) (err error) {
-	return n.SetXattrString(prefixes.TreesizeAttr, strconv.FormatUint(ts, 10))
+func (n *Node) SetTreeSize(ctx context.Context, ts uint64) (err error) {
+	return n.SetXattrString(ctx, prefixes.TreesizeAttr, strconv.FormatUint(ts, 10))
 }
 
 // GetBlobSize reads the blobsize from the extended attributes
-func (n *Node) GetBlobSize() (treesize uint64, err error) {
-	s, err := n.XattrInt64(prefixes.BlobsizeAttr)
+func (n *Node) GetBlobSize(ctx context.Context) (treesize uint64, err error) {
+	s, err := n.XattrInt64(ctx, prefixes.BlobsizeAttr)
 	if err != nil {
 		return 0, err
 	}
@@ -947,13 +951,13 @@ func (n *Node) GetBlobSize() (treesize uint64, err error) {
 }
 
 // SetChecksum writes the checksum with the given checksum type to the extended attributes
-func (n *Node) SetChecksum(csType string, h hash.Hash) (err error) {
-	return n.SetXattr(prefixes.ChecksumPrefix+csType, h.Sum(nil))
+func (n *Node) SetChecksum(ctx context.Context, csType string, h hash.Hash) (err error) {
+	return n.SetXattr(ctx, prefixes.ChecksumPrefix+csType, h.Sum(nil))
 }
 
 // UnsetTempEtag removes the temporary etag attribute
-func (n *Node) UnsetTempEtag() (err error) {
-	return n.RemoveXattr(prefixes.TmpEtagAttr)
+func (n *Node) UnsetTempEtag(ctx context.Context) (err error) {
+	return n.RemoveXattr(ctx, prefixes.TmpEtagAttr)
 }
 
 // ReadUserPermissions will assemble the permissions for the current user on the given node without parent nodes
@@ -1076,7 +1080,7 @@ func (n *Node) IsDenied(ctx context.Context) bool {
 // We don't want to wast time and memory by creating grantee objects.
 // The function will return a list of opaque strings that can be used to make a ReadGrant call
 func (n *Node) ListGrantees(ctx context.Context) (grantees []string, err error) {
-	attrs, err := n.Xattrs()
+	attrs, err := n.Xattrs(ctx)
 	if err != nil {
 		appctx.GetLogger(ctx).Error().Err(err).Str("node", n.ID).Msg("error listing attributes")
 		return nil, err
@@ -1091,7 +1095,7 @@ func (n *Node) ListGrantees(ctx context.Context) (grantees []string, err error) 
 
 // ReadGrant reads a CS3 grant
 func (n *Node) ReadGrant(ctx context.Context, grantee string) (g *provider.Grant, err error) {
-	xattr, err := n.Xattr(grantee)
+	xattr, err := n.Xattr(ctx, grantee)
 	if err != nil {
 		return nil, err
 	}
@@ -1163,7 +1167,7 @@ func parseMTime(v string) (t time.Time, err error) {
 
 // FindStorageSpaceRoot calls n.Parent() and climbs the tree
 // until it finds the space root node and adds it to the node
-func (n *Node) FindStorageSpaceRoot() error {
+func (n *Node) FindStorageSpaceRoot(ctx context.Context) error {
 	if n.SpaceRoot != nil {
 		return nil
 	}
@@ -1171,11 +1175,11 @@ func (n *Node) FindStorageSpaceRoot() error {
 	// remember the node we ask for and use parent to climb the tree
 	parent := n
 	for {
-		if parent.IsSpaceRoot() {
+		if parent.IsSpaceRoot(ctx) {
 			n.SpaceRoot = parent
 			break
 		}
-		if parent, err = parent.Parent(); err != nil {
+		if parent, err = parent.Parent(ctx); err != nil {
 			return err
 		}
 	}
@@ -1183,38 +1187,38 @@ func (n *Node) FindStorageSpaceRoot() error {
 }
 
 // UnmarkProcessing removes the processing flag from the node
-func (n *Node) UnmarkProcessing(uploadID string) error {
-	v, _ := n.XattrString(prefixes.StatusPrefix)
+func (n *Node) UnmarkProcessing(ctx context.Context, uploadID string) error {
+	v, _ := n.XattrString(ctx, prefixes.StatusPrefix)
 	if v != ProcessingStatus+uploadID {
 		// file started another postprocessing later - do not remove
 		return nil
 	}
-	return n.RemoveXattr(prefixes.StatusPrefix)
+	return n.RemoveXattr(ctx, prefixes.StatusPrefix)
 }
 
 // IsProcessing returns true if the node is currently being processed
-func (n *Node) IsProcessing() bool {
-	v, err := n.XattrString(prefixes.StatusPrefix)
+func (n *Node) IsProcessing(ctx context.Context) bool {
+	v, err := n.XattrString(ctx, prefixes.StatusPrefix)
 	return err == nil && strings.HasPrefix(v, ProcessingStatus)
 }
 
 // IsSpaceRoot checks if the node is a space root
-func (n *Node) IsSpaceRoot() bool {
-	_, err := n.Xattr(prefixes.SpaceNameAttr)
+func (n *Node) IsSpaceRoot(ctx context.Context) bool {
+	_, err := n.Xattr(ctx, prefixes.SpaceNameAttr)
 	return err == nil
 }
 
 // SetScanData sets the virus scan info to the node
-func (n *Node) SetScanData(info string, date time.Time) error {
+func (n *Node) SetScanData(ctx context.Context, info string, date time.Time) error {
 	attribs := Attributes{}
 	attribs.SetString(prefixes.ScanStatusPrefix, info)
 	attribs.SetString(prefixes.ScanDatePrefix, date.Format(time.RFC3339Nano))
-	return n.SetXattrs(attribs, true)
+	return n.SetXattrsWithContext(ctx, attribs, true)
 }
 
 // ScanData returns scanning information of the node
-func (n *Node) ScanData() (scanned bool, virus string, scantime time.Time) {
-	ti, _ := n.XattrString(prefixes.ScanDatePrefix)
+func (n *Node) ScanData(ctx context.Context) (scanned bool, virus string, scantime time.Time) {
+	ti, _ := n.XattrString(ctx, prefixes.ScanDatePrefix)
 	if ti == "" {
 		return // not scanned yet
 	}
@@ -1224,7 +1228,7 @@ func (n *Node) ScanData() (scanned bool, virus string, scantime time.Time) {
 		return
 	}
 
-	i, err := n.XattrString(prefixes.ScanStatusPrefix)
+	i, err := n.XattrString(ctx, prefixes.ScanStatusPrefix)
 	if err != nil {
 		return
 	}
@@ -1237,12 +1241,12 @@ func (n *Node) ScanData() (scanned bool, virus string, scantime time.Time) {
 // when creating a new file version. In such a case the function will
 // reduce the used bytes by the old file size and then add the new size.
 // If overwrite is false oldSize will be ignored.
-var CheckQuota = func(spaceRoot *Node, overwrite bool, oldSize, newSize uint64) (quotaSufficient bool, err error) {
-	used, _ := spaceRoot.GetTreeSize()
+var CheckQuota = func(ctx context.Context, spaceRoot *Node, overwrite bool, oldSize, newSize uint64) (quotaSufficient bool, err error) {
+	used, _ := spaceRoot.GetTreeSize(ctx)
 	if !enoughDiskSpace(spaceRoot.InternalPath(), newSize) {
 		return false, errtypes.InsufficientStorage("disk full")
 	}
-	quotaByteStr, _ := spaceRoot.XattrString(prefixes.QuotaAttr)
+	quotaByteStr, _ := spaceRoot.XattrString(ctx, prefixes.QuotaAttr)
 	switch quotaByteStr {
 	case "":
 		// if quota is not set, it means unlimited

--- a/pkg/storage/utils/decomposedfs/node/node.go
+++ b/pkg/storage/utils/decomposedfs/node/node.go
@@ -50,6 +50,9 @@ import (
 	"github.com/pkg/errors"
 )
 
+// name is the Tracer name used to identify this instrumentation library.
+const tracerName = "decomposedfs.node"
+
 // Define keys and values used in the node metadata
 const (
 	LockdiscoveryKey = "DAV:lockdiscovery"
@@ -342,6 +345,9 @@ func readChildNodeFromLink(path string) (string, error) {
 
 // Child returns the child node with the given name
 func (n *Node) Child(ctx context.Context, name string) (*Node, error) {
+	ctx, span := appctx.GetTracerProvider(ctx).Tracer(tracerName).Start(ctx, "Child")
+	defer span.End()
+
 	spaceID := n.SpaceID
 	if spaceID == "" && n.ParentID == "root" {
 		spaceID = n.ID

--- a/pkg/storage/utils/decomposedfs/node/node.go
+++ b/pkg/storage/utils/decomposedfs/node/node.go
@@ -929,7 +929,7 @@ func (n *Node) IsDisabled(ctx context.Context) bool {
 func (n *Node) GetTreeSize(ctx context.Context) (treesize uint64, err error) {
 	ctx, span := appctx.GetTracerProvider(ctx).Tracer(tracerName).Start(ctx, "GetTreeSize")
 	defer span.End()
-	s, err := n.XattrUint64(prefixes.TreesizeAttr)
+	s, err := n.XattrUint64(ctx, prefixes.TreesizeAttr)
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/storage/utils/decomposedfs/node/node_test.go
+++ b/pkg/storage/utils/decomposedfs/node/node_test.go
@@ -94,7 +94,7 @@ var _ = Describe("Node", func() {
 			n.BlobID = "TestBlobID"
 			n.Blobsize = blobsize
 
-			err = n.SetXattrs(n.NodeMetadata(), true)
+			err = n.SetXattrs(n.NodeMetadata(env.Ctx), true)
 			Expect(err).ToNot(HaveOccurred())
 			n2, err := env.Lookup.NodeFromResource(env.Ctx, ref)
 			Expect(err).ToNot(HaveOccurred())
@@ -113,7 +113,7 @@ var _ = Describe("Node", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(child).ToNot(BeNil())
 
-			parent, err := child.Parent()
+			parent, err := child.Parent(env.Ctx)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(parent).ToNot(BeNil())
 			Expect(parent.ID).To(Equal(child.ParentID))
@@ -199,7 +199,7 @@ var _ = Describe("Node", func() {
 				before := ri.Etag
 
 				tmtime := time.Now()
-				Expect(n.SetTMTime(&tmtime)).To(Succeed())
+				Expect(n.SetTMTime(env.Ctx, &tmtime)).To(Succeed())
 
 				ri, err = n.AsResourceInfo(env.Ctx, &perms, []string{}, []string{}, false)
 				Expect(err).ToNot(HaveOccurred())

--- a/pkg/storage/utils/decomposedfs/node/permissions.go
+++ b/pkg/storage/utils/decomposedfs/node/permissions.go
@@ -149,7 +149,7 @@ func (p *Permissions) assemblePermissions(ctx context.Context, n *Node, failOnTr
 			// continue with next segment
 		}
 
-		if cn, err = cn.Parent(); err != nil {
+		if cn, err = cn.Parent(ctx); err != nil {
 			// We get an error but get a parent, but can not read it from disk (eg. it has been deleted already)
 			if cn != nil {
 				return ap, errors.Wrap(err, "Decomposedfs: error getting parent for node "+cn.ID)

--- a/pkg/storage/utils/decomposedfs/node/xattrs.go
+++ b/pkg/storage/utils/decomposedfs/node/xattrs.go
@@ -182,8 +182,8 @@ func (n *Node) XattrInt64(ctx context.Context, key string) (int64, error) {
 }
 
 // XattrUint64 returns the uint64 representation of an attribute
-func (n *Node) XattrUint64(key string) (uint64, error) {
-	b, err := n.XattrString(key)
+func (n *Node) XattrUint64(ctx context.Context, key string) (uint64, error) {
+	b, err := n.XattrString(ctx, key)
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/storage/utils/decomposedfs/node/xattrs.go
+++ b/pkg/storage/utils/decomposedfs/node/xattrs.go
@@ -57,7 +57,7 @@ func (n *Node) SetXattrsWithContext(ctx context.Context, attribs map[string][]by
 		}
 	}
 
-	return n.lu.MetadataBackend().SetMultipleWithContext(ctx, n.InternalPath(), attribs, acquireLock)
+	return n.lu.MetadataBackend().SetMultiple(ctx, n.InternalPath(), attribs, acquireLock)
 }
 
 // SetXattrs sets multiple extended attributes on the write-through cache/node
@@ -66,34 +66,34 @@ func (n *Node) SetXattrs(attribs map[string][]byte, acquireLock bool) (err error
 }
 
 // SetXattr sets an extended attribute on the write-through cache/node
-func (n *Node) SetXattr(key string, val []byte) (err error) {
+func (n *Node) SetXattr(ctx context.Context, key string, val []byte) (err error) {
 	if n.xattrsCache != nil {
 		n.xattrsCache[key] = val
 	}
 
-	return n.lu.MetadataBackend().Set(n.InternalPath(), key, val)
+	return n.lu.MetadataBackend().Set(ctx, n.InternalPath(), key, val)
 }
 
 // SetXattrString sets a string extended attribute on the write-through cache/node
-func (n *Node) SetXattrString(key, val string) (err error) {
+func (n *Node) SetXattrString(ctx context.Context, key, val string) (err error) {
 	if n.xattrsCache != nil {
 		n.xattrsCache[key] = []byte(val)
 	}
 
-	return n.lu.MetadataBackend().Set(n.InternalPath(), key, []byte(val))
+	return n.lu.MetadataBackend().Set(ctx, n.InternalPath(), key, []byte(val))
 }
 
 // RemoveXattr removes an extended attribute from the write-through cache/node
-func (n *Node) RemoveXattr(key string) error {
+func (n *Node) RemoveXattr(ctx context.Context, key string) error {
 	if n.xattrsCache != nil {
 		delete(n.xattrsCache, key)
 	}
-	return n.lu.MetadataBackend().Remove(n.InternalPath(), key)
+	return n.lu.MetadataBackend().Remove(ctx, n.InternalPath(), key)
 }
 
 // XattrsWithReader returns the extended attributes of the node. If the attributes have already
 // been cached they are not read from disk again.
-func (n *Node) XattrsWithReader(r io.Reader) (Attributes, error) {
+func (n *Node) XattrsWithReader(ctx context.Context, r io.Reader) (Attributes, error) {
 	if n.ID == "" {
 		// Do not try to read the attribute of an empty node. The InternalPath points to the
 		// base nodes directory in this case.
@@ -107,9 +107,9 @@ func (n *Node) XattrsWithReader(r io.Reader) (Attributes, error) {
 	var attrs Attributes
 	var err error
 	if r != nil {
-		attrs, err = n.lu.MetadataBackend().AllWithLockedSource(n.InternalPath(), r)
+		attrs, err = n.lu.MetadataBackend().AllWithLockedSource(ctx, n.InternalPath(), r)
 	} else {
-		attrs, err = n.lu.MetadataBackend().All(n.InternalPath())
+		attrs, err = n.lu.MetadataBackend().All(ctx, n.InternalPath())
 	}
 	if err != nil {
 		return nil, err
@@ -121,13 +121,13 @@ func (n *Node) XattrsWithReader(r io.Reader) (Attributes, error) {
 
 // Xattrs returns the extended attributes of the node. If the attributes have already
 // been cached they are not read from disk again.
-func (n *Node) Xattrs() (Attributes, error) {
-	return n.XattrsWithReader(nil)
+func (n *Node) Xattrs(ctx context.Context) (Attributes, error) {
+	return n.XattrsWithReader(ctx, nil)
 }
 
 // Xattr returns an extended attribute of the node. If the attributes have already
 // been cached it is not read from disk again.
-func (n *Node) Xattr(key string) ([]byte, error) {
+func (n *Node) Xattr(ctx context.Context, key string) ([]byte, error) {
 	if n.ID == "" {
 		// Do not try to read the attribute of an empty node. The InternalPath points to the
 		// base nodes directory in this case.
@@ -135,7 +135,7 @@ func (n *Node) Xattr(key string) ([]byte, error) {
 	}
 
 	if n.xattrsCache == nil {
-		attrs, err := n.lu.MetadataBackend().All(n.InternalPath())
+		attrs, err := n.lu.MetadataBackend().All(ctx, n.InternalPath())
 		if err != nil {
 			return []byte{}, err
 		}
@@ -150,8 +150,8 @@ func (n *Node) Xattr(key string) ([]byte, error) {
 }
 
 // XattrString returns the string representation of an attribute
-func (n *Node) XattrString(key string) (string, error) {
-	b, err := n.Xattr(key)
+func (n *Node) XattrString(ctx context.Context, key string) (string, error) {
+	b, err := n.Xattr(ctx, key)
 	if err != nil {
 		return "", err
 	}
@@ -159,8 +159,8 @@ func (n *Node) XattrString(key string) (string, error) {
 }
 
 // XattrInt32 returns the int32 representation of an attribute
-func (n *Node) XattrInt32(key string) (int32, error) {
-	b, err := n.XattrString(key)
+func (n *Node) XattrInt32(ctx context.Context, key string) (int32, error) {
+	b, err := n.XattrString(ctx, key)
 	if err != nil {
 		return 0, err
 	}
@@ -173,8 +173,8 @@ func (n *Node) XattrInt32(key string) (int32, error) {
 }
 
 // XattrInt64 returns the int64 representation of an attribute
-func (n *Node) XattrInt64(key string) (int64, error) {
-	b, err := n.XattrString(key)
+func (n *Node) XattrInt64(ctx context.Context, key string) (int64, error) {
+	b, err := n.XattrString(ctx, key)
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/storage/utils/decomposedfs/node/xattrs.go
+++ b/pkg/storage/utils/decomposedfs/node/xattrs.go
@@ -19,6 +19,7 @@
 package node
 
 import (
+	"context"
 	"io"
 	"strconv"
 
@@ -49,14 +50,19 @@ func (md Attributes) SetInt64(key string, val int64) {
 }
 
 // SetXattrs sets multiple extended attributes on the write-through cache/node
-func (n *Node) SetXattrs(attribs map[string][]byte, acquireLock bool) (err error) {
+func (n *Node) SetXattrsWithContext(ctx context.Context, attribs map[string][]byte, acquireLock bool) (err error) {
 	if n.xattrsCache != nil {
 		for k, v := range attribs {
 			n.xattrsCache[k] = v
 		}
 	}
 
-	return n.lu.MetadataBackend().SetMultiple(n.InternalPath(), attribs, acquireLock)
+	return n.lu.MetadataBackend().SetMultipleWithContext(ctx, n.InternalPath(), attribs, acquireLock)
+}
+
+// SetXattrs sets multiple extended attributes on the write-through cache/node
+func (n *Node) SetXattrs(attribs map[string][]byte, acquireLock bool) (err error) {
+	return n.SetXattrsWithContext(context.Background(), attribs, acquireLock)
 }
 
 // SetXattr sets an extended attribute on the write-through cache/node

--- a/pkg/storage/utils/decomposedfs/recycle.go
+++ b/pkg/storage/utils/decomposedfs/recycle.go
@@ -88,7 +88,7 @@ func (fs *Decomposedfs) ListRecycle(ctx context.Context, ref *provider.Reference
 	}
 
 	origin := ""
-	attrs, err := fs.lu.MetadataBackend().All(originalPath)
+	attrs, err := fs.lu.MetadataBackend().All(ctx, originalPath)
 	if err != nil {
 		return items, err
 	}
@@ -111,7 +111,7 @@ func (fs *Decomposedfs) ListRecycle(ctx context.Context, ref *provider.Reference
 		sublog.Error().Err(err).Msg("could not parse time format, ignoring")
 	}
 
-	nodeType := fs.lu.TypeFromPath(originalPath)
+	nodeType := fs.lu.TypeFromPath(ctx, originalPath)
 	if nodeType != provider.ResourceType_RESOURCE_TYPE_CONTAINER {
 		// this is the case when we want to directly list a file in the trashbin
 		blobsize, err := strconv.ParseInt(string(attrs[prefixes.BlobsizeAttr]), 10, 64)
@@ -154,16 +154,16 @@ func (fs *Decomposedfs) ListRecycle(ctx context.Context, ref *provider.Reference
 
 		size := int64(0)
 
-		nodeType = fs.lu.TypeFromPath(resolvedChildPath)
+		nodeType = fs.lu.TypeFromPath(ctx, resolvedChildPath)
 		switch nodeType {
 		case provider.ResourceType_RESOURCE_TYPE_FILE:
-			size, err = fs.lu.ReadBlobSizeAttr(resolvedChildPath)
+			size, err = fs.lu.ReadBlobSizeAttr(ctx, resolvedChildPath)
 			if err != nil {
 				sublog.Error().Err(err).Str("name", name).Msg("invalid blob size, skipping")
 				continue
 			}
 		case provider.ResourceType_RESOURCE_TYPE_CONTAINER:
-			attr, err := fs.lu.MetadataBackend().Get(resolvedChildPath, prefixes.TreesizeAttr)
+			attr, err := fs.lu.MetadataBackend().Get(ctx, resolvedChildPath, prefixes.TreesizeAttr)
 			if err != nil {
 				sublog.Error().Err(err).Str("name", name).Msg("invalid tree size, skipping")
 				continue
@@ -235,13 +235,13 @@ func (fs *Decomposedfs) listTrashRoot(ctx context.Context, spaceID string) ([]*p
 			continue
 		}
 
-		attrs, err := fs.lu.MetadataBackend().All(nodePath)
+		attrs, err := fs.lu.MetadataBackend().All(ctx, nodePath)
 		if err != nil {
 			log.Error().Err(err).Str("trashRoot", trashRoot).Str("item", itemPath).Str("node_path", nodePath).Msg("could not get extended attributes, skipping")
 			continue
 		}
 
-		nodeType := fs.lu.TypeFromPath(nodePath)
+		nodeType := fs.lu.TypeFromPath(ctx, nodePath)
 		if nodeType == provider.ResourceType_RESOURCE_TYPE_INVALID {
 			log.Error().Err(err).Str("trashRoot", trashRoot).Str("item", itemPath).Str("node_path", nodePath).Msg("invalid node type, skipping")
 			continue

--- a/pkg/storage/utils/decomposedfs/spacepermissions.go
+++ b/pkg/storage/utils/decomposedfs/spacepermissions.go
@@ -7,6 +7,7 @@ import (
 	cs3permissions "github.com/cs3org/go-cs3apis/cs3/permissions/v1beta1"
 	v1beta11 "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+	"github.com/cs3org/reva/v2/pkg/appctx"
 	ctxpkg "github.com/cs3org/reva/v2/pkg/ctx"
 	"github.com/cs3org/reva/v2/pkg/rgrpc/todo/pool"
 	"github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/node"
@@ -38,6 +39,8 @@ func NewPermissions(item PermissionsChecker, permissionsSelector pool.Selectable
 
 // AssemblePermissions is used to assemble file permissions
 func (p Permissions) AssemblePermissions(ctx context.Context, n *node.Node) (provider.ResourcePermissions, error) {
+	ctx, span := appctx.GetTracerProvider(ctx).Tracer(tracerName).Start(ctx, "AssemblePermissions")
+	defer span.End()
 	return p.item.AssemblePermissions(ctx, n)
 }
 

--- a/pkg/storage/utils/decomposedfs/spacepermissions.go
+++ b/pkg/storage/utils/decomposedfs/spacepermissions.go
@@ -7,7 +7,6 @@ import (
 	cs3permissions "github.com/cs3org/go-cs3apis/cs3/permissions/v1beta1"
 	v1beta11 "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
-	"github.com/cs3org/reva/v2/pkg/appctx"
 	ctxpkg "github.com/cs3org/reva/v2/pkg/ctx"
 	"github.com/cs3org/reva/v2/pkg/rgrpc/todo/pool"
 	"github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/node"
@@ -39,7 +38,7 @@ func NewPermissions(item PermissionsChecker, permissionsSelector pool.Selectable
 
 // AssemblePermissions is used to assemble file permissions
 func (p Permissions) AssemblePermissions(ctx context.Context, n *node.Node) (provider.ResourcePermissions, error) {
-	ctx, span := appctx.GetTracerProvider(ctx).Tracer(tracerName).Start(ctx, "AssemblePermissions")
+	ctx, span := tracer.Start(ctx, "AssemblePermissions")
 	defer span.End()
 	return p.item.AssemblePermissions(ctx, n)
 }

--- a/pkg/storage/utils/decomposedfs/spaces.go
+++ b/pkg/storage/utils/decomposedfs/spaces.go
@@ -692,7 +692,7 @@ func (fs *Decomposedfs) UpdateStorageSpace(ctx context.Context, req *provider.Up
 	}
 
 	if mapHasKey(metadata, prefixes.QuotaAttr) {
-		typ, err := spaceNode.SpaceRoot.Xattr(prefixes.SpaceTypeAttr)
+		typ, err := spaceNode.SpaceRoot.Xattr(ctx, prefixes.SpaceTypeAttr)
 		if err != nil {
 			return &provider.UpdateStorageSpaceResponse{
 				Status: &v1beta11.Status{
@@ -716,7 +716,7 @@ func (fs *Decomposedfs) UpdateStorageSpace(ctx context.Context, req *provider.Up
 	}
 
 	if restore {
-		if err := spaceNode.SetDTime(nil); err != nil {
+		if err := spaceNode.SetDTime(ctx, nil); err != nil {
 			return nil, err
 		}
 	}
@@ -751,7 +751,7 @@ func (fs *Decomposedfs) DeleteStorageSpace(ctx context.Context, req *provider.De
 		return err
 	}
 
-	st, err := n.SpaceRoot.XattrString(prefixes.SpaceTypeAttr)
+	st, err := n.SpaceRoot.XattrString(ctx, prefixes.SpaceTypeAttr)
 	if err != nil {
 		return errtypes.InternalError(fmt.Sprintf("space %s does not have a spacetype, possible corrupt decompsedfs", n.ID))
 	}
@@ -760,11 +760,11 @@ func (fs *Decomposedfs) DeleteStorageSpace(ctx context.Context, req *provider.De
 		return err
 	}
 	if purge {
-		if !n.IsDisabled() {
+		if !n.IsDisabled(ctx) {
 			return errtypes.NewErrtypeFromStatus(status.NewInvalid(ctx, "can't purge enabled space"))
 		}
 
-		spaceType, err := n.XattrString(prefixes.SpaceTypeAttr)
+		spaceType, err := n.XattrString(ctx, prefixes.SpaceTypeAttr)
 		if err != nil {
 			return err
 		}
@@ -791,7 +791,7 @@ func (fs *Decomposedfs) DeleteStorageSpace(ctx context.Context, req *provider.De
 
 	// mark as disabled by writing a dtime attribute
 	dtime := time.Now()
-	return n.SetDTime(&dtime)
+	return n.SetDTime(ctx, &dtime)
 }
 
 func (fs *Decomposedfs) updateIndexes(ctx context.Context, grantee *provider.Grantee, spaceType, spaceID string) error {
@@ -904,7 +904,7 @@ func (fs *Decomposedfs) storageSpaceFromNode(ctx context.Context, n *node.Node, 
 			return nil, errtypes.NotFound(fmt.Sprintf("space %s not found", n.ID))
 		}
 
-		if n.SpaceRoot.IsDisabled() {
+		if n.SpaceRoot.IsDisabled(ctx) {
 			rp, err := fs.p.AssemblePermissions(ctx, n)
 			if err != nil || !IsManager(rp) {
 				return nil, errtypes.PermissionDenied(fmt.Sprintf("user %s is not allowed to list deleted spaces %s", user.Username, n.ID))
@@ -915,7 +915,7 @@ func (fs *Decomposedfs) storageSpaceFromNode(ctx context.Context, n *node.Node, 
 	var err error
 	// TODO apply more filters
 	var sname string
-	if sname, err = n.SpaceRoot.XattrString(prefixes.SpaceNameAttr); err != nil {
+	if sname, err = n.SpaceRoot.XattrString(ctx, prefixes.SpaceNameAttr); err != nil {
 		// FIXME: Is that a severe problem?
 		appctx.GetLogger(ctx).Debug().Err(err).Msg("space does not have a name attribute")
 	}
@@ -1020,12 +1020,12 @@ func (fs *Decomposedfs) storageSpaceFromNode(ctx context.Context, n *node.Node, 
 		// Mtime is set either as node.tmtime or as fi.mtime below
 	}
 
-	space.SpaceType, err = n.SpaceRoot.XattrString(prefixes.SpaceTypeAttr)
+	space.SpaceType, err = n.SpaceRoot.XattrString(ctx, prefixes.SpaceTypeAttr)
 	if err != nil {
 		appctx.GetLogger(ctx).Debug().Err(err).Msg("space does not have a type attribute")
 	}
 
-	if n.SpaceRoot.IsDisabled() {
+	if n.SpaceRoot.IsDisabled(ctx) {
 		space.Opaque = utils.AppendPlainToOpaque(space.Opaque, "trashed", "trashed")
 	}
 
@@ -1038,7 +1038,7 @@ func (fs *Decomposedfs) storageSpaceFromNode(ctx context.Context, n *node.Node, 
 	// we set the space mtime to the root item mtime
 	// override the stat mtime with a tmtime if it is present
 	var tmtime time.Time
-	if tmt, err := n.GetTMTime(); err == nil {
+	if tmt, err := n.GetTMTime(ctx); err == nil {
 		tmtime = tmt
 		un := tmt.UnixNano()
 		space.Mtime = &types.Timestamp{
@@ -1064,7 +1064,7 @@ func (fs *Decomposedfs) storageSpaceFromNode(ctx context.Context, n *node.Node, 
 		Value:   []byte(etag),
 	}
 
-	spaceAttributes, err := n.SpaceRoot.Xattrs()
+	spaceAttributes, err := n.SpaceRoot.Xattrs(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/storage/utils/decomposedfs/spaces.go
+++ b/pkg/storage/utils/decomposedfs/spaces.go
@@ -146,8 +146,7 @@ func (fs *Decomposedfs) CreateStorageSpace(ctx context.Context, req *provider.Cr
 		metadata.SetString(prefixes.SpaceAliasAttr, alias)
 	}
 
-	// Write node
-	if err := root.SetXattrs(metadata, true); err != nil {
+	if err := root.SetXattrsWithContext(ctx, metadata, true); err != nil {
 		return nil, err
 	}
 
@@ -711,7 +710,7 @@ func (fs *Decomposedfs) UpdateStorageSpace(ctx context.Context, req *provider.Up
 	}
 	metadata[prefixes.TreeMTimeAttr] = []byte(time.Now().UTC().Format(time.RFC3339Nano))
 
-	err = spaceNode.SetXattrs(metadata, true)
+	err = spaceNode.SetXattrsWithContext(ctx, metadata, true)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/storage/utils/decomposedfs/testhelpers/helpers.go
+++ b/pkg/storage/utils/decomposedfs/testhelpers/helpers.go
@@ -244,7 +244,7 @@ func (t *TestEnv) CreateTestFile(name, blobID, parentID, spaceID string, blobSiz
 	if err != nil {
 		return nil, err
 	}
-	err = n.SetXattrs(n.NodeMetadata(), true)
+	err = n.SetXattrs(n.NodeMetadata(t.Ctx), true)
 	if err != nil {
 		return nil, err
 	}
@@ -254,11 +254,11 @@ func (t *TestEnv) CreateTestFile(name, blobID, parentID, spaceID string, blobSiz
 	if err != nil {
 		return nil, err
 	}
-	if err := n.FindStorageSpaceRoot(); err != nil {
+	if err := n.FindStorageSpaceRoot(t.Ctx); err != nil {
 		return nil, err
 	}
 
-	return n, t.Tree.Propagate(context.Background(), n, blobSize)
+	return n, t.Tree.Propagate(t.Ctx, n, blobSize)
 
 }
 
@@ -302,7 +302,7 @@ func (t *TestEnv) CreateTestStorageSpace(typ string, quota *providerv1beta1.Quot
 	if err != nil {
 		return nil, err
 	}
-	if err = h.SetXattr(prefixes.SpaceNameAttr, []byte("username")); err != nil {
+	if err = h.SetXattr(t.Ctx, prefixes.SpaceNameAttr, []byte("username")); err != nil {
 		return nil, err
 	}
 

--- a/pkg/storage/utils/decomposedfs/tree/tree_test.go
+++ b/pkg/storage/utils/decomposedfs/tree/tree_test.go
@@ -122,7 +122,7 @@ var _ = Describe("Tree", func() {
 					resolveTrashPath, err := filepath.EvalSymlinks(trashPath)
 					Expect(err).ToNot(HaveOccurred())
 
-					attr, err := env.Lookup.MetadataBackend().Get(resolveTrashPath, prefixes.TrashOriginAttr)
+					attr, err := env.Lookup.MetadataBackend().Get(env.Ctx, resolveTrashPath, prefixes.TrashOriginAttr)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(string(attr)).To(Equal("/dir1/file1"))
 				})
@@ -335,7 +335,7 @@ var _ = Describe("Tree", func() {
 					OpaqueId:  dir.ID,
 				})
 				Expect(err).ToNot(HaveOccurred())
-				size, err := dir.GetTreeSize()
+				size, err := dir.GetTreeSize(env.Ctx)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(size).To(Equal(uint64(1)))
 			})
@@ -352,7 +352,7 @@ var _ = Describe("Tree", func() {
 					OpaqueId:  dir.ID,
 				})
 				Expect(err).ToNot(HaveOccurred())
-				size, err := dir.GetTreeSize()
+				size, err := dir.GetTreeSize(env.Ctx)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(size).To(Equal(uint64(101)))
 			})
@@ -360,7 +360,7 @@ var _ = Describe("Tree", func() {
 			It("adds the size of child directories", func() {
 				subdir, err := env.CreateTestDir("testdir/200bytes", &provider.Reference{ResourceId: env.SpaceRootRes})
 				Expect(err).ToNot(HaveOccurred())
-				err = subdir.SetTreeSize(uint64(200))
+				err = subdir.SetTreeSize(env.Ctx, uint64(200))
 				Expect(err).ToNot(HaveOccurred())
 				err = env.Tree.Propagate(env.Ctx, subdir, 200)
 				Expect(err).ToNot(HaveOccurred())
@@ -374,7 +374,7 @@ var _ = Describe("Tree", func() {
 					OpaqueId:  dir.ID,
 				})
 				Expect(err).ToNot(HaveOccurred())
-				size, err := dir.GetTreeSize()
+				size, err := dir.GetTreeSize(env.Ctx)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(size).To(Equal(uint64(201)))
 			})
@@ -382,7 +382,7 @@ var _ = Describe("Tree", func() {
 			It("stops at nodes with no propagation flag", func() {
 				subdir, err := env.CreateTestDir("testdir/200bytes", &provider.Reference{ResourceId: env.SpaceRootRes})
 				Expect(err).ToNot(HaveOccurred())
-				err = subdir.SetTreeSize(uint64(200))
+				err = subdir.SetTreeSize(env.Ctx, uint64(200))
 				Expect(err).ToNot(HaveOccurred())
 				err = env.Tree.Propagate(env.Ctx, subdir, 200)
 				Expect(err).ToNot(HaveOccurred())
@@ -393,17 +393,17 @@ var _ = Describe("Tree", func() {
 					OpaqueId:  dir.ID,
 				})
 				Expect(err).ToNot(HaveOccurred())
-				size, err := dir.GetTreeSize()
+				size, err := dir.GetTreeSize(env.Ctx)
 				Expect(size).To(Equal(uint64(200)))
 				Expect(err).ToNot(HaveOccurred())
 
 				stopdir, err := env.CreateTestDir("testdir/stophere", &provider.Reference{ResourceId: env.SpaceRootRes})
 				Expect(err).ToNot(HaveOccurred())
-				err = stopdir.SetXattrString(prefixes.PropagationAttr, "0")
+				err = stopdir.SetXattrString(env.Ctx, prefixes.PropagationAttr, "0")
 				Expect(err).ToNot(HaveOccurred())
 				otherdir, err := env.CreateTestDir("testdir/stophere/lotsofbytes", &provider.Reference{ResourceId: env.SpaceRootRes})
 				Expect(err).ToNot(HaveOccurred())
-				err = otherdir.SetTreeSize(uint64(100000))
+				err = otherdir.SetTreeSize(env.Ctx, uint64(100000))
 				Expect(err).ToNot(HaveOccurred())
 				err = env.Tree.Propagate(env.Ctx, otherdir, 100000)
 				Expect(err).ToNot(HaveOccurred())
@@ -414,7 +414,7 @@ var _ = Describe("Tree", func() {
 					OpaqueId:  dir.ID,
 				})
 				Expect(err).ToNot(HaveOccurred())
-				size, err = dir.GetTreeSize()
+				size, err = dir.GetTreeSize(env.Ctx)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(size).To(Equal(uint64(200)))
 			})

--- a/pkg/storage/utils/decomposedfs/upload.go
+++ b/pkg/storage/utils/decomposedfs/upload.go
@@ -196,7 +196,7 @@ func (fs *Decomposedfs) InitiateUpload(ctx context.Context, ref *provider.Refere
 
 	log.Debug().Interface("info", info).Interface("node", n).Interface("metadata", metadata).Msg("Decomposedfs: resolved filename")
 
-	_, err = node.CheckQuota(n.SpaceRoot, n.Exists, uint64(n.Blobsize), uint64(info.Size))
+	_, err = node.CheckQuota(ctx, n.SpaceRoot, n.Exists, uint64(n.Blobsize), uint64(info.Size))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/storage/utils/decomposedfs/upload/processing.go
+++ b/pkg/storage/utils/decomposedfs/upload/processing.go
@@ -294,7 +294,7 @@ func CreateNodeForUpload(upload *Upload, initAttrs node.Attributes) (*node.Node,
 	initAttrs.SetString(prefixes.StatusPrefix, node.ProcessingStatus+upload.Info.ID)
 
 	// update node metadata with new blobid etc
-	err = n.SetXattrs(initAttrs, false)
+	err = n.SetXattrsWithContext(context.TODO(), initAttrs, false)
 	if err != nil {
 		return nil, errors.Wrap(err, "Decomposedfs: could not write metadata")
 	}

--- a/pkg/storage/utils/decomposedfs/upload/processing.go
+++ b/pkg/storage/utils/decomposedfs/upload/processing.go
@@ -83,7 +83,7 @@ func New(ctx context.Context, info tusd.FileInfo, lu *lookup.Lookup, tp Tree, p 
 	log.Debug().Interface("info", info).Interface("node", n).Msg("Decomposedfs: resolved filename")
 
 	// the parent owner will become the new owner
-	parent, perr := n.Parent()
+	parent, perr := n.Parent(ctx)
 	if perr != nil {
 		return nil, errors.Wrap(perr, "Decomposedfs: error getting parent "+n.ParentID)
 	}
@@ -117,7 +117,7 @@ func New(ctx context.Context, info tusd.FileInfo, lu *lookup.Lookup, tp Tree, p 
 	}
 
 	// are we trying to overwriting a folder with a file?
-	if n.Exists && n.IsDir() {
+	if n.Exists && n.IsDir(ctx) {
 		return nil, errtypes.PreconditionFailed("resource is not a file")
 	}
 
@@ -347,7 +347,7 @@ func initNewNode(upload *Upload, n *node.Node, fsize uint64) (*lockedfile.File, 
 		// nothing to do
 	}
 
-	if _, err := node.CheckQuota(n.SpaceRoot, false, 0, fsize); err != nil {
+	if _, err := node.CheckQuota(upload.Ctx, n.SpaceRoot, false, 0, fsize); err != nil {
 		return f, err
 	}
 
@@ -374,11 +374,11 @@ func initNewNode(upload *Upload, n *node.Node, fsize uint64) (*lockedfile.File, 
 
 func updateExistingNode(upload *Upload, n *node.Node, spaceID string, fsize uint64) (*lockedfile.File, error) {
 	old, _ := node.ReadNode(upload.Ctx, upload.lu, spaceID, n.ID, false, nil, false)
-	if _, err := node.CheckQuota(n.SpaceRoot, true, uint64(old.Blobsize), fsize); err != nil {
+	if _, err := node.CheckQuota(upload.Ctx, n.SpaceRoot, true, uint64(old.Blobsize), fsize); err != nil {
 		return nil, err
 	}
 
-	tmtime, err := old.GetTMTime()
+	tmtime, err := old.GetTMTime(upload.Ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -414,7 +414,7 @@ func updateExistingNode(upload *Upload, n *node.Node, spaceID string, fsize uint
 	}
 
 	// copy blob metadata to version node
-	if err := upload.lu.CopyMetadataWithSourceLock(targetPath, upload.versionsPath, func(attributeName string) bool {
+	if err := upload.lu.CopyMetadataWithSourceLock(upload.Ctx, targetPath, upload.versionsPath, func(attributeName string) bool {
 		return strings.HasPrefix(attributeName, prefixes.ChecksumPrefix) ||
 			attributeName == prefixes.TypeAttr ||
 			attributeName == prefixes.BlobIDAttr ||

--- a/pkg/storage/utils/decomposedfs/upload/upload.go
+++ b/pkg/storage/utils/decomposedfs/upload/upload.go
@@ -129,7 +129,7 @@ func Cleanup(upload *Upload, failure bool, keepUpload bool) {
 
 	// unset processing status
 	if upload.Node != nil { // node can be nil when there was an error before it was created (eg. checksum-mismatch)
-		if err := upload.Node.UnmarkProcessing(upload.Info.ID); err != nil {
+		if err := upload.Node.UnmarkProcessing(upload.Ctx, upload.Info.ID); err != nil {
 			upload.log.Info().Str("path", upload.Node.InternalPath()).Err(err).Msg("unmarking processing failed")
 		}
 	}
@@ -370,7 +370,7 @@ func (upload *Upload) cleanup(cleanNode, cleanBin, cleanInfo bool) {
 			upload.Node = nil
 		default:
 
-			if err := upload.lu.CopyMetadata(p, upload.Node.InternalPath(), func(attributeName string) bool {
+			if err := upload.lu.CopyMetadata(upload.Ctx, p, upload.Node.InternalPath(), func(attributeName string) bool {
 				return strings.HasPrefix(attributeName, prefixes.ChecksumPrefix) ||
 					attributeName == prefixes.TypeAttr ||
 					attributeName == prefixes.BlobIDAttr ||

--- a/pkg/storage/utils/decomposedfs/upload_test.go
+++ b/pkg/storage/utils/decomposedfs/upload_test.go
@@ -154,7 +154,7 @@ var _ = Describe("File uploads", func() {
 		When("the user wants to initiate a file upload", func() {
 			It("fails", func() {
 				var originalFunc = node.CheckQuota
-				node.CheckQuota = func(spaceRoot *node.Node, overwrite bool, oldSize, newSize uint64) (quotaSufficient bool, err error) {
+				node.CheckQuota = func(ctx context.Context, spaceRoot *node.Node, overwrite bool, oldSize, newSize uint64) (quotaSufficient bool, err error) {
 					return false, errtypes.InsufficientStorage("quota exceeded")
 				}
 				_, err := fs.InitiateUpload(ctx, ref, 10, map[string]string{})
@@ -186,7 +186,7 @@ var _ = Describe("File uploads", func() {
 			// the space name attribute is the stop condition in the lookup
 			h, err := lu.NodeFromResource(ctx, rootRef)
 			Expect(err).ToNot(HaveOccurred())
-			err = h.SetXattrString(prefixes.SpaceNameAttr, "username")
+			err = h.SetXattrString(ctx, prefixes.SpaceNameAttr, "username")
 			Expect(err).ToNot(HaveOccurred())
 			permissions.On("AssemblePermissions", mock.Anything, mock.Anything, mock.Anything).Return(provider.ResourcePermissions{
 				Stat: true,

--- a/pkg/trace/trace.go
+++ b/pkg/trace/trace.go
@@ -38,21 +38,19 @@ import (
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 
+	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
 )
 
 var (
 	// Propagator is the default Reva propagator.
 	Propagator      = propagation.NewCompositeTextMapPropagator(propagation.Baggage{}, propagation.TraceContext{})
-	defaultProvider = revaDefaultTracerProvider{
-		provider: trace.NewNoopTracerProvider(),
-	}
+	defaultProvider = revaDefaultTracerProvider{}
 )
 
 type revaDefaultTracerProvider struct {
 	mutex       sync.RWMutex
 	initialized bool
-	provider    trace.TracerProvider
 }
 
 // NewTracerProvider returns a new TracerProvider, configure for the specified service
@@ -86,9 +84,7 @@ func NewTracerProvider(opts ...Option) trace.TracerProvider {
 
 // SetDefaultTracerProvider sets the default trace provider
 func SetDefaultTracerProvider(tp trace.TracerProvider) {
-	defaultProvider.mutex.Lock()
-	defer defaultProvider.mutex.Unlock()
-	defaultProvider.provider = tp
+	otel.SetTracerProvider(tp)
 	defaultProvider.initialized = true
 }
 
@@ -99,14 +95,13 @@ func InitDefaultTracerProvider(collector, endpoint string) {
 	defaultProvider.mutex.Lock()
 	defer defaultProvider.mutex.Unlock()
 	if !defaultProvider.initialized {
-		defaultProvider.provider = getJaegerTracerProvider(Options{
+		SetDefaultTracerProvider(getJaegerTracerProvider(Options{
 			Enabled:     true,
 			Collector:   collector,
 			Endpoint:    endpoint,
 			ServiceName: "reva default jaeger provider",
-		})
+		}))
 	}
-	defaultProvider.initialized = true
 }
 
 // DefaultProvider returns the "global" default TracerProvider
@@ -114,7 +109,7 @@ func InitDefaultTracerProvider(collector, endpoint string) {
 func DefaultProvider() trace.TracerProvider {
 	defaultProvider.mutex.RLock()
 	defer defaultProvider.mutex.RUnlock()
-	return defaultProvider.provider
+	return otel.GetTracerProvider()
 }
 
 // getJaegerTracerProvider returns a new TracerProvider, configure for the specified service


### PR DESCRIPTION
rewrote this as a pr to pass the context deep down into decomposedfs metadata backends and trace syscall durations