### PR TITLE
Bump go-micro redis store

### DIFF
--- a/changelog/unreleased/bump-micro-redis-store.md
+++ b/changelog/unreleased/bump-micro-redis-store.md
@@ -1,0 +1,6 @@
+Bugfix: Bump micro redis store
+
+We updated the micro store implementation for redis to use SCAN instead of KEYS
+
+https://github.com/cs3org/reva/pull/3815
+https://github.com/cs3org/reva/pull/3809

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/go-micro/plugins/v4/events/natsjs v1.1.0
 	github.com/go-micro/plugins/v4/server/http v1.1.1
 	github.com/go-micro/plugins/v4/store/nats-js v1.1.0
-	github.com/go-micro/plugins/v4/store/redis v1.2.0
+	github.com/go-micro/plugins/v4/store/redis v1.2.1-0.20230405210006-efd9191305c5
 	github.com/go-redis/redis/v8 v8.11.5
 	github.com/go-sql-driver/mysql v1.6.0
 	github.com/gofrs/flock v0.8.1

--- a/go.sum
+++ b/go.sum
@@ -351,8 +351,8 @@ github.com/go-micro/plugins/v4/server/http v1.1.1 h1:n45l9rrJUWXT25W3DmTBl9DJoc3
 github.com/go-micro/plugins/v4/server/http v1.1.1/go.mod h1:ZjVZi1l16RjzyT3IISirh9BEZdqzaLLwiE/1fvdSbnI=
 github.com/go-micro/plugins/v4/store/nats-js v1.1.0 h1:6Fe1/eLtg8kRyaGvMILp4olYtTDGwYNBXyb1sYfAWGk=
 github.com/go-micro/plugins/v4/store/nats-js v1.1.0/go.mod h1:jJf7Gm39OafZlT3s3UE2/9NIYj6OlI2fmZ4czSA3gvo=
-github.com/go-micro/plugins/v4/store/redis v1.2.0 h1:jR7sHOD1a735cxyBNFif58tP0Ck8OUklpDN1IzzDoRg=
-github.com/go-micro/plugins/v4/store/redis v1.2.0/go.mod h1:MbCG0YiyPqETTtm7uHFmxQNCaW1o9hBoYtFwhbVjLUg=
+github.com/go-micro/plugins/v4/store/redis v1.2.1-0.20230405210006-efd9191305c5 h1:W5HQDVr+6u9yQpnFZxMBRQd2rQCjOw/17Yb3dp6SQhE=
+github.com/go-micro/plugins/v4/store/redis v1.2.1-0.20230405210006-efd9191305c5/go.mod h1:MbCG0YiyPqETTtm7uHFmxQNCaW1o9hBoYtFwhbVjLUg=
 github.com/go-openapi/analysis v0.21.2/go.mod h1:HZwRk4RRisyG8vx2Oe6aqeSQcoxRp47Xkp3+K6q+LdY=
 github.com/go-openapi/errors v0.19.8/go.mod h1:cM//ZKUKyO06HSwqAelJ5NsEMMcpa6VpXe8DOa1Mi1M=
 github.com/go-openapi/errors v0.19.9/go.mod h1:cM//ZKUKyO06HSwqAelJ5NsEMMcpa6VpXe8DOa1Mi1M=


### PR DESCRIPTION
We updated the micro store implementation for redis to use SCAN instead of KEYS