### PR TITLE
pipeline cache deletes

### DIFF
--- a/changelog/unreleased/pipeline-cache-delete.md
+++ b/changelog/unreleased/pipeline-cache-delete.md
@@ -1,0 +1,6 @@
+Bugfix: Pipeline cache deletes
+
+The gateway now pipelines deleting keys from the stat and provider cache
+
+https://github.com/cs3org/reva/pull/3817
+https://github.com/cs3org/reva/pull/3809


### PR DESCRIPTION
The gateway now pipelines deleting keys from the stat and provider cache

@micbar we should disable the stat cache in ocis dig into invalidating the cache entries from storage providers (especially for sharing and public ...)