### PR TITLE
invalidate cache when deleting space

### DIFF
--- a/changelog/unreleased/invalidate-cache-when-deleting-space.md
+++ b/changelog/unreleased/invalidate-cache-when-deleting-space.md
@@ -1,0 +1,5 @@
+Bugfix: Invalidate cache when deleting space
+
+Decomposedfs now invalidates the cache when deleting a space.
+
+https://github.com/cs3org/reva/pull/3818

--- a/pkg/storage/utils/decomposedfs/spaces.go
+++ b/pkg/storage/utils/decomposedfs/spaces.go
@@ -634,8 +634,12 @@ func (fs *Decomposedfs) DeleteStorageSpace(ctx context.Context, req *provider.De
 			return err
 		}
 
-		// FIXME remove space blobs
-		// FIXME invalidate cache
+		// invalidate cache
+		if err := fs.lu.MetadataBackend().Purge(n.InternalPath()); err != nil {
+			return err
+		}
+
+		// TODO remove space blobs with s3 backend by adding a purge method to the Blobstore interface
 
 		return nil
 	}


### PR DESCRIPTION
Decomposedfs now invalidates the cache when deleting a space.