### PR TITLE
Internal Links Backdoor

### DIFF
--- a/changelog/unreleased/internal-links-backdoor.md
+++ b/changelog/unreleased/internal-links-backdoor.md
@@ -1,0 +1,5 @@
+Enhancement: Allow creating internal links without permission
+
+Allows creating/updating/deleting internal links without `PublicLink.Write` permission
+
+https://github.com/cs3org/reva/pull/3819


### PR DESCRIPTION
Allows creating/updating/deleting internal links without `PublicLink.Write` permission

Fixes https://github.com/owncloud/ocis/issues/6036