### PR TITLE
Serverless services

### DIFF
--- a/changelog/unreleased/serverless-services.md
+++ b/changelog/unreleased/serverless-services.md
@@ -1,0 +1,7 @@
+Enhancement: Serverless Services
+
+New type of service (along with http and grpc)
+which does not have a listening server. Useful for
+the notifications service and others in the future.
+
+https://github.com/cs3org/reva/pull/3824

--- a/cmd/revad/runtime/loader.go
+++ b/cmd/revad/runtime/loader.go
@@ -27,6 +27,7 @@ import (
 	_ "github.com/cs3org/reva/internal/http/interceptors/auth/tokenwriter/loader"
 	_ "github.com/cs3org/reva/internal/http/interceptors/loader"
 	_ "github.com/cs3org/reva/internal/http/services/loader"
+	_ "github.com/cs3org/reva/internal/serverless/services/loader"
 	_ "github.com/cs3org/reva/pkg/app/provider/loader"
 	_ "github.com/cs3org/reva/pkg/app/registry/loader"
 	_ "github.com/cs3org/reva/pkg/appauth/manager/loader"

--- a/cmd/revad/runtime/runtime.go
+++ b/cmd/revad/runtime/runtime.go
@@ -106,6 +106,9 @@ func run(mainConf map[string]interface{}, coreConf *coreConf, logger *zerolog.Lo
 		log.Panic(err)
 	}
 	listeners := initListeners(watcher, servers, logger)
+	if serverless != nil {
+		watcher.SL = serverless
+	}
 
 	start(mainConf, servers, serverless, listeners, logger, watcher)
 }

--- a/cmd/revad/runtime/runtime.go
+++ b/cmd/revad/runtime/runtime.go
@@ -157,6 +157,7 @@ func initServerless(mainConf map[string]interface{}, log *zerolog.Logger) *rserv
 		serverless, err := getServerless(mainConf["serverless"], log)
 		if err != nil {
 			log.Error().Err(err).Msg("error")
+			os.Exit(1)
 		}
 		return serverless
 	}

--- a/cmd/revad/runtime/runtime.go
+++ b/cmd/revad/runtime/runtime.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cs3org/reva/pkg/registry/memory"
 	"github.com/cs3org/reva/pkg/rgrpc"
 	"github.com/cs3org/reva/pkg/rhttp"
+	"github.com/cs3org/reva/pkg/rserverless"
 	"github.com/cs3org/reva/pkg/sharedconf"
 	rtrace "github.com/cs3org/reva/pkg/trace"
 	"github.com/cs3org/reva/pkg/utils"
@@ -93,13 +94,20 @@ func run(mainConf map[string]interface{}, coreConf *coreConf, logger *zerolog.Lo
 	initCPUCount(coreConf, logger)
 
 	servers := initServers(mainConf, logger)
+	serverless := initServerless(mainConf, logger)
+
+	if len(servers) == 0 && serverless == nil {
+		logger.Info().Msg("nothing to do, no grpc/http/serverless enabled_services declared in config")
+		os.Exit(1)
+	}
+
 	watcher, err := initWatcher(logger, filename)
 	if err != nil {
 		log.Panic(err)
 	}
 	listeners := initListeners(watcher, servers, logger)
 
-	start(mainConf, servers, listeners, logger, watcher)
+	start(mainConf, servers, serverless, listeners, logger, watcher)
 }
 
 func initListeners(watcher *grace.Watcher, servers map[string]grace.Server, log *zerolog.Logger) map[string]net.Listener {
@@ -141,11 +149,19 @@ func initServers(mainConf map[string]interface{}, log *zerolog.Logger) map[strin
 		servers["grpc"] = s
 	}
 
-	if len(servers) == 0 {
-		log.Info().Msg("nothing to do, no grpc/http enabled_services declared in config")
-		os.Exit(1)
-	}
 	return servers
+}
+
+func initServerless(mainConf map[string]interface{}, log *zerolog.Logger) *rserverless.Serverless {
+	if isEnabledServerless(mainConf) {
+		serverless, err := getServerless(mainConf["serverless"], log)
+		if err != nil {
+			log.Error().Err(err).Msg("error")
+		}
+		return serverless
+	}
+
+	return nil
 }
 
 func initTracing(conf *coreConf) {
@@ -184,7 +200,7 @@ func handlePIDFlag(l *zerolog.Logger, pidFile string) (*grace.Watcher, error) {
 	return w, nil
 }
 
-func start(mainConf map[string]interface{}, servers map[string]grace.Server, listeners map[string]net.Listener, log *zerolog.Logger, watcher *grace.Watcher) {
+func start(mainConf map[string]interface{}, servers map[string]grace.Server, serverless *rserverless.Serverless, listeners map[string]net.Listener, log *zerolog.Logger, watcher *grace.Watcher) {
 	if isEnabledHTTP(mainConf) {
 		go func() {
 			if err := servers["http"].(*rhttp.Server).Start(listeners["http"]); err != nil {
@@ -201,6 +217,13 @@ func start(mainConf map[string]interface{}, servers map[string]grace.Server, lis
 			}
 		}()
 	}
+	if isEnabledServerless(mainConf) {
+		if err := serverless.Start(); err != nil {
+			log.Error().Err(err).Msg("error starting serverless services")
+			watcher.Exit(1)
+		}
+	}
+
 	watcher.TrapSignals()
 }
 
@@ -262,6 +285,11 @@ func getHTTPServer(conf interface{}, l *zerolog.Logger) (*rhttp.Server, error) {
 		return nil, err
 	}
 	return s, nil
+}
+
+func getServerless(conf interface{}, l *zerolog.Logger) (*rserverless.Serverless, error) {
+	sub := l.With().Str("pkg", "rserverless").Logger()
+	return rserverless.New(conf, sub)
 }
 
 //	adjustCPU parses string cpu and sets GOMAXPROCS
@@ -363,6 +391,10 @@ func isEnabledHTTP(conf map[string]interface{}) bool {
 
 func isEnabledGRPC(conf map[string]interface{}) bool {
 	return isEnabled("grpc", conf)
+}
+
+func isEnabledServerless(conf map[string]interface{}) bool {
+	return isEnabled("serverless", conf)
 }
 
 func isEnabled(key string, conf map[string]interface{}) bool {

--- a/examples/serverless-example/notifications.toml
+++ b/examples/serverless-example/notifications.toml
@@ -1,0 +1,32 @@
+[log]
+output = "/var/log/revad/revad-notifications.log"
+mode = "json"
+
+[shared]
+gatewaysvc = "localhost:19000"
+jwt_secret = "Pive-Fumkiu4"
+skip_user_groups_in_token = true
+
+[serverless.services.notifications]
+nats_address = "nats-server-01.example.com"
+nats_token = "secret-token-example"
+nats_template_subject = "reva-notifications-template"
+nats_notification_subject = "reva-notifications-notification"
+nats_trigger_subject = "reva-notifications-trigger"
+storage_driver = "sql"
+grouping_interval = 60
+grouping_maxsize = 100
+
+[serverless.services.notifications.storage_drivers.sql]
+db_username = "username"
+db_password = "password"
+db_host = "database.example.com"
+db_port = 3306
+db_name = "notifications"
+
+[serverless.services.notifications.handlers.email]
+smtp_server = "mx.example.com:25"
+disable_auth = true
+default_sender = "noreply@cernbox.cern.ch"
+
+[tracing]

--- a/internal/serverless/services/helloworld/helloworld.go
+++ b/internal/serverless/services/helloworld/helloworld.go
@@ -1,0 +1,105 @@
+// Copyright 2018-2023 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package helloworld
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/cs3org/reva/pkg/rserverless"
+	"github.com/mitchellh/mapstructure"
+	"github.com/rs/zerolog"
+)
+
+type config struct {
+	Outfile    string `mapstructure:"outfile"`
+	DieTimeout int64  `mapstructure:"die_timeout"`
+}
+
+func (c *config) init() {
+	if c.Outfile == "" {
+		c.Outfile = "/tmp/revad-helloworld-hello"
+	}
+}
+
+type svc struct {
+	conf *config
+	file *os.File
+	log  *zerolog.Logger
+}
+
+func init() {
+	rserverless.Register("helloworld", New)
+}
+
+// New returns a new helloworld service.
+func New(m map[string]interface{}, log *zerolog.Logger) (rserverless.Service, error) {
+	conf := &config{}
+	conf.init()
+
+	if err := mapstructure.Decode(m, conf); err != nil {
+		return nil, err
+	}
+
+	file, err := os.OpenFile(conf.Outfile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		log.Err(err)
+		return nil, err
+	}
+
+	s := &svc{
+		conf: conf,
+		log:  log,
+		file: file,
+	}
+
+	return s, nil
+}
+
+// Start starts the helloworld service.
+func (s *svc) Start() {
+	s.log.Debug().Msgf("helloworld server started with timeout %d, saying hello at %s", s.conf.DieTimeout, s.conf.Outfile)
+	go s.sayHello(s.conf.Outfile)
+}
+
+func (s *svc) GracefulStop() error {
+	s.log.Debug().Msgf("graceful stop requested, simulating delay of %d seconds", s.conf.DieTimeout)
+	time.Sleep(time.Second * time.Duration(s.conf.DieTimeout))
+	return s.file.Close()
+}
+
+// Stop stops the helloworld service.
+func (s *svc) Stop() error {
+	s.log.Debug().Msgf("hard stop requested")
+	return s.file.Close()
+}
+
+func (s *svc) sayHello(filename string) {
+	for {
+		s.log.Info().Msg("saying hello")
+		h := fmt.Sprintf("%s - hello world!\n", time.Now().String())
+
+		_, err := s.file.Write([]byte(h))
+		if err != nil {
+			s.log.Err(err)
+		}
+		time.Sleep(5 * time.Second)
+	}
+}

--- a/internal/serverless/services/helloworld/helloworld.go
+++ b/internal/serverless/services/helloworld/helloworld.go
@@ -19,6 +19,7 @@
 package helloworld
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"time"
@@ -29,8 +30,7 @@ import (
 )
 
 type config struct {
-	Outfile    string `mapstructure:"outfile"`
-	DieTimeout int64  `mapstructure:"die_timeout"`
+	Outfile string `mapstructure:"outfile"`
 }
 
 func (c *config) init() {
@@ -75,19 +75,12 @@ func New(m map[string]interface{}, log *zerolog.Logger) (rserverless.Service, er
 
 // Start starts the helloworld service.
 func (s *svc) Start() {
-	s.log.Debug().Msgf("helloworld server started with timeout %d, saying hello at %s", s.conf.DieTimeout, s.conf.Outfile)
+	s.log.Debug().Msgf("helloworld server started, saying hello at %s", s.conf.Outfile)
 	go s.sayHello(s.conf.Outfile)
 }
 
-func (s *svc) GracefulStop() error {
-	s.log.Debug().Msgf("graceful stop requested, simulating delay of %d seconds", s.conf.DieTimeout)
-	time.Sleep(time.Second * time.Duration(s.conf.DieTimeout))
-	return s.file.Close()
-}
-
-// Stop stops the helloworld service.
-func (s *svc) Stop() error {
-	s.log.Debug().Msgf("hard stop requested")
+// Close stops the helloworld service.
+func (s *svc) Close(ctx context.Context) error {
 	return s.file.Close()
 }
 

--- a/internal/serverless/services/loader/loader.go
+++ b/internal/serverless/services/loader/loader.go
@@ -1,0 +1,22 @@
+// Copyright 2018-2023 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package loader
+
+// Load core serverless services.
+// Add your own service here.

--- a/internal/serverless/services/loader/loader.go
+++ b/internal/serverless/services/loader/loader.go
@@ -18,5 +18,8 @@
 
 package loader
 
-// Load core serverless services.
-// Add your own service here.
+import (
+	// Load core serverless services.
+	_ "github.com/cs3org/reva/internal/serverless/services/helloworld"
+	// Add your own service here.
+)

--- a/pkg/rhttp/rhttp.go
+++ b/pkg/rhttp/rhttp.go
@@ -200,7 +200,8 @@ func (s *Server) registerServices() error {
 	for svcName := range s.conf.Services {
 		if s.isServiceEnabled(svcName) {
 			newFunc := global.Services[svcName]
-			svc, err := newFunc(s.conf.Services[svcName], &s.log)
+			svcLogger := s.log.With().Str("service", svcName).Logger()
+			svc, err := newFunc(s.conf.Services[svcName], &svcLogger)
 			if err != nil {
 				err = errors.Wrapf(err, "http service %s could not be started,", svcName)
 				return err

--- a/pkg/rserverless/rserverless.go
+++ b/pkg/rserverless/rserverless.go
@@ -88,9 +88,8 @@ func (s *Serverless) registerServices() error {
 				return errors.Wrapf(err, "serverless service %s could not be initialized", svcName)
 			}
 
-			go func() {
-				svc.Start()
-			}()
+			go svc.Start()
+
 			s.services[svcName] = svc
 
 			s.log.Info().Msgf("serverless service enabled: %s", svcName)

--- a/pkg/rserverless/rserverless.go
+++ b/pkg/rserverless/rserverless.go
@@ -1,0 +1,107 @@
+// Copyright 2018-2023 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package rserverless
+
+import (
+	"fmt"
+
+	"github.com/mitchellh/mapstructure"
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog"
+)
+
+// Service represents a serverless service.
+type Service interface {
+	Start()
+}
+
+// Services is a map of service name and its new function.
+var Services = map[string]NewService{}
+
+// Register registers a new serverless service with name and new function.
+func Register(name string, newFunc NewService) {
+	Services[name] = newFunc
+}
+
+// NewService is the function that serverless services need to register at init time.
+type NewService func(conf map[string]interface{}, log *zerolog.Logger) (Service, error)
+
+// Serverless contains the serveless collection of services.
+type Serverless struct {
+	conf     *config
+	log      zerolog.Logger
+	services map[string]Service
+}
+
+type config struct {
+	Services map[string]map[string]interface{} `mapstructure:"services"`
+}
+
+// New returns a new serverless collection of services.
+func New(m interface{}, l zerolog.Logger) (*Serverless, error) {
+	conf := &config{}
+	if err := mapstructure.Decode(m, conf); err != nil {
+		return nil, err
+	}
+
+	n := &Serverless{
+		conf:     conf,
+		log:      l,
+		services: map[string]Service{},
+	}
+	return n, nil
+}
+
+func (s *Serverless) isServiceEnabled(svcName string) bool {
+	_, ok := Services[svcName]
+	return ok
+}
+
+// Start starts the serverless service collection.
+func (s *Serverless) Start() error {
+	if err := s.registerServices(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *Serverless) registerServices() error {
+	for svcName := range s.conf.Services {
+		if s.isServiceEnabled(svcName) {
+			newFunc := Services[svcName]
+			svc, err := newFunc(s.conf.Services[svcName], &s.log)
+			if err != nil {
+				return errors.Wrapf(err, "serverless service %s could not be initialized", svcName)
+			}
+
+			go func() {
+				svc.Start()
+			}()
+			s.services[svcName] = svc
+
+			s.log.Info().Msgf("serverless service enabled: %s", svcName)
+		} else {
+			message := fmt.Sprintf("serverless service %s does not exist", svcName)
+			return errors.New(message)
+		}
+	}
+
+	return nil
+}

--- a/pkg/rserverless/rserverless.go
+++ b/pkg/rserverless/rserverless.go
@@ -75,11 +75,7 @@ func (s *Serverless) isServiceEnabled(svcName string) bool {
 
 // Start starts the serverless service collection.
 func (s *Serverless) Start() error {
-	if err := s.registerServices(); err != nil {
-		return err
-	}
-
-	return nil
+	return s.registerServices()
 }
 
 func (s *Serverless) registerServices() error {

--- a/pkg/rserverless/rserverless.go
+++ b/pkg/rserverless/rserverless.go
@@ -82,7 +82,8 @@ func (s *Serverless) registerServices() error {
 	for svcName := range s.conf.Services {
 		if s.isServiceEnabled(svcName) {
 			newFunc := Services[svcName]
-			svc, err := newFunc(s.conf.Services[svcName], &s.log)
+			svcLogger := s.log.With().Str("service", svcName).Logger()
+			svc, err := newFunc(s.conf.Services[svcName], &svcLogger)
 			if err != nil {
 				return errors.Wrapf(err, "serverless service %s could not be initialized", svcName)
 			}


### PR DESCRIPTION
This PR adds Serverless services to Reva. It is the first step before the big PR for the Notifications Service.

This adds a new type of service which doesn't have a listener (neither http or grp). As the Notifications service is communicating via NATS only with other backend services, it doesn't need to be exposed.

It could later on be used to implement other services which don't need http/grp endpoints, like metrics.