### PR TITLE
Send quota when listing spaces in decomposedfs

### DIFF
--- a/changelog/unreleased/send-quota-when-listing-spaces.md
+++ b/changelog/unreleased/send-quota-when-listing-spaces.md
@@ -1,0 +1,5 @@
+Bugfix: Send quota when listing spaces in decomposedfs
+
+We now include free, used and remaining quota when listing spaces
+
+https://github.com/cs3org/reva/pull/3828

--- a/pkg/storage/utils/decomposedfs/decomposedfs.go
+++ b/pkg/storage/utils/decomposedfs/decomposedfs.go
@@ -438,11 +438,18 @@ func (fs *Decomposedfs) GetQuota(ctx context.Context, ref *provider.Reference) (
 		quotaStr = string(ri.Opaque.Map["quota"].Value)
 	}
 
+	// FIXME this reads remaining disk size from the local disk, not the blobstore
 	remaining, err = node.GetAvailableSize(n.InternalPath())
 	if err != nil {
 		return 0, 0, 0, err
 	}
 
+	return fs.calculateTotalUsedRemaining(quotaStr, ri.Size, remaining)
+}
+
+func (fs *Decomposedfs) calculateTotalUsedRemaining(quotaStr string, inUse, remaining uint64) (uint64, uint64, uint64, error) {
+	var err error
+	var total uint64
 	switch quotaStr {
 	case node.QuotaUncalculated, node.QuotaUnknown:
 		// best we can do is return current total
@@ -457,15 +464,14 @@ func (fs *Decomposedfs) GetQuota(ctx context.Context, ref *provider.Reference) (
 
 		if total <= remaining {
 			// Prevent overflowing
-			if ri.Size >= total {
+			if inUse >= total {
 				remaining = 0
 			} else {
-				remaining = total - ri.Size
+				remaining = total - inUse
 			}
 		}
 	}
-
-	return total, ri.Size, remaining, nil
+	return total, inUse, remaining, nil
 }
 
 // CreateHome creates a new home node for the given user

--- a/pkg/storage/utils/decomposedfs/spaces.go
+++ b/pkg/storage/utils/decomposedfs/spaces.go
@@ -39,6 +39,7 @@ import (
 	"github.com/cs3org/reva/v2/pkg/errtypes"
 	"github.com/cs3org/reva/v2/pkg/rgrpc/status"
 	"github.com/cs3org/reva/v2/pkg/rgrpc/todo/pool"
+	sdk "github.com/cs3org/reva/v2/pkg/sdk/common"
 	"github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/lookup"
 	"github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/metadata/prefixes"
 	"github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/node"
@@ -1023,8 +1024,8 @@ func (fs *Decomposedfs) storageSpaceFromNode(ctx context.Context, n *node.Node, 
 	// we cannot put free, used and remaining into the quota, as quota, when set would always imply a quota limit
 	// for now we use opaque properties with a 'quota.' prefix
 	quotaStr := node.QuotaUnknown
-	if space.RootInfo.Opaque != nil && space.RootInfo.Opaque.Map != nil && space.RootInfo.Opaque.Map["quota"] != nil && space.RootInfo.Opaque.Map["quota"].Decoder == "plain" {
-		quotaStr = string(space.RootInfo.Opaque.Map["quota"].Value)
+	if quotaInOpaque := sdk.DecodeOpaqueMap(space.RootInfo.Opaque)["quota"]; quotaInOpaque != "" {
+		quotaStr = quotaInOpaque
 	}
 
 	// FIXME this reads remaining disk size from the local disk, not the blobstore

--- a/pkg/storage/utils/decomposedfs/spaces.go
+++ b/pkg/storage/utils/decomposedfs/spaces.go
@@ -989,14 +989,6 @@ func (fs *Decomposedfs) storageSpaceFromNode(ctx context.Context, n *node.Node, 
 		space.Quota = &provider.Quota{
 			QuotaMaxBytes: uint64(q),
 			QuotaMaxFiles: math.MaxUint64, // TODO MaxUInt64? = unlimited? why even max files? 0 = unlimited?
-			Opaque: &types.Opaque{
-				Map: map[string]*types.OpaqueEntry{
-					"remaining": {
-						Decoder: "plain",
-						//Value: []byte(strconv.FormatUint(remaining, 10)),
-					},
-				},
-			},
 		}
 
 	}


### PR DESCRIPTION
We now include free, used and remaining quota when listing spaces