### PR TITLE
Bump go in docker build

### DIFF
--- a/Dockerfile.revad-ceph
+++ b/Dockerfile.revad-ceph
@@ -26,12 +26,12 @@ RUN dnf update -y && dnf install -y \
   librbd-devel \
   librados-devel
 
-ADD https://golang.org/dl/go1.19.linux-amd64.tar.gz \
-  go1.19.linux-amd64.tar.gz
+ADD https://golang.org/dl/go1.19.8.linux-amd64.tar.gz \
+  go1.19.8.linux-amd64.tar.gz
 
 RUN rm -rf /usr/local/go && \
-  tar -C /usr/local -xzf go1.19.linux-amd64.tar.gz && \
-  rm go1.19.linux-amd64.tar.gz
+  tar -C /usr/local -xzf go1.19.8.linux-amd64.tar.gz && \
+  rm go1.19.8.linux-amd64.tar.gz
 
 ENV PATH /go/bin:/usr/local/go/bin:$PATH
 ENV GOPATH /go

--- a/changelog/unreleased/bump-go-in-docker-build.md
+++ b/changelog/unreleased/bump-go-in-docker-build.md
@@ -1,0 +1,5 @@
+Enhancement: Bump go version in docker build
+
+We now download go 1.18.8 in the docker ceph build
+
+https://github.com/cs3org/reva/pull/3829


### PR DESCRIPTION
I'm just frustrated with constant errors like [this](https://github.com/cs3org/reva/actions/runs/4830407065/jobs/8606599604?pr=3828):
```
ERROR: failed to solve: DeadlineExceeded: failed to load cache key: Get "https://dl.google.com/go/go1.19.linux-amd64.tar.gz": dial tcp 203.208.39.225:443: i/o timeout
Error: buildx failed with: ERROR: failed to solve: DeadlineExceeded: failed to load cache key: Get "https://dl.google.com/go/go1.19.linux-amd64.tar.gz": dial tcp 203.208.39.225:443: i/o timeout
```

dunno if this helps...