### PR TITLE
Be more robust when logging errors

### DIFF
--- a/changelog/unreleased/be-robust-when-logging-errors.md
+++ b/changelog/unreleased/be-robust-when-logging-errors.md
@@ -1,0 +1,5 @@
+Bugfix: Be more robust when logging errors
+
+We fixed a problem where logging errors resulted in a panic.
+
+https://github.com/cs3org/reva/pull/3830

--- a/pkg/publicshare/manager/json/json.go
+++ b/pkg/publicshare/manager/json/json.go
@@ -519,7 +519,14 @@ func (m *manager) ListPublicShares(ctx context.Context, u *user.User, filters []
 		key := strings.Join([]string{local.ResourceId.StorageId, local.ResourceId.OpaqueId}, "!")
 		if _, hit := cache[key]; !hit && !publicshare.IsCreatedByUser(local.PublicShare, u) {
 			sRes, err := client.Stat(ctx, &provider.StatRequest{Ref: &provider.Reference{ResourceId: local.ResourceId}})
-			if err != nil || sRes.Status.Code != rpc.Code_CODE_OK {
+			if err != nil {
+				log.Error().
+					Err(err).
+					Interface("resource_id", local.ResourceId).
+					Msg("ListShares: could not stat resource")
+				continue
+			}
+			if sRes.Status.Code != rpc.Code_CODE_OK {
 				log.Error().
 					Err(err).
 					Interface("status", sRes.Status).


### PR DESCRIPTION
We fixed a problem where logging errors resulted in a panic.