### PR TITLE
ignore 'null' mtime on tus upload

### DIFF
--- a/changelog/unreleased/fix-null-mtime.md
+++ b/changelog/unreleased/fix-null-mtime.md
@@ -1,0 +1,5 @@
+Bugfix: ignore 'null' mtime on tus upload
+
+decomposedfs now ignores 'null' as an mtime
+
+https://github.com/cs3org/reva/pull/3831

--- a/pkg/storage/utils/decomposedfs/upload.go
+++ b/pkg/storage/utils/decomposedfs/upload.go
@@ -165,10 +165,14 @@ func (fs *Decomposedfs) InitiateUpload(ctx context.Context, ref *provider.Refere
 	if metadata != nil {
 		info.MetaData["providerID"] = metadata["providerID"]
 		if mtime, ok := metadata["mtime"]; ok {
-			info.MetaData["mtime"] = mtime
+			if mtime != "null" {
+				info.MetaData["mtime"] = mtime
+			}
 		}
 		if expiration, ok := metadata["expires"]; ok {
-			info.MetaData["expires"] = expiration
+			if expiration != "null" {
+				info.MetaData["expires"] = expiration
+			}
 		}
 		if _, ok := metadata["sizedeferred"]; ok {
 			info.SizeIsDeferred = true


### PR DESCRIPTION
decomposedfs now ignores 'null' as an mtime

in case the ui incodes the string `null` when writing metadata. some strict type checking problem in JS ;-)