### PR TITLE
perf(mime): Prevent overriding mime type mappings in RegisterMime

### DIFF
--- a/changelog/unreleased/mime-type-mappings.md
+++ b/changelog/unreleased/mime-type-mappings.md
@@ -1,0 +1,9 @@
+Enhancement: Prevent overriding mime type mappings in RegisterMime
+
+## Description
+
+This PR updates the **`RegisterMime`** function in the **`mime`** package to prevent overriding mime type mappings. The updated function checks if the given extension already exists in the **`mimes`** map before adding it. If the extension is already registered, the function returns an error. This ensures that existing mime type mappings are not accidentally overwritten.
+
+To implement this change, I added an **`error`** return value to the **`RegisterMime`** function signature and modified the function body to use the **`LoadOrStore`** method of the **`sync.Map`** to atomically check for the existence of the extension in the map and add it if it does not already exist.
+
+https://github.com/cs3org/reva/pull/3833

--- a/internal/grpc/services/appprovider/appprovider.go
+++ b/internal/grpc/services/appprovider/appprovider.go
@@ -23,6 +23,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
 	"os"
 	"strconv"
 	"time"
@@ -124,7 +125,12 @@ func registerMimeTypes(mappingFile string) error {
 		}
 		// register all mime types that were read
 		for e, m := range mimeTypes {
-			mime.RegisterMime(e, m)
+			if err := mime.RegisterMime(e, m); err != nil {
+				// handle the error here
+				log.Printf("Failed to register mime type for extension '%s': %v\n", e, err)
+				// return the error, or continue processing
+				return err // or continue
+			}
 		}
 	}
 	return nil

--- a/internal/grpc/services/storageprovider/storageprovider.go
+++ b/internal/grpc/services/storageprovider/storageprovider.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
 	"net/url"
 	"os"
 	"path"
@@ -153,10 +154,15 @@ func registerMimeTypes(mappingFile string) error {
 		if err != nil {
 			return fmt.Errorf("storageprovider: error unmarshalling the custom mime types file: +%v", err)
 		}
-		// register all mime types that were read
 		for e, m := range mimeTypes {
-			mime.RegisterMime(e, m)
+			if err := mime.RegisterMime(e, m); err != nil {
+				// handle the error here
+				log.Printf("Failed to register mime type for extension '%s': %v\n", e, err)
+				// return the error, or continue processing
+				return err // or continue
+			}
 		}
+
 	}
 	return nil
 }

--- a/pkg/mime/mime.go
+++ b/pkg/mime/mime.go
@@ -19,6 +19,7 @@
 package mime
 
 import (
+	"fmt"
 	"path"
 	"strings"
 	"sync"
@@ -36,9 +37,13 @@ func init() {
 
 // RegisterMime is a package level function that registers
 // a mime type with the given extension.
-// TODO(labkode): check that we do not override mime type mappings?
-func RegisterMime(ext, mime string) {
-	mimes.Store(ext, mime)
+// It returns an error if the extension is already registered.
+func RegisterMime(ext, mime string) error {
+	_, loaded := mimes.LoadOrStore(ext, mime)
+	if loaded {
+		return fmt.Errorf("mime type for extension '%s' already registered", ext)
+	}
+	return nil
 }
 
 // Detect returns the mimetype associated with the given filename.


### PR DESCRIPTION
## Description

This PR updates the **`RegisterMime`** function in the **`mime`** package to prevent overriding mime type mappings. The updated function checks if the given extension already exists in the **`mimes`** map before adding it. If the extension is already registered, the function returns an error. This ensures that existing mime type mappings are not accidentally overwritten.

To implement this change, I added an **`error`** return value to the **`RegisterMime`** function signature and modified the function body to use the **`LoadOrStore`** method of the **`sync.Map`** to atomically check for the existence of the extension in the map and add it if it does not already exist.
