### PR TITLE
fix error during mkcol

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -139,6 +139,14 @@ def coverage():
             {
                 "name": "unit-test",
                 "image": OC_CI_GOLANG,
+                "environment": {
+                    "HTTP_PROXY": {
+                        "from_secret": "drone_http_proxy",
+                    },
+                    "HTTPS_PROXY": {
+                        "from_secret": "drone_http_proxy",
+                    },
+                },
                 "commands": [
                     "make test",
                 ],
@@ -194,6 +202,12 @@ def testIntegration():
                 ],
                 "environment": {
                     "REDIS_ADDRESS": "redis:6379",
+                    "HTTP_PROXY": {
+                        "from_secret": "drone_http_proxy",
+                    },
+                    "HTTPS_PROXY": {
+                        "from_secret": "drone_http_proxy",
+                    },
                 },
             },
         ],

--- a/changelog/unreleased/fix-mkcol.md
+++ b/changelog/unreleased/fix-mkcol.md
@@ -1,0 +1,5 @@
+Bugfix: Return correct error during MKCOL
+
+We need to return a "PreconditionFailed" error if one of the parent folders during a MKCOL does not exist.
+
+https://github.com/cs3org/reva/pull/3834

--- a/pkg/storage/utils/decomposedfs/decomposedfs.go
+++ b/pkg/storage/utils/decomposedfs/decomposedfs.go
@@ -553,6 +553,9 @@ func (fs *Decomposedfs) CreateDir(ctx context.Context, ref *provider.Reference) 
 	// verify parent exists
 	var n *node.Node
 	if n, err = fs.lu.NodeFromResource(ctx, parentRef); err != nil {
+		if e, ok := err.(errtypes.NotFound); ok {
+			return errtypes.PreconditionFailed(e.Error())
+		}
 		return
 	}
 	// TODO check if user has access to root / space

--- a/pkg/storage/utils/decomposedfs/decomposedfs.go
+++ b/pkg/storage/utils/decomposedfs/decomposedfs.go
@@ -553,9 +553,6 @@ func (fs *Decomposedfs) CreateDir(ctx context.Context, ref *provider.Reference) 
 	// verify parent exists
 	var n *node.Node
 	if n, err = fs.lu.NodeFromResource(ctx, parentRef); err != nil {
-		if e, ok := err.(errtypes.NotFound); ok {
-			return errtypes.PreconditionFailed(e.Error())
-		}
 		return
 	}
 	// TODO check if user has access to root / space

--- a/pkg/storage/utils/decomposedfs/decomposedfs_test.go
+++ b/pkg/storage/utils/decomposedfs/decomposedfs_test.go
@@ -127,7 +127,7 @@ var _ = Describe("Decomposed", func() {
 				env.Permissions.On("AssemblePermissions", mock.Anything, mock.Anything, mock.Anything).Return(provider.ResourcePermissions{CreateContainer: true}, nil)
 				err := env.Fs.CreateDir(env.Ctx, dir2)
 				Expect(err).To(HaveOccurred())
-				Expect(err).Should(MatchError(errtypes.PreconditionFailed("dir2")))
+				Expect(err).Should(MatchError(errtypes.PreconditionFailed("error: not found: dir2")))
 			})
 		})
 	})

--- a/pkg/storage/utils/decomposedfs/lookup/lookup.go
+++ b/pkg/storage/utils/decomposedfs/lookup/lookup.go
@@ -225,7 +225,7 @@ func (lu *Lookup) WalkPath(ctx context.Context, r *node.Node, p string, followRe
 		}
 
 		if !r.Exists && i < len(segments)-1 {
-			return r, errtypes.NotFound(segments[i])
+			return r, errtypes.PreconditionFailed(segments[i])
 		}
 		if f != nil {
 			if err = f(ctx, r); err != nil {

--- a/pkg/storage/utils/decomposedfs/lookup/lookup.go
+++ b/pkg/storage/utils/decomposedfs/lookup/lookup.go
@@ -225,7 +225,7 @@ func (lu *Lookup) WalkPath(ctx context.Context, r *node.Node, p string, followRe
 		}
 
 		if !r.Exists && i < len(segments)-1 {
-			return r, errtypes.PreconditionFailed(segments[i])
+			return r, errtypes.NotFound(segments[i])
 		}
 		if f != nil {
 			if err = f(ctx, r); err != nil {


### PR DESCRIPTION
# Description

We need to return `409 Conflict` when one or more path elements during an MKCOL do not exist.

Fixes: https://github.com/owncloud/ocis/issues/6136