### PR TITLE
Fix the space id in the decomposedFS storageSpaceFromNode

### DIFF
--- a/changelog/unreleased/fix-spaceid-node.md
+++ b/changelog/unreleased/fix-spaceid-node.md
@@ -1,0 +1,5 @@
+Bugfix: Fix spaceID in the decomposedFS
+
+We returned the wrong spaceID within ``storageSpaceFromNode``. This was fixed and the storageprovider ID handling refactored.
+
+https://github.com/cs3org/reva/pull/3836

--- a/pkg/storage/utils/decomposedfs/spaces.go
+++ b/pkg/storage/utils/decomposedfs/spaces.go
@@ -897,7 +897,7 @@ func (fs *Decomposedfs) storageSpaceFromNode(ctx context.Context, n *node.Node, 
 		&provider.Reference{
 			ResourceId: &provider.ResourceId{
 				SpaceId:  n.SpaceRoot.SpaceID,
-				OpaqueId: n.ID},
+				OpaqueId: n.SpaceRoot.ID},
 		},
 	)
 	if err != nil {
@@ -923,7 +923,7 @@ func (fs *Decomposedfs) storageSpaceFromNode(ctx context.Context, n *node.Node, 
 		Id: &provider.StorageSpaceId{OpaqueId: ssID},
 		Root: &provider.ResourceId{
 			SpaceId:  n.SpaceRoot.SpaceID,
-			OpaqueId: n.ID,
+			OpaqueId: n.SpaceRoot.ID,
 		},
 		Name: sname,
 		// SpaceType is read from xattr below
@@ -974,7 +974,7 @@ func (fs *Decomposedfs) storageSpaceFromNode(ctx context.Context, n *node.Node, 
 		Value:   []byte(etag),
 	}
 
-	spaceAttributes, err := n.Xattrs()
+	spaceAttributes, err := n.SpaceRoot.Xattrs()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
# Bugfix: Fix spaceID in the decomposedFS

We returned the wrong spaceID within ``storageSpaceFromNode``. This was fixed and the storageprovider ID handling refactored.