### PR TITLE
fix nil pointer and improve logging

### DIFF
--- a/changelog/unreleased/fix-nil-pointer.md
+++ b/changelog/unreleased/fix-nil-pointer.md
@@ -1,0 +1,5 @@
+Bugfix: Fix nil pointer and improve logging
+
+We fixed a nil pointer error due to a wrong log statement and improved the logging in the json public share manager.
+
+https://github.com/cs3org/reva/pull/3841

--- a/internal/grpc/services/storageprovider/storageprovider.go
+++ b/internal/grpc/services/storageprovider/storageprovider.go
@@ -728,7 +728,7 @@ func (s *service) Stat(ctx context.Context, req *provider.StatRequest) (*provide
 
 	span.SetAttributes(attribute.KeyValue{
 		Key:   "reference",
-		Value: attribute.StringValue(req.Ref.String()),
+		Value: attribute.StringValue(req.GetRef().String()),
 	})
 
 	md, err := s.storage.GetMD(ctx, req.GetRef(), req.GetArbitraryMetadataKeys(), req.GetFieldMask().GetPaths())

--- a/pkg/publicshare/manager/json/json.go
+++ b/pkg/publicshare/manager/json/json.go
@@ -523,12 +523,20 @@ func (m *manager) ListPublicShares(ctx context.Context, u *user.User, filters []
 				log.Error().
 					Err(err).
 					Interface("resource_id", local.ResourceId).
-					Msg("ListShares: could not stat resource")
+					Msg("ListShares: an error occurred during stat on the resource")
 				continue
 			}
 			if sRes.Status.Code != rpc.Code_CODE_OK {
+				if sRes.Status.Code == rpc.Code_CODE_NOT_FOUND {
+					log.Debug().
+						Str("message", sRes.Status.Message).
+						Interface("status", sRes.Status).
+						Interface("resource_id", local.ResourceId).
+						Msg("ListShares: Resource not found")
+					continue
+				}
 				log.Error().
-					Err(err).
+					Str("message", sRes.Status.Message).
 					Interface("status", sRes.Status).
 					Interface("resource_id", local.ResourceId).
 					Msg("ListShares: could not stat resource")

--- a/pkg/storage/utils/decomposedfs/node/permissions.go
+++ b/pkg/storage/utils/decomposedfs/node/permissions.go
@@ -146,7 +146,7 @@ func (p *Permissions) AssemblePermissions(ctx context.Context, n *Node) (ap prov
 			// continue with next segment
 		}
 		if cn, err = cn.Parent(); err != nil {
-			return ap, errors.Wrap(err, "Decomposedfs: error getting parent "+cn.ParentID)
+			return ap, errors.Wrap(err, "Decomposedfs: error getting parent for node "+cn.ID)
 		}
 	}
 


### PR DESCRIPTION
# Description

Fix nil pointer due to wrong variable in log statement (tried to log ParentID when no parent is found)