### PR TITLE
allow scope check to impersonate space owners

### DIFF
--- a/changelog/unreleased/allow-scope-to-impersonate-space-owner.md
+++ b/changelog/unreleased/allow-scope-to-impersonate-space-owner.md
@@ -1,0 +1,6 @@
+Bugfix: allow scope check to impersonate space owners
+
+The publicshare scope check now fakes a user to mint an access token when impersonating a user of type `SPACE_OWNER` which is used for project spaces. This fixes downloading archives from public link shares in project spaces.
+
+https://github.com/cs3org/reva/pull/3843
+https://github.com/owncloud/ocis/issues/5229


### PR DESCRIPTION
The publicshare scope check now fakes a user to mint an access token when impersonating a user of type `SPACE_OWNER` which is used for project spaces. This fixes downloading archives from public link shares in project spaces.

Fixes https://github.com/owncloud/ocis/issues/5229