### PR TITLE
Fix propagation in concurrency scenarios

### DIFF
--- a/changelog/unreleased/fix-propagation.md
+++ b/changelog/unreleased/fix-propagation.md
@@ -1,0 +1,5 @@
+Bugfix: Fix propagation
+
+Fix propagation in concurrency scenarios
+
+https://github.com/cs3org/reva/pull/3845


### PR DESCRIPTION
With the previous code the propagation code read the parent node before grabbing the according write lock. That had the effect that when a directory was being updated concurrently by different operations the calculations were made on an outdated state, leading to incorrect numbers.

After this change we grab the lock BEFORE actually reading the node which ensures that we always work with the proper data.

Fixes https://github.com/owncloud/ocis/issues/6215