### PR TITLE
Pass remote id and sharedSecret in OCM call

### DIFF
--- a/internal/grpc/services/ocmproviderauthorizer/ocmproviderauthorizer.go
+++ b/internal/grpc/services/ocmproviderauthorizer/ocmproviderauthorizer.go
@@ -120,7 +120,7 @@ func (s *service) GetInfoByDomain(ctx context.Context, req *ocmprovider.GetInfoB
 
 func (s *service) IsProviderAllowed(ctx context.Context, req *ocmprovider.IsProviderAllowedRequest) (*ocmprovider.IsProviderAllowedResponse, error) {
 	log := appctx.GetLogger(ctx)
-	log.Debug().Msgf("is provider '%s' allowed?", req.Provider)
+	log.Debug().Msgf("is provider '%s' allowed?", req.Provider.Domain)
 	err := s.pa.IsProviderAllowed(ctx, req.Provider)
 	if err != nil {
 		return &ocmprovider.IsProviderAllowedResponse{

--- a/internal/grpc/services/ocmproviderauthorizer/ocmproviderauthorizer.go
+++ b/internal/grpc/services/ocmproviderauthorizer/ocmproviderauthorizer.go
@@ -22,6 +22,7 @@ import (
 	"context"
 
 	ocmprovider "github.com/cs3org/go-cs3apis/cs3/ocm/provider/v1beta1"
+	"github.com/cs3org/reva/pkg/appctx"
 	"github.com/cs3org/reva/pkg/errtypes"
 	"github.com/cs3org/reva/pkg/ocm/provider"
 	"github.com/cs3org/reva/pkg/ocm/provider/authorizer/registry"
@@ -118,6 +119,8 @@ func (s *service) GetInfoByDomain(ctx context.Context, req *ocmprovider.GetInfoB
 }
 
 func (s *service) IsProviderAllowed(ctx context.Context, req *ocmprovider.IsProviderAllowedRequest) (*ocmprovider.IsProviderAllowedResponse, error) {
+	log := appctx.GetLogger(ctx)
+	log.Debug().Msgf("is provider '%s' allowed?", req.Provider)
 	err := s.pa.IsProviderAllowed(ctx, req.Provider)
 	if err != nil {
 		return &ocmprovider.IsProviderAllowedResponse{

--- a/internal/grpc/services/ocmshareprovider/ocmshareprovider.go
+++ b/internal/grpc/services/ocmshareprovider/ocmshareprovider.go
@@ -195,7 +195,7 @@ func (s *service) getWebdavProtocol(ctx context.Context, share *ocm.Share, m *oc
 	return &ocmd.WebDAV{
 		Permissions: perms,
 		URL:         s.webdavURL(ctx, share),
-		sharedSecret: share.Token,
+		SharedSecret: share.Token,
 	}
 }
 

--- a/internal/grpc/services/ocmshareprovider/ocmshareprovider.go
+++ b/internal/grpc/services/ocmshareprovider/ocmshareprovider.go
@@ -195,6 +195,7 @@ func (s *service) getWebdavProtocol(ctx context.Context, share *ocm.Share, m *oc
 	return &ocmd.WebDAV{
 		Permissions: perms,
 		URL:         s.webdavURL(ctx, share),
+		sharedSecret: share.Token,
 	}
 }
 
@@ -299,6 +300,7 @@ func (s *service) CreateOCMShare(ctx context.Context, req *ocm.CreateOCMShareReq
 	newShareReq := &client.NewShareRequest{
 		ShareWith:  formatOCMUser(req.Grantee.GetUserId()),
 		Name:       ocmshare.Name,
+		// FIXME: https://github.com/pondersource/nc-sciencemesh/issues/293#issuecomment-1537528109
 		// ResourceID: fmt.Sprintf("%s:%s", req.ResourceId.StorageId, req.ResourceId.OpaqueId),
 		ResourceID: ocmshare.Id.OpaqueId,
 		Owner: formatOCMUser(&userpb.UserId{

--- a/internal/grpc/services/ocmshareprovider/ocmshareprovider.go
+++ b/internal/grpc/services/ocmshareprovider/ocmshareprovider.go
@@ -299,7 +299,8 @@ func (s *service) CreateOCMShare(ctx context.Context, req *ocm.CreateOCMShareReq
 	newShareReq := &client.NewShareRequest{
 		ShareWith:  formatOCMUser(req.Grantee.GetUserId()),
 		Name:       ocmshare.Name,
-		ResourceID: fmt.Sprintf("%s:%s", req.ResourceId.StorageId, req.ResourceId.OpaqueId),
+		// ResourceID: fmt.Sprintf("%s:%s", req.ResourceId.StorageId, req.ResourceId.OpaqueId),
+		ResourceID: ocmshare.Id.OpaqueId,
 		Owner: formatOCMUser(&userpb.UserId{
 			OpaqueId: info.Owner.OpaqueId,
 			Idp:      s.conf.ProviderDomain, // FIXME: this is not generally true in case of resharing

--- a/internal/http/services/ocmd/shares.go
+++ b/internal/http/services/ocmd/shares.go
@@ -38,6 +38,7 @@ import (
 	rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
 	"github.com/cs3org/reva/internal/http/services/reqres"
 	"github.com/cs3org/reva/pkg/rgrpc/todo/pool"
+	"github.com/cs3org/reva/pkg/appctx"
 	"github.com/cs3org/reva/pkg/utils"
 	"github.com/go-playground/validator/v10"
 )
@@ -78,7 +79,7 @@ type createShareRequest struct {
 // synchronization between the two services.
 func (h *sharesHandler) CreateShare(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-
+  log := appctx.GetLogger(ctx)
 	req, err := getCreateShareRequest(r)
 	if err != nil {
 		reqres.WriteError(w, r, reqres.APIErrorInvalidParameter, err.Error(), nil)
@@ -86,6 +87,7 @@ func (h *sharesHandler) CreateShare(w http.ResponseWriter, r *http.Request) {
 	}
 
 	_, meshProvider, err := getIDAndMeshProvider(req.Sender)
+	log.Debug().Msgf("Determined Mesh Provider '%s' from req.Sender '%s'", meshProvider, req.Sender)
 	if err != nil {
 		reqres.WriteError(w, r, reqres.APIErrorInvalidParameter, err.Error(), nil)
 		return

--- a/internal/http/services/sciencemesh/share.go
+++ b/internal/http/services/sciencemesh/share.go
@@ -103,6 +103,7 @@ func (h *sharesHandler) CreateShare(w http.ResponseWriter, r *http.Request) {
 
 	perm, viewMode := getPermissionsByRole(req.Role)
 
+	log.Debug().Msg("calling gatewayClient.CreatOCMShare from sciencemesh/share.go")
 	shareRes, err := h.gatewayClient.CreateOCMShare(ctx, &ocm.CreateOCMShareRequest{
 		ResourceId: statRes.Info.Id,
 		Grantee: &providerpb.Grantee{
@@ -120,6 +121,8 @@ func (h *sharesHandler) CreateShare(w http.ResponseWriter, r *http.Request) {
 			share.NewWebappAccessMethod(viewMode),
 		},
 	})
+	log.Debug().Msg("called gatewayClient.CreatOCMShare from sciencemesh/share.go")
+
 	switch {
 	case err != nil:
 		reqres.WriteError(w, r, reqres.APIErrorServerError, "error sending a grpc CreateOCMShare", err)

--- a/internal/http/services/sciencemesh/share.go
+++ b/internal/http/services/sciencemesh/share.go
@@ -103,7 +103,7 @@ func (h *sharesHandler) CreateShare(w http.ResponseWriter, r *http.Request) {
 
 	perm, viewMode := getPermissionsByRole(req.Role)
 
-	log.Debug().Msg("calling gatewayClient.CreatOCMShare from sciencemesh/share.go")
+	log.Debug().Msg("calling gatewayClient.CreateOCMShare from sciencemesh/share.go")
 	shareRes, err := h.gatewayClient.CreateOCMShare(ctx, &ocm.CreateOCMShareRequest{
 		ResourceId: statRes.Info.Id,
 		Grantee: &providerpb.Grantee{
@@ -121,7 +121,7 @@ func (h *sharesHandler) CreateShare(w http.ResponseWriter, r *http.Request) {
 			share.NewWebappAccessMethod(viewMode),
 		},
 	})
-	log.Debug().Msg("called gatewayClient.CreatOCMShare from sciencemesh/share.go")
+	log.Debug().Msg("called gatewayClient.CreateOCMShare from sciencemesh/share.go")
 
 	switch {
 	case err != nil:

--- a/pkg/ocm/client/client.go
+++ b/pkg/ocm/client/client.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/cs3org/reva/internal/http/services/ocmd"
+	"github.com/cs3org/reva/pkg/appctx"
 	"github.com/cs3org/reva/pkg/errtypes"
 	"github.com/cs3org/reva/pkg/rhttp"
 	"github.com/pkg/errors"
@@ -195,6 +196,8 @@ func (c *OCMClient) NewShare(ctx context.Context, endpoint string, r *NewShareRe
 		return nil, err
 	}
 
+	log := appctx.GetLogger(ctx)
+	log.Debug().Msgf("Sending OCM /shares POST to %s: %s", url, body)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, body)
 	if err != nil {
 		return nil, errors.Wrap(err, "error creating request")

--- a/pkg/ocm/provider/authorizer/json/json.go
+++ b/pkg/ocm/provider/authorizer/json/json.go
@@ -28,6 +28,7 @@ import (
 	"sync"
 
 	ocmprovider "github.com/cs3org/go-cs3apis/cs3/ocm/provider/v1beta1"
+	"github.com/cs3org/reva/pkg/appctx"
 	"github.com/cs3org/reva/pkg/errtypes"
 	"github.com/cs3org/reva/pkg/ocm/provider"
 	"github.com/cs3org/reva/pkg/ocm/provider/authorizer/registry"
@@ -114,6 +115,7 @@ func (a *authorizer) GetInfoByDomain(ctx context.Context, domain string) (*ocmpr
 }
 
 func (a *authorizer) IsProviderAllowed(ctx context.Context, pi *ocmprovider.ProviderInfo) error {
+	log := appctx.GetLogger(ctx)
 	var err error
 	normalizedDomain, err := normalizeDomain(pi.Domain)
 	if err != nil {
@@ -142,6 +144,7 @@ func (a *authorizer) IsProviderAllowed(ctx context.Context, pi *ocmprovider.Prov
 
 	var ocmHost string
 	for _, p := range a.providers {
+		log.Debug().Msgf("Comparing '%s' to '%s'", p.Domain, normalizedDomain)
 		if p.Domain == normalizedDomain {
 			ocmHost, err = a.getOCMHost(p)
 			if err != nil {


### PR DESCRIPTION
In `internal/grpc/services/ocmshareprovider/ocmshareprovider.go`, pass `share.Token` as `SharedSecret` inside the WebDAV protocol details, and use the remote id as the resource id.

This PR also adds some debug messages.