### PR TITLE
Fix nil-pointer exception on trashbin purge

### DIFF
--- a/changelog/unreleased/fix-trashbin-purge.md
+++ b/changelog/unreleased/fix-trashbin-purge.md
@@ -1,0 +1,6 @@
+Bugfix: Fix trashbin purge
+
+We have fixed a nil-pointer-exception, when purging files from the trashbin that do not have a parent (any more)
+
+https://github.com/cs3org/reva/pull/3857
+https://github.com/owncloud/ocis/issues/6245

--- a/pkg/storage/utils/decomposedfs/node/permissions.go
+++ b/pkg/storage/utils/decomposedfs/node/permissions.go
@@ -145,8 +145,14 @@ func (p *Permissions) AssemblePermissions(ctx context.Context, n *Node) (ap prov
 			appctx.GetLogger(ctx).Error().Err(err).Interface("node", cn.ID).Msg("error reading permissions")
 			// continue with next segment
 		}
+
 		if cn, err = cn.Parent(); err != nil {
-			return ap, errors.Wrap(err, "Decomposedfs: error getting parent for node "+cn.ID)
+			// We get an error but get a parent, but can not read it from disk (eg. it has been deleted already)
+			if cn != nil {
+				return ap, errors.Wrap(err, "Decomposedfs: error getting parent for node "+cn.ID)
+			}
+			// We do not have a parent, so we assume the next valid parent is the spaceRoot (which must always exist)
+			cn = n.SpaceRoot
 		}
 	}
 


### PR DESCRIPTION
We have fixed a nil-pointer-exception, when purging files from the trashbin that do not have a parent (any more)

fixes https://github.com/owncloud/ocis/issues/6245