### PR TITLE
Fix public link lookup performance

### DIFF
--- a/changelog/unreleased/space-registry-path-filtering.md
+++ b/changelog/unreleased/space-registry-path-filtering.md
@@ -1,0 +1,5 @@
+Bugfix: Fix public link lookup performance
+
+Fix inefficient path based space lookup for public links
+
+https://github.com/cs3org/reva/pull/3866

--- a/internal/grpc/services/gateway/storageprovider.go
+++ b/internal/grpc/services/gateway/storageprovider.go
@@ -242,7 +242,7 @@ func (s *svc) ListStorageSpaces(ctx context.Context, req *provider.ListStorageSp
 		filters["mask"] = mask
 	}
 	path := utils.ReadPlainFromOpaque(req.Opaque, "path")
-	if mask != "" {
+	if path != "" {
 		// TODO check for allowed filters
 		filters["path"] = path
 	}

--- a/internal/grpc/services/gateway/storageprovider.go
+++ b/internal/grpc/services/gateway/storageprovider.go
@@ -241,6 +241,11 @@ func (s *svc) ListStorageSpaces(ctx context.Context, req *provider.ListStorageSp
 		// TODO check for allowed filters
 		filters["mask"] = mask
 	}
+	path := utils.ReadPlainFromOpaque(req.Opaque, "path")
+	if mask != "" {
+		// TODO check for allowed filters
+		filters["path"] = path
+	}
 
 	for _, f := range req.Filters {
 		switch f.Type {

--- a/pkg/storage/registry/spaces/spaces.go
+++ b/pkg/storage/registry/spaces/spaces.go
@@ -549,12 +549,30 @@ func (r *registry) findProvidersForAbsolutePathReference(ctx context.Context, pa
 		var spaces []*providerpb.StorageSpace
 		var err error
 
+		// check if any space in the provider has a valid mountpoint
+		containsRelatedSpace := false
+		for _, space := range provider.Spaces {
+			// either the mountpoint is a prefix of the path
+			if strings.HasPrefix(path, space.MountPoint) {
+				containsRelatedSpace = true
+				break
+			}
+			// or the path is a prefix of the mountpoint
+			if strings.HasPrefix(space.MountPoint, path) {
+				containsRelatedSpace = true
+				break
+			}
+		}
+		if !containsRelatedSpace {
+			continue
+		}
+
 		// when listing paths also return mountpoints
 		filters := []*providerpb.ListStorageSpacesRequest_Filter{
 			{
 				Type: providerpb.ListStorageSpacesRequest_Filter_TYPE_PATH,
 				Term: &providerpb.ListStorageSpacesRequest_Filter_Path{
-					Path: strings.TrimPrefix(path, p.ProviderPath),
+					Path: strings.TrimPrefix(path, p.ProviderPath), // FIXME this no longer has an effect as the p.Providerpath is always empty
 				},
 			},
 			{

--- a/pkg/storage/registry/spaces/spaces.go
+++ b/pkg/storage/registry/spaces/spaces.go
@@ -552,13 +552,20 @@ func (r *registry) findProvidersForAbsolutePathReference(ctx context.Context, pa
 		// check if any space in the provider has a valid mountpoint
 		containsRelatedSpace := false
 		for _, space := range provider.Spaces {
+			spacePath, err := space.SpacePath(currentUser, nil)
+			if err != nil || strings.Contains(spacePath, "{{") {
+				// couldn't fully evaluate the template. opt on the safe side
+				// and consider the provider relevant
+				containsRelatedSpace = true
+				break
+			}
 			// either the mountpoint is a prefix of the path
-			if strings.HasPrefix(path, space.MountPoint) {
+			if strings.HasPrefix(path, spacePath) {
 				containsRelatedSpace = true
 				break
 			}
 			// or the path is a prefix of the mountpoint
-			if strings.HasPrefix(space.MountPoint, path) {
+			if strings.HasPrefix(spacePath, path) {
 				containsRelatedSpace = true
 				break
 			}


### PR DESCRIPTION
Fix inefficient path based space lookup for public links.

public links use `/public/{token}` path based references. This PR checks the configured mountpoint of a space to skip storage providers that don't have a matching mountpoint, when looking up spaces for a path.