### PR TITLE
Restore last version after positive result

### DIFF
--- a/changelog/unreleased/fix-version-restore-after-pp.md
+++ b/changelog/unreleased/fix-version-restore-after-pp.md
@@ -1,0 +1,6 @@
+Bugfix: Restore last version after positive result
+
+We fixed a bug in the copy routine that prevented restoring of a previous version after post-processing (e.g. virus scanning)
+
+https://github.com/cs3org/reva/pull/3867
+https://github.com/owncloud/enterprise/issues/5709

--- a/pkg/storage/utils/decomposedfs/upload/upload.go
+++ b/pkg/storage/utils/decomposedfs/upload/upload.go
@@ -370,7 +370,7 @@ func (upload *Upload) cleanup(cleanNode, cleanBin, cleanInfo bool) {
 			upload.Node = nil
 		default:
 
-			if err := upload.lu.CopyMetadata(upload.Node.InternalPath(), p, func(attributeName string) bool {
+			if err := upload.lu.CopyMetadata(p, upload.Node.InternalPath(), func(attributeName string) bool {
 				return strings.HasPrefix(attributeName, prefixes.ChecksumPrefix) ||
 					attributeName == prefixes.TypeAttr ||
 					attributeName == prefixes.BlobIDAttr ||


### PR DESCRIPTION
We fixed a bug in the copy routine that prevented restoring of a previous version after post-processing (e.g. virus scanning)

fixes https://github.com/owncloud/enterprise/issues/5709