### PR TITLE
decomposedfs no longer deadlocks when cache is disabled

### DIFF
--- a/changelog/unreleased/fix-propagation-deadlock.md
+++ b/changelog/unreleased/fix-propagation-deadlock.md
@@ -1,0 +1,5 @@
+Bugfix: decomposedfs no longer deadlocks when cache is disabled
+
+We fixed a bug in the decomposedfs that causes the propagation to deadlock if caching is disabled.
+
+https://github.com/cs3org/reva/pull/3880

--- a/pkg/storage/utils/decomposedfs/decomposedfs.go
+++ b/pkg/storage/utils/decomposedfs/decomposedfs.go
@@ -207,7 +207,7 @@ func (fs *Decomposedfs) Postprocessing(ch <-chan events.Event) {
 				keepUpload bool
 			)
 
-			n, err := node.ReadNode(ctx, fs.lu, up.Info.Storage["SpaceRoot"], up.Info.Storage["NodeId"], false, nil, true)
+			n, err := node.ReadNode(ctx, fs.lu, up.Info.Storage["SpaceRoot"], up.Info.Storage["NodeId"], false, nil, true, nil)
 			if err != nil {
 				log.Error().Err(err).Str("uploadID", ev.UploadID).Msg("could not read node")
 				continue
@@ -232,7 +232,7 @@ func (fs *Decomposedfs) Postprocessing(ch <-chan events.Event) {
 			}
 
 			now := time.Now()
-			if p, err := node.ReadNode(ctx, fs.lu, up.Info.Storage["SpaceRoot"], n.ParentID, false, nil, true); err != nil {
+			if p, err := node.ReadNode(ctx, fs.lu, up.Info.Storage["SpaceRoot"], n.ParentID, false, nil, true, nil); err != nil {
 				log.Error().Err(err).Str("uploadID", ev.UploadID).Msg("could not read parent")
 			} else {
 				// update parent tmtime to propagate etag change
@@ -370,7 +370,7 @@ func (fs *Decomposedfs) Postprocessing(ch <-chan events.Event) {
 					continue
 				}
 
-				no, err := node.ReadNode(up.Ctx, fs.lu, up.Info.Storage["SpaceRoot"], up.Info.Storage["NodeId"], false, nil, false)
+				no, err := node.ReadNode(up.Ctx, fs.lu, up.Info.Storage["SpaceRoot"], up.Info.Storage["NodeId"], false, nil, false, nil)
 				if err != nil {
 					log.Error().Err(err).Interface("uploadID", ev.UploadID).Msg("Failed to get node after scan")
 					continue

--- a/pkg/storage/utils/decomposedfs/node/node.go
+++ b/pkg/storage/utils/decomposedfs/node/node.go
@@ -218,6 +218,19 @@ func ReadNode(ctx context.Context, lu PathLookup, spaceID, nodeID string, canLis
 			ID:      spaceID,
 		}
 		spaceRoot.SpaceRoot = spaceRoot
+
+		// Initialize node attribute cache from the given reader if possible
+		if nodeID == spaceID && r != nil {
+			_, err = spaceRoot.XattrsWithReader(r)
+		} else {
+			_, err = spaceRoot.Xattrs()
+		}
+		switch {
+		case metadata.IsNotExist(err):
+			return spaceRoot, nil // swallow not found, the node defaults to exists = false
+		case err != nil:
+			return nil, err
+		}
 		spaceRoot.owner, err = spaceRoot.readOwner()
 		switch {
 		case metadata.IsNotExist(err):

--- a/pkg/storage/utils/decomposedfs/node/node_test.go
+++ b/pkg/storage/utils/decomposedfs/node/node_test.go
@@ -74,7 +74,7 @@ var _ = Describe("Node", func() {
 			})
 			Expect(err).ToNot(HaveOccurred())
 
-			n, err := node.ReadNode(env.Ctx, env.Lookup, lookupNode.SpaceID, lookupNode.ID, false, nil, false)
+			n, err := node.ReadNode(env.Ctx, env.Lookup, lookupNode.SpaceID, lookupNode.ID, false, nil, false, nil)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(n.BlobID).To(Equal("file1-blobid"))
 		})
@@ -327,7 +327,7 @@ var _ = Describe("Node", func() {
 			})
 			Expect(err).ToNot(HaveOccurred())
 			// checking that the path "subpath" is denied properly
-			subfolder, err = node.ReadNode(env.Ctx, env.Lookup, subfolder.SpaceID, subfolder.ID, false, nil, false)
+			subfolder, err = node.ReadNode(env.Ctx, env.Lookup, subfolder.SpaceID, subfolder.ID, false, nil, false, nil)
 			Expect(err).ToNot(HaveOccurred())
 			subfolderActual, denied := subfolder.PermissionSet(env.Ctx)
 			subfolderExpected := ocsconv.NewDeniedRole().CS3ResourcePermissions()

--- a/pkg/storage/utils/decomposedfs/revisions.go
+++ b/pkg/storage/utils/decomposedfs/revisions.go
@@ -124,7 +124,7 @@ func (fs *Decomposedfs) DownloadRevision(ctx context.Context, ref *provider.Refe
 
 	spaceID := ref.ResourceId.SpaceId
 	// check if the node is available and has not been deleted
-	n, err := node.ReadNode(ctx, fs.lu, spaceID, kp[0], false, nil, false)
+	n, err := node.ReadNode(ctx, fs.lu, spaceID, kp[0], false, nil, false, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -178,7 +178,7 @@ func (fs *Decomposedfs) RestoreRevision(ctx context.Context, ref *provider.Refer
 
 	spaceID := ref.ResourceId.SpaceId
 	// check if the node is available and has not been deleted
-	n, err := node.ReadNode(ctx, fs.lu, spaceID, kp[0], false, nil, false)
+	n, err := node.ReadNode(ctx, fs.lu, spaceID, kp[0], false, nil, false, nil)
 	if err != nil {
 		return err
 	}
@@ -315,7 +315,7 @@ func (fs *Decomposedfs) getRevisionNode(ctx context.Context, ref *provider.Refer
 
 	spaceID := ref.ResourceId.SpaceId
 	// check if the node is available and has not been deleted
-	n, err := node.ReadNode(ctx, fs.lu, spaceID, kp[0], false, nil, false)
+	n, err := node.ReadNode(ctx, fs.lu, spaceID, kp[0], false, nil, false, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/storage/utils/decomposedfs/spaces.go
+++ b/pkg/storage/utils/decomposedfs/spaces.go
@@ -86,7 +86,7 @@ func (fs *Decomposedfs) CreateStorageSpace(ctx context.Context, req *provider.Cr
 		alias = templates.WithSpacePropertiesAndUser(u, req.Type, req.Name, fs.o.PersonalSpaceAliasTemplate)
 	}
 
-	root, err := node.ReadNode(ctx, fs.lu, spaceID, spaceID, true, nil, false) // will fall into `Exists` case below
+	root, err := node.ReadNode(ctx, fs.lu, spaceID, spaceID, true, nil, false, nil) // will fall into `Exists` case below
 	switch {
 	case err != nil:
 		return nil, err
@@ -273,7 +273,7 @@ func (fs *Decomposedfs) ListStorageSpaces(ctx context.Context, filter []*provide
 
 	if spaceID != spaceIDAny && nodeID != spaceIDAny {
 		// try directly reading the node
-		n, err := node.ReadNode(ctx, fs.lu, spaceID, nodeID, true, nil, false) // permission to read disabled space is checked later
+		n, err := node.ReadNode(ctx, fs.lu, spaceID, nodeID, true, nil, false, nil) // permission to read disabled space is checked later
 		if err != nil {
 			appctx.GetLogger(ctx).Error().Err(err).Str("id", nodeID).Msg("could not read node")
 			return nil, err
@@ -387,7 +387,7 @@ func (fs *Decomposedfs) ListStorageSpaces(ctx context.Context, filter []*provide
 			continue
 		}
 
-		n, err := node.ReadNode(ctx, fs.lu, spaceID, nodeID, true, nil, true)
+		n, err := node.ReadNode(ctx, fs.lu, spaceID, nodeID, true, nil, true, nil)
 		if err != nil {
 			appctx.GetLogger(ctx).Error().Err(err).Str("id", nodeID).Msg("could not read node, skipping")
 			continue
@@ -427,7 +427,7 @@ func (fs *Decomposedfs) ListStorageSpaces(ctx context.Context, filter []*provide
 	// if there are no matches (or they happened to be spaces for the owner) and the node is a child return a space
 	if len(matches) <= numShares && nodeID != spaceID {
 		// try node id
-		n, err := node.ReadNode(ctx, fs.lu, spaceID, nodeID, true, nil, false) // permission to read disabled space is checked in storageSpaceFromNode
+		n, err := node.ReadNode(ctx, fs.lu, spaceID, nodeID, true, nil, false, nil) // permission to read disabled space is checked in storageSpaceFromNode
 		if err != nil {
 			return nil, err
 		}
@@ -540,7 +540,7 @@ func (fs *Decomposedfs) UpdateStorageSpace(ctx context.Context, req *provider.Up
 	}
 
 	// check which permissions are needed
-	spaceNode, err := node.ReadNode(ctx, fs.lu, spaceID, spaceID, true, nil, false)
+	spaceNode, err := node.ReadNode(ctx, fs.lu, spaceID, spaceID, true, nil, false, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -641,7 +641,7 @@ func (fs *Decomposedfs) DeleteStorageSpace(ctx context.Context, req *provider.De
 		return err
 	}
 
-	n, err := node.ReadNode(ctx, fs.lu, spaceID, spaceID, true, nil, false) // permission to read disabled space is checked later
+	n, err := node.ReadNode(ctx, fs.lu, spaceID, spaceID, true, nil, false, nil) // permission to read disabled space is checked later
 	if err != nil {
 		return err
 	}

--- a/pkg/storage/utils/decomposedfs/testhelpers/helpers.go
+++ b/pkg/storage/utils/decomposedfs/testhelpers/helpers.go
@@ -285,7 +285,7 @@ func (t *TestEnv) CreateTestStorageSpace(typ string, quota *providerv1beta1.Quot
 	if err != nil {
 		return nil, err
 	}
-	h, err := node.ReadNode(t.Ctx, t.Lookup, sid.SpaceId, sid.OpaqueId, false, nil, false)
+	h, err := node.ReadNode(t.Ctx, t.Lookup, sid.SpaceId, sid.OpaqueId, false, nil, false, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/storage/utils/decomposedfs/tree/tree.go
+++ b/pkg/storage/utils/decomposedfs/tree/tree.go
@@ -710,7 +710,14 @@ func (t *Tree) Propagate(ctx context.Context, n *node.Node, sizeDiff int64) (err
 		attrs := node.Attributes{}
 
 		var f io.Closer
-		f, n, err = t.lookup.LockAndRead(ctx, &provider.ResourceId{SpaceId: n.SpaceID, OpaqueId: n.ParentID}, n.SpaceRoot)
+
+		sr := n.SpaceRoot
+		if n.ParentID == n.SpaceRoot.ID {
+			sr = nil
+		}
+
+		f, n, err = t.lookup.LockAndRead(ctx, &provider.ResourceId{SpaceId: n.SpaceID, OpaqueId: n.ParentID}, sr)
+
 		// always log error if closing node fails
 		defer func() {
 			// ignore already closed error

--- a/pkg/storage/utils/decomposedfs/upload/processing.go
+++ b/pkg/storage/utils/decomposedfs/upload/processing.go
@@ -256,7 +256,7 @@ func CreateNodeForUpload(upload *Upload, initAttrs node.Attributes) (*node.Node,
 		nil,
 		upload.lu,
 	)
-	n.SpaceRoot, err = node.ReadNode(upload.Ctx, upload.lu, spaceID, spaceID, false, nil, false)
+	n.SpaceRoot, err = node.ReadNode(upload.Ctx, upload.lu, spaceID, spaceID, false, nil, false, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -372,7 +372,7 @@ func initNewNode(upload *Upload, n *node.Node, fsize uint64) (*lockedfile.File, 
 }
 
 func updateExistingNode(upload *Upload, n *node.Node, spaceID string, fsize uint64) (*lockedfile.File, error) {
-	old, _ := node.ReadNode(upload.Ctx, upload.lu, spaceID, n.ID, false, nil, false)
+	old, _ := node.ReadNode(upload.Ctx, upload.lu, spaceID, n.ID, false, nil, false, nil)
 	if _, err := node.CheckQuota(n.SpaceRoot, true, uint64(old.Blobsize), fsize); err != nil {
 		return nil, err
 	}

--- a/pkg/storage/utils/decomposedfs/upload/upload.go
+++ b/pkg/storage/utils/decomposedfs/upload/upload.go
@@ -327,7 +327,7 @@ func (upload *Upload) Finalize() (err error) {
 	n := upload.Node
 	if n == nil {
 		var err error
-		n, err = node.ReadNode(upload.Ctx, upload.lu, upload.Info.Storage["SpaceRoot"], upload.Info.Storage["NodeId"], false, nil, false)
+		n, err = node.ReadNode(upload.Ctx, upload.lu, upload.Info.Storage["SpaceRoot"], upload.Info.Storage["NodeId"], false, nil, false, nil)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
We fixed a bug in the decomposedfs that causes the propagation to deadlock if caching is disabled.
