### PR TITLE
use context to pass reader for locked files

### DIFF
--- a/changelog/unreleased/pass-file-in-context.md
+++ b/changelog/unreleased/pass-file-in-context.md
@@ -1,0 +1,5 @@
+Bugfix: decomposedfs no longer deadlocks when cache is disabled
+
+We now pass a context to lower level functions which allows passing a reader for already locked files.
+
+https://github.com/cs3org/reva/pull/3885

--- a/pkg/storage/utils/decomposedfs/node/context.go
+++ b/pkg/storage/utils/decomposedfs/node/context.go
@@ -1,0 +1,20 @@
+package node
+
+import (
+	"context"
+	"io"
+)
+
+// readerKey is the key for a reader to use when reading metadata
+type readerKey struct{}
+
+// ContextWithReader makes a new context that contains a reader to use when reading metadata. Use it if you want to read metadata from a locked node.
+func ContextWithReader(parent context.Context, r io.Reader) context.Context {
+	return context.WithValue(parent, readerKey{}, r)
+}
+
+// ReaderFromContext returns the reader stored in a context, or nil if there isn't one.
+func ReaderFromContext(ctx context.Context) io.Reader {
+	s, _ := ctx.Value(readerKey{}).(io.Reader)
+	return s
+}

--- a/pkg/storage/utils/decomposedfs/node/node.go
+++ b/pkg/storage/utils/decomposedfs/node/node.go
@@ -405,8 +405,8 @@ func (n *Node) Child(ctx context.Context, name string) (*Node, error) {
 	return c, nil
 }
 
-// Parent returns the parent node
-func (n *Node) Parent() (p *Node, err error) {
+// ParentWithContext returns the parent node
+func (n *Node) ParentWithContext(ctx context.Context) (p *Node, err error) {
 	if n.ParentID == "" {
 		return nil, fmt.Errorf("decomposedfs: root has no parent")
 	}
@@ -417,6 +417,8 @@ func (n *Node) Parent() (p *Node, err error) {
 		SpaceRoot: n.SpaceRoot,
 	}
 
+	p.XattrsWithContext(ctx)
+
 	// lookup name and parent id in extended attributes
 	p.ParentID, _ = p.XattrString(prefixes.ParentidAttr)
 	p.Name, _ = p.XattrString(prefixes.NameAttr)
@@ -426,6 +428,11 @@ func (n *Node) Parent() (p *Node, err error) {
 		p.Exists = true
 	}
 	return
+}
+
+// Parent returns the parent node
+func (n *Node) Parent() (p *Node, err error) {
+	return n.ParentWithContext(context.TODO())
 }
 
 // Owner returns the space owner

--- a/pkg/storage/utils/decomposedfs/node/xattrs.go
+++ b/pkg/storage/utils/decomposedfs/node/xattrs.go
@@ -19,6 +19,7 @@
 package node
 
 import (
+	"context"
 	"strconv"
 
 	"github.com/pkg/xattr"
@@ -84,19 +85,32 @@ func (n *Node) RemoveXattr(key string) error {
 	return n.lu.MetadataBackend().Remove(n.InternalPath(), key)
 }
 
-// Xattrs returns the extended attributes of the node. If the attributes have already
+// XattrsWithContext returns the extended attributes of the node. If the attributes have already
 // been cached they are not read from disk again.
-func (n *Node) Xattrs() (Attributes, error) {
+func (n *Node) XattrsWithContext(ctx context.Context) (Attributes, error) {
 	if n.xattrsCache != nil {
 		return n.xattrsCache, nil
 	}
 
-	attrs, err := n.lu.MetadataBackend().All(n.InternalPath())
+	var attrs Attributes
+	var err error
+	if reader := ReaderFromContext(ctx); reader != nil {
+		attrs, err = n.lu.MetadataBackend().AllWithLockedSource(n.InternalPath(), reader)
+	} else {
+		attrs, err = n.lu.MetadataBackend().All(n.InternalPath())
+	}
 	if err != nil {
 		return nil, err
 	}
+
 	n.xattrsCache = attrs
 	return n.xattrsCache, nil
+}
+
+// Xattrs returns the extended attributes of the node. If the attributes have already
+// been cached they are not read from disk again.
+func (n *Node) Xattrs() (Attributes, error) {
+	return n.XattrsWithContext(context.TODO())
 }
 
 // Xattr returns an extended attribute of the node. If the attributes have already

--- a/pkg/storage/utils/decomposedfs/tree/tree.go
+++ b/pkg/storage/utils/decomposedfs/tree/tree.go
@@ -731,7 +731,8 @@ func (t *Tree) Propagate(ctx context.Context, n *node.Node, sizeDiff int64) (err
 			}
 		}()
 
-		if n, err = n.Parent(); err != nil {
+		ctx = node.ContextWithReader(ctx, f)
+		if n, err = n.ParentWithContext(ctx); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
We now pass a context to lower level functions which allows passing a reader for already locked files.

alternative approach to https://github.com/cs3org/reva/pull/3880