### PR TITLE
allow passing reader to read metadata

### DIFF
--- a/changelog/unreleased/fix-deadlock-by-passing-reader.md
+++ b/changelog/unreleased/fix-deadlock-by-passing-reader.md
@@ -1,0 +1,5 @@
+Bugfix: decomposedfs no longer deadlocks when cache is disabled
+
+We now pass a Reader for the locked file to lower level functions so metadata can be read without aquiring a new file lock.
+
+https://github.com/cs3org/reva/pull/3886

--- a/pkg/storage/utils/decomposedfs/node/node.go
+++ b/pkg/storage/utils/decomposedfs/node/node.go
@@ -405,8 +405,8 @@ func (n *Node) Child(ctx context.Context, name string) (*Node, error) {
 	return c, nil
 }
 
-// Parent returns the parent node
-func (n *Node) Parent() (p *Node, err error) {
+// ParentWithReader returns the parent node
+func (n *Node) ParentWithReader(r io.Reader) (p *Node, err error) {
 	if n.ParentID == "" {
 		return nil, fmt.Errorf("decomposedfs: root has no parent")
 	}
@@ -417,6 +417,9 @@ func (n *Node) Parent() (p *Node, err error) {
 		SpaceRoot: n.SpaceRoot,
 	}
 
+	// fill metadata cache using the reader
+	_, _ = p.XattrsWithReader(r)
+
 	// lookup name and parent id in extended attributes
 	p.ParentID, _ = p.XattrString(prefixes.ParentidAttr)
 	p.Name, _ = p.XattrString(prefixes.NameAttr)
@@ -426,6 +429,11 @@ func (n *Node) Parent() (p *Node, err error) {
 		p.Exists = true
 	}
 	return
+}
+
+// Parent returns the parent node
+func (n *Node) Parent() (p *Node, err error) {
+	return n.ParentWithReader(nil)
 }
 
 // Owner returns the space owner

--- a/pkg/storage/utils/decomposedfs/tree/tree.go
+++ b/pkg/storage/utils/decomposedfs/tree/tree.go
@@ -731,7 +731,7 @@ func (t *Tree) Propagate(ctx context.Context, n *node.Node, sizeDiff int64) (err
 			}
 		}()
 
-		if n, err = n.Parent(); err != nil {
+		if n, err = n.ParentWithReader(f); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
We now pass a Reader for the locked file to lower level functions so metadata can be read without aquiring a new file lock.

Yet another Alternative to https://github.com/cs3org/reva/pull/3880
Less magic approach than https://github.com/cs3org/reva/pull/3885