### PR TITLE
space member changes do not need to fetch all group members

### DIFF
--- a/changelog/unreleased/efficient-space-sharing-for-groups.md
+++ b/changelog/unreleased/efficient-space-sharing-for-groups.md
@@ -1,0 +1,5 @@
+Bugfix: We fixed a bug that unnecessarily fetched all members of a group
+
+Adding or removing groups to spaces is now done without retrieving all group members
+
+https://github.com/cs3org/reva/pull/3888

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/spaces.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/spaces.go
@@ -61,8 +61,9 @@ func (h *Handler) getGrantee(ctx context.Context, name string) (provider.Grantee
 	log.Debug().Str("name", name).Msg("no user found")
 
 	groupRes, err := client.GetGroupByClaim(ctx, &groupv1beta1.GetGroupByClaimRequest{
-		Claim: "group_name",
-		Value: name,
+		Claim:               "group_name",
+		Value:               name,
+		SkipFetchingMembers: true,
 	})
 	if err == nil && groupRes.Status.Code == rpc.Code_CODE_OK {
 		return provider.Grantee{


### PR DESCRIPTION
Adding or removing groups to spaces is now done without retrieving all group members

fixes https://github.com/owncloud/ocis/issues/6298
