### PR TITLE
Bump space TreeMTime when changing the metadata

### DIFF
--- a/changelog/unreleased/fix-space-root-mtime-update.md
+++ b/changelog/unreleased/fix-space-root-mtime-update.md
@@ -1,0 +1,6 @@
+Bugfix: Update space root mtime when changing space metadata
+
+We fixed a problem where space mtimes were not updated when their metadata changed, resulting in changes not being picked up by other services like search.
+
+https://github.com/cs3org/reva/pull/3889
+https://github.com/owncloud/ocis/issues/6289

--- a/pkg/storage/utils/decomposedfs/spaces.go
+++ b/pkg/storage/utils/decomposedfs/spaces.go
@@ -604,6 +604,7 @@ func (fs *Decomposedfs) UpdateStorageSpace(ctx context.Context, req *provider.Up
 			}, nil
 		}
 	}
+	metadata[prefixes.TreeMTimeAttr] = []byte(time.Now().UTC().Format(time.RFC3339Nano))
 
 	err = spaceNode.SetXattrs(metadata, true)
 	if err != nil {


### PR DESCRIPTION
This enables the search to pick up the changes properly.

Part of the fix for https://github.com/owncloud/ocis/issues/6289