### PR TITLE
Fix Public Link Path matching

### DIFF
--- a/changelog/unreleased/fix-public-links.md
+++ b/changelog/unreleased/fix-public-links.md
@@ -1,0 +1,5 @@
+Bugfix: Fix public links
+
+Public links would not work when not send on the root level. Reason was wrong path matching. Also fixes a critical bug that was unfound before
+
+https://github.com/cs3org/reva/pull/3892


### PR DESCRIPTION
Fixes matching of pathes when resolving public links.

We need another `GetPath` call to get the necessary information.
