### PR TITLE
Cleanup Space Delete Permissions

### DIFF
--- a/changelog/unreleased/cleanup-space-delete-permissions.md
+++ b/changelog/unreleased/cleanup-space-delete-permissions.md
@@ -1,0 +1,10 @@
+Enhancement: Cleanup Space Delete permissions
+
+Space Delete and Disable permissions ("Drive.ReadWriteEnabled", "delete-all-spaces", "delete-all-home-spaces") were overlapping and not clear differentiatable.
+The new logic is as follows:
+  -  "Drive.ReadWriteEnabled" allows enabling or disabling a project space
+  -  "delete-all-home-spaces" allows deleting personal spaces of users
+  -  "delete-all-spaces" allows deleting a project space
+  -  Space Mangers can still disable/enable a drive
+
+https://github.com/cs3org/reva/pull/3893

--- a/pkg/storage/utils/decomposedfs/spaces.go
+++ b/pkg/storage/utils/decomposedfs/spaces.go
@@ -652,29 +652,9 @@ func (fs *Decomposedfs) DeleteStorageSpace(ctx context.Context, req *provider.De
 		return errtypes.InternalError(fmt.Sprintf("space %s does not have a spacetype, possible corrupt decompsedfs", n.ID))
 	}
 
-	// - spaces of type personal can be deleted by users with the "delete-all-home-spaces" permission
-	// - a User with the "delete-all-spaces" permission can delete any project space
-	// - otherwise a space can be disabled by its manager (i.e. users have the "remove" grant) or a user with "Drive.ReadWriteEnabled"
-	switch {
-	case st == "personal":
-		if !fs.p.DeleteAllHomeSpaces(ctx) {
-			return errtypes.PermissionDenied(fmt.Sprintf("user is not allowed to delete home space %s", n.ID))
-		}
-	case purge:
-		// We are trying to purge a space - delete permission is needed for that
-		if !fs.p.DeleteAllSpaces(ctx) {
-			return errtypes.PermissionDenied(fmt.Sprintf("user is not allowed to purge space %s", n.ID))
-		}
-	default: // aka "disable a non-personal space"
-		// managers and users with 'space ability' permission are allowed to disable a drive
-		if !fs.p.SpaceAbility(ctx, spaceID) {
-			rp, err := fs.p.AssemblePermissions(ctx, n)
-			if err != nil || !IsManager(rp) {
-				return errtypes.PermissionDenied(fmt.Sprintf("user is not allowed to delete spaces %s", n.ID))
-			}
-		}
+	if err := canDeleteSpace(ctx, spaceID, st, purge, n, fs.p); err != nil {
+		return err
 	}
-
 	if purge {
 		if !n.IsDisabled() {
 			return errtypes.NewErrtypeFromStatus(status.NewInvalid(ctx, "can't purge enabled space"))
@@ -1058,4 +1038,36 @@ func isGrantExpired(g *provider.Grant) bool {
 
 func (fs *Decomposedfs) getSpaceRoot(spaceID string) string {
 	return filepath.Join(fs.o.Root, "spaces", lookup.Pathify(spaceID, 1, 2))
+}
+
+// Space deletion can be tricky as there are lots of different cases:
+// - spaces of type personal can only be disabled and deleted by users with the "delete-all-home-spaces" permission
+// - a user with the "delete-all-spaces" permission may delete but not enable/disable any project space
+// - a user with the "Drive.ReadWriteEnabled" permission may enable/disable but not delete any project space
+// - a project space can always be enabled/disabled/deleted by its manager (i.e. users have the "remove" grant)
+func canDeleteSpace(ctx context.Context, spaceID string, typ string, purge bool, n *node.Node, p Permissions) error {
+	// delete-all-home spaces allows to disable and delete a personal space
+	if typ == "personal" {
+		if p.DeleteAllHomeSpaces(ctx) {
+			return nil
+		}
+		return errtypes.PermissionDenied("user is not allowed to delete a personal space")
+	}
+
+	// space managers are allowed to disable and delete their project spaces
+	if rp, err := p.AssemblePermissions(ctx, n); err == nil && IsManager(rp) {
+		return nil
+	}
+
+	// delete-all-spaces permissions allows to delete (purge, NOT disable) project spaces
+	if purge && p.DeleteAllSpaces(ctx) {
+		return nil
+	}
+
+	// Drive.ReadWriteEnabled allows to disable a space
+	if !purge && p.SpaceAbility(ctx, spaceID) {
+		return nil
+	}
+
+	return errtypes.PermissionDenied(fmt.Sprintf("user is not allowed to delete space %s", n.ID))
 }


### PR DESCRIPTION
Space Delete and Disable permissions ("Drive.ReadWriteEnabled", "delete-all-spaces", "delete-all-home-spaces") were overlapping and not clear differentiatable.
The new logic is as follows:
  -  "Drive.ReadWriteEnabled" allows enabling or disabling a project space
  -  "delete-all-home-spaces" allows deleting personal spaces of users
  -  "delete-all-spaces" allows deleting a project space
  -  Space Mangers can still disable/enable/delete a drive 


Backend part of: https://github.com/owncloud/ocis/issues/5872