### PR TITLE
harden uploads

### DIFF
--- a/changelog/unreleased/harden-uploads.md
+++ b/changelog/unreleased/harden-uploads.md
@@ -1,0 +1,5 @@
+Bugfix: harden uploads
+
+Uploads now check response headers for a file id and omit a subsequent stat request which might land on a storage provider that does not yet see the new file due to latency, eg. when NFS caches direntries.
+
+https://github.com/cs3org/reva/pull/3899

--- a/internal/http/services/owncloud/ocdav/tus.go
+++ b/internal/http/services/owncloud/ocdav/tus.go
@@ -278,6 +278,12 @@ func (s *svc) handleTusPost(ctx context.Context, w http.ResponseWriter, r *http.
 		if length == 0 || httpRes.Header.Get(net.HeaderUploadOffset) == r.Header.Get(net.HeaderUploadLength) {
 			// get uploaded file metadata
 
+			if resid, err := storagespace.ParseID(httpRes.Header.Get(net.HeaderOCFileID)); err == nil {
+				sReq.Ref = &provider.Reference{
+					ResourceId: &resid,
+				}
+			}
+
 			sRes, err := s.gwClient.Stat(ctx, sReq)
 			if err != nil {
 				log.Error().Err(err).Msg("error sending grpc stat request")


### PR DESCRIPTION
Uploads now check response headers for a file id and omit a subsequent stat request which might land on a storage provider that does not yet see the new file due to latency, eg. when NFS caches direntries.
