### PR TITLE
Do not read empty node metadata

### DIFF
--- a/changelog/unreleased/fix-cache-usage.md
+++ b/changelog/unreleased/fix-cache-usage.md
@@ -1,0 +1,5 @@
+Bugfix: Do not try to use the cache for empty node
+
+We fixed a problem where nodes that did not have an ID set were still trying to use the cache for their metadata resulting in clashing cache keys.
+
+https://github.com/cs3org/reva/pull/3902

--- a/pkg/storage/utils/decomposedfs/node/xattrs.go
+++ b/pkg/storage/utils/decomposedfs/node/xattrs.go
@@ -91,7 +91,7 @@ func (n *Node) XattrsWithReader(r io.Reader) (Attributes, error) {
 	if n.ID == "" {
 		// Do not try to read the attribute of an empty node. The InternalPath points to the
 		// base nodes directory in this case.
-		return Attributes{}, &xattr.Error{Op: "xattr.all", Path: n.InternalPath(), Err: xattr.ENOATTR}
+		return Attributes{}, &xattr.Error{Op: "node.XattrsWithReader", Path: n.InternalPath(), Err: xattr.ENOATTR}
 	}
 
 	if n.xattrsCache != nil {
@@ -125,7 +125,7 @@ func (n *Node) Xattr(key string) ([]byte, error) {
 	if n.ID == "" {
 		// Do not try to read the attribute of an empty node. The InternalPath points to the
 		// base nodes directory in this case.
-		return []byte{}, &xattr.Error{Op: "xattr.get", Path: n.InternalPath(), Name: key, Err: xattr.ENOATTR}
+		return []byte{}, &xattr.Error{Op: "node.Xattr", Path: n.InternalPath(), Name: key, Err: xattr.ENOATTR}
 	}
 
 	if n.xattrsCache == nil {
@@ -140,7 +140,7 @@ func (n *Node) Xattr(key string) ([]byte, error) {
 		return val, nil
 	}
 	// wrap the error as xattr does
-	return []byte{}, &xattr.Error{Op: "xattr.get", Path: n.InternalPath(), Name: key, Err: xattr.ENOATTR}
+	return []byte{}, &xattr.Error{Op: "node.Xattr", Path: n.InternalPath(), Name: key, Err: xattr.ENOATTR}
 }
 
 // XattrString returns the string representation of an attribute

--- a/pkg/storage/utils/decomposedfs/node/xattrs.go
+++ b/pkg/storage/utils/decomposedfs/node/xattrs.go
@@ -88,6 +88,12 @@ func (n *Node) RemoveXattr(key string) error {
 // XattrsWithReader returns the extended attributes of the node. If the attributes have already
 // been cached they are not read from disk again.
 func (n *Node) XattrsWithReader(r io.Reader) (Attributes, error) {
+	if n.ID == "" {
+		// Do not try to read the attribute of an empty node. The InternalPath points to the
+		// base nodes directory in this case.
+		return Attributes{}, &xattr.Error{Op: "xattr.all", Path: n.InternalPath(), Err: xattr.ENOATTR}
+	}
+
 	if n.xattrsCache != nil {
 		return n.xattrsCache, nil
 	}
@@ -116,6 +122,12 @@ func (n *Node) Xattrs() (Attributes, error) {
 // Xattr returns an extended attribute of the node. If the attributes have already
 // been cached it is not read from disk again.
 func (n *Node) Xattr(key string) ([]byte, error) {
+	if n.ID == "" {
+		// Do not try to read the attribute of an empty node. The InternalPath points to the
+		// base nodes directory in this case.
+		return []byte{}, &xattr.Error{Op: "xattr.get", Path: n.InternalPath(), Name: key, Err: xattr.ENOATTR}
+	}
+
 	if n.xattrsCache == nil {
 		attrs, err := n.lu.MetadataBackend().All(n.InternalPath())
 		if err != nil {


### PR DESCRIPTION
Do not try to read the attribute of an empty node. The InternalPath points to the base nodes directory in this case.