### PR TITLE
Remove config for invite_link

### DIFF
--- a/changelog/unreleased/def-invite-link.md
+++ b/changelog/unreleased/def-invite-link.md
@@ -1,0 +1,8 @@
+Enhancement: Remove config for invite_link
+
+This is to drop invite_link from the OCM-related config.
+
+The link template is still defined in a constant but not exposed
+ in the config, as it depends on Mentix and should not be changed.
+
+https://github.com/cs3org/reva/pull/3905

--- a/changelog/unreleased/def-invite-link.md
+++ b/changelog/unreleased/def-invite-link.md
@@ -1,7 +1,6 @@
-Enhancement: Remove config for invite_link
+Enhancement: Remove redundant config for invite_link_template
 
-This is to drop invite_link from the OCM-related config.
-
+This is to drop invite_link_template from the OCM-related config.
 The link template is still defined in a constant but not exposed
  in the config, as it depends on Mentix and should not be changed.
 

--- a/changelog/unreleased/def-invite-link.md
+++ b/changelog/unreleased/def-invite-link.md
@@ -1,7 +1,8 @@
 Enhancement: Remove redundant config for invite_link_template
 
 This is to drop invite_link_template from the OCM-related config.
-The link template is still defined in a constant but not exposed
- in the config, as it depends on Mentix and should not be changed.
+Now the provider_domain and mesh_directory_url config options
+are both mandatory in the sciencemesh http service, and the link
+is directly built out of the context.
 
 https://github.com/cs3org/reva/pull/3905

--- a/docs/content/en/docs/config/packages/cbox/group/rest/_index.md
+++ b/docs/content/en/docs/config/packages/cbox/group/rest/_index.md
@@ -9,7 +9,7 @@ description: >
 # _struct: config_
 
 {{% dir name="redis_address" type="string" default="localhost:6379" %}}
-The address at which the redis server is running [[Ref]](https://github.com/cs3org/reva/tree/master/pkg/cbox/group/rest/rest.go#L56)
+The address at which the redis server is running [[Ref]](https://github.com/cs3org/reva/tree/master/pkg/cbox/group/rest/rest.go#L55)
 {{< highlight toml >}}
 [cbox.group.rest]
 redis_address = "localhost:6379"
@@ -17,7 +17,7 @@ redis_address = "localhost:6379"
 {{% /dir %}}
 
 {{% dir name="group_members_cache_expiration" type="int" default=5 %}}
-The time in minutes for which the members of a group would be cached [[Ref]](https://github.com/cs3org/reva/tree/master/pkg/cbox/group/rest/rest.go#L62)
+The time in minutes for which the members of a group would be cached [[Ref]](https://github.com/cs3org/reva/tree/master/pkg/cbox/group/rest/rest.go#L61)
 {{< highlight toml >}}
 [cbox.group.rest]
 group_members_cache_expiration = 5
@@ -25,7 +25,7 @@ group_members_cache_expiration = 5
 {{% /dir %}}
 
 {{% dir name="id_provider" type="string" default="http://cernbox.cern.ch" %}}
-The OIDC Provider [[Ref]](https://github.com/cs3org/reva/tree/master/pkg/cbox/group/rest/rest.go#L64)
+The OIDC Provider [[Ref]](https://github.com/cs3org/reva/tree/master/pkg/cbox/group/rest/rest.go#L63)
 {{< highlight toml >}}
 [cbox.group.rest]
 id_provider = "http://cernbox.cern.ch"
@@ -33,7 +33,7 @@ id_provider = "http://cernbox.cern.ch"
 {{% /dir %}}
 
 {{% dir name="api_base_url" type="string" default="https://authorization-service-api-dev.web.cern.ch" %}}
-Base API Endpoint [[Ref]](https://github.com/cs3org/reva/tree/master/pkg/cbox/group/rest/rest.go#L66)
+Base API Endpoint [[Ref]](https://github.com/cs3org/reva/tree/master/pkg/cbox/group/rest/rest.go#L65)
 {{< highlight toml >}}
 [cbox.group.rest]
 api_base_url = "https://authorization-service-api-dev.web.cern.ch"
@@ -41,7 +41,7 @@ api_base_url = "https://authorization-service-api-dev.web.cern.ch"
 {{% /dir %}}
 
 {{% dir name="client_id" type="string" default="-" %}}
-Client ID needed to authenticate [[Ref]](https://github.com/cs3org/reva/tree/master/pkg/cbox/group/rest/rest.go#L68)
+Client ID needed to authenticate [[Ref]](https://github.com/cs3org/reva/tree/master/pkg/cbox/group/rest/rest.go#L67)
 {{< highlight toml >}}
 [cbox.group.rest]
 client_id = "-"
@@ -49,7 +49,7 @@ client_id = "-"
 {{% /dir %}}
 
 {{% dir name="client_secret" type="string" default="-" %}}
-Client Secret [[Ref]](https://github.com/cs3org/reva/tree/master/pkg/cbox/group/rest/rest.go#L70)
+Client Secret [[Ref]](https://github.com/cs3org/reva/tree/master/pkg/cbox/group/rest/rest.go#L69)
 {{< highlight toml >}}
 [cbox.group.rest]
 client_secret = "-"
@@ -57,7 +57,7 @@ client_secret = "-"
 {{% /dir %}}
 
 {{% dir name="oidc_token_endpoint" type="string" default="https://keycloak-dev.cern.ch/auth/realms/cern/api-access/token" %}}
-Endpoint to generate token to access the API [[Ref]](https://github.com/cs3org/reva/tree/master/pkg/cbox/group/rest/rest.go#L73)
+Endpoint to generate token to access the API [[Ref]](https://github.com/cs3org/reva/tree/master/pkg/cbox/group/rest/rest.go#L72)
 {{< highlight toml >}}
 [cbox.group.rest]
 oidc_token_endpoint = "https://keycloak-dev.cern.ch/auth/realms/cern/api-access/token"
@@ -65,7 +65,7 @@ oidc_token_endpoint = "https://keycloak-dev.cern.ch/auth/realms/cern/api-access/
 {{% /dir %}}
 
 {{% dir name="target_api" type="string" default="authorization-service-api" %}}
-The target application for which token needs to be generated [[Ref]](https://github.com/cs3org/reva/tree/master/pkg/cbox/group/rest/rest.go#L75)
+The target application for which token needs to be generated [[Ref]](https://github.com/cs3org/reva/tree/master/pkg/cbox/group/rest/rest.go#L74)
 {{< highlight toml >}}
 [cbox.group.rest]
 target_api = "authorization-service-api"
@@ -73,7 +73,7 @@ target_api = "authorization-service-api"
 {{% /dir %}}
 
 {{% dir name="group_fetch_interval" type="int" default=3600 %}}
-The time in seconds between bulk fetch of groups [[Ref]](https://github.com/cs3org/reva/tree/master/pkg/cbox/group/rest/rest.go#L77)
+The time in seconds between bulk fetch of groups [[Ref]](https://github.com/cs3org/reva/tree/master/pkg/cbox/group/rest/rest.go#L76)
 {{< highlight toml >}}
 [cbox.group.rest]
 group_fetch_interval = 3600

--- a/examples/storage-references/gateway.toml
+++ b/examples/storage-references/gateway.toml
@@ -48,3 +48,16 @@ mime_types = [
 [http.services.ocdav]
 [http.services.ocs]
 [http.services.appprovider]
+
+[http.services.sciencemesh]
+mesh_directory_url = 'https://sciencemesh.cesnet.cz/iop/meshdir'
+provider_domain = 'your-domain.org'
+body_template_path = '/etc/revad/sciencemesh_email_body'
+ocm_mount_point = '/sciencemesh'
+
+[http.services.sciencemesh.smtp_credentials]
+disable_auth = true
+sender_mail = "sciencemesh@your-domain.org"
+smtp_server = "your-smtp-server.your-domain.org"
+smtp_port = 25
+

--- a/internal/http/services/sciencemesh/email.go
+++ b/internal/http/services/sciencemesh/email.go
@@ -119,14 +119,7 @@ func (h *tokenHandler) initSubjectTemplate(subjTempl string) error {
 }
 
 func (h *tokenHandler) initInviteLinkTemplate(inviteTempl string) error {
-	var t string
-	if inviteTempl == "" {
-		t = defaultInviteLink
-	} else {
-		t = inviteTempl
-	}
-
-	tpl, err := template.New("tpl_invite").Parse(t)
+	tpl, err := template.New("tpl_invite").Parse(inviteTempl)
 	if err != nil {
 		return err
 	}

--- a/internal/http/services/sciencemesh/email.go
+++ b/internal/http/services/sciencemesh/email.go
@@ -117,12 +117,3 @@ func (h *tokenHandler) initSubjectTemplate(subjTempl string) error {
 	h.tplSubj = tpl
 	return nil
 }
-
-func (h *tokenHandler) initInviteLinkTemplate(inviteTempl string) error {
-	tpl, err := template.New("tpl_invite").Parse(inviteTempl)
-	if err != nil {
-		return err
-	}
-	h.tplInviteLink = tpl
-	return nil
-}

--- a/internal/http/services/sciencemesh/sciencemesh.go
+++ b/internal/http/services/sciencemesh/sciencemesh.go
@@ -62,15 +62,14 @@ func (s *svc) Close() error {
 }
 
 type config struct {
-	Prefix             string                      `mapstructure:"prefix"`
-	SMTPCredentials    *smtpclient.SMTPCredentials `mapstructure:"smtp_credentials"`
-	GatewaySvc         string                      `mapstructure:"gatewaysvc"`
-	MeshDirectoryURL   string                      `mapstructure:"mesh_directory_url"`
-	ProviderDomain     string                      `mapstructure:"provider_domain"`
-	SubjectTemplate    string                      `mapstructure:"subject_template"`
-	BodyTemplatePath   string                      `mapstructure:"body_template_path"`
-	OCMMountPoint      string                      `mapstructure:"ocm_mount_point"`
-	InviteLinkTemplate string                      `mapstructure:"invite_link_template"`
+	Prefix           string                      `mapstructure:"prefix"`
+	SMTPCredentials  *smtpclient.SMTPCredentials `mapstructure:"smtp_credentials"`
+	GatewaySvc       string                      `mapstructure:"gatewaysvc"`
+	MeshDirectoryURL string                      `mapstructure:"mesh_directory_url"`
+	ProviderDomain   string                      `mapstructure:"provider_domain"`
+	SubjectTemplate  string                      `mapstructure:"subject_template"`
+	BodyTemplatePath string                      `mapstructure:"body_template_path"`
+	OCMMountPoint    string                      `mapstructure:"ocm_mount_point"`
 }
 
 func (c *config) init() {

--- a/internal/http/services/sciencemesh/sciencemesh.go
+++ b/internal/http/services/sciencemesh/sciencemesh.go
@@ -19,6 +19,7 @@
 package sciencemesh
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/cs3org/reva/pkg/appctx"
@@ -42,6 +43,9 @@ func New(m map[string]interface{}, log *zerolog.Logger) (global.Service, error) 
 	}
 
 	conf.init()
+	if conf.ProviderDomain == "" {
+		return nil, errors.New("provider_domain missing from configuration")
+	}
 
 	r := chi.NewRouter()
 	s := &svc{

--- a/internal/http/services/sciencemesh/sciencemesh.go
+++ b/internal/http/services/sciencemesh/sciencemesh.go
@@ -44,7 +44,10 @@ func New(m map[string]interface{}, log *zerolog.Logger) (global.Service, error) 
 
 	conf.init()
 	if conf.ProviderDomain == "" {
-		return nil, errors.New("provider_domain missing from configuration")
+		return nil, errors.New("sciencemesh: provider_domain is missing from configuration")
+	}
+	if conf.MeshDirectoryURL == "" {
+		return nil, errors.New("sciencemesh: mesh_directory_url is missing from configuration")
 	}
 
 	r := chi.NewRouter()

--- a/internal/http/services/sciencemesh/token.go
+++ b/internal/http/services/sciencemesh/token.go
@@ -42,9 +42,8 @@ type tokenHandler struct {
 	smtpCredentials  *smtpclient.SMTPCredentials
 	meshDirectoryURL string
 	providerDomain   string
-
-	tplSubj *template.Template
-	tplBody *template.Template
+	tplSubj          *template.Template
+	tplBody          *template.Template
 }
 
 func (h *tokenHandler) init(c *config) error {
@@ -59,6 +58,7 @@ func (h *tokenHandler) init(c *config) error {
 	}
 
 	h.meshDirectoryURL = c.MeshDirectoryURL
+	h.providerDomain = c.ProviderDomain
 
 	if err := h.initSubjectTemplate(c.SubjectTemplate); err != nil {
 		return err
@@ -68,10 +68,6 @@ func (h *tokenHandler) init(c *config) error {
 		return err
 	}
 
-	if c.ProviderDomain == "" {
-		return errors.New("provider_domain missing from configuration")
-	}
-	h.providerDomain = c.ProviderDomain
 	return nil
 }
 

--- a/internal/http/services/sciencemesh/token.go
+++ b/internal/http/services/sciencemesh/token.go
@@ -38,7 +38,7 @@ import (
 	"github.com/cs3org/reva/pkg/smtpclient"
 )
 
-const defaultInviteLink = "{{.MeshDirectoryURL}}?token={{.Token}}&providerDomain={{.User.Id.Idp}}"
+const defaultInviteLinkPrefix = "{{.MeshDirectoryURL}}?token={{.Token}}&providerDomain="
 
 type tokenHandler struct {
 	gatewayClient    gateway.GatewayAPIClient
@@ -71,7 +71,10 @@ func (h *tokenHandler) init(c *config) error {
 		return err
 	}
 
-	return h.initInviteLinkTemplate(c.InviteLinkTemplate)
+	if c.ProviderDomain == "" {
+		return errors.New("provider_domain missing from configuration")
+	}
+	return h.initInviteLinkTemplate(defaultInviteLinkPrefix + c.ProviderDomain)
 }
 
 type token struct {

--- a/tests/integration/grpc/fixtures/ocm-server-cernbox-http.toml
+++ b/tests/integration/grpc/fixtures/ocm-server-cernbox-http.toml
@@ -10,6 +10,8 @@ address = "{{grpc_address}}"
 [http.services.ocmd]
 
 [http.services.sciencemesh]
+provider_domain = "{{cernboxhttp_address}}"
+mesh_directory_url = "http://meshdir"
 
 [http.middlewares.cors]
 

--- a/tests/integration/grpc/fixtures/ocm-server-cesnet-http.toml
+++ b/tests/integration/grpc/fixtures/ocm-server-cesnet-http.toml
@@ -10,6 +10,8 @@ address = "{{grpc_address}}"
 [http.services.ocmd]
 
 [http.services.sciencemesh]
+provider_domain = "{{cesnethttp_address}}"
+mesh_directory_url = "http://meshdir"
 
 [http.middlewares.cors]
 

--- a/tests/integration/grpc/fixtures/ocm-share/ocm-server-cernbox-http.toml
+++ b/tests/integration/grpc/fixtures/ocm-share/ocm-server-cernbox-http.toml
@@ -10,6 +10,8 @@ address = "{{grpc_address}}"
 [http.services.ocmd]
 
 [http.services.sciencemesh]
+provider_domain = "{{cernboxhttp_address}}"
+mesh_directory_url = "http://meshdir"
 
 [http.middlewares.cors]
 

--- a/tests/integration/grpc/fixtures/ocm-share/ocm-server-cesnet-http.toml
+++ b/tests/integration/grpc/fixtures/ocm-share/ocm-server-cesnet-http.toml
@@ -10,6 +10,8 @@ address = "{{grpc_address}}"
 [http.services.ocmd]
 
 [http.services.sciencemesh]
+provider_domain = "{{cesnethttp_address}}"
+mesh_directory_url = "http://meshdir"
 
 [http.middlewares.cors]
 


### PR DESCRIPTION
This mini-PR drops invite_link from the OCM-related config.

~~The link template is still defined in a constant but not exposed in the config, as it depends on Mentix and should not be changed.~~

Edit: the link is not any longer a template and it is instead constructed out of the needed parameters.
Also, the `provider_domain` and `mesh_directory_url` configuration options are now mandatory, and the `sciencemesh` service won't start without it.