### PR TITLE
introduce micro based app registry

### DIFF
--- a/pkg/app/registry/loader/loader.go
+++ b/pkg/app/registry/loader/loader.go
@@ -20,6 +20,7 @@ package loader
 
 import (
 	// Load core app registry drivers.
+	_ "github.com/cs3org/reva/v2/pkg/app/registry/micro"
 	_ "github.com/cs3org/reva/v2/pkg/app/registry/static"
 	// Add your own here
 )

--- a/pkg/app/registry/micro/micro.go
+++ b/pkg/app/registry/micro/micro.go
@@ -1,0 +1,415 @@
+// Copyright 2018-2021 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package micro
+
+import (
+	"container/heap"
+	"context"
+	"strings"
+	"sync"
+	"time"
+
+	registrypb "github.com/cs3org/go-cs3apis/cs3/app/registry/v1beta1"
+	typesv1beta1 "github.com/cs3org/go-cs3apis/cs3/types/v1beta1"
+	"github.com/cs3org/reva/v2/pkg/app"
+	"github.com/cs3org/reva/v2/pkg/app/registry/registry"
+	"github.com/cs3org/reva/v2/pkg/appctx"
+	"github.com/cs3org/reva/v2/pkg/errtypes"
+	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
+	oreg "github.com/owncloud/ocis/v2/ocis-pkg/registry"
+	"github.com/rs/zerolog/log"
+	orderedmap "github.com/wk8/go-ordered-map"
+	mreg "go-micro.dev/v4/registry"
+)
+
+func init() {
+	registry.Register("micro", New)
+}
+
+const defaultPriority = "0"
+
+type mimeTypeConfig struct {
+	MimeType      string `mapstructure:"mime_type"`
+	Extension     string `mapstructure:"extension"`
+	Name          string `mapstructure:"name"`
+	Description   string `mapstructure:"description"`
+	Icon          string `mapstructure:"icon"`
+	DefaultApp    string `mapstructure:"default_app"`
+	AllowCreation bool   `mapstructure:"allow_creation"`
+	apps          providerHeap
+}
+
+type config struct {
+	Namespace string            `mapstructure:"namespace"`
+	MimeTypes []*mimeTypeConfig `mapstructure:"mime_types"`
+}
+
+func (c *config) init() {
+	if c.Namespace == "" {
+		c.Namespace = "cs3"
+	}
+}
+
+func parseConfig(m map[string]interface{}) (*config, error) {
+	c := &config{}
+	if err := mapstructure.Decode(m, c); err != nil {
+		return nil, err
+	}
+	return c, nil
+}
+
+type manager struct {
+	namespace string
+	mimetypes *orderedmap.OrderedMap // map[string]*mimeTypeConfig  ->  map the mime type to the addresses of the corresponding providers
+	sync.RWMutex
+}
+
+// New returns an implementation of the app.Registry interface.
+func New(m map[string]interface{}) (app.Registry, error) {
+	c, err := parseConfig(m)
+	if err != nil {
+		return nil, err
+	}
+	c.init()
+
+	mimetypes := orderedmap.New()
+
+	for _, mime := range c.MimeTypes {
+		mimetypes.Set(mime.MimeType, mime)
+	}
+
+	newManager := manager{
+		mimetypes: mimetypes,
+	}
+	return &newManager, nil
+}
+
+func getPriority(p *registrypb.ProviderInfo) string {
+	if p.Opaque != nil && len(p.Opaque.Map) != 0 {
+		if priority, ok := p.Opaque.Map["priority"]; ok {
+			return string(priority.GetValue())
+		}
+	}
+	return defaultPriority
+}
+
+// use the UTF-8 record seperator
+func splitMimeTypes(s string) []string {
+	return strings.Split(s, "␞")
+}
+
+func joinMimeTypes(mimetypes []string) string {
+	return strings.Join(mimetypes, "␞")
+}
+
+func (m *manager) providerFromMetadata(metadata map[string]string) registrypb.ProviderInfo {
+	p := registrypb.ProviderInfo{
+		MimeTypes: splitMimeTypes(metadata[m.namespace+".app-provider.mime_type"]),
+		//		Address:     node.Address,
+		Name:        metadata[m.namespace+".app-provider.name"],
+		Description: metadata[m.namespace+".app-provider.description"],
+		Icon:        metadata[m.namespace+".app-provider.icon"],
+		DesktopOnly: metadata[m.namespace+".app-provider.desktop_only"] == "true",
+		Capability:  registrypb.ProviderInfo_Capability(registrypb.ProviderInfo_Capability_value[metadata[m.namespace+".app-provider.capability"]]),
+	}
+	if metadata[m.namespace+".app-provider.priority"] != "" {
+		p.Opaque = &typesv1beta1.Opaque{Map: map[string]*typesv1beta1.OpaqueEntry{
+			"priority": {
+				Decoder: "plain",
+				Value:   []byte(metadata[m.namespace+".app-provider.priority"]),
+			},
+		}}
+	}
+	return p
+}
+
+func (m *manager) FindProviders(ctx context.Context, mimeType string) ([]*registrypb.ProviderInfo, error) {
+	reg := oreg.GetRegistry()
+	services, err := reg.GetService(m.namespace+".api.app-provider", mreg.GetContext(ctx))
+	if err != nil {
+		return nil, err
+	}
+
+	var providers = make([]*registrypb.ProviderInfo, 0)
+	if len(services) == 0 {
+		return nil, errtypes.NotFound("no application provider service found for mime type " + mimeType)
+	}
+	if len(services) > 1 {
+		// TODO we could iterate over all ?
+		return nil, errtypes.InternalError("more than one application provider service registered for mimetype " + mimeType)
+	}
+
+	// find longest match
+	var match string
+	for _, node := range services[0].Nodes {
+		for _, providerMimeType := range splitMimeTypes(node.Metadata[m.namespace+".app-provider.mime_type"]) {
+			if strings.HasPrefix(mimeType, providerMimeType) && len(providerMimeType) > len(match) {
+				match = providerMimeType
+			}
+		}
+	}
+
+	if match == "" {
+		return nil, errtypes.NotFound("application provider not found for mime type " + mimeType)
+	}
+
+	for _, node := range services[0].Nodes {
+		for _, providerMimeType := range splitMimeTypes(node.Metadata[m.namespace+".app-provider.mime_type"]) {
+			if match == providerMimeType {
+				p := m.providerFromMetadata(node.Metadata)
+				p.Address = node.Address
+				providers = append(providers, &p)
+			}
+		}
+	}
+
+	// TODO sort by priority?
+
+	return providers, nil
+}
+
+func (m *manager) AddProvider(ctx context.Context, p *registrypb.ProviderInfo) error {
+	log := appctx.GetLogger(ctx)
+
+	log.Debug().Interface("provider", p).Msg("AddProvider")
+
+	reg := oreg.GetRegistry()
+
+	serviceID := m.namespace + "app-provider"
+
+	node := &mreg.Node{
+		Id:       serviceID + "-" + uuid.New().String(),
+		Address:  p.Address,
+		Metadata: make(map[string]string),
+	}
+
+	node.Metadata["registry"] = reg.String()
+	node.Metadata["server"] = "grpc"
+	node.Metadata["transport"] = "grpc"
+	node.Metadata["protocol"] = "grpc"
+
+	node.Metadata[m.namespace+".app-provider.mime_type"] = joinMimeTypes(p.MimeTypes)
+	node.Metadata[m.namespace+".app-provider.name"] = p.Name
+	node.Metadata[m.namespace+".app-provider.description"] = p.Description
+	node.Metadata[m.namespace+".app-provider.icon"] = p.Icon
+	//node.Metadata[m.namespace+".app-provider.default_app"] =
+	node.Metadata[m.namespace+".app-provider.allow_creation"] = registrypb.ProviderInfo_Capability_name[int32(p.Capability)]
+	node.Metadata[m.namespace+".app-provider.priority"] = getPriority(p)
+	if p.DesktopOnly {
+		node.Metadata[m.namespace+".app-provider.desktop_only"] = "true"
+	}
+
+	service := &mreg.Service{
+		Name: serviceID,
+		//Version:   version,
+		Nodes:     []*mreg.Node{node},
+		Endpoints: make([]*mreg.Endpoint, 0),
+	}
+
+	log.Info().Msgf("registering external service %v@%v", node.Id, node.Address)
+
+	rOpts := []mreg.RegisterOption{mreg.RegisterTTL(time.Minute)}
+	if err := reg.Register(service, rOpts...); err != nil {
+		log.Fatal().Err(err).Msgf("Registration error for external service %v", serviceID)
+	}
+
+	t := time.NewTicker(time.Second * 30)
+
+	go func() {
+		for {
+			select {
+			case <-t.C:
+				log.Debug().Interface("service", service).Msg("refreshing external service-registration")
+				err := reg.Register(service, rOpts...)
+				if err != nil {
+					log.Error().Err(err).Msgf("registration error for external service %v", serviceID)
+				}
+			case <-ctx.Done():
+				log.Debug().Interface("service", service).Msg("unregistering")
+				t.Stop()
+				err := reg.Deregister(service)
+				if err != nil {
+					log.Err(err).Msgf("Error unregistering external service %v", serviceID)
+				}
+				// FIXME how do we end this when a provider reregisters?
+			}
+		}
+	}()
+
+	return nil
+}
+
+func (m *manager) ListProviders(ctx context.Context) ([]*registrypb.ProviderInfo, error) {
+	reg := oreg.GetRegistry()
+	services, err := reg.GetService(m.namespace+".api.app-provider", mreg.GetContext(ctx))
+	if err != nil {
+		return nil, err
+	}
+
+	if len(services) == 0 {
+		return nil, errtypes.NotFound("no application provider service registered")
+	}
+	if len(services) > 1 {
+		return nil, errtypes.InternalError("more than one application provider services registered")
+	}
+
+	providers := make([]*registrypb.ProviderInfo, 0, len(services[0].Nodes))
+	for _, node := range services[0].Nodes {
+		p := m.providerFromMetadata(node.Metadata)
+		p.Address = node.Address
+		providers = append(providers, &p)
+	}
+	return providers, nil
+}
+
+func (m *manager) ListSupportedMimeTypes(ctx context.Context) ([]*registrypb.MimeTypeInfo, error) {
+	m.RLock()
+	defer m.RUnlock()
+
+	res := make([]*registrypb.MimeTypeInfo, 0, m.mimetypes.Len())
+
+	for pair := m.mimetypes.Oldest(); pair != nil; pair = pair.Next() {
+
+		mime := pair.Value.(*mimeTypeConfig)
+
+		res = append(res, &registrypb.MimeTypeInfo{
+			MimeType:           mime.MimeType,
+			Ext:                mime.Extension,
+			Name:               mime.Name,
+			Description:        mime.Description,
+			Icon:               mime.Icon,
+			AppProviders:       mime.apps.getOrderedProviderByPriority(),
+			AllowCreation:      mime.AllowCreation,
+			DefaultApplication: mime.DefaultApp,
+		})
+
+	}
+
+	return res, nil
+}
+
+func (h providerHeap) getOrderedProviderByPriority() []*registrypb.ProviderInfo {
+	providers := make([]*registrypb.ProviderInfo, 0, h.Len())
+	for _, pp := range h {
+		providers = append(providers, pp.provider)
+	}
+	return providers
+}
+
+func getIndex(h providerHeap, s *registrypb.ProviderInfo) (int, bool) {
+	for i, e := range h {
+		if equalsProviderInfo(e.provider, s) {
+			return i, true
+		}
+	}
+	return -1, false
+}
+
+func (m *manager) SetDefaultProviderForMimeType(ctx context.Context, mimeType string, p *registrypb.ProviderInfo) error {
+	mimeInterface, ok := m.mimetypes.Get(mimeType)
+	if ok {
+		mime := mimeInterface.(*mimeTypeConfig)
+		mime.DefaultApp = p.Address
+
+		registerProvider(p, mime)
+	} else {
+		// the mime type should be already registered as config in the AppRegistry
+		// we will create a new entry fot the mimetype, but leaving a warning for
+		// future log inspection for weird behaviour
+		log.Warn().Msgf("config for mimetype '%s' not found while setting a new default AppProvider", mimeType)
+		m.mimetypes.Set(mimeType, dummyMimeType(mimeType, []*registrypb.ProviderInfo{p}))
+	}
+	return nil
+}
+
+func dummyMimeType(m string, apps []*registrypb.ProviderInfo) *mimeTypeConfig {
+	appsHeap := providerHeap{}
+	for _, p := range apps {
+		heap.Push(&appsHeap, providerWithPriority{
+			provider: p,
+			priority: getPriority(p),
+		})
+	}
+
+	return &mimeTypeConfig{
+		MimeType: m,
+		apps:     appsHeap,
+		//Extension: "", // there is no meaningful general extension, so omit it
+		//Name:        "", // there is no meaningful general name, so omit it
+		//Description: "", // there is no meaningful general description, so omit it
+	}
+}
+
+func (m *manager) GetDefaultProviderForMimeType(ctx context.Context, mimeType string) (*registrypb.ProviderInfo, error) {
+	m.RLock()
+	defer m.RUnlock()
+
+	mimeInterface, ok := m.mimetypes.Get(mimeType)
+	if ok {
+		mime := mimeInterface.(*mimeTypeConfig)
+		// default by provider address
+		if p, ok := m.providers[mime.DefaultApp]; ok {
+			return p, nil
+		}
+
+		// default by provider name
+		for _, p := range m.providers {
+			if p.Name == mime.DefaultApp {
+				return p, nil
+			}
+		}
+	}
+
+	return nil, errtypes.NotFound("default application provider not set for mime type " + mimeType)
+}
+
+func equalsProviderInfo(p1, p2 *registrypb.ProviderInfo) bool {
+	return p1.Name == p2.Name
+}
+
+type providerWithPriority struct {
+	provider *registrypb.ProviderInfo
+	priority uint64
+}
+
+type providerHeap []providerWithPriority
+
+func (h providerHeap) Len() int {
+	return len(h)
+}
+
+func (h providerHeap) Less(i, j int) bool {
+	return h[i].priority > h[j].priority
+}
+
+func (h providerHeap) Swap(i, j int) {
+	h[i], h[j] = h[j], h[i]
+}
+
+func (h *providerHeap) Push(x interface{}) {
+	*h = append(*h, x.(providerWithPriority))
+}
+
+func (h *providerHeap) Pop() interface{} {
+	last := len(*h) - 1
+	x := (*h)[last]
+	*h = (*h)[:last]
+	return x
+}

--- a/pkg/app/registry/micro/micro_test.go
+++ b/pkg/app/registry/micro/micro_test.go
@@ -1,0 +1,1182 @@
+// Copyright 2018-2021 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package micro
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	registrypb "github.com/cs3org/go-cs3apis/cs3/app/registry/v1beta1"
+	typesv1beta1 "github.com/cs3org/go-cs3apis/cs3/types/v1beta1"
+	"github.com/cs3org/reva/v2/pkg/errtypes"
+)
+
+func TestFindProviders(t *testing.T) {
+
+	testCases := []struct {
+		name         string
+		mimeTypes    []*mimeTypeConfig
+		regProviders []*registrypb.ProviderInfo
+		mimeType     string
+		expectedRes  []*registrypb.ProviderInfo
+		expectedErr  error
+	}{
+		{
+			name:        "no mime types registered",
+			mimeTypes:   []*mimeTypeConfig{},
+			mimeType:    "SOMETHING",
+			expectedErr: errtypes.NotFound("application provider not found for mime type SOMETHING"),
+		},
+		{
+			name: "one provider registered for one mime type",
+			mimeTypes: []*mimeTypeConfig{
+				{
+					MimeType:   "text/json",
+					Extension:  "json",
+					Name:       "JSON File",
+					Icon:       "https://example.org/icons&file=json.png",
+					DefaultApp: "some Address",
+				},
+			},
+			regProviders: []*registrypb.ProviderInfo{
+				{
+					MimeTypes: []string{"text/json"},
+					Address:   "some Address",
+					Name:      "some Name",
+				},
+			},
+			mimeType:    "text/json",
+			expectedErr: nil,
+			expectedRes: []*registrypb.ProviderInfo{
+				{
+					MimeTypes: []string{"text/json"},
+					Address:   "some Address",
+					Name:      "some Name",
+				},
+			},
+		},
+		{
+			name: "more providers registered for one mime type",
+			mimeTypes: []*mimeTypeConfig{
+				{
+					MimeType:   "text/json",
+					Extension:  "json",
+					Name:       "JSON File",
+					Icon:       "https://example.org/icons&file=json.png",
+					DefaultApp: "provider2",
+				},
+			},
+			regProviders: []*registrypb.ProviderInfo{
+				{
+					MimeTypes: []string{"text/json"},
+					Address:   "ip-provider1",
+					Name:      "provider1",
+				},
+				{
+					MimeTypes: []string{"text/json"},
+					Address:   "ip-provider2",
+					Name:      "provider2",
+				},
+				{
+					MimeTypes: []string{"text/json"},
+					Address:   "ip-provider3",
+					Name:      "provider3",
+				},
+			},
+			mimeType:    "text/json",
+			expectedErr: nil,
+			expectedRes: []*registrypb.ProviderInfo{
+				{
+					MimeTypes: []string{"text/json"},
+					Address:   "ip-provider1",
+					Name:      "provider1",
+				},
+				{
+					MimeTypes: []string{"text/json"},
+					Address:   "ip-provider2",
+					Name:      "provider2",
+				},
+				{
+					MimeTypes: []string{"text/json"},
+					Address:   "ip-provider3",
+					Name:      "provider3",
+				},
+			},
+		},
+		{
+			name: "more providers registered for different mime types",
+			mimeTypes: []*mimeTypeConfig{
+				{
+					MimeType:   "text/json",
+					Extension:  "json",
+					Name:       "JSON File",
+					Icon:       "https://example.org/icons&file=json.png",
+					DefaultApp: "provider2",
+				},
+				{
+					MimeType:   "text/xml",
+					Extension:  "xml",
+					Name:       "XML File",
+					Icon:       "https://example.org/icons&file=xml.png",
+					DefaultApp: "provider1",
+				},
+			},
+			regProviders: []*registrypb.ProviderInfo{
+				{
+					MimeTypes: []string{"text/json", "text/xml"},
+					Address:   "ip-provider1",
+					Name:      "provider1",
+				},
+				{
+					MimeTypes: []string{"text/json"},
+					Address:   "ip-provider2",
+					Name:      "provider2",
+				},
+				{
+					MimeTypes: []string{"text/xml"},
+					Address:   "ip-provider3",
+					Name:      "provider3",
+				},
+			},
+			mimeType:    "text/json",
+			expectedErr: nil,
+			expectedRes: []*registrypb.ProviderInfo{
+				{
+					MimeTypes: []string{"text/json", "text/xml"},
+					Address:   "ip-provider1",
+					Name:      "provider1",
+				},
+				{
+					MimeTypes: []string{"text/json"},
+					Address:   "ip-provider2",
+					Name:      "provider2",
+				},
+			},
+		},
+	}
+
+	for _, tt := range testCases {
+
+		t.Run(tt.name, func(t *testing.T) {
+
+			ctx := context.TODO()
+
+			registry, err := New(map[string]interface{}{
+				"mime_types": tt.mimeTypes,
+				"providers":  tt.regProviders,
+			})
+			if err != nil {
+				t.Error("unexpected error creating the registry:", err)
+			}
+
+			providers, err := registry.FindProviders(ctx, tt.mimeType)
+
+			// check that the error returned by FindProviders is the same as the expected
+			if tt.expectedErr != err {
+				t.Errorf("different error returned: got=%v expected=%v", err, tt.expectedErr)
+			}
+
+			if !providersEquals(providers, tt.expectedRes) {
+				t.Errorf("providers list different from expected: \n\tgot=%v\n\texp=%v", providers, tt.expectedRes)
+			}
+
+		})
+
+	}
+
+}
+
+// check that all providers in the two lists are equals
+func providersEquals(l1, l2 []*registrypb.ProviderInfo) bool {
+	if len(l1) != len(l2) {
+		return false
+	}
+
+	for i := 0; i < len(l1); i++ {
+		if !equalsProviderInfo(l1[i], l2[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func TestFindProvidersWithPriority(t *testing.T) {
+
+	testCases := []struct {
+		name         string
+		mimeTypes    []*mimeTypeConfig
+		regProviders []*registrypb.ProviderInfo
+		mimeType     string
+		expectedRes  []*registrypb.ProviderInfo
+		expectedErr  error
+	}{
+		{
+			name:        "no mime types registered",
+			mimeTypes:   []*mimeTypeConfig{},
+			mimeType:    "SOMETHING",
+			expectedErr: errtypes.NotFound("application provider not found for mime type SOMETHING"),
+		},
+		{
+			name: "one provider registered for one mime type",
+			mimeTypes: []*mimeTypeConfig{
+				{
+					MimeType:   "text/json",
+					Extension:  "json",
+					Name:       "JSON File",
+					Icon:       "https://example.org/icons&file=json.png",
+					DefaultApp: "some Address",
+				},
+			},
+			regProviders: []*registrypb.ProviderInfo{
+				{
+					MimeTypes: []string{"text/json"},
+					Address:   "some Address",
+					Name:      "some Name",
+					Opaque: &typesv1beta1.Opaque{
+						Map: map[string]*typesv1beta1.OpaqueEntry{
+							"priority": {
+								Decoder: "plain",
+								Value:   []byte("100"),
+							},
+						},
+					},
+				},
+			},
+			mimeType:    "text/json",
+			expectedErr: nil,
+			expectedRes: []*registrypb.ProviderInfo{
+				{
+					MimeTypes: []string{"text/json"},
+					Address:   "some Address",
+					Name:      "some Name",
+				},
+			},
+		},
+		{
+			name: "more providers registered for one mime type",
+			mimeTypes: []*mimeTypeConfig{
+				{
+					MimeType:   "text/json",
+					Extension:  "json",
+					Name:       "JSON File",
+					Icon:       "https://example.org/icons&file=json.png",
+					DefaultApp: "provider2",
+				},
+			},
+			regProviders: []*registrypb.ProviderInfo{
+				{
+					MimeTypes: []string{"text/json"},
+					Address:   "ip-provider1",
+					Name:      "provider1",
+					Opaque: &typesv1beta1.Opaque{
+						Map: map[string]*typesv1beta1.OpaqueEntry{
+							"priority": {
+								Decoder: "plain",
+								Value:   []byte("10"),
+							},
+						},
+					},
+				},
+				{
+					MimeTypes: []string{"text/json"},
+					Address:   "ip-provider2",
+					Name:      "provider2",
+					Opaque: &typesv1beta1.Opaque{
+						Map: map[string]*typesv1beta1.OpaqueEntry{
+							"priority": {
+								Decoder: "plain",
+								Value:   []byte("20"),
+							},
+						},
+					},
+				},
+				{
+					MimeTypes: []string{"text/json"},
+					Address:   "ip-provider3",
+					Name:      "provider3",
+					Opaque: &typesv1beta1.Opaque{
+						Map: map[string]*typesv1beta1.OpaqueEntry{
+							"priority": {
+								Decoder: "plain",
+								Value:   []byte("5"),
+							},
+						},
+					},
+				},
+			},
+			mimeType:    "text/json",
+			expectedErr: nil,
+			expectedRes: []*registrypb.ProviderInfo{
+				{
+					MimeTypes: []string{"text/json"},
+					Address:   "ip-provider2",
+					Name:      "provider2",
+				},
+				{
+					MimeTypes: []string{"text/json"},
+					Address:   "ip-provider1",
+					Name:      "provider1",
+				},
+				{
+					MimeTypes: []string{"text/json"},
+					Address:   "ip-provider3",
+					Name:      "provider3",
+				},
+			},
+		},
+		{
+			name: "more providers registered for different mime types",
+			mimeTypes: []*mimeTypeConfig{
+				{
+					MimeType:   "text/json",
+					Extension:  "json",
+					Name:       "JSON File",
+					Icon:       "https://example.org/icons&file=json.png",
+					DefaultApp: "provider2",
+				},
+				{
+					MimeType:   "text/xml",
+					Extension:  "xml",
+					Name:       "XML File",
+					Icon:       "https://example.org/icons&file=xml.png",
+					DefaultApp: "provider1",
+				},
+			},
+			regProviders: []*registrypb.ProviderInfo{
+				{
+					MimeTypes: []string{"text/json", "text/xml"},
+					Address:   "ip-provider1",
+					Name:      "provider1",
+					Opaque: &typesv1beta1.Opaque{
+						Map: map[string]*typesv1beta1.OpaqueEntry{
+							"priority": {
+								Decoder: "plain",
+								Value:   []byte("5"),
+							},
+						},
+					},
+				},
+				{
+					MimeTypes: []string{"text/json"},
+					Address:   "ip-provider2",
+					Name:      "provider2",
+					Opaque: &typesv1beta1.Opaque{
+						Map: map[string]*typesv1beta1.OpaqueEntry{
+							"priority": {
+								Decoder: "plain",
+								Value:   []byte("100"),
+							},
+						},
+					},
+				},
+				{
+					MimeTypes: []string{"text/xml"},
+					Address:   "ip-provider3",
+					Name:      "provider3",
+					Opaque: &typesv1beta1.Opaque{
+						Map: map[string]*typesv1beta1.OpaqueEntry{
+							"priority": {
+								Decoder: "plain",
+								Value:   []byte("20"),
+							},
+						},
+					},
+				},
+			},
+			mimeType:    "text/json",
+			expectedErr: nil,
+			expectedRes: []*registrypb.ProviderInfo{
+				{
+					MimeTypes: []string{"text/json"},
+					Address:   "ip-provider2",
+					Name:      "provider2",
+				},
+				{
+					MimeTypes: []string{"text/json", "text/xml"},
+					Address:   "ip-provider1",
+					Name:      "provider1",
+				},
+			},
+		},
+		{
+			name: "more providers registered for different mime types2",
+			mimeTypes: []*mimeTypeConfig{
+				{
+					MimeType:   "text/json",
+					Extension:  "json",
+					Name:       "JSON File",
+					Icon:       "https://example.org/icons&file=json.png",
+					DefaultApp: "provider2",
+				},
+				{
+					MimeType:   "text/xml",
+					Extension:  "xml",
+					Name:       "XML File",
+					Icon:       "https://example.org/icons&file=xml.png",
+					DefaultApp: "provider1",
+				},
+			},
+			regProviders: []*registrypb.ProviderInfo{
+				{
+					MimeTypes: []string{"text/json", "text/xml"},
+					Address:   "ip-provider1",
+					Name:      "provider1",
+					Opaque: &typesv1beta1.Opaque{
+						Map: map[string]*typesv1beta1.OpaqueEntry{
+							"priority": {
+								Decoder: "plain",
+								Value:   []byte("5"),
+							},
+						},
+					},
+				},
+				{
+					MimeTypes: []string{"text/json"},
+					Address:   "ip-provider2",
+					Name:      "provider2",
+					Opaque: &typesv1beta1.Opaque{
+						Map: map[string]*typesv1beta1.OpaqueEntry{
+							"priority": {
+								Decoder: "plain",
+								Value:   []byte("100"),
+							},
+						},
+					},
+				},
+				{
+					MimeTypes: []string{"text/xml"},
+					Address:   "ip-provider3",
+					Name:      "provider3",
+					Opaque: &typesv1beta1.Opaque{
+						Map: map[string]*typesv1beta1.OpaqueEntry{
+							"priority": {
+								Decoder: "plain",
+								Value:   []byte("20"),
+							},
+						},
+					},
+				},
+			},
+			mimeType:    "text/xml",
+			expectedErr: nil,
+			expectedRes: []*registrypb.ProviderInfo{
+				{
+					MimeTypes: []string{"text/xml"},
+					Address:   "ip-provider3",
+					Name:      "provider3",
+				},
+				{
+					MimeTypes: []string{"text/json", "text/xml"},
+					Address:   "ip-provider1",
+					Name:      "provider1",
+				},
+			},
+		},
+	}
+
+	for _, tt := range testCases {
+
+		t.Run(tt.name, func(t *testing.T) {
+
+			ctx := context.TODO()
+
+			registry, err := New(map[string]interface{}{
+				"mime_types": tt.mimeTypes,
+			})
+			if err != nil {
+				t.Error("unexpected error creating the registry:", err)
+			}
+
+			// register all the providers
+			for _, p := range tt.regProviders {
+				err := registry.AddProvider(ctx, p)
+				if err != nil {
+					t.Error("unexpected error adding a new provider in the registry:", err)
+				}
+			}
+
+			providers, err := registry.FindProviders(ctx, tt.mimeType)
+
+			// check that the error returned by FindProviders is the same as the expected
+			if tt.expectedErr != err {
+				t.Errorf("different error returned: got=%v expected=%v", err, tt.expectedErr)
+			}
+
+			if !providersEquals(providers, tt.expectedRes) {
+				t.Errorf("providers list different from expected: \n\tgot=%v\n\texp=%v", providers, tt.expectedRes)
+			}
+
+		})
+
+	}
+
+}
+
+func TestAddProvider(t *testing.T) {
+
+	testCases := []struct {
+		name              string
+		mimeTypes         []*mimeTypeConfig
+		newProvider       *registrypb.ProviderInfo
+		expectedProviders map[string][]*registrypb.ProviderInfo
+	}{
+		{
+			name:      "no mime types defined - no initial providers",
+			mimeTypes: []*mimeTypeConfig{},
+			newProvider: &registrypb.ProviderInfo{
+				MimeTypes: []string{"text/json"},
+				Address:   "ip-provider1",
+				Name:      "provider1",
+			},
+			expectedProviders: map[string][]*registrypb.ProviderInfo{
+				"text/json": {
+					{
+						MimeTypes: []string{"text/json"},
+						Address:   "ip-provider1",
+						Name:      "provider1",
+					},
+				},
+			},
+		},
+		{
+			name: "one mime types defined - no initial providers - registering provider is the default",
+			mimeTypes: []*mimeTypeConfig{
+				{
+					MimeType:   "text/json",
+					Extension:  "json",
+					Name:       "JSON File",
+					Icon:       "https://example.org/icons&file=json.png",
+					DefaultApp: "provider1",
+				},
+			},
+			newProvider: &registrypb.ProviderInfo{
+				MimeTypes: []string{"text/json"},
+				Address:   "ip-provider1",
+				Name:      "provider1",
+			},
+			expectedProviders: map[string][]*registrypb.ProviderInfo{
+				"text/json": {
+					{
+						MimeTypes: []string{"text/json"},
+						Address:   "ip-provider2",
+						Name:      "provider2",
+					},
+					{
+						MimeTypes: []string{"text/json"},
+						Address:   "ip-provider1",
+						Name:      "provider1",
+					},
+				},
+			},
+		},
+		{
+			name: "one mime types defined - default already registered",
+			mimeTypes: []*mimeTypeConfig{
+				{
+					MimeType:   "text/json",
+					Extension:  "json",
+					Name:       "JSON File",
+					Icon:       "https://example.org/icons&file=json.png",
+					DefaultApp: "provider2",
+				},
+			},
+			newProvider: &registrypb.ProviderInfo{
+				MimeTypes: []string{"text/json"},
+				Address:   "ip-provider1",
+				Name:      "provider1",
+			},
+			expectedProviders: map[string][]*registrypb.ProviderInfo{
+				"text/json": {
+					{
+						MimeTypes: []string{"text/json"},
+						Address:   "ip-provider2",
+						Name:      "provider2",
+					},
+					{
+						MimeTypes: []string{"text/json"},
+						Address:   "ip-provider1",
+						Name:      "provider1",
+					},
+				},
+			},
+		},
+		{
+			name: "register a provider already registered",
+			mimeTypes: []*mimeTypeConfig{
+				{
+					MimeType:   "text/json",
+					Extension:  "json",
+					Name:       "JSON File",
+					Icon:       "https://example.org/icons&file=json.png",
+					DefaultApp: "provider2",
+				},
+			},
+			newProvider: &registrypb.ProviderInfo{
+				MimeTypes: []string{"text/json"},
+				Address:   "ip-provider1",
+				Name:      "provider1",
+			},
+			expectedProviders: map[string][]*registrypb.ProviderInfo{
+				"text/json": {
+					{
+						MimeTypes: []string{"text/json"},
+						Address:   "ip-provider2",
+						Name:      "provider2",
+					},
+					{
+						MimeTypes: []string{"text/json"},
+						Address:   "ip-provider1",
+						Name:      "provider1",
+					},
+				},
+			},
+		},
+		{
+			name: "register a provider already registered supporting more mime types",
+			mimeTypes: []*mimeTypeConfig{
+				{
+					MimeType:   "text/json",
+					Extension:  "json",
+					Name:       "JSON File",
+					Icon:       "https://example.org/icons&file=json.png",
+					DefaultApp: "provider2",
+				},
+				{
+					MimeType:   "text/xml",
+					Extension:  "xml",
+					Name:       "XML File",
+					Icon:       "https://example.org/icons&file=xml.png",
+					DefaultApp: "provider1",
+				},
+			},
+			newProvider: &registrypb.ProviderInfo{
+				MimeTypes: []string{"text/json", "text/xml"},
+				Address:   "ip-provider1",
+				Name:      "provider1",
+			},
+			expectedProviders: map[string][]*registrypb.ProviderInfo{
+				"text/json": {
+					{
+						MimeTypes: []string{"text/json"},
+						Address:   "ip-provider2",
+						Name:      "provider2",
+					},
+					{
+						MimeTypes: []string{"text/json", "text/xml"},
+						Address:   "ip-provider1",
+						Name:      "provider1",
+					},
+				},
+				"text/xml": {
+					{
+						MimeTypes: []string{"text/json", "text/xml"},
+						Address:   "ip-provider1",
+						Name:      "provider1",
+					},
+				},
+			},
+		},
+		{
+			name: "register a provider already registered supporting less mime types",
+			mimeTypes: []*mimeTypeConfig{
+				{
+					MimeType:   "text/json",
+					Extension:  "json",
+					Name:       "JSON File",
+					Icon:       "https://example.org/icons&file=json.png",
+					DefaultApp: "provider2",
+				},
+				{
+					MimeType:   "text/xml",
+					Extension:  "xml",
+					Name:       "XML File",
+					Icon:       "https://example.org/icons&file=xml.png",
+					DefaultApp: "provider1",
+				},
+			},
+			newProvider: &registrypb.ProviderInfo{
+				MimeTypes: []string{"text/json"},
+				Address:   "ip-provider1",
+				Name:      "provider1",
+			},
+			expectedProviders: map[string][]*registrypb.ProviderInfo{
+				"text/json": {
+					{
+						MimeTypes: []string{"text/json"},
+						Address:   "ip-provider2",
+						Name:      "provider2",
+					},
+					{
+						MimeTypes: []string{"text/json"},
+						Address:   "ip-provider1",
+						Name:      "provider1",
+					},
+				},
+				"text/xml": {},
+			},
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+
+			ctx := context.TODO()
+
+			registry, err := New(map[string]interface{}{
+				//"providers":  tt.initProviders,
+				"mime_types": tt.mimeTypes,
+			})
+			if err != nil {
+				t.Error("unexpected error creating the registry:", err)
+			}
+
+			err = registry.AddProvider(ctx, tt.newProvider)
+			if err != nil {
+				t.Error("unexpected error adding a new provider:", err)
+			}
+
+			// test that the internal set of providers keep the new provider
+			// and the key is the provider's address
+			microReg := registry.(*manager)
+			/*
+				in, ok := microReg.providers[tt.newProvider.Address]
+				if !ok {
+					t.Error("cannot find a provider in the internal map with address", tt.newProvider.Address)
+				}
+
+				// check that the provider in the set is the same as the new one
+				if !equalsProviderInfo(tt.newProvider, in) {
+					t.Errorf("providers are different: got=%v expected=%v", in, tt.newProvider)
+				}
+
+			*/
+			for mime, expAddrs := range tt.expectedProviders {
+				mimeConfInterface, _ := microReg.mimetypes.Get(mime)
+				addrsReg := mimeConfInterface.(*mimeTypeConfig).apps.getOrderedProviderByPriority()
+
+				if !reflect.DeepEqual(expAddrs, addrsReg) {
+					t.Errorf("list of addresses different from expected: \n\tgot=%v\n\texp=%v", addrsReg, expAddrs)
+				}
+			}
+
+		})
+	}
+
+}
+
+func TestListSupportedMimeTypes(t *testing.T) {
+	testCases := []struct {
+		name         string
+		mimeTypes    []*mimeTypeConfig
+		newProviders []*registrypb.ProviderInfo
+		expected     []*registrypb.MimeTypeInfo
+	}{
+		{
+			name: "one mime type - no provider registered",
+			mimeTypes: []*mimeTypeConfig{
+				{
+					MimeType:   "text/json",
+					Extension:  "json",
+					Name:       "JSON File",
+					Icon:       "https://example.org/icons&file=json.png",
+					DefaultApp: "provider2",
+				},
+			},
+			newProviders: []*registrypb.ProviderInfo{},
+			expected: []*registrypb.MimeTypeInfo{
+				{
+					MimeType:           "text/json",
+					Ext:                "json",
+					AppProviders:       []*registrypb.ProviderInfo{},
+					Name:               "JSON File",
+					Icon:               "https://example.org/icons&file=json.png",
+					DefaultApplication: "provider2",
+				},
+			},
+		},
+		{
+			name: "one mime type - only default provider registered",
+			mimeTypes: []*mimeTypeConfig{
+				{
+					MimeType:   "text/json",
+					Extension:  "json",
+					Name:       "JSON File",
+					Icon:       "https://example.org/icons&file=json.png",
+					DefaultApp: "provider1",
+				},
+			},
+			newProviders: []*registrypb.ProviderInfo{
+				{
+					MimeTypes: []string{"text/json"},
+					Address:   "ip-provider1",
+					Name:      "provider1",
+				},
+			},
+			expected: []*registrypb.MimeTypeInfo{
+				{
+					MimeType: "text/json",
+					Ext:      "json",
+					AppProviders: []*registrypb.ProviderInfo{
+						{
+							MimeTypes: []string{"text/json"},
+							Address:   "ip-provider1",
+							Name:      "provider1",
+						},
+					},
+					DefaultApplication: "provider1",
+					Name:               "JSON File",
+					Icon:               "https://example.org/icons&file=json.png",
+				},
+			},
+		},
+		{
+			name: "one mime type - more providers",
+			mimeTypes: []*mimeTypeConfig{
+				{
+					MimeType:   "text/json",
+					Extension:  "json",
+					Name:       "JSON File",
+					Icon:       "https://example.org/icons&file=json.png",
+					DefaultApp: "JSON_DEFAULT_PROVIDER",
+				},
+			},
+			newProviders: []*registrypb.ProviderInfo{
+				{
+					MimeTypes: []string{"text/json"},
+					Address:   "ip-provider2",
+					Name:      "NOT_DEFAULT_PROVIDER",
+				},
+				{
+					MimeTypes: []string{"text/json"},
+					Address:   "ip-provider1",
+					Name:      "JSON_DEFAULT_PROVIDER",
+				},
+			},
+			expected: []*registrypb.MimeTypeInfo{
+				{
+					MimeType: "text/json",
+					Ext:      "json",
+					AppProviders: []*registrypb.ProviderInfo{
+						{
+							MimeTypes: []string{"text/json"},
+							Address:   "ip-provider2",
+							Name:      "NOT_DEFAULT_PROVIDER",
+						},
+						{
+							MimeTypes: []string{"text/json"},
+							Address:   "ip-provider1",
+							Name:      "JSON_DEFAULT_PROVIDER",
+						},
+					},
+					DefaultApplication: "JSON_DEFAULT_PROVIDER",
+					Name:               "JSON File",
+					Icon:               "https://example.org/icons&file=json.png",
+				},
+			},
+		},
+		{
+			name: "multiple mime types",
+			mimeTypes: []*mimeTypeConfig{
+				{
+					MimeType:   "text/json",
+					Extension:  "json",
+					Name:       "JSON File",
+					Icon:       "https://example.org/icons&file=json.png",
+					DefaultApp: "JSON_DEFAULT_PROVIDER",
+				},
+				{
+					MimeType:   "text/xml",
+					Extension:  "xml",
+					Name:       "XML File",
+					Icon:       "https://example.org/icons&file=xml.png",
+					DefaultApp: "XML_DEFAULT_PROVIDER",
+				},
+			},
+			newProviders: []*registrypb.ProviderInfo{
+				{
+					MimeTypes: []string{"text/json", "text/xml"},
+					Address:   "1",
+					Name:      "NOT_DEFAULT_PROVIDER2",
+				},
+				{
+					MimeTypes: []string{"text/xml"},
+					Address:   "2",
+					Name:      "NOT_DEFAULT_PROVIDER1",
+				},
+				{
+					MimeTypes: []string{"text/xml", "text/json"},
+					Address:   "3",
+					Name:      "JSON_DEFAULT_PROVIDER",
+				},
+				{
+					MimeTypes: []string{"text/xml", "text/json"},
+					Address:   "4",
+					Name:      "XML_DEFAULT_PROVIDER",
+				},
+			},
+			expected: []*registrypb.MimeTypeInfo{
+				{
+					MimeType: "text/json",
+					Ext:      "json",
+					AppProviders: []*registrypb.ProviderInfo{
+						{
+							MimeTypes: []string{"text/json", "text/xml"},
+							Address:   "1",
+							Name:      "NOT_DEFAULT_PROVIDER2",
+						},
+						{
+							MimeTypes: []string{"text/xml", "text/json"},
+							Address:   "3",
+							Name:      "JSON_DEFAULT_PROVIDER",
+						},
+						{
+							MimeTypes: []string{"text/xml", "text/json"},
+							Address:   "4",
+							Name:      "XML_DEFAULT_PROVIDER",
+						},
+					},
+					DefaultApplication: "JSON_DEFAULT_PROVIDER",
+					Name:               "JSON File",
+					Icon:               "https://example.org/icons&file=json.png",
+				},
+				{
+					MimeType: "text/xml",
+					Ext:      "xml",
+					AppProviders: []*registrypb.ProviderInfo{
+						{
+							MimeTypes: []string{"text/json", "text/xml"},
+							Address:   "1",
+							Name:      "NOT_DEFAULT_PROVIDER2",
+						},
+						{
+							MimeTypes: []string{"text/xml"},
+							Address:   "2",
+							Name:      "NOT_DEFAULT_PROVIDER1",
+						},
+						{
+							MimeTypes: []string{"text/xml", "text/json"},
+							Address:   "3",
+							Name:      "JSON_DEFAULT_PROVIDER",
+						},
+						{
+							MimeTypes: []string{"text/xml", "text/json"},
+							Address:   "4",
+							Name:      "XML_DEFAULT_PROVIDER",
+						},
+					},
+					DefaultApplication: "XML_DEFAULT_PROVIDER",
+					Name:               "XML File",
+					Icon:               "https://example.org/icons&file=xml.png",
+				},
+			},
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+
+			ctx := context.TODO()
+
+			registry, err := New(map[string]interface{}{
+				"mime_types": tt.mimeTypes,
+			})
+			if err != nil {
+				t.Error("unexpected error creating the registry:", err)
+			}
+
+			// add all the providers
+			for _, p := range tt.newProviders {
+				err = registry.AddProvider(ctx, p)
+				if err != nil {
+					t.Error("unexpected error creating adding new providers:", err)
+				}
+			}
+
+			got, err := registry.ListSupportedMimeTypes(ctx)
+			if err != nil {
+				t.Error("unexpected error listing supported mime types:", err)
+			}
+
+			if !mimeTypesEquals(got, tt.expected) {
+				t.Errorf("mime types list different from expected: \n\tgot=%v\n\texp=%v", got, tt.expected)
+			}
+
+		})
+	}
+}
+
+func TestSetDefaultProviderForMimeType(t *testing.T) {
+	testCases := []struct {
+		name          string
+		mimeTypes     []*mimeTypeConfig
+		initProviders []*registrypb.ProviderInfo
+		newDefault    struct {
+			mimeType string
+			provider *registrypb.ProviderInfo
+		}
+		newProviders []*registrypb.ProviderInfo
+	}{
+		{
+			name: "set new default - no new providers",
+			mimeTypes: []*mimeTypeConfig{
+				{
+					MimeType:   "text/json",
+					Extension:  "json",
+					Name:       "JSON File",
+					Icon:       "https://example.org/icons&file=json.png",
+					DefaultApp: "JSON_DEFAULT_PROVIDER",
+				},
+			},
+			initProviders: []*registrypb.ProviderInfo{
+				{
+					MimeTypes: []string{"text/json"},
+					Address:   "1",
+					Name:      "JSON_DEFAULT_PROVIDER",
+				},
+				{
+					MimeTypes: []string{"text/json"},
+					Address:   "2",
+					Name:      "NEW_DEFAULT",
+				},
+			},
+			newDefault: struct {
+				mimeType string
+				provider *registrypb.ProviderInfo
+			}{
+				mimeType: "text/json",
+				provider: &registrypb.ProviderInfo{
+					MimeTypes: []string{"text/json"},
+					Address:   "2",
+					Name:      "NEW_DEFAULT",
+				},
+			},
+			newProviders: []*registrypb.ProviderInfo{},
+		},
+		{
+			name: "set default - other providers (one is the previous default)",
+			mimeTypes: []*mimeTypeConfig{
+				{
+					MimeType:   "text/json",
+					Extension:  "json",
+					Name:       "JSON File",
+					Icon:       "https://example.org/icons&file=json.png",
+					DefaultApp: "JSON_DEFAULT_PROVIDER",
+				},
+			},
+			initProviders: []*registrypb.ProviderInfo{
+				{
+					MimeTypes: []string{"text/json"},
+					Address:   "4",
+					Name:      "NO_DEFAULT_PROVIDER",
+				},
+				{
+					MimeTypes: []string{"text/json"},
+					Address:   "2",
+					Name:      "NEW_DEFAULT",
+				},
+			},
+			newDefault: struct {
+				mimeType string
+				provider *registrypb.ProviderInfo
+			}{
+				mimeType: "text/json",
+				provider: &registrypb.ProviderInfo{
+					MimeTypes: []string{"text/json"},
+					Address:   "2",
+					Name:      "NEW_DEFAULT",
+				},
+			},
+			newProviders: []*registrypb.ProviderInfo{
+				{
+					MimeTypes: []string{"text/json"},
+					Address:   "1",
+					Name:      "JSON_DEFAULT_PROVIDER",
+				},
+				{
+					MimeTypes: []string{"text/json"},
+					Address:   "3",
+					Name:      "OTHER_PROVIDER",
+				},
+			},
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+
+			ctx := context.TODO()
+
+			registry, err := New(map[string]interface{}{
+				"providers":  tt.initProviders,
+				"mime_types": tt.mimeTypes,
+			})
+			if err != nil {
+				t.Error("unexpected error creating a new registry:", err)
+			}
+
+			err = registry.SetDefaultProviderForMimeType(ctx, tt.newDefault.mimeType, tt.newDefault.provider)
+			if err != nil {
+				t.Error("unexpected error setting a default provider for mime type:", err)
+			}
+
+			// add other provider to move things around internally :)
+			for _, p := range tt.newProviders {
+				err = registry.AddProvider(ctx, p)
+				if err != nil {
+					t.Error("unexpected error adding a new provider:", err)
+				}
+			}
+
+			// check if the new default is the one set
+			got, err := registry.GetDefaultProviderForMimeType(ctx, tt.newDefault.mimeType)
+			if err != nil {
+				t.Error("unexpected error getting the default app provider:", err)
+			}
+
+			if !equalsProviderInfo(got, tt.newDefault.provider) {
+				t.Errorf("provider differ from expected:\n\tgot=%v\n\texp=%v", got, tt.newDefault.provider)
+			}
+
+		})
+	}
+}
+
+func mimeTypesEquals(l1, l2 []*registrypb.MimeTypeInfo) bool {
+	if len(l1) != len(l2) {
+		return false
+	}
+
+	for i := 0; i < len(l1); i++ {
+		if !equalsMimeTypeInfo(l1[i], l2[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func equalsMimeTypeInfo(m1, m2 *registrypb.MimeTypeInfo) bool {
+	return m1.Description == m2.Description &&
+		m1.AllowCreation == m2.AllowCreation &&
+		providersEquals(m1.AppProviders, m2.AppProviders) &&
+		m1.Ext == m2.Ext &&
+		m1.MimeType == m2.MimeType &&
+		m1.Name == m2.Name &&
+		m1.DefaultApplication == m2.DefaultApplication
+}


### PR DESCRIPTION
To fix https://github.com/owncloud/ocis/issues/3832 we plan to rely on the micro registry. In kubernetes it will use the existing service registry, allowing kubernetes to move the app registry to other nodes without loosing the currently registered app providers.

Leaving this here as WIP as I'm off for the weekend...

- [ ] move code to a dedicated micro app registry
- [ ] make Register calls write to the micre registry as in ocis `RegisterGRPCEndpoint`
- [ ] move ocis-pkg registry to reva?

in ocis this needs a new parameter
```diff
diff --git a/ocis-pkg/service/external/external.go b/ocis-pkg/service/external/external.go
index 7b90fe7fb..29d8f7d04 100644
--- a/ocis-pkg/service/external/external.go
+++ b/ocis-pkg/service/external/external.go
@@ -11,7 +11,7 @@ import (
 
 // RegisterGRPCEndpoint publishes an arbitrary endpoint to the service-registry. This allows querying nodes of
 // non-micro GRPC-services like reva. No health-checks are done, thus the caller is responsible for canceling.
-func RegisterGRPCEndpoint(ctx context.Context, serviceID, uuid, addr string, version string, logger log.Logger) error {
+func RegisterGRPCEndpoint(ctx context.Context, serviceID, uuid, addr string, version string, logger log.Logger, nodeMetadata map[string]string) error {
        node := &registry.Node{
                Id:       serviceID + "-" + uuid,
                Address:  addr,
@@ -23,6 +23,9 @@ func RegisterGRPCEndpoint(ctx context.Context, serviceID, uuid, addr string, ver
        node.Metadata["server"] = "grpc"
        node.Metadata["transport"] = "grpc"
        node.Metadata["protocol"] = "grpc"
+       for k, v := range nodeMetadata {
+               node.Metadata[k] = v
+       }
 
        service := &registry.Service{
                Name:      serviceID,
diff --git a/services/app-provider/pkg/command/server.go b/services/app-provider/pkg/command/server.go
index a7fc216d0..85611476c 100644
--- a/services/app-provider/pkg/command/server.go
+++ b/services/app-provider/pkg/command/server.go
@@ -84,6 +84,17 @@ func Server(cfg *config.Config) *cli.Command {
                                cfg.GRPC.Addr,
                                version.GetString(),
                                logger,
+                               map[string]string{
+                                       "cs3.app-provider.mime_type":   "text/plain", // FIXME
+                                       "cs3.app-provider.extension":   "txt",
+                                       "cs3.app-provider.name":        "demo",
+                                       "cs3.app-provider.description": "Demo text",
+                                       //"cs3.app-provider.icon":           "",
+                                       //"cs3.app-provider.default_app":    "",
+                                       "cs3.app-provider.allow_creation": "true",
+                                       "cs3.app-provider.priority":       "100", // TODO needs cs3 property on ProviderInfo
+                                       "cs3.app-provider.desktop_only":   "false",
+                               },
                        ); err != nil {
                                logger.Fatal().Err(err).Msg("failed to register the grpc endpoint")
                        }
diff --git a/services/app-registry/pkg/command/server.go b/services/app-registry/pkg/command/server.go
index aa230570f..e8ae89a12 100644
--- a/services/app-registry/pkg/command/server.go
+++ b/services/app-registry/pkg/command/server.go
@@ -79,6 +79,7 @@ func Server(cfg *config.Config) *cli.Command {
                                cfg.GRPC.Addr,
                                version.GetString(),
                                logger,
+                               map[string]string{},
                        ); err != nil {
                                logger.Fatal().Err(err).Msg("failed to register the grpc endpoint")
                        }
diff --git a/services/app-registry/pkg/config/defaults/defaultconfig.go b/services/app-registry/pkg/config/defaults/defaultconfig.go
index 5cbc26c71..cd569f7fd 100644
--- a/services/app-registry/pkg/config/defaults/defaultconfig.go
+++ b/services/app-registry/pkg/config/defaults/defaultconfig.go
@@ -37,6 +37,12 @@ func DefaultConfig() *config.Config {
 
 func defaultMimeTypeConfig() []config.MimeTypeConfig {
        return []config.MimeTypeConfig{
+               {
+                       MimeType:    "text/plain",
+                       Extension:   "txt",
+                       Name:        "Demo",
+                       Description: "Demo text",
+               },
                {
                        MimeType:    "application/pdf",
                        Extension:   "pdf",
diff --git a/services/auth-basic/pkg/command/server.go b/services/auth-basic/pkg/command/server.go
index 4dc4ffba2..cef5af775 100644
--- a/services/auth-basic/pkg/command/server.go
+++ b/services/auth-basic/pkg/command/server.go
@@ -97,6 +97,7 @@ func Server(cfg *config.Config) *cli.Command {
                                cfg.GRPC.Addr,
                                version.GetString(),
                                logger,
+                               map[string]string{},
                        ); err != nil {
                                logger.Fatal().Err(err).Msg("failed to register the grpc endpoint")
                        }
diff --git a/services/auth-bearer/pkg/command/server.go b/services/auth-bearer/pkg/command/server.go
index 4c181bfab..f304c897d 100644
--- a/services/auth-bearer/pkg/command/server.go
+++ b/services/auth-bearer/pkg/command/server.go
@@ -84,6 +84,7 @@ func Server(cfg *config.Config) *cli.Command {
                                cfg.GRPC.Addr,
                                version.GetString(),
                                logger,
+                               map[string]string{},
                        ); err != nil {
                                logger.Fatal().Err(err).Msg("failed to register the grpc endpoint")
                        }
diff --git a/services/auth-machine/pkg/command/server.go b/services/auth-machine/pkg/command/server.go
index bf2ad19cc..0826eae01 100644
--- a/services/auth-machine/pkg/command/server.go
+++ b/services/auth-machine/pkg/command/server.go
@@ -84,6 +84,7 @@ func Server(cfg *config.Config) *cli.Command {
                                cfg.GRPC.Addr,
                                version.GetString(),
                                logger,
+                               map[string]string{},
                        ); err != nil {
                                logger.Fatal().Err(err).Msg("failed to register the grpc endpoint")
                        }
diff --git a/services/gateway/pkg/command/server.go b/services/gateway/pkg/command/server.go
index f2ddf03af..ac893acb4 100644
--- a/services/gateway/pkg/command/server.go
+++ b/services/gateway/pkg/command/server.go
@@ -79,6 +79,7 @@ func Server(cfg *config.Config) *cli.Command {
                                cfg.GRPC.Addr,
                                version.GetString(),
                                logger,
+                               map[string]string{},
                        ); err != nil {
                                logger.Fatal().Err(err).Msg("failed to register the grpc endpoint")
                        }
diff --git a/services/groups/pkg/command/server.go b/services/groups/pkg/command/server.go
index 6605c3dfd..85201e18c 100644
--- a/services/groups/pkg/command/server.go
+++ b/services/groups/pkg/command/server.go
@@ -97,6 +97,7 @@ func Server(cfg *config.Config) *cli.Command {
                                cfg.GRPC.Addr,
                                version.GetString(),
                                logger,
+                               map[string]string{},
                        ); err != nil {
                                logger.Fatal().Err(err).Msg("failed to register the grpc endpoint")
                        }
diff --git a/services/sharing/pkg/command/server.go b/services/sharing/pkg/command/server.go
index 6154ff20b..071cffd42 100644
--- a/services/sharing/pkg/command/server.go
+++ b/services/sharing/pkg/command/server.go
@@ -97,6 +97,7 @@ func Server(cfg *config.Config) *cli.Command {
                                cfg.GRPC.Addr,
                                version.GetString(),
                                logger,
+                               map[string]string{},
                        ); err != nil {
                                logger.Fatal().Err(err).Msg("failed to register the grpc endpoint")
                        }
diff --git a/services/storage-publiclink/pkg/command/server.go b/services/storage-publiclink/pkg/command/server.go
index 1c731ee52..3a050f198 100644
--- a/services/storage-publiclink/pkg/command/server.go
+++ b/services/storage-publiclink/pkg/command/server.go
@@ -84,6 +84,7 @@ func Server(cfg *config.Config) *cli.Command {
                                cfg.GRPC.Addr,
                                version.GetString(),
                                logger,
+                               map[string]string{},
                        ); err != nil {
                                logger.Fatal().Err(err).Msg("failed to register the grpc endpoint")
                        }
diff --git a/services/storage-shares/pkg/command/server.go b/services/storage-shares/pkg/command/server.go
index d3e507e2b..2b1160842 100644
--- a/services/storage-shares/pkg/command/server.go
+++ b/services/storage-shares/pkg/command/server.go
@@ -84,6 +84,7 @@ func Server(cfg *config.Config) *cli.Command {
                                cfg.GRPC.Addr,
                                version.GetString(),
                                logger,
+                               map[string]string{},
                        ); err != nil {
                                logger.Fatal().Err(err).Msg("failed to register the grpc endpoint")
                        }
diff --git a/services/storage-system/pkg/command/server.go b/services/storage-system/pkg/command/server.go
index de6095a66..285d51409 100644
--- a/services/storage-system/pkg/command/server.go
+++ b/services/storage-system/pkg/command/server.go
@@ -84,6 +84,7 @@ func Server(cfg *config.Config) *cli.Command {
                                cfg.GRPC.Addr,
                                version.GetString(),
                                logger,
+                               map[string]string{},
                        ); err != nil {
                                logger.Fatal().Err(err).Msg("failed to register the grpc endpoint")
                        }
diff --git a/services/storage-users/pkg/command/server.go b/services/storage-users/pkg/command/server.go
index ffff3afe2..47edf24b3 100644
--- a/services/storage-users/pkg/command/server.go
+++ b/services/storage-users/pkg/command/server.go
@@ -86,6 +86,7 @@ func Server(cfg *config.Config) *cli.Command {
                                cfg.GRPC.Addr,
                                version.GetString(),
                                logger,
+                               map[string]string{},
                        ); err != nil {
                                logger.Fatal().Err(err).Msg("failed to register the grpc endpoint")
                        }
diff --git a/services/users/pkg/command/server.go b/services/users/pkg/command/server.go
index b0419b305..b57189367 100644
--- a/services/users/pkg/command/server.go
+++ b/services/users/pkg/command/server.go
@@ -97,6 +97,7 @@ func Server(cfg *config.Config) *cli.Command {
                                cfg.GRPC.Addr,
                                version.GetString(),
                                logger,
+                               map[string]string{},
                        ); err != nil {
                                logger.Fatal().Err(err).Msg("failed to register the grpc endpoint")
                        }
```
I wonder if we shouldnt introduce options to `RegisterGRPCEndpoint`