### PR TITLE
Revert "bump golangci-lint to v1.53.2"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ toolchain-clean:
 
 $(GOLANGCI_LINT):
 	@mkdir -p $(@D)
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | BINDIR=$(@D) sh -s v1.53.2
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | BINDIR=$(@D) sh -s v1.50.1
 
 .PHONY: check-changelog
 lint: $(GOLANGCI_LINT)

--- a/changelog/unreleased/revert-linter-bump.md
+++ b/changelog/unreleased/revert-linter-bump.md
@@ -1,0 +1,3 @@
+Change: Revert golangci-lint back to 1.50.1
+
+https://github.com/cs3org/reva/pull/3945


### PR DESCRIPTION
This reverts commit 227853cdba8c3a9c0b0f7eacf36d37cf2e43f3a0.

The version bump caused a huge amount of new linter errors which need to be investigate first.