### PR TITLE
Filter OCM shares by path

### DIFF
--- a/changelog/unreleased/fix-ocm-share-filter-by-path.md
+++ b/changelog/unreleased/fix-ocm-share-filter-by-path.md
@@ -1,0 +1,5 @@
+Bugfix: Filter OCM shares by path
+
+Fixes the bug of duplicated OCM shares returned in the share with others response.
+
+https://github.com/cs3org/reva/pull/3946

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/remote.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/remote.go
@@ -244,8 +244,10 @@ func (h *Handler) mustGetRemoteUser(ctx context.Context, gw gatewayv1beta1.Gatew
 	}
 }
 
-func (h *Handler) listOutcomingFederatedShares(ctx context.Context, gw gatewayv1beta1.GatewayAPIClient) ([]*conversions.ShareData, error) {
-	listRes, err := gw.ListOCMShares(ctx, &ocm.ListOCMSharesRequest{})
+func (h *Handler) listOutcomingFederatedShares(ctx context.Context, gw gatewayv1beta1.GatewayAPIClient, filters []*ocm.ListOCMSharesRequest_Filter) ([]*conversions.ShareData, error) {
+	listRes, err := gw.ListOCMShares(ctx, &ocm.ListOCMSharesRequest{
+		Filters: filters,
+	})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR fixes the bug of duplicated OCM shares returned in the share with others response