### PR TITLE
link context in metadata client

### DIFF
--- a/changelog/unreleased/link-context.md
+++ b/changelog/unreleased/link-context.md
@@ -1,0 +1,5 @@
+Bugfix: link context in metadata client
+
+We now disconnect the existing outgoing grpc metadata when making calls in the metadata client. To keep track of related spans we link the two contexts.
+
+https://github.com/cs3org/reva/pull/3951


### PR DESCRIPTION
We now disconnect the existing outgoing grpc metadata when making calls in the metadata client. To keep track of related spans we link the two contexts.

A good introduction to opentelemetry tracing is https://lightstep.com/blog/opentelemetry-go-all-you-need-to-know