### PR TITLE
Bugfix: treesize interger overflows

### DIFF
--- a/changelog/unreleased/decomposedfs-treesize-overflow.md
+++ b/changelog/unreleased/decomposedfs-treesize-overflow.md
@@ -1,0 +1,7 @@
+Bugfix: treesize interger overflows
+
+Reading the treesize was parsing the string value as a signed integer while
+setting the treesize used unsigned integers this could cause failures (out of
+range errors) when reading very large treesizes.
+
+https://github.com/cs3org/reva/pull/3963

--- a/pkg/storage/utils/decomposedfs/node/node.go
+++ b/pkg/storage/utils/decomposedfs/node/node.go
@@ -948,11 +948,11 @@ func (n *Node) IsDisabled() bool {
 
 // GetTreeSize reads the treesize from the extended attributes
 func (n *Node) GetTreeSize() (treesize uint64, err error) {
-	s, err := n.XattrInt64(prefixes.TreesizeAttr)
+	s, err := n.XattrUint64(prefixes.TreesizeAttr)
 	if err != nil {
 		return 0, err
 	}
-	return uint64(s), nil
+	return s, nil
 }
 
 // SetTreeSize writes the treesize to the extended attributes

--- a/pkg/storage/utils/decomposedfs/node/xattrs.go
+++ b/pkg/storage/utils/decomposedfs/node/xattrs.go
@@ -174,3 +174,12 @@ func (n *Node) XattrInt64(key string) (int64, error) {
 	}
 	return strconv.ParseInt(b, 10, 64)
 }
+
+// XattrUint64 returns the uint64 representation of an attribute
+func (n *Node) XattrUint64(key string) (uint64, error) {
+	b, err := n.XattrString(key)
+	if err != nil {
+		return 0, err
+	}
+	return strconv.ParseUint(b, 10, 64)
+}


### PR DESCRIPTION
Reading the treesize was parsing the string value as a signed integer while setting the treesize used unsigned integers this could cause failures (out of range errors) when reading very large treesizes.

This PR is mainly a workaround for scenarios where the treesize propagation would result in negative treesize, which then are stored as unsigned integers in the xattrs. 

https://github.com/owncloud/enterprise/issues/5783