### PR TITLE
Reduce lock congestion

### DIFF
--- a/changelog/unreleased/jsoncs3-lock-congestion.md
+++ b/changelog/unreleased/jsoncs3-lock-congestion.md
@@ -1,0 +1,6 @@
+Bugfix: Reduce jsoncs3 lock congestion
+
+We changed the locking strategy in the jsoncs3 share manager to cause less lock
+ congestion increasing the performance in certain scenarios.
+
+https://github.com/cs3org/reva/pull/3964

--- a/pkg/share/manager/jsoncs3/providercache/providercache_test.go
+++ b/pkg/share/manager/jsoncs3/providercache/providercache_test.go
@@ -62,7 +62,7 @@ var _ = Describe("Cache", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		c = providercache.New(storage, 0*time.Second)
-		Expect(c).ToNot(BeNil()) // nolint:copylocks
+		Expect(c).ToNot(BeNil()) //nolint:all
 	})
 
 	AfterEach(func() {

--- a/pkg/share/manager/jsoncs3/providercache/providercache_test.go
+++ b/pkg/share/manager/jsoncs3/providercache/providercache_test.go
@@ -62,7 +62,7 @@ var _ = Describe("Cache", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		c = providercache.New(storage, 0*time.Second)
-		Expect(c).ToNot(BeNil())
+		Expect(c).ToNot(BeNil()) // nolint:copylocks
 	})
 
 	AfterEach(func() {

--- a/pkg/share/manager/jsoncs3/receivedsharecache/receivedsharecache_test.go
+++ b/pkg/share/manager/jsoncs3/receivedsharecache/receivedsharecache_test.go
@@ -63,7 +63,7 @@ var _ = Describe("Cache", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		c = receivedsharecache.New(storage, 0*time.Second)
-		Expect(c).ToNot(BeNil())
+		Expect(c).ToNot(BeNil()) // nolint:copylocks
 	})
 
 	AfterEach(func() {

--- a/pkg/share/manager/jsoncs3/receivedsharecache/receivedsharecache_test.go
+++ b/pkg/share/manager/jsoncs3/receivedsharecache/receivedsharecache_test.go
@@ -63,7 +63,7 @@ var _ = Describe("Cache", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		c = receivedsharecache.New(storage, 0*time.Second)
-		Expect(c).ToNot(BeNil()) // nolint:copylocks
+		Expect(c).ToNot(BeNil()) //nolint:all
 	})
 
 	AfterEach(func() {

--- a/pkg/share/manager/jsoncs3/sharecache/sharecache_test.go
+++ b/pkg/share/manager/jsoncs3/sharecache/sharecache_test.go
@@ -55,7 +55,7 @@ var _ = Describe("Sharecache", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		c = sharecache.New(storage, "users", "created.json", 0*time.Second)
-		Expect(c).ToNot(BeNil())
+		Expect(c).ToNot(BeNil()) // nolint:copylocks
 	})
 
 	AfterEach(func() {

--- a/pkg/share/manager/jsoncs3/sharecache/sharecache_test.go
+++ b/pkg/share/manager/jsoncs3/sharecache/sharecache_test.go
@@ -55,7 +55,7 @@ var _ = Describe("Sharecache", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		c = sharecache.New(storage, "users", "created.json", 0*time.Second)
-		Expect(c).ToNot(BeNil()) // nolint:copylocks
+		Expect(c).ToNot(BeNil()) //nolint:all
 	})
 
 	AfterEach(func() {


### PR DESCRIPTION
We removed the global lock in the jsoncs3 share manager by locking the different caches separately. We also reduced the lock congestion by using more fine-grained locks, i.e. locking the caches per user or space instead of locking the cache as a whole.

refs https://github.com/owncloud/ocis/issues/6497