### PR TITLE
ResumePostprocessing Event

### DIFF
--- a/changelog/unreleased/resume-postprocessing-event.md
+++ b/changelog/unreleased/resume-postprocessing-event.md
@@ -1,0 +1,5 @@
+Enhancement: ResumePostprocessing Event
+
+Add a new event: `ResumePostprocessing`. It can be emitted to repair broken postprocessing
+
+https://github.com/cs3org/reva/pull/3965

--- a/pkg/events/postprocessing.go
+++ b/pkg/events/postprocessing.go
@@ -171,3 +171,16 @@ func (UploadReady) Unmarshal(v []byte) (interface{}, error) {
 	err := json.Unmarshal(v, &e)
 	return e, err
 }
+
+// ResumePostprocessing can be emitted to repair broken postprocessing
+type ResumePostprocessing struct {
+	UploadID  string
+	Timestamp *types.Timestamp
+}
+
+// Unmarshal to fulfill umarshaller interface
+func (ResumePostprocessing) Unmarshal(v []byte) (interface{}, error) {
+	e := ResumePostprocessing{}
+	err := json.Unmarshal(v, &e)
+	return e, err
+}


### PR DESCRIPTION
Adds an event that can be emitted to resume postprocessing in case it got stuck
