### PR TITLE
add space metadata to ocs shares

### DIFF
--- a/changelog/unreleased/add-space-metadata-to-ocs.md
+++ b/changelog/unreleased/add-space-metadata-to-ocs.md
@@ -1,0 +1,5 @@
+Enhancement: Add space metadata to ocs shares list
+
+We needed to add the space ID and the space alias of the original space to the share metadata when we are listing shares. This is needed to directly navigate to the originating space location.
+
+https://github.com/cs3org/reva/pull/3966

--- a/internal/http/services/owncloud/ocs/conversions/main.go
+++ b/internal/http/services/owncloud/ocs/conversions/main.go
@@ -129,9 +129,13 @@ type ShareData struct {
 	// The type of the object being shared. This can be one of 'file' or 'folder'.
 	ItemType string `json:"item_type" xml:"item_type"`
 	// The RFC2045-compliant mimetype of the file.
-	MimeType  string `json:"mimetype" xml:"mimetype"`
-	StorageID string `json:"storage_id" xml:"storage_id"`
-	Storage   uint64 `json:"storage" xml:"storage"`
+	MimeType string `json:"mimetype" xml:"mimetype"`
+	// The space ID of the original file location
+	SpaceID string `json:"space_id" xml:"space_id"`
+	// The space alias of the original file location
+	SpaceAlias string `json:"space_alias" xml:"space_alias"`
+	StorageID  string `json:"storage_id" xml:"storage_id"`
+	Storage    uint64 `json:"storage" xml:"storage"`
 	// The unique node id of the item being shared.
 	ItemSource string `json:"item_source" xml:"item_source"`
 	// The unique node id of the item being shared. For legacy reasons item_source and file_source attributes have the same value.

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/shares.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/shares.go
@@ -1209,6 +1209,11 @@ func (h *Handler) addFileInfo(ctx context.Context, s *conversions.ShareData, inf
 	if s.UIDOwner == "" && owner != nil {
 		s.UIDOwner = owner.GetOpaqueId()
 	}
+
+	if info.GetSpace().GetRoot() != nil {
+		s.SpaceID = storagespace.FormatResourceID(*info.GetSpace().GetRoot())
+	}
+	s.SpaceAlias = utils.ReadPlainFromOpaque(info.GetSpace().GetOpaque(), "spaceAlias")
 }
 
 // mustGetIdentifiers always returns a struct with identifiers, if the user or group could not be found they will all be empty


### PR DESCRIPTION
# Description

Enhancement: Add space metadata to ocs shares list

We needed to add the space ID and the space alias of the orgininal space to the share metadata when we are listing shares. This is needed to directly navigate to the orgiginating space location.
