### PR TITLE
Do not try to initialize notification helper if settings are not there

### DIFF
--- a/changelog/unreleased/notifications-skip-init.md
+++ b/changelog/unreleased/notifications-skip-init.md
@@ -1,0 +1,6 @@
+Enhancement: Conditional notifications initialization
+
+Notification helpers in services will not try to initalize if
+there is no specific configuration.
+
+https://github.com/cs3org/reva/pull/3969

--- a/pkg/notification/db_changes.sql
+++ b/pkg/notification/db_changes.sql
@@ -19,8 +19,6 @@
 -- This file can be used to make the required changes to the MySQL DB. This is
 -- not a proper migration but it should work on most situations.
 
-USE cernboxngcopy;
-
 CREATE TABLE `cbox_notifications` (
 	`id` INT PRIMARY KEY AUTO_INCREMENT,
 	`ref` VARCHAR(3072) UNIQUE NOT NULL,
@@ -45,7 +43,7 @@ CREATE INDEX `cbox_notifications_ix0` ON `cbox_notifications` (`ref`);
 CREATE INDEX `cbox_notification_recipients_ix0` ON `cbox_notification_recipients` (`notification_id`);
 CREATE INDEX `cbox_notification_recipients_ix1` ON `cbox_notification_recipients` (`user_name`);
 
--- changes for added notifications on ocm shares
+-- changes for added notifications on oc shares
 
 ALTER TABLE cernboxngcopy.oc_share ADD notify_uploads BOOL DEFAULT false;
 

--- a/pkg/notification/utils/nats.go
+++ b/pkg/notification/utils/nats.go
@@ -38,10 +38,16 @@ func ConnectToNats(natsAddress, natsToken string, log zerolog.Logger) (*nats.Con
 			log.Error().Err(err).Msgf("nats error")
 		}),
 		nats.ClosedHandler(func(c *nats.Conn) {
-			log.Error().Err(c.LastError()).Msgf("connection to nats server closed")
+			if c.LastError() != nil {
+				log.Error().Err(c.LastError()).Msgf("connection to nats server closed")
+			} else {
+				log.Debug().Msgf("connection to nats server closed")
+			}
 		}),
 		nats.DisconnectErrHandler(func(_ *nats.Conn, err error) {
-			log.Error().Err(err).Msgf("connection to nats server disconnected")
+			if err != nil {
+				log.Error().Err(err).Msgf("connection to nats server disconnected")
+			}
 		}),
 		nats.CustomReconnectDelay(func(attempts int) time.Duration {
 			if attempts%3 == 0 {


### PR DESCRIPTION
This should prevent the errors seen [here](https://github.com/cs3org/reva/issues/3968#issue-1754282185), which should just be an `Info` level message about notifications not configured.

Also removes some typos and unneeded stuff from the sql script.