### PR TITLE
decomposedfs: prevent direct access to trash items

### DIFF
--- a/changelog/unreleased/hide-trash-items.md
+++ b/changelog/unreleased/hide-trash-items.md
@@ -1,0 +1,5 @@
+Bugfix: prevent direct access to trash items
+
+decomposedfs now prevents direct access to trash items
+
+https://github.com/cs3org/reva/pull/3977

--- a/pkg/storage/utils/decomposedfs/decomposedfs.go
+++ b/pkg/storage/utils/decomposedfs/decomposedfs.go
@@ -427,7 +427,7 @@ func (fs *Decomposedfs) GetQuota(ctx context.Context, ref *provider.Reference) (
 	rp, err := fs.p.AssemblePermissions(ctx, n)
 	switch {
 	case err != nil:
-		return 0, 0, 0, errtypes.InternalError(err.Error())
+		return 0, 0, 0, err
 	case !rp.GetQuota && !fs.p.ListAllSpaces(ctx):
 		f, _ := storagespace.FormatReference(ref)
 		if rp.Stat {
@@ -534,7 +534,7 @@ func (fs *Decomposedfs) GetPathByID(ctx context.Context, id *provider.ResourceId
 	rp, err := fs.p.AssemblePermissions(ctx, n)
 	switch {
 	case err != nil:
-		return "", errtypes.InternalError(err.Error())
+		return "", err
 	case !rp.GetPath:
 		f := storagespace.FormatResourceID(*id)
 		if rp.Stat {
@@ -581,7 +581,7 @@ func (fs *Decomposedfs) CreateDir(ctx context.Context, ref *provider.Reference) 
 	rp, err := fs.p.AssemblePermissions(ctx, n)
 	switch {
 	case err != nil:
-		return errtypes.InternalError(err.Error())
+		return err
 	case !rp.CreateContainer:
 		f, _ := storagespace.FormatReference(ref)
 		if rp.Stat {
@@ -637,7 +637,7 @@ func (fs *Decomposedfs) TouchFile(ctx context.Context, ref *provider.Reference, 
 	rp, err := fs.p.AssemblePermissions(ctx, n)
 	switch {
 	case err != nil:
-		return errtypes.InternalError(err.Error())
+		return err
 	case !rp.InitiateFileUpload:
 		f, _ := storagespace.FormatReference(ref)
 		if rp.Stat {
@@ -680,7 +680,7 @@ func (fs *Decomposedfs) Move(ctx context.Context, oldRef, newRef *provider.Refer
 	rp, err := fs.p.AssemblePermissions(ctx, oldNode)
 	switch {
 	case err != nil:
-		return errtypes.InternalError(err.Error())
+		return err
 	case !rp.Move:
 		f, _ := storagespace.FormatReference(oldRef)
 		if rp.Stat {
@@ -700,7 +700,7 @@ func (fs *Decomposedfs) Move(ctx context.Context, oldRef, newRef *provider.Refer
 	rp, err = fs.p.AssemblePermissions(ctx, newNode)
 	switch {
 	case err != nil:
-		return errtypes.InternalError(err.Error())
+		return err
 	case oldNode.IsDir() && !rp.CreateContainer:
 		f, _ := storagespace.FormatReference(newRef)
 		if rp.Stat {
@@ -746,7 +746,7 @@ func (fs *Decomposedfs) GetMD(ctx context.Context, ref *provider.Reference, mdKe
 	rp, err := fs.p.AssemblePermissions(ctx, node)
 	switch {
 	case err != nil:
-		return nil, errtypes.InternalError(err.Error())
+		return nil, err
 	case !rp.Stat:
 		f, _ := storagespace.FormatReference(ref)
 		return nil, errtypes.NotFound(f)
@@ -790,7 +790,7 @@ func (fs *Decomposedfs) ListFolder(ctx context.Context, ref *provider.Reference,
 	rp, err := fs.p.AssemblePermissions(ctx, n)
 	switch {
 	case err != nil:
-		return nil, errtypes.InternalError(err.Error())
+		return nil, err
 	case !rp.ListContainer:
 		f, _ := storagespace.FormatReference(ref)
 		if rp.Stat {
@@ -881,7 +881,7 @@ func (fs *Decomposedfs) Delete(ctx context.Context, ref *provider.Reference) (er
 	rp, err := fs.p.AssemblePermissions(ctx, node)
 	switch {
 	case err != nil:
-		return errtypes.InternalError(err.Error())
+		return err
 	case !rp.Delete:
 		f, _ := storagespace.FormatReference(ref)
 		if rp.Stat {
@@ -921,7 +921,7 @@ func (fs *Decomposedfs) Download(ctx context.Context, ref *provider.Reference) (
 	rp, err := fs.p.AssemblePermissions(ctx, node)
 	switch {
 	case err != nil:
-		return nil, errtypes.InternalError(err.Error())
+		return nil, err
 	case !rp.InitiateFileDownload:
 		f, _ := storagespace.FormatReference(ref)
 		if rp.Stat {
@@ -952,7 +952,7 @@ func (fs *Decomposedfs) GetLock(ctx context.Context, ref *provider.Reference) (*
 	rp, err := fs.p.AssemblePermissions(ctx, node)
 	switch {
 	case err != nil:
-		return nil, errtypes.InternalError(err.Error())
+		return nil, err
 	case !rp.InitiateFileDownload:
 		f, _ := storagespace.FormatReference(ref)
 		if rp.Stat {
@@ -978,7 +978,7 @@ func (fs *Decomposedfs) SetLock(ctx context.Context, ref *provider.Reference, lo
 	rp, err := fs.p.AssemblePermissions(ctx, node)
 	switch {
 	case err != nil:
-		return errtypes.InternalError(err.Error())
+		return err
 	case !rp.InitiateFileUpload:
 		f, _ := storagespace.FormatReference(ref)
 		if rp.Stat {
@@ -1008,7 +1008,7 @@ func (fs *Decomposedfs) RefreshLock(ctx context.Context, ref *provider.Reference
 	rp, err := fs.p.AssemblePermissions(ctx, node)
 	switch {
 	case err != nil:
-		return errtypes.InternalError(err.Error())
+		return err
 	case !rp.InitiateFileUpload:
 		f, _ := storagespace.FormatReference(ref)
 		if rp.Stat {
@@ -1038,7 +1038,7 @@ func (fs *Decomposedfs) Unlock(ctx context.Context, ref *provider.Reference, loc
 	rp, err := fs.p.AssemblePermissions(ctx, node)
 	switch {
 	case err != nil:
-		return errtypes.InternalError(err.Error())
+		return err
 	case !rp.InitiateFileUpload: // TODO do we need a dedicated permission?
 		f, _ := storagespace.FormatReference(ref)
 		if rp.Stat {

--- a/pkg/storage/utils/decomposedfs/grants.go
+++ b/pkg/storage/utils/decomposedfs/grants.go
@@ -63,7 +63,7 @@ func (fs *Decomposedfs) DenyGrant(ctx context.Context, ref *provider.Reference, 
 
 	switch {
 	case err != nil:
-		return errtypes.InternalError(err.Error())
+		return err
 	case !rp.DenyGrant:
 		return errtypes.PermissionDenied(filepath.Join(grantNode.ParentID, grantNode.Name))
 	}
@@ -102,7 +102,7 @@ func (fs *Decomposedfs) AddGrant(ctx context.Context, ref *provider.Reference, g
 		rp, err := fs.p.AssemblePermissions(ctx, grantNode)
 		switch {
 		case err != nil:
-			return errtypes.InternalError(err.Error())
+			return err
 		case !rp.AddGrant:
 			f, _ := storagespace.FormatReference(ref)
 			if rp.Stat {
@@ -128,7 +128,7 @@ func (fs *Decomposedfs) ListGrants(ctx context.Context, ref *provider.Reference)
 	rp, err := fs.p.AssemblePermissions(ctx, grantNode)
 	switch {
 	case err != nil:
-		return nil, errtypes.InternalError(err.Error())
+		return nil, err
 	case !rp.ListGrants && !rp.Stat:
 		f, _ := storagespace.FormatReference(ref)
 		return nil, errtypes.NotFound(f)
@@ -186,7 +186,7 @@ func (fs *Decomposedfs) RemoveGrant(ctx context.Context, ref *provider.Reference
 		rp, err := fs.p.AssemblePermissions(ctx, grantNode)
 		switch {
 		case err != nil:
-			return errtypes.InternalError(err.Error())
+			return err
 		case !rp.RemoveGrant:
 			f, _ := storagespace.FormatReference(ref)
 			if rp.Stat {
@@ -262,7 +262,7 @@ func (fs *Decomposedfs) UpdateGrant(ctx context.Context, ref *provider.Reference
 		rp, err := fs.p.AssemblePermissions(ctx, grantNode)
 		switch {
 		case err != nil:
-			return errtypes.InternalError(err.Error())
+			return err
 		case !rp.UpdateGrant:
 			f, _ := storagespace.FormatReference(ref)
 			if rp.Stat {

--- a/pkg/storage/utils/decomposedfs/metadata.go
+++ b/pkg/storage/utils/decomposedfs/metadata.go
@@ -52,7 +52,7 @@ func (fs *Decomposedfs) SetArbitraryMetadata(ctx context.Context, ref *provider.
 	rp, err := fs.p.AssemblePermissions(ctx, n)
 	switch {
 	case err != nil:
-		return errtypes.InternalError(err.Error())
+		return err
 	case !rp.InitiateFileUpload: // TODO add explicit SetArbitraryMetadata grant to CS3 api, tracked in https://github.com/cs3org/cs3apis/issues/91
 		f, _ := storagespace.FormatReference(ref)
 		if rp.Stat {
@@ -145,7 +145,7 @@ func (fs *Decomposedfs) UnsetArbitraryMetadata(ctx context.Context, ref *provide
 	rp, err := fs.p.AssemblePermissions(ctx, n)
 	switch {
 	case err != nil:
-		return errtypes.InternalError(err.Error())
+		return err
 	case !rp.InitiateFileUpload: // TODO use SetArbitraryMetadata grant to CS3 api, tracked in https://github.com/cs3org/cs3apis/issues/91
 		f, _ := storagespace.FormatReference(ref)
 		if rp.Stat {

--- a/pkg/storage/utils/decomposedfs/mocks/PermissionsChecker.go
+++ b/pkg/storage/utils/decomposedfs/mocks/PermissionsChecker.go
@@ -59,6 +59,30 @@ func (_m *PermissionsChecker) AssemblePermissions(ctx context.Context, n *node.N
 	return r0, r1
 }
 
+// AssembleTrashPermissions provides a mock function with given fields: ctx, n
+func (_m *PermissionsChecker) AssembleTrashPermissions(ctx context.Context, n *node.Node) (providerv1beta1.ResourcePermissions, error) {
+	ret := _m.Called(ctx, n)
+
+	var r0 providerv1beta1.ResourcePermissions
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, *node.Node) (providerv1beta1.ResourcePermissions, error)); ok {
+		return rf(ctx, n)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *node.Node) providerv1beta1.ResourcePermissions); ok {
+		r0 = rf(ctx, n)
+	} else {
+		r0 = ret.Get(0).(providerv1beta1.ResourcePermissions)
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *node.Node) error); ok {
+		r1 = rf(ctx, n)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 type mockConstructorTestingTNewPermissionsChecker interface {
 	mock.TestingT
 	Cleanup(func())

--- a/pkg/storage/utils/decomposedfs/node/permissions.go
+++ b/pkg/storage/utils/decomposedfs/node/permissions.go
@@ -98,6 +98,16 @@ func NewPermissions(lu PathLookup) *Permissions {
 
 // AssemblePermissions will assemble the permissions for the current user on the given node, taking into account all parent nodes
 func (p *Permissions) AssemblePermissions(ctx context.Context, n *Node) (ap provider.ResourcePermissions, err error) {
+	return p.assemblePermissions(ctx, n, true)
+}
+
+// AssembleTrashPermissions will assemble the permissions for the current user on the given node, taking into account all parent nodes
+func (p *Permissions) AssembleTrashPermissions(ctx context.Context, n *Node) (ap provider.ResourcePermissions, err error) {
+	return p.assemblePermissions(ctx, n, false)
+}
+
+// assemblePermissions will assemble the permissions for the current user on the given node, taking into account all parent nodes
+func (p *Permissions) assemblePermissions(ctx context.Context, n *Node, failOnTrashedSubtree bool) (ap provider.ResourcePermissions, err error) {
 	u, ok := ctxpkg.ContextGetUser(ctx)
 	if !ok {
 		return NoPermissions(), nil
@@ -147,7 +157,7 @@ func (p *Permissions) AssemblePermissions(ctx context.Context, n *Node) (ap prov
 			// We do not have a parent, so we assume the next valid parent is the spaceRoot (which must always exist)
 			cn = n.SpaceRoot
 		}
-		if !cn.Exists {
+		if failOnTrashedSubtree && !cn.Exists {
 			return NoPermissions(), errtypes.NotFound(n.ID)
 		}
 

--- a/pkg/storage/utils/decomposedfs/node/permissions.go
+++ b/pkg/storage/utils/decomposedfs/node/permissions.go
@@ -116,9 +116,7 @@ func (p *Permissions) AssemblePermissions(ctx context.Context, n *Node) (ap prov
 
 	// determine root
 	rn := n.SpaceRoot
-
 	cn := n
-
 	ap = provider.ResourcePermissions{}
 
 	// for an efficient group lookup convert the list of groups to a map

--- a/pkg/storage/utils/decomposedfs/recycle.go
+++ b/pkg/storage/utils/decomposedfs/recycle.go
@@ -65,7 +65,7 @@ func (fs *Decomposedfs) ListRecycle(ctx context.Context, ref *provider.Reference
 	rp, err := fs.p.AssemblePermissions(ctx, trashnode)
 	switch {
 	case err != nil:
-		return nil, errtypes.InternalError(err.Error())
+		return nil, err
 	case !rp.ListRecycle:
 		if rp.Stat {
 			return nil, errtypes.PermissionDenied(key)
@@ -303,7 +303,7 @@ func (fs *Decomposedfs) RestoreRecycleItem(ctx context.Context, ref *provider.Re
 	rp, err := fs.p.AssemblePermissions(ctx, rn)
 	switch {
 	case err != nil:
-		return errtypes.InternalError(err.Error())
+		return err
 	case !rp.RestoreRecycleItem:
 		if rp.Stat {
 			return errtypes.PermissionDenied(key)
@@ -318,7 +318,7 @@ func (fs *Decomposedfs) RestoreRecycleItem(ctx context.Context, ref *provider.Re
 	pp, err := fs.p.AssemblePermissions(ctx, parent)
 	switch {
 	case err != nil:
-		return errtypes.InternalError(err.Error())
+		return err
 	case !pp.InitiateFileUpload:
 		// share receiver cannot restore to a shared resource to which she does not have write permissions.
 		if rp.Stat {
@@ -349,7 +349,7 @@ func (fs *Decomposedfs) PurgeRecycleItem(ctx context.Context, ref *provider.Refe
 	rp, err := fs.p.AssemblePermissions(ctx, rn)
 	switch {
 	case err != nil:
-		return errtypes.InternalError(err.Error())
+		return err
 	case !rp.PurgeRecycle:
 		if rp.Stat {
 			return errtypes.PermissionDenied(key)

--- a/pkg/storage/utils/decomposedfs/recycle.go
+++ b/pkg/storage/utils/decomposedfs/recycle.go
@@ -62,7 +62,7 @@ func (fs *Decomposedfs) ListRecycle(ctx context.Context, ref *provider.Reference
 	if err != nil {
 		return nil, err
 	}
-	rp, err := fs.p.AssemblePermissions(ctx, trashnode)
+	rp, err := fs.p.AssembleTrashPermissions(ctx, trashnode)
 	switch {
 	case err != nil:
 		return nil, err
@@ -300,7 +300,7 @@ func (fs *Decomposedfs) RestoreRecycleItem(ctx context.Context, ref *provider.Re
 	}
 
 	// check permissions of deleted node
-	rp, err := fs.p.AssemblePermissions(ctx, rn)
+	rp, err := fs.p.AssembleTrashPermissions(ctx, rn)
 	switch {
 	case err != nil:
 		return err
@@ -346,7 +346,7 @@ func (fs *Decomposedfs) PurgeRecycleItem(ctx context.Context, ref *provider.Refe
 	}
 
 	// check permissions of deleted node
-	rp, err := fs.p.AssemblePermissions(ctx, rn)
+	rp, err := fs.p.AssembleTrashPermissions(ctx, rn)
 	switch {
 	case err != nil:
 		return err

--- a/pkg/storage/utils/decomposedfs/recycle_test.go
+++ b/pkg/storage/utils/decomposedfs/recycle_test.go
@@ -464,4 +464,10 @@ func registerPermissions(m *mocks.PermissionsChecker, uid string, exp *provider.
 		}),
 		mock.Anything,
 	).Return(p, nil)
+	m.On("AssembleTrashPermissions",
+		mock.MatchedBy(func(ctx context.Context) bool {
+			return uid == "" || ctxpkg.ContextMustGetUser(ctx).Id.OpaqueId == uid
+		}),
+		mock.Anything,
+	).Return(p, nil)
 }

--- a/pkg/storage/utils/decomposedfs/revisions.go
+++ b/pkg/storage/utils/decomposedfs/revisions.go
@@ -57,7 +57,7 @@ func (fs *Decomposedfs) ListRevisions(ctx context.Context, ref *provider.Referen
 	rp, err := fs.p.AssemblePermissions(ctx, n)
 	switch {
 	case err != nil:
-		return nil, errtypes.InternalError(err.Error())
+		return nil, err
 	case !rp.ListFileVersions:
 		f, _ := storagespace.FormatReference(ref)
 		if rp.Stat {
@@ -136,7 +136,7 @@ func (fs *Decomposedfs) DownloadRevision(ctx context.Context, ref *provider.Refe
 	rp, err := fs.p.AssemblePermissions(ctx, n)
 	switch {
 	case err != nil:
-		return nil, errtypes.InternalError(err.Error())
+		return nil, err
 	case !rp.ListFileVersions || !rp.InitiateFileDownload: // TODO add explicit permission in the CS3 api?
 		f, _ := storagespace.FormatReference(ref)
 		if rp.Stat {
@@ -190,7 +190,7 @@ func (fs *Decomposedfs) RestoreRevision(ctx context.Context, ref *provider.Refer
 	rp, err := fs.p.AssemblePermissions(ctx, n)
 	switch {
 	case err != nil:
-		return errtypes.InternalError(err.Error())
+		return err
 	case !rp.RestoreFileVersion:
 		f, _ := storagespace.FormatReference(ref)
 		if rp.Stat {
@@ -327,7 +327,7 @@ func (fs *Decomposedfs) getRevisionNode(ctx context.Context, ref *provider.Refer
 	p, err := fs.p.AssemblePermissions(ctx, n)
 	switch {
 	case err != nil:
-		return nil, errtypes.InternalError(err.Error())
+		return nil, err
 	case !hasPermission(&p):
 		return nil, errtypes.PermissionDenied(filepath.Join(n.ParentID, n.Name))
 	}

--- a/pkg/storage/utils/decomposedfs/spacepermissions.go
+++ b/pkg/storage/utils/decomposedfs/spacepermissions.go
@@ -17,6 +17,7 @@ import (
 // PermissionsChecker defines an interface for checking permissions on a Node
 type PermissionsChecker interface {
 	AssemblePermissions(ctx context.Context, n *node.Node) (ap provider.ResourcePermissions, err error)
+	AssembleTrashPermissions(ctx context.Context, n *node.Node) (ap provider.ResourcePermissions, err error)
 }
 
 // CS3PermissionsClient defines an interface for checking permissions against the CS3 permissions service
@@ -38,6 +39,11 @@ func NewPermissions(item PermissionsChecker, permissionsSelector pool.Selectable
 // AssemblePermissions is used to assemble file permissions
 func (p Permissions) AssemblePermissions(ctx context.Context, n *node.Node) (provider.ResourcePermissions, error) {
 	return p.item.AssemblePermissions(ctx, n)
+}
+
+// AssembleTrashPermissions is used to assemble file permissions
+func (p Permissions) AssembleTrashPermissions(ctx context.Context, n *node.Node) (provider.ResourcePermissions, error) {
+	return p.item.AssembleTrashPermissions(ctx, n)
 }
 
 // CreateSpace returns true when the user is allowed to create the space

--- a/pkg/storage/utils/decomposedfs/spaces.go
+++ b/pkg/storage/utils/decomposedfs/spaces.go
@@ -554,7 +554,7 @@ func (fs *Decomposedfs) UpdateStorageSpace(ctx context.Context, req *provider.Up
 	sp, err := fs.p.AssemblePermissions(ctx, spaceNode)
 	if err != nil {
 		return &provider.UpdateStorageSpaceResponse{
-			Status: &v1beta11.Status{Code: v1beta11.Code_CODE_INVALID, Message: err.Error()},
+			Status: status.NewStatusFromErrType(ctx, "assembling permissions failed", err),
 		}, nil
 
 	}
@@ -793,7 +793,7 @@ func (fs *Decomposedfs) storageSpaceFromNode(ctx context.Context, n *node.Node, 
 		rp, err := fs.p.AssemblePermissions(ctx, n)
 		switch {
 		case err != nil:
-			return nil, errtypes.InternalError(err.Error())
+			return nil, err
 		case !rp.Stat:
 			return nil, errtypes.NotFound(fmt.Sprintf("space %s not found", n.ID))
 		}

--- a/pkg/storage/utils/decomposedfs/upload/processing.go
+++ b/pkg/storage/utils/decomposedfs/upload/processing.go
@@ -114,7 +114,7 @@ func New(ctx context.Context, info tusd.FileInfo, lu *lookup.Lookup, tp Tree, p 
 	rp, err := p.AssemblePermissions(ctx, checkNode)
 	switch {
 	case err != nil:
-		return nil, errtypes.InternalError(err.Error())
+		return nil, err
 	case !rp.InitiateFileUpload:
 		return nil, errtypes.PermissionDenied(path)
 	}


### PR DESCRIPTION
to prevent direct access to trash items decomposedfs now uses the assemblePermissions call to prevent access if one of the items between the accessed resource and the space root has been trashed.