### PR TITLE
drop O_CREATE for messagepack backend

### DIFF
--- a/changelog/unreleased/no-o-create-for-messagepack.md
+++ b/changelog/unreleased/no-o-create-for-messagepack.md
@@ -1,0 +1,3 @@
+Bugfix: msgpack backend no longer creates empty file when propagating
+
+https://github.com/cs3org/reva/pull/3980

--- a/pkg/storage/utils/decomposedfs/tree/tree.go
+++ b/pkg/storage/utils/decomposedfs/tree/tree.go
@@ -754,10 +754,12 @@ func (t *Tree) Propagate(ctx context.Context, n *node.Node, sizeDiff int64) (err
 		switch t.lookup.MetadataBackend().(type) {
 		case metadata.MessagePackBackend:
 			parentFilename = t.lookup.MetadataBackend().MetadataPath(n.ParentPath())
-			f, err = lockedfile.OpenFile(parentFilename, os.O_RDWR|os.O_CREATE, 0600)
+			// no need to O_CREATE the file, we can use the metadata file. Actually, we want to error if the parent does not exist!
+			f, err = lockedfile.OpenFile(parentFilename, os.O_RDWR, 0600)
 		case metadata.XattrsBackend:
 			// we have to use dedicated lockfiles to lock directories
 			// this only works because the xattr backend also locks folders with separate lock files
+			// we need to O_CREATE a lockfile if it does not exist, yet
 			parentFilename = n.ParentPath() + filelocks.LockFileSuffix
 			f, err = lockedfile.OpenFile(parentFilename, os.O_RDWR|os.O_CREATE, 0600)
 		}


### PR DESCRIPTION
The decomposedfs messagepack backend now dies when trying to propagate metadata to a non existing parent
