### PR TITLE
Change userFeatureChangedEvent

### DIFF
--- a/changelog/unreleased/updaet-userFeatureChangedEvent.md
+++ b/changelog/unreleased/updaet-userFeatureChangedEvent.md
@@ -1,0 +1,6 @@
+Enhancement: We have updated the UserFeatureChangedEvent to reflect value changes
+
+A UserFeatureChanged Event can now contain an old and a new value to reflect value changes in audit logs.
+
+https://github.com/cs3org/reva/pull/3981
+https://github.com/owncloud/ocis/issues/3753

--- a/pkg/events/users.go
+++ b/pkg/events/users.go
@@ -55,9 +55,9 @@ func (UserDeleted) Unmarshal(v []byte) (interface{}, error) {
 
 // UserFeature represents a user feature
 type UserFeature struct {
-	Name      string
-	Value     string
-	Timestamp *types.Timestamp
+	Name     string
+	Value    string
+	OldValue *string
 }
 
 // UserFeatureChanged is emitted when a user feature was changed


### PR DESCRIPTION
A UserFeatureChanged Event can now contain an old and a new value to reflect value changes in audit logs.

refs https://github.com/owncloud/ocis/issues/3753