### PR TITLE
Fix concurrent access to the lock map

### DIFF
--- a/changelog/unreleased/jsoncs3-lock-congestion.md
+++ b/changelog/unreleased/jsoncs3-lock-congestion.md
@@ -3,4 +3,5 @@ Bugfix: Reduce jsoncs3 lock congestion
 We changed the locking strategy in the jsoncs3 share manager to cause less lock
  congestion increasing the performance in certain scenarios.
 
+https://github.com/cs3org/reva/pull/3985
 https://github.com/cs3org/reva/pull/3964


### PR DESCRIPTION
Fix concurrent access to the lock map by using a sync.Map to store the granular locks.