### PR TITLE
[tests-only] Remove 'make deps' from README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ You need to have [Go](https://golang.org/doc/install) (version 1.16 or higher), 
 ```
 $ git clone https://github.com/cs3org/reva
 $ cd reva
-$ make deps
 $ make build
 $ mkdir -p /etc/revad
 $ cp examples/storage-references/users.demo.json /etc/revad/users.json


### PR DESCRIPTION
```
phil@phil-Inspiron-5468:~/git/cs3org/reva$ make deps
make: *** No rule to make target 'deps'.  Stop.
```

I am trying to follow the instructions to run a local `reva` from the `edge` branch.

The first thing is that the `deps` Makefile target does not exist.

I suppose that it used to exist. Is there something different that we are supposed to do?

Maybe there is documentation elsewhere, and the README should be updated to link to the correct up-to-date docs for building and running the `edge` branch locally.