### PR TITLE
[tests-only] Add metadata_backend to oc-integration-tests local toml files

### DIFF
--- a/tests/oc-integration-tests/local/storage-users-0-9.toml
+++ b/tests/oc-integration-tests/local/storage-users-0-9.toml
@@ -30,6 +30,7 @@ root = "/var/tmp/reva/data-0-9"
 treetime_accounting = true
 treesize_accounting = true
 permissionssvc = "localhost:10000"
+metadata_backend = "messagepack"
 
 # we have a locally running dataprovider
 [http]
@@ -44,3 +45,4 @@ root = "/var/tmp/reva/data-0-9"
 treetime_accounting = true
 treesize_accounting = true
 permissionssvc = "localhost:10000"
+metadata_backend = "messagepack"

--- a/tests/oc-integration-tests/local/storage-users-a-f.toml
+++ b/tests/oc-integration-tests/local/storage-users-a-f.toml
@@ -30,6 +30,7 @@ root = "/var/tmp/reva/data-a-f"
 treetime_accounting = true
 treesize_accounting = true
 permissionssvc = "localhost:10000"
+metadata_backend = "messagepack"
 
 # we have a locally running dataprovider
 [http]
@@ -44,3 +45,4 @@ root = "/var/tmp/reva/data-a-f"
 treetime_accounting = true
 treesize_accounting = true
 permissionssvc = "localhost:10000"
+metadata_backend = "messagepack"

--- a/tests/oc-integration-tests/local/storage-users.toml
+++ b/tests/oc-integration-tests/local/storage-users.toml
@@ -36,6 +36,7 @@ treesize_accounting = true
 permissionssvc = "localhost:10000"
 personalspacealias_template = "{{.SpaceType}}/{{.User.Username}}"
 generalspacealias_template = "{{.SpaceType}}/{{.SpaceName | replace \" \" \"-\" | lower}}"
+metadata_backend = "messagepack"
 
 # we have a locally running dataprovider
 [http]
@@ -50,3 +51,4 @@ root = "/var/tmp/reva/data"
 treetime_accounting = true
 treesize_accounting = true
 permissionssvc = "localhost:10000"
+metadata_backend = "messagepack"


### PR DESCRIPTION
This was added to the toml files used in drone by PR #3711 

IMO it should also be added to these "local" toml files, to keep them up-to-date and give some chance for people to run tests locally.