### PR TITLE
Add Token to LinkAccessedEvent

### DIFF
--- a/changelog/unreleased/add-token-to-linkAccessed-event.md
+++ b/changelog/unreleased/add-token-to-linkAccessed-event.md
@@ -1,0 +1,6 @@
+Bugfix: Add token to LinkAccessedEvent
+
+We added the link token to the LinkAccessedEvent
+
+https://github.com/cs3org/reva/pull/3993
+https://github.com/owncloud/ocis/issues/3753

--- a/internal/grpc/interceptors/eventsmiddleware/conversion.go
+++ b/internal/grpc/interceptors/eventsmiddleware/conversion.go
@@ -168,6 +168,7 @@ func LinkAccessFailed(r *link.GetPublicShareByTokenResponse, req *link.GetPublic
 		Status:    r.Status.Code,
 		Message:   r.Status.Message,
 		Timestamp: utils.TSNow(),
+		Token:     req.Token,
 	}
 	if r.Share != nil {
 		e.ShareID = r.Share.Id


### PR DESCRIPTION
We added the link token to the LinkAccessedEvent

refs https://github.com/owncloud/ocis/issues/3753