### PR TITLE
Omit spaceroot when archiving

### DIFF
--- a/changelog/unreleased/omit-spaceroot-when-archiving.md
+++ b/changelog/unreleased/omit-spaceroot-when-archiving.md
@@ -1,0 +1,6 @@
+Bugfix: Omit spaceroot when archiving
+
+When archiving a space there was an empty folder named `.` added. This was because of the spaceroot which was wrongly interpreted.
+We now omit the space root when creating an archive.
+
+https://github.com/cs3org/reva/pull/3999

--- a/internal/http/services/archiver/manager/archiver.go
+++ b/internal/http/services/archiver/manager/archiver.go
@@ -73,6 +73,11 @@ func (a *Archiver) CreateTar(ctx context.Context, dst io.Writer) error {
 				return err
 			}
 
+			// when archiving a space we can omit the spaceroot
+			if isSpaceRoot(info) {
+				return nil
+			}
+
 			isDir := info.Type == provider.ResourceType_RESOURCE_TYPE_CONTAINER
 
 			filesCount++
@@ -140,6 +145,11 @@ func (a *Archiver) CreateZip(ctx context.Context, dst io.Writer) error {
 				return err
 			}
 
+			// when archiving a space we can omit the spaceroot
+			if isSpaceRoot(info) {
+				return nil
+			}
+
 			isDir := info.Type == provider.ResourceType_RESOURCE_TYPE_CONTAINER
 
 			filesCount++
@@ -188,4 +198,10 @@ func (a *Archiver) CreateZip(ctx context.Context, dst io.Writer) error {
 
 	}
 	return w.Close()
+}
+
+func isSpaceRoot(info *provider.ResourceInfo) bool {
+	f := info.GetId()
+	s := info.GetSpace().GetRoot()
+	return f.GetOpaqueId() == s.GetOpaqueId() && f.GetSpaceId() == s.GetSpaceId()
 }


### PR DESCRIPTION
Fixes empty `.` folder when archiving a space. See https://github.com/owncloud/ocis/issues/6387