### PR TITLE
Return storageprovider id in space root info

### DIFF
--- a/changelog/unreleased/fix-propfind-root-id.md
+++ b/changelog/unreleased/fix-propfind-root-id.md
@@ -1,0 +1,5 @@
+Bugfix: Fix propfind root id
+
+decomposedfs now returns the storageprovider id in the root info when listing spaces
+
+https://github.com/cs3org/reva/pull/4000

--- a/internal/grpc/services/storageprovider/storageprovider.go
+++ b/internal/grpc/services/storageprovider/storageprovider.go
@@ -516,6 +516,7 @@ func (s *service) CreateStorageSpace(ctx context.Context, req *provider.CreateSt
 	}
 
 	s.addMissingStorageProviderID(resp.GetStorageSpace().GetRoot(), resp.GetStorageSpace().GetId())
+	s.addMissingStorageProviderID(resp.GetStorageSpace().GetRootInfo().GetId(), nil)
 	return resp, nil
 }
 
@@ -560,6 +561,7 @@ func (s *service) ListStorageSpaces(ctx context.Context, req *provider.ListStora
 		}
 
 		s.addMissingStorageProviderID(sp.GetRoot(), sp.GetId())
+		s.addMissingStorageProviderID(sp.GetRootInfo().GetId(), nil)
 	}
 
 	return &provider.ListStorageSpacesResponse{
@@ -579,6 +581,7 @@ func (s *service) UpdateStorageSpace(ctx context.Context, req *provider.UpdateSt
 		return nil, err
 	}
 	s.addMissingStorageProviderID(res.GetStorageSpace().GetRoot(), res.GetStorageSpace().GetId())
+	s.addMissingStorageProviderID(res.GetStorageSpace().GetRootInfo().GetId(), nil)
 	return res, nil
 }
 


### PR DESCRIPTION
decomposedfs now returns the storageprovider id in the root info when listing spaces
