### PR TITLE
Fix panic when closing nats connection

### DIFF
--- a/changelog/unreleased/fix-panic-nats-close.md
+++ b/changelog/unreleased/fix-panic-nats-close.md
@@ -1,0 +1,6 @@
+Bugfix: Fix panic when closing notification service
+
+If the connection to the nats server was not yet estabished,
+the service on close was panicking. This has been now fixed.
+
+https://github.com/cs3org/reva/pull/4016

--- a/pkg/notification/notificationhelper/notificationhelper.go
+++ b/pkg/notification/notificationhelper/notificationhelper.go
@@ -125,6 +125,10 @@ func (nh *NotificationHelper) connect() error {
 
 // Stop stops the notification helper.
 func (nh *NotificationHelper) Stop() {
+	if nh.nc == nil {
+		// service didn't connect yet to nat server
+		return
+	}
 	if err := nh.nc.Drain(); err != nil {
 		nh.Log.Error().Err(err)
 	}


### PR DESCRIPTION
Fixes this panic:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x10d6188]

goroutine 1 [running]:
github.com/nats-io/nats%2ego.(*Conn).Drain(0x0)
        /home/gianmaria/go/pkg/mod/github.com/nats-io/nats.go@v1.25.0/nats.go:5190 +0x28
github.com/cs3org/reva/pkg/notification/notificationhelper.(*NotificationHelper).Stop(0xc000282f00)
        /home/gianmaria/Documenti/CERN/reva2/pkg/notification/notificationhelper/notificationhelper.go:124 +0x29
github.com/cs3org/reva/internal/http/services/owncloud/ocdav.(*svc).Close(0xc0007ca300)
        /home/gianmaria/Documenti/CERN/reva2/internal/http/services/owncloud/ocdav/ocdav.go:188 +0x34
github.com/cs3org/reva/pkg/rhttp.(*Server).closeServices(0xc0002180e0)
        /home/gianmaria/Documenti/CERN/reva2/pkg/rhttp/rhttp.go:154 +0xb7
github.com/cs3org/reva/pkg/rhttp.(*Server).Stop(0xc0002180e0)
        /home/gianmaria/Documenti/CERN/reva2/pkg/rhttp/rhttp.go:142 +0x45
github.com/cs3org/reva/cmd/revad/pkg/grace.(*Watcher).TrapSignals(0xc00098b790)
        /home/gianmaria/Documenti/CERN/reva2/cmd/revad/pkg/grace/grace.go:475 +0x9fd
github.com/cs3org/reva/cmd/revad/runtime.(*Reva).Start(0xc000368140)
        /home/gianmaria/Documenti/CERN/reva2/cmd/revad/runtime/runtime.go:238 +0x358
main.runSingle(0xc000719e80, {0xc00003f900, 0x33})
        /home/gianmaria/Documenti/CERN/reva2/cmd/revad/main.go:238 +0x266
main.runConfigs({0xc0005364a0, 0x1, 0x1})
        /home/gianmaria/Documenti/CERN/reva2/cmd/revad/main.go:217 +0x70
main.main()
        /home/gianmaria/Documenti/CERN/reva2/cmd/revad/main.go:89 +0x491
```
This was happening when the connection to nats server was not yet established, and a close to the notification service was triggered.