### PR TITLE
[tests-only][full-ci] Bump ocis commit id for tests 

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,4 +1,4 @@
 # The test runner source for API tests
-APITESTS_COMMITID=c8f8bc55e22597bc3d53b63b2f38f345b4814b07
-APITESTS_BRANCH=master
+APITESTS_COMMITID=4455480e9edf134891ae50b2d00a890ffae4c68d
+APITESTS_BRANCH=do-not-register-space-context-for-reva
 APITESTS_REPO_GIT_URL=https://github.com/owncloud/ocis.git


### PR DESCRIPTION
This PR bumps ocis commit id for tests
Part of: https://github.com/owncloud/QA/issues/815