### PR TITLE
Allow passing of external trace provider to reva.

### DIFF
--- a/changelog/unreleased/external-traceprovider.md
+++ b/changelog/unreleased/external-traceprovider.md
@@ -1,0 +1,5 @@
+Enhancement: Allow to use external trace provider
+
+Allow injecting of external trace provider instead of forcing the initialisation of an internal one.
+
+https://github.com/cs3org/reva/pull/4019

--- a/cmd/revad/runtime/option.go
+++ b/cmd/revad/runtime/option.go
@@ -21,6 +21,7 @@ package runtime
 import (
 	"github.com/rs/zerolog"
 	"go-micro.dev/v4/registry"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // Option defines a single option function.
@@ -28,8 +29,9 @@ type Option func(o *Options)
 
 // Options defines the available options for this package.
 type Options struct {
-	Logger   *zerolog.Logger
-	Registry registry.Registry
+	Logger        *zerolog.Logger
+	Registry      registry.Registry
+	TraceProvider trace.TracerProvider
 }
 
 // newOptions initializes the available default options.
@@ -54,5 +56,12 @@ func WithLogger(logger *zerolog.Logger) Option {
 func WithRegistry(r registry.Registry) Option {
 	return func(o *Options) {
 		o.Registry = r
+	}
+}
+
+// WithTraceProvider provides a function to set the trace provider.
+func WithTraceProvider(tp trace.TracerProvider) Option {
+	return func(o *Options) {
+		o.TraceProvider = tp
 	}
 }


### PR DESCRIPTION
This allows the passing of an external trace provider to reva, bypassing
the built in tracing initialisation. This makes it possible
for services that embed reva to use their own provider instead of
having reva initialise its own.