### PR TITLE
 [tests-only] [full-ci] Bumped ocis commit id

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,4 +1,4 @@
 # The test runner source for API tests
-APITESTS_COMMITID=2ea3b8c400688b14ef328786b3af445c2edbbe18
+APITESTS_COMMITID=a8ff963166ecd9adf3f44aa6fa9fe68f53517d05
 APITESTS_BRANCH=master
 APITESTS_REPO_GIT_URL=https://github.com/owncloud/ocis.git


### PR DESCRIPTION
This PR bumps the latest commit id from ocis
part of https://github.com/owncloud/QA/issues/815