### PR TITLE
Support multiple token strategies in auth middleware

### DIFF
--- a/changelog/unreleased/multiple-token-strategies.md
+++ b/changelog/unreleased/multiple-token-strategies.md
@@ -1,0 +1,11 @@
+Enhancement: Support multiple token strategies in auth middleware
+
+Different HTTP services can in general support different
+token strategies for validating the reva token.
+In this context, without updating every single client 
+a mono process deployment will never work.
+Now the HTTP auth middleware accepts in its configuration a
+token strategy chain, allowing to provide the reva
+token in multiple places (bearer auth, header).
+
+https://github.com/cs3org/reva/pull/4030


### PR DESCRIPTION
Different HTTP services can in general support different token strategies for validating the reva token, for example all the clients of a the data provider are including the token in the `x-access-token` header, while the CERNBox web interface is using the bearer authentication.
In this context, without updating every single client a mono process deployment will never work.

Now the HTTP auth middleware accepts in its configuration a token strategy chain, allowing to provide the reva token in multiple places (bearer auth, header).