### PR TITLE
Dump config on SIGUSR1

### DIFF
--- a/changelog/unreleased/dump-config.md
+++ b/changelog/unreleased/dump-config.md
@@ -1,0 +1,7 @@
+Enhancement: Dump reva config on SIGUSR1
+
+Add an option to the runtime to dump the configuration on a file
+(default to `/tmp/reva-dump.toml` and configurable) when the process
+receives a SIGUSR1 signal. Eventual errors are logged in the log.
+
+https://github.com/cs3org/reva/pull/4031

--- a/cmd/revad/main.go
+++ b/cmd/revad/main.go
@@ -115,6 +115,8 @@ func handleSignalFlag() {
 			signal = syscall.SIGQUIT
 		case "stop":
 			signal = syscall.SIGTERM
+		case "dump":
+			signal = syscall.SIGUSR1
 		default:
 			fmt.Fprintf(os.Stderr, "unknown signal %q\n", *signalFlag)
 			os.Exit(1)

--- a/cmd/revad/pkg/config/config.go
+++ b/cmd/revad/pkg/config/config.go
@@ -59,6 +59,7 @@ type Shared struct {
 // Core holds the core configuration.
 type Core struct {
 	MaxCPUs            string `key:"max_cpus"             mapstructure:"max_cpus"`
+	ConfigDumpFile     string `key:"config_dump_file"     mapstructure:"config_dump_file"     default:"/tmp/reva-dump.toml"`
 	TracingEnabled     bool   `key:"tracing_enabled"      mapstructure:"tracing_enabled"      default:"true"`
 	TracingEndpoint    string `key:"tracing_endpoint"     mapstructure:"tracing_endpoint"     default:"localhost:6831"`
 	TracingCollector   string `key:"tracing_collector"    mapstructure:"tracing_collector"`

--- a/cmd/revad/pkg/config/config_test.go
+++ b/cmd/revad/pkg/config/config_test.go
@@ -248,6 +248,7 @@ nats_token = "secret-token-example"`
 		MaxCPUs:         "1",
 		TracingEnabled:  true,
 		TracingEndpoint: "localhost:6831",
+		ConfigDumpFile:  "/tmp/reva-dump.toml",
 	}, c2.Core)
 
 	assert.Equal(t, Vars{
@@ -500,6 +501,7 @@ func TestDump(t *testing.T) {
 			"tracing_collector":    "",
 			"tracing_service_name": "",
 			"tracing_service":      "",
+			"config_dump_file":     "",
 		},
 		"vars": map[string]any{
 			"db_username": "root",


### PR DESCRIPTION
Now that the configuration has some randomness in the allocated addresses for each services, default configs, templates that needs to be resolved, the actual (resolved) config could not be clearly visible to the operator.
This PR add an option to the reva runtime to dump the configuration on a file (default to `/tmp/reva-dump.toml` and configurable)  when the process receives a SIGUSR1 signal. Eventual errors are logged in the log.