### PR TITLE
Temporarily exclude ceph-iscsi when building revad-ceph image

### DIFF
--- a/changelog/unreleased/exclude-ceph-iscsi.md
+++ b/changelog/unreleased/exclude-ceph-iscsi.md
@@ -1,0 +1,7 @@
+Bugfix: Temporarily exclude ceph-iscsi when building revad-ceph image
+
+Due to `Package ceph-iscsi-3.6-1.el8.noarch.rpm is not signed` error when
+building the revad-ceph docker image, the package `ceph-iscsi` has been excluded from the dnf update.
+It will be included again once the pkg will be signed again.
+
+https://github.com/cs3org/reva/pull/4032

--- a/docker/Dockerfile.revad-ceph
+++ b/docker/Dockerfile.revad-ceph
@@ -18,7 +18,7 @@
 
 FROM quay.io/ceph/ceph:v16
 
-RUN dnf update -y && dnf install -y \
+RUN dnf update --exclude=ceph-iscsi -y && dnf install -y \
   git \
   gcc \
   make \


### PR DESCRIPTION
Due to `Package ceph-iscsi-3.6-1.el8.noarch.rpm is not signed` error when building the `revad-ceph` docker image, the package `ceph-iscsi` has been excluded from the dnf update.
It will be included again once the pkg will be signed again.