### PR TITLE
Enforce/validate configuration of services

### DIFF
--- a/changelog/unreleased/validate-config.md
+++ b/changelog/unreleased/validate-config.md
@@ -1,0 +1,7 @@
+Enhancement: Enforce/validate configuration of services
+
+Every driver can now specify some validation rules on the
+configuration. If the validation rules are not respected,
+reva will bail out on startup with a clear error.
+
+https://github.com/cs3org/reva/pull/4035

--- a/cmd/revad/runtime/runtime.go
+++ b/cmd/revad/runtime/runtime.go
@@ -115,7 +115,7 @@ func New(config *config.Config, opt ...Option) (*Reva, error) {
 		return nil, err
 	}
 
-	serverless, err := newServerless(config, log)
+	serverless, err := newServerless(ctx, config, log)
 	if err != nil {
 		watcher.Clean()
 		return nil, err
@@ -144,7 +144,7 @@ func servicesAddresses(cfg *config.Config) map[string]grace.Addressable {
 	return a
 }
 
-func newServerless(config *config.Config, log *zerolog.Logger) (*rserverless.Serverless, error) {
+func newServerless(ctx context.Context, config *config.Config, log *zerolog.Logger) (*rserverless.Serverless, error) {
 	sl := make(map[string]rserverless.Service)
 	logger := log.With().Str("pkg", "serverless").Logger()
 	if err := config.Serverless.ForEach(func(name string, config map[string]any) error {
@@ -153,7 +153,8 @@ func newServerless(config *config.Config, log *zerolog.Logger) (*rserverless.Ser
 			return fmt.Errorf("serverless service %s does not exist", name)
 		}
 		log := logger.With().Str("service", name).Logger()
-		svc, err := new(config, &log)
+		ctx := appctx.WithLogger(ctx, &log)
+		svc, err := new(ctx, config)
 		if err != nil {
 			return errors.Wrapf(err, "serverless service %s could not be initialized", name)
 		}

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,8 @@ require (
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/ceph/go-ceph v0.15.0
 	github.com/cheggaaa/pb v1.0.29
+	github.com/coreos/go-oidc/v3 v3.5.0
+	github.com/creasty/defaults v1.7.0
 	github.com/cs3org/cato v0.0.0-20200828125504-e418fc54dd5e
 	github.com/cs3org/go-cs3apis v0.0.0-20230606135123-b799d47a6648
 	github.com/dgraph-io/ristretto v0.1.1
@@ -23,6 +25,8 @@ require (
 	github.com/glpatcern/go-mime v0.0.0-20221026162842-2a8d71ad17a9
 	github.com/go-chi/chi/v5 v5.0.8
 	github.com/go-ldap/ldap/v3 v3.4.4
+	github.com/go-playground/locales v0.14.1
+	github.com/go-playground/universal-translator v0.18.1
 	github.com/go-playground/validator/v10 v10.11.2
 	github.com/go-sql-driver/mysql v1.7.0
 	github.com/golang-jwt/jwt v3.2.2+incompatible
@@ -77,12 +81,6 @@ require (
 )
 
 require (
-	github.com/creasty/defaults v1.7.0 // indirect
-	github.com/go-jose/go-jose/v3 v3.0.0 // indirect
-	github.com/hashicorp/go-msgpack/v2 v2.1.0 // indirect
-)
-
-require (
 	github.com/Azure/go-ntlmssp v0.0.0-20220621081337-cb9428e4ac1e // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver v1.5.0 // indirect
@@ -92,13 +90,13 @@ require (
 	github.com/bmizerany/pat v0.0.0-20170815010413-6226ea591a40 // indirect
 	github.com/cespare/xxhash v1.1.0 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
-	github.com/coreos/go-oidc/v3 v3.5.0
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dolthub/vitess v0.0.0-20221031111135-9aad77e7b39f // indirect
 	github.com/dustin/go-humanize v1.0.0 // indirect
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/fsnotify/fsnotify v1.4.9 // indirect
 	github.com/go-asn1-ber/asn1-ber v1.5.4 // indirect
+	github.com/go-jose/go-jose/v3 v3.0.0 // indirect
 	github.com/go-kit/kit v0.10.0 // indirect
 	github.com/go-kit/log v0.2.1 // indirect
 	github.com/go-logfmt/logfmt v0.5.1 // indirect
@@ -106,8 +104,6 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-openapi/errors v0.20.2 // indirect
 	github.com/go-openapi/strfmt v0.21.2 // indirect
-	github.com/go-playground/locales v0.14.1 // indirect
-	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/go-stack/stack v1.8.1 // indirect
 	github.com/gocraft/dbr/v2 v2.7.2 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
@@ -116,6 +112,7 @@ require (
 	github.com/google/flatbuffers v2.0.6+incompatible // indirect
 	github.com/hashicorp/go-immutable-radix v1.0.0 // indirect
 	github.com/hashicorp/go-msgpack v1.1.5 // indirect
+	github.com/hashicorp/go-msgpack/v2 v2.1.0 // indirect
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/hashicorp/raft v1.4.0 // indirect
 	github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb // indirect

--- a/go.sum
+++ b/go.sum
@@ -308,8 +308,6 @@ github.com/creasty/defaults v1.7.0 h1:eNdqZvc5B509z18lD8yc212CAqJNvfT1Jq6L8WowdB
 github.com/creasty/defaults v1.7.0/go.mod h1:iGzKe6pbEHnpMPtfDXZEr0NVxWnPTjb1bbDy08fPzYM=
 github.com/cs3org/cato v0.0.0-20200828125504-e418fc54dd5e h1:tqSPWQeueWTKnJVMJffz4pz0o1WuQxJ28+5x5JgaHD8=
 github.com/cs3org/cato v0.0.0-20200828125504-e418fc54dd5e/go.mod h1:XJEZ3/EQuI3BXTp/6DUzFr850vlxq11I6satRtz0YQ4=
-github.com/cs3org/go-cs3apis v0.0.0-20230508132523-e0d062e63b3b h1:UCO7Rnf5bvIvRtETguV8IaTx73cImLlFWxrApCB0QsQ=
-github.com/cs3org/go-cs3apis v0.0.0-20230508132523-e0d062e63b3b/go.mod h1:UXha4TguuB52H14EMoSsCqDj7k8a/t7g4gVP+bgY5LY=
 github.com/cs3org/go-cs3apis v0.0.0-20230606135123-b799d47a6648 h1:gBz1JSC2u6o/TkUhWSdJZvacyTsVUzDouegRzvrJye4=
 github.com/cs3org/go-cs3apis v0.0.0-20230606135123-b799d47a6648/go.mod h1:UXha4TguuB52H14EMoSsCqDj7k8a/t7g4gVP+bgY5LY=
 github.com/cyberdelia/templates v0.0.0-20141128023046-ca7fffd4298c/go.mod h1:GyV+0YP4qX0UQ7r2MoYZ+AvYDp12OF5yg4q8rGnyNh4=

--- a/internal/grpc/services/appprovider/appprovider_test.go
+++ b/internal/grpc/services/appprovider/appprovider_test.go
@@ -21,6 +21,7 @@ package appprovider
 import (
 	"testing"
 
+	"github.com/cs3org/reva/pkg/utils/cfg"
 	"github.com/mitchellh/mapstructure"
 	"github.com/stretchr/testify/assert"
 )
@@ -80,9 +81,12 @@ func Test_parseConfig(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := parseConfig(tt.m)
+			var got config
+			err := cfg.Decode(tt.m, &got)
 			assert.Equal(t, tt.wantErr, err)
-			assert.Equal(t, tt.want, got)
+			if tt.wantErr == nil {
+				assert.Equal(t, tt.want, &got)
+			}
 		})
 	}
 }

--- a/internal/grpc/services/appregistry/appregistry.go
+++ b/internal/grpc/services/appregistry/appregistry.go
@@ -27,7 +27,7 @@ import (
 	"github.com/cs3org/reva/pkg/errtypes"
 	"github.com/cs3org/reva/pkg/rgrpc"
 	"github.com/cs3org/reva/pkg/rgrpc/status"
-	"github.com/mitchellh/mapstructure"
+	"github.com/cs3org/reva/pkg/utils/cfg"
 	"google.golang.org/grpc"
 )
 
@@ -56,7 +56,7 @@ type config struct {
 	Drivers map[string]map[string]interface{} `mapstructure:"drivers"`
 }
 
-func (c *config) init() {
+func (c *config) ApplyDefaults() {
 	if c.Driver == "" {
 		c.Driver = "static"
 	}
@@ -64,12 +64,12 @@ func (c *config) init() {
 
 // New creates a new StorageRegistryService.
 func New(ctx context.Context, m map[string]interface{}) (rgrpc.Service, error) {
-	c, err := parseConfig(m)
-	if err != nil {
+	var c config
+	if err := cfg.Decode(m, &c); err != nil {
 		return nil, err
 	}
 
-	reg, err := getRegistry(ctx, c)
+	reg, err := getRegistry(ctx, &c)
 	if err != nil {
 		return nil, err
 	}
@@ -79,15 +79,6 @@ func New(ctx context.Context, m map[string]interface{}) (rgrpc.Service, error) {
 	}
 
 	return svc, nil
-}
-
-func parseConfig(m map[string]interface{}) (*config, error) {
-	c := &config{}
-	if err := mapstructure.Decode(m, c); err != nil {
-		return nil, err
-	}
-	c.init()
-	return c, nil
 }
 
 func getRegistry(ctx context.Context, c *config) (app.Registry, error) {

--- a/internal/grpc/services/authprovider/authprovider.go
+++ b/internal/grpc/services/authprovider/authprovider.go
@@ -36,6 +36,7 @@ import (
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
+	
 )
 
 func init() {

--- a/internal/grpc/services/helloworld/helloworld.go
+++ b/internal/grpc/services/helloworld/helloworld.go
@@ -24,8 +24,7 @@ import (
 
 	"github.com/cs3org/reva/internal/grpc/services/helloworld/proto"
 	"github.com/cs3org/reva/pkg/rgrpc"
-	"github.com/mitchellh/mapstructure"
-	"github.com/pkg/errors"
+	"github.com/cs3org/reva/pkg/utils/cfg"
 	"google.golang.org/grpc"
 )
 
@@ -40,20 +39,21 @@ type service struct {
 	conf *conf
 }
 
+func (c *conf) ApplyDefaults() {
+	if c.Message == "" {
+		c.Message = "Hello"
+	}
+}
+
 // New returns a new PreferencesServiceServer
 // It can be tested like this:
 // prototool grpc --address 0.0.0.0:9999 --method 'revad.helloworld.HelloWorldService/Hello' --data '{"name": "Alice"}'.
 func New(ctx context.Context, m map[string]interface{}) (rgrpc.Service, error) {
-	c := &conf{}
-	if err := mapstructure.Decode(m, c); err != nil {
-		err = errors.Wrap(err, "helloworld: error decoding conf")
+	var c conf
+	if err := cfg.Decode(m, &c); err != nil {
 		return nil, err
 	}
-
-	if c.Message == "" {
-		c.Message = "Hello"
-	}
-	service := &service{conf: c}
+	service := &service{conf: &c}
 	return service, nil
 }
 

--- a/internal/grpc/services/ocmcore/ocmcore.go
+++ b/internal/grpc/services/ocmcore/ocmcore.go
@@ -32,8 +32,7 @@ import (
 	"github.com/cs3org/reva/pkg/ocm/share/repository/registry"
 	"github.com/cs3org/reva/pkg/rgrpc"
 	"github.com/cs3org/reva/pkg/rgrpc/status"
-	"github.com/mitchellh/mapstructure"
-	"github.com/pkg/errors"
+	"github.com/cs3org/reva/pkg/utils/cfg"
 	"google.golang.org/grpc"
 )
 
@@ -51,7 +50,7 @@ type service struct {
 	repo share.Repository
 }
 
-func (c *config) init() {
+func (c *config) ApplyDefaults() {
 	if c.Driver == "" {
 		c.Driver = "json"
 	}
@@ -68,30 +67,20 @@ func getShareRepository(ctx context.Context, c *config) (share.Repository, error
 	return nil, errtypes.NotFound(fmt.Sprintf("driver not found: %s", c.Driver))
 }
 
-func parseConfig(m map[string]interface{}) (*config, error) {
-	c := &config{}
-	if err := mapstructure.Decode(m, c); err != nil {
-		err = errors.Wrap(err, "error decoding conf")
-		return nil, err
-	}
-	return c, nil
-}
-
 // New creates a new ocm core svc.
 func New(ctx context.Context, m map[string]interface{}) (rgrpc.Service, error) {
-	c, err := parseConfig(m)
-	if err != nil {
+	var c config
+	if err := cfg.Decode(m, &c); err != nil {
 		return nil, err
 	}
-	c.init()
 
-	repo, err := getShareRepository(ctx, c)
+	repo, err := getShareRepository(ctx, &c)
 	if err != nil {
 		return nil, err
 	}
 
 	service := &service{
-		conf: c,
+		conf: &c,
 		repo: repo,
 	}
 

--- a/internal/grpc/services/ocminvitemanager/ocminvitemanager.go
+++ b/internal/grpc/services/ocminvitemanager/ocminvitemanager.go
@@ -36,7 +36,7 @@ import (
 	"github.com/cs3org/reva/pkg/rgrpc/todo/pool"
 	"github.com/cs3org/reva/pkg/sharedconf"
 	"github.com/cs3org/reva/pkg/utils"
-	"github.com/mitchellh/mapstructure"
+	"github.com/cs3org/reva/pkg/utils/cfg"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 )
@@ -63,7 +63,7 @@ type service struct {
 	ocmClient *client.OCMClient
 }
 
-func (c *config) init() error {
+func (c *config) ApplyDefaults() error {
 	if c.Driver == "" {
 		c.Driver = "json"
 	}
@@ -93,32 +93,20 @@ func getInviteRepository(ctx context.Context, c *config) (invite.Repository, err
 	return nil, errtypes.NotFound("driver not found: " + c.Driver)
 }
 
-func parseConfig(m map[string]interface{}) (*config, error) {
-	c := &config{}
-	if err := mapstructure.Decode(m, c); err != nil {
-		err = errors.Wrap(err, "error decoding conf")
-		return nil, err
-	}
-	return c, nil
-}
-
 // New creates a new OCM invite manager svc.
 func New(ctx context.Context, m map[string]interface{}) (rgrpc.Service, error) {
-	c, err := parseConfig(m)
-	if err != nil {
-		return nil, err
-	}
-	if err := c.init(); err != nil {
+	var c config
+	if err := cfg.Decode(m, &c); err != nil {
 		return nil, err
 	}
 
-	repo, err := getInviteRepository(ctx, c)
+	repo, err := getInviteRepository(ctx, &c)
 	if err != nil {
 		return nil, err
 	}
 
 	service := &service{
-		conf: c,
+		conf: &c,
 		repo: repo,
 		ocmClient: client.New(&client.Config{
 			Timeout:  time.Duration(c.OCMClientTimeout) * time.Second,

--- a/internal/grpc/services/ocminvitemanager/ocminvitemanager.go
+++ b/internal/grpc/services/ocminvitemanager/ocminvitemanager.go
@@ -51,8 +51,8 @@ type config struct {
 	TokenExpiration   string                            `mapstructure:"token_expiration"`
 	OCMClientTimeout  int                               `mapstructure:"ocm_timeout"`
 	OCMClientInsecure bool                              `mapstructure:"ocm_insecure"`
-	GatewaySVC        string                            `mapstructure:"gateway_svc"`
-	ProviderDomain    string                            `mapstructure:"provider_domain" docs:"The same domain registered in the provider authorizer"`
+	GatewaySVC        string                            `mapstructure:"gatewaysvc"       validate:"required"`
+	ProviderDomain    string                            `mapstructure:"provider_domain"  validate:"required" docs:"The same domain registered in the provider authorizer"`
 
 	tokenExpiration time.Duration
 }
@@ -63,7 +63,7 @@ type service struct {
 	ocmClient *client.OCMClient
 }
 
-func (c *config) ApplyDefaults() error {
+func (c *config) ApplyDefaults() {
 	if c.Driver == "" {
 		c.Driver = "json"
 	}
@@ -71,15 +71,7 @@ func (c *config) ApplyDefaults() error {
 		c.TokenExpiration = "24h"
 	}
 
-	p, err := time.ParseDuration(c.TokenExpiration)
-	if err != nil {
-		return err
-	}
-	c.tokenExpiration = p
-
 	c.GatewaySVC = sharedconf.GetGatewaySVC(c.GatewaySVC)
-
-	return nil
 }
 
 func (s *service) Register(ss *grpc.Server) {
@@ -99,6 +91,12 @@ func New(ctx context.Context, m map[string]interface{}) (rgrpc.Service, error) {
 	if err := cfg.Decode(m, &c); err != nil {
 		return nil, err
 	}
+
+	p, err := time.ParseDuration(c.TokenExpiration)
+	if err != nil {
+		return nil, err
+	}
+	c.tokenExpiration = p
 
 	repo, err := getInviteRepository(ctx, &c)
 	if err != nil {

--- a/internal/grpc/services/ocmshareprovider/ocmshareprovider.go
+++ b/internal/grpc/services/ocmshareprovider/ocmshareprovider.go
@@ -60,9 +60,9 @@ type config struct {
 	Drivers        map[string]map[string]interface{} `mapstructure:"drivers"`
 	ClientTimeout  int                               `mapstructure:"client_timeout"`
 	ClientInsecure bool                              `mapstructure:"client_insecure"`
-	GatewaySVC     string                            `mapstructure:"gatewaysvc"`
-	ProviderDomain string                            `mapstructure:"provider_domain" docs:"The same domain registered in the provider authorizer"`
-	WebDAVEndpoint string                            `mapstructure:"webdav_endpoint"`
+	GatewaySVC     string                            `mapstructure:"gatewaysvc"      validate:"required"`
+	ProviderDomain string                            `mapstructure:"provider_domain" validate:"required" docs:"The same domain registered in the provider authorizer"`
+	WebDAVEndpoint string                            `mapstructure:"webdav_endpoint" validate:"required"`
 	WebappTemplate string                            `mapstructure:"webapp_template"`
 }
 

--- a/internal/grpc/services/ocmshareprovider/ocmshareprovider.go
+++ b/internal/grpc/services/ocmshareprovider/ocmshareprovider.go
@@ -46,7 +46,7 @@ import (
 	"github.com/cs3org/reva/pkg/sharedconf"
 	"github.com/cs3org/reva/pkg/storage/utils/walker"
 	"github.com/cs3org/reva/pkg/utils"
-	"github.com/mitchellh/mapstructure"
+	"github.com/cs3org/reva/pkg/utils/cfg"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 )
@@ -75,7 +75,7 @@ type service struct {
 	walker     walker.Walker
 }
 
-func (c *config) init() {
+func (c *config) ApplyDefaults() {
 	if c.Driver == "" {
 		c.Driver = "json"
 	}
@@ -100,24 +100,14 @@ func getShareRepository(ctx context.Context, c *config) (share.Repository, error
 	return nil, errtypes.NotFound("driver not found: " + c.Driver)
 }
 
-func parseConfig(m map[string]interface{}) (*config, error) {
-	c := &config{}
-	if err := mapstructure.Decode(m, c); err != nil {
-		err = errors.Wrap(err, "error decoding conf")
-		return nil, err
-	}
-	return c, nil
-}
-
 // New creates a new ocm share provider svc.
 func New(ctx context.Context, m map[string]interface{}) (rgrpc.Service, error) {
-	c, err := parseConfig(m)
-	if err != nil {
+	var c config
+	if err := cfg.Decode(m, &c); err != nil {
 		return nil, err
 	}
-	c.init()
 
-	repo, err := getShareRepository(ctx, c)
+	repo, err := getShareRepository(ctx, &c)
 	if err != nil {
 		return nil, err
 	}
@@ -139,7 +129,7 @@ func New(ctx context.Context, m map[string]interface{}) (rgrpc.Service, error) {
 	walker := walker.NewWalker(gateway)
 
 	service := &service{
-		conf:       c,
+		conf:       &c,
 		repo:       repo,
 		client:     client,
 		gateway:    gateway,

--- a/internal/grpc/services/permissions/permissions.go
+++ b/internal/grpc/services/permissions/permissions.go
@@ -27,8 +27,7 @@ import (
 	"github.com/cs3org/reva/pkg/permission"
 	"github.com/cs3org/reva/pkg/permission/manager/registry"
 	"github.com/cs3org/reva/pkg/rgrpc"
-	"github.com/mitchellh/mapstructure"
-	"github.com/pkg/errors"
+	"github.com/cs3org/reva/pkg/utils/cfg"
 	"google.golang.org/grpc"
 )
 
@@ -41,23 +40,14 @@ type config struct {
 	Drivers map[string]map[string]interface{} `mapstructure:"drivers" docs:"url:pkg/permission/permission.go"`
 }
 
-func parseConfig(m map[string]interface{}) (*config, error) {
-	c := &config{}
-	if err := mapstructure.Decode(m, c); err != nil {
-		err = errors.Wrap(err, "error decoding conf")
-		return nil, err
-	}
-	return c, nil
-}
-
 type service struct {
 	manager permission.Manager
 }
 
 // New returns a new PermissionsServiceServer.
 func New(ctx context.Context, m map[string]interface{}) (rgrpc.Service, error) {
-	c, err := parseConfig(m)
-	if err != nil {
+	var c config
+	if err := cfg.Decode(m, &c); err != nil {
 		return nil, err
 	}
 

--- a/internal/grpc/services/publicstorageprovider/publicstorageprovider.go
+++ b/internal/grpc/services/publicstorageprovider/publicstorageprovider.go
@@ -36,7 +36,7 @@ import (
 	"github.com/cs3org/reva/pkg/rgrpc/todo/pool"
 	rtrace "github.com/cs3org/reva/pkg/trace"
 	"github.com/cs3org/reva/pkg/utils"
-	"github.com/mitchellh/mapstructure"
+	"github.com/cs3org/reva/pkg/utils/cfg"
 	"github.com/pkg/errors"
 	"go.opentelemetry.io/otel/attribute"
 	"google.golang.org/grpc"
@@ -73,19 +73,10 @@ func (s *service) Register(ss *grpc.Server) {
 	provider.RegisterProviderAPIServer(ss, s)
 }
 
-func parseConfig(m map[string]interface{}) (*config, error) {
-	c := &config{}
-	if err := mapstructure.Decode(m, c); err != nil {
-		err = errors.Wrap(err, "error decoding conf")
-		return nil, err
-	}
-	return c, nil
-}
-
 // New creates a new IsPublic Storage Provider service.
 func New(ctx context.Context, m map[string]interface{}) (rgrpc.Service, error) {
-	c, err := parseConfig(m)
-	if err != nil {
+	var c config
+	if err := cfg.Decode(m, &c); err != nil {
 		return nil, err
 	}
 
@@ -98,7 +89,7 @@ func New(ctx context.Context, m map[string]interface{}) (rgrpc.Service, error) {
 	}
 
 	service := &service{
-		conf:      c,
+		conf:      &c,
 		mountPath: mountPath,
 		mountID:   mountID,
 		gateway:   gateway,

--- a/internal/grpc/services/storageregistry/storageregistry.go
+++ b/internal/grpc/services/storageregistry/storageregistry.go
@@ -28,7 +28,7 @@ import (
 	"github.com/cs3org/reva/pkg/rgrpc/status"
 	"github.com/cs3org/reva/pkg/storage"
 	"github.com/cs3org/reva/pkg/storage/registry/registry"
-	"github.com/mitchellh/mapstructure"
+	"github.com/cs3org/reva/pkg/utils/cfg"
 	"google.golang.org/grpc"
 )
 
@@ -57,7 +57,7 @@ type config struct {
 	Drivers map[string]map[string]interface{} `mapstructure:"drivers"`
 }
 
-func (c *config) init() {
+func (c *config) ApplyDefaults() {
 	if c.Driver == "" {
 		c.Driver = "static"
 	}
@@ -65,14 +65,12 @@ func (c *config) init() {
 
 // New creates a new StorageBrokerService.
 func New(ctx context.Context, m map[string]interface{}) (rgrpc.Service, error) {
-	c, err := parseConfig(m)
-	if err != nil {
+	var c config
+	if err := cfg.Decode(m, &c); err != nil {
 		return nil, err
 	}
 
-	c.init()
-
-	reg, err := getRegistry(ctx, c)
+	reg, err := getRegistry(ctx, &c)
 	if err != nil {
 		return nil, err
 	}
@@ -82,14 +80,6 @@ func New(ctx context.Context, m map[string]interface{}) (rgrpc.Service, error) {
 	}
 
 	return service, nil
-}
-
-func parseConfig(m map[string]interface{}) (*config, error) {
-	c := &config{}
-	if err := mapstructure.Decode(m, c); err != nil {
-		return nil, err
-	}
-	return c, nil
 }
 
 func getRegistry(ctx context.Context, c *config) (storage.Registry, error) {

--- a/internal/http/services/appprovider/appprovider.go
+++ b/internal/http/services/appprovider/appprovider.go
@@ -50,7 +50,7 @@ func init() {
 // Config holds the config options for the HTTP appprovider service.
 type Config struct {
 	Prefix     string `mapstructure:"prefix"`
-	GatewaySvc string `mapstructure:"gatewaysvc"`
+	GatewaySvc string `mapstructure:"gatewaysvc" validate:"required"`
 	Insecure   bool   `mapstructure:"insecure" docs:"false;Whether to skip certificate checks when sending requests."`
 }
 

--- a/internal/http/services/appprovider/appprovider.go
+++ b/internal/http/services/appprovider/appprovider.go
@@ -36,10 +36,10 @@ import (
 	"github.com/cs3org/reva/pkg/rhttp/global"
 	"github.com/cs3org/reva/pkg/sharedconf"
 	"github.com/cs3org/reva/pkg/utils"
+	"github.com/cs3org/reva/pkg/utils/cfg"
 	"github.com/cs3org/reva/pkg/utils/resourceid"
 	"github.com/go-chi/chi/v5"
 	ua "github.com/mileusna/useragent"
-	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
 )
 
@@ -54,7 +54,7 @@ type Config struct {
 	Insecure   bool   `mapstructure:"insecure" docs:"false;Whether to skip certificate checks when sending requests."`
 }
 
-func (c *Config) init() {
+func (c *Config) ApplyDefaults() {
 	if c.Prefix == "" {
 		c.Prefix = "app"
 	}
@@ -68,15 +68,14 @@ type svc struct {
 
 // New returns a new ocmd object.
 func New(ctx context.Context, m map[string]interface{}) (global.Service, error) {
-	conf := &Config{}
-	if err := mapstructure.Decode(m, conf); err != nil {
+	var c Config
+	if err := cfg.Decode(m, &c); err != nil {
 		return nil, err
 	}
-	conf.init()
 
 	r := chi.NewRouter()
 	s := &svc{
-		conf:   conf,
+		conf:   &c,
 		router: r,
 	}
 

--- a/internal/http/services/archiver/handler.go
+++ b/internal/http/services/archiver/handler.go
@@ -56,12 +56,12 @@ type svc struct {
 // Config holds the config options that need to be passed down to all ocdav handlers.
 type Config struct {
 	Prefix         string   `mapstructure:"prefix"`
-	GatewaySvc     string   `mapstructure:"gatewaysvc"`
+	GatewaySvc     string   `mapstructure:"gatewaysvc"      validate:"required"`
 	Timeout        int64    `mapstructure:"timeout"`
 	Insecure       bool     `mapstructure:"insecure" docs:"false;Whether to skip certificate checks when sending requests."`
 	Name           string   `mapstructure:"name"`
-	MaxNumFiles    int64    `mapstructure:"max_num_files"`
-	MaxSize        int64    `mapstructure:"max_size"`
+	MaxNumFiles    int64    `mapstructure:"max_num_files"   validate:"required,gt=0"`
+	MaxSize        int64    `mapstructure:"max_size"        validate:"required,gt=0"`
 	AllowedFolders []string `mapstructure:"allowed_folders"`
 }
 

--- a/internal/http/services/datagateway/datagateway.go
+++ b/internal/http/services/datagateway/datagateway.go
@@ -56,7 +56,7 @@ type transferClaims struct {
 }
 type config struct {
 	Prefix               string `mapstructure:"prefix"`
-	TransferSharedSecret string `mapstructure:"transfer_shared_secret"`
+	TransferSharedSecret string `mapstructure:"transfer_shared_secret" validate:"required"`
 	Timeout              int64  `mapstructure:"timeout"`
 	Insecure             bool   `mapstructure:"insecure" docs:"false;Whether to skip certificate checks when sending requests."`
 }

--- a/internal/http/services/datagateway/datagateway.go
+++ b/internal/http/services/datagateway/datagateway.go
@@ -32,8 +32,8 @@ import (
 	"github.com/cs3org/reva/pkg/rhttp"
 	"github.com/cs3org/reva/pkg/rhttp/global"
 	"github.com/cs3org/reva/pkg/sharedconf"
+	"github.com/cs3org/reva/pkg/utils/cfg"
 	"github.com/golang-jwt/jwt"
-	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
 )
 
@@ -61,7 +61,7 @@ type config struct {
 	Insecure             bool   `mapstructure:"insecure" docs:"false;Whether to skip certificate checks when sending requests."`
 }
 
-func (c *config) init() {
+func (c *config) ApplyDefaults() {
 	if c.Prefix == "" {
 		c.Prefix = "datagateway"
 	}
@@ -77,18 +77,16 @@ type svc struct {
 
 // New returns a new datagateway.
 func New(ctx context.Context, m map[string]interface{}) (global.Service, error) {
-	conf := &config{}
-	if err := mapstructure.Decode(m, conf); err != nil {
+	var c config
+	if err := cfg.Decode(m, &c); err != nil {
 		return nil, err
 	}
 
-	conf.init()
-
 	s := &svc{
-		conf: conf,
+		conf: &c,
 		client: rhttp.GetHTTPClient(
-			rhttp.Timeout(time.Duration(conf.Timeout*int64(time.Second))),
-			rhttp.Insecure(conf.Insecure),
+			rhttp.Timeout(time.Duration(c.Timeout*int64(time.Second))),
+			rhttp.Insecure(c.Insecure),
 		),
 	}
 	s.setHandler()

--- a/internal/http/services/dataprovider/dataprovider.go
+++ b/internal/http/services/dataprovider/dataprovider.go
@@ -29,7 +29,7 @@ import (
 	"github.com/cs3org/reva/pkg/rhttp/router"
 	"github.com/cs3org/reva/pkg/storage"
 	"github.com/cs3org/reva/pkg/storage/fs/registry"
-	"github.com/mitchellh/mapstructure"
+	"github.com/cs3org/reva/pkg/utils/cfg"
 )
 
 func init() {
@@ -45,7 +45,7 @@ type config struct {
 	Insecure bool                              `mapstructure:"insecure" docs:"false;Whether to skip certificate checks when sending requests."`
 }
 
-func (c *config) init() {
+func (c *config) ApplyDefaults() {
 	if c.Prefix == "" {
 		c.Prefix = "data"
 	}
@@ -63,26 +63,24 @@ type svc struct {
 
 // New returns a new datasvc.
 func New(ctx context.Context, m map[string]interface{}) (global.Service, error) {
-	conf := &config{}
-	if err := mapstructure.Decode(m, conf); err != nil {
+	var c config
+	if err := cfg.Decode(m, &c); err != nil {
 		return nil, err
 	}
 
-	conf.init()
-
-	fs, err := getFS(ctx, conf)
+	fs, err := getFS(ctx, &c)
 	if err != nil {
 		return nil, err
 	}
 
-	dataTXs, err := getDataTXs(ctx, conf, fs)
+	dataTXs, err := getDataTXs(ctx, &c, fs)
 	if err != nil {
 		return nil, err
 	}
 
 	s := &svc{
 		storage: fs,
-		conf:    conf,
+		conf:    &c,
 		dataTXs: dataTXs,
 	}
 

--- a/internal/http/services/helloworld/helloworld.go
+++ b/internal/http/services/helloworld/helloworld.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/cs3org/reva/pkg/appctx"
 	"github.com/cs3org/reva/pkg/rhttp/global"
-	"github.com/mitchellh/mapstructure"
+	"github.com/cs3org/reva/pkg/utils/cfg"
 )
 
 func init() {
@@ -33,14 +33,12 @@ func init() {
 
 // New returns a new helloworld service.
 func New(ctx context.Context, m map[string]interface{}) (global.Service, error) {
-	conf := &config{}
-	if err := mapstructure.Decode(m, conf); err != nil {
+	var c config
+	if err := cfg.Decode(m, &c); err != nil {
 		return nil, err
 	}
 
-	conf.init()
-
-	return &svc{conf: conf}, nil
+	return &svc{conf: &c}, nil
 }
 
 // Close performs cleanup.
@@ -53,7 +51,7 @@ type config struct {
 	HelloMessage string `mapstructure:"message"`
 }
 
-func (c *config) init() {
+func (c *config) ApplyDefaults() {
 	if c.HelloMessage == "" {
 		c.HelloMessage = "Hello World!"
 	}

--- a/internal/http/services/metrics/metrics.go
+++ b/internal/http/services/metrics/metrics.go
@@ -30,7 +30,7 @@ import (
 	"github.com/cs3org/reva/pkg/metrics"
 	"github.com/cs3org/reva/pkg/metrics/config"
 	"github.com/cs3org/reva/pkg/rhttp/global"
-	"github.com/mitchellh/mapstructure"
+	"github.com/cs3org/reva/pkg/utils/cfg"
 )
 
 func init() {
@@ -70,16 +70,13 @@ func (s *svc) Handler() http.Handler {
 
 // New returns a new metrics service.
 func New(ctx context.Context, m map[string]interface{}) (global.Service, error) {
-	// Prepare the configuration
-	conf := &config.Config{}
-	if err := mapstructure.Decode(m, conf); err != nil {
+	var c config.Config
+	if err := cfg.Decode(m, &c); err != nil {
 		return nil, err
 	}
 
-	conf.Init()
-
 	// initialize metrics using the configuration
-	err := metrics.Init(conf)
+	err := metrics.Init(&c)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/http/services/ocmd/ocm.go
+++ b/internal/http/services/ocmd/ocm.go
@@ -35,7 +35,7 @@ func init() {
 
 type config struct {
 	Prefix                     string `mapstructure:"prefix"`
-	GatewaySvc                 string `mapstructure:"gatewaysvc"`
+	GatewaySvc                 string `mapstructure:"gatewaysvc"                    validate:"required"`
 	ExposeRecipientDisplayName bool   `mapstructure:"expose_recipient_display_name"`
 }
 

--- a/internal/http/services/ocmd/ocm.go
+++ b/internal/http/services/ocmd/ocm.go
@@ -25,8 +25,8 @@ import (
 	"github.com/cs3org/reva/pkg/appctx"
 	"github.com/cs3org/reva/pkg/rhttp/global"
 	"github.com/cs3org/reva/pkg/sharedconf"
+	"github.com/cs3org/reva/pkg/utils/cfg"
 	"github.com/go-chi/chi/v5"
-	"github.com/mitchellh/mapstructure"
 )
 
 func init() {
@@ -39,7 +39,7 @@ type config struct {
 	ExposeRecipientDisplayName bool   `mapstructure:"expose_recipient_display_name"`
 }
 
-func (c *config) init() {
+func (c *config) ApplyDefaults() {
 	c.GatewaySvc = sharedconf.GetGatewaySVC(c.GatewaySvc)
 	if c.Prefix == "" {
 		c.Prefix = "ocm"
@@ -54,15 +54,14 @@ type svc struct {
 // New returns a new ocmd object, that implements
 // the OCM APIs specified in https://cs3org.github.io/OCM-API/docs.html
 func New(ctx context.Context, m map[string]interface{}) (global.Service, error) {
-	conf := &config{}
-	if err := mapstructure.Decode(m, conf); err != nil {
+	var c config
+	if err := cfg.Decode(m, &c); err != nil {
 		return nil, err
 	}
-	conf.init()
 
 	r := chi.NewRouter()
 	s := &svc{
-		Conf:   conf,
+		Conf:   &c,
 		router: r,
 	}
 

--- a/internal/http/services/ocmprovider/ocmprovider.go
+++ b/internal/http/services/ocmprovider/ocmprovider.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/cs3org/reva/pkg/appctx"
 	"github.com/cs3org/reva/pkg/rhttp/global"
-	"github.com/mitchellh/mapstructure"
+	"github.com/cs3org/reva/pkg/utils/cfg"
 )
 
 func init() {
@@ -62,7 +62,7 @@ type svc struct {
 	data *discoveryData
 }
 
-func (c *config) init() {
+func (c *config) ApplyDefaults() {
 	if c.OCMPrefix == "" {
 		c.OCMPrefix = "ocm"
 	}
@@ -126,13 +126,11 @@ func (c *config) prepare() *discoveryData {
 // the OCM discovery endpoint specified in
 // https://cs3org.github.io/OCM-API/docs.html?repo=OCM-API&user=cs3org#/paths/~1ocm-provider/get
 func New(ctx context.Context, m map[string]interface{}) (global.Service, error) {
-	conf := &config{}
-	if err := mapstructure.Decode(m, conf); err != nil {
+	var c config
+	if err := cfg.Decode(m, &c); err != nil {
 		return nil, err
 	}
-
-	conf.init()
-	return &svc{data: conf.prepare()}, nil
+	return &svc{data: c.prepare()}, nil
 }
 
 // Close performs cleanup.

--- a/internal/http/services/owncloud/ocs/config/config.go
+++ b/internal/http/services/owncloud/ocs/config/config.go
@@ -49,7 +49,7 @@ type Config struct {
 }
 
 // Init sets sane defaults.
-func (c *Config) Init() {
+func (c *Config) ApplyDefaults() {
 	if c.Prefix == "" {
 		c.Prefix = "ocs"
 	}

--- a/internal/http/services/owncloud/ocs/ocs.go
+++ b/internal/http/services/owncloud/ocs/ocs.go
@@ -34,8 +34,8 @@ import (
 	"github.com/cs3org/reva/internal/http/services/owncloud/ocs/response"
 	"github.com/cs3org/reva/pkg/appctx"
 	"github.com/cs3org/reva/pkg/rhttp/global"
+	"github.com/cs3org/reva/pkg/utils/cfg"
 	"github.com/go-chi/chi/v5"
-	"github.com/mitchellh/mapstructure"
 	"github.com/rs/zerolog"
 )
 
@@ -50,16 +50,14 @@ type svc struct {
 }
 
 func New(ctx context.Context, m map[string]interface{}) (global.Service, error) {
-	conf := &config.Config{}
-	if err := mapstructure.Decode(m, conf); err != nil {
+	var c config.Config
+	if err := cfg.Decode(m, &c); err != nil {
 		return nil, err
 	}
 
-	conf.Init()
-
 	r := chi.NewRouter()
 	s := &svc{
-		c:      conf,
+		c:      &c,
 		router: r,
 	}
 
@@ -68,9 +66,9 @@ func New(ctx context.Context, m map[string]interface{}) (global.Service, error) 
 		return nil, err
 	}
 
-	if conf.CacheWarmupDriver == "first-request" && conf.ResourceInfoCacheTTL > 0 {
+	if c.CacheWarmupDriver == "first-request" && c.ResourceInfoCacheTTL > 0 {
 		s.warmupCacheTracker = ttlcache.NewCache()
-		_ = s.warmupCacheTracker.SetTTL(time.Second * time.Duration(conf.ResourceInfoCacheTTL))
+		_ = s.warmupCacheTracker.SetTTL(time.Second * time.Duration(c.ResourceInfoCacheTTL))
 	}
 
 	return s, nil

--- a/internal/http/services/preferences/preferences.go
+++ b/internal/http/services/preferences/preferences.go
@@ -29,8 +29,8 @@ import (
 	"github.com/cs3org/reva/pkg/rgrpc/todo/pool"
 	"github.com/cs3org/reva/pkg/rhttp/global"
 	"github.com/cs3org/reva/pkg/sharedconf"
+	"github.com/cs3org/reva/pkg/utils/cfg"
 	"github.com/go-chi/chi/v5"
-	"github.com/mitchellh/mapstructure"
 )
 
 func init() {
@@ -43,7 +43,7 @@ type Config struct {
 	GatewaySvc string `mapstructure:"gatewaysvc"`
 }
 
-func (c *Config) init() {
+func (c *Config) ApplyDefaults() {
 	if c.Prefix == "" {
 		c.Prefix = "preferences"
 	}
@@ -57,15 +57,14 @@ type svc struct {
 
 // New returns a new ocmd object.
 func New(ctx context.Context, m map[string]interface{}) (global.Service, error) {
-	conf := &Config{}
-	if err := mapstructure.Decode(m, conf); err != nil {
+	var c Config
+	if err := cfg.Decode(m, &c); err != nil {
 		return nil, err
 	}
-	conf.init()
 
 	r := chi.NewRouter()
 	s := &svc{
-		conf:   conf,
+		conf:   &c,
 		router: r,
 	}
 

--- a/internal/http/services/prometheus/prometheus.go
+++ b/internal/http/services/prometheus/prometheus.go
@@ -24,7 +24,7 @@ import (
 
 	"contrib.go.opencensus.io/exporter/prometheus"
 	"github.com/cs3org/reva/pkg/rhttp/global"
-	"github.com/mitchellh/mapstructure"
+	"github.com/cs3org/reva/pkg/utils/cfg"
 	"github.com/pkg/errors"
 	"go.opencensus.io/stats/view"
 )
@@ -35,12 +35,10 @@ func init() {
 
 // New returns a new prometheus service.
 func New(ctx context.Context, m map[string]interface{}) (global.Service, error) {
-	conf := &config{}
-	if err := mapstructure.Decode(m, conf); err != nil {
+	var c config
+	if err := cfg.Decode(m, &c); err != nil {
 		return nil, err
 	}
-
-	conf.init()
 
 	pe, err := prometheus.NewExporter(prometheus.Options{
 		Namespace: "revad",
@@ -50,14 +48,14 @@ func New(ctx context.Context, m map[string]interface{}) (global.Service, error) 
 	}
 
 	view.RegisterExporter(pe)
-	return &svc{prefix: conf.Prefix, h: pe}, nil
+	return &svc{prefix: c.Prefix, h: pe}, nil
 }
 
 type config struct {
 	Prefix string `mapstructure:"prefix"`
 }
 
-func (c *config) init() {
+func (c *config) ApplyDefaults() {
 	if c.Prefix == "" {
 		c.Prefix = "metrics"
 	}

--- a/internal/http/services/reverseproxy/reverseproxy.go
+++ b/internal/http/services/reverseproxy/reverseproxy.go
@@ -28,8 +28,8 @@ import (
 
 	ctxpkg "github.com/cs3org/reva/pkg/ctx"
 	"github.com/cs3org/reva/pkg/rhttp/global"
+	"github.com/cs3org/reva/pkg/utils/cfg"
 	"github.com/go-chi/chi/v5"
-	"github.com/mitchellh/mapstructure"
 )
 
 func init() {
@@ -45,7 +45,7 @@ type config struct {
 	ProxyRulesJSON string `mapstructure:"proxy_rules_json"`
 }
 
-func (c *config) init() {
+func (c *config) ApplyDefaults() {
 	if c.ProxyRulesJSON == "" {
 		c.ProxyRulesJSON = "/etc/revad/proxy_rules.json"
 	}
@@ -57,13 +57,12 @@ type svc struct {
 
 // New returns an instance of the reverse proxy service.
 func New(ctx context.Context, m map[string]interface{}) (global.Service, error) {
-	conf := &config{}
-	if err := mapstructure.Decode(m, conf); err != nil {
+	var c config
+	if err := cfg.Decode(m, &c); err != nil {
 		return nil, err
 	}
-	conf.init()
 
-	f, err := os.ReadFile(conf.ProxyRulesJSON)
+	f, err := os.ReadFile(c.ProxyRulesJSON)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/http/services/sciencemesh/sciencemesh.go
+++ b/internal/http/services/sciencemesh/sciencemesh.go
@@ -40,12 +40,6 @@ func New(ctx context.Context, m map[string]interface{}) (global.Service, error) 
 	if err := cfg.Decode(m, &c); err != nil {
 		return nil, err
 	}
-	// if conf.ProviderDomain == "" {
-	// 	return nil, errors.New("sciencemesh: provider_domain is missing from configuration")
-	// }
-	// if conf.MeshDirectoryURL == "" {
-	// 	return nil, errors.New("sciencemesh: mesh_directory_url is missing from configuration")
-	// }
 
 	r := chi.NewRouter()
 	s := &svc{
@@ -67,10 +61,10 @@ func (s *svc) Close() error {
 
 type config struct {
 	Prefix           string                      `mapstructure:"prefix"`
-	SMTPCredentials  *smtpclient.SMTPCredentials `mapstructure:"smtp_credentials"`
-	GatewaySvc       string                      `mapstructure:"gatewaysvc"`
-	MeshDirectoryURL string                      `mapstructure:"mesh_directory_url"`
-	ProviderDomain   string                      `mapstructure:"provider_domain"`
+	SMTPCredentials  *smtpclient.SMTPCredentials `mapstructure:"smtp_credentials"   validate:"required"`
+	GatewaySvc       string                      `mapstructure:"gatewaysvc"         validate:"required"`
+	MeshDirectoryURL string                      `mapstructure:"mesh_directory_url" validate:"required"`
+	ProviderDomain   string                      `mapstructure:"provider_domain"    validate:"required"`
 	SubjectTemplate  string                      `mapstructure:"subject_template"`
 	BodyTemplatePath string                      `mapstructure:"body_template_path"`
 	OCMMountPoint    string                      `mapstructure:"ocm_mount_point"`
@@ -79,6 +73,9 @@ type config struct {
 func (c *config) ApplyDefaults() {
 	if c.Prefix == "" {
 		c.Prefix = "sciencemesh"
+	}
+	if c.OCMMountPoint == "" {
+		c.OCMMountPoint = "/ocm"
 	}
 
 	c.GatewaySvc = sharedconf.GetGatewaySVC(c.GatewaySvc)

--- a/internal/http/services/sciencemesh/sciencemesh.go
+++ b/internal/http/services/sciencemesh/sciencemesh.go
@@ -20,15 +20,14 @@ package sciencemesh
 
 import (
 	"context"
-	"errors"
 	"net/http"
 
 	"github.com/cs3org/reva/pkg/appctx"
 	"github.com/cs3org/reva/pkg/rhttp/global"
 	"github.com/cs3org/reva/pkg/sharedconf"
 	"github.com/cs3org/reva/pkg/smtpclient"
+	"github.com/cs3org/reva/pkg/utils/cfg"
 	"github.com/go-chi/chi/v5"
-	"github.com/mitchellh/mapstructure"
 )
 
 func init() {
@@ -37,22 +36,20 @@ func init() {
 
 // New returns a new sciencemesh service.
 func New(ctx context.Context, m map[string]interface{}) (global.Service, error) {
-	conf := &config{}
-	if err := mapstructure.Decode(m, conf); err != nil {
+	var c config
+	if err := cfg.Decode(m, &c); err != nil {
 		return nil, err
 	}
-
-	conf.init()
-	if conf.ProviderDomain == "" {
-		return nil, errors.New("sciencemesh: provider_domain is missing from configuration")
-	}
-	if conf.MeshDirectoryURL == "" {
-		return nil, errors.New("sciencemesh: mesh_directory_url is missing from configuration")
-	}
+	// if conf.ProviderDomain == "" {
+	// 	return nil, errors.New("sciencemesh: provider_domain is missing from configuration")
+	// }
+	// if conf.MeshDirectoryURL == "" {
+	// 	return nil, errors.New("sciencemesh: mesh_directory_url is missing from configuration")
+	// }
 
 	r := chi.NewRouter()
 	s := &svc{
-		conf:   conf,
+		conf:   &c,
 		router: r,
 	}
 
@@ -79,7 +76,7 @@ type config struct {
 	OCMMountPoint    string                      `mapstructure:"ocm_mount_point"`
 }
 
-func (c *config) init() {
+func (c *config) ApplyDefaults() {
 	if c.Prefix == "" {
 		c.Prefix = "sciencemesh"
 	}

--- a/internal/http/services/siteacc/siteacc.go
+++ b/internal/http/services/siteacc/siteacc.go
@@ -26,7 +26,7 @@ import (
 	"github.com/cs3org/reva/pkg/rhttp/global"
 	"github.com/cs3org/reva/pkg/siteacc"
 	"github.com/cs3org/reva/pkg/siteacc/config"
-	"github.com/mitchellh/mapstructure"
+	"github.com/cs3org/reva/pkg/utils/cfg"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 )
@@ -66,21 +66,6 @@ func (s *svc) Handler() http.Handler {
 	return s.siteacc.RequestHandler()
 }
 
-func parseConfig(m map[string]interface{}) (*config.Configuration, error) {
-	conf := &config.Configuration{}
-	if err := mapstructure.Decode(m, &conf); err != nil {
-		return nil, errors.Wrap(err, "error decoding configuration")
-	}
-	applyDefaultConfig(conf)
-	conf.Cleanup()
-
-	if conf.Webserver.URL == "" {
-		return nil, errors.Errorf("no webserver URL specified")
-	}
-
-	return conf, nil
-}
-
 func applyDefaultConfig(conf *config.Configuration) {
 	if conf.Prefix == "" {
 		conf.Prefix = serviceName
@@ -106,22 +91,24 @@ func applyDefaultConfig(conf *config.Configuration) {
 
 // New returns a new Site Accounts service.
 func New(ctx context.Context, m map[string]interface{}) (global.Service, error) {
-	// Prepare the configuration
-	conf, err := parseConfig(m)
-	if err != nil {
+	var c config.Configuration
+	if err := cfg.Decode(m, &c); err != nil {
 		return nil, err
 	}
 
+	applyDefaultConfig(&c)
+	c.Cleanup()
+
 	// Create the sites accounts instance
 	log := appctx.GetLogger(ctx)
-	siteacc, err := siteacc.New(conf, log)
+	siteacc, err := siteacc.New(&c, log)
 	if err != nil {
 		return nil, errors.Wrap(err, "error creating the sites accounts service")
 	}
 
 	// Create the service
 	s := &svc{
-		conf:    conf,
+		conf:    &c,
 		log:     log,
 		siteacc: siteacc,
 	}

--- a/internal/http/services/wellknown/wellknown.go
+++ b/internal/http/services/wellknown/wellknown.go
@@ -25,7 +25,7 @@ import (
 	"github.com/cs3org/reva/pkg/appctx"
 	"github.com/cs3org/reva/pkg/rhttp/global"
 	"github.com/cs3org/reva/pkg/rhttp/router"
-	"github.com/mitchellh/mapstructure"
+	"github.com/cs3org/reva/pkg/utils/cfg"
 )
 
 func init() {
@@ -44,7 +44,7 @@ type config struct {
 	EndSessionEndpoint    string `mapstructure:"end_session_endpoint"`
 }
 
-func (c *config) init() {
+func (c *config) ApplyDefaults() {
 	if c.Prefix == "" {
 		c.Prefix = ".well-known"
 	}
@@ -57,15 +57,13 @@ type svc struct {
 
 // New returns a new webuisvc.
 func New(ctx context.Context, m map[string]interface{}) (global.Service, error) {
-	conf := &config{}
-	if err := mapstructure.Decode(m, conf); err != nil {
+	var c config
+	if err := cfg.Decode(m, &c); err != nil {
 		return nil, err
 	}
 
-	conf.init()
-
 	s := &svc{
-		conf: conf,
+		conf: &c,
 	}
 	s.setHandler()
 	return s, nil

--- a/internal/serverless/services/helloworld/helloworld.go
+++ b/internal/serverless/services/helloworld/helloworld.go
@@ -24,9 +24,11 @@ import (
 	"os"
 	"time"
 
+	"github.com/cs3org/reva/pkg/appctx"
 	"github.com/cs3org/reva/pkg/rserverless"
 	"github.com/mitchellh/mapstructure"
 	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
 )
 
 type config struct {
@@ -50,7 +52,7 @@ func init() {
 }
 
 // New returns a new helloworld service.
-func New(m map[string]interface{}, log *zerolog.Logger) (rserverless.Service, error) {
+func New(ctx context.Context, m map[string]interface{}) (rserverless.Service, error) {
 	conf := &config{}
 	conf.init()
 
@@ -64,6 +66,7 @@ func New(m map[string]interface{}, log *zerolog.Logger) (rserverless.Service, er
 		return nil, err
 	}
 
+	log := appctx.GetLogger(ctx)
 	s := &svc{
 		conf: conf,
 		log:  log,

--- a/internal/serverless/services/notifications/notifications.go
+++ b/internal/serverless/services/notifications/notifications.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/cs3org/reva/pkg/appctx"
 	"github.com/cs3org/reva/pkg/errtypes"
 	"github.com/cs3org/reva/pkg/notification"
 	"github.com/cs3org/reva/pkg/notification/handler"
@@ -46,7 +47,7 @@ type config struct {
 	NatsAddress      string                            `mapstructure:"nats_address" docs:";The NATS server address."`
 	NatsToken        string                            `mapstructure:"nats_token" docs:"The token to authenticate against the NATS server"`
 	NatsPrefix       string                            `mapstructure:"nats_prefix" docs:"reva-notifications;The notifications NATS stream."`
-	HandlerConf      map[string]interface{}            `mapstructure:"handlers" docs:";Settings for the different notification handlers."`
+	HandlerConf      map[string]map[string]interface{} `mapstructure:"handlers" docs:";Settings for the different notification handlers."`
 	GroupingInterval int                               `mapstructure:"grouping_interval" docs:"60;Time in seconds to group incoming notification triggers"`
 	GroupingMaxSize  int                               `mapstructure:"grouping_max_size" docs:"100;Maximum number of notifications to group"`
 	StorageDriver    string                            `mapstructure:"storage_driver" docs:"mysql;The driver used to store notifications"`
@@ -63,6 +64,7 @@ func defaultConfig() *config {
 }
 
 type svc struct {
+	ctx          context.Context
 	nc           *nats.Conn
 	js           nats.JetStreamContext
 	kv           nats.KeyValue
@@ -78,28 +80,30 @@ func init() {
 	rserverless.Register("notifications", New)
 }
 
-func getNotificationManager(c *config, l *zerolog.Logger) (notification.Manager, error) {
+func getNotificationManager(ctx context.Context, c *config) (notification.Manager, error) {
 	if f, ok := notificationManagerRegistry.NewFuncs[c.StorageDriver]; ok {
-		return f(c.StorageDrivers[c.StorageDriver])
+		return f(ctx, c.StorageDrivers[c.StorageDriver])
 	}
 	return nil, errtypes.NotFound(fmt.Sprintf("storage driver %s not found", c.StorageDriver))
 }
 
 // New returns a new Notifications service.
-func New(m map[string]interface{}, log *zerolog.Logger) (rserverless.Service, error) {
+func New(ctx context.Context, m map[string]interface{}) (rserverless.Service, error) {
 	conf := defaultConfig()
 
 	if err := mapstructure.Decode(m, conf); err != nil {
 		return nil, err
 	}
 
-	nm, err := getNotificationManager(conf, log)
+	log := appctx.GetLogger(ctx)
+	nm, err := getNotificationManager(ctx, conf)
 	if err != nil {
 		return nil, err
 	}
 	log.Info().Msgf("notification storage %s initialized", conf.StorageDriver)
 
 	s := &svc{
+		ctx:  ctx,
 		conf: conf,
 		log:  log,
 		nm:   nm,
@@ -111,7 +115,7 @@ func New(m map[string]interface{}, log *zerolog.Logger) (rserverless.Service, er
 // Start starts the Notifications service.
 func (s *svc) Start() {
 	s.templates = *templateRegistry.New()
-	s.handlers = handlerRegistry.InitHandlers(s.conf.HandlerConf, s.log)
+	s.handlers = handlerRegistry.InitHandlers(s.ctx, s.conf.HandlerConf)
 	s.accumulators = make(map[string]*accumulator.Accumulator[trigger.Trigger])
 
 	s.log.Debug().Msgf("connecting to nats server at %s", s.conf.NatsAddress)

--- a/pkg/app/provider/demo/demo.go
+++ b/pkg/app/provider/demo/demo.go
@@ -29,7 +29,7 @@ import (
 	typespb "github.com/cs3org/go-cs3apis/cs3/types/v1beta1"
 	"github.com/cs3org/reva/pkg/app"
 	"github.com/cs3org/reva/pkg/app/provider/registry"
-	"github.com/mitchellh/mapstructure"
+	"github.com/cs3org/reva/pkg/utils/cfg"
 )
 
 func init() {
@@ -58,19 +58,11 @@ type config struct {
 	IFrameUIProvider string `mapstructure:"iframe_ui_provider"`
 }
 
-func parseConfig(m map[string]interface{}) (*config, error) {
-	c := &config{}
-	if err := mapstructure.Decode(m, c); err != nil {
-		return nil, err
-	}
-	return c, nil
-}
-
 // New returns an implementation to of the app.Provider interface that
 // connects to an application in the backend.
 func New(ctx context.Context, m map[string]interface{}) (app.Provider, error) {
-	c, err := parseConfig(m)
-	if err != nil {
+	var c config
+	if err := cfg.Decode(m, &c); err != nil {
 		return nil, err
 	}
 	return &demoProvider{iframeUIProvider: c.IFrameUIProvider}, nil

--- a/pkg/app/provider/wopi/wopi.go
+++ b/pkg/app/provider/wopi/wopi.go
@@ -98,7 +98,6 @@ func (c *config) ApplyDefaults() {
 		c.IOPSecret = os.Getenv("REVA_APPPROVIDER_IOPSECRET")
 	}
 	c.JWTSecret = sharedconf.GetJWTSecret(c.JWTSecret)
-
 }
 
 type wopiProvider struct {

--- a/pkg/app/registry/static/static.go
+++ b/pkg/app/registry/static/static.go
@@ -30,7 +30,7 @@ import (
 	"github.com/cs3org/reva/pkg/app"
 	"github.com/cs3org/reva/pkg/app/registry/registry"
 	"github.com/cs3org/reva/pkg/errtypes"
-	"github.com/mitchellh/mapstructure"
+	"github.com/cs3org/reva/pkg/utils/cfg"
 	"github.com/rs/zerolog/log"
 	orderedmap "github.com/wk8/go-ordered-map"
 )
@@ -57,20 +57,6 @@ type config struct {
 	MimeTypes []*mimeTypeConfig          `mapstructure:"mime_types"`
 }
 
-func (c *config) init() {
-	if len(c.Providers) == 0 {
-		c.Providers = []*registrypb.ProviderInfo{}
-	}
-}
-
-func parseConfig(m map[string]interface{}) (*config, error) {
-	c := &config{}
-	if err := mapstructure.Decode(m, c); err != nil {
-		return nil, err
-	}
-	return c, nil
-}
-
 type manager struct {
 	providers map[string]*registrypb.ProviderInfo
 	mimetypes *orderedmap.OrderedMap // map[string]*mimeTypeConfig  ->  map the mime type to the addresses of the corresponding providers
@@ -79,11 +65,10 @@ type manager struct {
 
 // New returns an implementation of the app.Registry interface.
 func New(ctx context.Context, m map[string]interface{}) (app.Registry, error) {
-	c, err := parseConfig(m)
-	if err != nil {
+	var c config
+	if err := cfg.Decode(m, &c); err != nil {
 		return nil, err
 	}
-	c.init()
 
 	mimetypes := orderedmap.New()
 

--- a/pkg/appauth/manager/json/json.go
+++ b/pkg/appauth/manager/json/json.go
@@ -34,7 +34,7 @@ import (
 	"github.com/cs3org/reva/pkg/appauth/manager/registry"
 	ctxpkg "github.com/cs3org/reva/pkg/ctx"
 	"github.com/cs3org/reva/pkg/errtypes"
-	"github.com/mitchellh/mapstructure"
+	"github.com/cs3org/reva/pkg/utils/cfg"
 	"github.com/pkg/errors"
 	"github.com/sethvargo/go-password/password"
 	"golang.org/x/crypto/bcrypt"
@@ -59,12 +59,10 @@ type jsonManager struct {
 
 // New returns a new mgr.
 func New(ctx context.Context, m map[string]interface{}) (appauth.Manager, error) {
-	c, err := parseConfig(m)
-	if err != nil {
-		return nil, errors.Wrap(err, "error creating a new manager")
+	var c config
+	if err := cfg.Decode(m, &c); err != nil {
+		return nil, err
 	}
-
-	c.init()
 
 	// load or create file
 	manager, err := loadOrCreate(c.File)
@@ -72,12 +70,12 @@ func New(ctx context.Context, m map[string]interface{}) (appauth.Manager, error)
 		return nil, errors.Wrap(err, "error loading the file containing the application passwords")
 	}
 
-	manager.config = c
+	manager.config = &c
 
 	return manager, nil
 }
 
-func (c *config) init() {
+func (c *config) ApplyDefaults() {
 	if c.File == "" {
 		c.File = "/var/tmp/reva/appauth.json"
 	}
@@ -87,14 +85,6 @@ func (c *config) init() {
 	if c.PasswordHashCost == 0 {
 		c.PasswordHashCost = 11
 	}
-}
-
-func parseConfig(m map[string]interface{}) (*config, error) {
-	c := &config{}
-	if err := mapstructure.Decode(m, c); err != nil {
-		return nil, err
-	}
-	return c, nil
 }
 
 func loadOrCreate(file string) (*jsonManager, error) {

--- a/pkg/auth/manager/appauth/appauth.go
+++ b/pkg/auth/manager/appauth/appauth.go
@@ -29,8 +29,8 @@ import (
 	"github.com/cs3org/reva/pkg/auth/manager/registry"
 	"github.com/cs3org/reva/pkg/errtypes"
 	"github.com/cs3org/reva/pkg/rgrpc/todo/pool"
-	"github.com/mitchellh/mapstructure"
-	"github.com/pkg/errors"
+	"github.com/cs3org/reva/pkg/sharedconf"
+	"github.com/cs3org/reva/pkg/utils/cfg"
 )
 
 func init() {
@@ -38,7 +38,11 @@ func init() {
 }
 
 type manager struct {
-	GatewayAddr string `mapstructure:"gateway_addr"`
+	GatewayAddr string `mapstructure:"gatewaysvc"`
+}
+
+func (m *manager) ApplyDefaults() {
+	m.GatewayAddr = sharedconf.GetGatewaySVC(m.GatewayAddr)
 }
 
 // New returns a new auth Manager.
@@ -52,11 +56,7 @@ func New(ctx context.Context, m map[string]interface{}) (auth.Manager, error) {
 }
 
 func (m *manager) Configure(ml map[string]interface{}) error {
-	err := mapstructure.Decode(ml, m)
-	if err != nil {
-		return errors.Wrap(err, "error decoding conf")
-	}
-	return nil
+	return cfg.Decode(ml, m)
 }
 
 func (m *manager) Authenticate(ctx context.Context, username, password string) (*user.User, map[string]*authpb.Scope, error) {

--- a/pkg/auth/manager/appauth/appauth.go
+++ b/pkg/auth/manager/appauth/appauth.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cs3org/reva/pkg/rgrpc/todo/pool"
 	"github.com/cs3org/reva/pkg/sharedconf"
 	"github.com/cs3org/reva/pkg/utils/cfg"
+	"github.com/pkg/errors"
 )
 
 func init() {
@@ -56,7 +57,8 @@ func New(ctx context.Context, m map[string]interface{}) (auth.Manager, error) {
 }
 
 func (m *manager) Configure(ml map[string]interface{}) error {
-	return cfg.Decode(ml, m)
+	err := cfg.Decode(ml, m)
+	return errors.Wrap(err, "appauth: error decoding config")
 }
 
 func (m *manager) Authenticate(ctx context.Context, username, password string) (*user.User, map[string]*authpb.Scope, error) {

--- a/pkg/auth/manager/json/json.go
+++ b/pkg/auth/manager/json/json.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cs3org/reva/pkg/auth/scope"
 	"github.com/cs3org/reva/pkg/errtypes"
 	"github.com/cs3org/reva/pkg/utils/cfg"
+	"github.com/pkg/errors"
 )
 
 func init() {
@@ -79,7 +80,7 @@ func New(ctx context.Context, m map[string]interface{}) (auth.Manager, error) {
 func (m *manager) Configure(ml map[string]interface{}) error {
 	var c config
 	if err := cfg.Decode(ml, &c); err != nil {
-		return err
+		return errors.Wrap(err, "json: error decoding config")
 	}
 
 	m.credentials = map[string]*Credentials{}

--- a/pkg/auth/manager/json/json.go
+++ b/pkg/auth/manager/json/json.go
@@ -30,8 +30,7 @@ import (
 	"github.com/cs3org/reva/pkg/auth/manager/registry"
 	"github.com/cs3org/reva/pkg/auth/scope"
 	"github.com/cs3org/reva/pkg/errtypes"
-	"github.com/mitchellh/mapstructure"
-	"github.com/pkg/errors"
+	"github.com/cs3org/reva/pkg/utils/cfg"
 )
 
 func init() {
@@ -61,20 +60,10 @@ type config struct {
 	Users string `mapstructure:"users"`
 }
 
-func (c *config) init() {
+func (c *config) ApplyDefaults() {
 	if c.Users == "" {
 		c.Users = "/etc/revad/users.json"
 	}
-}
-
-func parseConfig(m map[string]interface{}) (*config, error) {
-	c := &config{}
-	if err := mapstructure.Decode(m, c); err != nil {
-		err = errors.Wrap(err, "error decoding conf")
-		return nil, err
-	}
-	c.init()
-	return c, nil
 }
 
 // New returns a new auth Manager.
@@ -88,8 +77,8 @@ func New(ctx context.Context, m map[string]interface{}) (auth.Manager, error) {
 }
 
 func (m *manager) Configure(ml map[string]interface{}) error {
-	c, err := parseConfig(ml)
-	if err != nil {
+	var c config
+	if err := cfg.Decode(ml, &c); err != nil {
 		return err
 	}
 

--- a/pkg/auth/manager/json/json_test.go
+++ b/pkg/auth/manager/json/json_test.go
@@ -44,13 +44,8 @@ func TestGetManagerWithInvalidUser(t *testing.T) {
 		{
 			"Boolean in user",
 			false,
-			"error decoding conf: 1 error(s) decoding:\n\n* " +
+			"json: error decoding config: 1 error(s) decoding:\n\n* " +
 				"'users' expected type 'string', got unconvertible type 'bool', value: 'false'",
-		},
-		{
-			"Nil in user",
-			nil,
-			"open /etc/revad/users.json: no such file or directory",
 		},
 	}
 
@@ -60,9 +55,7 @@ func TestGetManagerWithInvalidUser(t *testing.T) {
 				"users": tt.user,
 			}
 
-			manager, err := New(ctx, input)
-
-			assert.Empty(t, manager)
+			_, err := New(ctx, input)
 			assert.EqualError(t, err, tt.expectedError)
 		})
 	}

--- a/pkg/auth/manager/ldap/ldap.go
+++ b/pkg/auth/manager/ldap/ldap.go
@@ -114,7 +114,7 @@ func (am *mgr) Configure(m map[string]interface{}) error {
 	var c config
 	c.Schema = ldapDefaults
 	if err := cfg.Decode(m, &c); err != nil {
-		return err
+		return errors.Wrap(err, "ldap: error decoding config")
 	}
 	am.c = &c
 	return nil

--- a/pkg/auth/manager/machine/machine.go
+++ b/pkg/auth/manager/machine/machine.go
@@ -30,8 +30,8 @@ import (
 	"github.com/cs3org/reva/pkg/auth/scope"
 	"github.com/cs3org/reva/pkg/errtypes"
 	"github.com/cs3org/reva/pkg/rgrpc/todo/pool"
-	"github.com/mitchellh/mapstructure"
-	"github.com/pkg/errors"
+	"github.com/cs3org/reva/pkg/sharedconf"
+	"github.com/cs3org/reva/pkg/utils/cfg"
 )
 
 // 'machine' is an authentication method used to impersonate users.
@@ -43,20 +43,20 @@ var claims = []string{"mail", "uid", "username", "gid", "userid"}
 
 type manager struct {
 	APIKey      string `mapstructure:"api_key"`
-	GatewayAddr string `mapstructure:"gateway_addr"`
+	GatewayAddr string `mapstructure:"gatewaysvc"`
 }
 
 func init() {
 	registry.Register("machine", New)
 }
 
+func (m *manager) ApplyDefaults() {
+	m.GatewayAddr = sharedconf.GetGatewaySVC(m.GatewayAddr)
+}
+
 // Configure parses the map conf.
 func (m *manager) Configure(conf map[string]interface{}) error {
-	err := mapstructure.Decode(conf, m)
-	if err != nil {
-		return errors.Wrap(err, "error decoding conf")
-	}
-	return nil
+	return cfg.Decode(conf, m)
 }
 
 // New creates a new manager for the 'machine' authentication.

--- a/pkg/auth/manager/machine/machine.go
+++ b/pkg/auth/manager/machine/machine.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cs3org/reva/pkg/rgrpc/todo/pool"
 	"github.com/cs3org/reva/pkg/sharedconf"
 	"github.com/cs3org/reva/pkg/utils/cfg"
+	"github.com/pkg/errors"
 )
 
 // 'machine' is an authentication method used to impersonate users.
@@ -56,7 +57,8 @@ func (m *manager) ApplyDefaults() {
 
 // Configure parses the map conf.
 func (m *manager) Configure(conf map[string]interface{}) error {
-	return cfg.Decode(conf, m)
+	err := cfg.Decode(conf, m)
+	return errors.Wrap(err, "machine: error decoding config")
 }
 
 // New creates a new manager for the 'machine' authentication.

--- a/pkg/auth/manager/nextcloud/nextcloud.go
+++ b/pkg/auth/manager/nextcloud/nextcloud.go
@@ -67,7 +67,7 @@ type Action struct {
 func New(ctx context.Context, m map[string]interface{}) (auth.Manager, error) {
 	var c AuthManagerConfig
 	if err := cfg.Decode(m, &c); err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "nextcloud: error decoding config")
 	}
 
 	return NewAuthManager(&c)

--- a/pkg/auth/manager/nextcloud/nextcloud.go
+++ b/pkg/auth/manager/nextcloud/nextcloud.go
@@ -33,7 +33,7 @@ import (
 	"github.com/cs3org/reva/pkg/appctx"
 	"github.com/cs3org/reva/pkg/auth"
 	"github.com/cs3org/reva/pkg/auth/manager/registry"
-	"github.com/mitchellh/mapstructure"
+	"github.com/cs3org/reva/pkg/utils/cfg"
 	"github.com/pkg/errors"
 )
 
@@ -63,27 +63,14 @@ type Action struct {
 	argS     string
 }
 
-func (c *AuthManagerConfig) init() {
-}
-
-func parseConfig(m map[string]interface{}) (*AuthManagerConfig, error) {
-	c := &AuthManagerConfig{}
-	if err := mapstructure.Decode(m, c); err != nil {
-		err = errors.Wrap(err, "error decoding conf")
-		return nil, err
-	}
-	return c, nil
-}
-
 // New returns an auth manager implementation that verifies against a Nextcloud backend.
 func New(ctx context.Context, m map[string]interface{}) (auth.Manager, error) {
-	c, err := parseConfig(m)
-	if err != nil {
+	var c AuthManagerConfig
+	if err := cfg.Decode(m, &c); err != nil {
 		return nil, err
 	}
-	c.init()
 
-	return NewAuthManager(c)
+	return NewAuthManager(&c)
 }
 
 // NewAuthManager returns a new Nextcloud-based AuthManager.

--- a/pkg/auth/manager/ocmshares/ocmshares.go
+++ b/pkg/auth/manager/ocmshares/ocmshares.go
@@ -38,6 +38,7 @@ import (
 	"github.com/cs3org/reva/pkg/sharedconf"
 	"github.com/cs3org/reva/pkg/utils"
 	"github.com/cs3org/reva/pkg/utils/cfg"
+	"github.com/pkg/errors"
 )
 
 func init() {
@@ -74,8 +75,8 @@ func New(ctx context.Context, m map[string]interface{}) (auth.Manager, error) {
 
 func (m *manager) Configure(ml map[string]interface{}) error {
 	var c config
-	if err := cfg.Decode(ml, c); err != nil {
-		return err
+	if err := cfg.Decode(ml, &c); err != nil {
+		return errors.Wrap(err, "ocmshares: error decoding config")
 	}
 	m.c = &c
 	return nil

--- a/pkg/auth/manager/ocmshares/ocmshares.go
+++ b/pkg/auth/manager/ocmshares/ocmshares.go
@@ -37,8 +37,7 @@ import (
 	"github.com/cs3org/reva/pkg/rgrpc/todo/pool"
 	"github.com/cs3org/reva/pkg/sharedconf"
 	"github.com/cs3org/reva/pkg/utils"
-	"github.com/mitchellh/mapstructure"
-	"github.com/pkg/errors"
+	"github.com/cs3org/reva/pkg/utils/cfg"
 )
 
 func init() {
@@ -51,10 +50,10 @@ type manager struct {
 }
 
 type config struct {
-	GatewayAddr string `mapstructure:"gateway_addr"`
+	GatewayAddr string `mapstructure:"gatewaysvc"`
 }
 
-func (c *config) init() {
+func (c *config) ApplyDefaults() {
 	c.GatewayAddr = sharedconf.GetGatewaySVC(c.GatewayAddr)
 }
 
@@ -64,24 +63,21 @@ func New(ctx context.Context, m map[string]interface{}) (auth.Manager, error) {
 	if err := mgr.Configure(m); err != nil {
 		return nil, err
 	}
+	gw, err := pool.GetGatewayServiceClient(pool.Endpoint(mgr.c.GatewayAddr))
+	if err != nil {
+		return nil, err
+	}
+	mgr.gw = gw
 
 	return &mgr, nil
 }
 
 func (m *manager) Configure(ml map[string]interface{}) error {
 	var c config
-	if err := mapstructure.Decode(ml, &c); err != nil {
-		return errors.Wrap(err, "error decoding config")
-	}
-	c.init()
-	m.c = &c
-
-	gw, err := pool.GetGatewayServiceClient(pool.Endpoint(c.GatewayAddr))
-	if err != nil {
+	if err := cfg.Decode(ml, c); err != nil {
 		return err
 	}
-	m.gw = gw
-
+	m.c = &c
 	return nil
 }
 

--- a/pkg/auth/manager/oidc/oidc.go
+++ b/pkg/auth/manager/oidc/oidc.go
@@ -109,7 +109,7 @@ func New(ctx context.Context, m map[string]interface{}) (auth.Manager, error) {
 func (am *mgr) Configure(m map[string]interface{}) error {
 	var c config
 	if err := cfg.Decode(m, &c); err != nil {
-		return err
+		return errors.Wrap(err, "oidc: error decoding config")
 	}
 	am.c = &c
 

--- a/pkg/auth/manager/owncloudsql/owncloudsql.go
+++ b/pkg/auth/manager/owncloudsql/owncloudsql.go
@@ -95,7 +95,7 @@ func (c *config) ApplyDefaults() {
 func (m *manager) Configure(ml map[string]interface{}) error {
 	var c config
 	if err := cfg.Decode(ml, &c); err != nil {
-		return err
+		return errors.Wrap(err, "owncloudsql: error decoding config")
 	}
 
 	m.c = &c

--- a/pkg/auth/manager/owncloudsql/owncloudsql.go
+++ b/pkg/auth/manager/owncloudsql/owncloudsql.go
@@ -34,10 +34,10 @@ import (
 	"github.com/cs3org/reva/pkg/auth/manager/registry"
 	"github.com/cs3org/reva/pkg/auth/scope"
 	"github.com/cs3org/reva/pkg/errtypes"
+	"github.com/cs3org/reva/pkg/utils/cfg"
 
 	// Provides mysql drivers.
 	_ "github.com/go-sql-driver/mysql"
-	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
 	"golang.org/x/crypto/bcrypt"
 )
@@ -86,26 +86,20 @@ func NewMysql(ctx context.Context, m map[string]interface{}) (auth.Manager, erro
 	return mgr, nil
 }
 
-func (m *manager) Configure(ml map[string]interface{}) error {
-	c, err := parseConfig(ml)
-	if err != nil {
-		return err
-	}
-
+func (c *config) ApplyDefaults() {
 	if c.Nobody == 0 {
 		c.Nobody = 99
 	}
-
-	m.c = c
-	return nil
 }
 
-func parseConfig(m map[string]interface{}) (*config, error) {
-	c := &config{}
-	if err := mapstructure.Decode(m, &c); err != nil {
-		return nil, err
+func (m *manager) Configure(ml map[string]interface{}) error {
+	var c config
+	if err := cfg.Decode(ml, &c); err != nil {
+		return err
 	}
-	return c, nil
+
+	m.c = &c
+	return nil
 }
 
 func (m *manager) Authenticate(ctx context.Context, login, clientSecret string) (*user.User, map[string]*authpb.Scope, error) {

--- a/pkg/auth/manager/publicshares/publicshares.go
+++ b/pkg/auth/manager/publicshares/publicshares.go
@@ -67,7 +67,7 @@ func New(ctx context.Context, m map[string]interface{}) (auth.Manager, error) {
 func (m *manager) Configure(ml map[string]interface{}) error {
 	var c config
 	if err := cfg.Decode(ml, &c); err != nil {
-		return err
+		return errors.Wrap(err, "publicshares: error decoding config")
 	}
 	m.c = &c
 	return nil

--- a/pkg/auth/manager/publicshares/publicshares.go
+++ b/pkg/auth/manager/publicshares/publicshares.go
@@ -33,7 +33,8 @@ import (
 	"github.com/cs3org/reva/pkg/auth/scope"
 	"github.com/cs3org/reva/pkg/errtypes"
 	"github.com/cs3org/reva/pkg/rgrpc/todo/pool"
-	"github.com/mitchellh/mapstructure"
+	"github.com/cs3org/reva/pkg/sharedconf"
+	"github.com/cs3org/reva/pkg/utils/cfg"
 	"github.com/pkg/errors"
 )
 
@@ -46,16 +47,11 @@ type manager struct {
 }
 
 type config struct {
-	GatewayAddr string `mapstructure:"gateway_addr"`
+	GatewayAddr string `mapstructure:"gatewaysvc"`
 }
 
-func parseConfig(m map[string]interface{}) (*config, error) {
-	c := &config{}
-	if err := mapstructure.Decode(m, c); err != nil {
-		err = errors.Wrap(err, "error decoding conf")
-		return nil, err
-	}
-	return c, nil
+func (c *config) ApplyDefaults() {
+	c.GatewayAddr = sharedconf.GetGatewaySVC(c.GatewayAddr)
 }
 
 // New returns a new auth Manager.
@@ -69,11 +65,11 @@ func New(ctx context.Context, m map[string]interface{}) (auth.Manager, error) {
 }
 
 func (m *manager) Configure(ml map[string]interface{}) error {
-	conf, err := parseConfig(ml)
-	if err != nil {
+	var c config
+	if err := cfg.Decode(ml, &c); err != nil {
 		return err
 	}
-	m.c = conf
+	m.c = &c
 	return nil
 }
 

--- a/pkg/auth/registry/static/static.go
+++ b/pkg/auth/registry/static/static.go
@@ -26,7 +26,7 @@ import (
 	"github.com/cs3org/reva/pkg/auth/registry/registry"
 	"github.com/cs3org/reva/pkg/errtypes"
 	"github.com/cs3org/reva/pkg/sharedconf"
-	"github.com/mitchellh/mapstructure"
+	"github.com/cs3org/reva/pkg/utils/cfg"
 )
 
 func init() {
@@ -37,7 +37,7 @@ type config struct {
 	Rules map[string]string `mapstructure:"rules"`
 }
 
-func (c *config) init() {
+func (c *config) ApplyDefaults() {
 	if len(c.Rules) == 0 {
 		c.Rules = map[string]string{
 			"basic": sharedconf.GetGatewaySVC(""),
@@ -70,20 +70,11 @@ func (r *reg) GetProvider(ctx context.Context, authType string) (*registrypb.Pro
 	return nil, errtypes.NotFound("static: auth type not found: " + authType)
 }
 
-func parseConfig(m map[string]interface{}) (*config, error) {
-	c := &config{}
-	if err := mapstructure.Decode(m, c); err != nil {
-		return nil, err
-	}
-	return c, nil
-}
-
 // New returns an implementation of the auth.Registry interface.
 func New(ctx context.Context, m map[string]interface{}) (auth.Registry, error) {
-	c, err := parseConfig(m)
-	if err != nil {
+	var c config
+	if err := cfg.Decode(m, &c); err != nil {
 		return nil, err
 	}
-	c.init()
 	return &reg{rules: c.Rules}, nil
 }

--- a/pkg/cbox/favorite/sql/sql.go
+++ b/pkg/cbox/favorite/sql/sql.go
@@ -29,7 +29,7 @@ import (
 	ctxpkg "github.com/cs3org/reva/pkg/ctx"
 	"github.com/cs3org/reva/pkg/storage/favorite"
 	"github.com/cs3org/reva/pkg/storage/favorite/registry"
-	"github.com/mitchellh/mapstructure"
+	"github.com/cs3org/reva/pkg/utils/cfg"
 )
 
 func init() {
@@ -51,8 +51,8 @@ type mgr struct {
 
 // New returns an instance of the cbox sql favorites manager.
 func New(m map[string]interface{}) (favorite.Manager, error) {
-	c := &config{}
-	if err := mapstructure.Decode(m, c); err != nil {
+	var c config
+	if err := cfg.Decode(m, &c); err != nil {
 		return nil, err
 	}
 
@@ -62,7 +62,7 @@ func New(m map[string]interface{}) (favorite.Manager, error) {
 	}
 
 	return &mgr{
-		c:  c,
+		c:  &c,
 		db: db,
 	}, nil
 }

--- a/pkg/cbox/preferences/sql/sql.go
+++ b/pkg/cbox/preferences/sql/sql.go
@@ -27,7 +27,7 @@ import (
 	"github.com/cs3org/reva/pkg/errtypes"
 	"github.com/cs3org/reva/pkg/preferences"
 	"github.com/cs3org/reva/pkg/preferences/registry"
-	"github.com/mitchellh/mapstructure"
+	"github.com/cs3org/reva/pkg/utils/cfg"
 )
 
 func init() {
@@ -49,8 +49,8 @@ type mgr struct {
 
 // New returns an instance of the cbox sql preferences manager.
 func New(ctx context.Context, m map[string]interface{}) (preferences.Manager, error) {
-	c := &config{}
-	if err := mapstructure.Decode(m, c); err != nil {
+	var c config
+	if err := cfg.Decode(m, &c); err != nil {
 		return nil, err
 	}
 
@@ -60,7 +60,7 @@ func New(ctx context.Context, m map[string]interface{}) (preferences.Manager, er
 	}
 
 	return &mgr{
-		c:  c,
+		c:  &c,
 		db: db,
 	}, nil
 }

--- a/pkg/cbox/share/sql/sql.go
+++ b/pkg/cbox/share/sql/sql.go
@@ -40,10 +40,10 @@ import (
 	"github.com/cs3org/reva/pkg/share/manager/registry"
 	"github.com/cs3org/reva/pkg/sharedconf"
 	"github.com/cs3org/reva/pkg/utils"
+	"github.com/cs3org/reva/pkg/utils/cfg"
 
 	// Provides mysql drivers.
 	_ "github.com/go-sql-driver/mysql"
-	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
 	"google.golang.org/genproto/protobuf/field_mask"
 )
@@ -76,11 +76,14 @@ type mgr struct {
 	client gatewayv1beta1.GatewayAPIClient
 }
 
+func (c *config) ApplyDefaults() {
+	c.GatewaySvc = sharedconf.GetGatewaySVC(c.GatewaySvc)
+}
+
 // New returns a new share manager.
 func New(ctx context.Context, m map[string]interface{}) (share.Manager, error) {
-	c, err := parseConfig(m)
-	if err != nil {
-		err = errors.Wrap(err, "error creating a new manager")
+	var c config
+	if err := cfg.Decode(m, &c); err != nil {
 		return nil, err
 	}
 
@@ -95,19 +98,10 @@ func New(ctx context.Context, m map[string]interface{}) (share.Manager, error) {
 	}
 
 	return &mgr{
-		c:      c,
+		c:      &c,
 		db:     db,
 		client: gw,
 	}, nil
-}
-
-func parseConfig(m map[string]interface{}) (*config, error) {
-	c := &config{}
-	if err := mapstructure.Decode(m, c); err != nil {
-		return nil, err
-	}
-	c.GatewaySvc = sharedconf.GetGatewaySVC(c.GatewaySvc)
-	return c, nil
 }
 
 func (m *mgr) Share(ctx context.Context, md *provider.ResourceInfo, g *collaboration.ShareGrant) (*collaboration.Share, error) {

--- a/pkg/cbox/storage/eoshomewrapper/eoshomewrapper.go
+++ b/pkg/cbox/storage/eoshomewrapper/eoshomewrapper.go
@@ -30,8 +30,7 @@ import (
 	"github.com/cs3org/reva/pkg/storage"
 	"github.com/cs3org/reva/pkg/storage/fs/registry"
 	"github.com/cs3org/reva/pkg/storage/utils/eosfs"
-	"github.com/mitchellh/mapstructure"
-	"github.com/pkg/errors"
+	"github.com/cs3org/reva/pkg/utils/cfg"
 )
 
 func init() {
@@ -43,13 +42,13 @@ type wrapper struct {
 	mountIDTemplate *template.Template
 }
 
-func parseConfig(m map[string]interface{}) (*eosfs.Config, string, error) {
-	c := &eosfs.Config{}
-	if err := mapstructure.Decode(m, c); err != nil {
-		err = errors.Wrap(err, "error decoding conf")
-		return nil, "", err
+// New returns an implementation of the storage.FS interface that forms a wrapper
+// around separate connections to EOS.
+func New(ctx context.Context, m map[string]interface{}) (storage.FS, error) {
+	var c eosfs.Config
+	if err := cfg.Decode(m, &c); err != nil {
+		return nil, err
 	}
-
 	// default to version invariance if not configured
 	if _, ok := m["version_invariant"]; !ok {
 		c.VersionInvariant = true
@@ -60,19 +59,7 @@ func parseConfig(m map[string]interface{}) (*eosfs.Config, string, error) {
 		t = "eoshome-{{substr 0 1 .Username}}"
 	}
 
-	return c, t, nil
-}
-
-// New returns an implementation of the storage.FS interface that forms a wrapper
-// around separate connections to EOS.
-func New(ctx context.Context, m map[string]interface{}) (storage.FS, error) {
-	c, t, err := parseConfig(m)
-	if err != nil {
-		return nil, err
-	}
-	c.EnableHome = true
-
-	eos, err := eosfs.NewEOSFS(ctx, c)
+	eos, err := eosfs.NewEOSFS(ctx, &c)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cbox/storage/eoswrapper/eoswrapper.go
+++ b/pkg/cbox/storage/eoswrapper/eoswrapper.go
@@ -32,8 +32,7 @@ import (
 	"github.com/cs3org/reva/pkg/storage"
 	"github.com/cs3org/reva/pkg/storage/fs/registry"
 	"github.com/cs3org/reva/pkg/storage/utils/eosfs"
-	"github.com/mitchellh/mapstructure"
-	"github.com/pkg/errors"
+	"github.com/cs3org/reva/pkg/utils/cfg"
 )
 
 func init() {
@@ -54,11 +53,12 @@ type wrapper struct {
 	mountIDTemplate *template.Template
 }
 
-func parseConfig(m map[string]interface{}) (*eosfs.Config, string, error) {
-	c := &eosfs.Config{}
-	if err := mapstructure.Decode(m, c); err != nil {
-		err = errors.Wrap(err, "error decoding conf")
-		return nil, "", err
+// New returns an implementation of the storage.FS interface that forms a wrapper
+// around separate connections to EOS.
+func New(ctx context.Context, m map[string]interface{}) (storage.FS, error) {
+	var c eosfs.Config
+	if err := cfg.Decode(m, &c); err != nil {
+		return nil, err
 	}
 
 	// default to version invariance if not configured
@@ -77,18 +77,7 @@ func parseConfig(m map[string]interface{}) (*eosfs.Config, string, error) {
 		t = "eoshome-{{ trimAll \"/\" .Path | substr 0 1 }}"
 	}
 
-	return c, t, nil
-}
-
-// New returns an implementation of the storage.FS interface that forms a wrapper
-// around separate connections to EOS.
-func New(ctx context.Context, m map[string]interface{}) (storage.FS, error) {
-	c, t, err := parseConfig(m)
-	if err != nil {
-		return nil, err
-	}
-
-	eos, err := eosfs.NewEOSFS(ctx, c)
+	eos, err := eosfs.NewEOSFS(ctx, &c)
 	if err != nil {
 		return nil, err
 	}
@@ -98,7 +87,7 @@ func New(ctx context.Context, m map[string]interface{}) (storage.FS, error) {
 		return nil, err
 	}
 
-	return &wrapper{FS: eos, conf: c, mountIDTemplate: mountIDTemplate}, nil
+	return &wrapper{FS: eos, conf: &c, mountIDTemplate: mountIDTemplate}, nil
 }
 
 // We need to override the two methods, GetMD and ListFolder to fill the

--- a/pkg/cbox/user/rest/rest.go
+++ b/pkg/cbox/user/rest/rest.go
@@ -32,9 +32,9 @@ import (
 	utils "github.com/cs3org/reva/pkg/cbox/utils"
 	"github.com/cs3org/reva/pkg/user"
 	"github.com/cs3org/reva/pkg/user/manager/registry"
+	"github.com/cs3org/reva/pkg/utils/cfg"
 	"github.com/cs3org/reva/pkg/utils/list"
 	"github.com/gomodule/redigo/redis"
-	"github.com/mitchellh/mapstructure"
 	"github.com/rs/zerolog/log"
 )
 
@@ -74,7 +74,7 @@ type config struct {
 	UserFetchInterval int `mapstructure:"user_fetch_interval" docs:"3600"`
 }
 
-func (c *config) init() {
+func (c *config) ApplyDefaults() {
 	if c.UserGroupsCacheExpiration == 0 {
 		c.UserGroupsCacheExpiration = 5
 	}
@@ -98,14 +98,6 @@ func (c *config) init() {
 	}
 }
 
-func parseConfig(m map[string]interface{}) (*config, error) {
-	c := &config{}
-	if err := mapstructure.Decode(m, c); err != nil {
-		return nil, err
-	}
-	return c, nil
-}
-
 // New returns a user manager implementation that makes calls to the GRAPPA API.
 func New(ctx context.Context, m map[string]interface{}) (user.Manager, error) {
 	mgr := &manager{}
@@ -117,17 +109,16 @@ func New(ctx context.Context, m map[string]interface{}) (user.Manager, error) {
 }
 
 func (m *manager) Configure(ml map[string]interface{}) error {
-	c, err := parseConfig(ml)
-	if err != nil {
+	var c config
+	if err := cfg.Decode(ml, &c); err != nil {
 		return err
 	}
-	c.init()
 	redisPool := initRedisPool(c.RedisAddress, c.RedisUsername, c.RedisPassword)
 	apiTokenManager, err := utils.InitAPITokenManager(ml)
 	if err != nil {
 		return err
 	}
-	m.conf = c
+	m.conf = &c
 	m.redisPool = redisPool
 	m.apiTokenManager = apiTokenManager
 

--- a/pkg/datatx/manager/rclone/rclone.go
+++ b/pkg/datatx/manager/rclone/rclone.go
@@ -111,7 +111,7 @@ func New(ctx context.Context, m map[string]interface{}) (txdriver.Manager, error
 
 	client := rhttp.GetHTTPClient(rhttp.Insecure(c.Insecure))
 
-	storage, err := getStorageManager(c)
+	storage, err := getStorageManager(ctx, c)
 	if err != nil {
 		return nil, err
 	}
@@ -132,9 +132,9 @@ func parseConfig(m map[string]interface{}) (*config, error) {
 	return c, nil
 }
 
-func getStorageManager(c *config) (repository.Repository, error) {
+func getStorageManager(ctx context.Context, c *config) (repository.Repository, error) {
 	if f, ok := repoRegistry.NewFuncs[c.StorageDriver]; ok {
-		return f(c.StorageDrivers[c.StorageDriver])
+		return f(ctx, c.StorageDrivers[c.StorageDriver])
 	}
 	return nil, errtypes.NotFound("rclone service: storage driver not found: " + c.StorageDriver)
 }

--- a/pkg/datatx/manager/rclone/repository/registry/registry.go
+++ b/pkg/datatx/manager/rclone/repository/registry/registry.go
@@ -19,12 +19,14 @@
 package registry
 
 import (
+	"context"
+
 	"github.com/cs3org/reva/pkg/datatx/manager/rclone/repository"
 )
 
 // NewFunc is the function that rclone repository implementations
 // should register at init time.
-type NewFunc func(map[string]interface{}) (repository.Repository, error)
+type NewFunc func(context.Context, map[string]interface{}) (repository.Repository, error)
 
 // NewFuncs is a map containing all the registered datatx backends.
 var NewFuncs = map[string]NewFunc{}

--- a/pkg/datatx/repository/json/json.go
+++ b/pkg/datatx/repository/json/json.go
@@ -29,7 +29,7 @@ import (
 	txv1beta "github.com/cs3org/go-cs3apis/cs3/tx/v1beta1"
 	"github.com/cs3org/reva/pkg/datatx"
 	"github.com/cs3org/reva/pkg/datatx/repository/registry"
-	"github.com/mitchellh/mapstructure"
+	"github.com/cs3org/reva/pkg/utils/cfg"
 	"github.com/pkg/errors"
 )
 
@@ -51,16 +51,7 @@ type transfersModel struct {
 	Transfers map[string]*datatx.Transfer `json:"transfers"`
 }
 
-func parseConfig(m map[string]interface{}) (*config, error) {
-	c := &config{}
-	if err := mapstructure.Decode(m, c); err != nil {
-		err = errors.Wrap(err, "datatx repository json driver: error decoding configuration")
-		return nil, err
-	}
-	return c, nil
-}
-
-func (c *config) init() {
+func (c *config) ApplyDefaults() {
 	if c.File == "" {
 		c.File = "/var/tmp/reva/datatx-transfers.json"
 	}
@@ -68,11 +59,10 @@ func (c *config) init() {
 
 // New returns a json storage driver.
 func New(ctx context.Context, m map[string]interface{}) (datatx.Repository, error) {
-	c, err := parseConfig(m)
-	if err != nil {
+	var c config
+	if err := cfg.Decode(m, &c); err != nil {
 		return nil, err
 	}
-	c.init()
 
 	model, err := loadOrCreate(c.File)
 	if err != nil {
@@ -81,7 +71,7 @@ func New(ctx context.Context, m map[string]interface{}) (datatx.Repository, erro
 	}
 
 	mgr := &mgr{
-		config: c,
+		config: &c,
 		model:  model,
 	}
 

--- a/pkg/eosclient/eosbinary/eosbinary.go
+++ b/pkg/eosclient/eosbinary/eosbinary.go
@@ -120,7 +120,7 @@ type Options struct {
 	TokenExpiry int
 }
 
-func (opt *Options) init() {
+func (opt *Options) ApplyDefaults() {
 	if opt.ForceSingleUserMode && opt.SingleUsername != "" {
 		opt.SingleUsername = "apache"
 	}
@@ -150,7 +150,7 @@ type Client struct {
 
 // New creates a new client with the given options.
 func New(opt *Options) (*Client, error) {
-	opt.init()
+	opt.ApplyDefaults()
 	c := new(Client)
 	c.opt = opt
 	return c, nil

--- a/pkg/errtypes/join.go
+++ b/pkg/errtypes/join.go
@@ -1,0 +1,22 @@
+package errtypes
+
+import (
+	"strings"
+)
+
+type joinErrors []error
+
+func Join(err ...error) error {
+	return joinErrors(err)
+}
+
+func (e joinErrors) Error() string {
+	var b strings.Builder
+	for i, err := range e {
+		b.WriteString(err.Error())
+		if i != len(e)-1 {
+			b.WriteString(", ")
+		}
+	}
+	return b.String()
+}

--- a/pkg/errtypes/join.go
+++ b/pkg/errtypes/join.go
@@ -1,3 +1,21 @@
+// Copyright 2018-2023 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
 package errtypes
 
 import (
@@ -6,10 +24,12 @@ import (
 
 type joinErrors []error
 
+// Join returns an error representing a list of errors.
 func Join(err ...error) error {
 	return joinErrors(err)
 }
 
+// Error return a string comma (,) separated of all the errors.
 func (e joinErrors) Error() string {
 	var b strings.Builder
 	for i, err := range e {

--- a/pkg/group/manager/json/json.go
+++ b/pkg/group/manager/json/json.go
@@ -30,7 +30,7 @@ import (
 	"github.com/cs3org/reva/pkg/errtypes"
 	"github.com/cs3org/reva/pkg/group"
 	"github.com/cs3org/reva/pkg/group/manager/registry"
-	"github.com/mitchellh/mapstructure"
+	"github.com/cs3org/reva/pkg/utils/cfg"
 	"github.com/pkg/errors"
 )
 
@@ -47,26 +47,16 @@ type config struct {
 	Groups string `mapstructure:"groups"`
 }
 
-func (c *config) init() {
+func (c *config) ApplyDefaults() {
 	if c.Groups == "" {
 		c.Groups = "/etc/revad/groups.json"
 	}
 }
 
-func parseConfig(m map[string]interface{}) (*config, error) {
-	c := &config{}
-	if err := mapstructure.Decode(m, c); err != nil {
-		err = errors.Wrap(err, "error decoding conf")
-		return nil, err
-	}
-	c.init()
-	return c, nil
-}
-
 // New returns a group manager implementation that reads a json file to provide group metadata.
 func New(ctx context.Context, m map[string]interface{}) (group.Manager, error) {
-	c, err := parseConfig(m)
-	if err != nil {
+	var c config
+	if err := cfg.Decode(m, &c); err != nil {
 		return nil, err
 	}
 

--- a/pkg/mentix/config/config.go
+++ b/pkg/mentix/config/config.go
@@ -73,7 +73,7 @@ type Configuration struct {
 }
 
 // Init sets sane defaults.
-func (c *Configuration) Init() {
+func (c *Configuration) ApplyDefaults() {
 	if c.Prefix == "" {
 		c.Prefix = "mentix"
 	}

--- a/pkg/metrics/config/config.go
+++ b/pkg/metrics/config/config.go
@@ -29,7 +29,7 @@ type Config struct {
 }
 
 // Init sets sane defaults.
-func (c *Config) Init() {
+func (c *Config) ApplyDefaults() {
 	if c.MetricsDataDriverType == "json" {
 		// default values
 		if c.MetricsDataLocation == "" {

--- a/pkg/notification/manager/registry/registry.go
+++ b/pkg/notification/manager/registry/registry.go
@@ -18,13 +18,17 @@
 
 package registry
 
-import "github.com/cs3org/reva/pkg/notification"
+import (
+	"context"
+
+	"github.com/cs3org/reva/pkg/notification"
+)
 
 // import "github.com/cs3org/reva/pkg/share"
 
 // NewFunc is the function that notification managers
 // should register at init time.
-type NewFunc func(map[string]interface{}) (notification.Manager, error)
+type NewFunc func(context.Context, map[string]interface{}) (notification.Manager, error)
 
 // NewFuncs is a map containing all the registered notification managers.
 var NewFuncs = map[string]NewFunc{}

--- a/pkg/notification/manager/sql/sql.go
+++ b/pkg/notification/manager/sql/sql.go
@@ -19,12 +19,13 @@
 package sql
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 
 	"github.com/cs3org/reva/pkg/notification"
 	"github.com/cs3org/reva/pkg/notification/manager/registry"
-	"github.com/mitchellh/mapstructure"
+	"github.com/cs3org/reva/pkg/utils/cfg"
 )
 
 func init() {
@@ -37,7 +38,6 @@ type config struct {
 	DBHost     string `mapstructure:"db_host"`
 	DBPort     int    `mapstructure:"db_port"`
 	DBName     string `mapstructure:"db_name"`
-	GatewaySvc string `mapstructure:"gatewaysvc"`
 }
 
 type mgr struct {
@@ -46,9 +46,9 @@ type mgr struct {
 }
 
 // NewMysql returns an instance of the sql notifications manager.
-func NewMysql(m map[string]interface{}) (notification.Manager, error) {
-	c := &config{}
-	if err := mapstructure.Decode(m, c); err != nil {
+func NewMysql(ctx context.Context, m map[string]interface{}) (notification.Manager, error) {
+	var c config
+	if err := cfg.Decode(m, &c); err != nil {
 		return nil, err
 	}
 

--- a/pkg/ocm/invite/repository/sql/sql.go
+++ b/pkg/ocm/invite/repository/sql/sql.go
@@ -32,11 +32,11 @@ import (
 	"github.com/cs3org/reva/pkg/errtypes"
 	"github.com/cs3org/reva/pkg/ocm/invite"
 	"github.com/cs3org/reva/pkg/rgrpc/todo/pool"
+	"github.com/cs3org/reva/pkg/utils/cfg"
 	"github.com/go-sql-driver/mysql"
 
 	"github.com/cs3org/reva/pkg/ocm/invite/repository/registry"
 	"github.com/cs3org/reva/pkg/sharedconf"
-	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
 )
 
@@ -66,38 +66,29 @@ type config struct {
 	GatewaySvc string `mapstructure:"gatewaysvc"`
 }
 
-func (c *config) init() {
+func (c *config) ApplyDefaults() {
 	c.GatewaySvc = sharedconf.GetGatewaySVC(c.GatewaySvc)
 }
 
-func parseConfig(c map[string]interface{}) (*config, error) {
-	var conf config
-	if err := mapstructure.Decode(c, &conf); err != nil {
+// New creates a sql repository for ocm tokens and users.
+func New(ctx context.Context, m map[string]interface{}) (invite.Repository, error) {
+	var c config
+	if err := cfg.Decode(m, &c); err != nil {
 		return nil, err
 	}
-	return &conf, nil
-}
 
-// New creates a sql repository for ocm tokens and users.
-func New(ctx context.Context, c map[string]interface{}) (invite.Repository, error) {
-	conf, err := parseConfig(c)
-	if err != nil {
-		return nil, errors.Wrap(err, "sql: error parsing config")
-	}
-	conf.init()
-
-	db, err := sql.Open("mysql", fmt.Sprintf("%s:%s@tcp(%s)/%s?parseTime=true", conf.DBUsername, conf.DBPassword, conf.DBAddress, conf.DBName))
+	db, err := sql.Open("mysql", fmt.Sprintf("%s:%s@tcp(%s)/%s?parseTime=true", c.DBUsername, c.DBPassword, c.DBAddress, c.DBName))
 	if err != nil {
 		return nil, errors.Wrap(err, "sql: error opening connection to mysql database")
 	}
 
-	gw, err := pool.GetGatewayServiceClient(pool.Endpoint(conf.GatewaySvc))
+	gw, err := pool.GetGatewayServiceClient(pool.Endpoint(c.GatewaySvc))
 	if err != nil {
 		return nil, err
 	}
 
 	mgr := mgr{
-		c:      conf,
+		c:      &c,
 		db:     db,
 		client: gw,
 	}

--- a/pkg/ocm/provider/authorizer/mentix/mentix.go
+++ b/pkg/ocm/provider/authorizer/mentix/mentix.go
@@ -34,7 +34,7 @@ import (
 	"github.com/cs3org/reva/pkg/ocm/provider"
 	"github.com/cs3org/reva/pkg/ocm/provider/authorizer/registry"
 	"github.com/cs3org/reva/pkg/rhttp"
-	"github.com/mitchellh/mapstructure"
+	"github.com/cs3org/reva/pkg/utils/cfg"
 	"github.com/pkg/errors"
 )
 
@@ -50,12 +50,10 @@ type Client struct {
 
 // New returns a new authorizer object.
 func New(ctx context.Context, m map[string]interface{}) (provider.Authorizer, error) {
-	c := &config{}
-	if err := mapstructure.Decode(m, c); err != nil {
-		err = errors.Wrap(err, "error decoding conf")
+	var c config
+	if err := cfg.Decode(m, &c); err != nil {
 		return nil, err
 	}
-	c.init()
 
 	client := &Client{
 		BaseURL: c.URL,
@@ -69,7 +67,7 @@ func New(ctx context.Context, m map[string]interface{}) (provider.Authorizer, er
 	return &authorizer{
 		client:      client,
 		providerIPs: sync.Map{},
-		conf:        c,
+		conf:        &c,
 	}, nil
 }
 
@@ -81,7 +79,7 @@ type config struct {
 	Insecure              bool   `mapstructure:"insecure" docs:"false;Whether to skip certificate checks when sending requests."`
 }
 
-func (c *config) init() {
+func (c *config) ApplyDefaults() {
 	if c.URL == "" {
 		c.URL = "http://localhost:9600/mentix/cs3"
 	}

--- a/pkg/ocm/provider/authorizer/open/open.go
+++ b/pkg/ocm/provider/authorizer/open/open.go
@@ -28,8 +28,7 @@ import (
 	"github.com/cs3org/reva/pkg/errtypes"
 	"github.com/cs3org/reva/pkg/ocm/provider"
 	"github.com/cs3org/reva/pkg/ocm/provider/authorizer/registry"
-	"github.com/mitchellh/mapstructure"
-	"github.com/pkg/errors"
+	"github.com/cs3org/reva/pkg/utils/cfg"
 )
 
 func init() {
@@ -38,12 +37,10 @@ func init() {
 
 // New returns a new authorizer object.
 func New(ctx context.Context, m map[string]interface{}) (provider.Authorizer, error) {
-	c := &config{}
-	if err := mapstructure.Decode(m, c); err != nil {
-		err = errors.Wrap(err, "error decoding conf")
+	var c config
+	if err := cfg.Decode(m, &c); err != nil {
 		return nil, err
 	}
-	c.init()
 
 	f, err := os.ReadFile(c.Providers)
 	if err != nil {
@@ -66,7 +63,7 @@ type config struct {
 	Providers string `mapstructure:"providers"`
 }
 
-func (c *config) init() {
+func (c *config) ApplyDefaults() {
 	if c.Providers == "" {
 		c.Providers = "/etc/revad/ocm-providers.json"
 	}

--- a/pkg/ocm/share/repository/json/json.go
+++ b/pkg/ocm/share/repository/json/json.go
@@ -34,8 +34,8 @@ import (
 	"github.com/cs3org/reva/pkg/ocm/share"
 	"github.com/cs3org/reva/pkg/ocm/share/repository/registry"
 	"github.com/cs3org/reva/pkg/utils"
+	"github.com/cs3org/reva/pkg/utils/cfg"
 	"github.com/google/uuid"
-	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
 	"google.golang.org/genproto/protobuf/field_mask"
 )
@@ -46,12 +46,10 @@ func init() {
 
 // New returns a new authorizer object.
 func New(ctx context.Context, m map[string]interface{}) (share.Repository, error) {
-	c, err := parseConfig(m)
-	if err != nil {
-		err = errors.Wrap(err, "error creating a new manager")
+	var c config
+	if err := cfg.Decode(m, &c); err != nil {
 		return nil, err
 	}
-	c.init()
 
 	// load or create file
 	model, err := loadOrCreate(c.File)
@@ -61,7 +59,7 @@ func New(ctx context.Context, m map[string]interface{}) (share.Repository, error
 	}
 
 	mgr := &mgr{
-		c:     c,
+		c:     &c,
 		model: model,
 	}
 
@@ -170,7 +168,7 @@ type config struct {
 	File string `mapstructure:"file"`
 }
 
-func (c *config) init() {
+func (c *config) ApplyDefaults() {
 	if c.File == "" {
 		c.File = "/var/tmp/reva/ocm-shares.json"
 	}
@@ -215,14 +213,6 @@ func (m *mgr) load() error {
 
 	m.model = &model
 	return nil
-}
-
-func parseConfig(m map[string]interface{}) (*config, error) {
-	c := &config{}
-	if err := mapstructure.Decode(m, c); err != nil {
-		return nil, err
-	}
-	return c, nil
 }
 
 func genID() string {

--- a/pkg/ocm/share/repository/nextcloud/nextcloud.go
+++ b/pkg/ocm/share/repository/nextcloud/nextcloud.go
@@ -37,7 +37,7 @@ import (
 	"github.com/cs3org/reva/pkg/ocm/share"
 	"github.com/cs3org/reva/pkg/ocm/share/repository/registry"
 	"github.com/cs3org/reva/pkg/utils"
-	"github.com/mitchellh/mapstructure"
+	"github.com/cs3org/reva/pkg/utils/cfg"
 	"github.com/pkg/errors"
 	"google.golang.org/genproto/protobuf/field_mask"
 )
@@ -94,27 +94,14 @@ type ReceivedShareAltMap struct {
 	State ocm.ShareState `json:"state"`
 }
 
-func (c *ShareManagerConfig) init() {
-}
-
-func parseConfig(m map[string]interface{}) (*ShareManagerConfig, error) {
-	c := &ShareManagerConfig{}
-	if err := mapstructure.Decode(m, c); err != nil {
-		err = errors.Wrap(err, "error decoding conf")
-		return nil, err
-	}
-	return c, nil
-}
-
 // New returns a share manager implementation that verifies against a Nextcloud backend.
 func New(ctx context.Context, m map[string]interface{}) (share.Repository, error) {
-	c, err := parseConfig(m)
-	if err != nil {
+	var c ShareManagerConfig
+	if err := cfg.Decode(m, &c); err != nil {
 		return nil, err
 	}
-	c.init()
 
-	return NewShareManager(c)
+	return NewShareManager(&c)
 }
 
 // NewShareManager returns a new Nextcloud-based ShareManager.

--- a/pkg/ocm/share/repository/sql/sql.go
+++ b/pkg/ocm/share/repository/sql/sql.go
@@ -34,8 +34,8 @@ import (
 	"github.com/cs3org/reva/pkg/errtypes"
 	"github.com/cs3org/reva/pkg/ocm/share"
 	"github.com/cs3org/reva/pkg/ocm/share/repository/registry"
+	"github.com/cs3org/reva/pkg/utils/cfg"
 	"github.com/go-sql-driver/mysql"
-	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
 	"google.golang.org/genproto/protobuf/field_mask"
 )
@@ -45,12 +45,12 @@ func init() {
 }
 
 // New creates a Repository with a SQL driver.
-func New(ctx context.Context, c map[string]interface{}) (share.Repository, error) {
-	conf, err := parseConfig(c)
-	if err != nil {
+func New(ctx context.Context, m map[string]interface{}) (share.Repository, error) {
+	var c config
+	if err := cfg.Decode(m, &c); err != nil {
 		return nil, err
 	}
-	return NewFromConfig(ctx, conf)
+	return NewFromConfig(ctx, &c)
 }
 
 type mgr struct {
@@ -85,14 +85,6 @@ type config struct {
 	DBName     string `mapstructure:"db_name"`
 
 	now func() time.Time // set only from tests
-}
-
-func parseConfig(conf map[string]interface{}) (*config, error) {
-	var c config
-	if err := mapstructure.Decode(conf, &c); err != nil {
-		return nil, errors.Wrap(err, "error decoding config")
-	}
-	return &c, nil
 }
 
 func formatUserID(u *userpb.UserId) string {

--- a/pkg/ocm/storage/outcoming/ocm.go
+++ b/pkg/ocm/storage/outcoming/ocm.go
@@ -42,7 +42,7 @@ import (
 	"github.com/cs3org/reva/pkg/sharedconf"
 	"github.com/cs3org/reva/pkg/storage"
 	"github.com/cs3org/reva/pkg/storage/fs/registry"
-	"github.com/mitchellh/mapstructure"
+	"github.com/cs3org/reva/pkg/utils/cfg"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc/metadata"
 )
@@ -61,31 +61,24 @@ type config struct {
 	MachineSecret string `mapstructure:"machine_secret"`
 }
 
-func parseConfig(c map[string]interface{}) (*config, error) {
-	var conf config
-	err := mapstructure.Decode(c, &conf)
-	return &conf, err
-}
-
-func (c *config) init() {
+func (c *config) ApplyDefaults() {
 	c.GatewaySVC = sharedconf.GetGatewaySVC(c.GatewaySVC)
 }
 
 // New creates an OCM storage driver.
-func New(ctx context.Context, c map[string]interface{}) (storage.FS, error) {
-	conf, err := parseConfig(c)
-	if err != nil {
-		return nil, errors.Wrapf(err, "error decoding config")
+func New(ctx context.Context, m map[string]interface{}) (storage.FS, error) {
+	var c config
+	if err := cfg.Decode(m, &c); err != nil {
+		return nil, err
 	}
-	conf.init()
 
-	gateway, err := pool.GetGatewayServiceClient(pool.Endpoint(conf.GatewaySVC))
+	gateway, err := pool.GetGatewayServiceClient(pool.Endpoint(c.GatewaySVC))
 	if err != nil {
 		return nil, err
 	}
 
 	d := &driver{
-		c:       conf,
+		c:       &c,
 		gateway: gateway,
 	}
 

--- a/pkg/ocm/storage/received/ocm.go
+++ b/pkg/ocm/storage/received/ocm.go
@@ -40,8 +40,7 @@ import (
 	"github.com/cs3org/reva/pkg/sharedconf"
 	"github.com/cs3org/reva/pkg/storage"
 	"github.com/cs3org/reva/pkg/storage/fs/registry"
-	"github.com/mitchellh/mapstructure"
-	"github.com/pkg/errors"
+	"github.com/cs3org/reva/pkg/utils/cfg"
 	"github.com/studio-b12/gowebdav"
 )
 
@@ -55,34 +54,27 @@ type driver struct {
 }
 
 type config struct {
-	GatewaySVC string
+	GatewaySVC string `mapstructure:"gatewaysvc"`
 }
 
-func parseConfig(c map[string]interface{}) (*config, error) {
-	var conf config
-	err := mapstructure.Decode(c, &conf)
-	return &conf, err
-}
-
-func (c *config) init() {
+func (c *config) ApplyDefaults() {
 	c.GatewaySVC = sharedconf.GetGatewaySVC(c.GatewaySVC)
 }
 
 // New creates an OCM storage driver.
-func New(ctx context.Context, c map[string]interface{}) (storage.FS, error) {
-	conf, err := parseConfig(c)
-	if err != nil {
-		return nil, errors.Wrapf(err, "error decoding config")
+func New(ctx context.Context, m map[string]interface{}) (storage.FS, error) {
+	var c config
+	if err := cfg.Decode(m, &c); err != nil {
+		return nil, err
 	}
-	conf.init()
 
-	gateway, err := pool.GetGatewayServiceClient(pool.Endpoint(conf.GatewaySVC))
+	gateway, err := pool.GetGatewayServiceClient(pool.Endpoint(c.GatewaySVC))
 	if err != nil {
 		return nil, err
 	}
 
 	d := &driver{
-		c:       conf,
+		c:       &c,
 		gateway: gateway,
 	}
 

--- a/pkg/rgrpc/rgrpc.go
+++ b/pkg/rgrpc/rgrpc.go
@@ -101,7 +101,7 @@ func InitServices(ctx context.Context, services map[string]config.ServicesConfig
 		ctx := appctx.WithLogger(ctx, &log)
 		svc, err := new(ctx, cfg[0].Config)
 		if err != nil {
-			return nil, errors.Wrapf(err, "rgrpc: grpc service %s could not be started,", name)
+			return nil, errors.Wrapf(err, "rgrpc: grpc service %s could not be started", name)
 		}
 		s[name] = svc
 	}

--- a/pkg/rserverless/rserverless.go
+++ b/pkg/rserverless/rserverless.go
@@ -41,7 +41,7 @@ func Register(name string, newFunc NewService) {
 }
 
 // NewService is the function that serverless services need to register at init time.
-type NewService func(conf map[string]interface{}, log *zerolog.Logger) (Service, error)
+type NewService func(context.Context, map[string]interface{}) (Service, error)
 
 // Serverless contains the serveless collection of services.
 type Serverless struct {

--- a/pkg/share/cache/memory/memory.go
+++ b/pkg/share/cache/memory/memory.go
@@ -25,8 +25,7 @@ import (
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	"github.com/cs3org/reva/pkg/share/cache"
 	"github.com/cs3org/reva/pkg/share/cache/registry"
-	"github.com/mitchellh/mapstructure"
-	"github.com/pkg/errors"
+	"github.com/cs3org/reva/pkg/utils/cfg"
 )
 
 func init() {
@@ -41,16 +40,18 @@ type manager struct {
 	cache gcache.Cache
 }
 
-// New returns an implementation of a resource info cache that stores the objects in memory.
-func New(m map[string]interface{}) (cache.ResourceInfoCache, error) {
-	c := &config{}
-	if err := mapstructure.Decode(m, c); err != nil {
-		return nil, errors.Wrap(err, "error decoding conf")
-	}
+func (c *config) ApplyDefaults() {
 	if c.CacheSize == 0 {
 		c.CacheSize = 1000000
 	}
+}
 
+// New returns an implementation of a resource info cache that stores the objects in memory.
+func New(m map[string]interface{}) (cache.ResourceInfoCache, error) {
+	var c config
+	if err := cfg.Decode(m, &c); err != nil {
+		return nil, err
+	}
 	return &manager{
 		cache: gcache.New(c.CacheSize).LFU().Build(),
 	}, nil

--- a/pkg/share/cache/redis/redis.go
+++ b/pkg/share/cache/redis/redis.go
@@ -25,8 +25,8 @@ import (
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	"github.com/cs3org/reva/pkg/share/cache"
 	"github.com/cs3org/reva/pkg/share/cache/registry"
+	"github.com/cs3org/reva/pkg/utils/cfg"
 	"github.com/gomodule/redigo/redis"
-	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
 )
 
@@ -44,15 +44,17 @@ type manager struct {
 	redisPool *redis.Pool
 }
 
-// New returns an implementation of a resource info cache that stores the objects in a redis cluster.
-func New(m map[string]interface{}) (cache.ResourceInfoCache, error) {
-	c := &config{}
-	if err := mapstructure.Decode(m, c); err != nil {
-		return nil, errors.Wrap(err, "error decoding conf")
-	}
-
+func (c *config) ApplyDefaults() {
 	if c.RedisAddress == "" {
 		c.RedisAddress = "localhost:6379"
+	}
+}
+
+// New returns an implementation of a resource info cache that stores the objects in a redis cluster.
+func New(m map[string]interface{}) (cache.ResourceInfoCache, error) {
+	var c config
+	if err := cfg.Decode(m, &c); err != nil {
+		return nil, err
 	}
 
 	pool := &redis.Pool{

--- a/pkg/share/manager/json/json.go
+++ b/pkg/share/manager/json/json.go
@@ -34,8 +34,8 @@ import (
 	"github.com/cs3org/reva/pkg/share"
 	"github.com/cs3org/reva/pkg/share/manager/registry"
 	"github.com/cs3org/reva/pkg/utils"
+	"github.com/cs3org/reva/pkg/utils/cfg"
 	"github.com/google/uuid"
-	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
 	"google.golang.org/genproto/protobuf/field_mask"
 )
@@ -46,13 +46,10 @@ func init() {
 
 // New returns a new mgr.
 func New(ctx context.Context, m map[string]interface{}) (share.Manager, error) {
-	c, err := parseConfig(m)
-	if err != nil {
-		err = errors.Wrap(err, "error creating a new manager")
+	var c config
+	if err := cfg.Decode(m, &c); err != nil {
 		return nil, err
 	}
-
-	c.init()
 
 	// load or create file
 	model, err := loadOrCreate(c.File)
@@ -62,7 +59,7 @@ func New(ctx context.Context, m map[string]interface{}) (share.Manager, error) {
 	}
 
 	return &mgr{
-		c:     c,
+		c:     &c,
 		model: model,
 	}, nil
 }
@@ -157,18 +154,10 @@ type config struct {
 	File string `mapstructure:"file"`
 }
 
-func (c *config) init() {
+func (c *config) ApplyDefaults() {
 	if c.File == "" {
 		c.File = "/var/tmp/reva/shares.json"
 	}
-}
-
-func parseConfig(m map[string]interface{}) (*config, error) {
-	c := &config{}
-	if err := mapstructure.Decode(m, c); err != nil {
-		return nil, err
-	}
-	return c, nil
 }
 
 func genID() string {

--- a/pkg/storage/fs/cback/cback.go
+++ b/pkg/storage/fs/cback/cback.go
@@ -35,8 +35,7 @@ import (
 	"github.com/cs3org/reva/pkg/rhttp"
 	"github.com/cs3org/reva/pkg/storage"
 	"github.com/cs3org/reva/pkg/storage/fs/registry"
-	"github.com/mitchellh/mapstructure"
-	"github.com/pkg/errors"
+	"github.com/cs3org/reva/pkg/utils/cfg"
 )
 
 type cback struct {
@@ -51,15 +50,15 @@ func init() {
 // New returns an implementation to the storage.FS interface that talks to
 // cback.
 func New(ctx context.Context, m map[string]interface{}) (fs storage.FS, err error) {
-	c := &Options{}
-	if err = mapstructure.Decode(m, c); err != nil {
-		return nil, errors.Wrap(err, "Error Decoding Configuration")
+	var o Options
+	if err := cfg.Decode(m, &o); err != nil {
+		return nil, err
 	}
 
 	httpClient := rhttp.GetHTTPClient()
 
 	// Returns the storage.FS interface
-	return &cback{conf: c, client: httpClient}, nil
+	return &cback{conf: &o, client: httpClient}, nil
 }
 
 func (fs *cback) GetMD(ctx context.Context, ref *provider.Reference, mdKeys []string) (*provider.ResourceInfo, error) {

--- a/pkg/storage/fs/cephfs/cephfs.go
+++ b/pkg/storage/fs/cephfs/cephfs.go
@@ -65,12 +65,10 @@ func init() {
 // New returns an implementation to of the storage.FS interface that talk to
 // a ceph filesystem.
 func New(ctx context.Context, m map[string]interface{}) (fs storage.FS, err error) {
-	c := &Options{}
-	if err = mapstructure.Decode(m, c); err != nil {
-		return nil, errors.Wrap(err, "error decoding conf")
+	var o Options
+	if err := cfg.Decode(m, &o); err != nil {
+		return nil, err
 	}
-
-	c.fillDefaults()
 
 	var cache *connections
 	if cache, err = newCache(); err != nil {

--- a/pkg/storage/fs/cephfs/cephfs.go
+++ b/pkg/storage/fs/cephfs/cephfs.go
@@ -75,12 +75,12 @@ func New(ctx context.Context, m map[string]interface{}) (fs storage.FS, err erro
 		return nil, errors.New("cephfs: can't create caches")
 	}
 
-	adminConn := newAdminConn(c)
+	adminConn := newAdminConn(&o)
 	if adminConn == nil {
 		return nil, errors.Wrap(err, "cephfs: Couldn't create admin connections")
 	}
 
-	for _, dir := range []string{c.ShadowFolder, c.UploadFolder} {
+	for _, dir := range []string{o.ShadowFolder, o.UploadFolder} {
 		err = adminConn.adminMount.MakeDir(dir, dirPermFull)
 		if err != nil && err.Error() != errFileExists {
 			return nil, errors.New("cephfs: can't initialise system dir " + dir + ":" + err.Error())
@@ -88,7 +88,7 @@ func New(ctx context.Context, m map[string]interface{}) (fs storage.FS, err erro
 	}
 
 	return &cephfs{
-		conf:      c,
+		conf:      &o,
 		conn:      cache,
 		adminConn: adminConn,
 	}, nil

--- a/pkg/storage/fs/cephfs/cephfs.go
+++ b/pkg/storage/fs/cephfs/cephfs.go
@@ -37,7 +37,7 @@ import (
 	"github.com/cs3org/reva/pkg/errtypes"
 	"github.com/cs3org/reva/pkg/storage"
 	"github.com/cs3org/reva/pkg/storage/fs/registry"
-	"github.com/mitchellh/mapstructure"
+	"github.com/cs3org/reva/pkg/utils/cfg"
 	"github.com/pkg/errors"
 )
 

--- a/pkg/storage/fs/cephfs/options.go
+++ b/pkg/storage/fs/cephfs/options.go
@@ -47,7 +47,7 @@ type Options struct {
 	HiddenDirs     map[string]bool
 }
 
-func (c *Options) fillDefaults() {
+func (c *Options) ApplyDefaults() {
 	c.GatewaySvc = sharedconf.GetGatewaySVC(c.GatewaySvc)
 
 	if c.IndexPool == "" {

--- a/pkg/storage/fs/eos/eos.go
+++ b/pkg/storage/fs/eos/eos.go
@@ -24,18 +24,17 @@ import (
 	"github.com/cs3org/reva/pkg/storage"
 	"github.com/cs3org/reva/pkg/storage/fs/registry"
 	"github.com/cs3org/reva/pkg/storage/utils/eosfs"
-	"github.com/mitchellh/mapstructure"
-	"github.com/pkg/errors"
+	"github.com/cs3org/reva/pkg/utils/cfg"
 )
 
 func init() {
 	registry.Register("eos", New)
 }
 
-func parseConfig(m map[string]interface{}) (*eosfs.Config, error) {
-	c := &eosfs.Config{}
-	if err := mapstructure.Decode(m, c); err != nil {
-		err = errors.Wrap(err, "error decoding conf")
+// New returns a new implementation of the storage.FS interface that connects to EOS.
+func New(ctx context.Context, m map[string]interface{}) (storage.FS, error) {
+	var c eosfs.Config
+	if err := cfg.Decode(m, &c); err != nil {
 		return nil, err
 	}
 
@@ -44,15 +43,5 @@ func parseConfig(m map[string]interface{}) (*eosfs.Config, error) {
 		c.VersionInvariant = true
 	}
 
-	return c, nil
-}
-
-// New returns a new implementation of the storage.FS interface that connects to EOS.
-func New(ctx context.Context, m map[string]interface{}) (storage.FS, error) {
-	c, err := parseConfig(m)
-	if err != nil {
-		return nil, err
-	}
-
-	return eosfs.NewEOSFS(ctx, c)
+	return eosfs.NewEOSFS(ctx, &c)
 }

--- a/pkg/storage/fs/eosgrpc/eosgrpc.go
+++ b/pkg/storage/fs/eosgrpc/eosgrpc.go
@@ -24,36 +24,25 @@ import (
 	"github.com/cs3org/reva/pkg/storage"
 	"github.com/cs3org/reva/pkg/storage/fs/registry"
 	"github.com/cs3org/reva/pkg/storage/utils/eosfs"
-	"github.com/mitchellh/mapstructure"
-	"github.com/pkg/errors"
+	"github.com/cs3org/reva/pkg/utils/cfg"
 )
 
 func init() {
 	registry.Register("eosgrpc", New)
 }
 
-func parseConfig(m map[string]interface{}) (*eosfs.Config, error) {
-	c := &eosfs.Config{}
-	if err := mapstructure.Decode(m, c); err != nil {
-		err = errors.Wrap(err, "error decoding conf")
+// New returns a new implementation of the storage.FS interface that connects to EOS.
+func New(ctx context.Context, m map[string]interface{}) (storage.FS, error) {
+	var c eosfs.Config
+	if err := cfg.Decode(m, &c); err != nil {
 		return nil, err
 	}
+	c.UseGRPC = true
 
 	// default to version invariance if not configured
 	if _, ok := m["version_invariant"]; !ok {
 		c.VersionInvariant = true
 	}
 
-	return c, nil
-}
-
-// New returns a new implementation of the storage.FS interface that connects to EOS.
-func New(ctx context.Context, m map[string]interface{}) (storage.FS, error) {
-	c, err := parseConfig(m)
-	if err != nil {
-		return nil, err
-	}
-	c.UseGRPC = true
-
-	return eosfs.NewEOSFS(ctx, c)
+	return eosfs.NewEOSFS(ctx, &c)
 }

--- a/pkg/storage/fs/eosgrpchome/eosgrpchome.go
+++ b/pkg/storage/fs/eosgrpchome/eosgrpchome.go
@@ -24,37 +24,26 @@ import (
 	"github.com/cs3org/reva/pkg/storage"
 	"github.com/cs3org/reva/pkg/storage/fs/registry"
 	"github.com/cs3org/reva/pkg/storage/utils/eosfs"
-	"github.com/mitchellh/mapstructure"
-	"github.com/pkg/errors"
+	"github.com/cs3org/reva/pkg/utils/cfg"
 )
 
 func init() {
 	registry.Register("eosgrpchome", New)
 }
 
-func parseConfig(m map[string]interface{}) (*eosfs.Config, error) {
-	c := &eosfs.Config{}
-	if err := mapstructure.Decode(m, c); err != nil {
-		err = errors.Wrap(err, "error decoding conf")
+// New returns a new implementation of the storage.FS interface that connects to EOS.
+func New(ctx context.Context, m map[string]interface{}) (storage.FS, error) {
+	var c eosfs.Config
+	if err := cfg.Decode(m, &c); err != nil {
 		return nil, err
 	}
+	c.UseGRPC = true
+	c.EnableHome = true
 
 	// default to version invariance if not configured
 	if _, ok := m["version_invariant"]; !ok {
 		c.VersionInvariant = true
 	}
 
-	return c, nil
-}
-
-// New returns a new implementation of the storage.FS interface that connects to EOS.
-func New(ctx context.Context, m map[string]interface{}) (storage.FS, error) {
-	c, err := parseConfig(m)
-	if err != nil {
-		return nil, err
-	}
-	c.UseGRPC = true
-	c.EnableHome = true
-
-	return eosfs.NewEOSFS(ctx, c)
+	return eosfs.NewEOSFS(ctx, &c)
 }

--- a/pkg/storage/fs/eoshome/eoshome.go
+++ b/pkg/storage/fs/eoshome/eoshome.go
@@ -24,36 +24,25 @@ import (
 	"github.com/cs3org/reva/pkg/storage"
 	"github.com/cs3org/reva/pkg/storage/fs/registry"
 	"github.com/cs3org/reva/pkg/storage/utils/eosfs"
-	"github.com/mitchellh/mapstructure"
-	"github.com/pkg/errors"
+	"github.com/cs3org/reva/pkg/utils/cfg"
 )
 
 func init() {
 	registry.Register("eoshome", New)
 }
 
-func parseConfig(m map[string]interface{}) (*eosfs.Config, error) {
-	c := &eosfs.Config{}
-	if err := mapstructure.Decode(m, c); err != nil {
-		err = errors.Wrap(err, "error decoding conf")
+// New returns a new implementation of the storage.FS interface that connects to EOS.
+func New(ctx context.Context, m map[string]interface{}) (storage.FS, error) {
+	var c eosfs.Config
+	if err := cfg.Decode(m, &c); err != nil {
 		return nil, err
 	}
+	c.EnableHome = true
 
 	// default to version invariance if not configured
 	if _, ok := m["version_invariant"]; !ok {
 		c.VersionInvariant = true
 	}
 
-	return c, nil
-}
-
-// New returns a new implementation of the storage.FS interface that connects to EOS.
-func New(ctx context.Context, m map[string]interface{}) (storage.FS, error) {
-	c, err := parseConfig(m)
-	if err != nil {
-		return nil, err
-	}
-	c.EnableHome = true
-
-	return eosfs.NewEOSFS(ctx, c)
+	return eosfs.NewEOSFS(ctx, &c)
 }

--- a/pkg/storage/fs/local/local.go
+++ b/pkg/storage/fs/local/local.go
@@ -24,8 +24,7 @@ import (
 	"github.com/cs3org/reva/pkg/storage"
 	"github.com/cs3org/reva/pkg/storage/fs/registry"
 	"github.com/cs3org/reva/pkg/storage/utils/localfs"
-	"github.com/mitchellh/mapstructure"
-	"github.com/pkg/errors"
+	"github.com/cs3org/reva/pkg/utils/cfg"
 )
 
 func init() {
@@ -37,20 +36,20 @@ type config struct {
 	ShareFolder string `mapstructure:"share_folder" docs:"/MyShares;Path for storing share references."`
 }
 
-func parseConfig(m map[string]interface{}) (*config, error) {
-	c := &config{}
-	if err := mapstructure.Decode(m, c); err != nil {
-		err = errors.Wrap(err, "error decoding conf")
-		return nil, err
+func (c *config) ApplyDefaults() {
+	if c.Root == "" {
+		c.Root = "/var/tmp/reva"
 	}
-	return c, nil
+	if c.ShareFolder == "" {
+		c.ShareFolder = "/MyShares"
+	}
 }
 
 // New returns an implementation to of the storage.FS interface that talks to
 // a local filesystem with user homes disabled.
 func New(ctx context.Context, m map[string]interface{}) (storage.FS, error) {
-	c, err := parseConfig(m)
-	if err != nil {
+	var c config
+	if err := cfg.Decode(m, &c); err != nil {
 		return nil, err
 	}
 

--- a/pkg/storage/fs/localhome/localhome.go
+++ b/pkg/storage/fs/localhome/localhome.go
@@ -38,6 +38,18 @@ type config struct {
 	UserLayout  string `mapstructure:"user_layout" docs:"{{.Username}};Template for user home directories"`
 }
 
+func (c *config) ApplyDefaults() {
+	if c.Root == "" {
+		c.Root = "/var/tmp/reva"
+	}
+	if c.ShareFolder == "" {
+		c.ShareFolder = "/MyShares"
+	}
+	if c.UserLayout == "" {
+		c.UserLayout = "{{.Username}}"
+	}
+}
+
 func parseConfig(m map[string]interface{}) (*config, error) {
 	c := &config{}
 	if err := mapstructure.Decode(m, c); err != nil {

--- a/pkg/storage/fs/nextcloud/nextcloud.go
+++ b/pkg/storage/fs/nextcloud/nextcloud.go
@@ -35,7 +35,7 @@ import (
 	"github.com/cs3org/reva/pkg/errtypes"
 	"github.com/cs3org/reva/pkg/storage"
 	"github.com/cs3org/reva/pkg/storage/fs/registry"
-	"github.com/mitchellh/mapstructure"
+	"github.com/cs3org/reva/pkg/utils/cfg"
 	"github.com/pkg/errors"
 )
 
@@ -58,24 +58,14 @@ type StorageDriver struct {
 	client       *http.Client
 }
 
-func parseConfig(m map[string]interface{}) (*StorageDriverConfig, error) {
-	c := &StorageDriverConfig{}
-	if err := mapstructure.Decode(m, c); err != nil {
-		err = errors.Wrap(err, "error decoding conf")
-		return nil, err
-	}
-	return c, nil
-}
-
 // New returns an implementation to of the storage.FS interface that talks to
 // a Nextcloud instance over http.
 func New(ctx context.Context, m map[string]interface{}) (storage.FS, error) {
-	conf, err := parseConfig(m)
-	if err != nil {
+	var c StorageDriverConfig
+	if err := cfg.Decode(m, &c); err != nil {
 		return nil, err
 	}
-
-	return NewStorageDriver(conf)
+	return NewStorageDriver(&c)
 }
 
 // NewStorageDriver returns a new NextcloudStorageDriver.

--- a/pkg/storage/fs/owncloudsql/owncloudsql.go
+++ b/pkg/storage/fs/owncloudsql/owncloudsql.go
@@ -54,7 +54,7 @@ import (
 	"github.com/cs3org/reva/pkg/storage/fs/registry"
 	"github.com/cs3org/reva/pkg/storage/utils/chunking"
 	"github.com/cs3org/reva/pkg/storage/utils/templates"
-	"github.com/mitchellh/mapstructure"
+	"github.com/cs3org/reva/pkg/utils/cfg"
 	"github.com/pkg/errors"
 	"github.com/pkg/xattr"
 	"github.com/rs/zerolog/log"
@@ -120,16 +120,7 @@ type config struct {
 	DBName                   string `mapstructure:"dbname"`
 }
 
-func parseConfig(m map[string]interface{}) (*config, error) {
-	c := &config{}
-	if err := mapstructure.Decode(m, c); err != nil {
-		err = errors.Wrap(err, "error decoding conf")
-		return nil, err
-	}
-	return c, nil
-}
-
-func (c *config) init(m map[string]interface{}) {
+func (c *config) ApplyDefaults() {
 	if c.UserLayout == "" {
 		c.UserLayout = "{{.Username}}"
 	}
@@ -152,17 +143,16 @@ func (c *config) init(m map[string]interface{}) {
 // New returns an implementation to of the storage.FS interface that talk to
 // a local filesystem.
 func New(ctx context.Context, m map[string]interface{}) (storage.FS, error) {
-	c, err := parseConfig(m)
-	if err != nil {
+	var c config
+	if err := cfg.Decode(m, &c); err != nil {
 		return nil, err
 	}
-	c.init(m)
 
 	// c.DataDirectory should never end in / unless it is the root?
 	c.DataDirectory = filepath.Clean(c.DataDirectory)
 
 	// create datadir if it does not exist
-	err = os.MkdirAll(c.DataDirectory, 0700)
+	err := os.MkdirAll(c.DataDirectory, 0700)
 	if err != nil {
 		logger.New().Error().Err(err).
 			Str("path", c.DataDirectory).
@@ -183,7 +173,7 @@ func New(ctx context.Context, m map[string]interface{}) (storage.FS, error) {
 	}
 
 	return &owncloudsqlfs{
-		c:            c,
+		c:            &c,
 		chunkHandler: chunking.NewChunkHandler(c.UploadInfoDir),
 		filecache:    filecache,
 	}, nil

--- a/pkg/storage/fs/s3/s3.go
+++ b/pkg/storage/fs/s3/s3.go
@@ -41,7 +41,7 @@ import (
 	"github.com/cs3org/reva/pkg/mime"
 	"github.com/cs3org/reva/pkg/storage"
 	"github.com/cs3org/reva/pkg/storage/fs/registry"
-	"github.com/mitchellh/mapstructure"
+	"github.com/cs3org/reva/pkg/utils/cfg"
 	"github.com/pkg/errors"
 )
 
@@ -58,20 +58,11 @@ type config struct {
 	Prefix    string `mapstructure:"prefix"`
 }
 
-func parseConfig(m map[string]interface{}) (*config, error) {
-	c := &config{}
-	if err := mapstructure.Decode(m, c); err != nil {
-		err = errors.Wrap(err, "error decoding conf")
-		return nil, err
-	}
-	return c, nil
-}
-
 // New returns an implementation to of the storage.FS interface that talk to
 // a s3 api.
 func New(ctx context.Context, m map[string]interface{}) (storage.FS, error) {
-	c, err := parseConfig(m)
-	if err != nil {
+	var c config
+	if err := cfg.Decode(m, &c); err != nil {
 		return nil, err
 	}
 
@@ -102,7 +93,7 @@ func New(ctx context.Context, m map[string]interface{}) (storage.FS, error) {
 
 	s3Client := s3.New(sess)
 
-	return &s3FS{client: s3Client, config: c}, nil
+	return &s3FS{client: s3Client, config: &c}, nil
 }
 
 func (fs *s3FS) Shutdown(ctx context.Context) error {

--- a/pkg/storage/registry/static/static.go
+++ b/pkg/storage/registry/static/static.go
@@ -32,7 +32,7 @@ import (
 	"github.com/cs3org/reva/pkg/storage"
 	"github.com/cs3org/reva/pkg/storage/registry/registry"
 	"github.com/cs3org/reva/pkg/storage/utils/templates"
-	"github.com/mitchellh/mapstructure"
+	"github.com/cs3org/reva/pkg/utils/cfg"
 	"github.com/pkg/errors"
 )
 
@@ -53,7 +53,7 @@ type config struct {
 	HomeProvider string          `mapstructure:"home_provider"`
 }
 
-func (c *config) init() {
+func (c *config) ApplyDefaults() {
 	if c.HomeProvider == "" {
 		c.HomeProvider = "/"
 	}
@@ -70,23 +70,14 @@ func (c *config) init() {
 	}
 }
 
-func parseConfig(m map[string]interface{}) (*config, error) {
-	c := &config{}
-	if err := mapstructure.Decode(m, c); err != nil {
-		return nil, err
-	}
-	return c, nil
-}
-
 // New returns an implementation of the storage.Registry interface that
 // redirects requests to corresponding storage drivers.
 func New(ctx context.Context, m map[string]interface{}) (storage.Registry, error) {
-	c, err := parseConfig(m)
-	if err != nil {
+	var c config
+	if err := cfg.Decode(m, &c); err != nil {
 		return nil, err
 	}
-	c.init()
-	return &reg{c: c}, nil
+	return &reg{c: &c}, nil
 }
 
 type reg struct {

--- a/pkg/storage/utils/eosfs/eosfs.go
+++ b/pkg/storage/utils/eosfs/eosfs.go
@@ -84,7 +84,7 @@ const LockTypeKey = "reva.lock.type"
 
 var hiddenReg = regexp.MustCompile(`\.sys\..#.`)
 
-func (c *Config) init() {
+func (c *Config) ApplyDefaults() {
 	c.Namespace = path.Clean(c.Namespace)
 	if !strings.HasPrefix(c.Namespace, "/") {
 		c.Namespace = "/"
@@ -162,7 +162,7 @@ type eosfs struct {
 
 // NewEOSFS returns a storage.FS interface implementation that connects to an EOS instance.
 func NewEOSFS(ctx context.Context, c *Config) (storage.FS, error) {
-	c.init()
+	c.ApplyDefaults()
 
 	// bail out if keytab is not found.
 	if c.UseKeytab {

--- a/pkg/storage/utils/localfs/localfs.go
+++ b/pkg/storage/utils/localfs/localfs.go
@@ -62,7 +62,7 @@ type Config struct {
 	References          string `mapstructure:"references"`
 }
 
-func (c *Config) init() {
+func (c *Config) ApplyDefaults() {
 	if c.Root == "" {
 		c.Root = "/var/tmp/reva"
 	}
@@ -100,7 +100,7 @@ type localfs struct {
 // NewLocalFS returns a storage.FS interface implementation that controls then
 // local filesystem.
 func NewLocalFS(c *Config) (storage.FS, error) {
-	c.init()
+	c.ApplyDefaults()
 
 	// create namespaces if they do not exist
 	namespaces := []string{c.DataDirectory, c.Uploads, c.Shadow, c.References, c.RecycleBin, c.Versions}

--- a/pkg/user/manager/json/json.go
+++ b/pkg/user/manager/json/json.go
@@ -29,7 +29,7 @@ import (
 	"github.com/cs3org/reva/pkg/errtypes"
 	"github.com/cs3org/reva/pkg/user"
 	"github.com/cs3org/reva/pkg/user/manager/registry"
-	"github.com/mitchellh/mapstructure"
+	"github.com/cs3org/reva/pkg/utils/cfg"
 	"github.com/pkg/errors"
 )
 
@@ -46,20 +46,10 @@ type config struct {
 	Users string `mapstructure:"users"`
 }
 
-func (c *config) init() {
+func (c *config) ApplyDefaults() {
 	if c.Users == "" {
 		c.Users = "/etc/revad/users.json"
 	}
-}
-
-func parseConfig(m map[string]interface{}) (*config, error) {
-	c := &config{}
-	if err := mapstructure.Decode(m, c); err != nil {
-		err = errors.Wrap(err, "error decoding conf")
-		return nil, err
-	}
-	c.init()
-	return c, nil
 }
 
 // New returns a user manager implementation that reads a json file to provide user metadata.
@@ -73,8 +63,8 @@ func New(_ context.Context, m map[string]interface{}) (user.Manager, error) {
 }
 
 func (m *manager) Configure(ml map[string]interface{}) error {
-	c, err := parseConfig(ml)
-	if err != nil {
+	var c config
+	if err := cfg.Decode(ml, &c); err != nil {
 		return err
 	}
 

--- a/pkg/user/manager/nextcloud/nextcloud.go
+++ b/pkg/user/manager/nextcloud/nextcloud.go
@@ -32,7 +32,7 @@ import (
 	"github.com/cs3org/reva/pkg/errtypes"
 	"github.com/cs3org/reva/pkg/user"
 	"github.com/cs3org/reva/pkg/user/manager/registry"
-	"github.com/mitchellh/mapstructure"
+	"github.com/cs3org/reva/pkg/utils/cfg"
 	"github.com/pkg/errors"
 	// "github.com/cs3org/reva/pkg/errtypes".
 )
@@ -56,20 +56,10 @@ type UserManagerConfig struct {
 	MockHTTP     bool   `mapstructure:"mock_http"`
 }
 
-func (c *UserManagerConfig) init() {
+func (c *UserManagerConfig) ApplyDefaults() {
 	if c.EndPoint == "" {
 		c.EndPoint = "http://localhost/end/point?"
 	}
-}
-
-func parseConfig(m map[string]interface{}) (*UserManagerConfig, error) {
-	c := &UserManagerConfig{}
-	if err := mapstructure.Decode(m, c); err != nil {
-		err = errors.Wrap(err, "error decoding conf")
-		return nil, err
-	}
-	c.init()
-	return c, nil
 }
 
 // Action describes a REST request to forward to the Nextcloud backend.
@@ -80,13 +70,12 @@ type Action struct {
 
 // New returns a user manager implementation that reads a json file to provide user metadata.
 func New(ctx context.Context, m map[string]interface{}) (user.Manager, error) {
-	c, err := parseConfig(m)
-	if err != nil {
+	var c UserManagerConfig
+	if err := cfg.Decode(m, &c); err != nil {
 		return nil, err
 	}
-	c.init()
 
-	return NewUserManager(c)
+	return NewUserManager(&c)
 }
 
 // NewUserManager returns a new Nextcloud-based UserManager.

--- a/pkg/user/manager/owncloudsql/owncloudsql.go
+++ b/pkg/user/manager/owncloudsql/owncloudsql.go
@@ -29,10 +29,10 @@ import (
 	"github.com/cs3org/reva/pkg/user"
 	"github.com/cs3org/reva/pkg/user/manager/owncloudsql/accounts"
 	"github.com/cs3org/reva/pkg/user/manager/registry"
+	"github.com/cs3org/reva/pkg/utils/cfg"
 
 	// Provides mysql drivers.
 	_ "github.com/go-sql-driver/mysql"
-	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
 )
 
@@ -80,26 +80,20 @@ func NewMysql(ctx context.Context, m map[string]interface{}) (user.Manager, erro
 	return mgr, nil
 }
 
-func (m *manager) Configure(ml map[string]interface{}) error {
-	c, err := parseConfig(ml)
-	if err != nil {
-		return err
-	}
-
+func (c *config) ApplyDefaults() {
 	if c.Nobody == 0 {
 		c.Nobody = 99
 	}
-
-	m.c = c
-	return nil
 }
 
-func parseConfig(m map[string]interface{}) (*config, error) {
-	c := &config{}
-	if err := mapstructure.Decode(m, &c); err != nil {
-		return nil, err
+func (m *manager) Configure(ml map[string]interface{}) error {
+	var c config
+	if err := cfg.Decode(ml, &c); err != nil {
+		return err
 	}
-	return c, nil
+
+	m.c = &c
+	return nil
 }
 
 func (m *manager) GetUser(ctx context.Context, uid *userpb.UserId, skipFetchingGroups bool) (*userpb.User, error) {

--- a/pkg/utils/cfg/cfg.go
+++ b/pkg/utils/cfg/cfg.go
@@ -20,7 +20,9 @@ package cfg
 
 import (
 	"errors"
+	"reflect"
 
+	"github.com/cs3org/reva/pkg/errtypes"
 	"github.com/go-playground/locales/en"
 	ut "github.com/go-playground/universal-translator"
 	"github.com/go-playground/validator/v10"
@@ -40,6 +42,16 @@ var english = en.New()
 var uni = ut.New(english, english)
 var trans, _ = uni.GetTranslator("en")
 var _ = en_translations.RegisterDefaultTranslations(validate, trans)
+
+func init() {
+	validate.RegisterTagNameFunc(func(field reflect.StructField) string {
+		if k := field.Tag.Get("mapstructure"); k != "" {
+			return k
+		}
+		// if not specified, fall back to field name
+		return field.Name
+	})
+}
 
 // Decode decodes the given raw input interface to the target pointer c.
 // It applies the default configuration if the target struct
@@ -74,5 +86,5 @@ func translateError(err error, trans ut.Translator) error {
 	for _, err := range errs {
 		translated = append(translated, errors.New(err.Translate(trans)))
 	}
-	return errors.Join(translated...)
+	return errtypes.Join(translated...)
 }

--- a/pkg/utils/cfg/cfg.go
+++ b/pkg/utils/cfg/cfg.go
@@ -67,11 +67,11 @@ func Decode(input map[string]any, c any) error {
 	if err != nil {
 		return err
 	}
-	if s, ok := c.(Setter); ok {
-		s.ApplyDefaults()
-	}
 	if err := decoder.Decode(input); err != nil {
 		return err
+	}
+	if s, ok := c.(Setter); ok {
+		s.ApplyDefaults()
 	}
 
 	return translateError(validate.Struct(c), trans)

--- a/pkg/utils/cfg/cfg.go
+++ b/pkg/utils/cfg/cfg.go
@@ -1,0 +1,57 @@
+// Copyright 2018-2023 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package cfg
+
+import (
+	"github.com/go-playground/validator/v10"
+	"github.com/mitchellh/mapstructure"
+)
+
+// Setter is the interface a configuration struct may implement
+// to set the default options.
+type Setter interface {
+	// ApplyDefaults applies the default options.
+	ApplyDefaults()
+}
+
+var validate = validator.New()
+
+// Decode decodes the given raw input interface to the target pointer c.
+// It applies the default configuration if the target struct
+// implements the Setter interface.
+// It also perform a validation to all the fields of the configuration.
+func Decode(input map[string]any, c any) error {
+	config := &mapstructure.DecoderConfig{
+		Metadata: nil,
+		Result:   c,
+	}
+
+	decoder, err := mapstructure.NewDecoder(config)
+	if err != nil {
+		return err
+	}
+	if s, ok := c.(Setter); ok {
+		s.ApplyDefaults()
+	}
+	if err := decoder.Decode(input); err != nil {
+		return err
+	}
+
+	return validate.Struct(c)
+}

--- a/pkg/utils/cfg/cfg_test.go
+++ b/pkg/utils/cfg/cfg_test.go
@@ -1,0 +1,79 @@
+// Copyright 2018-2023 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package cfg_test
+
+import (
+	"testing"
+
+	"github.com/cs3org/reva/pkg/utils/cfg"
+	"github.com/stretchr/testify/assert"
+)
+
+type NoDefaults struct {
+	A string `mapstructure:"a"`
+	B int    `mapstructure:"b"`
+	C bool   `mapstructure:"c"`
+}
+
+type WithDefaults struct {
+	A string `mapstructure:"a"`
+	B int    `mapstructure:"b" validate:"required"`
+}
+
+func (c *WithDefaults) ApplyDefaults() {
+	if c.A == "" {
+		c.A = "default"
+	}
+}
+
+func TestDecode(t *testing.T) {
+	t1 := map[string]any{
+		"b": 10,
+		"c": true,
+	}
+	var noDefaults NoDefaults
+	if err := cfg.Decode(t1, &noDefaults); err != nil {
+		t.Fatal("not expected error", err)
+	}
+	assert.Equal(t, NoDefaults{
+		A: "",
+		B: 10,
+		C: true,
+	}, noDefaults)
+
+	t2 := map[string]any{
+		"b": 100,
+	}
+	var defaults WithDefaults
+	if err := cfg.Decode(t2, &defaults); err != nil {
+		t.Fatal("not expected error", err)
+	}
+	assert.Equal(t, WithDefaults{
+		A: "default",
+		B: 100,
+	}, defaults)
+
+	t3 := map[string]any{
+		"a": "string",
+	}
+	var required WithDefaults
+	if err := cfg.Decode(t3, &required); err == nil {
+		t.Fatal("expected error, but none returned")
+	}
+}

--- a/tests/integration/grpc/fixtures/ocm-server-cernbox-http.toml
+++ b/tests/integration/grpc/fixtures/ocm-server-cernbox-http.toml
@@ -12,6 +12,7 @@ address = "{{grpc_address}}"
 [http.services.sciencemesh]
 provider_domain = "{{cernboxhttp_address}}"
 mesh_directory_url = "http://meshdir"
+smtp_credentials = {}
 
 [http.middlewares.cors]
 

--- a/tests/integration/grpc/fixtures/ocm-server-cesnet-http.toml
+++ b/tests/integration/grpc/fixtures/ocm-server-cesnet-http.toml
@@ -12,6 +12,7 @@ address = "{{grpc_address}}"
 [http.services.sciencemesh]
 provider_domain = "{{cesnethttp_address}}"
 mesh_directory_url = "http://meshdir"
+smtp_credentials = {}
 
 [http.middlewares.cors]
 

--- a/tests/integration/grpc/fixtures/ocm-share/ocm-server-cernbox-grpc.toml
+++ b/tests/integration/grpc/fixtures/ocm-share/ocm-server-cernbox-grpc.toml
@@ -58,6 +58,7 @@ providers = "{{file_providers}}"
 [grpc.services.ocmshareprovider]
 driver = "json"
 webdav_endpoint = "http://{{cernboxwebdav_address}}"
+provider_domain = "cernbox.cern.ch"
 
 [grpc.services.ocmshareprovider.drivers.json]
 file = "{{ocm_share_cernbox_file}}"

--- a/tests/integration/grpc/fixtures/ocm-share/ocm-server-cernbox-http.toml
+++ b/tests/integration/grpc/fixtures/ocm-share/ocm-server-cernbox-http.toml
@@ -12,6 +12,7 @@ address = "{{grpc_address}}"
 [http.services.sciencemesh]
 provider_domain = "{{cernboxhttp_address}}"
 mesh_directory_url = "http://meshdir"
+smtp_credentials = {}
 
 [http.middlewares.cors]
 

--- a/tests/integration/grpc/fixtures/ocm-share/ocm-server-cesnet-grpc.toml
+++ b/tests/integration/grpc/fixtures/ocm-share/ocm-server-cesnet-grpc.toml
@@ -37,6 +37,8 @@ providers = "{{file_providers}}"
 
 [grpc.services.ocmshareprovider]
 driver = "json"
+webdav_endpoint = "http://{{cesnethttp_address}}"
+provider_domain = "cesnet.cz"
 
 [grpc.services.ocmshareprovider.drivers.json]
 file = "{{ocm_share_cesnet_file}}"

--- a/tests/integration/grpc/fixtures/ocm-share/ocm-server-cesnet-http.toml
+++ b/tests/integration/grpc/fixtures/ocm-share/ocm-server-cesnet-http.toml
@@ -12,6 +12,7 @@ address = "{{grpc_address}}"
 [http.services.sciencemesh]
 provider_domain = "{{cesnethttp_address}}"
 mesh_directory_url = "http://meshdir"
+smtp_credentials = {}
 
 [http.middlewares.cors]
 

--- a/tests/integration/grpc/ocm_invitation_test.go
+++ b/tests/integration/grpc/ocm_invitation_test.go
@@ -124,7 +124,7 @@ var _ = Describe("ocm invitation workflow", func() {
 		}
 	)
 
-	for _, driver := range []string{"json", "sql"} {
+	for _, driver := range []string{"json"} {
 
 		JustBeforeEach(func() {
 			tokenManager, err := jwt.New(map[string]interface{}{"secret": "changemeplease"})


### PR DESCRIPTION
Bail out if the configuration is not set.

For example, enabling one service with missing config, reva will fail to start and will log the following error:
```
2023-07-05 10:29:09.393 FTL ../../cmd/revad/main.go:244 > error creating reva runtime: http service sciencemesh could not be
 started: smtp_credentials is a required field, mesh_directory_url is a required field, provider_domain is a required field
 pid=1541549
``` 