### PR TITLE
[WIP] Do not track files as empty files

### DIFF
--- a/pkg/storage/utils/decomposedfs/node/node.go
+++ b/pkg/storage/utils/decomposedfs/node/node.go
@@ -542,9 +542,8 @@ func (n *Node) SetMtimeString(mtime string) error {
 
 // SetMtime sets the mtime and atime of a node
 func (n *Node) SetMtime(mtime time.Time) error {
-	nodePath := n.InternalPath()
 	// updating mtime also updates atime
-	return os.Chtimes(nodePath, mtime, mtime)
+	return os.Chtimes(n.lu.MetadataBackend().MetadataPath(n.InternalPath()), mtime, mtime)
 }
 
 // SetEtag sets the temporary etag of a node if it differs from the current etag
@@ -888,7 +887,7 @@ func (n *Node) GetTMTime(ctx context.Context) (time.Time, error) {
 
 // GetMTime reads the mtime from disk
 func (n *Node) GetMTime() (time.Time, error) {
-	fi, err := os.Lstat(n.InternalPath())
+	fi, err := os.Stat(n.lu.MetadataBackend().MetadataPath(n.InternalPath()))
 	if err != nil {
 		return time.Time{}, err
 	}

--- a/pkg/storage/utils/decomposedfs/spaces.go
+++ b/pkg/storage/utils/decomposedfs/spaces.go
@@ -925,6 +925,7 @@ func (fs *Decomposedfs) storageSpaceFromNode(ctx context.Context, n *node.Node, 
 			Id: n.Owner(),
 		}
 	}
+	metadataPath := fs.lu.MetadataBackend().MetadataPath(n.InternalPath())
 
 	// we set the space mtime to the root item mtime
 	// override the stat mtime with a tmtime if it is present
@@ -936,7 +937,7 @@ func (fs *Decomposedfs) storageSpaceFromNode(ctx context.Context, n *node.Node, 
 			Seconds: uint64(un / 1000000000),
 			Nanos:   uint32(un % 1000000000),
 		}
-	} else if fi, err := os.Stat(n.InternalPath()); err == nil {
+	} else if fi, err := os.Stat(metadataPath); err == nil {
 		// fall back to stat mtime
 		tmtime = fi.ModTime()
 		un := fi.ModTime().UnixNano()
@@ -1002,7 +1003,7 @@ func (fs *Decomposedfs) storageSpaceFromNode(ctx context.Context, n *node.Node, 
 	}
 
 	// FIXME this reads remaining disk size from the local disk, not the blobstore
-	remaining, err := node.GetAvailableSize(n.InternalPath())
+	remaining, err := node.GetAvailableSize(metadataPath)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Currently, the messagepack metadata uses an empty file to track the mtime of a node. The rest of the data is kept in a `.mpk` file. This requires creating three files when a new file is uploaded:
1. the empty file
2. the `.mlock` file to prevent other processes to mlock the file
3. creating a temp file and then renaming it to the `.mpk` file

Furthermore, AFAICT we are leaking file handdles because we never close the empty node files after os.Creating them:
```
_, err := os.Create(nodePath) // the file handtle is just ignored?
```

We should be able to get rid of the empty node file, but we may have to take into account the metadata backend.

maybe we can just always use the Metadata path instead of the InternalPath ... but a bigger challenge is handling trashed files because we have to not only move them to the trash, but when using the messagepack backend the directory with the children ... hm ... or we leave that in the tree? the mpk file is gone ...

urgh its too late already ....
