### PR TITLE
Micro: Add TraceProvider injector.

### DIFF
--- a/changelog/unreleased/external-traceprovider-micro.md
+++ b/changelog/unreleased/external-traceprovider-micro.md
@@ -1,0 +1,5 @@
+Enhancement: Allow to use external trace provider in micro service
+
+Allow injecting of external trace provider in the micro service instead of forcing the initialisation of an internal one.
+
+https://github.com/cs3org/reva/pull/4040

--- a/pkg/micro/ocdav/option.go
+++ b/pkg/micro/ocdav/option.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cs3org/reva/v2/pkg/storage/favorite"
 	"github.com/rs/zerolog"
 	"go-micro.dev/v4/broker"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // Option defines a single option function.
@@ -53,6 +54,8 @@ type Options struct {
 	TracingExporter  string
 	TracingCollector string
 	TracingEndpoint  string
+
+	TraceProvider trace.TracerProvider
 
 	MetricsEnabled   bool
 	MetricsNamespace string
@@ -231,6 +234,13 @@ func WithTracingInsecure() Option {
 func WithTracingExporter(exporter string) Option {
 	return func(o *Options) {
 		o.TracingExporter = exporter
+	}
+}
+
+// WithTraceProvider option
+func WithTraceProvider(provider trace.TracerProvider) Option {
+	return func(o *Options) {
+		o.TraceProvider = provider
 	}
 }
 


### PR DESCRIPTION
This allows to inject a TraceProvider into the service constructor,
instead of letting the service constructor create one.