### PR TITLE
Prevent 0-byte messagepack metadata files

### DIFF
--- a/Dockerfile.revad-ceph
+++ b/Dockerfile.revad-ceph
@@ -18,7 +18,7 @@
 
 FROM quay.io/ceph/ceph:v16
 
-RUN dnf update -y && dnf install -y \
+RUN dnf update --exclude=ceph-iscsi -y && dnf install -y \
   git \
   gcc \
   make \

--- a/changelog/unreleased/exclude-ceph-iscsi.md
+++ b/changelog/unreleased/exclude-ceph-iscsi.md
@@ -1,0 +1,7 @@
+Bugfix: Temporarily exclude ceph-iscsi when building revad-ceph image
+
+Due to `Package ceph-iscsi-3.6-1.el8.noarch.rpm is not signed` error when
+building the revad-ceph docker image, the package `ceph-iscsi` has been excluded from the dnf update.
+It will be included again once the pkg will be signed again.
+
+https://github.com/cs3org/reva/pull/4032

--- a/changelog/unreleased/fix-0-byte-msgpack.md
+++ b/changelog/unreleased/fix-0-byte-msgpack.md
@@ -2,4 +2,5 @@ Bugfix: fix writing 0 byte msgpack metadata
 
 File metadata is now written atomically to be more resilient during timeouts
 
+https://github.com/cs3org/reva/pull/4034
 https://github.com/cs3org/reva/pull/4033

--- a/changelog/unreleased/fix-0-byte-msgpack.md
+++ b/changelog/unreleased/fix-0-byte-msgpack.md
@@ -1,0 +1,5 @@
+Bugfix: fix writing 0 byte msgpack metadata
+
+File metadata is now written atomically to be more resilient during timeouts
+
+https://github.com/cs3org/reva/pull/4033

--- a/changelog/unreleased/fix-0-byte-msgpack.md
+++ b/changelog/unreleased/fix-0-byte-msgpack.md
@@ -2,5 +2,5 @@ Bugfix: fix writing 0 byte msgpack metadata
 
 File metadata is now written atomically to be more resilient during timeouts
 
-https://github.com/cs3org/reva/pull/4034
+https://github.com/cs3org/reva/pull/4043
 https://github.com/cs3org/reva/pull/4033

--- a/go.mod
+++ b/go.mod
@@ -138,6 +138,7 @@ require (
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1 // indirect
+	github.com/google/renameio/v2 v2.0.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.13.0 // indirect
 	github.com/hashicorp/consul/api v1.15.2 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -781,6 +781,8 @@ github.com/google/pprof v0.0.0-20210609004039-a478d1d731e9/go.mod h1:kpwsk12EmLe
 github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1 h1:K6RDEckDVWvDI9JAJYCmNdQXq6neHJOYx3V6jnqNEec=
 github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
+github.com/google/renameio/v2 v2.0.0 h1:UifI23ZTGY8Tt29JbYFiuyIU3eX+RNFtUwefq9qAhxg=
+github.com/google/renameio/v2 v2.0.0/go.mod h1:BtmJXm5YlszgC+TD4HOEEUFgkJP3nLxehU6hfe7jRt4=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/pkg/storage/utils/decomposedfs/metadata/messagepack_backend.go
+++ b/pkg/storage/utils/decomposedfs/metadata/messagepack_backend.go
@@ -19,7 +19,9 @@
 package metadata
 
 import (
+	"errors"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -27,6 +29,7 @@ import (
 	"time"
 
 	"github.com/cs3org/reva/v2/pkg/storage/cache"
+	"github.com/google/renameio/v2"
 	"github.com/pkg/xattr"
 	"github.com/rogpeppe/go-internal/lockedfile"
 	"github.com/shamaton/msgpack/v2"
@@ -130,57 +133,55 @@ func (b MessagePackBackend) saveAttributes(path string, setAttribs map[string][]
 		f   readWriteCloseSeekTruncater
 		err error
 	)
+
+	lockPath := b.LockfilePath(path)
 	metaPath := b.MetadataPath(path)
 	if acquireLock {
-		f, err = lockedfile.OpenFile(metaPath, os.O_RDWR|os.O_CREATE, 0600)
-	} else {
-		f, err = os.OpenFile(metaPath, os.O_RDWR|os.O_CREATE, 0600)
+		f, err = lockedfile.OpenFile(lockPath, os.O_RDWR|os.O_CREATE, 0600)
+		defer func() { _ = f.Close() }()
 	}
 	if err != nil {
 		return err
 	}
-	defer f.Close()
 
 	// Invalidate cache early
 	_ = b.metaCache.RemoveMetadata(b.cacheKey(path))
 
 	// Read current state
-	msgBytes, err := io.ReadAll(f)
-	if err != nil {
-		return err
-	}
+	var msgBytes []byte
+	msgBytes, err = os.ReadFile(metaPath)
 	attribs := map[string][]byte{}
-	if len(msgBytes) > 0 {
+	switch {
+	case err != nil:
+		if !errors.Is(err, fs.ErrNotExist) {
+			return err
+		}
+	case len(msgBytes) == 0:
+		// ugh. an empty file? bail out
+		return errors.New("encountered empty metadata file")
+	default:
+		// only unmarshal if we read data
 		err = msgpack.Unmarshal(msgBytes, &attribs)
 		if err != nil {
 			return err
 		}
 	}
 
-	// set new metadata
+	// prepare metadata
 	for key, val := range setAttribs {
 		attribs[key] = val
 	}
 	for _, key := range deleteAttribs {
 		delete(attribs, key)
 	}
-
-	// Truncate file
-	_, err = f.Seek(0, io.SeekStart)
-	if err != nil {
-		return err
-	}
-	err = f.Truncate(0)
+	var d []byte
+	d, err = msgpack.Marshal(attribs)
 	if err != nil {
 		return err
 	}
 
-	// Write new metadata to file
-	d, err := msgpack.Marshal(attribs)
-	if err != nil {
-		return err
-	}
-	_, err = f.Write(d)
+	// overwrite file atomically
+	err = renameio.WriteFile(metaPath, d, 0600)
 	if err != nil {
 		return err
 	}
@@ -196,9 +197,11 @@ func (b MessagePackBackend) loadAttributes(path string, source io.Reader) (map[s
 	}
 
 	metaPath := b.MetadataPath(path)
+	var msgBytes []byte
+
 	if source == nil {
-		source, err = lockedfile.Open(metaPath)
 		// // No cached entry found. Read from storage and store in cache
+		source, err = os.Open(metaPath)
 		if err != nil {
 			if os.IsNotExist(err) {
 				// some of the caller rely on ENOTEXISTS to be returned when the
@@ -211,10 +214,12 @@ func (b MessagePackBackend) loadAttributes(path string, source io.Reader) (map[s
 				return attribs, nil // no attributes set yet
 			}
 		}
-		defer source.(*lockedfile.File).Close()
+		msgBytes, err = io.ReadAll(source)
+		source.(*os.File).Close()
+	} else {
+		msgBytes, err = io.ReadAll(source)
 	}
 
-	msgBytes, err := io.ReadAll(source)
 	if err != nil {
 		return nil, err
 	}
@@ -234,7 +239,9 @@ func (b MessagePackBackend) loadAttributes(path string, source io.Reader) (map[s
 }
 
 // IsMetaFile returns whether the given path represents a meta file
-func (MessagePackBackend) IsMetaFile(path string) bool { return strings.HasSuffix(path, ".mpk") }
+func (MessagePackBackend) IsMetaFile(path string) bool {
+	return strings.HasSuffix(path, ".mpk") || strings.HasSuffix(path, ".mpk.lock")
+}
 
 // Purge purges the data of a given path
 func (b MessagePackBackend) Purge(path string) error {
@@ -264,6 +271,9 @@ func (b MessagePackBackend) Rename(oldPath, newPath string) error {
 
 // MetadataPath returns the path of the file holding the metadata for the given path
 func (MessagePackBackend) MetadataPath(path string) string { return path + ".mpk" }
+
+// LockfilePath returns the path of the lock file
+func (MessagePackBackend) LockfilePath(path string) string { return path + ".mpk.lock" }
 
 func (b MessagePackBackend) cacheKey(path string) string {
 	// rootPath is guaranteed to have no trailing slash

--- a/pkg/storage/utils/decomposedfs/metadata/messagepack_backend.go
+++ b/pkg/storage/utils/decomposedfs/metadata/messagepack_backend.go
@@ -240,7 +240,7 @@ func (b MessagePackBackend) loadAttributes(path string, source io.Reader) (map[s
 
 // IsMetaFile returns whether the given path represents a meta file
 func (MessagePackBackend) IsMetaFile(path string) bool {
-	return strings.HasSuffix(path, ".mpk") || strings.HasSuffix(path, ".mpk.lock")
+	return strings.HasSuffix(path, ".mpk") || strings.HasSuffix(path, ".mlock")
 }
 
 // Purge purges the data of a given path

--- a/pkg/storage/utils/decomposedfs/metadata/messagepack_backend.go
+++ b/pkg/storage/utils/decomposedfs/metadata/messagepack_backend.go
@@ -273,7 +273,7 @@ func (b MessagePackBackend) Rename(oldPath, newPath string) error {
 func (MessagePackBackend) MetadataPath(path string) string { return path + ".mpk" }
 
 // LockfilePath returns the path of the lock file
-func (MessagePackBackend) LockfilePath(path string) string { return path + ".mpk.lock" }
+func (MessagePackBackend) LockfilePath(path string) string { return path + ".mlock" }
 
 func (b MessagePackBackend) cacheKey(path string) string {
 	// rootPath is guaranteed to have no trailing slash

--- a/pkg/storage/utils/decomposedfs/metadata/metadata.go
+++ b/pkg/storage/utils/decomposedfs/metadata/metadata.go
@@ -42,6 +42,7 @@ type Backend interface {
 	Rename(oldPath, newPath string) error
 	IsMetaFile(path string) bool
 	MetadataPath(path string) string
+	LockfilePath(path string) string
 
 	AllWithLockedSource(path string, source io.Reader) (map[string][]byte, error)
 }
@@ -87,6 +88,9 @@ func (NullBackend) Rename(oldPath, newPath string) error { return errUnconfigure
 
 // MetadataPath returns the path of the file holding the metadata for the given path
 func (NullBackend) MetadataPath(path string) string { return "" }
+
+// LockfilePath returns the path of the lock file
+func (NullBackend) LockfilePath(path string) string { return "" }
 
 // AllWithLockedSource reads all extended attributes from the given reader
 // The path argument is used for storing the data in the cache

--- a/pkg/storage/utils/decomposedfs/metadata/metadata_test.go
+++ b/pkg/storage/utils/decomposedfs/metadata/metadata_test.go
@@ -30,9 +30,8 @@ import (
 
 var _ = Describe("Backend", func() {
 	var (
-		tmpdir   string
-		file     string
-		metafile string
+		tmpdir string
+		file   string
 
 		backend metadata.Backend
 	)
@@ -45,9 +44,6 @@ var _ = Describe("Backend", func() {
 
 	JustBeforeEach(func() {
 		file = path.Join(tmpdir, "file")
-		metafile = backend.MetadataPath(file)
-		_, err := os.Create(metafile)
-		Expect(err).ToNot(HaveOccurred())
 	})
 
 	AfterEach(func() {
@@ -146,10 +142,9 @@ var _ = Describe("Backend", func() {
 				Expect(v["bar"]).To(Equal([]byte("baz")))
 			})
 
-			It("returns an empty map", func() {
-				v, err := backend.All(file)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(v).To(Equal(map[string][]byte{}))
+			It("fails when the metafile does not exist", func() {
+				_, err := backend.All(file)
+				Expect(err).To(HaveOccurred())
 			})
 		})
 
@@ -164,10 +159,9 @@ var _ = Describe("Backend", func() {
 				Expect(v).To(ConsistOf("foo", "bar"))
 			})
 
-			It("returns an empty list", func() {
-				v, err := backend.List(file)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(v).To(Equal([]string{}))
+			It("fails when the metafile does not exist", func() {
+				_, err := backend.List(file)
+				Expect(err).To(HaveOccurred())
 			})
 		})
 

--- a/pkg/storage/utils/decomposedfs/metadata/xattrs_backend.go
+++ b/pkg/storage/utils/decomposedfs/metadata/xattrs_backend.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 
 	"github.com/cs3org/reva/v2/pkg/storage/utils/filelocks"
 	"github.com/pkg/errors"
@@ -155,7 +156,7 @@ func (XattrsBackend) Remove(filePath string, key string) (err error) {
 }
 
 // IsMetaFile returns whether the given path represents a meta file
-func (XattrsBackend) IsMetaFile(path string) bool { return false }
+func (XattrsBackend) IsMetaFile(path string) bool { return strings.HasSuffix(path, ".meta.lock") }
 
 // Purge purges the data of a given path
 func (XattrsBackend) Purge(path string) error { return nil }
@@ -165,6 +166,9 @@ func (XattrsBackend) Rename(oldPath, newPath string) error { return nil }
 
 // MetadataPath returns the path of the file holding the metadata for the given path
 func (XattrsBackend) MetadataPath(path string) string { return path }
+
+// LockfilePath returns the path of the lock file
+func (XattrsBackend) LockfilePath(path string) string { return path + ".meta.lock" }
 
 func cleanupLockfile(f *lockedfile.File) {
 	_ = f.Close()

--- a/pkg/storage/utils/decomposedfs/metadata/xattrs_backend.go
+++ b/pkg/storage/utils/decomposedfs/metadata/xattrs_backend.go
@@ -168,7 +168,7 @@ func (XattrsBackend) Rename(oldPath, newPath string) error { return nil }
 func (XattrsBackend) MetadataPath(path string) string { return path }
 
 // LockfilePath returns the path of the lock file
-func (XattrsBackend) LockfilePath(path string) string { return path + ".meta.lock" }
+func (XattrsBackend) LockfilePath(path string) string { return path + ".mlock" }
 
 func cleanupLockfile(f *lockedfile.File) {
 	_ = f.Close()

--- a/pkg/storage/utils/decomposedfs/revisions.go
+++ b/pkg/storage/utils/decomposedfs/revisions.go
@@ -70,7 +70,7 @@ func (fs *Decomposedfs) ListRevisions(ctx context.Context, ref *provider.Referen
 	np := n.InternalPath()
 	if items, err := filepath.Glob(np + node.RevisionIDDelimiter + "*"); err == nil {
 		for i := range items {
-			if fs.lu.MetadataBackend().IsMetaFile(items[i]) {
+			if fs.lu.MetadataBackend().IsMetaFile(items[i]) || strings.HasSuffix(items[i], ".lock") {
 				continue
 			}
 
@@ -237,7 +237,7 @@ func (fs *Decomposedfs) RestoreRevision(ctx context.Context, ref *provider.Refer
 				attributeName == prefixes.BlobsizeAttr
 		})
 		if err != nil {
-			return errtypes.InternalError("failed to copy blob xattrs to version node")
+			return errtypes.InternalError("failed to copy blob xattrs to version node: " + err.Error())
 		}
 
 		// remember mtime from node as new revision mtime
@@ -256,7 +256,7 @@ func (fs *Decomposedfs) RestoreRevision(ctx context.Context, ref *provider.Refer
 				attributeName == prefixes.BlobsizeAttr
 		})
 		if err != nil {
-			return errtypes.InternalError("failed to copy blob xattrs to old revision to node")
+			return errtypes.InternalError("failed to copy blob xattrs to old revision to node: " + err.Error())
 		}
 
 		revisionSize, err := fs.lu.MetadataBackend().GetInt64(restoredRevisionPath, prefixes.BlobsizeAttr)

--- a/pkg/storage/utils/decomposedfs/revisions.go
+++ b/pkg/storage/utils/decomposedfs/revisions.go
@@ -70,7 +70,7 @@ func (fs *Decomposedfs) ListRevisions(ctx context.Context, ref *provider.Referen
 	np := n.InternalPath()
 	if items, err := filepath.Glob(np + node.RevisionIDDelimiter + "*"); err == nil {
 		for i := range items {
-			if fs.lu.MetadataBackend().IsMetaFile(items[i]) || strings.HasSuffix(items[i], ".lock") {
+			if fs.lu.MetadataBackend().IsMetaFile(items[i]) || strings.HasSuffix(items[i], ".mlock") {
 				continue
 			}
 


### PR DESCRIPTION
Prevent 0-byte messagepack metadata files by writing the metadata atomically.