### PR TITLE
Added /app/notify endpoint for logging/tracking apps

### DIFF
--- a/changelog/unreleased/app-notif.md
+++ b/changelog/unreleased/app-notif.md
@@ -1,0 +1,7 @@
+Enhancement: added an /app/notify endpoint for logging/tracking apps
+
+The new endpoint serves to probe the health state of apps such as
+Microsoft Office Online, and it is expected to be called by the frontend
+upon successful loading of the document by the underlying app
+
+https://github.com/cs3org/reva/pull/4044

--- a/pkg/app/provider/wopi/wopi.go
+++ b/pkg/app/provider/wopi/wopi.go
@@ -338,7 +338,6 @@ func (p *wopiProvider) GetAppURL(ctx context.Context, resource *provider.Resourc
 		}
 	}
 
-	log.Info().Str("url", appFullURL).Str("resource", resource.Path).Msg("wopi: returning URL for file")
 	return &appprovider.OpenInAppURL{
 		AppUrl:         appFullURL,
 		Method:         method,


### PR DESCRIPTION
The new endpoint serves to probe the health state of apps such as Microsoft Office Online, and it is expected to be called by the frontend upon successful loading of the document by the underlying app.