### PR TITLE
Fix messagepack propagation

### DIFF
--- a/changelog/unreleased/fix-messagepack-propagation.md
+++ b/changelog/unreleased/fix-messagepack-propagation.md
@@ -1,0 +1,5 @@
+Bugfix: fix messagepack propagation
+
+We cannot read from the lockfile. The data is in the metadata file.
+
+https://github.com/cs3org/reva/pull/4048

--- a/pkg/storage/utils/decomposedfs/tree/tree.go
+++ b/pkg/storage/utils/decomposedfs/tree/tree.go
@@ -767,7 +767,7 @@ func (t *Tree) Propagate(ctx context.Context, n *node.Node, sizeDiff int64) (err
 			}
 		}()
 
-		if n, err = n.ParentWithReader(ctx, f); err != nil {
+		if n, err = n.Parent(ctx); err != nil {
 			sublog.Error().Err(err).
 				Msg("Propagation failed. Could not read parent node.")
 			return err


### PR DESCRIPTION
We cannot read from the lockfile. The data is in the metadata file.

extracted from https://github.com/cs3org/reva/pull/4017