### PR TITLE
do not invalidate filemetadata cache early

### DIFF
--- a/changelog/unreleased/do-not-invalidate-filemetdadata-cache-early.md
+++ b/changelog/unreleased/do-not-invalidate-filemetdadata-cache-early.md
@@ -1,0 +1,5 @@
+Enhancement: Do not invalidate filemetadata cache early
+
+We can postpone overwriting the cache until the metadata has ben written to disk. This prevents other requests trying to read metadata from having to wait for a readlock for the metadata file.
+
+https://github.com/cs3org/reva/pull/4049

--- a/pkg/storage/utils/decomposedfs/metadata/messagepack_backend.go
+++ b/pkg/storage/utils/decomposedfs/metadata/messagepack_backend.go
@@ -157,13 +157,8 @@ func (b MessagePackBackend) saveAttributes(ctx context.Context, path string, set
 		return err
 	}
 
-	// Invalidate cache early
-	_, subspan := tracer.Start(ctx, "metaCache.RemoveMetadata")
-	_ = b.metaCache.RemoveMetadata(b.cacheKey(path))
-	subspan.End()
-
 	// Read current state
-	_, subspan = tracer.Start(ctx, "os.ReadFile")
+	_, subspan := tracer.Start(ctx, "os.ReadFile")
 	var msgBytes []byte
 	msgBytes, err = os.ReadFile(metaPath)
 	subspan.End()


### PR DESCRIPTION
We can postpone overwriting the cache until the metadata has ben written to disk. This prevents other requests trying to read metadata from having to wait for a readlock for the metadata file.

extracted from https://github.com/cs3org/reva/pull/4017