### PR TITLE
decomposedfs: Set treesize to zero when creating a space

### DIFF
--- a/changelog/unreleased/decomposedfs-initial-treesize.md
+++ b/changelog/unreleased/decomposedfs-initial-treesize.md
@@ -1,0 +1,7 @@
+Bugfix: Set treesize when creating a storage space
+
+We now explicitly set the treesize metadata to zero when creating a new
+storage space. This prevents empty treesize values for spaces with out
+any data.
+
+https://github.com/cs3org/reva/pull/4051

--- a/pkg/storage/utils/decomposedfs/node/xattrs.go
+++ b/pkg/storage/utils/decomposedfs/node/xattrs.go
@@ -49,6 +49,16 @@ func (md Attributes) SetInt64(key string, val int64) {
 	md[key] = []byte(strconv.FormatInt(val, 10))
 }
 
+// UInt64 reads an uint64 value
+func (md Attributes) UInt64(key string) (uint64, error) {
+	return strconv.ParseUint(string(md[key]), 10, 64)
+}
+
+// SetInt64 sets an uint64 value
+func (md Attributes) SetUInt64(key string, val uint64) {
+	md[key] = []byte(strconv.FormatUint(val, 10))
+}
+
 // SetXattrs sets multiple extended attributes on the write-through cache/node
 func (n *Node) SetXattrsWithContext(ctx context.Context, attribs map[string][]byte, acquireLock bool) (err error) {
 	if n.xattrsCache != nil {

--- a/pkg/storage/utils/decomposedfs/spaces.go
+++ b/pkg/storage/utils/decomposedfs/spaces.go
@@ -122,6 +122,9 @@ func (fs *Decomposedfs) CreateStorageSpace(ctx context.Context, req *provider.Cr
 	metadata.SetString(prefixes.NameAttr, req.Name)
 	metadata.SetString(prefixes.SpaceNameAttr, req.Name)
 
+	// This space is empty so set initial treesize to 0
+	metadata.SetUInt64(prefixes.TreesizeAttr, 0)
+
 	if req.Type != "" {
 		metadata.SetString(prefixes.SpaceTypeAttr, req.Type)
 	}


### PR DESCRIPTION
Set the initial treesize of a new storage space to zero instead of leaving it unset until the first item is uploaded.