### PR TITLE
Bump go-ldap to v3.4.5

### DIFF
--- a/changelog/unreleased/update-go-ldap.md
+++ b/changelog/unreleased/update-go-ldap.md
@@ -1,0 +1,6 @@
+Enhancement: Update go-ldap to v3.4.5
+
+Updated go-ldap/ldap/v3 to the latest upstream release to get back to
+a released version (we were targeting a specific bugfix commit previously)
+
+https://github.com/cs3org/reva/pull/4052

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/eventials/go-tus v0.0.0-20220610120217-05d0564bb571
 	github.com/gdexlab/go-render v1.0.1
 	github.com/go-chi/chi/v5 v5.0.8
-	github.com/go-ldap/ldap/v3 v3.4.5-0.20230327113050-32d292ef5ded
+	github.com/go-ldap/ldap/v3 v3.4.5
 	github.com/go-micro/plugins/v4/events/natsjs v1.2.0
 	github.com/go-micro/plugins/v4/server/http v1.2.1
 	github.com/go-micro/plugins/v4/store/nats-js v1.1.0
@@ -38,6 +38,7 @@ require (
 	github.com/gomodule/redigo v1.8.9
 	github.com/google/go-cmp v0.5.9
 	github.com/google/go-github v17.0.0+incompatible
+	github.com/google/renameio/v2 v2.0.0
 	github.com/google/uuid v1.3.0
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/hashicorp/go-hclog v1.3.1
@@ -138,7 +139,6 @@ require (
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1 // indirect
-	github.com/google/renameio/v2 v2.0.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.13.0 // indirect
 	github.com/hashicorp/consul/api v1.15.2 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -593,8 +593,8 @@ github.com/go-kit/log v0.1.0/go.mod h1:zbhenjAZHb184qTLMA9ZjW7ThYL0H2mk7Q6pNt4vb
 github.com/go-kit/log v0.2.0/go.mod h1:NwTd00d/i8cPZ3xOwwiv2PO5MOcx78fFErGNcVmBjv0=
 github.com/go-kit/log v0.2.1 h1:MRVx0/zhvdseW+Gza6N9rVzU/IVzaeE1SFI4raAhmBU=
 github.com/go-kit/log v0.2.1/go.mod h1:NwTd00d/i8cPZ3xOwwiv2PO5MOcx78fFErGNcVmBjv0=
-github.com/go-ldap/ldap/v3 v3.4.5-0.20230327113050-32d292ef5ded h1:DCi4j5aIjsT27tSluBdFlDkYvHnNSxwnua+hjt+1wtk=
-github.com/go-ldap/ldap/v3 v3.4.5-0.20230327113050-32d292ef5ded/go.mod h1:bMGIq3AGbytbaMwf8wdv5Phdxz0FWHTIYMSzyrYgnQs=
+github.com/go-ldap/ldap/v3 v3.4.5 h1:ekEKmaDrpvR2yf5Nc/DClsGG9lAmdDixe44mLzlW5r8=
+github.com/go-ldap/ldap/v3 v3.4.5/go.mod h1:bMGIq3AGbytbaMwf8wdv5Phdxz0FWHTIYMSzyrYgnQs=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=

--- a/pkg/utils/ldap/reconnect.go
+++ b/pkg/utils/ldap/reconnect.go
@@ -240,7 +240,23 @@ func (c *ConnWithReconnect) StartTLS(*tls.Config) error {
 }
 
 // Close implements the ldap.Client interface
-func (c *ConnWithReconnect) Close() {}
+func (c *ConnWithReconnect) Close() (err error) {
+	conn, err := c.getConnection()
+
+	if err != nil {
+		return err
+	}
+	return conn.Close()
+}
+
+func (c *ConnWithReconnect) GetLastError() error {
+	conn, err := c.getConnection()
+
+	if err != nil {
+		return err
+	}
+	return conn.GetLastError()
+}
 
 // IsClosing implements the ldap.Client interface
 func (c *ConnWithReconnect) IsClosing() bool {
@@ -303,4 +319,9 @@ func (c *ConnWithReconnect) TLSConnectionState() (tls.ConnectionState, bool) {
 // Unbind implements the ldap.Client interface
 func (c *ConnWithReconnect) Unbind() error {
 	return ldap.NewError(ldap.LDAPResultNotSupported, fmt.Errorf("not implemented"))
+}
+
+// DirSync implements the ldap.Client interface
+func (c *ConnWithReconnect) DirSync(searchRequest *ldap.SearchRequest, flags, maxAttrCount int64, cookie []byte) (*ldap.SearchResult, error) {
+	return nil, ldap.NewError(ldap.LDAPResultNotSupported, fmt.Errorf("not implemented"))
 }


### PR DESCRIPTION
Updated go-ldap/ldap/v3 to the latest upstream release to get back to a released version (we were targeting a specific bugfix commit previously)