### PR TITLE
Proper error handling publicshareprovider

### DIFF
--- a/changelog/unreleased/fix-error-handling-in-publicshareprovider.md
+++ b/changelog/unreleased/fix-error-handling-in-publicshareprovider.md
@@ -1,0 +1,5 @@
+Bugfix: Properly handle not-found errors when getting a public share
+
+We fixed a problem where not-found errors caused a hard error instead of a proper RPC error state.
+
+https://github.com/cs3org/reva/pull/4057

--- a/pkg/publicshare/manager/json/json.go
+++ b/pkg/publicshare/manager/json/json.go
@@ -430,7 +430,7 @@ func (m *manager) GetPublicShare(ctx context.Context, u *user.User, ref *link.Pu
 	if ref.GetToken() != "" {
 		ps, pw, err := m.getByToken(ctx, ref.GetToken())
 		if err != nil {
-			return nil, errors.New("no shares found by token")
+			return nil, errtypes.NotFound("no shares found by token")
 		}
 		if ps.PasswordProtected && sign {
 			err := publicshare.AddSignature(ps, pw)
@@ -463,7 +463,7 @@ func (m *manager) GetPublicShare(ctx context.Context, u *user.User, ref *link.Pu
 				if err := m.revokeExpiredPublicShare(ctx, &ps, u); err != nil {
 					return nil, err
 				}
-				return nil, errors.New("no shares found by id:" + ref.GetId().String())
+				return nil, errtypes.NotFound("no shares found by id:" + ref.GetId().String())
 			}
 			if ps.PasswordProtected && sign {
 				err := publicshare.AddSignature(&ps, passDB)
@@ -475,7 +475,7 @@ func (m *manager) GetPublicShare(ctx context.Context, u *user.User, ref *link.Pu
 		}
 
 	}
-	return nil, errors.New("no shares found by id:" + ref.GetId().String())
+	return nil, errtypes.NotFound("no shares found by id:" + ref.GetId().String())
 }
 
 // ListPublicShares retrieves all the shares on the manager that are valid.


### PR DESCRIPTION
We fixed a problem where not-found errors caused a hard error instead of a proper RPC error state.
