### PR TITLE
Fix invalid space index format from migration

### DIFF
--- a/changelog/unreleased/decomposedfs-space-index.md
+++ b/changelog/unreleased/decomposedfs-space-index.md
@@ -4,5 +4,6 @@ The directory tree based decomposedfs space indexes have been replaced
 with messagepack base indexes which improves performance when reading
 the index, especially on slow storages.
 
+https://github.com/cs3org/reva/pull/4059
 https://github.com/cs3org/reva/pull/4058
 https://github.com/cs3org/reva/pull/3995

--- a/pkg/storage/utils/decomposedfs/migrator/0005_fix_messagepack_space_index_format.go
+++ b/pkg/storage/utils/decomposedfs/migrator/0005_fix_messagepack_space_index_format.go
@@ -1,0 +1,68 @@
+// Copyright 2018-2023 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package migrator
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/shamaton/msgpack/v2"
+)
+
+// Migration0005 fixes the messagepack space index data structure
+func (m *Migrator) Migration0005() (Result, error) {
+	root := m.lu.InternalRoot()
+
+	indexes, err := filepath.Glob(filepath.Join(root, "indexes", "**", "*.mpk"))
+	if err != nil {
+		return resultFailed, err
+	}
+	for _, i := range indexes {
+		m.log.Info().Str("root", m.lu.InternalRoot()).Msg("Fixing index format of " + i)
+
+		// Read old-format index
+		oldData, err := os.ReadFile(i)
+		if err != nil {
+			return resultFailed, err
+		}
+		oldIndex := map[string][]byte{}
+		err = msgpack.Unmarshal(oldData, &oldIndex)
+		if err != nil {
+			// likely already migrated -> skip
+			m.log.Warn().Str("root", m.lu.InternalRoot()).Msg("Invalid index format found in " + i)
+			continue
+		}
+
+		// Write new-format index
+		newIndex := map[string]string{}
+		for k, v := range oldIndex {
+			newIndex[k] = string(v)
+		}
+		newData, err := msgpack.Marshal(newIndex)
+		if err != nil {
+			return resultFailed, err
+		}
+		err = os.WriteFile(i, newData, 0600)
+		if err != nil {
+			return resultFailed, err
+		}
+	}
+	m.log.Info().Msg("done.")
+	return resultSucceeded, nil
+}

--- a/pkg/storage/utils/decomposedfs/migrator/migrator.go
+++ b/pkg/storage/utils/decomposedfs/migrator/migrator.go
@@ -29,7 +29,7 @@ import (
 	"github.com/rs/zerolog"
 )
 
-var allMigrations = []string{"0001", "0002", "0003", "0004"}
+var allMigrations = []string{"0001", "0002", "0003", "0004", "0005"}
 
 const (
 	resultFailed            = "failed"


### PR DESCRIPTION
The space index migration wrongly migrated to a `map[string][]byte` data structure while the proper data structure is `map[string]string`. This PR adds another migration which fixes that issue.

Fixes https://github.com/owncloud/ocis/issues/6781