### PR TITLE
[tests-only][full-ci]bump latest ocis commit id edge

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,4 +1,4 @@
 # The test runner source for API tests
-APITESTS_COMMITID=941ef59cc97793ebd18df1c344a9b45cb96b46ff
+APITESTS_COMMITID=6e45113e76c60965c5e1a3bad42e5b5459960571
 APITESTS_BRANCH=master
 APITESTS_REPO_GIT_URL=https://github.com/owncloud/ocis.git


### PR DESCRIPTION
This PR bumps the latest commit id from ocis
part of https://github.com/owncloud/QA/issues/819