### PR TITLE
upload directly to dataprovider

### DIFF
--- a/changelog/unreleased/upload-directly-to-dataprovider.md
+++ b/changelog/unreleased/upload-directly-to-dataprovider.md
@@ -1,0 +1,6 @@
+Enhancement: upload directly to dataprovider
+
+The ocdav service can now bypass the datagateway if it is configured with a transfer secret. This prevents unnecessary roundtrips and halves the network traffic during uploads for the proxy.
+
+https://github.com/cs3org/reva/pull/4065
+https://github.com/owncloud/ocis/issues/6296

--- a/internal/http/services/owncloud/ocdav/ocdav.go
+++ b/internal/http/services/owncloud/ocdav/ocdav.go
@@ -85,6 +85,8 @@ type Config struct {
 	Product                string                            `mapstructure:"product"`
 	ProductName            string                            `mapstructure:"product_name"`
 	ProductVersion         string                            `mapstructure:"product_version"`
+	// optional, if set will unpack the transfer token and directly send uploads to the data provider
+	TransferSharedSecret string `mapstructure:"transfer_shared_secret"`
 
 	NameValidation NameValidation `mapstructure:"validation"`
 

--- a/internal/http/services/owncloud/ocdav/put.go
+++ b/internal/http/services/owncloud/ocdav/put.go
@@ -298,6 +298,18 @@ func (s *svc) handlePut(ctx context.Context, w http.ResponseWriter, r *http.Requ
 		}
 	}
 
+	// if we know the transfer secret we can directly talk to the dataprovider
+	if s.c.TransferSharedSecret != "" {
+		claims, err := datagateway.Verify(ctx, token, s.c.TransferSharedSecret)
+		if err != nil {
+			log.Error().Err(err).Msg("error verifying transfer token")
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		// directly send request to target
+		ep = claims.Target
+	}
+
 	httpReq, err := rhttp.NewRequest(ctx, http.MethodPut, ep, r.Body)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)

--- a/pkg/micro/ocdav/option.go
+++ b/pkg/micro/ocdav/option.go
@@ -43,8 +43,9 @@ type Options struct {
 	Context   context.Context
 	// Metrics   *metrics.Metrics
 	// Flags     []cli.Flag
-	Name      string
-	JWTSecret string
+	Name           string
+	JWTSecret      string
+	TransferSecret string
 
 	FavoriteManager favorite.Manager
 	GatewaySelector pool.Selectable[gateway.GatewayAPIClient]
@@ -106,6 +107,13 @@ func Address(val string) Option {
 func JWTSecret(s string) Option {
 	return func(o *Options) {
 		o.JWTSecret = s
+	}
+}
+
+// TransferSecret provides a function to set the transfer secret option.
+func TransferSecret(s string) Option {
+	return func(o *Options) {
+		o.config.TransferSharedSecret = s
 	}
 }
 


### PR DESCRIPTION
The ocdav service can now bypass the datagateway if it is configured with a transfer secret. This prevents unnecessary roundtrips and halves the network traffic during uploads for the proxy.

adresses https://github.com/owncloud/ocis/issues/6296