### PR TITLE
Selectable propagators

### DIFF
--- a/changelog/unreleased/async-propagator.md
+++ b/changelog/unreleased/async-propagator.md
@@ -1,5 +1,5 @@
 Enhancement: async propagation (experimental)
 
-decomposedfs can now be configured to propagat treetime/treesize changes asynchronously.
+decomposedfs can now be configured to propagate treetime/treesize changes asynchronously.
 
 https://github.com/cs3org/reva/pull/4070

--- a/changelog/unreleased/async-propagator.md
+++ b/changelog/unreleased/async-propagator.md
@@ -1,0 +1,5 @@
+Enhancement: async propagation (experimental)
+
+decomposedfs can now be configured to propagat treetime/treesize changes asynchronously.
+
+https://github.com/cs3org/reva/pull/4070

--- a/go.mod
+++ b/go.mod
@@ -38,6 +38,7 @@ require (
 	github.com/gomodule/redigo v1.8.9
 	github.com/google/go-cmp v0.5.9
 	github.com/google/go-github v17.0.0+incompatible
+	github.com/google/renameio v0.1.0
 	github.com/google/renameio/v2 v2.0.0
 	github.com/google/uuid v1.3.0
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -780,6 +780,7 @@ github.com/google/pprof v0.0.0-20210601050228-01bbb1931b22/go.mod h1:kpwsk12EmLe
 github.com/google/pprof v0.0.0-20210609004039-a478d1d731e9/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1 h1:K6RDEckDVWvDI9JAJYCmNdQXq6neHJOYx3V6jnqNEec=
 github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
+github.com/google/renameio v0.1.0 h1:GOZbcHa3HfsPKPlmyPyN2KEohoMXOhdMbHrvbpl2QaA=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/renameio/v2 v2.0.0 h1:UifI23ZTGY8Tt29JbYFiuyIU3eX+RNFtUwefq9qAhxg=
 github.com/google/renameio/v2 v2.0.0/go.mod h1:BtmJXm5YlszgC+TD4HOEEUFgkJP3nLxehU6hfe7jRt4=

--- a/pkg/storage/utils/decomposedfs/lookup/lookup.go
+++ b/pkg/storage/utils/decomposedfs/lookup/lookup.go
@@ -44,6 +44,20 @@ func init() {
 	tracer = otel.Tracer("github.com/cs3org/reva/pkg/storage/utils/decomposedfs/lookup")
 }
 
+// PathLookup defines the interface for the lookup component
+type PathLookup interface {
+	NodeFromResource(ctx context.Context, ref *provider.Reference) (*node.Node, error)
+	NodeFromID(ctx context.Context, id *provider.ResourceId) (n *node.Node, err error)
+
+	InternalRoot() string
+	InternalPath(spaceID, nodeID string) string
+	Path(ctx context.Context, n *node.Node, hasPermission node.PermissionFunc) (path string, err error)
+	MetadataBackend() metadata.Backend
+	ReadBlobSizeAttr(ctx context.Context, path string) (int64, error)
+	ReadBlobIDAttr(ctx context.Context, path string) (string, error)
+	TypeFromPath(ctx context.Context, path string) provider.ResourceType
+}
+
 // Lookup implements transformations from filepath to node and back
 type Lookup struct {
 	Options *options.Options

--- a/pkg/storage/utils/decomposedfs/options/options.go
+++ b/pkg/storage/utils/decomposedfs/options/options.go
@@ -41,6 +41,9 @@ type Options struct {
 	// the metadata backend to use, currently supports `xattr` or `ini`
 	MetadataBackend string `mapstructure:"metadata_backend"`
 
+	// the propagator to use for this fs. currently only `sync` is fully supported, `async` is available as an experimental feature
+	Propagator string `mapstructure:"propagator"`
+
 	// ocis fs works on top of a dir of uuid nodes
 	Root string `mapstructure:"root"`
 
@@ -143,6 +146,10 @@ func New(m map[string]interface{}) (*Options, error) {
 
 	if o.MaxConcurrency <= 0 {
 		o.MaxConcurrency = 100
+	}
+
+	if o.Propagator == "" {
+		o.Propagator = "sync"
 	}
 
 	return o, nil

--- a/pkg/storage/utils/decomposedfs/options/options.go
+++ b/pkg/storage/utils/decomposedfs/options/options.go
@@ -21,6 +21,7 @@ package options
 import (
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/cs3org/reva/v2/pkg/rgrpc/todo/pool"
 	"github.com/cs3org/reva/v2/pkg/sharedconf"
@@ -43,6 +44,8 @@ type Options struct {
 
 	// the propagator to use for this fs. currently only `sync` is fully supported, `async` is available as an experimental feature
 	Propagator string `mapstructure:"propagator"`
+	// Options specific to the async propagator
+	AsyncPropagatorOptions AsyncPropagatorOptions `mapstructure:"async_propagator_options"`
 
 	// ocis fs works on top of a dir of uuid nodes
 	Root string `mapstructure:"root"`
@@ -79,6 +82,11 @@ type Options struct {
 	MaxConcurrency          int `mapstructure:"max_concurrency"`
 
 	MaxQuota uint64 `mapstructure:"max_quota"`
+}
+
+// AsyncPropagatorOptions holds the configuration for the async propagator
+type AsyncPropagatorOptions struct {
+	PropagationDelay time.Duration `mapstructure:"propagation_delay"`
 }
 
 // EventOptions are the configurable options for events
@@ -150,6 +158,9 @@ func New(m map[string]interface{}) (*Options, error) {
 
 	if o.Propagator == "" {
 		o.Propagator = "sync"
+	}
+	if o.AsyncPropagatorOptions.PropagationDelay == 0 {
+		o.AsyncPropagatorOptions.PropagationDelay = 5 * time.Second
 	}
 
 	return o, nil

--- a/pkg/storage/utils/decomposedfs/tree/propagator/async.go
+++ b/pkg/storage/utils/decomposedfs/tree/propagator/async.go
@@ -1,0 +1,314 @@
+// Copyright 2018-2021 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package propagator
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strconv"
+	"time"
+
+	"github.com/cs3org/reva/v2/pkg/appctx"
+	"github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/lookup"
+	"github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/metadata"
+	"github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/metadata/prefixes"
+	"github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/node"
+	"github.com/google/uuid"
+	"github.com/pkg/errors"
+	"github.com/rogpeppe/go-internal/lockedfile"
+	"github.com/shamaton/msgpack/v2"
+)
+
+type AsyncPropagator struct {
+	treeSizeAccounting bool
+	treeTimeAccounting bool
+	lookup             lookup.PathLookup
+}
+
+type Change struct {
+	SyncTime time.Time
+	SizeDiff int64
+}
+
+func NewAsyncPropagator(treeSizeAccounting, treeTimeAccounting bool, lookup lookup.PathLookup) AsyncPropagator {
+	return AsyncPropagator{
+		treeSizeAccounting: treeSizeAccounting,
+		treeTimeAccounting: treeTimeAccounting,
+		lookup:             lookup,
+	}
+}
+
+func (p AsyncPropagator) Propagate(ctx context.Context, n *node.Node, sizeDiff int64) error {
+	ctx, span := tracer.Start(ctx, "Propagate")
+	defer span.End()
+	sublog := appctx.GetLogger(ctx).With().
+		Str("method", "async.Propagate").
+		Str("spaceid", n.SpaceID).
+		Str("nodeid", n.ID).
+		Int64("sizeDiff", sizeDiff).
+		Logger()
+
+	if !p.treeTimeAccounting && (!p.treeSizeAccounting || sizeDiff == 0) {
+		// no propagation enabled
+		sublog.Debug().Msg("propagation disabled or nothing to propagate")
+		return nil
+	}
+
+	// add a change to the parent node
+	changePath := filepath.Join(p.lookup.InternalRoot(), "spaces", lookup.Pathify(n.SpaceID, 1, 2), "changes", n.ParentID, uuid.New().String()+".mpk")
+
+	c := Change{
+		// use a sync time and don't rely on the mtime of the current node, as the stat might not change when a rename happened too quickly
+		SyncTime: time.Now().UTC(),
+		SizeDiff: sizeDiff,
+	}
+
+	data, err := msgpack.Marshal(c)
+	if err != nil {
+		sublog.Error().Err(err).Msg("Could not marshal change data")
+		return err
+	}
+
+	_ = os.MkdirAll(filepath.Dir(changePath), 0700)
+	for {
+		err := os.WriteFile(changePath, data, 0644)
+		if err == nil {
+			break
+		}
+		_ = os.MkdirAll(filepath.Dir(changePath), 0700)
+	}
+	// what if the file is moved away after writing this change? a subseqent call to Propagation will subtract the size diff again
+
+	// we will start a goroutine here to propagate this change. it will walk up the tree
+	go p.propagate(ctx, n.SpaceID, n.ParentID)
+
+	return nil
+}
+
+func (p AsyncPropagator) propagate(ctx context.Context, spaceid, nodeid string) {
+	sublog := appctx.GetLogger(ctx).With().
+		Str("method", "async.propagate").
+		Str("spaceid", spaceid).
+		Str("nodeid", nodeid).
+		Logger()
+
+	time.Sleep(time.Millisecond * 300) // wait a moment before propagating
+
+	sublog.Debug().Msg("propagating")
+
+	// add a change to the parent node
+	changeDirPath := filepath.Join(p.lookup.InternalRoot(), "spaces", lookup.Pathify(spaceid, 1, 2), "changes", nodeid)
+
+	// TODO what if a rename is already in progress? we need to create a .processing.lock file so other goroutines wait for this?
+
+	// first rename the existing node dir
+	err := os.Rename(changeDirPath, changeDirPath+".processing")
+	if err != nil {
+		return // has already been propagated by another goroutine
+	}
+
+	d, err := os.Open(changeDirPath + ".processing")
+	if err != nil {
+		sublog.Error().Err(err).Msg("Could not open change .processing dir")
+		return
+	}
+	defer d.Close()
+	names, err := d.Readdirnames(0)
+	if err != nil {
+		sublog.Error().Err(err).Msg("Could not read dirnames")
+		return
+	}
+
+	pc := Change{}
+	for _, name := range names {
+		b, err := os.ReadFile(filepath.Join(changeDirPath+".processing", name))
+		if err != nil {
+			sublog.Error().Err(err).Msg("Could not read change") // TODO what if the file was not yet fully written? retry empty files?
+			return
+		}
+		c := Change{}
+		err = msgpack.Unmarshal(b, &c)
+		if err != nil {
+			sublog.Error().Err(err).Msg("Could not unmarshal change")
+			return
+		}
+		if c.SyncTime.After(pc.SyncTime) {
+			pc.SyncTime = c.SyncTime
+		}
+		pc.SizeDiff = pc.SizeDiff + c.SizeDiff
+	}
+
+	// TODO do we need to write an aggregated parentchange file?
+
+	attrs := node.Attributes{}
+
+	var f *lockedfile.File
+	// lock parent before reading treesize or tree time
+
+	nodePath := filepath.Join(p.lookup.InternalRoot(), "spaces", lookup.Pathify(spaceid, 1, 2), "nodes", lookup.Pathify(nodeid, 4, 2))
+
+	_, subspan := tracer.Start(ctx, "lockedfile.OpenFile")
+	lockFilepath := p.lookup.MetadataBackend().LockfilePath(nodePath)
+	f, err = lockedfile.OpenFile(lockFilepath, os.O_RDWR|os.O_CREATE, 0600)
+	subspan.End()
+	if err != nil {
+		sublog.Error().Err(err).
+			Str("lock filepath", lockFilepath).
+			Msg("Propagation failed. Could not open metadata for node with lock.")
+		return
+	}
+	// always log error if closing node fails
+	defer func() {
+		// ignore already closed error
+		cerr := f.Close()
+		if err == nil && cerr != nil && !errors.Is(cerr, os.ErrClosed) {
+			err = cerr // only overwrite err with en error from close if the former was nil
+		}
+	}()
+
+	var n *node.Node
+	if n, err = node.ReadNode(ctx, p.lookup, spaceid, nodeid, false, nil, false); err != nil {
+		sublog.Error().Err(err).
+			Msg("Propagation failed. Could not read node.")
+		return
+	}
+
+	// TODO none, sync and async?
+	if !n.HasPropagation(ctx) {
+		sublog.Debug().Str("attr", prefixes.PropagationAttr).Msg("propagation attribute not set or unreadable, not propagating")
+		// if the attribute is not set treat it as false / none / no propagation
+		return
+	}
+
+	if p.treeTimeAccounting {
+		// update the parent tree time if it is older than the nodes mtime
+		updateSyncTime := false
+
+		var tmTime time.Time
+		tmTime, err = n.GetTMTime(ctx)
+		switch {
+		case err != nil:
+			// missing attribute, or invalid format, overwrite
+			sublog.Debug().Err(err).
+				Msg("could not read tmtime attribute, overwriting")
+			updateSyncTime = true
+		case tmTime.Before(pc.SyncTime):
+			sublog.Debug().
+				Time("tmtime", tmTime).
+				Time("stime", pc.SyncTime).
+				Msg("parent tmtime is older than node mtime, updating")
+			updateSyncTime = true
+		default:
+			sublog.Debug().
+				Time("tmtime", tmTime).
+				Time("stime", pc.SyncTime).
+				Dur("delta", pc.SyncTime.Sub(tmTime)).
+				Msg("node tmtime is younger than stime, not updating")
+		}
+
+		if updateSyncTime {
+			// update the tree time of the parent node
+			attrs.SetString(prefixes.TreeMTimeAttr, pc.SyncTime.UTC().Format(time.RFC3339Nano))
+		}
+
+		attrs.SetString(prefixes.TmpEtagAttr, "")
+	}
+
+	// size accounting
+	if p.treeSizeAccounting && pc.SizeDiff != 0 {
+		var newSize uint64
+
+		// read treesize
+		treeSize, err := n.GetTreeSize(ctx)
+		switch {
+		case metadata.IsAttrUnset(err):
+			// fallback to calculating the treesize
+			sublog.Warn().Msg("treesize attribute unset, falling back to calculating the treesize")
+			newSize, err = calculateTreeSize(ctx, p.lookup, n.InternalPath())
+			if err != nil {
+				sublog.Error().Err(err).
+					Msg("Error when calculating treesize of node.") // FIXME wat?
+				return
+			}
+		case err != nil:
+			sublog.Error().Err(err).
+				Msg("Failed to propagate treesize change. Error when reading the treesize attribute from node")
+			return
+		case pc.SizeDiff > 0:
+			newSize = treeSize + uint64(pc.SizeDiff)
+		case uint64(-pc.SizeDiff) > treeSize:
+			// The sizeDiff is larger than the current treesize. Which would result in
+			// a negative new treesize. Something must have gone wrong with the accounting.
+			// Reset the current treesize to 0.
+			sublog.Error().Uint64("treeSize", treeSize).Int64("sizeDiff", pc.SizeDiff).
+				Msg("Error when updating treesize of node. Updated treesize < 0. Reestting to 0")
+			newSize = 0
+		default:
+			newSize = treeSize - uint64(-pc.SizeDiff)
+		}
+
+		// update the tree size of the node
+		attrs.SetString(prefixes.TreesizeAttr, strconv.FormatUint(newSize, 10))
+		sublog.Debug().Uint64("newSize", newSize).Msg("updated treesize of node")
+	}
+
+	if err = n.SetXattrsWithContext(ctx, attrs, false); err != nil {
+		sublog.Error().Err(err).Msg("Failed to update extend attributes of node")
+		return
+	}
+
+	// Release node lock early, ignore already closed error
+	_, subspan = tracer.Start(ctx, "f.Close")
+	cerr := f.Close()
+	subspan.End()
+	if cerr != nil && !errors.Is(cerr, os.ErrClosed) {
+		sublog.Error().Err(cerr).Msg("Failed to close node and release lock")
+		return
+	}
+
+	err = os.RemoveAll(changeDirPath + ".processing")
+	if err != nil {
+		sublog.Error().Err(err).Msg("Could not remove .processing dir")
+		return
+	}
+
+	if !n.IsSpaceRoot(ctx) { // This does not seem robust as it checks the space name property
+
+		// add a change to the parent node
+		changePath := filepath.Join(p.lookup.InternalRoot(), "spaces", lookup.Pathify(n.SpaceID, 1, 2), "changes", n.ParentID, uuid.New().String()+".mpk")
+
+		data, err := msgpack.Marshal(pc)
+		if err != nil {
+			sublog.Error().Err(err).Msg("Could not marshal change data")
+			return
+		}
+
+		_ = os.MkdirAll(filepath.Dir(changePath), 0700)
+		for {
+			err := os.WriteFile(changePath, data, 0644)
+			if err == nil {
+				break
+			}
+			_ = os.MkdirAll(filepath.Dir(changePath), 0700)
+		}
+
+		p.propagate(ctx, n.SpaceID, n.ParentID)
+	}
+}

--- a/pkg/storage/utils/decomposedfs/tree/propagator/async.go
+++ b/pkg/storage/utils/decomposedfs/tree/propagator/async.go
@@ -288,13 +288,11 @@ func (p AsyncPropagator) propagate(ctx context.Context, spaceID, nodeID string, 
 	subspan.End()
 	if cerr != nil && !errors.Is(cerr, os.ErrClosed) {
 		log.Error().Err(cerr).Msg("Failed to close node and release lock")
-		return
 	}
 
 	err = os.RemoveAll(changeDirPath + ".processing")
 	if err != nil {
 		log.Error().Err(err).Msg("Could not remove .processing dir")
-		return
 	}
 
 	if !n.IsSpaceRoot(ctx) { // This does not seem robust as it checks the space name property

--- a/pkg/storage/utils/decomposedfs/tree/propagator/async.go
+++ b/pkg/storage/utils/decomposedfs/tree/propagator/async.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/metadata"
 	"github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/metadata/prefixes"
 	"github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/node"
+	"github.com/google/renameio"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	"github.com/rogpeppe/go-internal/lockedfile"
@@ -97,7 +98,7 @@ func (p AsyncPropagator) propagateChange(ctx context.Context, spaceID, nodeID st
 	ready := false
 	_ = os.MkdirAll(filepath.Dir(changePath), 0700)
 	for retries := 0; retries <= 5; retries += 1 {
-		err := os.WriteFile(changePath, data, 0644)
+		err := renameio.WriteFile(changePath, data, 0644)
 		if err == nil {
 			ready = true
 			break

--- a/pkg/storage/utils/decomposedfs/tree/propagator/async.go
+++ b/pkg/storage/utils/decomposedfs/tree/propagator/async.go
@@ -84,6 +84,7 @@ func NewAsyncPropagator(treeSizeAccounting, treeTimeAccounting bool, o options.A
 
 			entries, err := filepath.Glob(changesDirPath + "/**/*")
 			if err != nil {
+				log.Error().Err(err).Msg("failed to list changes")
 				continue
 			}
 

--- a/pkg/storage/utils/decomposedfs/tree/propagator/async.go
+++ b/pkg/storage/utils/decomposedfs/tree/propagator/async.go
@@ -301,5 +301,5 @@ func (p AsyncPropagator) propagate(ctx context.Context, spaceID, nodeID string, 
 }
 
 func (p AsyncPropagator) changesPath(spaceID, nodeID, filename string) string {
-	return filepath.Join(p.lookup.InternalRoot(), "spaces", lookup.Pathify(spaceID, 1, 2), "changes", nodeID, filename)
+	return filepath.Join(p.lookup.InternalRoot(), "changes", spaceID+":"+nodeID, filename)
 }

--- a/pkg/storage/utils/decomposedfs/tree/propagator/async.go
+++ b/pkg/storage/utils/decomposedfs/tree/propagator/async.go
@@ -152,7 +152,7 @@ func (p AsyncPropagator) propagate(ctx context.Context, spaceid, nodeid string) 
 		if c.SyncTime.After(pc.SyncTime) {
 			pc.SyncTime = c.SyncTime
 		}
-		pc.SizeDiff = pc.SizeDiff + c.SizeDiff
+		pc.SizeDiff += c.SizeDiff
 	}
 
 	// TODO do we need to write an aggregated parentchange file?

--- a/pkg/storage/utils/decomposedfs/tree/propagator/async.go
+++ b/pkg/storage/utils/decomposedfs/tree/propagator/async.go
@@ -104,7 +104,7 @@ func NewAsyncPropagator(treeSizeAccounting, treeTimeAccounting bool, lookup look
 						if err != nil {
 							return
 						}
-						changesDirPath = changesDirPath + ".processing"
+						changesDirPath += ".processing"
 					}
 
 					log.Debug().Str("dir", changesDirPath).Msg("propagating stale .processing dir")
@@ -164,7 +164,7 @@ func (p AsyncPropagator) queuePropagation(ctx context.Context, spaceID, nodeID s
 	_ = os.MkdirAll(filepath.Dir(filepath.Dir(changePath)), 0700)
 	err = os.Mkdir(filepath.Dir(changePath), 0700)
 	triggerPropagation = err == nil || os.IsExist(err) // only the first goroutine, which succeeds to create the directory, is supposed to actually trigger the propagation
-	for retries := 0; retries <= 500; retries += 1 {
+	for retries := 0; retries <= 500; retries++ {
 		err := renameio.WriteFile(changePath, data, 0644)
 		if err == nil {
 			ready = true

--- a/pkg/storage/utils/decomposedfs/tree/propagator/async.go
+++ b/pkg/storage/utils/decomposedfs/tree/propagator/async.go
@@ -116,6 +116,11 @@ func NewAsyncPropagator(treeSizeAccounting, treeTimeAccounting bool, o options.A
 
 					log.Debug().Str("dir", changesDirPath).Msg("propagating stale .processing dir")
 					parts := strings.SplitN(entry.Name(), ":", 2)
+					if len(parts) != 2 {
+						log.Error().Str("file", entry.Name()).Msg("encountered invalid .processing dir")
+						return
+					}
+
 					now := time.Now()
 					_ = os.Chtimes(changesDirPath, now, now)
 					p.propagate(context.Background(), parts[0], strings.TrimSuffix(parts[1], ".processing"), true, *log)

--- a/pkg/storage/utils/decomposedfs/tree/propagator/async.go
+++ b/pkg/storage/utils/decomposedfs/tree/propagator/async.go
@@ -86,20 +86,9 @@ func NewAsyncPropagator(treeSizeAccounting, treeTimeAccounting bool, lookup look
 				continue
 			}
 
-			// changesDir, err := os.Open(changesDirPath)
-			// if err != nil {
-			// log.Error().Err(err).Msg("failed to open changes dir")
-			// continue
-			// }
-
-			// entries, err := changesDir.Readdir(0)
-			// if err != nil {
-			// 	log.Error().Err(err).Msg("failed to list changes dir")
-			// 	continue
-			// }
-
 			for _, e := range entries {
-				entry, err := os.Stat(e)
+				changesDirPath := e
+				entry, err := os.Stat(changesDirPath)
 				if err != nil {
 					continue
 				}
@@ -109,7 +98,6 @@ func NewAsyncPropagator(treeSizeAccounting, treeTimeAccounting bool, lookup look
 				}
 
 				go func() {
-					changesDirPath := filepath.Join(changesDirPath, entry.Name())
 					if !strings.HasSuffix(changesDirPath, ".processing") {
 						// first rename the existing node dir
 						err = os.Rename(changesDirPath, changesDirPath+".processing")

--- a/pkg/storage/utils/decomposedfs/tree/propagator/propagator.go
+++ b/pkg/storage/utils/decomposedfs/tree/propagator/propagator.go
@@ -1,0 +1,100 @@
+// Copyright 2018-2021 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package propagator
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strconv"
+
+	sprovider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+	"github.com/cs3org/reva/v2/pkg/appctx"
+	"github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/lookup"
+	"github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/metadata/prefixes"
+	"github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/node"
+	"github.com/pkg/errors"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/trace"
+)
+
+var tracer trace.Tracer
+
+func init() {
+	tracer = otel.Tracer("github.com/cs3org/reva/pkg/storage/utils/decomposedfs/tree/propagator")
+}
+
+type Propagator interface {
+	Propagate(ctx context.Context, node *node.Node, sizediff int64) error
+}
+
+func New(propagatorType string, treeSizeAccounting, treeTimeAccounting bool, lookup lookup.PathLookup) Propagator {
+	switch propagatorType {
+	case "async":
+		return NewAsyncPropagator(treeSizeAccounting, treeTimeAccounting, lookup)
+	default:
+		return NewSyncPropagator(treeSizeAccounting, treeTimeAccounting, lookup)
+	}
+}
+
+func calculateTreeSize(ctx context.Context, lookup lookup.PathLookup, childrenPath string) (uint64, error) {
+	ctx, span := tracer.Start(ctx, "calculateTreeSize")
+	defer span.End()
+	var size uint64
+
+	f, err := os.Open(childrenPath)
+	if err != nil {
+		appctx.GetLogger(ctx).Error().Err(err).Str("childrenPath", childrenPath).Msg("could not open dir")
+		return 0, err
+	}
+	defer f.Close()
+
+	names, err := f.Readdirnames(0)
+	if err != nil {
+		appctx.GetLogger(ctx).Error().Err(err).Str("childrenPath", childrenPath).Msg("could not read dirnames")
+		return 0, err
+	}
+	for i := range names {
+		cPath := filepath.Join(childrenPath, names[i])
+		resolvedPath, err := filepath.EvalSymlinks(cPath)
+		if err != nil {
+			appctx.GetLogger(ctx).Error().Err(err).Str("childpath", cPath).Msg("could not resolve child entry symlink")
+			continue // continue after an error
+		}
+
+		// raw read of the attributes for performance reasons
+		attribs, err := lookup.MetadataBackend().All(ctx, resolvedPath)
+		if err != nil {
+			appctx.GetLogger(ctx).Error().Err(err).Str("childpath", cPath).Msg("could not read attributes of child entry")
+			continue // continue after an error
+		}
+		sizeAttr := ""
+		if string(attribs[prefixes.TypeAttr]) == strconv.FormatUint(uint64(sprovider.ResourceType_RESOURCE_TYPE_FILE), 10) {
+			sizeAttr = string(attribs[prefixes.BlobsizeAttr])
+		} else {
+			sizeAttr = string(attribs[prefixes.TreesizeAttr])
+		}
+		csize, err := strconv.ParseInt(sizeAttr, 10, 64)
+		if err != nil {
+			return 0, errors.Wrapf(err, "invalid blobsize xattr format")
+		}
+		size += uint64(csize)
+	}
+	return size, err
+}

--- a/pkg/storage/utils/decomposedfs/tree/propagator/propagator.go
+++ b/pkg/storage/utils/decomposedfs/tree/propagator/propagator.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/lookup"
 	"github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/metadata/prefixes"
 	"github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/node"
+	"github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/options"
 	"github.com/pkg/errors"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
@@ -44,12 +45,12 @@ type Propagator interface {
 	Propagate(ctx context.Context, node *node.Node, sizediff int64) error
 }
 
-func New(propagatorType string, treeSizeAccounting, treeTimeAccounting bool, lookup lookup.PathLookup) Propagator {
-	switch propagatorType {
+func New(lookup lookup.PathLookup, o *options.Options) Propagator {
+	switch o.Propagator {
 	case "async":
-		return NewAsyncPropagator(treeSizeAccounting, treeTimeAccounting, lookup)
+		return NewAsyncPropagator(o.TreeSizeAccounting, o.TreeTimeAccounting, o.AsyncPropagatorOptions, lookup)
 	default:
-		return NewSyncPropagator(treeSizeAccounting, treeTimeAccounting, lookup)
+		return NewSyncPropagator(o.TreeSizeAccounting, o.TreeTimeAccounting, lookup)
 	}
 }
 

--- a/pkg/storage/utils/decomposedfs/tree/propagator/sync.go
+++ b/pkg/storage/utils/decomposedfs/tree/propagator/sync.go
@@ -33,12 +33,14 @@ import (
 	"github.com/rogpeppe/go-internal/lockedfile"
 )
 
+// SyncPropagator implements synchronous treetime & treesize propagation
 type SyncPropagator struct {
 	treeSizeAccounting bool
 	treeTimeAccounting bool
 	lookup             lookup.PathLookup
 }
 
+// NewSyncPropagator returns a new AsyncPropagator instance
 func NewSyncPropagator(treeSizeAccounting, treeTimeAccounting bool, lookup lookup.PathLookup) SyncPropagator {
 	return SyncPropagator{
 		treeSizeAccounting: treeSizeAccounting,
@@ -47,6 +49,7 @@ func NewSyncPropagator(treeSizeAccounting, treeTimeAccounting bool, lookup looku
 	}
 }
 
+// Propagate triggers a propagation
 func (p SyncPropagator) Propagate(ctx context.Context, n *node.Node, sizeDiff int64) error {
 	ctx, span := tracer.Start(ctx, "Propagate")
 	defer span.End()
@@ -104,7 +107,6 @@ func (p SyncPropagator) Propagate(ctx context.Context, n *node.Node, sizeDiff in
 			return err
 		}
 
-		// TODO none, sync and async?
 		if !n.HasPropagation(ctx) {
 			sublog.Debug().Str("attr", prefixes.PropagationAttr).Msg("propagation attribute not set or unreadable, not propagating")
 			// if the attribute is not set treat it as false / none / no propagation

--- a/pkg/storage/utils/decomposedfs/tree/propagator/sync.go
+++ b/pkg/storage/utils/decomposedfs/tree/propagator/sync.go
@@ -1,0 +1,206 @@
+// Copyright 2018-2021 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package propagator
+
+import (
+	"context"
+	"errors"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/cs3org/reva/v2/pkg/appctx"
+	"github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/lookup"
+	"github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/metadata"
+	"github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/metadata/prefixes"
+	"github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/node"
+	"github.com/rogpeppe/go-internal/lockedfile"
+)
+
+type SyncPropagator struct {
+	treeSizeAccounting bool
+	treeTimeAccounting bool
+	lookup             lookup.PathLookup
+}
+
+func NewSyncPropagator(treeSizeAccounting, treeTimeAccounting bool, lookup lookup.PathLookup) SyncPropagator {
+	return SyncPropagator{
+		treeSizeAccounting: treeSizeAccounting,
+		treeTimeAccounting: treeTimeAccounting,
+		lookup:             lookup,
+	}
+}
+
+func (p SyncPropagator) Propagate(ctx context.Context, n *node.Node, sizeDiff int64) error {
+	ctx, span := tracer.Start(ctx, "Propagate")
+	defer span.End()
+	sublog := appctx.GetLogger(ctx).With().
+		Str("method", "sync.Propagate").
+		Str("spaceid", n.SpaceID).
+		Str("nodeid", n.ID).
+		Int64("sizeDiff", sizeDiff).
+		Logger()
+
+	if !p.treeTimeAccounting && (!p.treeSizeAccounting || sizeDiff == 0) {
+		// no propagation enabled
+		sublog.Debug().Msg("propagation disabled or nothing to propagate")
+		return nil
+	}
+
+	// is propagation enabled for the parent node?
+	root := n.SpaceRoot
+
+	// use a sync time and don't rely on the mtime of the current node, as the stat might not change when a rename happened too quickly
+	sTime := time.Now().UTC()
+
+	// we loop until we reach the root
+	var err error
+	for err == nil && n.ID != root.ID {
+		sublog.Debug().Msg("propagating")
+
+		attrs := node.Attributes{}
+
+		var f *lockedfile.File
+		// lock parent before reading treesize or tree time
+
+		_, subspan := tracer.Start(ctx, "lockedfile.OpenFile")
+		parentFilename := p.lookup.MetadataBackend().LockfilePath(n.ParentPath())
+		f, err = lockedfile.OpenFile(parentFilename, os.O_RDWR|os.O_CREATE, 0600)
+		subspan.End()
+		if err != nil {
+			sublog.Error().Err(err).
+				Str("parent filename", parentFilename).
+				Msg("Propagation failed. Could not open metadata for parent with lock.")
+			return err
+		}
+		// always log error if closing node fails
+		defer func() {
+			// ignore already closed error
+			cerr := f.Close()
+			if err == nil && cerr != nil && !errors.Is(cerr, os.ErrClosed) {
+				err = cerr // only overwrite err with en error from close if the former was nil
+			}
+		}()
+
+		if n, err = n.Parent(ctx); err != nil {
+			sublog.Error().Err(err).
+				Msg("Propagation failed. Could not read parent node.")
+			return err
+		}
+
+		// TODO none, sync and async?
+		if !n.HasPropagation(ctx) {
+			sublog.Debug().Str("attr", prefixes.PropagationAttr).Msg("propagation attribute not set or unreadable, not propagating")
+			// if the attribute is not set treat it as false / none / no propagation
+			return nil
+		}
+
+		sublog = sublog.With().Str("spaceid", n.SpaceID).Str("nodeid", n.ID).Logger()
+
+		if p.treeTimeAccounting {
+			// update the parent tree time if it is older than the nodes mtime
+			updateSyncTime := false
+
+			var tmTime time.Time
+			tmTime, err = n.GetTMTime(ctx)
+			switch {
+			case err != nil:
+				// missing attribute, or invalid format, overwrite
+				sublog.Debug().Err(err).
+					Msg("could not read tmtime attribute, overwriting")
+				updateSyncTime = true
+			case tmTime.Before(sTime):
+				sublog.Debug().
+					Time("tmtime", tmTime).
+					Time("stime", sTime).
+					Msg("parent tmtime is older than node mtime, updating")
+				updateSyncTime = true
+			default:
+				sublog.Debug().
+					Time("tmtime", tmTime).
+					Time("stime", sTime).
+					Dur("delta", sTime.Sub(tmTime)).
+					Msg("parent tmtime is younger than node mtime, not updating")
+			}
+
+			if updateSyncTime {
+				// update the tree time of the parent node
+				attrs.SetString(prefixes.TreeMTimeAttr, sTime.UTC().Format(time.RFC3339Nano))
+			}
+
+			attrs.SetString(prefixes.TmpEtagAttr, "")
+		}
+
+		// size accounting
+		if p.treeSizeAccounting && sizeDiff != 0 {
+			var newSize uint64
+
+			// read treesize
+			treeSize, err := n.GetTreeSize(ctx)
+			switch {
+			case metadata.IsAttrUnset(err):
+				// fallback to calculating the treesize
+				sublog.Warn().Msg("treesize attribute unset, falling back to calculating the treesize")
+				newSize, err = calculateTreeSize(ctx, p.lookup, n.InternalPath())
+				if err != nil {
+					return err
+				}
+			case err != nil:
+				sublog.Error().Err(err).
+					Msg("Faild to propagate treesize change. Error when reading the treesize attribute from parent")
+				return err
+			case sizeDiff > 0:
+				newSize = treeSize + uint64(sizeDiff)
+			case uint64(-sizeDiff) > treeSize:
+				// The sizeDiff is larger than the current treesize. Which would result in
+				// a negative new treesize. Something must have gone wrong with the accounting.
+				// Reset the current treesize to 0.
+				sublog.Error().Uint64("treeSize", treeSize).Int64("sizeDiff", sizeDiff).
+					Msg("Error when updating treesize of parent node. Updated treesize < 0. Reestting to 0")
+				newSize = 0
+			default:
+				newSize = treeSize - uint64(-sizeDiff)
+			}
+
+			// update the tree size of the node
+			attrs.SetString(prefixes.TreesizeAttr, strconv.FormatUint(newSize, 10))
+			sublog.Debug().Uint64("newSize", newSize).Msg("updated treesize of parent node")
+		}
+
+		if err = n.SetXattrsWithContext(ctx, attrs, false); err != nil {
+			sublog.Error().Err(err).Msg("Failed to update extend attributes of parent node")
+			return err
+		}
+
+		// Release node lock early, ignore already closed error
+		_, subspan = tracer.Start(ctx, "f.Close")
+		cerr := f.Close()
+		subspan.End()
+		if cerr != nil && !errors.Is(cerr, os.ErrClosed) {
+			sublog.Error().Err(cerr).Msg("Failed to close parent node and release lock")
+			return cerr
+		}
+	}
+	if err != nil {
+		sublog.Error().Err(err).Msg("error propagating")
+		return err
+	}
+	return nil
+
+}

--- a/pkg/storage/utils/decomposedfs/tree/tree.go
+++ b/pkg/storage/utils/decomposedfs/tree/tree.go
@@ -85,7 +85,7 @@ func New(lu lookup.PathLookup, bs Blobstore, o *options.Options, cache store.Sto
 		blobstore:  bs,
 		options:    o,
 		idCache:    cache,
-		propagator: propagator.New(o.Propagator, o.TreeSizeAccounting, o.TreeTimeAccounting, lu),
+		propagator: propagator.New(lu, o),
 	}
 }
 


### PR DESCRIPTION
This PR adds an experimental asynchronous propagator which propagates changes asynchronously outside of the request scope. It also combines changes that happen shortly after each other into one change.

The propagator can be configured, the original `sync` propagator is still the default.