### PR TITLE
Handle target in OpenInApp response

### DIFF
--- a/changelog/unreleased/openappintab.md
+++ b/changelog/unreleased/openappintab.md
@@ -3,7 +3,8 @@ Enhancement: Handle target in OpenInApp response
 This PR adds the OpenInApp.target and AppProviderInfo.action properties
 to the respective responses (/app/open and /app/list), to support
 different app integrations.
-In addition, the archiver was extended to support a query parameter
-to override the archive type, as it will be used in an upcoming app.
+In addition, the archiver was extended to use the name of the file/folder
+as opposed to "download", and to include a query parameter to
+override the archive type, as it will be used in an upcoming app.
 
 https://github.com/cs3org/reva/pull/4077

--- a/changelog/unreleased/openappintab.md
+++ b/changelog/unreleased/openappintab.md
@@ -1,5 +1,9 @@
 Enhancement: Handle target in OpenInApp response
 
-Implements the OpenInApp.target property
+This PR adds the OpenInApp.target and AppProviderInfo.action properties
+to the respective responses (/app/open and /app/list), to support
+different app integrations.
+In addition, the archiver was extended to support a query parameter
+to override the archive type, as it will be used in an upcoming app.
 
 https://github.com/cs3org/reva/pull/4077

--- a/changelog/unreleased/openappintab.md
+++ b/changelog/unreleased/openappintab.md
@@ -1,0 +1,5 @@
+Enhancement: Handle target in OpenInApp response
+
+Implements the OpenInApp.target property
+
+https://github.com/cs3org/reva/pull/4077

--- a/docs/content/en/docs/config/grpc/services/appprovider/_index.md
+++ b/docs/content/en/docs/config/grpc/services/appprovider/_index.md
@@ -9,7 +9,7 @@ description: >
 # _struct: config_
 
 {{% dir name="mime_types" type="[]string" default=nil %}}
-A list of mime types supported by this app. [[Ref]](https://github.com/cs3org/reva/tree/master/internal/grpc/services/appprovider/appprovider.go#L62)
+A list of mime types supported by this app. [[Ref]](https://github.com/cs3org/reva/tree/master/internal/grpc/services/appprovider/appprovider.go#L69)
 {{< highlight toml >}}
 [grpc.services.appprovider]
 mime_types = nil
@@ -17,7 +17,7 @@ mime_types = nil
 {{% /dir %}}
 
 {{% dir name="custom_mime_types_json" type="string" default="nil" %}}
-An optional mapping file with the list of supported custom file extensions and corresponding mime types. [[Ref]](https://github.com/cs3org/reva/tree/master/internal/grpc/services/appprovider/appprovider.go#L63)
+An optional mapping file with the list of supported custom file extensions and corresponding mime types. [[Ref]](https://github.com/cs3org/reva/tree/master/internal/grpc/services/appprovider/appprovider.go#L70)
 {{< highlight toml >}}
 [grpc.services.appprovider]
 custom_mime_types_json = "nil"

--- a/docs/content/en/docs/config/grpc/services/appprovider/_index.md
+++ b/docs/content/en/docs/config/grpc/services/appprovider/_index.md
@@ -9,7 +9,7 @@ description: >
 # _struct: config_
 
 {{% dir name="mime_types" type="[]string" default=nil %}}
-A list of mime types supported by this app. [[Ref]](https://github.com/cs3org/reva/tree/master/internal/grpc/services/appprovider/appprovider.go#L69)
+A list of mime types supported by this app. [[Ref]](https://github.com/cs3org/reva/tree/master/internal/grpc/services/appprovider/appprovider.go#L68)
 {{< highlight toml >}}
 [grpc.services.appprovider]
 mime_types = nil
@@ -17,7 +17,7 @@ mime_types = nil
 {{% /dir %}}
 
 {{% dir name="custom_mime_types_json" type="string" default="nil" %}}
-An optional mapping file with the list of supported custom file extensions and corresponding mime types. [[Ref]](https://github.com/cs3org/reva/tree/master/internal/grpc/services/appprovider/appprovider.go#L70)
+An optional mapping file with the list of supported custom file extensions and corresponding mime types. [[Ref]](https://github.com/cs3org/reva/tree/master/internal/grpc/services/appprovider/appprovider.go#L69)
 {{< highlight toml >}}
 [grpc.services.appprovider]
 custom_mime_types_json = "nil"

--- a/docs/content/en/docs/config/grpc/services/ocminvitemanager/_index.md
+++ b/docs/content/en/docs/config/grpc/services/ocminvitemanager/_index.md
@@ -9,7 +9,7 @@ description: >
 # _struct: config_
 
 {{% dir name="provider_domain" type="string" default="The same domain registered in the provider authorizer" %}}
- [[Ref]](https://github.com/cs3org/reva/tree/master/internal/grpc/services/ocminvitemanager/ocminvitemanager.go#L55)
+ [[Ref]](https://github.com/cs3org/reva/tree/master/internal/grpc/services/ocminvitemanager/ocminvitemanager.go#L61)
 {{< highlight toml >}}
 [grpc.services.ocminvitemanager]
 provider_domain = "The same domain registered in the provider authorizer"

--- a/docs/content/en/docs/config/grpc/services/ocmshareprovider/_index.md
+++ b/docs/content/en/docs/config/grpc/services/ocmshareprovider/_index.md
@@ -9,7 +9,7 @@ description: >
 # _struct: config_
 
 {{% dir name="provider_domain" type="string" default="The same domain registered in the provider authorizer" %}}
- [[Ref]](https://github.com/cs3org/reva/tree/master/internal/grpc/services/ocmshareprovider/ocmshareprovider.go#L64)
+ [[Ref]](https://github.com/cs3org/reva/tree/master/internal/grpc/services/ocmshareprovider/ocmshareprovider.go#L70)
 {{< highlight toml >}}
 [grpc.services.ocmshareprovider]
 provider_domain = "The same domain registered in the provider authorizer"

--- a/docs/content/en/docs/config/grpc/services/permissions/_index.md
+++ b/docs/content/en/docs/config/grpc/services/permissions/_index.md
@@ -9,7 +9,7 @@ description: >
 # _struct: config_
 
 {{% dir name="driver" type="string" default="localhome" %}}
-The permission driver to be used. [[Ref]](https://github.com/cs3org/reva/tree/master/internal/grpc/services/permissions/permissions.go#L40)
+The permission driver to be used. [[Ref]](https://github.com/cs3org/reva/tree/master/internal/grpc/services/permissions/permissions.go#L46)
 {{< highlight toml >}}
 [grpc.services.permissions]
 driver = "localhome"
@@ -17,7 +17,7 @@ driver = "localhome"
 {{% /dir %}}
 
 {{% dir name="drivers" type="map[string]map[string]interface{}" default="permission" %}}
- [[Ref]](https://github.com/cs3org/reva/tree/master/internal/grpc/services/permissions/permissions.go#L41)
+ [[Ref]](https://github.com/cs3org/reva/tree/master/internal/grpc/services/permissions/permissions.go#L47)
 {{< highlight toml >}}
 [grpc.services.permissions.drivers.permission]
 

--- a/docs/content/en/docs/config/grpc/services/storageprovider/_index.md
+++ b/docs/content/en/docs/config/grpc/services/storageprovider/_index.md
@@ -9,7 +9,7 @@ description: >
 # _struct: config_
 
 {{% dir name="mount_path" type="string" default="/" %}}
-The path where the file system would be mounted. [[Ref]](https://github.com/cs3org/reva/tree/master/internal/grpc/services/storageprovider/storageprovider.go#L57)
+The path where the file system would be mounted. [[Ref]](https://github.com/cs3org/reva/tree/master/internal/grpc/services/storageprovider/storageprovider.go#L63)
 {{< highlight toml >}}
 [grpc.services.storageprovider]
 mount_path = "/"
@@ -17,7 +17,7 @@ mount_path = "/"
 {{% /dir %}}
 
 {{% dir name="mount_id" type="string" default="-" %}}
-The ID of the mounted file system. [[Ref]](https://github.com/cs3org/reva/tree/master/internal/grpc/services/storageprovider/storageprovider.go#L58)
+The ID of the mounted file system. [[Ref]](https://github.com/cs3org/reva/tree/master/internal/grpc/services/storageprovider/storageprovider.go#L64)
 {{< highlight toml >}}
 [grpc.services.storageprovider]
 mount_id = "-"
@@ -25,7 +25,7 @@ mount_id = "-"
 {{% /dir %}}
 
 {{% dir name="driver" type="string" default="localhome" %}}
-The storage driver to be used. [[Ref]](https://github.com/cs3org/reva/tree/master/internal/grpc/services/storageprovider/storageprovider.go#L59)
+The storage driver to be used. [[Ref]](https://github.com/cs3org/reva/tree/master/internal/grpc/services/storageprovider/storageprovider.go#L65)
 {{< highlight toml >}}
 [grpc.services.storageprovider]
 driver = "localhome"
@@ -33,7 +33,7 @@ driver = "localhome"
 {{% /dir %}}
 
 {{% dir name="drivers" type="map[string]map[string]interface{}" default="localhome" %}}
- [[Ref]](https://github.com/cs3org/reva/tree/master/internal/grpc/services/storageprovider/storageprovider.go#L60)
+ [[Ref]](https://github.com/cs3org/reva/tree/master/internal/grpc/services/storageprovider/storageprovider.go#L66)
 {{< highlight toml >}}
 [grpc.services.storageprovider.drivers.localhome]
 root = "/var/tmp/reva/"
@@ -44,7 +44,7 @@ user_layout = "{{.Username}}"
 {{% /dir %}}
 
 {{% dir name="tmp_folder" type="string" default="/var/tmp" %}}
-Path to temporary folder. [[Ref]](https://github.com/cs3org/reva/tree/master/internal/grpc/services/storageprovider/storageprovider.go#L61)
+Path to temporary folder. [[Ref]](https://github.com/cs3org/reva/tree/master/internal/grpc/services/storageprovider/storageprovider.go#L67)
 {{< highlight toml >}}
 [grpc.services.storageprovider]
 tmp_folder = "/var/tmp"
@@ -52,7 +52,7 @@ tmp_folder = "/var/tmp"
 {{% /dir %}}
 
 {{% dir name="data_server_url" type="string" default="http://localhost/data" %}}
-The URL for the data server. [[Ref]](https://github.com/cs3org/reva/tree/master/internal/grpc/services/storageprovider/storageprovider.go#L62)
+The URL for the data server. [[Ref]](https://github.com/cs3org/reva/tree/master/internal/grpc/services/storageprovider/storageprovider.go#L68)
 {{< highlight toml >}}
 [grpc.services.storageprovider]
 data_server_url = "http://localhost/data"
@@ -60,7 +60,7 @@ data_server_url = "http://localhost/data"
 {{% /dir %}}
 
 {{% dir name="expose_data_server" type="bool" default=false %}}
-Whether to expose data server. [[Ref]](https://github.com/cs3org/reva/tree/master/internal/grpc/services/storageprovider/storageprovider.go#L63)
+Whether to expose data server. [[Ref]](https://github.com/cs3org/reva/tree/master/internal/grpc/services/storageprovider/storageprovider.go#L69)
 {{< highlight toml >}}
 [grpc.services.storageprovider]
 expose_data_server = false
@@ -68,7 +68,7 @@ expose_data_server = false
 {{% /dir %}}
 
 {{% dir name="available_checksums" type="map[string]uint32" default=nil %}}
-List of available checksums. [[Ref]](https://github.com/cs3org/reva/tree/master/internal/grpc/services/storageprovider/storageprovider.go#L64)
+List of available checksums. [[Ref]](https://github.com/cs3org/reva/tree/master/internal/grpc/services/storageprovider/storageprovider.go#L70)
 {{< highlight toml >}}
 [grpc.services.storageprovider]
 available_checksums = nil
@@ -76,7 +76,7 @@ available_checksums = nil
 {{% /dir %}}
 
 {{% dir name="custom_mime_types_json" type="string" default="nil" %}}
-An optional mapping file with the list of supported custom file extensions and corresponding mime types. [[Ref]](https://github.com/cs3org/reva/tree/master/internal/grpc/services/storageprovider/storageprovider.go#L65)
+An optional mapping file with the list of supported custom file extensions and corresponding mime types. [[Ref]](https://github.com/cs3org/reva/tree/master/internal/grpc/services/storageprovider/storageprovider.go#L71)
 {{< highlight toml >}}
 [grpc.services.storageprovider]
 custom_mime_types_json = "nil"

--- a/docs/content/en/docs/config/http/services/appprovider/_index.md
+++ b/docs/content/en/docs/config/http/services/appprovider/_index.md
@@ -9,7 +9,7 @@ description: >
 # _struct: Config_
 
 {{% dir name="insecure" type="bool" default=false %}}
-Whether to skip certificate checks when sending requests. [[Ref]](https://github.com/cs3org/reva/tree/master/internal/http/services/appprovider/appprovider.go#L55)
+Whether to skip certificate checks when sending requests. [[Ref]](https://github.com/cs3org/reva/tree/master/internal/http/services/appprovider/appprovider.go#L56)
 {{< highlight toml >}}
 [http.services.appprovider]
 insecure = false

--- a/docs/content/en/docs/config/http/services/appprovider/_index.md
+++ b/docs/content/en/docs/config/http/services/appprovider/_index.md
@@ -9,7 +9,7 @@ description: >
 # _struct: Config_
 
 {{% dir name="insecure" type="bool" default=false %}}
-Whether to skip certificate checks when sending requests. [[Ref]](https://github.com/cs3org/reva/tree/master/internal/http/services/appprovider/appprovider.go#L54)
+Whether to skip certificate checks when sending requests. [[Ref]](https://github.com/cs3org/reva/tree/master/internal/http/services/appprovider/appprovider.go#L55)
 {{< highlight toml >}}
 [http.services.appprovider]
 insecure = false

--- a/docs/content/en/docs/config/http/services/archiver/_index.md
+++ b/docs/content/en/docs/config/http/services/archiver/_index.md
@@ -9,7 +9,7 @@ description: >
 # _struct: Config_
 
 {{% dir name="insecure" type="bool" default=false %}}
-Whether to skip certificate checks when sending requests. [[Ref]](https://github.com/cs3org/reva/tree/master/internal/http/services/archiver/handler.go#L61)
+Whether to skip certificate checks when sending requests. [[Ref]](https://github.com/cs3org/reva/tree/master/internal/http/services/archiver/handler.go#L62)
 {{< highlight toml >}}
 [http.services.archiver]
 insecure = false

--- a/docs/content/en/docs/config/http/services/archiver/_index.md
+++ b/docs/content/en/docs/config/http/services/archiver/_index.md
@@ -9,7 +9,7 @@ description: >
 # _struct: Config_
 
 {{% dir name="insecure" type="bool" default=false %}}
-Whether to skip certificate checks when sending requests. [[Ref]](https://github.com/cs3org/reva/tree/master/internal/http/services/archiver/handler.go#L62)
+Whether to skip certificate checks when sending requests. [[Ref]](https://github.com/cs3org/reva/tree/master/internal/http/services/archiver/handler.go#L63)
 {{< highlight toml >}}
 [http.services.archiver]
 insecure = false

--- a/docs/content/en/docs/config/http/services/archiver/_index.md
+++ b/docs/content/en/docs/config/http/services/archiver/_index.md
@@ -9,7 +9,7 @@ description: >
 # _struct: Config_
 
 {{% dir name="insecure" type="bool" default=false %}}
-Whether to skip certificate checks when sending requests. [[Ref]](https://github.com/cs3org/reva/tree/master/internal/http/services/archiver/handler.go#L63)
+Whether to skip certificate checks when sending requests. [[Ref]](https://github.com/cs3org/reva/tree/master/internal/http/services/archiver/handler.go#L61)
 {{< highlight toml >}}
 [http.services.archiver]
 insecure = false

--- a/docs/content/en/docs/config/http/services/datagateway/_index.md
+++ b/docs/content/en/docs/config/http/services/datagateway/_index.md
@@ -9,7 +9,7 @@ description: >
 # _struct: config_
 
 {{% dir name="insecure" type="bool" default=false %}}
-Whether to skip certificate checks when sending requests. [[Ref]](https://github.com/cs3org/reva/tree/master/internal/http/services/datagateway/datagateway.go#L62)
+Whether to skip certificate checks when sending requests. [[Ref]](https://github.com/cs3org/reva/tree/master/internal/http/services/datagateway/datagateway.go#L61)
 {{< highlight toml >}}
 [http.services.datagateway]
 insecure = false

--- a/docs/content/en/docs/config/http/services/owncloud/ocdav/_index.md
+++ b/docs/content/en/docs/config/http/services/owncloud/ocdav/_index.md
@@ -9,7 +9,7 @@ description: >
 # _struct: Config_
 
 {{% dir name="insecure" type="bool" default=false %}}
-Whether to skip certificate checks when sending requests. [[Ref]](https://github.com/cs3org/reva/tree/master/internal/http/services/owncloud/ocdav/ocdav.go#L104)
+Whether to skip certificate checks when sending requests. [[Ref]](https://github.com/cs3org/reva/tree/master/internal/http/services/owncloud/ocdav/ocdav.go#L103)
 {{< highlight toml >}}
 [http.services.owncloud.ocdav]
 insecure = false
@@ -17,7 +17,7 @@ insecure = false
 {{% /dir %}}
 
 {{% dir name="notifications" type="map[string]interface{}" default=Settingsg for the Notification Helper %}}
- [[Ref]](https://github.com/cs3org/reva/tree/master/internal/http/services/owncloud/ocdav/ocdav.go#L115)
+ [[Ref]](https://github.com/cs3org/reva/tree/master/internal/http/services/owncloud/ocdav/ocdav.go#L114)
 {{< highlight toml >}}
 [http.services.owncloud.ocdav]
 notifications = Settingsg for the Notification Helper

--- a/docs/content/en/docs/config/packages/notification/handler/emailhandler/_index.md
+++ b/docs/content/en/docs/config/packages/notification/handler/emailhandler/_index.md
@@ -9,7 +9,7 @@ description: >
 # _struct: config_
 
 {{% dir name="smtp_server" type="string" default="" %}}
-The hostname and port of the SMTP server. [[Ref]](https://github.com/cs3org/reva/tree/master/pkg/notification/handler/emailhandler/emailhandler.go#L44)
+The hostname and port of the SMTP server. [[Ref]](https://github.com/cs3org/reva/tree/master/pkg/notification/handler/emailhandler/emailhandler.go#L46)
 {{< highlight toml >}}
 [notification.handler.emailhandler]
 smtp_server = ""
@@ -17,7 +17,7 @@ smtp_server = ""
 {{% /dir %}}
 
 {{% dir name="sender_login" type="string" default="" %}}
-The email to be used to send mails. [[Ref]](https://github.com/cs3org/reva/tree/master/pkg/notification/handler/emailhandler/emailhandler.go#L45)
+The email to be used to send mails. [[Ref]](https://github.com/cs3org/reva/tree/master/pkg/notification/handler/emailhandler/emailhandler.go#L47)
 {{< highlight toml >}}
 [notification.handler.emailhandler]
 sender_login = ""
@@ -25,7 +25,7 @@ sender_login = ""
 {{% /dir %}}
 
 {{% dir name="sender_password" type="string" default="" %}}
-The sender's password. [[Ref]](https://github.com/cs3org/reva/tree/master/pkg/notification/handler/emailhandler/emailhandler.go#L46)
+The sender's password. [[Ref]](https://github.com/cs3org/reva/tree/master/pkg/notification/handler/emailhandler/emailhandler.go#L48)
 {{< highlight toml >}}
 [notification.handler.emailhandler]
 sender_password = ""
@@ -33,7 +33,7 @@ sender_password = ""
 {{% /dir %}}
 
 {{% dir name="disable_auth" type="bool" default=false %}}
-Whether to disable SMTP auth. [[Ref]](https://github.com/cs3org/reva/tree/master/pkg/notification/handler/emailhandler/emailhandler.go#L47)
+Whether to disable SMTP auth. [[Ref]](https://github.com/cs3org/reva/tree/master/pkg/notification/handler/emailhandler/emailhandler.go#L49)
 {{< highlight toml >}}
 [notification.handler.emailhandler]
 disable_auth = false
@@ -41,7 +41,7 @@ disable_auth = false
 {{% /dir %}}
 
 {{% dir name="default_sender" type="string" default="no-reply@cernbox.cern.ch" %}}
-Default sender when not specified in the trigger. [[Ref]](https://github.com/cs3org/reva/tree/master/pkg/notification/handler/emailhandler/emailhandler.go#L48)
+Default sender when not specified in the trigger. [[Ref]](https://github.com/cs3org/reva/tree/master/pkg/notification/handler/emailhandler/emailhandler.go#L50)
 {{< highlight toml >}}
 [notification.handler.emailhandler]
 default_sender = "no-reply@cernbox.cern.ch"

--- a/docs/content/en/docs/config/packages/ocm/provider/authorizer/mentix/_index.md
+++ b/docs/content/en/docs/config/packages/ocm/provider/authorizer/mentix/_index.md
@@ -9,7 +9,7 @@ description: >
 # _struct: config_
 
 {{% dir name="insecure" type="bool" default=false %}}
-Whether to skip certificate checks when sending requests. [[Ref]](https://github.com/cs3org/reva/tree/master/pkg/ocm/provider/authorizer/mentix/mentix.go#L81)
+Whether to skip certificate checks when sending requests. [[Ref]](https://github.com/cs3org/reva/tree/master/pkg/ocm/provider/authorizer/mentix/mentix.go#L79)
 {{< highlight toml >}}
 [ocm.provider.authorizer.mentix]
 insecure = false

--- a/docs/content/en/docs/config/packages/storage/fs/local/_index.md
+++ b/docs/content/en/docs/config/packages/storage/fs/local/_index.md
@@ -9,7 +9,7 @@ description: >
 # _struct: config_
 
 {{% dir name="root" type="string" default="/var/tmp/reva/" %}}
-Path of root directory for user storage. [[Ref]](https://github.com/cs3org/reva/tree/master/pkg/storage/fs/local/local.go#L34)
+Path of root directory for user storage. [[Ref]](https://github.com/cs3org/reva/tree/master/pkg/storage/fs/local/local.go#L35)
 {{< highlight toml >}}
 [storage.fs.local]
 root = "/var/tmp/reva/"
@@ -17,7 +17,7 @@ root = "/var/tmp/reva/"
 {{% /dir %}}
 
 {{% dir name="share_folder" type="string" default="/MyShares" %}}
-Path for storing share references. [[Ref]](https://github.com/cs3org/reva/tree/master/pkg/storage/fs/local/local.go#L35)
+Path for storing share references. [[Ref]](https://github.com/cs3org/reva/tree/master/pkg/storage/fs/local/local.go#L36)
 {{< highlight toml >}}
 [storage.fs.local]
 share_folder = "/MyShares"

--- a/docs/content/en/docs/config/packages/storage/fs/localhome/_index.md
+++ b/docs/content/en/docs/config/packages/storage/fs/localhome/_index.md
@@ -9,7 +9,7 @@ description: >
 # _struct: config_
 
 {{% dir name="root" type="string" default="/var/tmp/reva/" %}}
-Path of root directory for user storage. [[Ref]](https://github.com/cs3org/reva/tree/master/pkg/storage/fs/localhome/localhome.go#L34)
+Path of root directory for user storage. [[Ref]](https://github.com/cs3org/reva/tree/master/pkg/storage/fs/localhome/localhome.go#L36)
 {{< highlight toml >}}
 [storage.fs.localhome]
 root = "/var/tmp/reva/"
@@ -17,7 +17,7 @@ root = "/var/tmp/reva/"
 {{% /dir %}}
 
 {{% dir name="share_folder" type="string" default="/MyShares" %}}
-Path for storing share references. [[Ref]](https://github.com/cs3org/reva/tree/master/pkg/storage/fs/localhome/localhome.go#L35)
+Path for storing share references. [[Ref]](https://github.com/cs3org/reva/tree/master/pkg/storage/fs/localhome/localhome.go#L37)
 {{< highlight toml >}}
 [storage.fs.localhome]
 share_folder = "/MyShares"
@@ -25,7 +25,7 @@ share_folder = "/MyShares"
 {{% /dir %}}
 
 {{% dir name="user_layout" type="string" default="{{.Username}}" %}}
-Template for user home directories [[Ref]](https://github.com/cs3org/reva/tree/master/pkg/storage/fs/localhome/localhome.go#L36)
+Template for user home directories [[Ref]](https://github.com/cs3org/reva/tree/master/pkg/storage/fs/localhome/localhome.go#L38)
 {{< highlight toml >}}
 [storage.fs.localhome]
 user_layout = "{{.Username}}"

--- a/docs/content/en/docs/config/serverless/services/notifications/_index.md
+++ b/docs/content/en/docs/config/serverless/services/notifications/_index.md
@@ -9,7 +9,7 @@ description: >
 # _struct: config_
 
 {{% dir name="nats_address" type="string" default="" %}}
-The NATS server address. [[Ref]](https://github.com/cs3org/reva/tree/master/internal/serverless/services/notifications/notifications.go#L46)
+The NATS server address. [[Ref]](https://github.com/cs3org/reva/tree/master/internal/serverless/services/notifications/notifications.go#L47)
 {{< highlight toml >}}
 [serverless.services.notifications]
 nats_address = ""
@@ -17,7 +17,7 @@ nats_address = ""
 {{% /dir %}}
 
 {{% dir name="nats_token" type="string" default="The token to authenticate against the NATS server" %}}
- [[Ref]](https://github.com/cs3org/reva/tree/master/internal/serverless/services/notifications/notifications.go#L47)
+ [[Ref]](https://github.com/cs3org/reva/tree/master/internal/serverless/services/notifications/notifications.go#L48)
 {{< highlight toml >}}
 [serverless.services.notifications]
 nats_token = "The token to authenticate against the NATS server"
@@ -25,15 +25,15 @@ nats_token = "The token to authenticate against the NATS server"
 {{% /dir %}}
 
 {{% dir name="nats_prefix" type="string" default="reva-notifications" %}}
-The notifications NATS stream. [[Ref]](https://github.com/cs3org/reva/tree/master/internal/serverless/services/notifications/notifications.go#L48)
+The notifications NATS stream. [[Ref]](https://github.com/cs3org/reva/tree/master/internal/serverless/services/notifications/notifications.go#L49)
 {{< highlight toml >}}
 [serverless.services.notifications]
 nats_prefix = "reva-notifications"
 {{< /highlight >}}
 {{% /dir %}}
 
-{{% dir name="handlers" type="map[string]interface{}" default= %}}
-Settings for the different notification handlers. [[Ref]](https://github.com/cs3org/reva/tree/master/internal/serverless/services/notifications/notifications.go#L49)
+{{% dir name="handlers" type="map[string]map[string]interface{}" default= %}}
+Settings for the different notification handlers. [[Ref]](https://github.com/cs3org/reva/tree/master/internal/serverless/services/notifications/notifications.go#L50)
 {{< highlight toml >}}
 [serverless.services.notifications]
 handlers = 
@@ -41,7 +41,7 @@ handlers =
 {{% /dir %}}
 
 {{% dir name="grouping_interval" type="int" default=60 %}}
-Time in seconds to group incoming notification triggers [[Ref]](https://github.com/cs3org/reva/tree/master/internal/serverless/services/notifications/notifications.go#L50)
+Time in seconds to group incoming notification triggers [[Ref]](https://github.com/cs3org/reva/tree/master/internal/serverless/services/notifications/notifications.go#L51)
 {{< highlight toml >}}
 [serverless.services.notifications]
 grouping_interval = 60
@@ -49,7 +49,7 @@ grouping_interval = 60
 {{% /dir %}}
 
 {{% dir name="grouping_max_size" type="int" default=100 %}}
-Maximum number of notifications to group [[Ref]](https://github.com/cs3org/reva/tree/master/internal/serverless/services/notifications/notifications.go#L51)
+Maximum number of notifications to group [[Ref]](https://github.com/cs3org/reva/tree/master/internal/serverless/services/notifications/notifications.go#L52)
 {{< highlight toml >}}
 [serverless.services.notifications]
 grouping_max_size = 100
@@ -57,7 +57,7 @@ grouping_max_size = 100
 {{% /dir %}}
 
 {{% dir name="storage_driver" type="string" default="mysql" %}}
-The driver used to store notifications [[Ref]](https://github.com/cs3org/reva/tree/master/internal/serverless/services/notifications/notifications.go#L52)
+The driver used to store notifications [[Ref]](https://github.com/cs3org/reva/tree/master/internal/serverless/services/notifications/notifications.go#L53)
 {{< highlight toml >}}
 [serverless.services.notifications]
 storage_driver = "mysql"

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/coreos/go-oidc/v3 v3.5.0
 	github.com/creasty/defaults v1.7.0
 	github.com/cs3org/cato v0.0.0-20200828125504-e418fc54dd5e
-	github.com/cs3org/go-cs3apis v0.0.0-20230606135123-b799d47a6648
+	github.com/cs3org/go-cs3apis v0.0.0-20230727093620-0f4399be4543
 	github.com/dgraph-io/ristretto v0.1.1
 	github.com/dolthub/go-mysql-server v0.14.0
 	github.com/eventials/go-tus v0.0.0-20200718001131-45c7ec8f5d59

--- a/go.sum
+++ b/go.sum
@@ -308,8 +308,8 @@ github.com/creasty/defaults v1.7.0 h1:eNdqZvc5B509z18lD8yc212CAqJNvfT1Jq6L8WowdB
 github.com/creasty/defaults v1.7.0/go.mod h1:iGzKe6pbEHnpMPtfDXZEr0NVxWnPTjb1bbDy08fPzYM=
 github.com/cs3org/cato v0.0.0-20200828125504-e418fc54dd5e h1:tqSPWQeueWTKnJVMJffz4pz0o1WuQxJ28+5x5JgaHD8=
 github.com/cs3org/cato v0.0.0-20200828125504-e418fc54dd5e/go.mod h1:XJEZ3/EQuI3BXTp/6DUzFr850vlxq11I6satRtz0YQ4=
-github.com/cs3org/go-cs3apis v0.0.0-20230606135123-b799d47a6648 h1:gBz1JSC2u6o/TkUhWSdJZvacyTsVUzDouegRzvrJye4=
-github.com/cs3org/go-cs3apis v0.0.0-20230606135123-b799d47a6648/go.mod h1:UXha4TguuB52H14EMoSsCqDj7k8a/t7g4gVP+bgY5LY=
+github.com/cs3org/go-cs3apis v0.0.0-20230727093620-0f4399be4543 h1:IFo6dj0XEOIA6i2baRWMC3vd+fAmuIUAVfSf77ZhoQg=
+github.com/cs3org/go-cs3apis v0.0.0-20230727093620-0f4399be4543/go.mod h1:UXha4TguuB52H14EMoSsCqDj7k8a/t7g4gVP+bgY5LY=
 github.com/cyberdelia/templates v0.0.0-20141128023046-ca7fffd4298c/go.mod h1:GyV+0YP4qX0UQ7r2MoYZ+AvYDp12OF5yg4q8rGnyNh4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/internal/grpc/services/appprovider/appprovider.go
+++ b/internal/grpc/services/appprovider/appprovider.go
@@ -21,7 +21,6 @@ package appprovider
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -211,7 +210,7 @@ func (s *service) OpenInApp(ctx context.Context, req *providerpb.OpenInAppReques
 	appURL, err := s.provider.GetAppURL(ctx, req.ResourceInfo, req.ViewMode, req.AccessToken, req.Opaque.Map, s.conf.Language)
 	if err != nil {
 		res := &providerpb.OpenInAppResponse{
-			Status: status.NewInternal(ctx, errors.New("appprovider: error calling GetAppURL"), err.Error()),
+			Status: status.NewStatusFromErrType(ctx, "appprovider: error calling GetAppURL", err),
 		}
 		return res, nil
 	}

--- a/internal/http/services/appprovider/appprovider.go
+++ b/internal/http/services/appprovider/appprovider.go
@@ -530,6 +530,6 @@ func appTargetToString(t apppb.Target) string {
 	case apppb.Target_TARGET_BLANK:
 		return "blank"
 	default:
-		return "iframe"
+		return "invalid"
 	}
 }

--- a/internal/http/services/appprovider/appprovider.go
+++ b/internal/http/services/appprovider/appprovider.go
@@ -408,6 +408,10 @@ func (s *svc) handleOpen(w http.ResponseWriter, r *http.Request) {
 			writeError(w, r, appErrorNotFound, openRes.Status.Message, nil)
 			return
 		}
+		if openRes.Status.Code == rpc.Code_CODE_ALREADY_EXISTS {
+			writeError(w, r, appErrorAlreadyExists, openRes.Status.Message, nil)
+			return
+		}
 		writeError(w, r, appErrorServerError, openRes.Status.Message,
 			status.NewErrorFromCode(openRes.Status.Code, "error calling OpenInApp"))
 		return

--- a/internal/http/services/appprovider/appprovider.go
+++ b/internal/http/services/appprovider/appprovider.go
@@ -421,7 +421,7 @@ func (s *svc) handleOpen(w http.ResponseWriter, r *http.Request) {
 	}
 
 	log := appctx.GetLogger(ctx)
-	log.Info().Str("url", openRes.AppUrl.AppUrl).Interface("resource", fileRef).Msg("returning app URL for file")
+	log.Info().Interface("resource", fileRef).Str("url", openRes.AppUrl.AppUrl).Str("method", openRes.AppUrl.Method).Interface("target", openRes.AppUrl.Target).Msg("returning app URL for file")
 
 	w.Header().Set("Content-Type", "application/json")
 	if _, err = w.Write(js); err != nil {

--- a/internal/http/services/archiver/handler.go
+++ b/internal/http/services/archiver/handler.go
@@ -25,6 +25,7 @@ import (
 	"net/http"
 	"path/filepath"
 	"regexp"
+	"strings"
 	"time"
 
 	gateway "github.com/cs3org/go-cs3apis/cs3/gateway/v1beta1"
@@ -243,7 +244,7 @@ func (s *svc) Handler() http.Handler {
 
 		var archName string
 		if len(files) == 1 {
-			archName = filepath.Base(files[0]) + "." + archType
+			archName = strings.TrimSuffix(filepath.Base(files[0]), filepath.Ext(files[0])) + "." + archType
 		} else {
 			// TODO(lopresti) we may want to generate a meaningful name out of the list
 			archName = s.config.Name + "." + archType

--- a/pkg/app/provider/demo/demo.go
+++ b/pkg/app/provider/demo/demo.go
@@ -45,12 +45,16 @@ func (p *demoProvider) GetAppURL(ctx context.Context, resource *provider.Resourc
 	return &appprovider.OpenInAppURL{
 		AppUrl: url,
 		Method: http.MethodGet,
+		Target: appprovider.Target_TARGET_IFRAME, // alternatively, appprovider.Target_TARGET_BLANK
 	}, nil
 }
 
 func (p *demoProvider) GetAppProviderInfo(ctx context.Context) (*appregistry.ProviderInfo, error) {
 	return &appregistry.ProviderInfo{
-		Name: "demo-app",
+		Name:        "demo-app",
+		Description: "A dummy app provider",
+		MimeTypes:   []string{},
+		Action:      "Demo open",
 	}, nil
 }
 

--- a/pkg/app/provider/wopi/wopi.go
+++ b/pkg/app/provider/wopi/wopi.go
@@ -336,6 +336,7 @@ func (p *wopiProvider) GetAppURL(ctx context.Context, resource *provider.Resourc
 		AppUrl:         appFullURL,
 		Method:         method,
 		FormParameters: formParams,
+		Target:         appprovider.Target_TARGET_IFRAME,
 	}, nil
 }
 

--- a/pkg/errtypes/errtypes.go
+++ b/pkg/errtypes/errtypes.go
@@ -22,7 +22,7 @@
 // and error is a reserved word :)
 package errtypes
 
-// NotFound is the error to use when a something is not found.
+// NotFound is the error to use when something is not found.
 type NotFound string
 
 func (e NotFound) Error() string { return "error: not found: " + string(e) }
@@ -46,7 +46,7 @@ func (e PermissionDenied) Error() string { return "error: permission denied: " +
 // IsPermissionDenied implements the IsPermissionDenied interface.
 func (e PermissionDenied) IsPermissionDenied() {}
 
-// AlreadyExists is the error to use when a resource something is not found.
+// AlreadyExists is the error to use when a resource already exists and can't be overwritten.
 type AlreadyExists string
 
 func (e AlreadyExists) Error() string { return "error: already exists: " + string(e) }
@@ -54,7 +54,7 @@ func (e AlreadyExists) Error() string { return "error: already exists: " + strin
 // IsAlreadyExists implements the IsAlreadyExists interface.
 func (e AlreadyExists) IsAlreadyExists() {}
 
-// UserRequired represents an error when a resource is not found.
+// UserRequired represents an error when a user could not be found from the context.
 type UserRequired string
 
 func (e UserRequired) Error() string { return "error: user required: " + string(e) }

--- a/pkg/rgrpc/status/status.go
+++ b/pkg/rgrpc/status/status.go
@@ -181,6 +181,8 @@ func NewStatusFromErrType(ctx context.Context, msg string, err error) *rpc.Statu
 		return NewUnimplemented(ctx, err, "gateway: "+msg+":"+err.Error())
 	case errtypes.BadRequest:
 		return NewInvalidArg(ctx, "gateway: "+msg+":"+err.Error())
+	case errtypes.AlreadyExists:
+		return NewAlreadyExists(ctx, err, "gateway: "+msg+":"+err.Error())
 	}
 
 	// map GRPC status codes coming from the auth middleware


### PR DESCRIPTION
This PR adds the `OpenInApp.target` and `AppProviderInfo.action` properties to the respective responses (from `/app/open` and `/app/list`), to support different app integrations. Builds on top of https://github.com/cs3org/cs3apis/pull/212.

In addition, the archiver was extended to use the name of the file/folder as opposed to `download`, and to include a query parameter to override the archive type, as it will be used in an upcoming app, see #4084.