### PR TITLE
Fix PROPFIND permissions

### DIFF
--- a/changelog/unreleased/fix-propfind-permissions.md
+++ b/changelog/unreleased/fix-propfind-permissions.md
@@ -1,0 +1,6 @@
+Bugfix: Fix propfind permissions
+
+Propfinds permissions field would always contain the permissions of the requested resource, even for its children
+This is fixed.
+
+https://github.com/cs3org/reva/pull/4082

--- a/pkg/storage/utils/decomposedfs/decomposedfs.go
+++ b/pkg/storage/utils/decomposedfs/decomposedfs.go
@@ -912,7 +912,7 @@ func (fs *Decomposedfs) ListFolder(ctx context.Context, ref *provider.Reference,
 			for child := range work {
 				np := rp
 				// add this childs permissions
-				pset, _ := n.PermissionSet(ctx)
+				pset, _ := child.PermissionSet(ctx)
 				node.AddPermissions(&np, &pset)
 				ri, err := child.AsResourceInfo(ctx, &np, mdKeys, fieldMask, utils.IsRelativeReference(ref))
 				if err != nil {


### PR DESCRIPTION
Fixes PROPFIND permissions. They would always contain the permissions of the requested resource, even for their children. See details here: https://github.com/owncloud/ocis/issues/6884
