### PR TITLE
Remove app ticker logs

### DIFF
--- a/changelog/unreleased/remove-app-ticker-logs.md
+++ b/changelog/unreleased/remove-app-ticker-logs.md
@@ -1,0 +1,4 @@
+Enhancement: Remove app ticker logs
+
+Logs would show regardless of log level as there is no configuration done beforehand. We remove the logs for now.
+https://github.com/cs3org/reva/pull/4097

--- a/internal/grpc/services/appprovider/appprovider.go
+++ b/internal/grpc/services/appprovider/appprovider.go
@@ -39,7 +39,6 @@ import (
 	"github.com/cs3org/reva/v2/pkg/utils"
 	"github.com/juliangruber/go-intersect"
 	"github.com/mitchellh/mapstructure"
-	"github.com/rs/zerolog/log"
 	"google.golang.org/grpc"
 )
 
@@ -111,10 +110,8 @@ func New(m map[string]interface{}, ss *grpc.Server) (rgrpc.Service, error) {
 		for {
 			select {
 			case <-t.C:
-				log.Debug().Msg("app provider tick, registering Provider")
 				service.registerProvider()
 			case <-service.context.Done():
-				log.Debug().Msg("app provider stopped")
 				t.Stop()
 			}
 		}


### PR DESCRIPTION
Removes logs that would always show, regardless of log level
