### PR TITLE
S3ng include md5 checksum on put

### DIFF
--- a/changelog/unreleased/fix-logging-upload-errors.md
+++ b/changelog/unreleased/fix-logging-upload-errors.md
@@ -1,0 +1,5 @@
+Bugfix: Fix logging upload errors
+
+We fixed a problem where problems with uploading blobs to the blobstore weren't logged.
+
+https://github.com/cs3org/reva/pull/4099

--- a/changelog/unreleased/fix-s3-put-md5.md
+++ b/changelog/unreleased/fix-s3-put-md5.md
@@ -1,0 +1,7 @@
+Bugfix: S3ng include md5 checksum on put
+
+We've fixed the S3 put operation of the S3ng storage to include a md5 checksum.
+
+This md5 checksum is needed when a bucket has a retention period configured (see https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html).
+
+https://github.com/cs3org/reva/pull/4100

--- a/pkg/storage/fs/s3ng/blobstore/blobstore.go
+++ b/pkg/storage/fs/s3ng/blobstore/blobstore.go
@@ -71,9 +71,9 @@ func (bs *Blobstore) Upload(node *node.Node, source string) error {
 	}
 	defer reader.Close()
 
-	_, err1 := bs.client.PutObject(context.Background(), bs.bucket, bs.path(node), reader, node.Blobsize, minio.PutObjectOptions{ContentType: "application/octet-stream"})
+	_, err = bs.client.PutObject(context.Background(), bs.bucket, bs.path(node), reader, node.Blobsize, minio.PutObjectOptions{ContentType: "application/octet-stream"})
 
-	if err1 != nil {
+	if err != nil {
 		return errors.Wrapf(err, "could not store object '%s' into bucket '%s'", bs.path(node), bs.bucket)
 	}
 	return nil

--- a/pkg/storage/fs/s3ng/blobstore/blobstore.go
+++ b/pkg/storage/fs/s3ng/blobstore/blobstore.go
@@ -71,7 +71,7 @@ func (bs *Blobstore) Upload(node *node.Node, source string) error {
 	}
 	defer reader.Close()
 
-	_, err = bs.client.PutObject(context.Background(), bs.bucket, bs.path(node), reader, node.Blobsize, minio.PutObjectOptions{ContentType: "application/octet-stream"})
+	_, err = bs.client.PutObject(context.Background(), bs.bucket, bs.path(node), reader, node.Blobsize, minio.PutObjectOptions{ContentType: "application/octet-stream", SendContentMd5: true})
 
 	if err != nil {
 		return errors.Wrapf(err, "could not store object '%s' into bucket '%s'", bs.path(node), bs.bucket)

--- a/pkg/storage/utils/decomposedfs/upload/upload.go
+++ b/pkg/storage/utils/decomposedfs/upload/upload.go
@@ -292,6 +292,7 @@ func (upload *Upload) FinishUpload(_ context.Context) error {
 		err = upload.Finalize()
 		Cleanup(upload, err != nil, false)
 		if err != nil {
+			log.Error().Err(err).Msg("failed to upload")
 			return err
 		}
 	}


### PR DESCRIPTION
Bugfix: S3ng include md5 checksum on put

We've fixed the S3 put operation of the S3ng storage to include a md5 checksum.

This md5 checksum is needed when a bucket has a retention period configured (see https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html).
