### PR TITLE
[tests-only][full-ci]bumped ocis commit id reva edge

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,4 +1,4 @@
 # The test runner source for API tests
-APITESTS_COMMITID=43ee37d02ed652b89e88c03c6bbeb5c89a62ce16
+APITESTS_COMMITID=cbe945af4a97b1bafbc903ab5ac2905258f19a62
 APITESTS_BRANCH=master
 APITESTS_REPO_GIT_URL=https://github.com/owncloud/ocis.git


### PR DESCRIPTION
Bump ocis latest commit to reva edge
part of https://github.com/owncloud/QA/issues/822