### PR TITLE
Add tracing propagation to events

### DIFF
--- a/changelog/unreleased/tracing-events-propagator.md
+++ b/changelog/unreleased/tracing-events-propagator.md
@@ -1,0 +1,5 @@
+Enhancement: tracing events propgation
+
+tracing information will now be propagated via events
+
+https://github.com/cs3org/reva/pull/4110

--- a/internal/grpc/interceptors/eventsmiddleware/events.go
+++ b/internal/grpc/interceptors/eventsmiddleware/events.go
@@ -194,7 +194,7 @@ func NewUnary(m map[string]interface{}) (grpc.UnaryServerInterceptor, int, error
 		}
 
 		if ev != nil {
-			if err := events.Publish(publisher, ev); err != nil {
+			if err := events.Publish(ctx, publisher, ev); err != nil {
 				log.Error(err)
 			}
 		}

--- a/pkg/events/example/publisher/publisher.go
+++ b/pkg/events/example/publisher/publisher.go
@@ -20,6 +20,7 @@
 package publisher
 
 import (
+	"context"
 	"log"
 
 	user "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
@@ -29,7 +30,7 @@ import (
 // Example publishes events to the queue
 func Example(p events.Publisher) {
 	// nothing to do - just publish!
-	err := events.Publish(p, events.ShareCreated{
+	err := events.Publish(context.Background(), p, events.ShareCreated{
 		Sharer: &user.UserId{
 			OpaqueId: "123",
 		},
@@ -40,5 +41,4 @@ func Example(p events.Publisher) {
 	if err != nil {
 		log.Fatal(err)
 	}
-
 }

--- a/pkg/rhttp/datatx/datatx.go
+++ b/pkg/rhttp/datatx/datatx.go
@@ -51,7 +51,7 @@ func EmitFileUploadedEvent(spaceOwnerOrManager, executant *userv1beta1.UserId, r
 		Timestamp:  utils.TSNow(),
 	}
 
-	return events.Publish(publisher, uploadedEv)
+	return events.Publish(context.Background(), publisher, uploadedEv)
 }
 
 // InvalidateCache is a helper function which invalidates the stat cache

--- a/pkg/share/manager/jsoncs3/jsoncs3.go
+++ b/pkg/share/manager/jsoncs3/jsoncs3.go
@@ -304,7 +304,7 @@ func (m *Manager) Share(ctx context.Context, md *provider.ResourceInfo, g *colla
 
 	// check if share already exists.
 	key := &collaboration.ShareKey{
-		//Owner:      md.Owner, owner no longer matters as it belongs to the space
+		// Owner:      md.Owner, owner no longer matters as it belongs to the space
 		ResourceId: md.Id,
 		Grantee:    g.Grantee,
 	}
@@ -337,7 +337,6 @@ func (m *Manager) Share(ctx context.Context, md *provider.ResourceInfo, g *colla
 
 	eg.Go(func() error {
 		err := m.Cache.Add(ctx, md.Id.StorageId, md.Id.SpaceId, shareID, s)
-
 		if err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
@@ -348,7 +347,6 @@ func (m *Manager) Share(ctx context.Context, md *provider.ResourceInfo, g *colla
 
 	eg.Go(func() error {
 		err := m.CreatedCache.Add(ctx, s.GetCreator().GetOpaqueId(), shareID)
-
 		if err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
@@ -369,7 +367,6 @@ func (m *Manager) Share(ctx context.Context, md *provider.ResourceInfo, g *colla
 				State: collaboration.ShareState_SHARE_STATE_PENDING,
 			}
 			err := m.UserReceivedStates.Add(ctx, userid, spaceID, rs)
-
 			if err != nil {
 				span.RecordError(err)
 				span.SetStatus(codes.Error, err.Error())
@@ -381,7 +378,6 @@ func (m *Manager) Share(ctx context.Context, md *provider.ResourceInfo, g *colla
 		eg.Go(func() error {
 			groupid := g.Grantee.GetGroupId().GetOpaqueId()
 			err := m.GroupReceivedCache.Add(ctx, groupid, shareID)
-
 			if err != nil {
 				span.RecordError(err)
 				span.SetStatus(codes.Error, err.Error())
@@ -458,7 +454,7 @@ func (m *Manager) GetShare(ctx context.Context, ref *collaboration.ShareReferenc
 			log.Error().Err(err).
 				Msg("failed to unshare expired share")
 		}
-		if err := events.Publish(m.eventStream, events.ShareExpired{
+		if err := events.Publish(ctx, m.eventStream, events.ShareExpired{
 			ShareID:        s.GetId(),
 			ShareOwner:     s.GetOwner(),
 			ItemID:         s.GetResourceId(),
@@ -643,7 +639,7 @@ func (m *Manager) listSharesByIDs(ctx context.Context, user *userv1beta1.User, f
 						log.Error().Err(err).
 							Msg("failed to unshare expired share")
 					}
-					if err := events.Publish(m.eventStream, events.ShareExpired{
+					if err := events.Publish(ctx, m.eventStream, events.ShareExpired{
 						ShareOwner:     s.GetOwner(),
 						ItemID:         s.GetResourceId(),
 						ExpiredAt:      time.Unix(int64(s.GetExpiration().GetSeconds()), int64(s.GetExpiration().GetNanos())),
@@ -711,7 +707,7 @@ func (m *Manager) listCreatedShares(ctx context.Context, user *userv1beta1.User,
 					log.Error().Err(err).
 						Msg("failed to unshare expired share")
 				}
-				if err := events.Publish(m.eventStream, events.ShareExpired{
+				if err := events.Publish(ctx, m.eventStream, events.ShareExpired{
 					ShareOwner:     s.GetOwner(),
 					ItemID:         s.GetResourceId(),
 					ExpiredAt:      time.Unix(int64(s.GetExpiration().GetSeconds()), int64(s.GetExpiration().GetNanos())),
@@ -834,7 +830,7 @@ func (m *Manager) ListReceivedShares(ctx context.Context, filters []*collaborati
 							log.Error().Err(err).
 								Msg("failed to unshare expired share")
 						}
-						if err := events.Publish(m.eventStream, events.ShareExpired{
+						if err := events.Publish(ctx, m.eventStream, events.ShareExpired{
 							ShareOwner:     s.GetOwner(),
 							ItemID:         s.GetResourceId(),
 							ExpiredAt:      time.Unix(int64(s.GetExpiration().GetSeconds()), int64(s.GetExpiration().GetNanos())),
@@ -934,7 +930,7 @@ func (m *Manager) getReceived(ctx context.Context, ref *collaboration.ShareRefer
 			log.Error().Err(err).
 				Msg("failed to unshare expired share")
 		}
-		if err := events.Publish(m.eventStream, events.ShareExpired{
+		if err := events.Publish(ctx, m.eventStream, events.ShareExpired{
 			ShareOwner:     s.GetOwner(),
 			ItemID:         s.GetResourceId(),
 			ExpiredAt:      time.Unix(int64(s.GetExpiration().GetSeconds()), int64(s.GetExpiration().GetNanos())),
@@ -988,6 +984,7 @@ func (m *Manager) UpdateReceivedShare(ctx context.Context, receivedShare *collab
 func shareIsRoutable(share *collaboration.Share) bool {
 	return strings.Contains(share.Id.OpaqueId, shareid.IDDelimiter)
 }
+
 func updateShareID(share *collaboration.Share) {
 	share.Id.OpaqueId = shareid.Encode(share.ResourceId.StorageId, share.ResourceId.SpaceId, share.Id.OpaqueId)
 }

--- a/pkg/storage/utils/decomposedfs/decomposedfs.go
+++ b/pkg/storage/utils/decomposedfs/decomposedfs.go
@@ -305,6 +305,7 @@ func (fs *Decomposedfs) Postprocessing(ch <-chan events.Event) {
 			fs.cache.RemoveStatContext(ctx, ev.ExecutingUser.GetId(), &provider.ResourceId{SpaceId: n.SpaceID, OpaqueId: n.ID})
 
 			if err := events.Publish(
+				ctx,
 				fs.stream,
 				events.UploadReady{
 					UploadID:      ev.UploadID,
@@ -342,7 +343,7 @@ func (fs *Decomposedfs) Postprocessing(ch <-chan events.Event) {
 				continue
 			}
 			// restart postprocessing
-			if err := events.Publish(fs.stream, events.BytesReceived{
+			if err := events.Publish(ctx, fs.stream, events.BytesReceived{
 				UploadID:      up.Info.ID,
 				URL:           s,
 				SpaceOwner:    n.SpaceOwnerOrManager(up.Ctx),
@@ -474,7 +475,6 @@ func (fs *Decomposedfs) Postprocessing(ch <-chan events.Event) {
 			log.Error().Interface("event", ev).Msg("Unknown event")
 		}
 	}
-
 }
 
 // Shutdown shuts down the storage

--- a/pkg/storage/utils/decomposedfs/upload/upload.go
+++ b/pkg/storage/utils/decomposedfs/upload/upload.go
@@ -274,7 +274,7 @@ func (upload *Upload) FinishUpload(_ context.Context) error {
 			return err
 		}
 
-		if err := events.Publish(upload.pub, events.BytesReceived{
+		if err := events.Publish(ctx, upload.pub, events.BytesReceived{
 			UploadID:      upload.Info.ID,
 			URL:           s,
 			SpaceOwner:    n.SpaceOwnerOrManager(upload.Ctx),


### PR DESCRIPTION
This adds a TraceParent field to the event envelope, adds context as
a parameter to the Publish function, adds functionality to extract
the traceparent from the context, and added a method to the envelope
to recover the tracing info and add it to the context.

This also passes context (empty if no context was present in the calling
function) to Publish wherever it is called.