### PR TITLE
Expire cached users and groups entries

### DIFF
--- a/pkg/cbox/group/rest/cache.go
+++ b/pkg/cbox/group/rest/cache.go
@@ -158,21 +158,22 @@ func (m *manager) fetchCachedGroupDetails(gid *grouppb.GroupId) (*grouppb.Group,
 }
 
 func (m *manager) cacheGroupDetails(g *grouppb.Group) error {
+	expiration := (m.conf.GroupFetchInterval + 1) * 3600
 	encodedGroup, err := json.Marshal(&g)
 	if err != nil {
 		return err
 	}
-	if err = m.setVal(groupPrefix+idPrefix+strings.ToLower(g.Id.OpaqueId), string(encodedGroup), -1); err != nil {
+	if err = m.setVal(groupPrefix+idPrefix+strings.ToLower(g.Id.OpaqueId), string(encodedGroup), expiration); err != nil {
 		return err
 	}
 
 	if g.GidNumber != 0 {
-		if err = m.setVal(groupPrefix+gidPrefix+strconv.FormatInt(g.GidNumber, 10), g.Id.OpaqueId, -1); err != nil {
+		if err = m.setVal(groupPrefix+gidPrefix+strconv.FormatInt(g.GidNumber, 10), g.Id.OpaqueId, expiration); err != nil {
 			return err
 		}
 	}
 	if g.DisplayName != "" {
-		if err = m.setVal(groupPrefix+namePrefix+g.Id.OpaqueId+"_"+strings.ToLower(g.DisplayName), g.Id.OpaqueId, -1); err != nil {
+		if err = m.setVal(groupPrefix+namePrefix+g.Id.OpaqueId+"_"+strings.ToLower(g.DisplayName), g.Id.OpaqueId, expiration); err != nil {
 			return err
 		}
 	}

--- a/pkg/cbox/user/rest/cache.go
+++ b/pkg/cbox/user/rest/cache.go
@@ -150,26 +150,27 @@ func (m *manager) fetchCachedUserDetails(uid *userpb.UserId) (*userpb.User, erro
 }
 
 func (m *manager) cacheUserDetails(u *userpb.User) error {
+	expiration := (m.conf.UserFetchInterval + 1) * 3600
 	encodedUser, err := json.Marshal(&u)
 	if err != nil {
 		return err
 	}
-	if err = m.setVal(userPrefix+usernamePrefix+strings.ToLower(u.Id.OpaqueId), string(encodedUser), -1); err != nil {
+	if err = m.setVal(userPrefix+usernamePrefix+strings.ToLower(u.Id.OpaqueId), string(encodedUser), expiration); err != nil {
 		return err
 	}
 
 	if u.Mail != "" {
-		if err = m.setVal(userPrefix+mailPrefix+strings.ToLower(u.Mail), string(encodedUser), -1); err != nil {
+		if err = m.setVal(userPrefix+mailPrefix+strings.ToLower(u.Mail), string(encodedUser), expiration); err != nil {
 			return err
 		}
 	}
 	if u.DisplayName != "" {
-		if err = m.setVal(userPrefix+namePrefix+u.Id.OpaqueId+"_"+strings.ReplaceAll(strings.ToLower(u.DisplayName), " ", "_"), string(encodedUser), -1); err != nil {
+		if err = m.setVal(userPrefix+namePrefix+u.Id.OpaqueId+"_"+strings.ReplaceAll(strings.ToLower(u.DisplayName), " ", "_"), string(encodedUser), expiration); err != nil {
 			return err
 		}
 	}
 	if u.UidNumber != 0 {
-		if err = m.setVal(userPrefix+uidPrefix+strconv.FormatInt(u.UidNumber, 10), string(encodedUser), -1); err != nil {
+		if err = m.setVal(userPrefix+uidPrefix+strconv.FormatInt(u.UidNumber, 10), string(encodedUser), expiration); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Entries in the rest user and group drivers do not expire. This means that old users/groups that have been deleted are still in cache.
This has been fixed in this PR setting an expiration for the entries to `fetch interval + 1` hours.