### PR TITLE
Allow sharing resources to lightweight accounts members of groups

### DIFF
--- a/internal/grpc/services/storageprovider/storageprovider.go
+++ b/internal/grpc/services/storageprovider/storageprovider.go
@@ -30,20 +30,27 @@ import (
 	"strconv"
 	"strings"
 
+	gateway "github.com/cs3org/go-cs3apis/cs3/gateway/v1beta1"
+	groupb "github.com/cs3org/go-cs3apis/cs3/identity/group/v1beta1"
+	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	"github.com/cs3org/reva/pkg/appctx"
+	ctxpkg "github.com/cs3org/reva/pkg/ctx"
 	"github.com/cs3org/reva/pkg/errtypes"
 	"github.com/cs3org/reva/pkg/mime"
 	"github.com/cs3org/reva/pkg/plugin"
 	"github.com/cs3org/reva/pkg/rgrpc"
 	"github.com/cs3org/reva/pkg/rgrpc/status"
+	"github.com/cs3org/reva/pkg/rgrpc/todo/pool"
 	"github.com/cs3org/reva/pkg/rhttp/router"
+	"github.com/cs3org/reva/pkg/sharedconf"
 	"github.com/cs3org/reva/pkg/storage"
 	"github.com/cs3org/reva/pkg/storage/fs/registry"
 	rtrace "github.com/cs3org/reva/pkg/trace"
 	"github.com/cs3org/reva/pkg/utils"
 	"github.com/cs3org/reva/pkg/utils/cfg"
+	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	"go.opentelemetry.io/otel/attribute"
@@ -68,6 +75,7 @@ type config struct {
 	DataServerURL                   string                            `mapstructure:"data_server_url" docs:"http://localhost/data;The URL for the data server."`
 	ExposeDataServer                bool                              `mapstructure:"expose_data_server" docs:"false;Whether to expose data server."` // if true the client will be able to upload/download directly to it
 	AvailableXS                     map[string]uint32                 `mapstructure:"available_checksums" docs:"nil;List of available checksums."`
+	GatewaySvc                      string                            `mapstructure:"gatewaysvc" docs:"The gateway address"`
 	CustomMimeTypesJSON             string                            `mapstructure:"custom_mime_types_json" docs:"nil;An optional mapping file with the list of supported custom file extensions and corresponding mime types."`
 	MinimunAllowedPathLevelForShare int                               `mapstructure:"minimum_allowed_path_level_for_share"`
 }
@@ -102,6 +110,8 @@ func (c *config) ApplyDefaults() {
 	if len(c.AvailableXS) == 0 {
 		c.AvailableXS = map[string]uint32{"md5": 100, "unset": 1000}
 	}
+
+	c.GatewaySvc = sharedconf.GetGatewaySVC(c.GatewaySvc)
 }
 
 type service struct {
@@ -819,6 +829,16 @@ func (s *service) Stat(ctx context.Context, req *provider.StatRequest) (*provide
 		}, nil
 	}
 	s.fixPermissions(md)
+
+	if u, ok := ctxpkg.ContextGetUser(ctx); ok && utils.UserIsLightweight(u) {
+		err := s.fixLightweightPermissionsForGroups(ctx, u, md)
+		if err != nil {
+			return &provider.StatResponse{
+				Status: status.NewInternal(ctx, err, "error setting permissions to lightweight account"),
+			}, nil
+		}
+	}
+
 	res := &provider.StatResponse{
 		Status: status.NewOK(ctx),
 		Info:   md,
@@ -841,6 +861,76 @@ func (s *service) fixPermissions(md *provider.ResourceInfo) {
 		md.PermissionSet.DenyGrant = false
 		md.PermissionSet.UpdateGrant = false
 	}
+}
+
+func (s *service) fixLightweightPermissionsForGroups(ctx context.Context, user *userpb.User, rinfo *provider.ResourceInfo) error {
+	res, err := s.ListGrants(ctx, &provider.ListGrantsRequest{
+		Ref: &provider.Reference{
+			Path: rinfo.Path,
+		},
+	})
+	if err != nil {
+		return err
+	}
+	if res.Status.Code != rpc.Code_CODE_OK {
+		return errtypes.InternalError(res.Status.Message)
+	}
+
+	client, err := pool.GetGatewayServiceClient(pool.Endpoint(s.conf.GatewaySvc))
+	if err != nil {
+		return err
+	}
+
+	for _, g := range res.GetGrants() {
+		switch v := g.Grantee.Id.(type) {
+		case *provider.Grantee_GroupId:
+			if s.userIsMemberOfGroup(ctx, client, user.GetId(), v.GroupId) {
+				mergePermissions(rinfo.PermissionSet, g.Permissions)
+			}
+		default:
+			continue
+		}
+	}
+	return nil
+}
+
+func (s *service) userIsMemberOfGroup(ctx context.Context, client gateway.GatewayAPIClient, user *userpb.UserId, group *groupb.GroupId) bool {
+	res, err := client.HasMember(ctx, &groupb.HasMemberRequest{
+		GroupId: group,
+		UserId:  user,
+	})
+	if err != nil || res.Status.Code != rpc.Code_CODE_OK {
+		return false
+	}
+	return res.Ok
+}
+
+func mergePermissions(original, new *provider.ResourcePermissions) {
+	if cmp.Equal(provider.ResourcePermissions{}, *new) {
+		// permission denied. we have to deny the
+		// original permissions
+		*original = provider.ResourcePermissions{}
+		return
+	}
+	original.AddGrant = original.AddGrant || new.AddGrant
+	original.CreateContainer = original.CreateContainer || new.CreateContainer
+	original.Delete = original.Delete || new.Delete
+	original.GetPath = original.GetPath || new.GetPath
+	original.GetQuota = original.GetQuota || new.GetQuota
+	original.InitiateFileDownload = original.InitiateFileDownload || new.InitiateFileDownload
+	original.InitiateFileUpload = original.InitiateFileUpload || new.InitiateFileUpload
+	original.ListContainer = original.ListContainer || new.ListContainer
+	original.ListFileVersions = original.ListFileVersions || new.ListFileVersions
+	original.ListGrants = original.ListGrants || new.ListGrants
+	original.ListRecycle = original.ListRecycle || new.ListRecycle
+	original.Move = original.Move || new.Move
+	original.PurgeRecycle = original.PurgeRecycle || new.PurgeRecycle
+	original.RemoveGrant = original.RemoveGrant || new.RemoveGrant
+	original.RestoreFileVersion = original.RestoreFileVersion || new.RestoreFileVersion
+	original.RestoreRecycleItem = original.RestoreRecycleItem || new.RestoreRecycleItem
+	original.Stat = original.Stat || new.Stat
+	original.UpdateGrant = original.UpdateGrant || new.UpdateGrant
+	original.DenyGrant = original.DenyGrant || new.DenyGrant
 }
 
 func (s *service) statVirtualView(ctx context.Context, ref *provider.Reference) (*provider.StatResponse, error) {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -415,8 +415,7 @@ func HasPermissions(target, toCheck *provider.ResourcePermissions) bool {
 // UserIsLightweight returns true if the user is a lightweight
 // or federated account.
 func UserIsLightweight(u *userpb.User) bool {
-	return u.Id.Type == userpb.UserType_USER_TYPE_FEDERATED ||
-		u.Id.Type == userpb.UserType_USER_TYPE_LIGHTWEIGHT
+	return u.Id.Type == userpb.UserType_USER_TYPE_LIGHTWEIGHT
 }
 
 // Cast casts a value `v` to the value `to`.


### PR DESCRIPTION
Currently sharing to lightweight accounts is only possible by sharing with them directly.
If a group contains lightweight accounts, these cannot see the shares.

This PR allows sharing to lightweight accounts contained in groups.