### PR TITLE
Enable projects for lightweight accounts

### DIFF
--- a/changelog/unreleased/projects-lw.md
+++ b/changelog/unreleased/projects-lw.md
@@ -1,0 +1,5 @@
+Bugfix: Enable projects for lightweight accounts
+
+Enable CERNBox projects to be listed by a lightweight account
+
+https://github.com/cs3org/reva/pull/4125

--- a/pkg/auth/scope/lightweight.go
+++ b/pkg/auth/scope/lightweight.go
@@ -63,6 +63,7 @@ func checkLightweightPath(path string) bool {
 		"/dataprovider",
 		"/data",
 		"/app/open",
+		"/projects",
 	}
 	for _, p := range paths {
 		if strings.HasPrefix(path, p) {


### PR DESCRIPTION
Enable CERNBox projects to be listed by a lightweight account.