### PR TITLE
fall back to userid if ownclouduuid is empty

### DIFF
--- a/changelog/unreleased/users-owncloudsql-fallback.md
+++ b/changelog/unreleased/users-owncloudsql-fallback.md
@@ -1,0 +1,5 @@
+Bugfix: users owncloudsql now always returns a userid 
+
+When joining the ownclouduuid is disabled we now fall back to the userid.
+
+https://github.com/cs3org/reva/pull/4135

--- a/pkg/user/manager/owncloudsql/owncloudsql.go
+++ b/pkg/user/manager/owncloudsql/owncloudsql.go
@@ -167,6 +167,10 @@ func (m *manager) convertToCS3User(ctx context.Context, a *accounts.Account, ski
 		GidNumber: m.c.Nobody,
 		UidNumber: m.c.Nobody,
 	}
+	// fall back to userid
+	if u.Id.OpaqueId == "" {
+		u.Id.OpaqueId = a.UserID
+	}
 	if u.Username == "" {
 		u.Username = u.Id.OpaqueId
 	}


### PR DESCRIPTION
When joining the ownclouduuid is disabled we now fall back to the userid.
