### PR TITLE
Fix missing etag in shares jail

### DIFF
--- a/changelog/unreleased/fix-missing-sharesjail-etag.md
+++ b/changelog/unreleased/fix-missing-sharesjail-etag.md
@@ -1,0 +1,5 @@
+Bugfix: Fix missing etag in shares jail
+
+The shares jail can miss the etag if the first `receivedShare` is not accepted.
+
+https://github.com/cs3org/reva/pull/4140

--- a/internal/grpc/services/sharesstorageprovider/sharesstorageprovider.go
+++ b/internal/grpc/services/sharesstorageprovider/sharesstorageprovider.go
@@ -1167,7 +1167,7 @@ func findEarliestShare(receivedShares []*collaboration.ReceivedShare, shareInfo 
 		}
 
 		switch {
-		case earliestShare == nil:
+		case earliestShare == nil && hasCurrentMd:
 			earliestShare = current
 		// ignore if one of the shares has no metadata
 		case !hasEarliestMd || !hasCurrentMd:


### PR DESCRIPTION
Fixes a bug in the shares storage provider: 

When the first `receivedShare` is not accepted, the `findEarliestShare` function would always return this share, leading to missing `etag` and `mtime` in the drives list

References: https://github.com/owncloud/ocis/issues/7160 
