### PR TITLE
[tests-only][full-ci] bump ocis latest commit id

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,4 +1,4 @@
 # The test runner source for API tests
-APITESTS_COMMITID=d656b4ad19568612332f2cf4973fc859bdf8bc6b
+APITESTS_COMMITID=9c3511d2b08de25b16be3d309d0a7710b6848747
 APITESTS_BRANCH=master
 APITESTS_REPO_GIT_URL=https://github.com/owncloud/ocis.git


### PR DESCRIPTION
This PR bumps the latest commit id from ocis
part of https://github.com/owncloud/QA/issues/824