### PR TITLE
Fix accessing an OCM-shared resource containing spaces

### DIFF
--- a/changelog/unreleased/fix-spaces-ocm-basic-auth.md
+++ b/changelog/unreleased/fix-spaces-ocm-basic-auth.md
@@ -1,0 +1,6 @@
+Bugfix: Fix accessing an OCM-shared resource containing spaces
+
+Fixes the access of a resource OCM-shared containing spaces, that
+previously was failing with a `NotFound` error.
+
+https://github.com/cs3org/reva/pull/4171

--- a/internal/http/services/owncloud/ocdav/dav.go
+++ b/internal/http/services/owncloud/ocdav/dav.go
@@ -21,8 +21,8 @@ package ocdav
 import (
 	"context"
 	"net/http"
-	"net/url"
 	"path"
+	"path/filepath"
 	"strings"
 
 	gatewayv1beta1 "github.com/cs3org/go-cs3apis/cs3/gateway/v1beta1"
@@ -195,7 +195,7 @@ func (h *DavHandler) Handler(s *svc) http.Handler {
 			if ok {
 				// OCM 1.0
 				token = username
-				r.URL.Path, _ = url.JoinPath("/", token, r.URL.Path)
+				r.URL.Path = filepath.Join("/", token, r.URL.Path)
 				ctx = context.WithValue(ctx, ctxOCM10, true)
 			} else {
 				token, _ = router.ShiftPath(r.URL.Path)


### PR DESCRIPTION
Every WebDAV operation on a resource OCM-shared and accessed using basic auth was failing when the resource was containing a space with a `NotFound` error. This is because the implementation, to build the internal path, was using the function `url.JoinPath` function that encodes the final URL.
This has been fixed in this PR.