### PR TITLE
Hardcode access methods for outgoing OCM shares from OC/NC

### DIFF
--- a/changelog/unreleased/permissions-sm-nc.md
+++ b/changelog/unreleased/permissions-sm-nc.md
@@ -1,0 +1,5 @@
+Bugfix: hardcode access methods for outgoing OCM shares from OC/NC
+
+This is a workaround until sciencemesh/nc-sciencemesh#45 is properly implemented
+
+https://github.com/cs3org/reva/pull/4172

--- a/pkg/ocm/share/repository/nextcloud/nextcloud.go
+++ b/pkg/ocm/share/repository/nextcloud/nextcloud.go
@@ -30,7 +30,6 @@ import (
 
 	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 
-	appprovider "github.com/cs3org/go-cs3apis/cs3/app/provider/v1beta1"
 	ocm "github.com/cs3org/go-cs3apis/cs3/sharing/ocm/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	typespb "github.com/cs3org/go-cs3apis/cs3/types/v1beta1"
@@ -194,10 +193,10 @@ func (sm *Manager) efssShareToOcm(resp *ShareAltMap) *ocm.Share {
 		AccessMethods: []*ocm.AccessMethod{
 			// FIXME for webdav we should use conversions.RoleFromOCSPermissions(conversions.Permissions(resp.Permissions))).CS3ResourcePermissions()
 			share.NewWebDavAccessMethod(conversions.NewEditorRole().CS3ResourcePermissions()),
-			// FIXME assume apps are supported and in r/w mode
-			share.NewWebappAccessMethod(appprovider.ViewMode_VIEW_MODE_READ_WRITE),
-			// FIXME assume datatx are supported
-			share.NewTransferAccessMethod(),
+			// FIXME add if apps are supported
+			// share.NewWebappAccessMethod(appprovider.ViewMode_VIEW_MODE_READ_WRITE),
+			// FIXME add if datatx are supported
+			// share.NewTransferAccessMethod(),
 		},
 	}
 }

--- a/pkg/ocm/share/repository/nextcloud/nextcloud.go
+++ b/pkg/ocm/share/repository/nextcloud/nextcloud.go
@@ -30,6 +30,7 @@ import (
 
 	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 
+	appprovider "github.com/cs3org/go-cs3apis/cs3/app/provider/v1beta1"
 	ocm "github.com/cs3org/go-cs3apis/cs3/sharing/ocm/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	typespb "github.com/cs3org/go-cs3apis/cs3/types/v1beta1"
@@ -188,10 +189,15 @@ func (sm *Manager) efssShareToOcm(resp *ShareAltMap) *ocm.Share {
 		Ctime:     resp.Ctime,
 		Mtime:     resp.Mtime,
 		ShareType: ocm.ShareType_SHARE_TYPE_USER,
+		// FIXME the SM app does not provide methods and does not include permissions, see https://github.com/sciencemesh/nc-sciencemesh/issues/45
+		// the correct logic here is to include those access methods that come in the payload
 		AccessMethods: []*ocm.AccessMethod{
-			share.NewWebDavAccessMethod(conversions.RoleFromOCSPermissions(conversions.Permissions(resp.Permissions)).CS3ResourcePermissions()),
-			// FIXME share.NewWebAppAccessMethod()  missing from SM app
-			// FIXME share.NewDataTxAccessMethod()
+			// FIXME for webdav we should use conversions.RoleFromOCSPermissions(conversions.Permissions(resp.Permissions))).CS3ResourcePermissions()
+			share.NewWebDavAccessMethod(conversions.NewEditorRole().CS3ResourcePermissions()),
+			// FIXME assume apps are supported and in r/w mode
+			share.NewWebappAccessMethod(appprovider.ViewMode_VIEW_MODE_READ_WRITE),
+			// FIXME assume datatx are supported
+			share.NewTransferAccessMethod(),
 		},
 	}
 }

--- a/pkg/ocm/share/repository/nextcloud/nextcloud_test.go
+++ b/pkg/ocm/share/repository/nextcloud/nextcloud_test.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"os"
 
+	appprovider "github.com/cs3org/go-cs3apis/cs3/app/provider/v1beta1"
 	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	ocm "github.com/cs3org/go-cs3apis/cs3/sharing/ocm/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
@@ -280,7 +281,9 @@ var _ = Describe("Nextcloud", func() {
 					OpaqueId: "f7fbf8c8-139b-4376-b307-cf0a8c2d0d9c",
 				},
 				AccessMethods: []*ocm.AccessMethod{
-					masked_share.NewWebDavAccessMethod(conversions.RoleFromOCSPermissions(conversions.Permissions(1)).CS3ResourcePermissions()),
+					masked_share.NewWebDavAccessMethod(conversions.NewEditorRole().CS3ResourcePermissions()),
+					masked_share.NewWebappAccessMethod(appprovider.ViewMode_VIEW_MODE_READ_WRITE),
+					masked_share.NewTransferAccessMethod(),
 				},
 				Ctime: &types.Timestamp{
 					Seconds:              1234567890,
@@ -436,7 +439,9 @@ var _ = Describe("Nextcloud", func() {
 				},
 				ShareType: ocm.ShareType_SHARE_TYPE_USER,
 				AccessMethods: []*ocm.AccessMethod{
-					masked_share.NewWebDavAccessMethod(conversions.RoleFromOCSPermissions(conversions.Permissions(1)).CS3ResourcePermissions()),
+					masked_share.NewWebDavAccessMethod(conversions.NewEditorRole().CS3ResourcePermissions()),
+					masked_share.NewWebappAccessMethod(appprovider.ViewMode_VIEW_MODE_READ_WRITE),
+					masked_share.NewTransferAccessMethod(),
 				},
 				Token: "some-token",
 			}))

--- a/pkg/ocm/share/repository/nextcloud/nextcloud_test.go
+++ b/pkg/ocm/share/repository/nextcloud/nextcloud_test.go
@@ -22,7 +22,6 @@ import (
 	"context"
 	"os"
 
-	appprovider "github.com/cs3org/go-cs3apis/cs3/app/provider/v1beta1"
 	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	ocm "github.com/cs3org/go-cs3apis/cs3/sharing/ocm/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
@@ -282,8 +281,8 @@ var _ = Describe("Nextcloud", func() {
 				},
 				AccessMethods: []*ocm.AccessMethod{
 					masked_share.NewWebDavAccessMethod(conversions.NewEditorRole().CS3ResourcePermissions()),
-					masked_share.NewWebappAccessMethod(appprovider.ViewMode_VIEW_MODE_READ_WRITE),
-					masked_share.NewTransferAccessMethod(),
+					// masked_share.NewWebappAccessMethod(appprovider.ViewMode_VIEW_MODE_READ_WRITE),
+					// masked_share.NewTransferAccessMethod(),
 				},
 				Ctime: &types.Timestamp{
 					Seconds:              1234567890,
@@ -440,8 +439,8 @@ var _ = Describe("Nextcloud", func() {
 				ShareType: ocm.ShareType_SHARE_TYPE_USER,
 				AccessMethods: []*ocm.AccessMethod{
 					masked_share.NewWebDavAccessMethod(conversions.NewEditorRole().CS3ResourcePermissions()),
-					masked_share.NewWebappAccessMethod(appprovider.ViewMode_VIEW_MODE_READ_WRITE),
-					masked_share.NewTransferAccessMethod(),
+					// masked_share.NewWebappAccessMethod(appprovider.ViewMode_VIEW_MODE_READ_WRITE),
+					// masked_share.NewTransferAccessMethod(),
 				},
 				Token: "some-token",
 			}))


### PR DESCRIPTION
This is a workaround until https://github.com/sciencemesh/nc-sciencemesh/issues/45 is properly implemented