### PR TITLE
Support full URL endpoints in ocm-provider

### DIFF
--- a/changelog/unreleased/ocm-provider-root.md
+++ b/changelog/unreleased/ocm-provider-root.md
@@ -1,0 +1,8 @@
+Enhancement: support full URL endpoints in ocm-provider
+
+This patch enables a reva server to properly show any configured
+endpoint route in all relevant properties exposed by /ocm-provider.
+This allows reverse proxy configurations of the form https://server/route
+to be supported for the OCM discovery mechanism.
+
+https://github.com/cs3org/reva/pull/4189

--- a/internal/http/services/ocmprovider/ocmprovider.go
+++ b/internal/http/services/ocmprovider/ocmprovider.go
@@ -21,8 +21,9 @@ package ocmprovider
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"net/http"
+	"net/url"
+	"path/filepath"
 
 	"github.com/cs3org/reva/pkg/appctx"
 	"github.com/cs3org/reva/pkg/rhttp/global"
@@ -37,7 +38,7 @@ func init() {
 
 type config struct {
 	OCMPrefix    string `mapstructure:"ocm_prefix" docs:"ocm;The prefix URL where the OCM API is served."`
-	Endpoint     string `mapstructure:"endpoint" docs:"This host's URL. If it's not configured, it is assumed OCM is not available."`
+	Endpoint     string `mapstructure:"endpoint" docs:"This host's full URL. If it's not configured, it is assumed OCM is not available."`
 	Provider     string `mapstructure:"provider" docs:"reva;A friendly name that defines this service."`
 	WebdavRoot   string `mapstructure:"webdav_root" docs:"/remote.php/dav/ocm;The root URL of the WebDAV endpoint to serve OCM shares."`
 	WebappRoot   string `mapstructure:"webapp_root" docs:"/external/sciencemesh;The root URL to serve Web apps via OCM."`
@@ -86,33 +87,40 @@ func (c *config) ApplyDefaults() {
 }
 
 func (c *config) prepare() *DiscoveryData {
-	// generates the (static) data structure to be exposed by /ocm-provider
+	// generates the (static) data structure to be exposed by /ocm-provider:
+	// first prepare an empty and disabled payload
 	d := &DiscoveryData{}
+	d.Enabled = false
+	d.Endpoint = ""
+	d.APIVersion = OCMAPIVersion
+	d.Provider = c.Provider
+	d.ResourceTypes = []resourceTypes{{
+		Name:       "file",
+		ShareTypes: []string{},
+		Protocols:  map[string]string{},
+	}}
+	d.Capabilities = []string{}
+
 	if c.Endpoint == "" {
-		d.Enabled = false
-		d.Endpoint = ""
-		d.APIVersion = OCMAPIVersion
-		d.Provider = c.Provider
-		d.ResourceTypes = []resourceTypes{{
-			Name:       "file",
-			ShareTypes: []string{},
-			Protocols:  map[string]string{},
-		}}
-		d.Capabilities = []string{}
 		return d
 	}
+
+	endpointURL, err := url.Parse(c.Endpoint)
+	if err != nil {
+		return d
+	}
+
+	// now prepare the enabled one
 	d.Enabled = true
-	d.APIVersion = OCMAPIVersion
-	d.Endpoint = fmt.Sprintf("%s/%s", c.Endpoint, c.OCMPrefix)
-	d.Provider = c.Provider
+	d.Endpoint, _ = url.JoinPath(c.Endpoint, c.OCMPrefix)
 	rtProtos := map[string]string{}
 	// webdav is always enabled
-	rtProtos["webdav"] = c.WebdavRoot
+	rtProtos["webdav"] = filepath.Join(endpointURL.Path, c.WebdavRoot)
 	if c.EnableWebapp {
-		rtProtos["webapp"] = c.WebappRoot
+		rtProtos["webapp"] = filepath.Join(endpointURL.Path, c.WebappRoot)
 	}
 	if c.EnableDatatx {
-		rtProtos["datatx"] = c.WebdavRoot
+		rtProtos["datatx"] = filepath.Join(endpointURL.Path, c.WebdavRoot)
 	}
 	d.ResourceTypes = []resourceTypes{{
 		Name:       "file",           // so far we only support `file`


### PR DESCRIPTION
This patch enables a reva server to properly show any configured endpoint route in all relevant properties exposed by `/ocm-provider`.
This allows reverse proxy configurations of the form `https://server/route` to be supported for the OCM discovery mechanism. 
