### PR TITLE
show hide share status

### DIFF
--- a/changelog/unreleased/add-hide-flag-to-shares.md.md
+++ b/changelog/unreleased/add-hide-flag-to-shares.md.md
@@ -1,0 +1,7 @@
+Enhancement: Add hide flag to shares
+
+We have added the ability to hide shares through the
+ocs/v2.php/apps/files_sharing/api/v1/shares/pending/ endpoint
+by appending a POST-Variable called hide which can be true or false.
+
+https://github.com/cs3org/reva/pull/4194/files

--- a/go.mod
+++ b/go.mod
@@ -223,4 +223,5 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-replace github.com/cs3org/go-cs3apis => github.com/2403905/go-cs3apis v0.0.0-20230517122726-727045414fd1
+// the replacement build is based on https://github.com/dragonchaser/cs3apis/tree/master
+replace github.com/cs3org/go-cs3apis => github.com/dragonchaser/go-cs3apis v0.0.0-20230918130959-ae732d4b8147

--- a/go.sum
+++ b/go.sum
@@ -388,8 +388,6 @@ cloud.google.com/go/workflows v1.9.0/go.mod h1:ZGkj1aFIOd9c8Gerkjjq7OW7I5+l6cSvT
 contrib.go.opencensus.io/exporter/prometheus v0.4.2 h1:sqfsYl5GIY/L570iT+l93ehxaWJs2/OwXtiWwew3oAg=
 contrib.go.opencensus.io/exporter/prometheus v0.4.2/go.mod h1:dvEHbiKmgvbr5pjaF9fpw1KeYcjrnC1J8B+JKjsZyRQ=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
-github.com/2403905/go-cs3apis v0.0.0-20230517122726-727045414fd1 h1:dOIG9lXUo5CAZbjlegvZpeTqfAlH+zn+0uXbtlZjCPY=
-github.com/2403905/go-cs3apis v0.0.0-20230517122726-727045414fd1/go.mod h1:UXha4TguuB52H14EMoSsCqDj7k8a/t7g4gVP+bgY5LY=
 github.com/Azure/azure-pipeline-go v0.2.3/go.mod h1:x841ezTBIMG6O3lAcl8ATHnsOPVl2bqk7S3ta6S6u4k=
 github.com/Azure/azure-storage-blob-go v0.14.0/go.mod h1:SMqIBi+SuiQH32bvyjngEewEeXoPfKMgWlBDaYf6fck=
 github.com/Azure/go-autorest v14.2.0+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
@@ -531,6 +529,8 @@ github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUn
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
+github.com/dragonchaser/go-cs3apis v0.0.0-20230918130959-ae732d4b8147 h1:DIEKyIGBNDDzdwnHlbX2BFABHol6c9EEHuCDdVKgWsA=
+github.com/dragonchaser/go-cs3apis v0.0.0-20230918130959-ae732d4b8147/go.mod h1:TKUgPjk4kNU0KLd9ZxoFE74Wv6PiXckF4RB3749FztA=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
@@ -1729,7 +1729,6 @@ google.golang.org/appengine v1.6.7 h1:FZR1q0exgwxzPzp/aF+VccGrSfxfPpkBqjIIEq3ru6
 google.golang.org/appengine v1.6.7/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20190307195333-5fe7a883aa19/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
-google.golang.org/genproto v0.0.0-20190404172233-64821d5d2107/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
 google.golang.org/genproto v0.0.0-20190418145605-e7d98fc518a7/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
 google.golang.org/genproto v0.0.0-20190425155659-357c62f0e4bb/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
 google.golang.org/genproto v0.0.0-20190502173448-54afdca5d873/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=

--- a/internal/http/services/owncloud/ocs/conversions/main.go
+++ b/internal/http/services/owncloud/ocs/conversions/main.go
@@ -169,6 +169,7 @@ type ShareData struct {
 	Quicklink bool `json:"quicklink,omitempty" xml:"quicklink,omitempty"`
 	// PasswordProtected represents a public share is password protected
 	// PasswordProtected bool `json:"password_protected,omitempty" xml:"password_protected,omitempty"`
+	Hide bool `json:"hide" xml:"hide"`
 }
 
 // ShareeData holds share recipient search results
@@ -229,6 +230,7 @@ func CS3Share2ShareData(ctx context.Context, share *collaboration.Share) (*Share
 		// Displaynames are added later
 		UIDOwner:     LocalUserIDToString(share.GetCreator()),
 		UIDFileOwner: LocalUserIDToString(share.GetOwner()),
+		Hide:         share.Hide,
 	}
 
 	if share.Grantee.Type == provider.GranteeType_GRANTEE_TYPE_USER {

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/pending.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/pending.go
@@ -48,7 +48,6 @@ const (
 
 // AcceptReceivedShare handles Post Requests on /apps/files_sharing/api/v1/shares/{shareid}
 func (h *Handler) AcceptReceivedShare(w http.ResponseWriter, r *http.Request) {
-	// TODO: this needs to evaluate the hide form field maybe and pass it on to updateReceivedShare
 	ctx := r.Context()
 	shareID := chi.URLParam(r, shareidkey)
 	client, err := h.getClient()
@@ -135,7 +134,6 @@ func (h *Handler) AcceptReceivedShare(w http.ResponseWriter, r *http.Request) {
 
 // RejectReceivedShare handles DELETE Requests on /apps/files_sharing/api/v1/shares/{shareid}
 func (h *Handler) RejectReceivedShare(w http.ResponseWriter, r *http.Request) {
-	// TODO: this needs to evaluate the hide form field maybe and pass it on to updateReceivedShare
 	shareID := chi.URLParam(r, "shareid")
 	data := h.updateReceivedShare(w, r, shareID, true, "")
 	if data != nil {

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/pending.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/pending.go
@@ -48,6 +48,7 @@ const (
 
 // AcceptReceivedShare handles Post Requests on /apps/files_sharing/api/v1/shares/{shareid}
 func (h *Handler) AcceptReceivedShare(w http.ResponseWriter, r *http.Request) {
+	// TODO: this needs to evaluate the hide form field maybe and pass it on to updateReceivedShare
 	ctx := r.Context()
 	shareID := chi.URLParam(r, shareidkey)
 	client, err := h.getClient()
@@ -134,6 +135,7 @@ func (h *Handler) AcceptReceivedShare(w http.ResponseWriter, r *http.Request) {
 
 // RejectReceivedShare handles DELETE Requests on /apps/files_sharing/api/v1/shares/{shareid}
 func (h *Handler) RejectReceivedShare(w http.ResponseWriter, r *http.Request) {
+	// TODO: this needs to evaluate the hide form field maybe and pass it on to updateReceivedShare
 	shareID := chi.URLParam(r, "shareid")
 	data := h.updateReceivedShare(w, r, shareID, true, "")
 	if data != nil {
@@ -151,15 +153,20 @@ func (h *Handler) updateReceivedShare(w http.ResponseWriter, r *http.Request, sh
 		return nil
 	}
 
+	hideFlag, _ := strconv.ParseBool(r.URL.Query().Get("hide"))
+
 	// we need to add a path to the share
 	shareRequest := &collaboration.UpdateReceivedShareRequest{
 		Share: &collaboration.ReceivedShare{
-			Share: &collaboration.Share{Id: &collaboration.ShareId{OpaqueId: shareID}},
+			Share: &collaboration.Share{
+				Id:   &collaboration.ShareId{OpaqueId: shareID},
+				Hide: hideFlag,
+			},
 			MountPoint: &provider.Reference{
 				Path: mountPoint,
 			},
 		},
-		UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"state"}},
+		UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"state", "hide"}},
 	}
 	if rejectShare {
 		shareRequest.Share.State = collaboration.ShareState_SHARE_STATE_REJECTED

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/shares.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/shares.go
@@ -734,7 +734,7 @@ func (h *Handler) updateShare(w http.ResponseWriter, r *http.Request, share *col
 
 	share.Permissions = &collaboration.SharePermissions{Permissions: role.CS3ResourcePermissions()}
 
-	var fieldMaskPaths = []string{"permissions"}
+	var fieldMaskPaths = []string{"permissions", "hide"}
 
 	expireDate := r.PostFormValue("expireDate")
 	var expirationTs *types.Timestamp

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/shares.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/shares.go
@@ -863,6 +863,8 @@ func (h *Handler) listSharesWithMe(w http.ResponseWriter, r *http.Request) {
 	// which pending state to list
 	stateFilter := getStateFilter(r.FormValue("state"))
 
+	showHidden, _ := strconv.ParseBool(r.URL.Query().Get("show_hidden"))
+
 	ctx := r.Context()
 	p := r.URL.Query().Get("path")
 	shareRef := r.URL.Query().Get("share_ref")
@@ -950,6 +952,9 @@ func (h *Handler) listSharesWithMe(w http.ResponseWriter, r *http.Request) {
 
 	// TODO(refs) filter out "invalid" shares
 	for _, rs := range lrsRes.GetShares() {
+		if rs.Share.Hide && !showHidden {
+			continue
+		}
 		if stateFilter != ocsStateUnknown && rs.GetState() != stateFilter {
 			continue
 		}

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/user.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/user.go
@@ -244,7 +244,7 @@ func (h *Handler) listUserShares(r *http.Request, filters []*collaboration.Filte
 
 			h.addFileInfo(ctx, data, info)
 			h.mapUserIds(ctx, client, data)
-
+			//TODO: get filter list concorrent from a share manager service that deals with hidden shares
 			// Filter out a share if ShareWith is not found because the user or group already deleted
 			if data.ShareWith == "" {
 				continue

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/user.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/user.go
@@ -244,7 +244,6 @@ func (h *Handler) listUserShares(r *http.Request, filters []*collaboration.Filte
 
 			h.addFileInfo(ctx, data, info)
 			h.mapUserIds(ctx, client, data)
-			//TODO: get filter list concorrent from a share manager service that deals with hidden shares
 			// Filter out a share if ShareWith is not found because the user or group already deleted
 			if data.ShareWith == "" {
 				continue

--- a/pkg/share/manager/cs3/cs3.go
+++ b/pkg/share/manager/cs3/cs3.go
@@ -638,6 +638,8 @@ func (m *Manager) UpdateReceivedShare(ctx context.Context, rshare *collaboration
 			rs.State = rshare.State
 		case "mount_point":
 			rs.MountPoint = rshare.MountPoint
+		case "hide":
+			continue
 		default:
 			return nil, errtypes.NotSupported("updating " + fieldMask.Paths[i] + " is not supported")
 		}

--- a/pkg/share/manager/json/json.go
+++ b/pkg/share/manager/json/json.go
@@ -403,6 +403,8 @@ func (m *mgr) UpdateShare(ctx context.Context, ref *collaboration.ShareReference
 				m.model.Shares[idx].Permissions = updated.Permissions
 			case "expiration":
 				m.model.Shares[idx].Expiration = updated.Expiration
+			case "hide":
+				m.model.Shares[idx].Hide = updated.Hide
 			default:
 				return nil, errtypes.NotSupported("updating " + fieldMask.Paths[i] + " is not supported")
 			}

--- a/pkg/share/manager/json/json.go
+++ b/pkg/share/manager/json/json.go
@@ -404,7 +404,7 @@ func (m *mgr) UpdateShare(ctx context.Context, ref *collaboration.ShareReference
 			case "expiration":
 				m.model.Shares[idx].Expiration = updated.Expiration
 			case "hide":
-				m.model.Shares[idx].Hide = updated.Hide
+				continue
 			default:
 				return nil, errtypes.NotSupported("updating " + fieldMask.Paths[i] + " is not supported")
 			}

--- a/pkg/share/manager/jsoncs3/jsoncs3.go
+++ b/pkg/share/manager/jsoncs3/jsoncs3.go
@@ -511,6 +511,8 @@ func (m *Manager) UpdateShare(ctx context.Context, ref *collaboration.ShareRefer
 				toUpdate.Permissions = updated.Permissions
 			case "expiration":
 				toUpdate.Expiration = updated.Expiration
+			case "hide":
+				toUpdate.Hide = updated.Hide
 			default:
 				return nil, errtypes.NotSupported("updating " + fieldMask.Paths[i] + " is not supported")
 			}

--- a/pkg/share/manager/jsoncs3/jsoncs3.go
+++ b/pkg/share/manager/jsoncs3/jsoncs3.go
@@ -999,6 +999,8 @@ func (m *Manager) UpdateReceivedShare(ctx context.Context, receivedShare *collab
 			rs.State = receivedShare.State
 		case "mount_point":
 			rs.MountPoint = receivedShare.MountPoint
+		case "hide":
+			rs.Share.Hide = receivedShare.Share.Hide
 		default:
 			return nil, errtypes.NotSupported("updating " + fieldMask.Paths[i] + " is not supported")
 		}

--- a/pkg/share/manager/jsoncs3/jsoncs3.go
+++ b/pkg/share/manager/jsoncs3/jsoncs3.go
@@ -511,8 +511,6 @@ func (m *Manager) UpdateShare(ctx context.Context, ref *collaboration.ShareRefer
 				toUpdate.Permissions = updated.Permissions
 			case "expiration":
 				toUpdate.Expiration = updated.Expiration
-			case "hide":
-				toUpdate.Hide = updated.Hide
 			default:
 				return nil, errtypes.NotSupported("updating " + fieldMask.Paths[i] + " is not supported")
 			}
@@ -880,6 +878,7 @@ func (m *Manager) ListReceivedShares(ctx context.Context, filters []*collaborati
 
 					if share.IsGrantedToUser(s, user) {
 						if share.MatchesFiltersWithState(s, state.State, filters) {
+							s.Hide = state.Hide
 							rs := &collaboration.ReceivedShare{
 								Share:      s,
 								State:      state.State,
@@ -935,6 +934,7 @@ func (m *Manager) convert(ctx context.Context, userID string, s *collaboration.S
 	if err == nil && state != nil {
 		rs.State = state.State
 		rs.MountPoint = state.MountPoint
+		rs.Share.Hide = state.Hide
 	}
 	return rs
 }

--- a/pkg/share/manager/jsoncs3/jsoncs3_test.go
+++ b/pkg/share/manager/jsoncs3/jsoncs3_test.go
@@ -957,6 +957,36 @@ var _ = Describe("Jsoncs3", func() {
 				})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(rs.MountPoint.Path).To(Equal("newMP"))
+				Expect(rs.Share.Hide).To(Equal(false))
+			})
+
+			It("hides the share", func() {
+				rs, err := m.GetReceivedShare(granteeCtx, &collaboration.ShareReference{
+					Spec: &collaboration.ShareReference_Id{
+						Id: share.Id,
+					},
+				})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(rs.MountPoint).To(BeNil())
+
+				rs.MountPoint = &providerv1beta1.Reference{
+					Path: "newMP",
+				}
+				rs.Share.Hide = true
+
+				rs, err = m.UpdateReceivedShare(granteeCtx, rs, &fieldmaskpb.FieldMask{Paths: []string{"hide", "mount_point"}}, nil)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(rs.MountPoint.Path).To(Equal("newMP"))
+				Expect(rs.Share.Hide).To(Equal(true))
+
+				rs, err = m.GetReceivedShare(granteeCtx, &collaboration.ShareReference{
+					Spec: &collaboration.ShareReference_Id{
+						Id: share.Id,
+					},
+				})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(rs.MountPoint.Path).To(Equal("newMP"))
+				Expect(rs.Share.Hide).To(Equal(true))
 			})
 
 			It("handles invalid field masks", func() {

--- a/pkg/share/manager/jsoncs3/jsoncs3_test.go
+++ b/pkg/share/manager/jsoncs3/jsoncs3_test.go
@@ -1060,6 +1060,79 @@ var _ = Describe("Jsoncs3", func() {
 					Expect(err).ToNot(HaveOccurred())
 					Expect(rs.State).To(Equal(collaboration.ShareState_SHARE_STATE_ACCEPTED))
 				})
+
+				It("hides share and persists the change", func() {
+					rs, err := m.GetReceivedShare(granteeCtx, &collaboration.ShareReference{
+						Spec: &collaboration.ShareReference_Id{
+							Id: gshare.Id,
+						},
+					})
+					Expect(err).ToNot(HaveOccurred())
+					Expect(rs.State).To(Equal(collaboration.ShareState_SHARE_STATE_PENDING))
+
+					rs.State = collaboration.ShareState_SHARE_STATE_ACCEPTED
+					rs.Share.Hide = true
+					rs, err = m.UpdateReceivedShare(granteeCtx, rs, &fieldmaskpb.FieldMask{Paths: []string{"state", "hide"}}, nil)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(rs.State).To(Equal(collaboration.ShareState_SHARE_STATE_ACCEPTED))
+					Expect(rs.Share.Hide).To(Equal(true))
+
+					m, err := jsoncs3.New(storage, nil, 0, nil, 0) // Reset in-memory cache
+					Expect(err).ToNot(HaveOccurred())
+
+					rs, err = m.GetReceivedShare(granteeCtx, &collaboration.ShareReference{
+						Spec: &collaboration.ShareReference_Id{
+							Id: gshare.Id,
+						},
+					})
+					Expect(rs.Share.Hide).To(Equal(true))
+					Expect(err).ToNot(HaveOccurred())
+					Expect(rs.State).To(Equal(collaboration.ShareState_SHARE_STATE_ACCEPTED))
+				})
+
+				It("hides and unhides the share and persists the change", func() {
+					rs, err := m.GetReceivedShare(granteeCtx, &collaboration.ShareReference{
+						Spec: &collaboration.ShareReference_Id{
+							Id: gshare.Id,
+						},
+					})
+					Expect(err).ToNot(HaveOccurred())
+					Expect(rs.State).To(Equal(collaboration.ShareState_SHARE_STATE_PENDING))
+
+					rs.State = collaboration.ShareState_SHARE_STATE_ACCEPTED
+					rs.Share.Hide = true
+					rs, err = m.UpdateReceivedShare(granteeCtx, rs, &fieldmaskpb.FieldMask{Paths: []string{"state", "hide"}}, nil)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(rs.State).To(Equal(collaboration.ShareState_SHARE_STATE_ACCEPTED))
+					Expect(rs.Share.Hide).To(Equal(true))
+
+					m, err := jsoncs3.New(storage, nil, 0, nil, 0) // Reset in-memory cache
+					Expect(err).ToNot(HaveOccurred())
+
+					rs, err = m.GetReceivedShare(granteeCtx, &collaboration.ShareReference{
+						Spec: &collaboration.ShareReference_Id{
+							Id: gshare.Id,
+						},
+					})
+					Expect(rs.Share.Hide).To(Equal(true))
+					Expect(err).ToNot(HaveOccurred())
+					Expect(rs.State).To(Equal(collaboration.ShareState_SHARE_STATE_ACCEPTED))
+
+					rs.Share.Hide = false
+					rs, err = m.UpdateReceivedShare(granteeCtx, rs, &fieldmaskpb.FieldMask{Paths: []string{"state", "hide"}}, nil)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(rs.State).To(Equal(collaboration.ShareState_SHARE_STATE_ACCEPTED))
+					Expect(rs.Share.Hide).To(Equal(false))
+
+					rs, err = m.GetReceivedShare(granteeCtx, &collaboration.ShareReference{
+						Spec: &collaboration.ShareReference_Id{
+							Id: gshare.Id,
+						},
+					})
+					Expect(rs.Share.Hide).To(Equal(false))
+					Expect(err).ToNot(HaveOccurred())
+					Expect(rs.State).To(Equal(collaboration.ShareState_SHARE_STATE_ACCEPTED))
+				})
 			})
 		})
 	})

--- a/pkg/share/manager/jsoncs3/receivedsharecache/receivedsharecache.go
+++ b/pkg/share/manager/jsoncs3/receivedsharecache/receivedsharecache.go
@@ -68,6 +68,7 @@ type Space struct {
 type State struct {
 	State      collaboration.ShareState
 	MountPoint *provider.Reference
+	Hide       bool
 }
 
 // New returns a new Cache instance
@@ -117,6 +118,7 @@ func (c *Cache) Add(ctx context.Context, userID, spaceID string, rs *collaborati
 		receivedSpace.States[rs.Share.Id.GetOpaqueId()] = &State{
 			State:      rs.State,
 			MountPoint: rs.MountPoint,
+			Hide:       rs.Share.Hide,
 		}
 
 		return c.persist(ctx, userID)

--- a/pkg/share/manager/memory/memory.go
+++ b/pkg/share/manager/memory/memory.go
@@ -361,6 +361,8 @@ func (m *manager) UpdateReceivedShare(ctx context.Context, receivedShare *collab
 			rs.State = receivedShare.State
 		case "mount_point":
 			rs.MountPoint = receivedShare.MountPoint
+		case "hide":
+			continue
 		default:
 			return nil, errtypes.NotSupported("updating " + fieldMask.Paths[i] + " is not supported")
 		}

--- a/pkg/share/manager/memory/memory.go
+++ b/pkg/share/manager/memory/memory.go
@@ -242,6 +242,8 @@ func (m *manager) UpdateShare(ctx context.Context, ref *collaboration.ShareRefer
 							m.shares[i].Permissions = updated.Permissions
 						case "expiration":
 							m.shares[i].Expiration = updated.Expiration
+						case "hide":
+							m.shares[i].Hide = updated.Hide
 						default:
 							return nil, errtypes.NotSupported("updating " + path + " is not supported")
 						}

--- a/pkg/share/manager/owncloudsql/owncloudsql.go
+++ b/pkg/share/manager/owncloudsql/owncloudsql.go
@@ -447,6 +447,8 @@ func (m *mgr) UpdateReceivedShare(ctx context.Context, receivedShare *collaborat
 			fields = append(fields, "file_target=?")
 			rs.MountPoint = receivedShare.MountPoint
 			params = append(params, rs.MountPoint.Path)
+		case "hide":
+			continue
 		default:
 			return nil, errtypes.NotSupported("updating " + fieldMask.Paths[i] + " is not supported")
 		}


### PR DESCRIPTION
Enhancement: Add hide flag to shares

We have added the ability to hide shares through the
ocs/v2.php/apps/files_sharing/api/v1/shares/pending/ endpoint
by appending a POST-Variable called hide which can be true or false.