### PR TITLE
Dynamic storage router

### DIFF
--- a/changelog/unreleased/dynamic-storage-provider.md
+++ b/changelog/unreleased/dynamic-storage-provider.md
@@ -1,0 +1,8 @@
+Enhancement: Dynamic storage provider
+
+Add a new storage provider that can globally route to other providers. This
+provider uses a routing table in the database containing `path` - `mountid`
+pairs, and a mapping `mountid` - `address` in the config. It also support
+rewriting paths for resolution (to enable more complex cases).
+
+https://github.com/cs3org/reva/pull/4199

--- a/pkg/storage/registry/dynamic/db_changes.sql
+++ b/pkg/storage/registry/dynamic/db_changes.sql
@@ -21,8 +21,7 @@
 
 CREATE TABLE IF NOT EXISTS `routing` (
   `path`       VARCHAR(3072) NOT NULL,
-  `mount_id`   VARCHAR(255),
-  `mount_type` VARCHAR(100),
+  `mount_id`   VARCHAR(255) NOT NULL,
   PRIMARY KEY (path)
 )
 

--- a/pkg/storage/registry/dynamic/db_changes.sql
+++ b/pkg/storage/registry/dynamic/db_changes.sql
@@ -1,0 +1,29 @@
+-- Copyright 2018-2023 CERN
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+-- In applying this license, CERN does not waive the privileges and immunities
+-- granted to it by virtue of its status as an Intergovernmental Organization
+-- or submit itself to any jurisdiction.
+
+-- This file can be used to make the required changes to the MySQL DB. This is
+-- not a proper migration but it should work on most situations.
+
+CREATE TABLE IF NOT EXISTS `routing` (
+  `path`       VARCHAR(3072) NOT NULL,
+  `mount_id`   VARCHAR(255),
+  `mount_type` VARCHAR(100),
+  PRIMARY KEY (path)
+)
+
+COMMIT;

--- a/pkg/storage/registry/dynamic/dynamic.go
+++ b/pkg/storage/registry/dynamic/dynamic.go
@@ -89,13 +89,13 @@ func New(ctx context.Context, m map[string]interface{}) (storage.Registry, error
 	return d, nil
 }
 
-func initRoutingTree(dbusername, dbpassword, dbhost string, dbport int, dbname string) (*routingtree.RoutingTree, error) {
-	db, err := sql.Open("mysql", fmt.Sprintf("%s:%s@tcp(%s:%d)/%s", dbusername, dbpassword, dbhost, dbport, dbname))
+func initRoutingTree(dbUsername, dbPassword, dbHost string, dbPort int, dbName string) (*routingtree.RoutingTree, error) {
+	db, err := sql.Open("mysql", fmt.Sprintf("%s:%s@tcp(%s:%d)/%s", dbUsername, dbPassword, dbHost, dbPort, dbName))
 	if err != nil {
 		return nil, errors.Wrap(err, "error opening sql connection")
 	}
 
-	results, err := db.Query("SELECT path, mount_id, mount_type FROM routing")
+	results, err := db.Query("SELECT path, mount_id FROM routing")
 	if err != nil {
 		return nil, errors.Wrap(err, "error getting routing table from db")
 	}
@@ -104,7 +104,7 @@ func initRoutingTree(dbusername, dbpassword, dbhost string, dbport int, dbname s
 
 	for results.Next() {
 		var r routingtree.Route
-		err = results.Scan(&r.Path, &r.MountID, &r.MountType)
+		err = results.Scan(&r.Path, &r.MountID)
 		if err != nil {
 			return nil, errors.Wrap(err, "error scanning rows from db")
 		}

--- a/pkg/storage/registry/dynamic/dynamic.go
+++ b/pkg/storage/registry/dynamic/dynamic.go
@@ -1,0 +1,173 @@
+// Copyright 2018-2023 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+// Package dynamic contains the dynamic storage registry
+package dynamic
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+	registrypb "github.com/cs3org/go-cs3apis/cs3/storage/registry/v1beta1"
+	"github.com/cs3org/reva/pkg/appctx"
+	"github.com/cs3org/reva/pkg/errtypes"
+	"github.com/cs3org/reva/pkg/storage"
+	"github.com/cs3org/reva/pkg/storage/registry/dynamic/rewriter"
+	"github.com/cs3org/reva/pkg/storage/registry/dynamic/routingtree"
+	"github.com/cs3org/reva/pkg/storage/registry/registry"
+	"github.com/cs3org/reva/pkg/utils/cfg"
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog"
+)
+
+func init() {
+	registry.Register("dynamic", New)
+}
+
+type dynamic struct {
+	c   *config
+	log *zerolog.Logger
+	r   map[string]string
+	rt  *routingtree.RoutingTree
+	ur  *rewriter.UserRewriter
+}
+
+type config struct {
+	Rules      map[string]string `mapstructure:"rules"`
+	Rewrites   map[string]string `mapstructure:"rewrites"`
+	HomePath   string            `mapstructure:"home_path"`
+	DBUsername string            `mapstructure:"db_username"`
+	DBPassword string            `mapstructure:"db_password"`
+	DBHost     string            `mapstructure:"db_host"`
+	DBPort     int               `mapstructure:"db_port"`
+	DBName     string            `mapstructure:"db_name"`
+}
+
+// New returns an implementation of the storage.Registry interface that
+// redirects requests to corresponding storage drivers.
+func New(ctx context.Context, m map[string]interface{}) (storage.Registry, error) {
+	var c config
+	if err := cfg.Decode(m, &c); err != nil {
+		return nil, err
+	}
+
+	log := appctx.GetLogger(ctx)
+	annotatedLog := log.With().Str("storageprovider", "dynamic").Logger()
+
+	rt, err := initRoutingTree(c.DBUsername, c.DBPassword, c.DBHost, c.DBPort, c.DBName)
+	if err != nil {
+		return nil, errors.Wrap(err, "error initializing routing tree")
+	}
+
+	d := &dynamic{
+		c:   &c,
+		log: &annotatedLog,
+		r:   c.Rules,
+		rt:  rt,
+		ur: &rewriter.UserRewriter{
+			Tpls: c.Rewrites,
+		},
+	}
+
+	return d, nil
+}
+
+func initRoutingTree(DBUsername, DBPassword, DBHost string, DBPort int, DBName string) (*routingtree.RoutingTree, error) {
+	db, err := sql.Open("mysql", fmt.Sprintf("%s:%s@tcp(%s:%d)/%s", DBUsername, DBPassword, DBHost, DBPort, DBName))
+	if err != nil {
+		return nil, errors.Wrap(err, "error opening sql connection")
+	}
+
+	results, err := db.Query("SELECT path, mount_id, mount_type FROM routing")
+	if err != nil {
+		return nil, errors.Wrap(err, "error getting routing table from db")
+	}
+
+	var rs []routingtree.Route
+
+	for results.Next() {
+		var r routingtree.Route
+		err = results.Scan(&r.Path, &r.MountID, &r.MountType)
+		if err != nil {
+			return nil, errors.Wrap(err, "error scanning rows from db")
+		}
+		rs = append(rs, r)
+	}
+
+	return routingtree.New(rs), nil
+}
+
+// ListProviders lists all available storage providers
+func (d *dynamic) ListProviders(ctx context.Context) ([]*registrypb.ProviderInfo, error) {
+	providers := []*registrypb.ProviderInfo{}
+	for p, a := range d.r {
+		providers = append(providers, &registrypb.ProviderInfo{
+			ProviderPath: p,
+			Address:      a,
+		})
+	}
+
+	return providers, nil
+}
+
+// GetHome returns the storage provider for the home path
+func (d *dynamic) GetHome(ctx context.Context) (*registrypb.ProviderInfo, error) {
+	p, err := d.rt.GetProviders(d.c.HomePath)
+	if err != nil {
+		return nil, errors.New("failed to get home provider")
+	}
+
+	if a, ok := d.r[p[0]]; ok {
+		return &registrypb.ProviderInfo{
+			ProviderPath: d.c.HomePath,
+			Address:      a,
+		}, nil
+	}
+
+	return nil, errors.New("home not found")
+}
+
+func (d *dynamic) FindProviders(ctx context.Context, ref *provider.Reference) ([]*registrypb.ProviderInfo, error) {
+	l := d.log.With().Str("ref", ref.String()).Logger()
+
+	providerAlias := d.ur.GetAlias(ctx, ref.Path)
+	ps, err := d.rt.GetProviders(providerAlias)
+	if err != nil {
+		return nil, errtypes.NotFound("storage provider not found for ref " + ref.String())
+	}
+
+	var providers []*registrypb.ProviderInfo
+	for _, p := range ps {
+		if address, ok := d.r[p]; ok {
+			providers = append(providers, &registrypb.ProviderInfo{
+				ProviderPath: ref.Path,
+				Address:      address,
+			})
+		} else {
+			err := errors.New("storage provider address not configured for mountID " + p)
+			l.Error().Err(err).Msgf("error finding providers")
+			return nil, errtypes.InternalError(err.Error())
+		}
+	}
+
+	l.Trace().Msgf("resolved storage providers %+v", providers)
+
+	return providers, nil
+}

--- a/pkg/storage/registry/dynamic/dynamic.go
+++ b/pkg/storage/registry/dynamic/dynamic.go
@@ -89,8 +89,8 @@ func New(ctx context.Context, m map[string]interface{}) (storage.Registry, error
 	return d, nil
 }
 
-func initRoutingTree(DBUsername, DBPassword, DBHost string, DBPort int, DBName string) (*routingtree.RoutingTree, error) {
-	db, err := sql.Open("mysql", fmt.Sprintf("%s:%s@tcp(%s:%d)/%s", DBUsername, DBPassword, DBHost, DBPort, DBName))
+func initRoutingTree(dbusername, dbpassword, dbhost string, dbport int, dbname string) (*routingtree.RoutingTree, error) {
+	db, err := sql.Open("mysql", fmt.Sprintf("%s:%s@tcp(%s:%d)/%s", dbusername, dbpassword, dbhost, dbport, dbname))
 	if err != nil {
 		return nil, errors.Wrap(err, "error opening sql connection")
 	}
@@ -114,7 +114,7 @@ func initRoutingTree(DBUsername, DBPassword, DBHost string, DBPort int, DBName s
 	return routingtree.New(rs), nil
 }
 
-// ListProviders lists all available storage providers
+// ListProviders lists all available storage providers.
 func (d *dynamic) ListProviders(ctx context.Context) ([]*registrypb.ProviderInfo, error) {
 	providers := []*registrypb.ProviderInfo{}
 	for p, a := range d.r {
@@ -127,7 +127,7 @@ func (d *dynamic) ListProviders(ctx context.Context) ([]*registrypb.ProviderInfo
 	return providers, nil
 }
 
-// GetHome returns the storage provider for the home path
+// GetHome returns the storage provider for the home path.
 func (d *dynamic) GetHome(ctx context.Context) (*registrypb.ProviderInfo, error) {
 	p, err := d.rt.GetProviders(d.c.HomePath)
 	if err != nil {
@@ -144,6 +144,7 @@ func (d *dynamic) GetHome(ctx context.Context) (*registrypb.ProviderInfo, error)
 	return nil, errors.New("home not found")
 }
 
+// FindProviders returns the storage providers for a given ref.
 func (d *dynamic) FindProviders(ctx context.Context, ref *provider.Reference) ([]*registrypb.ProviderInfo, error) {
 	l := d.log.With().Str("ref", ref.String()).Logger()
 

--- a/pkg/storage/registry/dynamic/dynamic_suite_test.go
+++ b/pkg/storage/registry/dynamic/dynamic_suite_test.go
@@ -1,0 +1,31 @@
+// Copyright 2018-2023 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package dynamic_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestSql(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Dynamic driver Suite")
+}

--- a/pkg/storage/registry/dynamic/dynamic_test.go
+++ b/pkg/storage/registry/dynamic/dynamic_test.go
@@ -1,0 +1,334 @@
+// Copyright 2018-2023 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package dynamic
+
+import (
+	"context"
+	"fmt"
+
+	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
+	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+	registryv1beta1 "github.com/cs3org/go-cs3apis/cs3/storage/registry/v1beta1"
+	ctxpkg "github.com/cs3org/reva/pkg/ctx"
+	"github.com/cs3org/reva/pkg/errtypes"
+
+	"github.com/cs3org/reva/pkg/storage"
+	sqle "github.com/dolthub/go-mysql-server"
+	"github.com/dolthub/go-mysql-server/memory"
+	"github.com/dolthub/go-mysql-server/server"
+	"github.com/dolthub/go-mysql-server/sql"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func must(err error) {
+	if err != nil {
+		panic(err)
+	}
+}
+
+var _ = Describe("Dynamic storage provider", func() {
+	var (
+		ctxAlice = ctxpkg.ContextSetUser(context.Background(), &userpb.User{
+			Id: &userpb.UserId{
+				OpaqueId: "alice",
+			},
+		})
+		ctxBob = ctxpkg.ContextSetUser(context.Background(), &userpb.User{
+			Id: &userpb.UserId{
+				OpaqueId: "bob",
+			},
+		})
+		ctxCharlie = ctxpkg.ContextSetUser(context.Background(), &userpb.User{
+			Id: &userpb.UserId{
+				OpaqueId: "charlie",
+			},
+		})
+
+		routes = map[string]string{
+			"/home-a":                   "eoshome-i01",
+			"/home-b":                   "eoshome-i02",
+			"/home-c":                   "eoshome-i03",
+			"/eos/user/a":               "eosuser-i01",
+			"/eos/user/b":               "eosuser-i02",
+			"/eos/project/a":            "eosproject-i00",
+			"/eos/project/c":            "eosproject-i02",
+			"/cephfs/project/c/cephbox": "cephfs",
+			"/cephfs/project/s/sebtest": "vaultssda01",
+		}
+
+		rules = map[string]string{
+			"eoshome-i01":    "eoshome-i01:1234",
+			"eoshome-i02":    "eoshome-i02:1234",
+			"eosuser-i01":    "eosuser-i01:1234",
+			"eosuser-i02":    "eosuser-i02:1234",
+			"eosproject-i00": "eosproject-i00:1234",
+			"eosproject-i02": "eosproject-i02:1234",
+			"cephfs":         "cephfs:1234",
+			"vaultssda01":    "vaultssda01:1234",
+		}
+		rewrites = map[string]string{
+			"/home":   "/home-{{substr 0 1 .Id.OpaqueId}}",
+			"/Shares": "/{{substr 0 1 .Id.OpaqueId}}",
+		}
+		homePath = "/home"
+
+		d   storage.Registry
+		h   *registryv1beta1.ProviderInfo
+		err error
+
+		providers = map[string]*registryv1beta1.ProviderInfo{
+			"/home-a": {
+				ProviderPath: "/home",
+				Address:      "eoshome-i01:1234",
+			},
+			"/home-b": {
+				ProviderPath: "/home",
+				Address:      "eoshome-i02:1234",
+			},
+			"/eos/user/a": {
+				ProviderPath: "/eos/user/a",
+				Address:      "eosuser-i01:1234",
+			},
+			"/eos/user/b": {
+				ProviderPath: "/eos/user/b",
+				Address:      "eosuser-i02:1234",
+			},
+			"/eos/project/a": {
+				ProviderPath: "/eos/project/a",
+				Address:      "eosproject-i00:1234",
+			},
+			"/eos/project/c": {
+				ProviderPath: "/eos/project/c",
+				Address:      "eosproject-i02:1234",
+			},
+			"/cephfs/project/c/cephbox": {
+				ProviderPath: "/cephfs/project/c/cephbox",
+				Address:      "cephfs:1234",
+			},
+			"/cephfs/project/s/sebtest": {
+				ProviderPath: "/cephfs/project/s/sebtest",
+				Address:      "vaultssda01:1234",
+			},
+		}
+
+		testHomeRefs = map[string]*provider.Reference{
+			"/home": {
+				Path: "/home",
+			},
+			"/home/test/a/deep/folder": {
+				Path: "/home/test/a/deep/folder",
+			},
+		}
+
+		testPaths = map[string][]*registryv1beta1.ProviderInfo{
+			"/eos":                                 {providers["/eos/user/a"], providers["/eos/user/b"], providers["/eos/project/a"], providers["/eos/project/c"]},
+			"/eos/user":                            {providers["/eos/user/a"], providers["/eos/user/b"]},
+			"/eos/project":                         {providers["/eos/project/a"], providers["/eos/project/c"]},
+			"/cephfs":                              {providers["/cephfs/project/c/cephbox"], providers["/cephfs/project/s/sebtest"]},
+			"/eos/user/a/alice/test/a/deep/folder": {providers["/eos/user/a"]},
+		}
+	)
+
+	BeforeSuite(func() {
+		dbHost := "localhost"
+		dbPort := 3306
+		dbName := "reva_tests"
+		sqlCtx := sql.NewEmptyContext()
+		db := memory.NewDatabase(dbName)
+
+		db.EnablePrimaryKeyIndexes()
+
+		routingTable := memory.NewTable("routing", sql.NewPrimaryKeySchema(sql.Schema{
+			{Name: "path", Type: sql.Text, Nullable: false, Source: "routing", PrimaryKey: true},
+			{Name: "mount_id", Type: sql.Text, Nullable: false, Source: "routing"},
+		}), &memory.ForeignKeyCollection{})
+
+		must(routingTable.CreateIndex(sqlCtx, "idx_path", sql.IndexUsing_BTree, sql.IndexConstraint_Unique, []sql.IndexColumn{{Name: "path"}}, ""))
+
+		for m, a := range routes {
+			must(routingTable.Insert(sqlCtx, sql.NewRow(m, a)))
+		}
+
+		db.AddTable("routing", routingTable)
+
+		config := server.Config{
+			Protocol: "tcp",
+			Address:  fmt.Sprintf("%s:%d", dbHost, dbPort),
+		}
+
+		engine := sqle.NewDefault(memory.NewMemoryDBProvider(db))
+		s, err := server.NewDefaultServer(config, engine)
+		if err != nil {
+			panic(err)
+		}
+
+		go func() {
+			if err := s.Start(); err != nil {
+				panic(err)
+			}
+		}()
+
+		d, err = New(context.Background(), map[string]interface{}{
+			"rules":       rules,
+			"rewrites":    rewrites,
+			"home_path":   homePath,
+			"db_username": "test",
+			"db_password": "test",
+			"db_host":     dbHost,
+			"db_port":     dbPort,
+			"db_name":     dbName,
+		})
+		if err != nil {
+			panic(err)
+		}
+
+		if err := s.Close(); err != nil {
+			panic(err)
+		}
+	})
+
+	Context("initializing the provider", func() {
+		When("passed correct config", func() {
+			It("should return a correct dynamic provider", func() {
+				Expect(d).ToNot(BeNil())
+			})
+		})
+	})
+
+	Context("listing providers", func() {
+		It("should return a correct list of providers", func() {
+			p, err := d.ListProviders(context.Background())
+			Expect(p).To(HaveLen(len(providers)))
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	Context("getting home for user", func() {
+		When("passed context for user alice", func() {
+			It("should return the correct provider", func() {
+				h, err = d.GetHome(ctxAlice)
+				Expect(h).To(Equal(providers["/home-a"]))
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		When("passed context for user bob", func() {
+			It("should return the correct provider", func() {
+				h, err = d.GetHome(ctxBob)
+				Expect(h).To(Equal(providers["/home-b"]))
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		When("passed context for user charlie who has home provider with a defined route but no rule in config", func() {
+			It("should return a provider not found error", func() {
+				h, err = d.GetHome(ctxCharlie)
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(MatchError(errtypes.InternalError("storage provider address not configured for mountID eoshome-i03")))
+			})
+		})
+
+		When("passed context without user", func() {
+			It("should return an error", func() {
+				h, err = d.GetHome(context.Background())
+				Expect(err).To(HaveOccurred())
+			})
+		})
+	})
+
+	Context("finding providers for a reference", func() {
+		When("passed an storage id", func() {
+			It("should return the correct provider", func() {
+				ref := &provider.Reference{
+					ResourceId: &provider.ResourceId{
+						StorageId: "eoshome-i01",
+					},
+				}
+
+				p, err := d.FindProviders(ctxAlice, ref)
+				Expect(p).To(HaveLen(1))
+				Expect(p[0].Address).To(Equal("eoshome-i01:1234"))
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		When("passed a non-existing storage id and no path", func() {
+			It("should return a provider not found error", func() {
+				ref := &provider.Reference{
+					ResourceId: &provider.ResourceId{
+						StorageId: "nope",
+					},
+				}
+
+				_, err := d.FindProviders(ctxAlice, ref)
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(MatchError(errtypes.NotFound("storage provider not found for ref resource_id:<storage_id:\"nope\" > ")))
+			})
+		})
+
+		for u, ctx := range map[string]context.Context{"alice": ctxAlice, "bob": ctxBob} {
+			u := u
+			ctx := ctx
+			for _, ref := range testHomeRefs {
+				ref := ref
+				When("passed a home path for user "+u+": "+ref.Path, func() {
+					It("should return the correct provider", func() {
+						ps, err := d.FindProviders(ctx, ref)
+						Expect(err).ToNot(HaveOccurred())
+						Expect(ps).To(HaveLen(1))
+						Expect(ps[0].Address).To(Equal(providers["/home-"+string(u[0])].Address))
+					})
+				})
+			}
+		}
+
+		for path, providers := range testPaths {
+			path := path
+			providers := providers
+			When("passed a regular path: "+path, func() {
+				It("should return the correct providers", func() {
+					ps, err := d.FindProviders(context.Background(), &provider.Reference{Path: path})
+					Expect(err).ToNot(HaveOccurred())
+					Expect(ps).To(HaveLen(len(providers)))
+					Expect(ps).To(ContainElements(providers))
+				})
+			})
+		}
+
+		When("passed a home path for user charlie who has home provider with a defined route but no rule in config", func() {
+			It("should return a provider not found error", func() {
+				_, err := d.FindProviders(ctxCharlie, testHomeRefs["/home"])
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(MatchError(errtypes.InternalError("storage provider address not configured for mountID eoshome-i03")))
+			})
+		})
+
+		When("passed a non-existing path", func() {
+			It("should return a provider not found error", func() {
+				_, err := d.FindProviders(ctxCharlie, &provider.Reference{
+					Path: "/non/existent",
+				})
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(MatchError(errtypes.NotFound("storage provider not found for ref path:\"/non/existent\" ")))
+			})
+		})
+	})
+})

--- a/pkg/storage/registry/dynamic/rewriter/userrewriter.go
+++ b/pkg/storage/registry/dynamic/rewriter/userrewriter.go
@@ -28,7 +28,7 @@ import (
 	"github.com/cs3org/reva/pkg/storage/utils/templates"
 )
 
-// UserRewriter rewrites a route with data from a user
+// UserRewriter rewrites a route with data from a user.
 type UserRewriter struct {
 	Tpls map[string]string
 }
@@ -43,7 +43,7 @@ func (ur UserRewriter) getTemplate(route string) (string, error) {
 	return "", errors.New("no rewrite rule found for route")
 }
 
-// GetAlias returns the alias for a given route
+// GetAlias returns the alias for a given route.
 func (ur UserRewriter) GetAlias(ctx context.Context, route string) string {
 	tpl, err := ur.getTemplate(route)
 	if err != nil {

--- a/pkg/storage/registry/dynamic/rewriter/userrewriter.go
+++ b/pkg/storage/registry/dynamic/rewriter/userrewriter.go
@@ -1,0 +1,58 @@
+// Copyright 2018-2023 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+// Package rewriter contains the route rewriters
+package rewriter
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	ctxpkg "github.com/cs3org/reva/pkg/ctx"
+	"github.com/cs3org/reva/pkg/storage/utils/templates"
+)
+
+// UserRewriter rewrites a route with data from a user
+type UserRewriter struct {
+	Tpls map[string]string
+}
+
+func (ur UserRewriter) getTemplate(route string) (string, error) {
+	for key, tpl := range ur.Tpls {
+		if strings.HasPrefix(route, key) {
+			return tpl, nil
+		}
+	}
+
+	return "", errors.New("no rewrite rule found for route")
+}
+
+// GetAlias returns the alias for a given route
+func (ur UserRewriter) GetAlias(ctx context.Context, route string) string {
+	tpl, err := ur.getTemplate(route)
+	if err != nil {
+		return route
+	}
+
+	if u, ok := ctxpkg.ContextGetUser(ctx); ok {
+		return templates.WithUser(u, tpl)
+	}
+
+	return route
+}

--- a/pkg/storage/registry/dynamic/rewriter/userrewriter.go
+++ b/pkg/storage/registry/dynamic/rewriter/userrewriter.go
@@ -44,6 +44,7 @@ func (ur UserRewriter) getTemplate(route string) (string, error) {
 }
 
 // GetAlias returns the alias for a given route.
+// If an alias has not been configured for the route, it returns the route.
 func (ur UserRewriter) GetAlias(ctx context.Context, route string) string {
 	tpl, err := ur.getTemplate(route)
 	if err != nil {

--- a/pkg/storage/registry/dynamic/routingtree/routingtree.go
+++ b/pkg/storage/registry/dynamic/routingtree/routingtree.go
@@ -27,9 +27,8 @@ import (
 
 // Route represents a route inside a storage provider.
 type Route struct {
-	Path      string
-	MountID   string
-	MountType string
+	Path    string
+	MountID string
 }
 
 // RoutingTree is a tree made of maps of routes.
@@ -96,7 +95,6 @@ func (t *RoutingTree) AddRoute(r Route) {
 		}
 		if path == r.Path {
 			newNode.MountID = r.MountID
-			newNode.MountType = r.MountType
 		}
 		current = current.addNode(newNode)
 	}

--- a/pkg/storage/registry/dynamic/routingtree/routingtree.go
+++ b/pkg/storage/registry/dynamic/routingtree/routingtree.go
@@ -25,19 +25,19 @@ import (
 	"strings"
 )
 
-// Route represents a route inside a storage provider
+// Route represents a route inside a storage provider.
 type Route struct {
 	Name    string
 	MountID string
 }
 
-// RoutingTree is a tree containing routes
+// RoutingTree is a tree containing routes.
 type RoutingTree struct {
 	route Route
 	nodes map[string]*RoutingTree
 }
 
-// New returns a new RoutingTree
+// New returns a new RoutingTree.
 func New(routes map[string]string) *RoutingTree {
 	t := RoutingTree{
 		nodes: map[string]*RoutingTree{},

--- a/pkg/storage/registry/dynamic/routingtree/routingtree.go
+++ b/pkg/storage/registry/dynamic/routingtree/routingtree.go
@@ -55,10 +55,6 @@ func New(routes map[string]string) *RoutingTree {
 }
 
 func (t *RoutingTree) addNode(r Route) *RoutingTree {
-	if t.route.Name == r.Name {
-		return t
-	}
-
 	newNode, ok := t.nodes[r.Name]
 	if !ok {
 		newNode = &RoutingTree{
@@ -76,6 +72,10 @@ func (t *RoutingTree) addRoute(route, mountID string) {
 	current := t
 
 	for i, name := range parts {
+		if name == "" {
+			continue
+		}
+
 		newNode := Route{
 			Name: name,
 		}
@@ -124,7 +124,6 @@ func (t *RoutingTree) Resolve(p string) ([]*registrypb.ProviderInfo, error) {
 	}
 
 	providerMap := r.getMountID(p, map[string]*registrypb.ProviderInfo{})
-
 	providers := make([]*registrypb.ProviderInfo, 0, len(providerMap))
 	for _, p := range providerMap {
 		providers = append(providers, p)

--- a/pkg/storage/registry/dynamic/routingtree/routingtree.go
+++ b/pkg/storage/registry/dynamic/routingtree/routingtree.go
@@ -1,0 +1,176 @@
+// Copyright 2018-2023 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+// Package routingtree contains the routing tree implementation
+package routingtree
+
+import (
+	"errors"
+	"path"
+	"strings"
+)
+
+// Route represents a route inside a storage provider
+type Route struct {
+	Path      string
+	MountID   string
+	MountType string
+}
+
+// RoutingTree is a tree made of maps of routes
+type RoutingTree struct {
+	route Route
+	nodes map[string]*RoutingTree
+}
+
+// New returns a new RoutingTree
+func New(rs []Route) *RoutingTree {
+	rt := &RoutingTree{
+		route: Route{
+			Path: "/",
+		},
+		nodes: make(map[string]*RoutingTree),
+	}
+
+	for _, r := range rs {
+		rt.AddRoute(r)
+	}
+
+	return rt
+}
+
+func (t *RoutingTree) addNode(r Route) *RoutingTree {
+	if t.route.Path == r.Path {
+		return t
+	}
+
+	newNode, ok := t.nodes[r.Path]
+	if !ok {
+		newNode = &RoutingTree{
+			route: r,
+			nodes: make(map[string]*RoutingTree),
+		}
+		t.nodes[r.Path] = newNode
+	}
+
+	return newNode
+}
+
+func getAncestors(p string) []string {
+	p = path.Clean(p)
+	ancestors := []string{}
+	previous := "/"
+	parts := strings.Split(p, "/")
+
+	for _, part := range parts {
+		previous = path.Join(previous, part)
+		ancestors = append(ancestors, previous)
+	}
+
+	return ancestors
+}
+
+// AddRoute adds a new Route to the RoutingTree based on a path `p`
+func (t *RoutingTree) AddRoute(r Route) {
+	parts := getAncestors(r.Path)
+	current := t
+
+	for _, path := range parts {
+		newNode := Route{
+			Path: path,
+		}
+		if path == r.Path {
+			newNode.MountID = r.MountID
+			newNode.MountType = r.MountType
+		}
+		current = current.addNode(newNode)
+	}
+}
+
+func (t *RoutingTree) findNodeForPath(p string) (*RoutingTree, error) {
+	parts := getAncestors(p)
+	current := t
+
+	for _, part := range parts {
+		// If the current node matches the path part, continue
+		if current.route.Path == part {
+			continue
+		}
+
+		// If not, check if there is a children with the path part
+		if childNode, ok := current.nodes[part]; ok {
+			current = childNode
+		} else {
+			// If there is none but there are other children, this is an invalid path
+			if len(current.nodes) != 0 {
+				return nil, errors.New("invalid route")
+			}
+			// If there is none and the node is a leaf, then that means the rest of the
+			// path is not part of the route
+			return current, nil
+		}
+	}
+
+	return current, nil
+}
+
+func (t *RoutingTree) getLeaves() []*RoutingTree {
+	if len(t.nodes) == 0 {
+		return []*RoutingTree{t}
+	}
+
+	leafNodes := []*RoutingTree{}
+	queue := []*RoutingTree{t}
+
+	for len(queue) > 0 {
+		node := queue[0]
+		queue = queue[1:]
+
+		if len(node.nodes) == 0 {
+			leafNodes = append(leafNodes, node)
+		}
+
+		for _, child := range node.nodes {
+			queue = append(queue, child)
+		}
+	}
+
+	return leafNodes
+}
+
+// GetProviders returns a list of providers for a given path
+func (t *RoutingTree) GetProviders(p string) ([]string, error) {
+	subtree, err := t.findNodeForPath(path.Clean(p))
+	if err != nil || subtree == nil {
+		return nil, err
+	}
+
+	leaves := subtree.getLeaves()
+	providers := []string{}
+	providerMap := make(map[string]bool)
+
+	for _, l := range leaves {
+		providerMap[l.route.MountID] = true
+	}
+
+	for p := range providerMap {
+		providers = append(providers, p)
+	}
+
+	return providers, nil
+}

--- a/pkg/storage/registry/dynamic/routingtree/routingtree.go
+++ b/pkg/storage/registry/dynamic/routingtree/routingtree.go
@@ -16,7 +16,7 @@
 // granted to it by virtue of its status as an Intergovernmental Organization
 // or submit itself to any jurisdiction.
 
-// Package routingtree contains the routing tree implementation
+// Package routingtree contains the routing tree implementation.
 package routingtree
 
 import (
@@ -25,20 +25,20 @@ import (
 	"strings"
 )
 
-// Route represents a route inside a storage provider
+// Route represents a route inside a storage provider.
 type Route struct {
 	Path      string
 	MountID   string
 	MountType string
 }
 
-// RoutingTree is a tree made of maps of routes
+// RoutingTree is a tree made of maps of routes.
 type RoutingTree struct {
 	route Route
 	nodes map[string]*RoutingTree
 }
 
-// New returns a new RoutingTree
+// New returns a new RoutingTree.
 func New(rs []Route) *RoutingTree {
 	rt := &RoutingTree{
 		route: Route{
@@ -85,7 +85,7 @@ func getAncestors(p string) []string {
 	return ancestors
 }
 
-// AddRoute adds a new Route to the RoutingTree based on a path `p`
+// AddRoute adds a new Route to the RoutingTree based on a path `p`.
 func (t *RoutingTree) AddRoute(r Route) {
 	parts := getAncestors(r.Path)
 	current := t
@@ -153,7 +153,7 @@ func (t *RoutingTree) getLeaves() []*RoutingTree {
 	return leafNodes
 }
 
-// GetProviders returns a list of providers for a given path
+// GetProviders returns a list of providers for a given path.
 func (t *RoutingTree) GetProviders(p string) ([]string, error) {
 	subtree, err := t.findNodeForPath(path.Clean(p))
 	if err != nil || subtree == nil {

--- a/pkg/storage/registry/dynamic/routingtree/routingtree_suite_test.go
+++ b/pkg/storage/registry/dynamic/routingtree/routingtree_suite_test.go
@@ -1,0 +1,31 @@
+// Copyright 2018-2023 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package routingtree_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestSql(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "RoutingTree Suite")
+}

--- a/pkg/storage/registry/dynamic/routingtree/routingtree_test.go
+++ b/pkg/storage/registry/dynamic/routingtree/routingtree_test.go
@@ -1,0 +1,171 @@
+// Copyright 2018-2023 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package routingtree_test
+
+import (
+	"github.com/cs3org/reva/pkg/storage/registry/dynamic/routingtree"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Routing Tree", func() {
+	var (
+		routes = []routingtree.Route{
+			{
+				Path:      "/eos/user/j",
+				MountID:   "eoshome-i01",
+				MountType: "home",
+			},
+			{
+				Path:      "/eos/user/g",
+				MountID:   "eoshome-i02",
+				MountType: "home",
+			},
+			{
+				Path:      "/eos/project/a/atlas",
+				MountID:   "eosproject-i00",
+				MountType: "project",
+			},
+			{
+				Path:      "/eos/project/c/cernbox",
+				MountID:   "eosproject-i01",
+				MountType: "project",
+			},
+			{
+				Path:      "/eos/project/c/cernbox-2",
+				MountID:   "eosproject-i01",
+				MountType: "project",
+			},
+			{
+				Path:      "/cephfs/project/c/cephbox",
+				MountID:   "cephfs",
+				MountType: "project",
+			},
+		}
+
+		nonLeaf = map[string][]string{
+			"":                  {"eoshome-i01", "eoshome-i02", "eosproject-i00", "eosproject-i01", "cephfs"},
+			"/":                 {"eoshome-i01", "eoshome-i02", "eosproject-i00", "eosproject-i01", "cephfs"},
+			"/eos":              {"eoshome-i01", "eoshome-i02", "eosproject-i00", "eosproject-i01"},
+			"/eos/":             {"eoshome-i01", "eoshome-i02", "eosproject-i00", "eosproject-i01"},
+			"/eos/user":         {"eoshome-i01", "eoshome-i02"},
+			"/eos/user/":        {"eoshome-i01", "eoshome-i02"},
+			"/eos/project":      {"eosproject-i00", "eosproject-i01"},
+			"/eos/project/a":    {"eosproject-i00"},
+			"/eos/project/c":    {"eosproject-i01"},
+			"/cephfs":           {"cephfs"},
+			"/cephfs/project/":  {"cephfs"},
+			"/cephfs/project/c": {"cephfs"},
+		}
+
+		deepRoutes = map[string]string{
+			"/eos/project/c/cernbox/a/deep/route":           "eosproject-i01",
+			"/eos/user/j/jaferrer/test/folder/":             "eoshome-i01",
+			"/cephfs/project/c/cephbox/another/deep/folder": "cephfs",
+		}
+
+		badRoutes = []string{
+			"badroute",
+			"/badroute",
+			"/eos/badroute",
+			"/eos/project/badroute",
+			"/eos/user/xyz",
+			"/eos/user/very/long/bad/route/",
+			"/cephfs/bad",
+			"/cephfs/project/asdf",
+		}
+
+		t   routingtree.RoutingTree
+		p   []string
+		err error
+	)
+
+	BeforeEach(func() {
+		t = *routingtree.New(routes)
+	})
+
+	Context("resolving providers", func() {
+		for _, r := range routes {
+			r := r
+			When("passed an existing leaf route: "+r.Path, func() {
+				JustBeforeEach(func() {
+					p, err = t.GetProviders(r.Path)
+				})
+
+				It("should return the correct provider", func() {
+					Expect(err).ToNot(HaveOccurred())
+					Expect(p).To(ConsistOf(r.MountID))
+				})
+			})
+		}
+
+		When("passed a non-existing route", func() {
+			JustBeforeEach(func() {
+				p, err = t.GetProviders("/this/path/does/not/exist")
+			})
+
+			It("should return an error", func() {
+				Expect(err).To(HaveOccurred())
+			})
+		})
+
+		for nl, ps := range nonLeaf {
+			nl := nl
+			ps := ps
+			When("passed an existing non-leaf route: "+nl, func() {
+				JustBeforeEach(func() {
+					p, err = t.GetProviders(nl)
+				})
+
+				It("should return the correct providers", func() {
+					Expect(err).ToNot(HaveOccurred())
+					Expect(p).To(ConsistOf(ps))
+				})
+			})
+		}
+
+		for r, wp := range deepRoutes {
+			r := r
+			wp := wp
+			When("passed a deep route: "+r, func() {
+				JustBeforeEach(func() {
+					p, err = t.GetProviders(r)
+				})
+
+				It("should return the correct providers", func() {
+					Expect(err).ToNot(HaveOccurred())
+					Expect(p).To(ConsistOf(wp))
+				})
+			})
+		}
+
+		for _, r := range badRoutes {
+			r := r
+			When("passed a bad route: "+r, func() {
+				JustBeforeEach(func() {
+					p, err = t.GetProviders(r)
+				})
+
+				It("should return an error", func() {
+					Expect(err).To(HaveOccurred())
+				})
+			})
+		}
+	})
+})

--- a/pkg/storage/registry/dynamic/routingtree/routingtree_test.go
+++ b/pkg/storage/registry/dynamic/routingtree/routingtree_test.go
@@ -19,6 +19,8 @@
 package routingtree_test
 
 import (
+	registrypb "github.com/cs3org/go-cs3apis/cs3/storage/registry/v1beta1"
+
 	"github.com/cs3org/reva/pkg/storage/registry/dynamic/routingtree"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -29,30 +31,58 @@ var _ = Describe("Routing Tree", func() {
 		routes = map[string]string{
 			"/eos/user/j":               "eoshome-i01",
 			"/eos/user/g":               "eoshome-i02",
-			"/eos/project/a/atlas":      "eosproject-i00",
-			"/eos/project/c/cernbox":    "eosproject-i01",
-			"/eos/project/c/cernbox-2":  "eosproject-i01",
+			"/eos/project/a":            "eosproject-i00",
+			"/eos/project/c":            "eosproject-i01",
 			"/cephfs/project/c/cephbox": "cephfs",
 		}
 
-		nonLeaf = map[string][]string{
-			"/":                 {"eoshome-i01", "eoshome-i02", "eosproject-i00", "eosproject-i01", "cephfs"},
-			"/eos":              {"eoshome-i01", "eoshome-i02", "eosproject-i00", "eosproject-i01"},
-			"/eos/":             {"eoshome-i01", "eoshome-i02", "eosproject-i00", "eosproject-i01"},
-			"/eos/user":         {"eoshome-i01", "eoshome-i02"},
-			"/eos/user/":        {"eoshome-i01", "eoshome-i02"},
-			"/eos/project":      {"eosproject-i00", "eosproject-i01"},
-			"/eos/project/a":    {"eosproject-i00"},
-			"/eos/project/c":    {"eosproject-i01"},
-			"/cephfs":           {"cephfs"},
-			"/cephfs/project/":  {"cephfs"},
-			"/cephfs/project/c": {"cephfs"},
+		providers = map[string]*registrypb.ProviderInfo{
+			"eoshome-i01": {
+				ProviderId:   "eoshome-i01",
+				ProviderPath: "/eos/user/j",
+			},
+			"eoshome-i02": {
+				ProviderId:   "eoshome-i02",
+				ProviderPath: "/eos/user/g",
+			},
+			"eosproject-i00": {
+				ProviderId:   "eosproject-i00",
+				ProviderPath: "/eos/project/a",
+			},
+			"eosproject-i01": {
+				ProviderId:   "eosproject-i01",
+				ProviderPath: "/eos/project/c",
+			},
+			"cephfs": {
+				ProviderId:   "cephfs",
+				ProviderPath: "/cephfs/project/c/cephbox",
+			},
 		}
 
-		deepRoutes = map[string]string{
-			"/eos/project/c/cernbox/a/deep/route":           "eosproject-i01",
-			"/eos/user/j/jaferrer/test/folder/":             "eoshome-i01",
-			"/cephfs/project/c/cephbox/another/deep/folder": "cephfs",
+		leaf = map[string]*registrypb.ProviderInfo{
+			"/eos/user/j":               providers["eoshome-i01"],
+			"/eos/user/g":               providers["eoshome-i02"],
+			"/eos/project/a":            providers["eosproject-i00"],
+			"/eos/project/c":            providers["eosproject-i01"],
+			"/cephfs/project/c/cephbox": providers["cephfs"],
+		}
+
+		nonLeaf = map[string][]*registrypb.ProviderInfo{
+			"/":                 {providers["eoshome-i01"], providers["eoshome-i02"], providers["eosproject-i00"], providers["eosproject-i01"], providers["cephfs"]},
+			"/eos":              {providers["eoshome-i01"], providers["eoshome-i02"], providers["eosproject-i00"], providers["eosproject-i01"]},
+			"/eos/":             {providers["eoshome-i01"], providers["eoshome-i02"], providers["eosproject-i00"], providers["eosproject-i01"]},
+			"/eos/user":         {providers["eoshome-i01"], providers["eoshome-i02"]},
+			"/eos/user/":        {providers["eoshome-i01"], providers["eoshome-i02"]},
+			"/eos/project":      {providers["eosproject-i00"], providers["eosproject-i01"]},
+			"/cephfs":           {providers["cephfs"]},
+			"/cephfs/project/":  {providers["cephfs"]},
+			"/cephfs/project/c": {providers["cephfs"]},
+		}
+
+		deepRoutes = map[string]*registrypb.ProviderInfo{
+			"/eos/project/c/cernbox/a/deep/route":           providers["eosproject-i01"],
+			"/eos/user/j/jaferrer/test/folder/":             providers["eoshome-i01"],
+			"/cephfs/project/c/cephbox/another/deep/folder": providers["cephfs"],
 		}
 
 		badRoutes = []string{
@@ -68,7 +98,7 @@ var _ = Describe("Routing Tree", func() {
 		}
 
 		t   routingtree.RoutingTree
-		p   []string
+		p   []*registrypb.ProviderInfo
 		err error
 	)
 
@@ -77,27 +107,21 @@ var _ = Describe("Routing Tree", func() {
 	})
 
 	Context("resolving providers", func() {
-		for r, m := range routes {
+		for r, ps := range leaf {
 			r := r
-			m := m
+			ps := ps
 			When("passed an existing leaf route: "+r, func() {
-				JustBeforeEach(func() {
-					p, err = t.Resolve(r)
-				})
-
 				It("should return the correct provider", func() {
+					p, err = t.Resolve(r)
 					Expect(err).ToNot(HaveOccurred())
-					Expect(p).To(ConsistOf(m))
+					Expect(p).To(ConsistOf(ps))
 				})
 			})
 		}
 
 		When("passed a non-existing route", func() {
-			JustBeforeEach(func() {
-				p, err = t.Resolve("/this/path/does/not/exist")
-			})
-
 			It("should return an error", func() {
+				p, err = t.Resolve("/this/path/does/not/exist")
 				Expect(err).To(HaveOccurred())
 			})
 		})
@@ -106,11 +130,8 @@ var _ = Describe("Routing Tree", func() {
 			nl := nl
 			ps := ps
 			When("passed an existing non-leaf route: "+nl, func() {
-				JustBeforeEach(func() {
-					p, err = t.Resolve(nl)
-				})
-
 				It("should return the correct providers", func() {
+					p, err = t.Resolve(nl)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(p).To(ConsistOf(ps))
 				})
@@ -121,11 +142,8 @@ var _ = Describe("Routing Tree", func() {
 			r := r
 			wp := wp
 			When("passed a deep route: "+r, func() {
-				JustBeforeEach(func() {
-					p, err = t.Resolve(r)
-				})
-
 				It("should return the correct providers", func() {
+					p, err = t.Resolve(r)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(p).To(ConsistOf(wp))
 				})
@@ -135,11 +153,8 @@ var _ = Describe("Routing Tree", func() {
 		for _, r := range badRoutes {
 			r := r
 			When("passed a bad route: "+r, func() {
-				JustBeforeEach(func() {
-					p, err = t.Resolve(r)
-				})
-
 				It("should return an error", func() {
+					p, err = t.Resolve(r)
 					Expect(err).To(HaveOccurred())
 				})
 			})

--- a/pkg/storage/registry/dynamic/routingtree/routingtree_test.go
+++ b/pkg/storage/registry/dynamic/routingtree/routingtree_test.go
@@ -26,35 +26,16 @@ import (
 
 var _ = Describe("Routing Tree", func() {
 	var (
-		routes = []routingtree.Route{
-			{
-				Path:    "/eos/user/j",
-				MountID: "eoshome-i01",
-			},
-			{
-				Path:    "/eos/user/g",
-				MountID: "eoshome-i02",
-			},
-			{
-				Path:    "/eos/project/a/atlas",
-				MountID: "eosproject-i00",
-			},
-			{
-				Path:    "/eos/project/c/cernbox",
-				MountID: "eosproject-i01",
-			},
-			{
-				Path:    "/eos/project/c/cernbox-2",
-				MountID: "eosproject-i01",
-			},
-			{
-				Path:    "/cephfs/project/c/cephbox",
-				MountID: "cephfs",
-			},
+		routes = map[string]string{
+			"/eos/user/j":               "eoshome-i01",
+			"/eos/user/g":               "eoshome-i02",
+			"/eos/project/a/atlas":      "eosproject-i00",
+			"/eos/project/c/cernbox":    "eosproject-i01",
+			"/eos/project/c/cernbox-2":  "eosproject-i01",
+			"/cephfs/project/c/cephbox": "cephfs",
 		}
 
 		nonLeaf = map[string][]string{
-			"":                  {"eoshome-i01", "eoshome-i02", "eosproject-i00", "eosproject-i01", "cephfs"},
 			"/":                 {"eoshome-i01", "eoshome-i02", "eosproject-i00", "eosproject-i01", "cephfs"},
 			"/eos":              {"eoshome-i01", "eoshome-i02", "eosproject-i00", "eosproject-i01"},
 			"/eos/":             {"eoshome-i01", "eoshome-i02", "eosproject-i00", "eosproject-i01"},
@@ -75,6 +56,7 @@ var _ = Describe("Routing Tree", func() {
 		}
 
 		badRoutes = []string{
+			"",
 			"badroute",
 			"/badroute",
 			"/eos/badroute",
@@ -95,23 +77,24 @@ var _ = Describe("Routing Tree", func() {
 	})
 
 	Context("resolving providers", func() {
-		for _, r := range routes {
+		for r, m := range routes {
 			r := r
-			When("passed an existing leaf route: "+r.Path, func() {
+			m := m
+			When("passed an existing leaf route: "+r, func() {
 				JustBeforeEach(func() {
-					p, err = t.GetProviders(r.Path)
+					p, err = t.Resolve(r)
 				})
 
 				It("should return the correct provider", func() {
 					Expect(err).ToNot(HaveOccurred())
-					Expect(p).To(ConsistOf(r.MountID))
+					Expect(p).To(ConsistOf(m))
 				})
 			})
 		}
 
 		When("passed a non-existing route", func() {
 			JustBeforeEach(func() {
-				p, err = t.GetProviders("/this/path/does/not/exist")
+				p, err = t.Resolve("/this/path/does/not/exist")
 			})
 
 			It("should return an error", func() {
@@ -124,7 +107,7 @@ var _ = Describe("Routing Tree", func() {
 			ps := ps
 			When("passed an existing non-leaf route: "+nl, func() {
 				JustBeforeEach(func() {
-					p, err = t.GetProviders(nl)
+					p, err = t.Resolve(nl)
 				})
 
 				It("should return the correct providers", func() {
@@ -139,7 +122,7 @@ var _ = Describe("Routing Tree", func() {
 			wp := wp
 			When("passed a deep route: "+r, func() {
 				JustBeforeEach(func() {
-					p, err = t.GetProviders(r)
+					p, err = t.Resolve(r)
 				})
 
 				It("should return the correct providers", func() {
@@ -153,7 +136,7 @@ var _ = Describe("Routing Tree", func() {
 			r := r
 			When("passed a bad route: "+r, func() {
 				JustBeforeEach(func() {
-					p, err = t.GetProviders(r)
+					p, err = t.Resolve(r)
 				})
 
 				It("should return an error", func() {

--- a/pkg/storage/registry/dynamic/routingtree/routingtree_test.go
+++ b/pkg/storage/registry/dynamic/routingtree/routingtree_test.go
@@ -28,34 +28,28 @@ var _ = Describe("Routing Tree", func() {
 	var (
 		routes = []routingtree.Route{
 			{
-				Path:      "/eos/user/j",
-				MountID:   "eoshome-i01",
-				MountType: "home",
+				Path:    "/eos/user/j",
+				MountID: "eoshome-i01",
 			},
 			{
-				Path:      "/eos/user/g",
-				MountID:   "eoshome-i02",
-				MountType: "home",
+				Path:    "/eos/user/g",
+				MountID: "eoshome-i02",
 			},
 			{
-				Path:      "/eos/project/a/atlas",
-				MountID:   "eosproject-i00",
-				MountType: "project",
+				Path:    "/eos/project/a/atlas",
+				MountID: "eosproject-i00",
 			},
 			{
-				Path:      "/eos/project/c/cernbox",
-				MountID:   "eosproject-i01",
-				MountType: "project",
+				Path:    "/eos/project/c/cernbox",
+				MountID: "eosproject-i01",
 			},
 			{
-				Path:      "/eos/project/c/cernbox-2",
-				MountID:   "eosproject-i01",
-				MountType: "project",
+				Path:    "/eos/project/c/cernbox-2",
+				MountID: "eosproject-i01",
 			},
 			{
-				Path:      "/cephfs/project/c/cephbox",
-				MountID:   "cephfs",
-				MountType: "project",
+				Path:    "/cephfs/project/c/cephbox",
+				MountID: "cephfs",
 			},
 		}
 

--- a/pkg/storage/registry/loader/loader.go
+++ b/pkg/storage/registry/loader/loader.go
@@ -20,6 +20,7 @@ package loader
 
 import (
 	// Load core storage broker drivers.
+	_ "github.com/cs3org/reva/pkg/storage/registry/dynamic"
 	_ "github.com/cs3org/reva/pkg/storage/registry/static"
 	// Add your own here.
 )


### PR DESCRIPTION
This PR adds a dynamic storage router. It uses a db table as routing table (with `path` - `mountid` pairs), and configuration to map the mountids to different provider addresses.

TODO: provide a config example