### PR TITLE
[tests-only][full-ci]bump latest commit id for branch master

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,4 +1,4 @@
 # The test runner source for API tests
-APITESTS_COMMITID=143675deff76705a54f6427bf99d9dc39069e9ff
+APITESTS_COMMITID=8931ee1187fa2c2a696a68a99a6c1c77919630d0
 APITESTS_BRANCH=master
 APITESTS_REPO_GIT_URL=https://github.com/owncloud/ocis.git


### PR DESCRIPTION
This PR bumps latest ocis commit id.
Part of https://github.com/owncloud/QA/issues/827