### PR TITLE
pass default nats options

### DIFF
--- a/changelog/unreleased/pass-default-nats-options.md
+++ b/changelog/unreleased/pass-default-nats-options.md
@@ -1,0 +1,5 @@
+Bugfix: always pass adjusted default nats options
+
+The nats-js store will now automatically reconnect.
+
+https://github.com/cs3org/reva/pull/4214

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -119,9 +119,11 @@ func Create(opts ...microstore.Option) microstore.Store {
 		// TODO nats needs a DefaultTTL option as it does not support per Write TTL ...
 		// FIXME nats has restrictions on the key, we cannot use slashes AFAICT
 		// host, port, clusterid
+		natsOptions := nats.GetDefaultOptions()
+		natsOptions.Name = "TODO" // we can pass in the service name to allow identifying the client, but that requires adding a custom context option
 		return natsjs.NewStore(
 			append(opts,
-				natsjs.NatsOptions(nats.Options{Name: "TODO"}),
+				natsjs.NatsOptions(natsOptions), // always pass in properly initialized default nats options
 				natsjs.DefaultTTL(ttl))...,
 		) // TODO test with ocis nats
 	case TypeMemory, "mem", "": // allow existing short form and use as default


### PR DESCRIPTION
The nats option passed completely replace the default nats options, so we need to pass in adjusted default options.