### PR TITLE
Add missing case for "hide" in UpdateShares

### DIFF
--- a/changelog/unreleased/fix-missing-case.md
+++ b/changelog/unreleased/fix-missing-case.md
@@ -1,0 +1,5 @@
+Bugfix: Fix missing case for "hide" in UpdateShares
+
+We fixed a bug that caused ocs to throw a 996 on update of permissions.
+
+https://github.com/cs3org/reva/pull/4217

--- a/pkg/share/manager/jsoncs3/jsoncs3.go
+++ b/pkg/share/manager/jsoncs3/jsoncs3.go
@@ -511,6 +511,8 @@ func (m *Manager) UpdateShare(ctx context.Context, ref *collaboration.ShareRefer
 				toUpdate.Permissions = updated.Permissions
 			case "expiration":
 				toUpdate.Expiration = updated.Expiration
+			case "hide":
+				toUpdate.Hide = updated.Hide
 			default:
 				return nil, errtypes.NotSupported("updating " + fieldMask.Paths[i] + " is not supported")
 			}


### PR DESCRIPTION
Bugfix: Fix missing case for "hide" in UpdateShares

We fixed a bug that caused ocs to throw a 996 on update of permissions.