### PR TITLE
[tests-only][full-ci] bump latest commit id

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,4 +1,4 @@
 # The test runner source for API tests
-APITESTS_COMMITID=8931ee1187fa2c2a696a68a99a6c1c77919630d0
+APITESTS_COMMITID=836106d8024b22a3c6ba5e4d42484ed99b879c12
 APITESTS_BRANCH=master
 APITESTS_REPO_GIT_URL=https://github.com/owncloud/ocis.git


### PR DESCRIPTION
This PR bumps latest ocis commit id.
Part of https://github.com/owncloud/QA/issues/827