### PR TITLE
[tests-only] Improve error handling in utils pkg

### DIFF
--- a/changelog/unreleased/utils-error-handling.md
+++ b/changelog/unreleased/utils-error-handling.md
@@ -1,0 +1,5 @@
+Enhancement: Improve error handling in utils package
+
+Improves error handling in the utils package. This has no impact on users.
+
+https://github.com/cs3org/reva/pull/4232


### PR DESCRIPTION
Returns typed errors so the caller can check for `not found`, `permission denied` or other grpc error codes
