### PR TITLE
[tests-only] [full-ci] bump latest ocis commit id to edge

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,4 +1,4 @@
 # The test runner source for API tests
-APITESTS_COMMITID=eb1aa4502e084972a6fd7e57112ae81431961374
+APITESTS_COMMITID=c1dcc42ad5e289093ca761a2eb94b19fb64f571e
 APITESTS_BRANCH=master
 APITESTS_REPO_GIT_URL=https://github.com/owncloud/ocis.git


### PR DESCRIPTION
Part of https://github.com/owncloud/QA/issues/832