### PR TITLE
ldap: fix GetUserByClaim for binary encoded UUIDs

### DIFF
--- a/changelog/unreleased/fix-ldap-getuserbyclaim-userid.md
+++ b/changelog/unreleased/fix-ldap-getuserbyclaim-userid.md
@@ -1,0 +1,7 @@
+Bugfix: GetUserByClaim not working with MSAD for claim "userid"
+
+We fixed GetUserByClaim to correctly deal with binary encoded userid
+as e.g. used for Active Directory.
+
+https://github.com/cs3org/reva/pull/4249
+https://github.com/owncloud/ocis/issues/7469

--- a/pkg/utils/ldap/identity.go
+++ b/pkg/utils/ldap/identity.go
@@ -526,7 +526,7 @@ func (i *Identity) getUserAttributeFilter(attribute, value string) (string, erro
 	default:
 		return "", errors.New("ldap: invalid field " + attribute)
 	}
-	if attribute == "userid" && i.User.Schema.IDIsOctetString {
+	if attribute == i.User.Schema.ID && i.User.Schema.IDIsOctetString {
 		id, err := uuid.Parse(value)
 		if err != nil {
 			err := errors.Wrap(err, fmt.Sprintf("error parsing OpaqueID '%s' as UUID", value))
@@ -687,7 +687,7 @@ func (i *Identity) getGroupAttributeFilter(attribute, value string) (string, err
 	default:
 		return "", errors.New("ldap: invalid field " + attribute)
 	}
-	if attribute == "group_id" && i.Group.Schema.IDIsOctetString {
+	if attribute == i.Group.Schema.ID && i.Group.Schema.IDIsOctetString {
 		id, err := uuid.Parse(value)
 		if err != nil {
 			err := errors.Wrap(err, fmt.Sprintf("error parsing OpaqueID '%s' as UUID", value))


### PR DESCRIPTION
GetUserByClaim didn't correctly work for claim "userid" when "idIsOctetString" is set to true. Because the LDAP filter was not correctly hex-escaped.

Fixes: https://github.com/owncloud/ocis/issues/7469