### PR TITLE
[backport/2.16] ldap: fix GetUserByClaim for binary encoded UUIDs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,9 +41,9 @@ lint-fix: $(GOLANGCI_LINT)
 	gofmt -w .
 	$(GOLANGCI_LINT) run --fix
 
+CALENS_DIR := $(shell mktemp -d)
 $(CALENS):
 	@mkdir -p $(@D)
-	CALENS_DIR=`mktemp -d`
 	git clone --depth 1 --branch v0.2.0 -c advice.detachedHead=false https://github.com/restic/calens.git $(CALENS_DIR)
 	cd $(CALENS_DIR) && GOBIN=$(@D) go install
 	rm -rf $(CALENS_DIR)

--- a/Makefile
+++ b/Makefile
@@ -43,9 +43,10 @@ lint-fix: $(GOLANGCI_LINT)
 
 $(CALENS):
 	@mkdir -p $(@D)
-	git clone --depth 1 --branch v0.2.0 -c advice.detachedHead=false https://github.com/restic/calens.git /tmp/calens
-	cd /tmp/calens && GOBIN=$(@D) go install
-	rm -rf /tmp/calens
+	CALENS_DIR=`mktemp -d`
+	git clone --depth 1 --branch v0.2.0 -c advice.detachedHead=false https://github.com/restic/calens.git $(CALENS_DIR)
+	cd $(CALENS_DIR) && GOBIN=$(@D) go install
+	rm -rf $(CALENS_DIR)
 
 .PHONY: check-changelog
 check-changelog: $(CALENS)

--- a/changelog/unreleased/fix-ldap-getuserbyclaim-userid.md
+++ b/changelog/unreleased/fix-ldap-getuserbyclaim-userid.md
@@ -1,0 +1,8 @@
+Bugfix: GetUserByClaim not working with MSAD for claim "userid"
+
+We fixed GetUserByClaim to correctly deal with binary encoded userid
+as e.g. used for Active Directory.
+
+https://github.com/cs3org/reva/pull/4251
+https://github.com/cs3org/reva/pull/4249
+https://github.com/owncloud/ocis/issues/7469

--- a/pkg/utils/ldap/identity.go
+++ b/pkg/utils/ldap/identity.go
@@ -526,7 +526,7 @@ func (i *Identity) getUserAttributeFilter(attribute, value string) (string, erro
 	default:
 		return "", errors.New("ldap: invalid field " + attribute)
 	}
-	if attribute == "userid" && i.User.Schema.IDIsOctetString {
+	if attribute == i.User.Schema.ID && i.User.Schema.IDIsOctetString {
 		id, err := uuid.Parse(value)
 		if err != nil {
 			err := errors.Wrap(err, fmt.Sprintf("error parsing OpaqueID '%s' as UUID", value))
@@ -687,7 +687,7 @@ func (i *Identity) getGroupAttributeFilter(attribute, value string) (string, err
 	default:
 		return "", errors.New("ldap: invalid field " + attribute)
 	}
-	if attribute == "group_id" && i.Group.Schema.IDIsOctetString {
+	if attribute == i.Group.Schema.ID && i.Group.Schema.IDIsOctetString {
 		id, err := uuid.Parse(value)
 		if err != nil {
 			err := errors.Wrap(err, fmt.Sprintf("error parsing OpaqueID '%s' as UUID", value))


### PR DESCRIPTION
GetUserByClaim didn't correctly work for claim "userid" when "idIsOctetString" is set to true. Because the LDAP filter was not correctly hex-escaped.

Fixes: https://github.com/owncloud/ocis/issues/7469 (cherry picked from commit 9b24c1780d57f98cad5fbcf982165fe47e47690b)