### PR TITLE
backport: create temp directory for calens when cloning repository

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,9 +43,10 @@ lint-fix: $(GOLANGCI_LINT)
 
 $(CALENS):
 	@mkdir -p $(@D)
-	git clone --depth 1 --branch v0.2.0 -c advice.detachedHead=false https://github.com/restic/calens.git /tmp/calens
-	cd /tmp/calens && GOBIN=$(@D) go install
-	rm -rf /tmp/calens
+	CALENS_DIR=`mktemp -d`
+	git clone --depth 1 --branch v0.2.0 -c advice.detachedHead=false https://github.com/restic/calens.git $(CALENS_DIR)
+	cd $(CALENS_DIR) && GOBIN=$(@D) go install
+	rm -rf $(CALENS_DIR)
 
 .PHONY: check-changelog
 check-changelog: $(CALENS)


### PR DESCRIPTION
Backport of https://github.com/cs3org/reva/pull/4212/commits/bebbd4cd8df578a2fc3df5447cbe0126a6df5d15

Should fix failures like: https://github.com/cs3org/reva/actions/runs/6494887516/job/17638879023?pr=4251