### PR TITLE
[tests-only][full-ci]Bump ocis commit id for tests

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,4 +1,4 @@
 # The test runner source for API tests
-APITESTS_COMMITID=dc3ed28696c6823ad181627a6ac92bbeccf06565
+APITESTS_COMMITID=fbfb1a041bc951f18a36b4be74252354e969ecce
 APITESTS_BRANCH=master
 APITESTS_REPO_GIT_URL=https://github.com/owncloud/ocis.git


### PR DESCRIPTION
This PR bumps ocis commit id for tests
Part of: https://github.com/owncloud/QA/issues/834