### PR TITLE
delete public link passwords based on permission

### DIFF
--- a/changelog/unreleased/opt-out-public-link-pw.md
+++ b/changelog/unreleased/opt-out-public-link-pw.md
@@ -1,0 +1,6 @@
+Enhancement: Opt out of public link password enforcement
+
+Users with special permissions can now delete passwords on read-only public links.
+
+https://github.com/cs3org/reva/pull/4270
+https://github.com/owncloud/ocis/issues/7538

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/public.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/public.go
@@ -19,11 +19,13 @@
 package shares
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
 	"strconv"
 
+	userv1beta1 "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	permissionsv1beta1 "github.com/cs3org/go-cs3apis/cs3/permissions/v1beta1"
 	rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
 	link "github.com/cs3org/go-cs3apis/cs3/sharing/link/v1beta1"
@@ -469,9 +471,15 @@ func (h *Handler) updatePublicShare(w http.ResponseWriter, r *http.Request, shar
 	newPassword, ok := r.Form["password"]
 	// enforcePassword
 	if h.enforcePassword(permKey) {
-		if !ok && !share.PasswordProtected || ok && len(newPassword[0]) == 0 {
-			response.WriteOCSError(w, r, response.MetaBadRequest.StatusCode, "missing required password", err)
+		p, err := conversions.NewPermissions(decreasePermissionsIfNecessary(*permKey))
+		if err != nil {
+			response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "failed to check permissions from request", err)
 			return
+		}
+		if !ok && !share.PasswordProtected || ok && len(newPassword[0]) == 0 {
+			if h.checkPasswordEnforcement(ctx, user, p, w, r) != nil {
+				return
+			}
 		}
 	}
 
@@ -685,6 +693,41 @@ func permKeyFromRequest(r *http.Request, h *Handler) (*int, error) {
 	}
 
 	return &permKey, nil
+}
+
+// checkPasswordEnforcement checks if the password needs to be set for a link
+// some users can opt out of the enforcement based on a user permission
+func (h *Handler) checkPasswordEnforcement(ctx context.Context, user *userv1beta1.User, perm conversions.Permissions, w http.ResponseWriter, r *http.Request) error {
+	// Non-read-only links
+	if perm != conversions.PermissionRead {
+		response.WriteOCSError(w, r, response.MetaBadRequest.StatusCode, "missing required password", nil)
+		return errors.New("missing required password")
+	}
+	// Check if the user is allowed to opt out of the password enforcement
+	// for read-only links
+	gwC, err := h.getClient()
+	if err != nil {
+		response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "could not check permission", err)
+		return errors.New("could not check permission")
+	}
+	resp, err := gwC.CheckPermission(ctx, &permissionsv1beta1.CheckPermissionRequest{
+		SubjectRef: &permissionsv1beta1.SubjectReference{
+			Spec: &permissionsv1beta1.SubjectReference_UserId{
+				UserId: user.Id,
+			},
+		},
+		Permission: "ReadOnlyPublicLinkPassword.Delete",
+	})
+	if err != nil {
+		response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "failed to check user permission", err)
+		return errors.New("failed to check user permission")
+	}
+
+	if resp.Status.Code != rpc.Code_CODE_OK {
+		response.WriteOCSError(w, r, response.MetaForbidden.StatusCode, "user is not allowed to delete the password from the public link", nil)
+		return errors.New("user is not allowed to delete the password from the public link")
+	}
+	return nil
 }
 
 // TODO: add mapping for user share permissions to role

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/public.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/public.go
@@ -362,7 +362,7 @@ func (h *Handler) updatePublicShare(w http.ResponseWriter, r *http.Request, shar
 			return
 		}
 
-		if !sRes.Info.PermissionSet.UpdateGrant {
+		if sRes.Info == nil || !sRes.Info.GetPermissionSet().UpdateGrant {
 			response.WriteOCSError(w, r, response.MetaUnauthorized.StatusCode, "missing permissions to update share", err)
 			return
 		}


### PR DESCRIPTION
Enhancement: Opt out of public link password enforcement

Users with special permissions can now delete passwords on read-only public links.

https://github.com/owncloud/ocis/issues/7538

Needs https://github.com/owncloud/ocis/pull/7540

## Example

1. Create Space "Test" as Admin (Admin has the permission `ReadOnlyPublicLinkPassword.Delete`)
2. Invite Einstein as "Manager" 
3. Create Folder "New folder"
4. As Einstein, create public link with "View" permission

## No permission (Einstein)

As Einstein, try to remove the password after the link creation

### Request

```sh
curl -L -X PUT 'https://localhost:9200/ocs/v2.php/apps/files_sharing/api/v1/shares/VftJhiyPEQbvPWw' \
-H 'Authorization: Basic YWRtaW46YWRtaW4=' \
-F 'permissions="1"' \
-F 'name="Link"' \
-F 'password=""' \
-F 'expireDate=""'
```

#### Response `403 - Forbidden`
```xml
<?xml version="1.0" encoding="UTF-8"?>
<ocs>
    <meta>
        <status>error</status>
        <statuscode>104</statuscode>
        <message>user is not allowed to delete the password from the public link</message>
    </meta>
</ocs>
<?xml version="1.0" encoding="UTF-8"?>
<ocs>
    <meta>
        <status>ok</status>
        <statuscode>200</statuscode>
        <message>OK</message>
    </meta>
    <data>
        <id>VftJhiyPEQbvPWw</id>
        <share_type>3</share_type>
        <uid_owner>admin</uid_owner>
        <displayname_owner>Admin</displayname_owner>
        <additional_info_owner>admin@example.org</additional_info_owner>
        <permissions>1</permissions>
        <stime>1698057363</stime>
        <parent></parent>
        <expiration></expiration>
        <token>YPFrYuLKgiQqxgH</token>
        <uid_file_owner>e6c4fc73-ddbc-41c1-b0ee-c35a648bf6e4</uid_file_owner>
        <displayname_file_owner></displayname_file_owner>
        <additional_info_file_owner></additional_info_file_owner>
        <state>0</state>
        <path>/New folder</path>
        <item_type>folder</item_type>
        <mimetype>httpd/unix-directory</mimetype>
        <space_id>storage-users-1$e6c4fc73-ddbc-41c1-b0ee-c35a648bf6e4!e6c4fc73-ddbc-41c1-b0ee-c35a648bf6e4</space_id>
        <space_alias>project/test</space_alias>
        <storage_id>shared::/New folder</storage_id>
        <storage>0</storage>
        <item_source>storage-users-1$e6c4fc73-ddbc-41c1-b0ee-c35a648bf6e4!59fafad1-fdaf-49fc-81ed-9eced1c4ea34</item_source>
        <file_source>storage-users-1$e6c4fc73-ddbc-41c1-b0ee-c35a648bf6e4!59fafad1-fdaf-49fc-81ed-9eced1c4ea34</file_source>
        <file_parent>storage-users-1$e6c4fc73-ddbc-41c1-b0ee-c35a648bf6e4!e6c4fc73-ddbc-41c1-b0ee-c35a648bf6e4</file_parent>
        <file_target>/New folder</file_target>
        <share_with_user_type>0</share_with_user_type>
        <share_with_additional_info></share_with_additional_info>
        <mail_send>0</mail_send>
        <name>Link</name>
        <url>https://localhost:9200/s/YPFrYuLKgiQqxgH</url>
        <quicklink>true</quicklink>
        <hide>false</hide>
    </data>
</ocs>
```

## With permission (Admin)

As Admin, try to remove the password after the link creation

### Request

```sh
curl -L -X PUT 'https://localhost:9200/ocs/v2.php/apps/files_sharing/api/v1/shares/VftJhiyPEQbvPWw' \
-H 'Authorization: Basic YWRtaW46YWRtaW4=' \
-F 'permissions="1"' \
-F 'name="Link"' \
-F 'password=""' \
-F 'expireDate=""'
```

#### Response `200 - OK`

```xml
<?xml version="1.0" encoding="UTF-8"?>
<ocs>
    <meta>
        <status>ok</status>
        <statuscode>200</statuscode>
        <message>OK</message>
    </meta>
    <data>
        <id>VftJhiyPEQbvPWw</id>
        <share_type>3</share_type>
        <uid_owner>admin</uid_owner>
        <displayname_owner>Admin</displayname_owner>
        <additional_info_owner>admin@example.org</additional_info_owner>
        <permissions>1</permissions>
        <stime>1698057363</stime>
        <parent></parent>
        <expiration></expiration>
        <token>YPFrYuLKgiQqxgH</token>
        <uid_file_owner>e6c4fc73-ddbc-41c1-b0ee-c35a648bf6e4</uid_file_owner>
        <displayname_file_owner></displayname_file_owner>
        <additional_info_file_owner></additional_info_file_owner>
        <state>0</state>
        <path>/New folder</path>
        <item_type>folder</item_type>
        <mimetype>httpd/unix-directory</mimetype>
        <space_id>storage-users-1$e6c4fc73-ddbc-41c1-b0ee-c35a648bf6e4!e6c4fc73-ddbc-41c1-b0ee-c35a648bf6e4</space_id>
        <space_alias>project/test</space_alias>
        <storage_id>shared::/New folder</storage_id>
        <storage>0</storage>
        <item_source>storage-users-1$e6c4fc73-ddbc-41c1-b0ee-c35a648bf6e4!59fafad1-fdaf-49fc-81ed-9eced1c4ea34</item_source>
        <file_source>storage-users-1$e6c4fc73-ddbc-41c1-b0ee-c35a648bf6e4!59fafad1-fdaf-49fc-81ed-9eced1c4ea34</file_source>
        <file_parent>storage-users-1$e6c4fc73-ddbc-41c1-b0ee-c35a648bf6e4!e6c4fc73-ddbc-41c1-b0ee-c35a648bf6e4</file_parent>
        <file_target>/New folder</file_target>
        <share_with_user_type>0</share_with_user_type>
        <share_with_additional_info></share_with_additional_info>
        <mail_send>0</mail_send>
        <name>Link</name>
        <url>https://localhost:9200/s/YPFrYuLKgiQqxgH</url>
        <quicklink>true</quicklink>
        <hide>false</hide>
    </data>
</ocs>
```