### PR TITLE
Create ocm shares base dir

### DIFF
--- a/changelog/unreleased/ocm.md
+++ b/changelog/unreleased/ocm.md
@@ -2,4 +2,5 @@ Enhancement: Port OCM changes from master
 
 We pulled in the latest ocm changes from master and are now compatible with the main go-cs3apis again.
 
+https://github.com/cs3org/reva/pull/4281
 https://github.com/cs3org/reva/pull/4239

--- a/pkg/ocm/share/repository/json/json.go
+++ b/pkg/ocm/share/repository/json/json.go
@@ -23,6 +23,7 @@ import (
 	"encoding/json"
 	"io"
 	"os"
+	"path/filepath"
 	"sync"
 	"time"
 
@@ -69,6 +70,9 @@ func New(m map[string]interface{}) (share.Repository, error) {
 func loadOrCreate(file string) (*shareModel, error) {
 	_, err := os.Stat(file)
 	if os.IsNotExist(err) {
+		if err := os.MkdirAll(filepath.Dir(file), 0700); err != nil {
+			return nil, errors.Wrap(err, "error creating the base directory: "+filepath.Dir(file))
+		}
 		if err := os.WriteFile(file, []byte("{}"), 0700); err != nil {
 			return nil, errors.Wrap(err, "error creating the file: "+file)
 		}


### PR DESCRIPTION
This PR fixes a problem with the ocmsharesprovider when starting on a fresh installation.