### PR TITLE
Support multiple templates in config entries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ export PART			  ?= 1
 
 .PHONY: $(TEST)
 $(TEST): docker-eos-full-tests docker-revad-eos
-	docker compose -f ./tests/docker/docker-compose.yml up --force-recreate --always-recreate-deps --build --abort-on-container-exit -V --remove-orphans --exit-code-from $@ $@
+	docker-compose -f ./tests/docker/docker-compose.yml up --force-recreate --always-recreate-deps --build --abort-on-container-exit -V --remove-orphans --exit-code-from $@ $@
 
 .PHONY: test-go
 test-go:
@@ -141,7 +141,7 @@ toolchain-clean:
 
 .PHONY: docker-clean
 docker-clean:
-	docker compose -f ./tests/docker/docker-compose.yml down --rmi local -v --remove-orphans
+	docker-compose -f ./tests/docker/docker-compose.yml down --rmi local -v --remove-orphans
 
 .PHONY: clean
 clean: toolchain-clean docker-clean

--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ export PART			  ?= 1
 
 .PHONY: $(TEST)
 $(TEST): docker-eos-full-tests docker-revad-eos
-	docker-compose -f ./tests/docker/docker-compose.yml up --force-recreate --always-recreate-deps --build --abort-on-container-exit -V --remove-orphans --exit-code-from $@ $@
+	docker compose -f ./tests/docker/docker-compose.yml up --force-recreate --always-recreate-deps --build --abort-on-container-exit -V --remove-orphans --exit-code-from $@ $@
 
 .PHONY: test-go
 test-go:
@@ -141,7 +141,7 @@ toolchain-clean:
 
 .PHONY: docker-clean
 docker-clean:
-	docker-compose -f ./tests/docker/docker-compose.yml down --rmi local -v --remove-orphans
+	docker compose -f ./tests/docker/docker-compose.yml down --rmi local -v --remove-orphans
 
 .PHONY: clean
 clean: toolchain-clean docker-clean

--- a/changelog/unreleased/config-templ.md
+++ b/changelog/unreleased/config-templ.md
@@ -1,0 +1,8 @@
+Enhancement: support multiple templates in config entries
+
+This PR introduces support for config entries with multiple templates,
+such as `parameter = "{{ vars.v1 }} foo {{ vars.v2 }}"`.
+Previously, only one `{{ template }}` was allowed in a given
+configuration entry.
+
+https://github.com/cs3org/reva/pull/4282

--- a/cmd/revad/pkg/config/templates.go
+++ b/cmd/revad/pkg/config/templates.go
@@ -132,7 +132,8 @@ func applyTemplateString(l Lookuper, p setter, v reflect.Value) error {
 			return err
 		}
 		if val == nil {
-			val = ""
+			// key was not found, just keep it but stop further parsing
+			break
 		}
 
 		new, err := replaceTemplate(s, tmpl, val)
@@ -175,7 +176,8 @@ func applyTemplateInterface(l Lookuper, p setter, v reflect.Value) error {
 			return err
 		}
 		if val == nil {
-			val = ""
+			// key was not found, just keep it but stop further parsing
+			break
 		}
 
 		new, err := replaceTemplate(s, tmpl, val)

--- a/cmd/revad/pkg/config/templates_test.go
+++ b/cmd/revad/pkg/config/templates_test.go
@@ -96,10 +96,12 @@ func TestApplyTemplate(t *testing.T) {
 						Config: map[string]any{
 							"drivers": map[string]any{
 								"sql": map[string]any{
-									"db_username": "{{ vars.db_username }}",
-									"db_password": "{{ vars.db_password }}",
-									"key":         "value",
-									"port":        "{{ vars.port }}",
+									"db_username":    "{{ vars.db_username }}",
+									"db_password":    "{{ vars.db_password }}",
+									"key":            "value",
+									"port":           "{{ vars.port }}",
+									"user_and_token": "{{ vars.db_username }} and {{.Token}}",
+									"templated_path": "/path/{{.Token}}",
 								},
 							},
 						},
@@ -125,10 +127,12 @@ func TestApplyTemplate(t *testing.T) {
 	assert.ErrorIs(t, err, nil)
 	assert.Equal(t, "localhost:1901", cfg2.Shared.GatewaySVC)
 	assert.Equal(t, map[string]any{
-		"db_username": "root",
-		"db_password": "secretpassword",
-		"key":         "value",
-		"port":        1000,
+		"db_username":    "root",
+		"db_password":    "secretpassword",
+		"key":            "value",
+		"port":           1000,
+		"user_and_token": "root and {{.Token}}",
+		"templated_path": "/path/{{.Token}}",
 	}, cfg2.GRPC.Services["authregistry"][0].Config["drivers"].(map[string]any)["sql"])
 	assert.Equal(t, map[string]any{
 		"db_host": "http://localhost:1000",

--- a/cmd/revad/pkg/config/templates_test.go
+++ b/cmd/revad/pkg/config/templates_test.go
@@ -85,7 +85,8 @@ func TestApplyTemplate(t *testing.T) {
 		Vars: Vars{
 			"db_username": "root",
 			"db_password": "secretpassword",
-			"integer":     10,
+			"proto":       "http",
+			"port":        1000,
 		},
 		GRPC: &GRPC{
 			Services: map[string]ServicesConfig{
@@ -98,7 +99,7 @@ func TestApplyTemplate(t *testing.T) {
 									"db_username": "{{ vars.db_username }}",
 									"db_password": "{{ vars.db_password }}",
 									"key":         "value",
-									"int":         "{{ vars.integer }}",
+									"port":        "{{ vars.port }}",
 								},
 							},
 						},
@@ -110,7 +111,7 @@ func TestApplyTemplate(t *testing.T) {
 						Config: map[string]any{
 							"drivers": map[string]any{
 								"sql": map[string]any{
-									"db_host": "http://localhost:{{ vars.integer }}",
+									"db_host": "{{ vars.proto }}://localhost:{{ vars.port }}",
 								},
 							},
 						},
@@ -127,9 +128,9 @@ func TestApplyTemplate(t *testing.T) {
 		"db_username": "root",
 		"db_password": "secretpassword",
 		"key":         "value",
-		"int":         10,
+		"port":        1000,
 	}, cfg2.GRPC.Services["authregistry"][0].Config["drivers"].(map[string]any)["sql"])
 	assert.Equal(t, map[string]any{
-		"db_host": "http://localhost:10",
+		"db_host": "http://localhost:1000",
 	}, cfg2.GRPC.Services["other"][0].Config["drivers"].(map[string]any)["sql"])
 }


### PR DESCRIPTION
This PR introduces support for config entries with multiple templates, such as `parameter = "{{ vars.v1 }} foo {{ vars.v2 }}"`.
Previously, only one `{{ template }}` was allowed in a given configuration entry.
