### PR TITLE
Print plugin version

### DIFF
--- a/changelog/unreleased/plugin-versions.md
+++ b/changelog/unreleased/plugin-versions.md
@@ -1,0 +1,3 @@
+Enhancement: Print plugins' version
+
+https://github.com/cs3org/reva/pull/4288

--- a/cmd/revad/main.go
+++ b/cmd/revad/main.go
@@ -23,6 +23,8 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"slices"
+
 	"os"
 	"path"
 	"reflect"
@@ -41,6 +43,7 @@ import (
 	"github.com/cs3org/reva/pkg/logger"
 	"github.com/cs3org/reva/pkg/plugin"
 	"github.com/cs3org/reva/pkg/sysinfo"
+	"github.com/cs3org/reva/pkg/utils/maps"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
@@ -129,8 +132,13 @@ func handlePluginsFlag() {
 		bi = &debug.BuildInfo{}
 	}
 
+	namespaces := maps.Keys(grouped)
+	slices.Sort(namespaces)
+
 	count := 0
-	for ns, plugins := range grouped {
+	for _, ns := range namespaces {
+		plugins := grouped[ns]
+
 		fmt.Printf("[%s]\n", ns)
 		for _, p := range plugins {
 			pkgName := pkgOfFunction(p.New)

--- a/docker/Dockerfile.revad-ceph
+++ b/docker/Dockerfile.revad-ceph
@@ -26,12 +26,12 @@ RUN dnf update --exclude=ceph-iscsi -y && dnf install -y \
   librbd-devel \
   librados-devel
 
-ADD https://golang.org/dl/go1.19.linux-amd64.tar.gz \
-  go1.19.linux-amd64.tar.gz
+ADD https://go.dev/dl/go1.21.3.linux-amd64.tar.gz \
+  go1.21.3.linux-amd64.tar.gz
 
 RUN rm -rf /usr/local/go && \
-  tar -C /usr/local -xzf go1.19.linux-amd64.tar.gz && \
-  rm go1.19.linux-amd64.tar.gz
+  tar -C /usr/local -xzf go1.21.3.linux-amd64.tar.gz && \
+  rm go1.21.3.linux-amd64.tar.gz
 
 ENV PATH /go/bin:/usr/local/go/bin:$PATH
 ENV GOPATH /go
@@ -44,8 +44,8 @@ ARG VERSION
 ENV GIT_COMMIT=$GIT_COMMIT
 ENV VERSION=$VERSION
 RUN mkdir -p /go/bin && \
-    make revad-ceph && \
-    cp /go/src/github/cs3org/reva/cmd/revad/revad /usr/bin/revad
+  make revad-ceph && \
+  cp /go/src/github/cs3org/reva/cmd/revad/revad /usr/bin/revad
 
 RUN cp -r examples/ceph /etc/
 


### PR DESCRIPTION
Now on `revad -plugins`, the list reports the version of the plugins.
Example:

```
[grpc.services.groupprovider.drivers]
rest -> github.com/cernbox/reva-plugins/group (v0.0.4)
```