### PR TITLE
Return 403 when user is not permitted to lock

### DIFF
--- a/changelog/unreleased/return-403-when-not-lock-permitted.md
+++ b/changelog/unreleased/return-403-when-not-lock-permitted.md
@@ -1,0 +1,5 @@
+Bugfix: Return 403 when user is not permitted to log
+
+When a user tries to lock a file, but doesn't have write access, the correct status code is `403` not `500` like we did until now
+
+https://github.com/cs3org/reva/pull/4292

--- a/internal/http/services/owncloud/ocdav/locks.go
+++ b/internal/http/services/owncloud/ocdav/locks.go
@@ -506,10 +506,15 @@ func (s *svc) lockReference(ctx context.Context, w http.ResponseWriter, r *http.
 		//      this actually is a name based lock ... ugh
 		token, err = s.LockSystem.Create(ctx, now, ld)
 		if err != nil {
-			if _, ok := err.(errtypes.Aborted); ok {
+			switch err.(type) {
+			case errtypes.Aborted:
 				return http.StatusLocked, err
+			case errtypes.PermissionDenied:
+				return http.StatusForbidden, err
+			default:
+				return http.StatusInternalServerError, err
+
 			}
-			return http.StatusInternalServerError, err
 		}
 
 		defer func() {


### PR DESCRIPTION
Returns `403` instead `500` when a user tries to lock a file they have no write access to. See details: https://github.com/owncloud/ocis/issues/7600
