### PR TITLE
Fix http verb

### DIFF
--- a/changelog/unreleased/fix-http-verb.md
+++ b/changelog/unreleased/fix-http-verb.md
@@ -1,0 +1,7 @@
+Bugfix: Fix HTTP verb of the generate-invite endpoint
+
+We changed the HTTP verb of the /generate-invite endpoint of the sciencemesh
+service to POST as it clearly has side effects for the system, it's not just a
+read-only call.
+
+https://github.com/cs3org/reva/pull/4299

--- a/internal/http/services/sciencemesh/sciencemesh.go
+++ b/internal/http/services/sciencemesh/sciencemesh.go
@@ -105,7 +105,7 @@ func (s *svc) routerInit() error {
 		return err
 	}
 
-	s.router.Get("/generate-invite", tokenHandler.Generate)
+	s.router.Post("/generate-invite", tokenHandler.Generate)
 	s.router.Get("/list-invite", tokenHandler.ListInvite)
 	s.router.Post("/accept-invite", tokenHandler.AcceptInvite)
 	s.router.Get("/find-accepted-users", tokenHandler.FindAccepted)

--- a/pkg/ocm/provider/authorizer/json/json.go
+++ b/pkg/ocm/provider/authorizer/json/json.go
@@ -163,7 +163,11 @@ func (a *authorizer) IsProviderAllowed(ctx context.Context, pi *ocmprovider.Prov
 	if hostIPs, ok := a.providerIPs.Load(ocmHost); ok {
 		ipList = hostIPs.([]string)
 	} else {
-		addr, err := net.LookupIP(ocmHost)
+		host, _, err := net.SplitHostPort(ocmHost)
+		if err != nil {
+			return errors.Wrap(err, "json: error looking up client IP")
+		}
+		addr, err := net.LookupIP(host)
 		if err != nil {
 			return errors.Wrap(err, "json: error looking up client IP")
 		}

--- a/tests/integration/grpc/ocm_invitation_test.go
+++ b/tests/integration/grpc/ocm_invitation_test.go
@@ -386,7 +386,7 @@ var _ = Describe("ocm invitation workflow", func() {
 			}
 
 			generateToken := func(revaToken, domain string) (*generateInviteResponse, int) {
-				req, err := http.NewRequestWithContext(context.TODO(), http.MethodGet, fmt.Sprintf("http://%s/sciencemesh/generate-invite", domain), nil)
+				req, err := http.NewRequestWithContext(context.TODO(), http.MethodPost, fmt.Sprintf("http://%s/sciencemesh/generate-invite", domain), nil)
 				Expect(err).ToNot(HaveOccurred())
 				req.Header.Set("x-access-token", revaToken)
 


### PR DESCRIPTION
We changed the HTTP verb of the /generate-invite endpoint of the sciencemesh service to POST as it clearly has side effects for the system, it's not just a read-only call.