### PR TITLE
Fix filenamelength checking

### DIFF
--- a/changelog/unreleased/fix-filename-length-check.md
+++ b/changelog/unreleased/fix-filename-length-check.md
@@ -1,5 +1,5 @@
 Bugfix: Fix checking of filename length
 
-Instead of checking for length of the filename the ocs handler would sometimes check for complete file path.
+Instead of checking for length of the filename the ocdav handler would sometimes check for complete file path.
 
 https://github.com/cs3org/reva/pull/4302

--- a/changelog/unreleased/fix-filename-length-check.md
+++ b/changelog/unreleased/fix-filename-length-check.md
@@ -1,0 +1,5 @@
+Bugfix: Fix checking of filename length
+
+Instead of checking for length of the filename the ocs handler would sometimes check for complete file path.
+
+https://github.com/cs3org/reva/pull/4302

--- a/internal/http/services/owncloud/ocdav/copy.go
+++ b/internal/http/services/owncloud/ocdav/copy.go
@@ -88,14 +88,14 @@ func (s *svc) handlePathCopy(w http.ResponseWriter, r *http.Request, ns string) 
 		return
 	}
 
-	if err := ValidateName(src, s.nameValidators); err != nil {
+	if err := ValidateName(path.Base(src), s.nameValidators); err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		b, err := errors.Marshal(http.StatusBadRequest, "source failed naming rules", "")
 		errors.HandleWebdavError(appctx.GetLogger(ctx), w, b, err)
 		return
 	}
 
-	if err := ValidateName(dst, s.nameValidators); err != nil {
+	if err := ValidateName(path.Base(dst), s.nameValidators); err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		b, err := errors.Marshal(http.StatusBadRequest, "destination failed naming rules", "")
 		errors.HandleWebdavError(appctx.GetLogger(ctx), w, b, err)

--- a/internal/http/services/owncloud/ocdav/mkcol.go
+++ b/internal/http/services/owncloud/ocdav/mkcol.go
@@ -40,7 +40,7 @@ func (s *svc) handlePathMkcol(w http.ResponseWriter, r *http.Request, ns string)
 	defer span.End()
 
 	fn := path.Join(ns, r.URL.Path)
-	if err := ValidateName(fn, s.nameValidators); err != nil {
+	if err := ValidateName(path.Base(fn), s.nameValidators); err != nil {
 		return http.StatusBadRequest, err
 	}
 	sublog := appctx.GetLogger(ctx).With().Str("path", fn).Logger()

--- a/internal/http/services/owncloud/ocdav/move.go
+++ b/internal/http/services/owncloud/ocdav/move.go
@@ -60,14 +60,14 @@ func (s *svc) handlePathMove(w http.ResponseWriter, r *http.Request, ns string) 
 		return
 	}
 
-	if err := ValidateName(srcPath, s.nameValidators); err != nil {
+	if err := ValidateName(path.Base(srcPath), s.nameValidators); err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		b, err := errors.Marshal(http.StatusBadRequest, "source failed naming rules", "")
 		errors.HandleWebdavError(appctx.GetLogger(ctx), w, b, err)
 		return
 	}
 
-	if err := ValidateName(dstPath, s.nameValidators); err != nil {
+	if err := ValidateName(path.Base(dstPath), s.nameValidators); err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		b, err := errors.Marshal(http.StatusBadRequest, "destination naming rules", "")
 		errors.HandleWebdavError(appctx.GetLogger(ctx), w, b, err)

--- a/internal/http/services/owncloud/ocdav/put.go
+++ b/internal/http/services/owncloud/ocdav/put.go
@@ -141,8 +141,7 @@ func (s *svc) handlePut(ctx context.Context, w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	fn := filepath.Base(ref.Path)
-	if err := ValidateName(fn, s.nameValidators); err != nil {
+	if err := ValidateName(filepath.Base(ref.Path), s.nameValidators); err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		b, err := errors.Marshal(http.StatusBadRequest, err.Error(), "")
 		errors.HandleWebdavError(&log, w, b, err)

--- a/internal/http/services/owncloud/ocdav/tus.go
+++ b/internal/http/services/owncloud/ocdav/tus.go
@@ -57,7 +57,7 @@ func (s *svc) handlePathTusPost(w http.ResponseWriter, r *http.Request, ns strin
 
 	// read filename from metadata
 	meta := tusd.ParseMetadataHeader(r.Header.Get(net.HeaderUploadMetadata))
-	if err := ValidateName(meta["filename"], s.nameValidators); err != nil {
+	if err := ValidateName(path.Base(meta["filename"]), s.nameValidators); err != nil {
 		w.WriteHeader(http.StatusPreconditionFailed)
 		return
 	}
@@ -81,7 +81,7 @@ func (s *svc) handleSpacesTusPost(w http.ResponseWriter, r *http.Request, spaceI
 
 	// read filename from metadata
 	meta := tusd.ParseMetadataHeader(r.Header.Get(net.HeaderUploadMetadata))
-	if err := ValidateName(meta["filename"], s.nameValidators); err != nil {
+	if err := ValidateName(path.Base(meta["filename"]), s.nameValidators); err != nil {
 		w.WriteHeader(http.StatusPreconditionFailed)
 		return
 	}


### PR DESCRIPTION
Fixes a bug where the ocdav service would check for filepath length instead of filename length

Details: https://github.com/owncloud/ocis/issues/7610
