### PR TITLE
Dynamic storage provider add aliases

### DIFF
--- a/changelog/unreleased/storage-registry-aliases.md
+++ b/changelog/unreleased/storage-registry-aliases.md
@@ -1,0 +1,7 @@
+Bugfix: Dynamic storage registry storage_id aliases
+
+Fixes the bug where the dynamic storage registry would not be able to
+resolve storage ids like `eoshome-a`, as those are aliased and need to
+be resolved into the proper storage-id (`eoshome-i01`).
+
+https://github.com/cs3org/reva/pull/4307

--- a/pkg/storage/registry/dynamic/dynamic.go
+++ b/pkg/storage/registry/dynamic/dynamic.go
@@ -52,9 +52,9 @@ type dynamic struct {
 }
 
 type config struct {
-	Rules      map[string]string `docs:"nil;A map from mountID to provider address"                       mapstructure:"rules"`
-	Rewrites   map[string]string `docs:"nil;A map from a path to an template alias to use when resolving" mapstructure:"rewrites"`
-	IDAliases  map[string]string `docs:"mil;A map containing storageID aliases, can contain simple brackets" mapstructure:"aliases"`
+	Rules      map[string]string `docs:"nil;A map from mountID to provider address"                          mapstructure:"rules"`
+	Rewrites   map[string]string `docs:"nil;A map from a path to an template alias to use when resolving"    mapstructure:"rewrites"`
+	IDAliases  map[string]string `docs:"nil;A map containing storageID aliases, can contain simple brackets" mapstructure:"aliases"`
 	HomePath   string            `mapstructure:"home_path"`
 	DBUsername string            `mapstructure:"db_username"`
 	DBPassword string            `mapstructure:"db_password"`

--- a/pkg/storage/registry/static/static.go
+++ b/pkg/storage/registry/static/static.go
@@ -20,7 +20,6 @@ package static
 
 import (
 	"context"
-	"os"
 	"path"
 	"regexp"
 	"strings"
@@ -30,7 +29,6 @@ import (
 
 	"github.com/cs3org/reva/pkg/appctx"
 	"github.com/cs3org/reva/pkg/errtypes"
-	"github.com/cs3org/reva/pkg/logger"
 	"github.com/cs3org/reva/pkg/sharedconf"
 	"github.com/cs3org/reva/pkg/storage"
 	"github.com/cs3org/reva/pkg/storage/registry/registry"
@@ -132,7 +130,6 @@ func (b *reg) GetHome(ctx context.Context) (*registrypb.ProviderInfo, error) {
 }
 
 func (b *reg) FindProviders(ctx context.Context, ref *provider.Reference) ([]*registrypb.ProviderInfo, error) {
-	l := logger.New(logger.WithWriter(os.Stdout, logger.ConsoleMode))
 	// find longest match
 	var match *registrypb.ProviderInfo
 	var shardedMatches []*registrypb.ProviderInfo
@@ -195,7 +192,6 @@ func (b *reg) FindProviders(ctx context.Context, ref *provider.Reference) ([]*re
 		}
 	}
 
-	l.Debug().Msgf(">>>>>> match: %+v %+v", match, shardedMatches)
 	if match != nil && match.ProviderPath != "" {
 		return []*registrypb.ProviderInfo{match}, nil
 	} else if len(shardedMatches) > 0 {

--- a/pkg/storage/registry/utils/utils.go
+++ b/pkg/storage/registry/utils/utils.go
@@ -1,0 +1,31 @@
+// Package utils contains utilities for storage registries
+package utils
+
+import (
+	"regexp"
+	"strings"
+)
+
+// GenerateRegexCombinations expands bracket regexes
+func GenerateRegexCombinations(rex string) []string {
+	var bracketRegex = regexp.MustCompile(`\[(.*?)\]`)
+	m := bracketRegex.FindString(rex)
+	r := strings.Trim(strings.Trim(m, "["), "]")
+	if r == "" {
+		return []string{rex}
+	}
+	var combinations []string
+	for i := 0; i < len(r); i++ {
+		if i < len(r)-2 && r[i+1] == '-' {
+			for j := r[i]; j <= r[i+2]; j++ {
+				p := strings.Replace(rex, m, string(j), 1)
+				combinations = append(combinations, GenerateRegexCombinations(p)...)
+			}
+			i += 2
+		} else {
+			p := strings.Replace(rex, m, string(r[i]), 1)
+			combinations = append(combinations, GenerateRegexCombinations(p)...)
+		}
+	}
+	return combinations
+}

--- a/pkg/storage/registry/utils/utils.go
+++ b/pkg/storage/registry/utils/utils.go
@@ -1,3 +1,21 @@
+// Copyright 2018-2023 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
 // Package utils contains utilities for storage registries
 package utils
 
@@ -6,7 +24,7 @@ import (
 	"strings"
 )
 
-// GenerateRegexCombinations expands bracket regexes
+// GenerateRegexCombinations expands bracket regexes.
 func GenerateRegexCombinations(rex string) []string {
 	var bracketRegex = regexp.MustCompile(`\[(.*?)\]`)
 	m := bracketRegex.FindString(rex)


### PR DESCRIPTION
This PR solves the problem we found yesterday where it is impossible to resolve storage ids like: `eoshome-a`, as those are aliases of real storage ids like `eoshome-i01`.

We add a new section in the registry config:

```
[grpc.services.storageregistry.drivers.dynamic.aliases]
"eoshome-[dlntz]" = "eosuser-i00"
"eoshome-[agjkw]" = "eosuser-i01"
"eoshome-[horsy]" = "eosuser-i02"
"eoshome-[bemvx]" = "eosuser-i03"
"eoshome-[cfipqu]" = "eosuser-i04"
"newproject-[aegjkqvy]" = "eosproject-i00"
"newproject-[bfhlnopsw]" = "eosproject-i01"
"newproject-[cdimrtuxz]" = "eosproject-i02"
```

And when the storage registry is passed a `storage_id` to find its providers, it will ensure if the given `storage_id` is an alias, it will be resolved.

Fixes #4303 