### PR TITLE
Fixed typo in decomposedfs upload

### DIFF
--- a/pkg/storage/utils/decomposedfs/upload/upload.go
+++ b/pkg/storage/utils/decomposedfs/upload/upload.go
@@ -368,7 +368,7 @@ func (upload *Upload) Finalize() (err error) {
 	err = upload.tp.WriteBlob(n, upload.binPath)
 	subspan.End()
 	if err != nil {
-		return errors.Wrap(err, "failed to upload file to blostore")
+		return errors.Wrap(err, "failed to upload file to blobstore")
 	}
 
 	return nil


### PR DESCRIPTION
This PR just fixes a typo in the error message of a failed upload.