### PR TITLE
Sharing ng preparation and bugfix

### DIFF
--- a/changelog/unreleased/fix-shares-cleanup-config.md
+++ b/changelog/unreleased/fix-shares-cleanup-config.md
@@ -1,0 +1,5 @@
+Bugfix: Fix public shares cleanup config
+
+The public shares cleanup for expired shares was not configurable via ocis.
+
+https://github.com/cs3org/reva/pull/4335/

--- a/changelog/unreleased/new-permission-helper-function.md
+++ b/changelog/unreleased/new-permission-helper-function.md
@@ -1,0 +1,6 @@
+Enhancement: Add sufficient permissions check function
+
+We added a helper function to check for sufficient CS3 resource permissions.
+
+https://github.com/cs3org/reva/pull/4335/
+https://github.com/owncloud/ocis/issues/6993

--- a/internal/grpc/services/publicshareprovider/publicshareprovider.go
+++ b/internal/grpc/services/publicshareprovider/publicshareprovider.go
@@ -24,6 +24,7 @@ import (
 
 	rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
 	link "github.com/cs3org/go-cs3apis/cs3/sharing/link/v1beta1"
+	typesv1beta1 "github.com/cs3org/go-cs3apis/cs3/types/v1beta1"
 	"github.com/cs3org/reva/v2/pkg/appctx"
 	ctxpkg "github.com/cs3org/reva/v2/pkg/ctx"
 	"github.com/cs3org/reva/v2/pkg/errtypes"
@@ -31,7 +32,9 @@ import (
 	"github.com/cs3org/reva/v2/pkg/publicshare/manager/registry"
 	"github.com/cs3org/reva/v2/pkg/rgrpc"
 	"github.com/cs3org/reva/v2/pkg/rgrpc/status"
+	"github.com/cs3org/reva/v2/pkg/utils"
 	"github.com/mitchellh/mapstructure"
+	graph "github.com/owncloud/ocis/v2/services/graph/pkg/service/v0/errorcode"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 )
@@ -44,6 +47,7 @@ type config struct {
 	Driver                         string                            `mapstructure:"driver"`
 	Drivers                        map[string]map[string]interface{} `mapstructure:"drivers"`
 	AllowedPathsForShares          []string                          `mapstructure:"allowed_paths_for_shares"`
+	EnableExpiredSharesCleanup     bool                              `mapstructure:"enable_expired_shares_cleanup"`
 	WriteableShareMustHavePassword bool                              `mapstructure:"writeable_share_must_have_password"`
 }
 
@@ -159,10 +163,12 @@ func (s *service) CreatePublicShare(ctx context.Context, req *link.CreatePublicS
 	if err != nil {
 		log.Debug().Err(err).Str("createShare", "shares").Msg("error connecting to storage provider")
 	}
-
+	opaque := &typesv1beta1.Opaque{Map: map[string]*typesv1beta1.OpaqueEntry{}}
+	opaque = utils.AppendJSONToOpaque(opaque, "errorcode", graph.New(graph.InvalidAuthenticationToken, "test"))
 	res := &link.CreatePublicShareResponse{
 		Status: status.NewOK(ctx),
 		Share:  share,
+		Opaque: opaque,
 	}
 	return res, nil
 }

--- a/pkg/conversions/role_test.go
+++ b/pkg/conversions/role_test.go
@@ -1,0 +1,107 @@
+package conversions
+
+import (
+	"testing"
+
+	providerv1beta1 "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSufficientPermissions(t *testing.T) {
+	type testData struct {
+		Existing   *providerv1beta1.ResourcePermissions
+		Requested  *providerv1beta1.ResourcePermissions
+		Sufficient bool
+	}
+	table := []testData{
+		{
+			Existing:   nil,
+			Requested:  nil,
+			Sufficient: false,
+		},
+		{
+			Existing:   RoleFromName("editor", true).CS3ResourcePermissions(),
+			Requested:  nil,
+			Sufficient: false,
+		},
+		{
+			Existing:   nil,
+			Requested:  RoleFromName("viewer", true).CS3ResourcePermissions(),
+			Sufficient: false,
+		},
+		{
+			Existing:   RoleFromName("editor", true).CS3ResourcePermissions(),
+			Requested:  RoleFromName("viewer", true).CS3ResourcePermissions(),
+			Sufficient: true,
+		},
+		{
+			Existing:   RoleFromName("viewer", true).CS3ResourcePermissions(),
+			Requested:  RoleFromName("editor", true).CS3ResourcePermissions(),
+			Sufficient: false,
+		},
+		{
+			Existing:   RoleFromName("spaceviewer", true).CS3ResourcePermissions(),
+			Requested:  RoleFromName("spaceeditor", true).CS3ResourcePermissions(),
+			Sufficient: false,
+		},
+		{
+			Existing:   RoleFromName("manager", true).CS3ResourcePermissions(),
+			Requested:  RoleFromName("spaceeditor", true).CS3ResourcePermissions(),
+			Sufficient: true,
+		},
+		{
+			Existing:   RoleFromName("manager", true).CS3ResourcePermissions(),
+			Requested:  RoleFromName("spaceviewer", true).CS3ResourcePermissions(),
+			Sufficient: true,
+		},
+		{
+			Existing:   RoleFromName("manager", true).CS3ResourcePermissions(),
+			Requested:  RoleFromName("manager", true).CS3ResourcePermissions(),
+			Sufficient: true,
+		},
+		{
+			Existing:   RoleFromName("manager", true).CS3ResourcePermissions(),
+			Requested:  RoleFromName("denied", true).CS3ResourcePermissions(),
+			Sufficient: true,
+		},
+		{
+			Existing:   RoleFromName("spaceeditor", true).CS3ResourcePermissions(),
+			Requested:  RoleFromName("denied", true).CS3ResourcePermissions(),
+			Sufficient: false,
+		},
+		{
+			Existing:   RoleFromName("editor", true).CS3ResourcePermissions(),
+			Requested:  RoleFromName("denied", true).CS3ResourcePermissions(),
+			Sufficient: false,
+		},
+		{
+			Existing: &providerv1beta1.ResourcePermissions{
+				// all permissions, used for personal space owners
+				AddGrant:             true,
+				CreateContainer:      true,
+				Delete:               true,
+				GetPath:              true,
+				GetQuota:             true,
+				InitiateFileDownload: true,
+				InitiateFileUpload:   true,
+				ListContainer:        true,
+				ListFileVersions:     true,
+				ListGrants:           true,
+				ListRecycle:          true,
+				Move:                 true,
+				PurgeRecycle:         true,
+				RemoveGrant:          true,
+				RestoreFileVersion:   true,
+				RestoreRecycleItem:   true,
+				Stat:                 true,
+				UpdateGrant:          true,
+				DenyGrant:            true,
+			},
+			Requested:  RoleFromName("denied", true).CS3ResourcePermissions(),
+			Sufficient: true,
+		},
+	}
+	for _, test := range table {
+		assert.Equal(t, test.Sufficient, SufficientCS3Permissions(test.Existing, test.Requested))
+	}
+}


### PR DESCRIPTION
# Description

1. Fix bug for ocis sharing "EnableExpiredSharesCleanup" config.
2. Add helper function to check sufficient CS3ResourcePermissions

## Usage

@rhafer @fschade 

I think we can use that helper function to calculate the available permissions.

Please let me know if you see a more elegant way without reflection 😄 