### PR TITLE
Fix SpaceID in meta response

### DIFF
--- a/changelog/unreleased/fix-spaceid-in-metaresponse.md
+++ b/changelog/unreleased/fix-spaceid-in-metaresponse.md
@@ -1,0 +1,5 @@
+Bugfix: Fix spaceID in meta endpoint response
+
+When doing a `PROPFIND` on the meta endpoint the spaceID would not be rendered correctly. That is fixed now
+
+https://github.com/cs3org/reva/pull/4341

--- a/internal/http/services/owncloud/ocdav/meta.go
+++ b/internal/http/services/owncloud/ocdav/meta.go
@@ -158,7 +158,7 @@ func (h *MetaHandler) handlePathForUser(w http.ResponseWriter, r *http.Request, 
 			prop.Escaped("oc:meta-path-for-user", pathRes.Path),
 			prop.Escaped("oc:id", id),
 			prop.Escaped("oc:fileid", id),
-			prop.Escaped("oc:spaceid", rid.GetStorageId()),
+			prop.Escaped("oc:spaceid", storagespace.FormatStorageID(rid.GetStorageId(), rid.GetSpaceId())),
 		},
 	}
 	baseURI := ctx.Value(net.CtxKeyBaseURI).(string)


### PR DESCRIPTION
`PROPFINDS` on the meta endpoint would return the `storageID` instead of the `spaceID` in the `spaceid` prop. This PR returns the correctly rendered spaceid

See https://github.com/owncloud/ocis/issues/7729 for details