### PR TITLE
Another fix for converting custom ocs permissions to roles

### DIFF
--- a/changelog/unreleased/fix-roleconversion-custompermissions.md
+++ b/changelog/unreleased/fix-roleconversion-custompermissions.md
@@ -1,7 +1,8 @@
 Bugfix: Fix conversion of custom ocs permissions to roles
 
-When creating shares with just `view` permission we wrongly converted that
-into the `SpacerViewer` sharing role. The correct role for that would be `legacy`.
+When creating shares with custom permissions they were under certain conditions
+converted into the wrong corrensponding sharing role
 
+https://github.com/cs3org/reva/pull/4343
 https://github.com/cs3org/reva/pull/4342
 https://github.com/owncloud/enterprise/issues/6209

--- a/pkg/conversions/role.go
+++ b/pkg/conversions/role.go
@@ -389,7 +389,9 @@ func RoleFromOCSPermissions(p Permissions, ri *provider.ResourceInfo) *Role {
 				return NewEditorRole(true)
 			}
 
-			return NewSpaceEditorRole()
+			if isSpaceRoot(ri) {
+				return NewSpaceEditorRole()
+			}
 		}
 
 		if p == PermissionRead && isSpaceRoot(ri) {


### PR DESCRIPTION
When creating (public) shares with the permissions read,update,create,delete we wrongly converted that into the `SpacerEditor` sharing role. The correct role for that would be `legacy`.

Fixes: https://github.com/owncloud/enterprise/issues/6209