### PR TITLE
Add url extension to mime-type list

### DIFF
--- a/changelog/unreleased/add-url-extension-to-mime-type-list.md
+++ b/changelog/unreleased/add-url-extension-to-mime-type-list.md
@@ -1,0 +1,5 @@
+Enhancement: Add url extension to mime type list
+
+We have added the url extension to the mime type list
+
+https://github.com/cs3org/reva/pull/4344

--- a/pkg/mime/mime.go
+++ b/pkg/mime/mime.go
@@ -957,6 +957,7 @@ var mimeTypes = map[string]string{
 	"uoml":                     "application/vnd.uoml+xml",
 	"uri":                      "text/uri-list",
 	"uris":                     "text/uri-list",
+	"url":                      "text/uri-list",
 	"urls":                     "text/uri-list",
 	"ustar":                    "application/x-ustar",
 	"utz":                      "application/vnd.uiq.theme",


### PR DESCRIPTION
Adds url extension to the mime-type list.
This is necessary for owncloud/web to detect the correct mime type and handle url files correctly, e.G opens in a new browser.

We store url files in the following format: 
https://fileinfo.com/extension/url

Thus there is no real specification about it nor a well-fitting RFC specified mime type it's **up for discussion** which mime type fits the best, possible alternatives could be:
* text/url
* application/internet-shortcut 
 