### PR TITLE
fix(api): correct ocs to role conversion

### DIFF
--- a/changelog/unreleased/fix-roleconversion-custompermissions.md
+++ b/changelog/unreleased/fix-roleconversion-custompermissions.md
@@ -3,6 +3,7 @@ Bugfix: Fix conversion of custom ocs permissions to roles
 When creating shares with custom permissions they were under certain conditions
 converted into the wrong corrensponding sharing role
 
+https://github.com/cs3org/reva/pull/4345
 https://github.com/cs3org/reva/pull/4343
 https://github.com/cs3org/reva/pull/4342
 https://github.com/owncloud/enterprise/issues/6209

--- a/pkg/conversions/role.go
+++ b/pkg/conversions/role.go
@@ -283,7 +283,6 @@ func NewFileEditorRole(sharing bool) *Role {
 			GetPath:              true,
 			GetQuota:             true,
 			InitiateFileDownload: true,
-			ListGrants:           true,
 			ListContainer:        true,
 			ListRecycle:          true,
 			Stat:                 true,


### PR DESCRIPTION
The file editor role was incorrectly allowing to list grants.