### PR TITLE
fix 500 when open public link from deleted user

### DIFF
--- a/changelog/unreleased/fix-status-code.md
+++ b/changelog/unreleased/fix-status-code.md
@@ -1,0 +1,6 @@
+Bugfix: Fix 500 when open public link
+
+We fixed a bug that caused nil pointer and Error 500 when open a public link from a deleted user
+
+https://github.com/cs3org/reva/pull/4351
+https://github.com/owncloud/ocis/issues/7740


### PR DESCRIPTION
We fixed a bug that caused nil pointer and Error 500 when open a public link from a deleted user

[https://github.com/owncloud/ocis/issues/7740](https://github.com/owncloud/ocis/issues/7740)