### PR TITLE
add form mime type

### DIFF
--- a/changelog/unreleased/add-missing-form-mime.md
+++ b/changelog/unreleased/add-missing-form-mime.md
@@ -1,0 +1,6 @@
+Enhancement: Add support for .docxf files
+
+We have added the missing .docxf mime-type to the list of supported mime-types.
+
+https://github.com/cs3org/reva/pull/4353
+https://github.com/owncloud/ocis/issues/6989

--- a/pkg/mime/mime.go
+++ b/pkg/mime/mime.go
@@ -215,6 +215,7 @@ var mimeTypes = map[string]string{
 	"doc":                      "application/msword",
 	"docm":                     "application/vnd.ms-word.document.macroenabled.12",
 	"docx":                     "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+	"docxf":                    "application/vnd.openxmlformats-officedocument.wordprocessingml.form",
 	"dot":                      "application/msword",
 	"dotm":                     "application/vnd.ms-word.template.macroenabled.12",
 	"dotx":                     "application/vnd.openxmlformats-officedocument.wordprocessingml.template",


### PR DESCRIPTION
Enhancement: Add support for .docxf files

We have added the missing .docxf mime-type to the list of supported mime-types.

https://github.com/owncloud/ocis/issues/6989