### PR TITLE
chore: add capability for link default permissions

### DIFF
--- a/changelog/unreleased/add-links-default-permissions-capability.md
+++ b/changelog/unreleased/add-links-default-permissions-capability.md
@@ -1,0 +1,6 @@
+Enhancement: Add default permissions capability for links
+
+A capability for default permissions for links has been added.
+
+https://github.com/cs3org/reva/pull/4358
+https://github.com/owncloud/web/issues/9919

--- a/internal/http/services/owncloud/ocs/data/capabilities.go
+++ b/internal/http/services/owncloud/ocs/data/capabilities.go
@@ -236,6 +236,7 @@ type CapabilitiesFilesSharingPublic struct {
 	ExpireDate         *CapabilitiesFilesSharingPublicExpireDate `json:"expire_date" xml:"expire_date" mapstructure:"expire_date"`
 	CanEdit            ocsBool                                   `json:"can_edit" xml:"can_edit" mapstructure:"can_edit"`
 	Alias              ocsBool                                   `json:"alias" xml:"alias"`
+	DefaultPermissions int                                       `json:"default_permissions" xml:"default_permissions" mapstructure:"default_permissions"`
 }
 
 // CapabilitiesFilesSharingPublicPassword TODO document


### PR DESCRIPTION
Adds a capability for link default permissions as defined in https://github.com/owncloud/web/issues/9919.