### PR TITLE
Fix concurrent lookup

### DIFF
--- a/changelog/unreleased/fix-concurrent-lookup.md
+++ b/changelog/unreleased/fix-concurrent-lookup.md
@@ -1,0 +1,5 @@
+Bugfix: Fix concurrent lookup
+
+We have fixed a bug that overwrites existing variables, leading to flaky lookup of spaces
+
+https://github.com/cs3org/reva/pull/4362

--- a/pkg/storage/utils/decomposedfs/spaces.go
+++ b/pkg/storage/utils/decomposedfs/spaces.go
@@ -424,15 +424,15 @@ func (fs *Decomposedfs) ListStorageSpaces(ctx context.Context, filter []*provide
 					continue
 				}
 				// always read link in case storage space id != node id
-				spaceID, nodeID, err = ReadSpaceAndNodeFromIndexLink(match)
+				linkSpaceID, linkNodeID, err := ReadSpaceAndNodeFromIndexLink(match)
 				if err != nil {
 					appctx.GetLogger(ctx).Error().Err(err).Str("match", match).Msg("could not read link, skipping")
 					continue
 				}
 
-				n, err := node.ReadNode(ctx, fs.lu, spaceID, nodeID, true, nil, true)
+				n, err := node.ReadNode(ctx, fs.lu, linkSpaceID, linkNodeID, true, nil, true)
 				if err != nil {
-					appctx.GetLogger(ctx).Error().Err(err).Str("id", nodeID).Msg("could not read node, skipping")
+					appctx.GetLogger(ctx).Error().Err(err).Str("id", linkNodeID).Msg("could not read node, skipping")
 					continue
 				}
 
@@ -448,7 +448,7 @@ func (fs *Decomposedfs) ListStorageSpaces(ctx context.Context, filter []*provide
 					case errtypes.NotFound:
 						// ok
 					default:
-						appctx.GetLogger(ctx).Error().Err(err).Str("id", nodeID).Msg("could not convert to storage space")
+						appctx.GetLogger(ctx).Error().Err(err).Str("id", linkNodeID).Msg("could not convert to storage space")
 					}
 					continue
 				}


### PR DESCRIPTION
For whatever reason this fixes some flakyness in the ocis tests ... found while digging into https://github.com/owncloud/ocis/pull/7499

testing this in ocis with
```
while make test-acceptance-from-core-api TEST_SERVER_URL=https://cloud.ocis.test TEST_OCIS=true TEST_WITH_GRAPH_API=true BEHAT_FEATURE=../features/coreApiAuthWebDav/webDavPROPFINDAuth.feature:91; do :; done
```


resubmit of https://github.com/cs3org/reva/pull/4361 with changelog