### PR TITLE
fix: public link creation err return if not ok

### DIFF
--- a/changelog/unreleased/fix-public-link-creation-err.md
+++ b/changelog/unreleased/fix-public-link-creation-err.md
@@ -1,0 +1,5 @@
+Bugfix: Fix create public share
+
+If public link creation failed, it now returns a status error instead of sending ok.
+
+https://github.com/cs3org/reva/pull/4365


### PR DESCRIPTION
If public link creation failed, it now returns an error instead of continuing the process execution.