### PR TITLE
add ggs type mime.go

### DIFF
--- a/changelog/unreleased/add-ggs-mime.md
+++ b/changelog/unreleased/add-ggs-mime.md
@@ -1,0 +1,8 @@
+Enhancement: Add GGS mime type
+
+We have added a new mime type for GGS files. 
+This is a new file type that is used by geogebra application.
+
+https://github.com/cs3org/reva/pull/4367
+https://github.com/owncloud/ocis/pull/7804
+https://github.com/owncloud/ocis/issues/7768

--- a/pkg/mime/mime.go
+++ b/pkg/mime/mime.go
@@ -322,6 +322,7 @@ var mimeTypes = map[string]string{
 	"geojson":                  "application/geo+json",
 	"gex":                      "application/vnd.geometry-explorer",
 	"ggb":                      "application/vnd.geogebra.file",
+	"ggs":                      "application/vnd.geogebra.slides",
 	"ggt":                      "application/vnd.geogebra.tool",
 	"ghf":                      "application/vnd.groove-help",
 	"gif":                      "image/gif",


### PR DESCRIPTION
Enhancement: Add GGS mime type

We have added a new mime type for GGS files. 
This is a new file type that is used by geogebra application.

refs https://github.com/owncloud/ocis/pull/7804
refs https://github.com/owncloud/ocis/issues/7768