### PR TITLE
Storage registry: fail at init if config is missing any providers

### DIFF
--- a/changelog/unreleased/storage-registry-initfail.md
+++ b/changelog/unreleased/storage-registry-initfail.md
@@ -1,0 +1,8 @@
+Enhancement: Storage registry: fail at init if config is missing any providers
+
+This change makes the dynamic storage registry fail at startup if there are
+missing rules in the config file. That is, any `mount_id` in the routing table
+must have a corresponding `storage_id`/`address` pair in the config, otherwise
+the registry will fail to start.
+
+https://github.com/cs3org/reva/pull/4370

--- a/pkg/ocm/share/repository/sql/sql_test.go
+++ b/pkg/ocm/share/repository/sql/sql_test.go
@@ -47,7 +47,7 @@ import (
 var (
 	dbName               = "reva_tests"
 	address              = "localhost"
-	port                 = 3306
+	port                 = 33059
 	m                    sync.Mutex // for increasing the port
 	ocmShareTable        = "ocm_shares"
 	ocmAccessMethodTable = "ocm_shares_access_methods"

--- a/pkg/storage/registry/dynamic/dynamic_test.go
+++ b/pkg/storage/registry/dynamic/dynamic_test.go
@@ -65,7 +65,7 @@ var _ = Describe("Dynamic storage provider", func() {
 		})
 
 		dbHost = "localhost"
-		dbPort = 3305
+		dbPort = 33059
 		dbName = "reva_tests"
 		routes = map[string]string{
 			"/home-a":                   "eoshome-i01",
@@ -222,9 +222,6 @@ var _ = Describe("Dynamic storage provider", func() {
 					"db_name":     dbName,
 				})
 
-				prv, _ := d.FindProviders(context.Background(), &provider.Reference{Path: "/eos/"})
-				fmt.Printf("\n\n\n%+v\n\n\n", prv)
-
 				Expect(d).ToNot(BeNil())
 				Expect(err).ToNot(HaveOccurred())
 			})
@@ -259,8 +256,6 @@ var _ = Describe("Dynamic storage provider", func() {
 					"db_port":     dbPort,
 					"db_name":     dbName,
 				})
-
-				fmt.Printf("\n\n\n%+v\n\n\n", err)
 
 				Expect(d).To(BeNil())
 				Expect(err).To(HaveOccurred())

--- a/pkg/storage/registry/dynamic/dynamic_test.go
+++ b/pkg/storage/registry/dynamic/dynamic_test.go
@@ -63,11 +63,6 @@ var _ = Describe("Dynamic storage provider", func() {
 				OpaqueId: "bob",
 			},
 		})
-		ctxCharlie = appctx.ContextSetUser(context.Background(), &userpb.User{
-			Id: &userpb.UserId{
-				OpaqueId: "charlie",
-			},
-		})
 
 		dbHost = "localhost"
 		dbPort = 3305
@@ -75,7 +70,6 @@ var _ = Describe("Dynamic storage provider", func() {
 		routes = map[string]string{
 			"/home-a":                   "eoshome-i01",
 			"/home-b":                   "eoshome-i02",
-			"/home-c":                   "eoshome-i03",
 			"/eos/user/a":               "eosuser-i01",
 			"/eos/user/b":               "eosuser-i02",
 			"/eos/project/a":            "eosproject-i00",
@@ -92,6 +86,13 @@ var _ = Describe("Dynamic storage provider", func() {
 			"eosproject-i02": "eosproject-i02:1234",
 			"cephfs":         "cephfs:1234",
 			"vaultssda01":    "vaultssda01:1234",
+		}
+		badRules = map[string]string{
+			"eoshome-i01":    "eoshome-i01:1234",
+			"eosuser-i01":    "eosuser-i01:1234",
+			"eosuser-i02":    "eosuser-i02:1234",
+			"eosproject-i02": "eosproject-i02:1234",
+			"cephfs":         "cephfs:1234",
 		}
 		rewrites = map[string]string{
 			"/home":   "/home-{{substr 0 1 .Id.OpaqueId}}",
@@ -229,6 +230,23 @@ var _ = Describe("Dynamic storage provider", func() {
 			})
 		})
 
+		When("passed a config missing some rules", func() {
+			It("should return an error", func() {
+				_, err = New(context.Background(), map[string]interface{}{
+					"rules":       badRules,
+					"rewrites":    rewrites,
+					"home_path":   homePath,
+					"db_username": "test",
+					"db_password": "test",
+					"db_host":     dbHost,
+					"db_port":     dbPort,
+					"db_name":     dbName,
+				})
+
+				Expect(err).To(HaveOccurred())
+			})
+		})
+
 		When("passed a bad db host in the config", func() {
 			It("should return a en error", func() {
 				d, err = New(context.Background(), map[string]interface{}{
@@ -304,14 +322,6 @@ var _ = Describe("Dynamic storage provider", func() {
 			})
 		})
 
-		When("passed context for user charlie who has home provider with a defined route but no rule in config", func() {
-			It("should return a provider not found error", func() {
-				h, err = d.GetHome(ctxCharlie)
-				Expect(err).To(HaveOccurred())
-				Expect(err).To(MatchError(errtypes.InternalError("storage provider address not configured for mountID eoshome-i03")))
-			})
-		})
-
 		When("passed context without user", func() {
 			It("should return an error", func() {
 				h, err = d.GetHome(context.Background())
@@ -359,8 +369,7 @@ var _ = Describe("Dynamic storage provider", func() {
 				}
 
 				_, err := d.FindProviders(ctxAlice, ref)
-				Expect(err).To(HaveOccurred())
-				Expect(err).To(MatchError(errtypes.NotFound("storage provider not found for ref resource_id:<storage_id:\"nope\" > ")))
+				Expect(err).To(MatchError(errtypes.InternalError("storage provider address not found for nope")))
 			})
 		})
 
@@ -393,17 +402,16 @@ var _ = Describe("Dynamic storage provider", func() {
 			})
 		}
 
-		When("passed a home path for user charlie who has home provider with a defined route but no rule in config", func() {
-			It("should return a provider not found error", func() {
-				_, err := d.FindProviders(ctxCharlie, testHomeRefs["/home"])
+		When("passed a path which storage id has no entry in the configuration", func() {
+			It("should return an internal error", func() {
+				_, err := d.FindProviders(context.Background(), &provider.Reference{Path: "/cephfs/project/n/notconf"})
 				Expect(err).To(HaveOccurred())
-				Expect(err).To(MatchError(errtypes.InternalError("storage provider address not configured for mountID eoshome-i03")))
 			})
 		})
 
 		When("passed a non-existing path", func() {
 			It("should return a provider not found error", func() {
-				_, err := d.FindProviders(ctxCharlie, &provider.Reference{
+				_, err := d.FindProviders(ctxAlice, &provider.Reference{
 					Path: "/non/existent",
 				})
 				Expect(err).To(HaveOccurred())


### PR DESCRIPTION
This PR changes the behavior of the dynamic storage registry so it fails on initialization if the configuration is not complete (there are storage provider entries in the database with no entry in the config file)
