### PR TITLE
fix public link update

### DIFF
--- a/changelog/unreleased/fix-publick-link-update.md
+++ b/changelog/unreleased/fix-publick-link-update.md
@@ -1,0 +1,6 @@
+Bugfix: Fix the public link update
+
+We fixed a bug when normal users can update the public link to delete its password if permission is not sent in data.
+
+https://github.com/cs3org/reva/pull/4380        
+https://github.com/owncloud/ocis/issues/7821

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/public.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/public.go
@@ -419,9 +419,15 @@ func (h *Handler) updatePublicShare(w http.ResponseWriter, r *http.Request, shar
 	}
 
 	// empty permissions mean internal link here - NOT denial. Hence we need an extra check
-	if !sufficientPermissions(statRes.GetInfo().GetPermissionSet(), newPermissions, true) {
-		response.WriteOCSError(w, r, http.StatusForbidden, "no share permission", nil)
-		return
+	if newPermissions != nil {
+		if !sufficientPermissions(statRes.GetInfo().GetPermissionSet(), newPermissions, true) {
+			response.WriteOCSError(w, r, http.StatusForbidden, "no share permission", nil)
+			return
+		}
+	} else {
+		statRes.GetInfo().GetPermissionSet()
+		p := decreasePermissionsIfNecessary(int(conversions.RoleFromResourcePermissions(statRes.GetInfo().GetPermissionSet(), false).OCSPermissions()))
+		permKey = &p
 	}
 
 	// ExpireDate


### PR DESCRIPTION
e fixed a bug when normal users can update the public link to delete its password if permission is not sent in data.

[https://github.com/owncloud/ocis/pull/7862](https://github.com/owncloud/ocis/pull/7862)