### PR TITLE
Fix UpdateUserShare when just the expiration date is updated

### DIFF
--- a/changelog/unreleased/fix-update-userhare.md
+++ b/changelog/unreleased/fix-update-userhare.md
@@ -1,0 +1,6 @@
+Bugfix: Allow UpdateUserShare() to update just the expiration date
+
+The UpdateUserShare Request now works if it just contains an update of the
+expiration date.
+
+https://github.com/cs3org/reva/pull/4388

--- a/internal/grpc/services/gateway/usershareprovider.go
+++ b/internal/grpc/services/gateway/usershareprovider.go
@@ -123,9 +123,9 @@ func (s *svc) updateShare(ctx context.Context, req *collaboration.UpdateShareReq
 	if s.c.CommitShareToStorageGrant {
 		creator := ctxpkg.ContextMustGetUser(ctx)
 		grant := &provider.Grant{
-			Grantee:     req.GetShare().GetGrantee(),
-			Permissions: req.GetShare().GetPermissions().GetPermissions(),
-			Expiration:  req.GetShare().GetExpiration(),
+			Grantee:     res.GetShare().GetGrantee(),
+			Permissions: res.GetShare().GetPermissions().GetPermissions(),
+			Expiration:  res.GetShare().GetExpiration(),
 			Creator:     creator.GetId(),
 		}
 		updateGrantStatus, err := s.updateGrant(ctx, res.GetShare().GetResourceId(), grant, nil)


### PR DESCRIPTION
When updating the Grant we need to use the Share as returned in the UpdateUserShareResponse. The Share from the incoming request might just contain a subset of the attributes.