### PR TITLE
feat(propfind): add audio and location props

### DIFF
--- a/changelog/unreleased/add-audio-and-location-props.md
+++ b/changelog/unreleased/add-audio-and-location-props.md
@@ -1,0 +1,5 @@
+Enhancement: Add audio and location props
+
+Add `oc:audio` and `oc:location` props to PROPFIND responses for propall requests or when they are explicitly requested.
+
+https://github.com/cs3org/reva/pull/4389

--- a/internal/http/services/owncloud/ocdav/propfind/propfind.go
+++ b/internal/http/services/owncloud/ocdav/propfind/propfind.go
@@ -64,6 +64,7 @@ const (
 	tracerName = "ocdav"
 )
 
+// these keys are used to lookup in ArbitraryMetadata, generated prop names are lowercased
 var (
 	audioKeys = []string{
 		"album",
@@ -1123,17 +1124,18 @@ func mdToPropResponse(ctx context.Context, pf *XML, md *provider.ResourceInfo, p
 	appendMetadataProp := func(metadata map[string]string, tagNamespace string, name string, metadataPrefix string, keys []string) {
 		content := strings.Builder{}
 		for _, key := range keys {
+			lowerCaseKey := strings.ToLower(key)
 			if v, ok := metadata[fmt.Sprintf("%s.%s", metadataPrefix, key)]; ok {
 				content.WriteString("<")
 				content.WriteString(tagNamespace)
 				content.WriteString(":")
-				content.WriteString(key)
+				content.WriteString(lowerCaseKey)
 				content.WriteString(">")
 				content.Write(prop.Escaped("", v).InnerXML)
 				content.WriteString("</")
 				content.WriteString(tagNamespace)
 				content.WriteString(":")
-				content.WriteString(key)
+				content.WriteString(lowerCaseKey)
 				content.WriteString(">")
 			}
 		}

--- a/internal/http/services/owncloud/ocdav/propfind/propfind.go
+++ b/internal/http/services/owncloud/ocdav/propfind/propfind.go
@@ -64,6 +64,32 @@ const (
 	tracerName = "ocdav"
 )
 
+var (
+	audioKeys = []string{
+		"album",
+		"albumArtist",
+		"artist",
+		"bitrate",
+		"composers",
+		"copyright",
+		"disc",
+		"discCount",
+		"duration",
+		"genre",
+		"hasDrm",
+		"isVariableBitrate",
+		"title",
+		"track",
+		"trackCount",
+		"year",
+	}
+	locationKeys = []string{
+		"altitude",
+		"latitude",
+		"longitude",
+	}
+)
+
 type countingReader struct {
 	n int
 	r io.Reader
@@ -786,6 +812,14 @@ func (p *Handler) getSpaceResourceInfos(ctx context.Context, w http.ResponseWrit
 	return resourceInfos, true
 }
 
+func metadataKeysWithPrefix(prefix string, keys []string) []string {
+	fullKeys := []string{}
+	for _, key := range keys {
+		fullKeys = append(fullKeys, fmt.Sprintf("%s.%s", prefix, key))
+	}
+	return fullKeys
+}
+
 // metadataKeys splits the propfind properties into arbitrary metadata and ResourceInfo field mask paths
 func metadataKeys(pf XML) ([]string, []string) {
 
@@ -809,6 +843,10 @@ func metadataKeys(pf XML) ([]string, []string) {
 				switch key {
 				case "share-types":
 					fieldMaskKeys = append(fieldMaskKeys, key)
+				case "http://owncloud.org/ns/audio":
+					metadataKeys = append(metadataKeys, metadataKeysWithPrefix("libre.graph.audio", audioKeys)...)
+				case "http://owncloud.org/ns/location":
+					metadataKeys = append(metadataKeys, metadataKeysWithPrefix("libre.graph.location", locationKeys)...)
 				default:
 					metadataKeys = append(metadataKeys, key)
 				}
@@ -866,7 +904,7 @@ func requiresExplicitFetching(n *xml.Name) bool {
 		}
 	case net.NsOwncloud:
 		switch n.Local {
-		case "favorite", "share-types", "checksums", "size", "tags":
+		case "favorite", "share-types", "checksums", "size", "tags", "audio", "location":
 			return true
 		default:
 			return false
@@ -1082,6 +1120,32 @@ func mdToPropResponse(ctx context.Context, pf *XML, md *provider.ResourceInfo, p
 		appendToNotFound = func(p ...prop.PropertyXML) {}
 	}
 
+	appendMetadataProp := func(metadata map[string]string, tagNamespace string, name string, metadataPrefix string, keys []string) {
+		content := strings.Builder{}
+		for _, key := range keys {
+			if v, ok := metadata[fmt.Sprintf("%s.%s", metadataPrefix, key)]; ok {
+				content.WriteString("<")
+				content.WriteString(tagNamespace)
+				content.WriteString(":")
+				content.WriteString(key)
+				content.WriteString(">")
+				content.Write(prop.Escaped("", v).InnerXML)
+				content.WriteString("</")
+				content.WriteString(tagNamespace)
+				content.WriteString(":")
+				content.WriteString(key)
+				content.WriteString(">")
+			}
+		}
+
+		propName := fmt.Sprintf("%s:%s", tagNamespace, name)
+		if content.Len() > 0 {
+			appendToOK(prop.Raw(propName, content.String()))
+		} else {
+			appendToNotFound(prop.NotFound(propName))
+		}
+	}
+
 	// when allprops has been requested
 	if pf.Allprop != nil {
 		// return all known properties
@@ -1180,6 +1244,8 @@ func mdToPropResponse(ctx context.Context, pf *XML, md *provider.ResourceInfo, p
 
 		if k := md.GetArbitraryMetadata().GetMetadata(); k != nil {
 			propstatOK.Prop = append(propstatOK.Prop, prop.Raw("oc:tags", k["tags"]))
+			appendMetadataProp(k, "oc", "audio", "libre.graph.audio", audioKeys)
+			appendMetadataProp(k, "oc", "location", "libre.graph.location", locationKeys)
 		}
 
 		// ls do not report any properties as missing by default
@@ -1452,6 +1518,14 @@ func mdToPropResponse(ctx context.Context, pf *XML, md *provider.ResourceInfo, p
 				case "tags":
 					if k := md.GetArbitraryMetadata().GetMetadata(); k != nil {
 						propstatOK.Prop = append(propstatOK.Prop, prop.Raw("oc:tags", k["tags"]))
+					}
+				case "audio":
+					if k := md.GetArbitraryMetadata().GetMetadata(); k != nil {
+						appendMetadataProp(k, "oc", "audio", "libre.graph.audio", audioKeys)
+					}
+				case "location":
+					if k := md.GetArbitraryMetadata().GetMetadata(); k != nil {
+						appendMetadataProp(k, "oc", "location", "libre.graph.location", locationKeys)
 					}
 				case "name":
 					appendToOK(prop.Escaped("oc:name", md.Name))


### PR DESCRIPTION
Return `oc:audio` and `oc:location` props for allprops requests or when explicitly requested.
These are analogue to `audio` and `location` facets defined in LibreGraph API.

Camelcase seems off, should we lowercase or dasherize the prop names? For eg albumArtist

Audio data is already indexed in oCIS master, location data depends on https://github.com/owncloud/ocis/pull/7886
 
```xml
<d:multistatus xmlns:s="http://sabredav.org/ns" xmlns:d="DAV:" xmlns:oc="http://owncloud.org/ns">
  <d:response>
    <d:href>/remote.php/dav/spaces/storage-users-1$some-admin-user-id-0000-000000000000/Foo/</d:href>
    <d:propstat>
      <d:prop>
        <oc:id>storage-users-1$some-admin-user-id-0000-000000000000!746e171b-7143-4461-b1c0-f119cb57a3d1</oc:id>
        <oc:fileid>storage-users-1$some-admin-user-id-0000-000000000000!746e171b-7143-4461-b1c0-f119cb57a3d1</oc:fileid>
        <oc:spaceid>some-admin-user-id-0000-000000000000</oc:spaceid>
        <oc:file-parent>storage-users-1$some-admin-user-id-0000-000000000000!some-admin-user-id-0000-000000000000</oc:file-parent>
        <oc:name>Foo</oc:name>
        <d:getetag>&quot;2c7f03b3e0a1efc87ad6da4717ffb9ba&quot;</d:getetag>
        <oc:permissions>RDNVCKZP</oc:permissions>
        <d:resourcetype>
          <d:collection/>
        </d:resourcetype>
        <oc:size>7196356</oc:size>
        <d:getlastmodified>Tue, 05 Dec 2023 16:54:00 GMT</d:getlastmodified>
        <oc:tags/>
        <oc:favorite>0</oc:favorite>
      </d:prop>
      <d:status>HTTP/1.1 200 OK</d:status>
    </d:propstat>
    <d:propstat>
      <d:prop>
        <oc:audio/>
        <oc:location/>
      </d:prop>
      <d:status>HTTP/1.1 404 Not Found</d:status>
    </d:propstat>
  </d:response>
  <d:response>
    <d:href>/remote.php/dav/spaces/storage-users-1$some-admin-user-id-0000-000000000000/Foo/A_IMG_20231006_185428.jpg</d:href>
    <d:propstat>
      <d:prop>
        <oc:id>storage-users-1$some-admin-user-id-0000-000000000000!e3afec67-5e82-4c7b-884f-2f798029cee4</oc:id>
        <oc:fileid>storage-users-1$some-admin-user-id-0000-000000000000!e3afec67-5e82-4c7b-884f-2f798029cee4</oc:fileid>
        <oc:spaceid>some-admin-user-id-0000-000000000000</oc:spaceid>
        <oc:file-parent>storage-users-1$some-admin-user-id-0000-000000000000!746e171b-7143-4461-b1c0-f119cb57a3d1</oc:file-parent>
        <oc:name>A_IMG_20231006_185428.jpg</oc:name>
        <d:getetag>&quot;26c5b396fa752e90f271102690f61fd5&quot;</d:getetag>
        <oc:permissions>RDNVWZP</oc:permissions>
        <d:resourcetype/>
        <d:getcontentlength>1347813</d:getcontentlength>
        <d:getcontenttype>image/jpeg</d:getcontenttype>
        <d:getlastmodified>Tue, 05 Dec 2023 15:59:36 GMT</d:getlastmodified>
        <oc:checksums>
          <oc:checksum>SHA1:da95c8511b6e4bbc9f580457d8b36ca9599b1862 MD5:d365cb975fa598b49289a348d32247d5 ADLER32:c586519c</oc:checksum>
        </oc:checksums>
        <oc:tags/>
        <oc:location>
          <oc:latitude>49.801781</oc:latitude>
          <oc:longitude>9.932846</oc:longitude>
        </oc:location>
        <oc:favorite>0</oc:favorite>
      </d:prop>
      <d:status>HTTP/1.1 200 OK</d:status>
    </d:propstat>
    <d:propstat>
      <d:prop>
        <oc:audio/>
      </d:prop>
      <d:status>HTTP/1.1 404 Not Found</d:status>
    </d:propstat>
  </d:response>
  <d:response>
    <d:href>/remote.php/dav/spaces/storage-users-1$some-admin-user-id-0000-000000000000/Foo/01%20-%20Sucker.mp3</d:href>
    <d:propstat>
      <d:prop>
        <oc:id>storage-users-1$some-admin-user-id-0000-000000000000!6f3f2980-6dd7-4b4a-b01c-722bf3d53ec0</oc:id>
        <oc:fileid>storage-users-1$some-admin-user-id-0000-000000000000!6f3f2980-6dd7-4b4a-b01c-722bf3d53ec0</oc:fileid>
        <oc:spaceid>some-admin-user-id-0000-000000000000</oc:spaceid>
        <oc:file-parent>storage-users-1$some-admin-user-id-0000-000000000000!746e171b-7143-4461-b1c0-f119cb57a3d1</oc:file-parent>
        <oc:name>01 - Sucker.mp3</oc:name>
        <d:getetag>&quot;5897769a2eaec9573c6f0919464e1796&quot;</d:getetag>
        <oc:permissions>RDNVWZP</oc:permissions>
        <d:resourcetype/>
        <d:getcontentlength>5848543</d:getcontentlength>
        <d:getcontenttype>audio/mpeg</d:getcontenttype>
        <d:getlastmodified>Fri, 13 Oct 2023 16:00:21 GMT</d:getlastmodified>
        <oc:checksums>
          <oc:checksum>SHA1:28b306e048d26df4c53e66263959a5c0dc267204 MD5:4aaad82c633c17db5f94fd38c1c89082 ADLER32:072717cd</oc:checksum>
        </oc:checksums>
        <oc:tags/>
        <oc:audio>
          <oc:album>Kiss Of Death</oc:album>
          <oc:albumArtist>Foobar</oc:albumArtist>
          <oc:artist>Motörhead</oc:artist>
          <oc:disc>4</oc:disc>
          <oc:genre/>
          <oc:title>Sucker</oc:title>
          <oc:year>2006</oc:year>
        </oc:audio>
        <oc:favorite>0</oc:favorite>
      </d:prop>
      <d:status>HTTP/1.1 200 OK</d:status>
    </d:propstat>
    <d:propstat>
      <d:prop>
        <oc:location/>
      </d:prop>
      <d:status>HTTP/1.1 404 Not Found</d:status>
    </d:propstat>
  </d:response>
</d:multistatus>
```

