### PR TITLE
Write blob parts directly to blobstore

### DIFF
--- a/pkg/storage/utils/decomposedfs/metadata/prefixes/prefixes.go
+++ b/pkg/storage/utils/decomposedfs/metadata/prefixes/prefixes.go
@@ -36,8 +36,9 @@ const (
 	// updated when the file is renamed or moved
 	NameAttr string = OcisPrefix + "name"
 
-	BlobIDAttr   string = OcisPrefix + "blobid"
-	BlobsizeAttr string = OcisPrefix + "blobsize"
+	BlobIDAttr      string = OcisPrefix + "blobid"
+	BlobsizeAttr    string = OcisPrefix + "blobsize"
+	BlobOffsetsAttr string = OcisPrefix + "bloboffsets"
 
 	// statusPrefix is the prefix for the node status
 	StatusPrefix string = OcisPrefix + "nodestatus"

--- a/pkg/storage/utils/decomposedfs/revisions.go
+++ b/pkg/storage/utils/decomposedfs/revisions.go
@@ -247,6 +247,7 @@ func (fs *Decomposedfs) RestoreRevision(ctx context.Context, ref *provider.Refer
 			attributeName == prefixes.TypeAttr ||
 			attributeName == prefixes.BlobIDAttr ||
 			attributeName == prefixes.BlobsizeAttr ||
+			attributeName == prefixes.BlobOffsetsAttr ||
 			attributeName == prefixes.MTimeAttr // FIXME somewhere I mix up the revision time and the mtime, causing the restore to overwrite the other existing revisien
 	}, f, true)
 	if err != nil {
@@ -270,7 +271,8 @@ func (fs *Decomposedfs) RestoreRevision(ctx context.Context, ref *provider.Refer
 		return value, strings.HasPrefix(attributeName, prefixes.ChecksumPrefix) ||
 			attributeName == prefixes.TypeAttr ||
 			attributeName == prefixes.BlobIDAttr ||
-			attributeName == prefixes.BlobsizeAttr
+			attributeName == prefixes.BlobsizeAttr ||
+			attributeName == prefixes.BlobOffsetsAttr
 	}, false)
 	if err != nil {
 		return errtypes.InternalError("failed to copy blob xattrs to old revision to node: " + err.Error())

--- a/pkg/storage/utils/decomposedfs/tree/tree.go
+++ b/pkg/storage/utils/decomposedfs/tree/tree.go
@@ -62,6 +62,9 @@ type Blobstore interface {
 	Upload(node *node.Node, source string) error
 	Download(node *node.Node) (io.ReadCloser, error)
 	Delete(node *node.Node) error
+
+	StreamingUpload(ctx context.Context, spaceid, blobid string, offset, objectSize int64, reader io.Reader, userMetadata map[string]string) error
+	StreamingDownload(ctx context.Context, spaceid, blobid string, offset, objectSize int64) (io.ReadCloser, error)
 }
 
 // Tree manages a hierarchical tree
@@ -710,6 +713,14 @@ func (t *Tree) Propagate(ctx context.Context, n *node.Node, sizeDiff int64) (err
 // WriteBlob writes a blob to the blobstore
 func (t *Tree) WriteBlob(node *node.Node, source string) error {
 	return t.blobstore.Upload(node, source)
+}
+
+// StreamBlob streams a blob to the blobstore
+func (t *Tree) StreamBlob(ctx context.Context, spaceid, blobid string, offset, objectSize int64, reader io.Reader, userMetadata map[string]string) error {
+	return t.blobstore.StreamingUpload(ctx, spaceid, blobid, offset, objectSize, reader, userMetadata)
+}
+func (t *Tree) BlobReader(ctx context.Context, spaceid, blobid string, offset, objectSize int64) (io.ReadCloser, error) {
+	return t.blobstore.StreamingDownload(ctx, spaceid, blobid, offset, objectSize)
 }
 
 // ReadBlob reads a blob from the blobstore

--- a/pkg/storage/utils/decomposedfs/upload/part_producer.go
+++ b/pkg/storage/utils/decomposedfs/upload/part_producer.go
@@ -1,0 +1,54 @@
+package upload
+
+import (
+	"bytes"
+	"io"
+)
+
+// partProducer converts a stream of bytes from the reader into a stream memory of buffers
+type partProducer struct {
+	parts chan<- *bytes.Buffer
+	done  chan struct{}
+	err   error
+	r     io.Reader
+}
+
+func (spp *partProducer) produce(partSize int64) {
+	for {
+		file, err := spp.nextPart(partSize)
+		if err != nil {
+			spp.err = err
+			close(spp.parts)
+			return
+		}
+		if file == nil {
+			close(spp.parts)
+			return
+		}
+		select {
+		case spp.parts <- file:
+		case <-spp.done:
+			close(spp.parts)
+			return
+		}
+	}
+}
+
+func (spp *partProducer) nextPart(size int64) (*bytes.Buffer, error) {
+	buf := new(bytes.Buffer)
+
+	limitedReader := io.LimitReader(spp.r, size)
+	n, err := buf.ReadFrom(limitedReader)
+	if err != nil {
+		return nil, err
+	}
+
+	// If the entire request body is read and no more data is available,
+	// buf.ReadFrom returns 0 since it is unable to read any bytes. In that
+	// case, we can close the partProducer.
+	if n == 0 {
+		return nil, nil
+	}
+
+	return buf, nil
+}


### PR DESCRIPTION
different approach to write directly to blobstore

uses memory buffer to split incoming upload and directly write it to the blobstore.

as it turns out the web ui sends 10mb PATCH requests anyway .... 