### PR TITLE
[backport stable-2.16] auth interceptor: Default to empty credentials chain

### DIFF
--- a/changelog/unreleased/fix-auth-allow-empty-cred-chain.md
+++ b/changelog/unreleased/fix-auth-allow-empty-cred-chain.md
@@ -1,0 +1,9 @@
+Bugfix: Allow an empty credentials chain in the auth middleware
+
+When running with ocis, all external http-authentication is handled by the proxy
+service. So the reva auth middleware should not try to do any basic or
+bearer auth.
+
+https://github.com/cs3org/reva/pull/4396
+https://github.com/cs3org/reva/pull/4241
+https://github.com/owncloud/ocis/issues/6692

--- a/internal/http/interceptors/auth/auth.go
+++ b/internal/http/interceptors/auth/auth.go
@@ -109,10 +109,6 @@ func New(m map[string]interface{}, unprotected []string, tp trace.TracerProvider
 		conf.TokenManager = "jwt"
 	}
 
-	if len(conf.CredentialChain) == 0 {
-		conf.CredentialChain = []string{"basic", "bearer"}
-	}
-
 	if conf.CredentialsByUserAgent == nil {
 		conf.CredentialsByUserAgent = map[string]string{}
 	}

--- a/tests/oc-integration-tests/drone/frontend-global.toml
+++ b/tests/oc-integration-tests/drone/frontend-global.toml
@@ -15,6 +15,9 @@ address = "0.0.0.0:20180"
 [http.middlewares.cors]
 allow_credentials = true
 
+[http.middlewares.auth]
+credential_chain = ["basic"]
+
 [http.services.ocdav]
 # serve ocdav on the root path
 prefix = ""

--- a/tests/oc-integration-tests/drone/frontend.toml
+++ b/tests/oc-integration-tests/drone/frontend.toml
@@ -16,6 +16,9 @@ address = "0.0.0.0:20080"
 [http.middlewares.cors]
 allow_credentials = true
 
+[http.middlewares.auth]
+credential_chain = ["basic"]
+
 [http.services.ocdav]
 # serve ocdav on the root path
 prefix = ""

--- a/tests/oc-integration-tests/local/frontend.toml
+++ b/tests/oc-integration-tests/local/frontend.toml
@@ -23,6 +23,9 @@ address = "0.0.0.0:20080"
 [http.middlewares.cors]
 allow_credentials = true
 
+[http.middlewares.auth]
+credential_chain = ["basic"]
+
 [http.services.ocdav]
 # serve ocdav on the root path
 prefix = ""


### PR DESCRIPTION
When running with ocis, all external http-authentication is handled by the proxy service. So the reva auth middleware should not try to do any basic or bearer auth.

Related ocis ticket: https://github.com/owncloud/ocis/issues/6692

(cherry picked from commit 5da9c009db66509db68342268ffe179e92598457)