### PR TITLE
Backport UploadSessionLister interface to 2.16

### DIFF
--- a/changelog/unreleased/extract-uploadsessionlister-interface.md
+++ b/changelog/unreleased/extract-uploadsessionlister-interface.md
@@ -2,4 +2,5 @@ Enhancement: Introduce UploadSessionLister interface
 
 We introduced a new UploadSessionLister interface that allows better control of upload sessions. Upload sessions include the processing state and can be used to filter and purge the list of currently ongoing upload sessions.
 
+https://github.com/cs3org/reva/pull/4397
 https://github.com/cs3org/reva/pull/4375

--- a/changelog/unreleased/extract-uploadsessionlister-interface.md
+++ b/changelog/unreleased/extract-uploadsessionlister-interface.md
@@ -1,0 +1,5 @@
+Enhancement: Introduce UploadSessionLister interface
+
+We introduced a new UploadSessionLister interface that allows better control of upload sessions. Upload sessions include the processing state and can be used to filter and purge the list of currently ongoing upload sessions.
+
+https://github.com/cs3org/reva/pull/4375

--- a/pkg/rhttp/datatx/manager/tus/tus.go
+++ b/pkg/rhttp/datatx/manager/tus/tus.go
@@ -101,12 +101,12 @@ func (m *manager) Handler(fs storage.FS) (http.Handler, error) {
 		return nil, err
 	}
 
-	if _, ok := fs.(storage.UploadsManager); ok {
-		// TODO we can currently only send updates if the fs is decomposedfs as we read very specific keys from the storage map of the tus info
+	if _, ok := fs.(storage.UploadSessionLister); ok {
+		// We can currently only send updates if the fs is decomposedfs as we read very specific keys from the storage map of the tus info
 		go func() {
 			for {
 				ev := <-handler.CompleteUploads
-				// TODO we should be able to get the upload progress with fs.GetUploadProgress, but currently tus will erase the info files
+				// We should be able to get the upload progress with fs.GetUploadProgress, but currently tus will erase the info files
 				// so we create a Progress instance here that is used to read the correct properties
 				up := upload.Progress{
 					Info: ev.Upload,
@@ -194,7 +194,6 @@ func setHeaders(fs storage.FS, w http.ResponseWriter, r *http.Request) {
 	}
 	expires := info.MetaData["expires"]
 	if expires != "" {
-		// FIXME currently info.MetaData["expires"] is an int ... but it MUST be RFC 7231 datetime format, see https://tus.io/protocols/resumable-upload#upload-expires
 		w.Header().Set(net.HeaderTusUploadExpires, expires)
 	}
 	resourceid := provider.ResourceId{

--- a/pkg/rhttp/datatx/manager/tus/tus.go
+++ b/pkg/rhttp/datatx/manager/tus/tus.go
@@ -23,13 +23,11 @@ import (
 	"log"
 	"net/http"
 	"path"
-	"path/filepath"
 	"time"
 
 	"github.com/pkg/errors"
 	tusd "github.com/tus/tusd/pkg/handler"
 
-	userv1beta1 "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	"github.com/cs3org/reva/v2/internal/http/services/owncloud/ocdav/net"
 	"github.com/cs3org/reva/v2/pkg/appctx"
@@ -40,8 +38,8 @@ import (
 	"github.com/cs3org/reva/v2/pkg/rhttp/datatx/metrics"
 	"github.com/cs3org/reva/v2/pkg/storage"
 	"github.com/cs3org/reva/v2/pkg/storage/cache"
+	"github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/upload"
 	"github.com/cs3org/reva/v2/pkg/storagespace"
-	"github.com/cs3org/reva/v2/pkg/utils"
 	"github.com/mitchellh/mapstructure"
 )
 
@@ -103,33 +101,27 @@ func (m *manager) Handler(fs storage.FS) (http.Handler, error) {
 		return nil, err
 	}
 
-	go func() {
-		for {
-			ev := <-handler.CompleteUploads
-			info := ev.Upload
-			spaceOwner := &userv1beta1.UserId{
-				OpaqueId: info.Storage["SpaceOwnerOrManager"],
-			}
-			owner := &userv1beta1.UserId{
-				Idp:      info.Storage["Idp"],
-				OpaqueId: info.Storage["UserId"],
-			}
-			ref := &provider.Reference{
-				ResourceId: &provider.ResourceId{
-					StorageId: info.MetaData["providerID"],
-					SpaceId:   info.Storage["SpaceRoot"],
-					OpaqueId:  info.Storage["SpaceRoot"],
-				},
-				Path: utils.MakeRelativePath(filepath.Join(info.MetaData["dir"], info.MetaData["filename"])),
-			}
-			datatx.InvalidateCache(owner, ref, m.statCache)
-			if m.publisher != nil {
-				if err := datatx.EmitFileUploadedEvent(spaceOwner, owner, ref, m.publisher); err != nil {
-					appctx.GetLogger(context.Background()).Error().Err(err).Msg("failed to publish FileUploaded event")
+	if _, ok := fs.(storage.UploadsManager); ok {
+		// TODO we can currently only send updates if the fs is decomposedfs as we read very specific keys from the storage map of the tus info
+		go func() {
+			for {
+				ev := <-handler.CompleteUploads
+				// TODO we should be able to get the upload progress with fs.GetUploadProgress, but currently tus will erase the info files
+				// so we create a Progress instance here that is used to read the correct properties
+				up := upload.Progress{
+					Info: ev.Upload,
+				}
+				executant := up.Executant()
+				ref := up.Reference()
+				datatx.InvalidateCache(&executant, &ref, m.statCache)
+				if m.publisher != nil {
+					if err := datatx.EmitFileUploadedEvent(up.SpaceOwner(), &executant, &ref, m.publisher); err != nil {
+						appctx.GetLogger(context.Background()).Error().Err(err).Msg("failed to publish FileUploaded event")
+					}
 				}
 			}
-		}
-	}()
+		}()
+	}
 
 	h := handler.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		method := r.Method
@@ -202,6 +194,7 @@ func setHeaders(fs storage.FS, w http.ResponseWriter, r *http.Request) {
 	}
 	expires := info.MetaData["expires"]
 	if expires != "" {
+		// FIXME currently info.MetaData["expires"] is an int ... but it MUST be RFC 7231 datetime format, see https://tus.io/protocols/resumable-upload#upload-expires
 		w.Header().Set(net.HeaderTusUploadExpires, expires)
 	}
 	resourceid := provider.ResourceId{

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -22,15 +22,10 @@ import (
 	"context"
 	"io"
 	"net/url"
-	"time"
 
-	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	registry "github.com/cs3org/go-cs3apis/cs3/storage/registry/v1beta1"
 )
-
-// UploadFinishedFunc is a callback function used in storage drivers to indicate that an upload has finished
-type UploadFinishedFunc func(spaceOwner, executant *userpb.UserId, ref *provider.Reference)
 
 // FS is the interface to implement access to the storage.
 type FS interface {
@@ -74,40 +69,6 @@ type FS interface {
 	CreateStorageSpace(ctx context.Context, req *provider.CreateStorageSpaceRequest) (*provider.CreateStorageSpaceResponse, error)
 	UpdateStorageSpace(ctx context.Context, req *provider.UpdateStorageSpaceRequest) (*provider.UpdateStorageSpaceResponse, error)
 	DeleteStorageSpace(ctx context.Context, req *provider.DeleteStorageSpaceRequest) error
-}
-
-// UploadsManager defines the interface for FS implementations that allow for managing uploads
-type UploadsManager interface {
-	// ListUploads returns a list of all currently known uploads
-	// TODO and their processing state
-	ListUploads() ([]UploadProgress, error)
-	// PurgeExpiredUploads purges expired uploads
-	// TODO skip uploads in progress
-	PurgeExpiredUploads(chan<- UploadProgress) error
-	// GetUploadProgress returns the upload progress
-	GetUploadProgress(ctx context.Context, uploadID string) (UploadProgress, error)
-}
-
-type UploadProgress interface {
-	// ID returns the upload id
-	ID() string
-	// Filename returns the filename of the file
-	Filename() string
-	// Size returns the size of the upload
-	Size() int64
-	// Offset returns the current offset
-	Offset() int64
-	// Reference returns a reference for the file being uploaded. May be absolute id based or relative to e.g. a space root
-	Reference() provider.Reference
-	// Executant returns the userid of the user that created the upload
-	Executant() userpb.UserId
-	// SpaceOwner returns the owner of a space if set. optional
-	SpaceOwner() *userpb.UserId
-	// Expires returns the time when the upload cen no longer be used
-	Expires() time.Time
-
-	// Purge allows completely removing an upload. Should emit a PostprocessingFinished event with a Delete outcome
-	Purge() error
 }
 
 // Registry is the interface that storage registries implement

--- a/pkg/storage/uploads.go
+++ b/pkg/storage/uploads.go
@@ -1,0 +1,79 @@
+// Copyright 2018-2021 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package storage
+
+import (
+	"context"
+	"io"
+	"time"
+
+	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
+	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+)
+
+// UploadFinishedFunc is a callback function used in storage drivers to indicate that an upload has finished
+type UploadFinishedFunc func(spaceOwner, executant *userpb.UserId, ref *provider.Reference)
+
+type UploadRequest struct {
+	Ref    *provider.Reference
+	Body   io.ReadCloser
+	Length int64
+}
+
+// UploadsManager defines the interface for FS implementations that allow for managing uploads
+type UploadsManager interface {
+	// GetUploadProgress returns the upload progress
+	ListUploadSessions(ctx context.Context, filter UploadSessionFilter) ([]UploadSession, error)
+}
+
+type UploadSession interface {
+	// ID returns the upload id
+	ID() string
+	// Filename returns the filename of the file
+	Filename() string
+	// Size returns the size of the upload
+	Size() int64
+	// Offset returns the current offset
+	Offset() int64
+	// Reference returns a reference for the file being uploaded. May be absolute id based or relative to e.g. a space root
+	Reference() provider.Reference
+	// Executant returns the userid of the user that created the upload
+	Executant() userpb.UserId
+	// SpaceOwner returns the owner of a space if set. optional
+	SpaceOwner() *userpb.UserId
+	// Expires returns the time when the upload can no longer be used
+	Expires() time.Time
+
+	// IsProcessing returns true if postprocessing has not finished, yet
+	// The actual postprocessing state is tracked in the postprocessing service.
+	IsProcessing() bool
+	// MalwareDescription returns the scan result returned by the scanner
+	MalwareDescription() string
+	// MalwareScanTime returns the timestamp the upload was scanned. Default time means the item has not been scanned
+	MalwareScanTime() time.Time
+
+	// Purge allows completely removing an upload. Should emit a PostprocessingFinished event with a Delete outcome
+	Purge() error
+}
+
+type UploadSessionFilter struct {
+	Id         *string
+	Processing *bool
+	Expired    *bool
+}

--- a/pkg/storage/uploads.go
+++ b/pkg/storage/uploads.go
@@ -31,6 +31,7 @@ import (
 // UploadFinishedFunc is a callback function used in storage drivers to indicate that an upload has finished
 type UploadFinishedFunc func(spaceOwner, executant *userpb.UserId, ref *provider.Reference)
 
+// UploadRequest us used in FS.Upload() to carry required upload metadata
 type UploadRequest struct {
 	Ref    *provider.Reference
 	Body   io.ReadCloser
@@ -46,10 +47,11 @@ type UploadsManager interface {
 
 // UploadSessionLister defines the interface for FS implementations that allow listing and purging upload sessions
 type UploadSessionLister interface {
-	// GetUploadProgress returns the upload progress
+	// ListUploadSessions returns the upload sessions matching the given filter
 	ListUploadSessions(ctx context.Context, filter UploadSessionFilter) ([]UploadSession, error)
 }
 
+// UploadSession is the interface that storage drivers need to return whan listing upload sessions.
 type UploadSession interface {
 	// ID returns the upload id
 	ID() string
@@ -76,6 +78,7 @@ type UploadSession interface {
 	Purge(ctx context.Context) error
 }
 
+// UploadSessionFilter can be used to filter upload sessions
 type UploadSessionFilter struct {
 	ID         *string
 	Processing *bool

--- a/pkg/storage/utils/decomposedfs/upload.go
+++ b/pkg/storage/utils/decomposedfs/upload.go
@@ -243,7 +243,7 @@ func (fs *Decomposedfs) GetUpload(ctx context.Context, id string) (tusd.Upload, 
 	return upload.Get(ctx, id, fs.lu, fs.tp, fs.o.Root, fs.stream, fs.o.AsyncFileUploads, fs.o.Tokens)
 }
 
-// GetUploadProgress returns the metadata for the given upload id
+// ListUploadSessions returns the upload sessions for the given filter
 func (fs *Decomposedfs) ListUploadSessions(ctx context.Context, filter storage.UploadSessionFilter) ([]storage.UploadSession, error) {
 	var sessions []storage.UploadSession
 	if filter.ID != nil && *filter.ID != "" {

--- a/pkg/storage/utils/decomposedfs/upload.go
+++ b/pkg/storage/utils/decomposedfs/upload.go
@@ -93,8 +93,9 @@ func (fs *Decomposedfs) Upload(ctx context.Context, ref *provider.Reference, r i
 			ResourceId: &provider.ResourceId{
 				StorageId: info.MetaData["providerID"],
 				SpaceId:   info.Storage["SpaceRoot"],
-				OpaqueId:  info.Storage["NodeId"],
+				OpaqueId:  info.Storage["SpaceRoot"],
 			},
+			Path: utils.MakeRelativePath(filepath.Join(info.MetaData["dir"], info.MetaData["filename"])),
 		}
 		executant, ok := ctxpkg.ContextGetUser(uploadInfo.Ctx)
 		if !ok {

--- a/pkg/storage/utils/decomposedfs/upload/processing.go
+++ b/pkg/storage/utils/decomposedfs/upload/processing.go
@@ -498,8 +498,6 @@ type Progress struct {
 	Path       string
 	Info       tusd.FileInfo
 	Processing bool
-	ScanStatus string
-	ScanTime   time.Time
 }
 
 func (p Progress) ID() string {
@@ -519,7 +517,7 @@ func (p Progress) Reference() provider.Reference {
 		ResourceId: &provider.ResourceId{
 			StorageId: p.Info.MetaData["providerID"],
 			SpaceId:   p.Info.Storage["SpaceRoot"],
-			OpaqueId:  p.Info.Storage["NodeId"], // Node id is always set in Initiate Upload
+			OpaqueId:  p.Info.Storage["NodeId"], // Node id is always set in InitiateUpload
 		},
 	}
 }
@@ -532,8 +530,8 @@ func (p Progress) Executant() userpb.UserId {
 }
 func (p Progress) SpaceOwner() *userpb.UserId {
 	return &userpb.UserId{
+		// idp and type do not seem to be consumed and the node currently only stores the user id anyway
 		OpaqueId: p.Info.Storage["SpaceOwnerOrManager"],
-		// TODO idp and type?
 	}
 }
 func (p Progress) Expires() time.Time {
@@ -544,15 +542,8 @@ func (p Progress) Expires() time.Time {
 func (p Progress) IsProcessing() bool {
 	return p.Processing
 }
-func (p Progress) MalwareDescription() string {
-	return p.ScanStatus
-}
-func (p Progress) MalwareScanTime() time.Time {
-	return p.ScanTime
-}
 
-func (p Progress) Purge() error {
-	// TODO we should use the upload id to look up the tus upload and Terminate() that
+func (p Progress) Purge(ctx context.Context) error {
 	err := os.Remove(p.Info.Storage["BinPath"])
 	if err != nil {
 		return err

--- a/pkg/storage/utils/decomposedfs/upload/processing.go
+++ b/pkg/storage/utils/decomposedfs/upload/processing.go
@@ -495,8 +495,11 @@ func lookupNode(ctx context.Context, spaceRoot *node.Node, path string, lu *look
 }
 
 type Progress struct {
-	Path string
-	Info tusd.FileInfo
+	Path       string
+	Info       tusd.FileInfo
+	Processing bool
+	ScanStatus string
+	ScanTime   time.Time
 }
 
 func (p Progress) ID() string {
@@ -536,6 +539,16 @@ func (p Progress) SpaceOwner() *userpb.UserId {
 func (p Progress) Expires() time.Time {
 	mt, _ := utils.MTimeToTime(p.Info.MetaData["expires"])
 	return mt
+}
+
+func (p Progress) IsProcessing() bool {
+	return p.Processing
+}
+func (p Progress) MalwareDescription() string {
+	return p.ScanStatus
+}
+func (p Progress) MalwareScanTime() time.Time {
+	return p.ScanTime
 }
 
 func (p Progress) Purge() error {

--- a/pkg/storage/utils/decomposedfs/upload/processing.go
+++ b/pkg/storage/utils/decomposedfs/upload/processing.go
@@ -21,6 +21,7 @@ package upload
 import (
 	"context"
 	"encoding/json"
+	stderrors "errors"
 	"fmt"
 	iofs "io/fs"
 	"os"
@@ -494,24 +495,34 @@ func lookupNode(ctx context.Context, spaceRoot *node.Node, path string, lu *look
 	return n, nil
 }
 
+// Progress adapts the persisted upload metadata for the UploadSessionLister interface
 type Progress struct {
 	Path       string
 	Info       tusd.FileInfo
 	Processing bool
 }
 
+// ID implements the storage.UploadSession interface
 func (p Progress) ID() string {
 	return p.Info.ID
 }
+
+// Filename implements the storage.UploadSession interface
 func (p Progress) Filename() string {
 	return p.Info.MetaData["filename"]
 }
+
+// Size implements the storage.UploadSession interface
 func (p Progress) Size() int64 {
 	return p.Info.Size
 }
+
+// Offset implements the storage.UploadSession interface
 func (p Progress) Offset() int64 {
 	return p.Info.Offset
 }
+
+// Reference implements the storage.UploadSession interface
 func (p Progress) Reference() provider.Reference {
 	return provider.Reference{
 		ResourceId: &provider.ResourceId{
@@ -521,6 +532,8 @@ func (p Progress) Reference() provider.Reference {
 		},
 	}
 }
+
+// Executant implements the storage.UploadSession interface
 func (p Progress) Executant() userpb.UserId {
 	return userpb.UserId{
 		Idp:      p.Info.Storage["Idp"],
@@ -528,27 +541,38 @@ func (p Progress) Executant() userpb.UserId {
 		Type:     utils.UserTypeMap(p.Info.Storage["UserType"]),
 	}
 }
+
+// SpaceOwner implements the storage.UploadSession interface
 func (p Progress) SpaceOwner() *userpb.UserId {
 	return &userpb.UserId{
 		// idp and type do not seem to be consumed and the node currently only stores the user id anyway
 		OpaqueId: p.Info.Storage["SpaceOwnerOrManager"],
 	}
 }
+
+// Expires implements the storage.UploadSession interface
 func (p Progress) Expires() time.Time {
 	mt, _ := utils.MTimeToTime(p.Info.MetaData["expires"])
 	return mt
 }
 
+// IsProcessing implements the storage.UploadSession interface
 func (p Progress) IsProcessing() bool {
 	return p.Processing
 }
 
+// Purge implements the storage.UploadSession interface
 func (p Progress) Purge(ctx context.Context) error {
-	err := os.Remove(p.Info.Storage["BinPath"])
-	if err != nil {
-		return err
+	berr := os.Remove(p.Info.Storage["BinPath"])
+	if berr != nil {
+		appctx.GetLogger(ctx).Error().Str("id", p.Info.ID).Interface("path", p.Info.Storage["BinPath"]).Msg("Decomposedfs: could not purge bin path for upload session")
 	}
 
 	// remove upload metadata
-	return os.Remove(p.Path)
+	merr := os.Remove(p.Path)
+	if merr != nil {
+		appctx.GetLogger(ctx).Error().Str("id", p.Info.ID).Interface("path", p.Path).Msg("Decomposedfs: could not purge metadata path for upload session")
+	}
+
+	return stderrors.Join(berr, merr)
 }

--- a/pkg/storage/utils/decomposedfs/upload/processing.go
+++ b/pkg/storage/utils/decomposedfs/upload/processing.go
@@ -493,3 +493,58 @@ func lookupNode(ctx context.Context, spaceRoot *node.Node, path string, lu *look
 	}
 	return n, nil
 }
+
+type Progress struct {
+	Path string
+	Info tusd.FileInfo
+}
+
+func (p Progress) ID() string {
+	return p.Info.ID
+}
+func (p Progress) Filename() string {
+	return p.Info.MetaData["filename"]
+}
+func (p Progress) Size() int64 {
+	return p.Info.Size
+}
+func (p Progress) Offset() int64 {
+	return p.Info.Offset
+}
+func (p Progress) Reference() provider.Reference {
+	return provider.Reference{
+		ResourceId: &provider.ResourceId{
+			StorageId: p.Info.MetaData["providerID"],
+			SpaceId:   p.Info.Storage["SpaceRoot"],
+			OpaqueId:  p.Info.Storage["NodeId"], // Node id is always set in Initiate Upload
+		},
+	}
+}
+func (p Progress) Executant() userpb.UserId {
+	return userpb.UserId{
+		Idp:      p.Info.Storage["Idp"],
+		OpaqueId: p.Info.Storage["UserId"],
+		Type:     utils.UserTypeMap(p.Info.Storage["UserType"]),
+	}
+}
+func (p Progress) SpaceOwner() *userpb.UserId {
+	return &userpb.UserId{
+		OpaqueId: p.Info.Storage["SpaceOwnerOrManager"],
+		// TODO idp and type?
+	}
+}
+func (p Progress) Expires() time.Time {
+	mt, _ := utils.MTimeToTime(p.Info.MetaData["expires"])
+	return mt
+}
+
+func (p Progress) Purge() error {
+	// TODO we should use the upload id to look up the tus upload and Terminate() that
+	err := os.Remove(p.Info.Storage["BinPath"])
+	if err != nil {
+		return err
+	}
+
+	// remove upload metadata
+	return os.Remove(p.Path)
+}


### PR DESCRIPTION
backport of https://github.com/cs3org/reva/pull/4375

Enhancement: Introduce UploadSessionLister interface

We introduced a new UploadSessionLister interface that allows better control of upload sessions. Upload sessions include the processing state and can be used to filter and purge the list of currently ongoing upload sessions.


