### PR TITLE
oc:spaceid should be in the form of {providerid}${spaceid}

### DIFF
--- a/changelog/unreleased/fix-ocdav-spaceid.md
+++ b/changelog/unreleased/fix-ocdav-spaceid.md
@@ -1,0 +1,5 @@
+Bugfix: make ocdav return correct oc:spaceid
+
+propfinds now return `oc:spaceid` in the form of `{providerid}${spaceid}`
+
+https://github.com/cs3org/reva/pull/4407

--- a/internal/http/services/owncloud/ocdav/propfind/propfind.go
+++ b/internal/http/services/owncloud/ocdav/propfind/propfind.go
@@ -1156,7 +1156,7 @@ func mdToPropResponse(ctx context.Context, pf *XML, md *provider.ResourceInfo, p
 			appendToOK(
 				prop.Escaped("oc:id", sid),
 				prop.Escaped("oc:fileid", sid),
-				prop.Escaped("oc:spaceid", id.SpaceId),
+				prop.Escaped("oc:spaceid", storagespace.FormatStorageID(id.StorageId, id.SpaceId)),
 			)
 		}
 
@@ -1296,7 +1296,7 @@ func mdToPropResponse(ctx context.Context, pf *XML, md *provider.ResourceInfo, p
 					}
 				case "spaceid":
 					if id != nil {
-						appendToOK(prop.Escaped("oc:spaceid", id.SpaceId))
+						appendToOK(prop.Escaped("oc:spaceid", storagespace.FormatStorageID(id.StorageId, id.SpaceId)))
 					} else {
 						appendToNotFound(prop.Escaped("oc:spaceid", ""))
 					}


### PR DESCRIPTION
propfinds now return `oc:spaceid` in the form of `{providerid}${spaceid}`

cc @individual-it @kobergj  I assume there  will be api test fallout ...