### PR TITLE
upload session metrics

### DIFF
--- a/changelog/unreleased/upload-session-metrics.md
+++ b/changelog/unreleased/upload-session-metrics.md
@@ -1,0 +1,5 @@
+Enhancement: track more upload session metrics
+
+We added a gauge for the number of uploads currently in postprocessing as well as counters for different postprocessing outcomes.
+
+https://github.com/cs3org/reva/pull/4414

--- a/pkg/rhttp/datatx/metrics/metrics.go
+++ b/pkg/rhttp/datatx/metrics/metrics.go
@@ -17,4 +17,44 @@ var (
 		Name: "reva_upload_active",
 		Help: "Number of active uploads",
 	})
+	// UploadProcessing is the number of uploads in processing
+	UploadProcessing = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "reva_upload_processing",
+		Help: "Number of uploads in processing",
+	})
+	// UploadSessionsInitiated is the number of upload sessions that have been initiated
+	UploadSessionsInitiated = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "reva_upload_sessions_initiated",
+		Help: "Number of uploads sessions that were initiated",
+	})
+	// UploadSessionsBytesReceived is the number of upload sessions that have received all bytes
+	UploadSessionsBytesReceived = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "reva_upload_sessions_bytes_received",
+		Help: "Number of uploads sessions that have received all bytes",
+	})
+	// UploadSessionsFinalized is the number of upload sessions that have received all bytes
+	UploadSessionsFinalized = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "reva_upload_sessions_finalized",
+		Help: "Number of uploads sessions that have successfully completed",
+	})
+	// UploadSessionsAborted is the number of upload sessions that have been aborted
+	UploadSessionsAborted = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "reva_upload_sessions_aborted",
+		Help: "Number of uploads sessions that have aborted by postprocessing",
+	})
+	// UploadSessionsDeleted is the number of upload sessions that have been deleted
+	UploadSessionsDeleted = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "reva_upload_sessions_deleted",
+		Help: "Number of uploads sessions that have been deleted by postprocessing",
+	})
+	// UploadSessionsRestarted is the number of upload sessions that have been restarted
+	UploadSessionsRestarted = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "reva_upload_sessions_restarted",
+		Help: "Number of uploads sessions that have been restarted by postprocessing",
+	})
+	// UploadSessionsScanned is the number of upload sessions that have been scanned by antivirus
+	UploadSessionsScanned = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "reva_upload_sessions_scanned",
+		Help: "Number of uploads sessions that have been scanned by antivirus",
+	})
 )

--- a/pkg/storage/utils/decomposedfs/node/node.go
+++ b/pkg/storage/utils/decomposedfs/node/node.go
@@ -41,6 +41,7 @@ import (
 	ctxpkg "github.com/cs3org/reva/v2/pkg/ctx"
 	"github.com/cs3org/reva/v2/pkg/errtypes"
 	"github.com/cs3org/reva/v2/pkg/mime"
+	"github.com/cs3org/reva/v2/pkg/rhttp/datatx/metrics"
 	"github.com/cs3org/reva/v2/pkg/storage/utils/ace"
 	"github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/metadata"
 	"github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/metadata/prefixes"
@@ -1220,6 +1221,9 @@ func (n *Node) FindStorageSpaceRoot(ctx context.Context) error {
 
 // UnmarkProcessing removes the processing flag from the node
 func (n *Node) UnmarkProcessing(ctx context.Context, uploadID string) error {
+	// we currently have to decrease the counter for every processing run to match the incrases
+	metrics.UploadProcessing.Sub(1)
+
 	v, _ := n.XattrString(ctx, prefixes.StatusPrefix)
 	if v != ProcessingStatus+uploadID {
 		// file started another postprocessing later - do not remove

--- a/pkg/storage/utils/decomposedfs/upload.go
+++ b/pkg/storage/utils/decomposedfs/upload.go
@@ -34,6 +34,7 @@ import (
 	"github.com/cs3org/reva/v2/pkg/appctx"
 	ctxpkg "github.com/cs3org/reva/v2/pkg/ctx"
 	"github.com/cs3org/reva/v2/pkg/errtypes"
+	"github.com/cs3org/reva/v2/pkg/rhttp/datatx/metrics"
 	"github.com/cs3org/reva/v2/pkg/storage"
 	"github.com/cs3org/reva/v2/pkg/storage/utils/chunking"
 	"github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/node"
@@ -214,6 +215,8 @@ func (fs *Decomposedfs) InitiateUpload(ctx context.Context, ref *provider.Refere
 	}
 
 	info, _ = upload.GetInfo(ctx)
+
+	metrics.UploadSessionsInitiated.Inc()
 
 	return map[string]string{
 		"simple": info.ID,


### PR DESCRIPTION
We added a gauge for the number of uploads currently in postprocessing as well as counters for different postprocessing outcomes:
```golang
	// UploadProcessing is the number of uploads in processing
	UploadProcessing = promauto.NewGauge(prometheus.GaugeOpts{
		Name: "reva_upload_processing",
		Help: "Number of uploads in processing",
	})
	// UploadSessionsInitiated is the number of upload sessions that have been initiated
	UploadSessionsInitiated = promauto.NewCounter(prometheus.CounterOpts{
		Name: "reva_upload_sessions_initiated",
		Help: "Number of uploads sessions that were initiated",
	})
	// UploadSessionsBytesReceived is the number of upload sessions that have received all bytes
	UploadSessionsBytesReceived = promauto.NewCounter(prometheus.CounterOpts{
		Name: "reva_upload_sessions_bytes_received",
		Help: "Number of uploads sessions that have received all bytes",
	})
	// UploadSessionsFinalized is the number of upload sessions that have received all bytes
	UploadSessionsFinalized = promauto.NewCounter(prometheus.CounterOpts{
		Name: "reva_upload_sessions_finalized",
		Help: "Number of uploads sessions that have successfully completed",
	})
	// UploadSessionsAborted is the number of upload sessions that have been aborted
	UploadSessionsAborted = promauto.NewCounter(prometheus.CounterOpts{
		Name: "reva_upload_sessions_aborted",
		Help: "Number of uploads sessions that have aborted by postprocessing",
	})
	// UploadSessionsDeleted is the number of upload sessions that have been deleted
	UploadSessionsDeleted = promauto.NewCounter(prometheus.CounterOpts{
		Name: "reva_upload_sessions_deleted",
		Help: "Number of uploads sessions that have been deleted by postprocessing",
	})
	// UploadSessionsRestarted is the number of upload sessions that have been restarted
	UploadSessionsRestarted = promauto.NewCounter(prometheus.CounterOpts{
		Name: "reva_upload_sessions_restarted",
		Help: "Number of uploads sessions that have been restarted by postprocessing",
	})
	// UploadSessionsScanned is the number of upload sessions that have been scanned by antivirus
	UploadSessionsScanned = promauto.NewCounter(prometheus.CounterOpts{
		Name: "reva_upload_sessions_scanned",
		Help: "Number of uploads sessions that have been scanned by antivirus",
	})
)
```