### PR TITLE
Fix interceptor order to make sure tracing is set up first

### DIFF
--- a/changelog/unreleased/fix-disconnected-traces.md
+++ b/changelog/unreleased/fix-disconnected-traces.md
@@ -1,0 +1,5 @@
+Bugfix: Fix disconnected traces
+
+We fixed a problem where the appctx logger was using a new traceid instead of picking up the one from the trace parent.
+
+https://github.com/cs3org/reva/pull/4422

--- a/pkg/rgrpc/rgrpc.go
+++ b/pkg/rgrpc/rgrpc.go
@@ -371,20 +371,23 @@ func (s *Server) getInterceptors(unprotected []string) ([]grpc.ServerOption, err
 		return nil, errors.Wrap(err, "rgrpc: error creating stream auth interceptor")
 	}
 
-	streamInterceptors := []grpc.StreamServerInterceptor{authStream}
-	for _, t := range streamTriples {
-		streamInterceptors = append(streamInterceptors, t.Interceptor)
-		s.log.Info().Msgf("rgrpc: chaining grpc streaming interceptor %s with priority %d", t.Name, t.Priority)
-	}
-
-	streamInterceptors = append([]grpc.StreamServerInterceptor{
-		authStream,
+	streamInterceptors := []grpc.StreamServerInterceptor{
+		otelgrpc.StreamServerInterceptor(
+			otelgrpc.WithTracerProvider(s.tracerProvider),
+			otelgrpc.WithPropagators(rtrace.Propagator),
+		),
 		appctx.NewStream(s.log, s.tracerProvider),
 		token.NewStream(),
 		useragent.NewStream(),
 		log.NewStream(),
 		recovery.NewStream(),
-	}, streamInterceptors...)
+		authStream,
+	}
+
+	for _, t := range streamTriples {
+		streamInterceptors = append(streamInterceptors, t.Interceptor)
+		s.log.Info().Msgf("rgrpc: chaining grpc streaming interceptor %s with priority %d", t.Name, t.Priority)
+	}
 	streamChain := grpc_middleware.ChainStreamServer(streamInterceptors...)
 
 	opts := []grpc.ServerOption{


### PR DESCRIPTION
This PR fixes a problem where the appctx logger was using a new traceid instead of picking up the one from the trace parent.

Part of the fix of https://github.com/owncloud/ocis/issues/7928