### PR TITLE
Avoid concurrent mapwrites in receivedsharecache

### DIFF
--- a/changelog/unreleased/avoid-panic-in-cache.md
+++ b/changelog/unreleased/avoid-panic-in-cache.md
@@ -1,0 +1,5 @@
+Bugfix: fixed panic in receivedsharecache pkg
+
+The receivedsharecache pkg would sometime run into concurrent map writes. This is fixed by using maptimesyncedcache pkg instead of a plain map.
+
+https://github.com/cs3org/reva/pull/4424


### PR DESCRIPTION
Avoid panics due to concurrent map writes in the receivedsharecache pkg.

References https://github.com/owncloud/ocis/issues/7697
