### PR TITLE
Fix overwriting files with empty files

### DIFF
--- a/changelog/unreleased/fix-0-byte-overwrites.md
+++ b/changelog/unreleased/fix-0-byte-overwrites.md
@@ -1,0 +1,5 @@
+Bugfix: Fix overwriting files with empty files
+
+We fixed a bug where files could not be overwritten with empty files using the desktop client.
+
+https://github.com/cs3org/reva/pull/4425

--- a/internal/http/services/owncloud/ocdav/tus.go
+++ b/internal/http/services/owncloud/ocdav/tus.go
@@ -175,7 +175,13 @@ func (s *svc) handleTusPost(ctx context.Context, w http.ResponseWriter, r *http.
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
-		if tfRes.Status.Code != rpc.Code_CODE_OK {
+		switch tfRes.Status.Code {
+		case rpc.Code_CODE_OK:
+			w.WriteHeader(http.StatusCreated)
+			return
+		case rpc.Code_CODE_ALREADY_EXISTS:
+			// Fall through to the tus case
+		default:
 			log.Error().Interface("status", tfRes.Status).Msg("error touching file")
 			w.WriteHeader(http.StatusInternalServerError)
 			return


### PR DESCRIPTION
This PR fixes a bug where files can not be overwritten with empty files via POST requests as the desktop client makes them.

Fixes https://github.com/owncloud/ocis/issues/8003