### PR TITLE
publicsshareprovider: Allow creating/updating public links on received shares

### DIFF
--- a/changelog/unreleased/fix-internallink-permission-check.md
+++ b/changelog/unreleased/fix-internallink-permission-check.md
@@ -1,0 +1,7 @@
+Bugfix: Internal link creation
+
+We fix the permission checks for creating and updating public share so that it is
+possible again to create internal links for received shares.
+
+https://github.com/cs3org/reva/pull/4429
+https://github.com/owncloud/ocis/issues/8039

--- a/internal/grpc/services/publicshareprovider/publicshareprovider.go
+++ b/internal/grpc/services/publicshareprovider/publicshareprovider.go
@@ -241,8 +241,10 @@ func (s *service) CreatePublicShare(ctx context.Context, req *link.CreatePublicS
 		}, nil
 	}
 
-	// check if the user can share with the desired permissions
-	if !conversions.SufficientCS3Permissions(sRes.GetInfo().GetPermissionSet(), req.GetGrant().GetPermissions().GetPermissions()) {
+	// check if the user can share with the desired permissions. For internal links this is skipped,
+	// users can always create internal links provided they have the AddGrant permission, which was already
+	// checked above
+	if !isInternalLink && !conversions.SufficientCS3Permissions(sRes.GetInfo().GetPermissionSet(), req.GetGrant().GetPermissions().GetPermissions()) {
 		return &link.CreatePublicShareResponse{
 			Status: status.NewInvalidArg(ctx, "insufficient permissions to create that kind of share"),
 		}, nil
@@ -512,6 +514,7 @@ func (s *service) UpdatePublicShare(ctx context.Context, req *link.UpdatePublicS
 	// check if the user can change the permissions to the desired permissions
 	updatePermissions := req.GetUpdate().GetType() == link.UpdatePublicShareRequest_Update_TYPE_PERMISSIONS
 	if updatePermissions &&
+		!isInternalLink &&
 		!conversions.SufficientCS3Permissions(
 			sRes.GetInfo().GetPermissionSet(),
 			req.GetUpdate().GetGrant().GetPermissions().GetPermissions(),


### PR DESCRIPTION
The permission check when trying to create an internal link of a received share did not work correctly. Internal links have all Permissions set to false. The 'SufficientCS3Permissions' method treats an all-false PermissionSet as a deny grant, which a wrong in the public link case.
We can skip the 'SufficientCS3Permissions' check for internal links however, since the creation of a internal link should always be allowed as long as the user has the 'AddGrant' permission.

Related Issue: https://github.com/owncloud/ocis/issues/8039