### PR TITLE
Revert "bugfix: Don't return disabled users on GetUser call"

### DIFF
--- a/changelog/unreleased/fix-hide-disabled-users.md
+++ b/changelog/unreleased/fix-hide-disabled-users.md
@@ -1,7 +1,0 @@
-Bugfix: Don't return disabled users in GetUser call
-
-We fixed a bug where it was still possible to lookup a disabled User if
-the user's ID was known.
-
-https://github.com/cs3org/reva/pull/4426
-https://github.com/owncloud/ocis/issues/7962

--- a/pkg/user/manager/ldap/ldap.go
+++ b/pkg/user/manager/ldap/ldap.go
@@ -116,10 +116,6 @@ func (m *manager) GetUser(ctx context.Context, uid *userpb.UserId, skipFetchingG
 		return nil, err
 	}
 
-	if m.c.LDAPIdentity.IsLDAPUserInDisabledGroup(log, m.ldapClient, userEntry) {
-		return nil, errtypes.NotFound("user is locally disabled")
-	}
-
 	if skipFetchingGroups {
 		return u, nil
 	}

--- a/pkg/utils/ldap/identity.go
+++ b/pkg/utils/ldap/identity.go
@@ -503,12 +503,11 @@ func (i *Identity) getUserFilter(uid string) (string, error) {
 		escapedUUID = ldap.EscapeFilter(uid)
 	}
 
-	return fmt.Sprintf("(&%s(objectclass=%s)(%s=%s)%s)",
+	return fmt.Sprintf("(&%s(objectclass=%s)(%s=%s))",
 		i.User.Filter,
 		i.User.Objectclass,
 		i.User.Schema.ID,
 		escapedUUID,
-		i.disabledFilter(),
 	), nil
 }
 


### PR DESCRIPTION
If you think https://github.com/cs3org/reva/pull/4430 is too much for now. We can also revert the original PR

This reverts commit 9b7ec1e4afc754b9ce39cd053aa793febec478a7.

This needs some more work we need to allow admins to lookup disabled users.