### PR TITLE
Fix /dav/meta for shares

### DIFF
--- a/changelog/unreleased/fix-dav-meta-for-shares.md
+++ b/changelog/unreleased/fix-dav-meta-for-shares.md
@@ -1,0 +1,5 @@
+Bugfix: Fix /dav/meta endpoint for shares
+
+We fixed a bug in the /dav/meta endpoint leading to internal server errors when used with shares.
+
+https://github.com/cs3org/reva/pull/4432

--- a/internal/grpc/services/sharesstorageprovider/sharesstorageprovider.go
+++ b/internal/grpc/services/sharesstorageprovider/sharesstorageprovider.go
@@ -302,7 +302,27 @@ func (s *service) GetPath(ctx context.Context, req *provider.GetPathRequest) (*p
 		}, nil
 	}
 
-	return nil, gstatus.Errorf(codes.Unimplemented, "method not implemented")
+	receivedShare, rpcStatus, err := s.resolveAcceptedShare(ctx, &provider.Reference{
+		ResourceId: req.ResourceId,
+	})
+	appctx.GetLogger(ctx).Debug().
+		Interface("resourceId", req.ResourceId).
+		Interface("received_share", receivedShare).
+		Msg("sharesstorageprovider: Got GetPath request")
+	if err != nil {
+		return nil, err
+	}
+	if rpcStatus.Code != rpc.Code_CODE_OK {
+		return &provider.GetPathResponse{
+			Status: rpcStatus,
+		}, nil
+	}
+
+	return &provider.GetPathResponse{
+		Status: status.NewOK(ctx),
+		Path:   receivedShare.MountPoint.Path,
+	}, nil
+
 }
 
 func (s *service) GetHome(ctx context.Context, req *provider.GetHomeRequest) (*provider.GetHomeResponse, error) {

--- a/internal/grpc/services/usershareprovider/usershareprovider.go
+++ b/internal/grpc/services/usershareprovider/usershareprovider.go
@@ -450,9 +450,16 @@ func (s *service) GetReceivedShare(ctx context.Context, req *collaboration.GetRe
 	share, err := s.sm.GetReceivedShare(ctx, req.Ref)
 	if err != nil {
 		log.Err(err).Msg("error getting received share")
-		return &collaboration.GetReceivedShareResponse{
-			Status: status.NewInternal(ctx, "error getting received share"),
-		}, nil
+		switch err.(type) {
+		case errtypes.NotFound:
+			return &collaboration.GetReceivedShareResponse{
+				Status: status.NewNotFound(ctx, "error getting received share"),
+			}, nil
+		default:
+			return &collaboration.GetReceivedShareResponse{
+				Status: status.NewInternal(ctx, "error getting received share"),
+			}, nil
+		}
 	}
 
 	res := &collaboration.GetReceivedShareResponse{


### PR DESCRIPTION
This PR fixes an internal server error when trying to query the `/dav/meta` endpoint with a sharestorageprovider id. It also fixes the response status in case a share can not be found.

Fixes https://github.com/owncloud/ocis/issues/8033