### PR TITLE
fix the upload postprocessing when the destination file does not exis…

### DIFF
--- a/changelog/unreleased/fix-upload-postprocessing.md
+++ b/changelog/unreleased/fix-upload-postprocessing.md
@@ -1,0 +1,5 @@
+Bugfix: Fix the upload postprocessing
+
+We fixed the upload postprocessing when the destination file does not exist anymore.
+
+https://github.com/cs3org/reva/pull/4434

--- a/pkg/storage/utils/decomposedfs/decomposedfs.go
+++ b/pkg/storage/utils/decomposedfs/decomposedfs.go
@@ -274,16 +274,21 @@ func (fs *Decomposedfs) Postprocessing(ch <-chan events.Event) {
 				continue // NOTE: since we can't get the upload, we can't delete the blob
 			}
 
-			var (
-				failed     bool
-				keepUpload bool
-			)
-
 			n, err := session.Node(ctx)
 			if err != nil {
 				log.Error().Err(err).Str("uploadID", ev.UploadID).Msg("could not read node")
 				continue
 			}
+			if !n.Exists {
+				log.Debug().Str("uploadID", ev.UploadID).Str("nodeID", session.NodeID()).Msg("node no longer exists")
+				fs.sessionStore.Cleanup(ctx, session, false, false)
+				continue
+			}
+
+			var (
+				failed     bool
+				keepUpload bool
+			)
 
 			switch ev.Outcome {
 			default:

--- a/pkg/storage/utils/decomposedfs/tree/tree.go
+++ b/pkg/storage/utils/decomposedfs/tree/tree.go
@@ -375,6 +375,7 @@ func (t *Tree) ListFolder(ctx context.Context, n *node.Node) ([]*node.Node, erro
 	// Spawn workers that'll concurrently work the queue
 	for i := 0; i < numWorkers; i++ {
 		g.Go(func() error {
+			var err error
 			for name := range work {
 				path := filepath.Join(dir, name)
 				nodeID := getNodeIDFromCache(ctx, path, t.idCache)

--- a/pkg/storage/utils/decomposedfs/upload/session.go
+++ b/pkg/storage/utils/decomposedfs/upload/session.go
@@ -162,11 +162,7 @@ func (s *OcisSession) HeaderIfUnmodifiedSince() string {
 
 // Node returns the node for the session
 func (s *OcisSession) Node(ctx context.Context) (*node.Node, error) {
-	n, err := node.ReadNode(ctx, s.store.lu, s.SpaceID(), s.info.Storage["NodeId"], false, nil, true)
-	if err != nil {
-		return nil, err
-	}
-	return n, nil
+	return node.ReadNode(ctx, s.store.lu, s.SpaceID(), s.info.Storage["NodeId"], false, nil, true)
 }
 
 // ID returns the upload session id


### PR DESCRIPTION
Fix the upload postprocessing when the destination file does not exist anymore.

## Describe the bug
When a file gets deleted before the postprocessing the destination and blob file are not found and BlobID is empty
[https://github.com/owncloud/ocis/issues/7909](https://github.com/owncloud/ocis/issues/7909)
## Steps to reproduce
```
folder='ff'
file2='ff2.txt'
# get the drive id
driveid=`curl -ku admin:admin https://host.docker.internal:9200/graph/v1.0/me/drives | jq -c '.[] | .[] | select(.driveAlias | contains("personal")) | .id' -r`

# create a folder
curl -ku admin:admin -XMKCOL 'https://host.docker.internal:9200/dav/spaces/'$driveid'/'$folder

# create, delete, and overwrite the same file 
curl -ku admin:admin -XPUT -d"content" 'https://host.docker.internal:9200/dav/spaces/'$driveid'/'$folder'/'$file2
curl -ku admin:admin -XDELETE 'https://host.docker.internal:9200/dav/spaces/'$driveid'/'$folder'/'$file2
```

## Expected behavior
ff2.txt is not found, and the upload is interrupted.

## Actual behavior
The post-processing tries to handle the upload

## Setup
Please describe how you started the server and provide a list of relevant environment variables or configuration files.

<details>
<p>

```console
POSTPROCESSING_DELAY=10s PROXY_ENABLE_BASIC_AUTH=true OCIS_INSECURE=true PROXY_HTTP_ADDR=0.0.0.0:9200 OCIS_URL=https://host.docker.internal:9200 PROXY_TRANSPORT_TLS_KEY=./ocis.pem PROXY_TRANSPORT_TLS_CERT=./ocis.crt ./ocis/bin/ocis server
```

</p>
</details>

## Additional context
logs:
```
{"level":"error","error":"decomposedfs: root has no parent","uploadID":"0645d53a-355c-4aca-9cb5-2177d11c582e","time":"2023-12-07T17:36:02+05:45","message":"could not propagate tree size change"}
{"level":"error","error":"failed to upload file to blobstore: could not open blob '~/.ocis/storage/users/spaces/00/364da3-abb6-47d0-8002-6cd66ed6eea5/blobs' for writing: open ~/.ocis/storage/users/spaces/00/364da3-abb6-47d0-8002-6cd66ed6eea5/blobs: is a directory","uploadID":"1d13ffb8-24bf-4fdd-b321-d5c774fcf353","time":"2023-12-07T17:36:32+05:45","message":"could not finalize upload"}
```

