### PR TITLE
fix: correct status code when move is denied

### DIFF
--- a/changelog/unreleased/fix-statuscode-move-denied.md
+++ b/changelog/unreleased/fix-statuscode-move-denied.md
@@ -1,0 +1,5 @@
+Bugfix: Fixed wrong status code when moving a file to a denied path
+
+We fixed a bug when the status code was 403 instead of 502 when moving a file to a denied path to be compatible with oc10.
+
+https://github.com/cs3org/reva/pull/4439

--- a/changelog/unreleased/fix-statuscode-move-denied.md
+++ b/changelog/unreleased/fix-statuscode-move-denied.md
@@ -1,5 +1,5 @@
 Bugfix: Fixed wrong status code when moving a file to a denied path
 
-We fixed a bug when the status code was 403 instead of 502 when moving a file to a denied path to be compatible with oc10.
+We fixed a bug when the status code 502 was returned when moving a file to a denied path. Status code 403 (forbidden) is now returned to be compatible with oc10.
 
 https://github.com/cs3org/reva/pull/4439

--- a/internal/grpc/services/sharesstorageprovider/sharesstorageprovider.go
+++ b/internal/grpc/services/sharesstorageprovider/sharesstorageprovider.go
@@ -666,7 +666,7 @@ func (s *service) Move(ctx context.Context, req *provider.MoveRequest) (*provide
 
 	if dstReceivedShare.Share.Id.OpaqueId != srcReceivedShare.Share.Id.OpaqueId {
 		return &provider.MoveResponse{
-			Status: status.NewUnimplemented(ctx, nil, "sharesstorageprovider: can not move between shares"),
+			Status: status.NewPermissionDenied(ctx, nil, "sharesstorageprovider: can not move between shares"),
 		}, nil
 	}
 

--- a/internal/grpc/services/sharesstorageprovider/sharesstorageprovider_test.go
+++ b/internal/grpc/services/sharesstorageprovider/sharesstorageprovider_test.go
@@ -808,7 +808,7 @@ var _ = Describe("Sharesstorageprovider", func() {
 				gatewayClient.AssertNotCalled(GinkgoT(), "Move", mock.Anything, mock.Anything)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(res).ToNot(BeNil())
-				Expect(res.Status.Code).To(Equal(rpc.Code_CODE_UNIMPLEMENTED))
+				Expect(res.Status.Code).To(Equal(rpc.Code_CODE_PERMISSION_DENIED))
 			})
 
 			It("refuses to move a file between shares resolving to the same space", func() {
@@ -826,7 +826,7 @@ var _ = Describe("Sharesstorageprovider", func() {
 				gatewayClient.AssertNotCalled(GinkgoT(), "Move", mock.Anything, mock.Anything)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(res).ToNot(BeNil())
-				Expect(res.Status.Code).To(Equal(rpc.Code_CODE_UNIMPLEMENTED))
+				Expect(res.Status.Code).To(Equal(rpc.Code_CODE_PERMISSION_DENIED))
 			})
 
 			It("moves a file", func() {

--- a/internal/http/services/owncloud/ocdav/move.go
+++ b/internal/http/services/owncloud/ocdav/move.go
@@ -281,6 +281,10 @@ func (s *svc) handleMove(ctx context.Context, w http.ResponseWriter, r *http.Req
 		switch mRes.Status.Code {
 		case rpc.Code_CODE_ABORTED:
 			status = http.StatusPreconditionFailed
+		case rpc.Code_CODE_PERMISSION_DENIED:
+			status = http.StatusForbidden
+			// create oc10 compatible error message
+			m = "Destination directory is not writable"
 		case rpc.Code_CODE_UNIMPLEMENTED:
 			// We translate this into a Bad Gateway error as per https://www.rfc-editor.org/rfc/rfc4918#section-9.9.4
 			// > 502 (Bad Gateway) - This may occur when the destination is on another


### PR DESCRIPTION
# Description

We fixed a bug when the status code was 502 instead of 403 when moving a file to a denied path to be compatible with oc10.

https://github.com/owncloud/ocis/issues/8063