### PR TITLE
disallow to delete a file during the processing

### DIFF
--- a/changelog/unreleased/fix-deleting-during-postprocessing.md
+++ b/changelog/unreleased/fix-deleting-during-postprocessing.md
@@ -1,0 +1,5 @@
+Bugfix: Disallow to delete a file during the processing
+
+We want to disallow deleting a file during the processing to prevent collecting the orphan uploads.
+
+https://github.com/cs3org/reva/pull/4446


### PR DESCRIPTION
We want to disallow deleting a file during the processing to prevent collecting the orphan uploads.