### PR TITLE
fix: correct statuscode and message when MOVEing between cross spaces

### DIFF
--- a/pkg/storage/utils/decomposedfs/tree/tree.go
+++ b/pkg/storage/utils/decomposedfs/tree/tree.go
@@ -228,7 +228,7 @@ func (t *Tree) Move(ctx context.Context, oldNode *node.Node, newNode *node.Node)
 		// > This could also occur when the destination is on another sub-section
 		// > of the same server namespace.
 		// but we only have a not supported error
-		return errtypes.NotSupported("cannot move across spaces")
+		return errtypes.PermissionDenied("cross storage moves are not permitted, use copy and delete")
 	}
 	// if target exists delete it without trashing it
 	if newNode.Exists {


### PR DESCRIPTION
This PR changes the `502` statuscode to `403` with correct message while MOVEing between cross spaces.

Fixes:
- https://github.com/owncloud/ocis/issues/8116
- https://github.com/owncloud/ocis/issues/7618
- https://github.com/owncloud/ocis/issues/8124
- https://github.com/owncloud/ocis/issues/8125

BUT there is this note in the code:
>WebDAV RFC https://www.rfc-editor.org/rfc/rfc4918#section-9.9.4 says to use
> 502 (Bad Gateway) - This may occur when the destination is on another
> server and the destination server refuses to accept the resource.
> This could also occur when the destination is on another sub-section
> of the same server namespace. but we only have a not supported error

Q: What should we expect in test? `502` or `403`?
CC @micbar @kobergj