### PR TITLE
keep failed processing status

### DIFF
--- a/changelog/unreleased/keep-failed-processing-status.md
+++ b/changelog/unreleased/keep-failed-processing-status.md
@@ -1,0 +1,5 @@
+Bugfix: Keep failed processing status
+
+We now keep tho postprocessing status when a blob could not be copied to the blobstore.
+
+https://github.com/cs3org/reva/pull/4449


### PR DESCRIPTION
The whole upload processing revisions locking logic is far too complicated. This is actually just a hack, but a proper fix requires way more work. After the release.