### PR TITLE
[WIP] Lock file by parentid childname

### DIFF
--- a/pkg/storage/utils/decomposedfs/lookup/lookup.go
+++ b/pkg/storage/utils/decomposedfs/lookup/lookup.go
@@ -298,6 +298,7 @@ func refFromCS3(b []byte) (*provider.Reference, error) {
 func (lu *Lookup) CopyMetadata(ctx context.Context, src, target string, filter func(attributeName string, value []byte) (newValue []byte, copy bool), acquireTargetLock bool) (err error) {
 	// Acquire a read log on the source node
 	// write lock existing node before reading treesize or tree time
+	// FIXME urhg .... just a path? so look at the callers? change the signature?
 	lock, err := lockedfile.OpenFile(lu.MetadataBackend().LockfilePath(src), os.O_RDONLY|os.O_CREATE, 0600)
 	if err != nil {
 		return err

--- a/pkg/storage/utils/decomposedfs/metadata/messagepack_backend.go
+++ b/pkg/storage/utils/decomposedfs/metadata/messagepack_backend.go
@@ -144,7 +144,7 @@ func (b MessagePackBackend) saveAttributes(ctx context.Context, path string, set
 		span.End()
 	}()
 
-	lockPath := b.LockfilePath(path)
+	lockPath := b.LockfilePath(path) // FIXME ... and we have no name
 	metaPath := b.MetadataPath(path)
 	if acquireLock {
 		_, subspan := tracer.Start(ctx, "lockedfile.OpenFile")

--- a/pkg/storage/utils/decomposedfs/metadata/xattrs_backend.go
+++ b/pkg/storage/utils/decomposedfs/metadata/xattrs_backend.go
@@ -66,6 +66,7 @@ func (XattrsBackend) List(ctx context.Context, filePath string) (attribs []strin
 		return attrs, nil
 	}
 
+	// FIXME and we have no name
 	f, err := lockedfile.OpenFile(filePath+filelocks.LockFileSuffix, os.O_CREATE|os.O_WRONLY, 0600)
 	if err != nil {
 		return nil, err
@@ -119,6 +120,7 @@ func (XattrsBackend) SetMultiple(ctx context.Context, path string, attribs map[s
 		if err != nil {
 			return err
 		}
+		// FIXME and we have no name
 		lockedFile, err := lockedfile.OpenFile(path+filelocks.LockFileSuffix, os.O_CREATE|os.O_WRONLY, 0600)
 		if err != nil {
 			return err
@@ -148,6 +150,7 @@ func (XattrsBackend) SetMultiple(ctx context.Context, path string, attribs map[s
 // Remove an extended attribute key
 func (XattrsBackend) Remove(ctx context.Context, filePath string, key string, acquireLock bool) (err error) {
 	if acquireLock {
+		// FIXME and we have no name
 		lockedFile, err := lockedfile.OpenFile(filePath+filelocks.LockFileSuffix, os.O_CREATE|os.O_WRONLY, 0600)
 		if err != nil {
 			return err

--- a/pkg/storage/utils/decomposedfs/revisions.go
+++ b/pkg/storage/utils/decomposedfs/revisions.go
@@ -209,7 +209,7 @@ func (fs *Decomposedfs) RestoreRevision(ctx context.Context, ref *provider.Refer
 	}
 
 	// write lock node before copying metadata
-	f, err := lockedfile.OpenFile(fs.lu.MetadataBackend().LockfilePath(n.InternalPath()), os.O_RDWR|os.O_CREATE, 0600)
+	f, err := lockedfile.OpenFile(fs.lu.MetadataBackend().LockfilePath(n.ParentPath()+"-"+n.Name), os.O_RDWR|os.O_CREATE, 0600)
 	if err != nil {
 		return err
 	}
@@ -262,6 +262,7 @@ func (fs *Decomposedfs) RestoreRevision(ctx context.Context, ref *provider.Refer
 
 	// copy blob metadata from restored revision to node
 	restoredRevisionPath := fs.lu.InternalPath(spaceID, revisionKey)
+	// FIXME what do we pass as restoredRevisionPath here? shouldn't we lock by name? didn't we already lock the node? why do we have to lock the individual revisions?
 	err = fs.lu.CopyMetadata(ctx, restoredRevisionPath, nodePath, func(attributeName string, value []byte) (newValue []byte, copy bool) {
 		if attributeName == prefixes.MTimeAttr {
 			// update mtime

--- a/pkg/storage/utils/decomposedfs/tree/propagator/async.go
+++ b/pkg/storage/utils/decomposedfs/tree/propagator/async.go
@@ -279,6 +279,7 @@ func (p AsyncPropagator) propagate(ctx context.Context, spaceID, nodeID string, 
 
 	var f *lockedfile.File
 	// lock parent before reading treesize or tree time
+	// FIXME and we have no name ... we could try locking files by parent-child and dirs by id?
 	nodePath := filepath.Join(p.lookup.InternalRoot(), "spaces", lookup.Pathify(spaceID, 1, 2), "nodes", lookup.Pathify(nodeID, 4, 2))
 
 	_, subspan = tracer.Start(ctx, "lockedfile.OpenFile")

--- a/pkg/storage/utils/decomposedfs/tree/propagator/sync.go
+++ b/pkg/storage/utils/decomposedfs/tree/propagator/sync.go
@@ -84,6 +84,7 @@ func (p SyncPropagator) Propagate(ctx context.Context, n *node.Node, sizeDiff in
 
 		_, subspan := tracer.Start(ctx, "lockedfile.OpenFile")
 		parentFilename := p.lookup.MetadataBackend().LockfilePath(n.ParentPath())
+		// FIXME again no name ... lock dir metadata by id?
 		f, err = lockedfile.OpenFile(parentFilename, os.O_RDWR|os.O_CREATE, 0600)
 		subspan.End()
 		if err != nil {

--- a/pkg/storage/utils/decomposedfs/upload/store.go
+++ b/pkg/storage/utils/decomposedfs/upload/store.go
@@ -260,7 +260,7 @@ func (store OcisStore) initNewNode(ctx context.Context, session *OcisSession, n 
 	}
 
 	// create and write lock new node metadata
-	f, err := lockedfile.OpenFile(store.lu.MetadataBackend().LockfilePath(n.InternalPath()), os.O_RDWR|os.O_CREATE, 0600)
+	f, err := lockedfile.OpenFile(store.lu.MetadataBackend().LockfilePath(n.ParentPath()+"-"+n.Name), os.O_RDWR|os.O_CREATE, 0600)
 	if err != nil {
 		return nil, err
 	}
@@ -298,7 +298,7 @@ func (store OcisStore) initNewNode(ctx context.Context, session *OcisSession, n 
 }
 
 func (store OcisStore) updateExistingNode(ctx context.Context, session *OcisSession, n *node.Node, spaceID string, fsize uint64) (*lockedfile.File, error) {
-	targetPath := n.InternalPath()
+	targetPath := n.ParentPath() + "-" + n.Name
 
 	// write lock existing node before reading any metadata
 	f, err := lockedfile.OpenFile(store.lu.MetadataBackend().LockfilePath(targetPath), os.O_RDWR|os.O_CREATE, 0600)


### PR DESCRIPTION
In order to be able to lock a new node during upload of a new file we need to be able to lock a node that does not exist, which would work by a parentid&childname based lock. buuut that has problems.

Another solution would be to create the node with the InitiateUpload call. Similar to an fopen it should always create a 0 byte file. This will generate an id that can subsequently be used. IMO we need a 0 byte file so clients can detect that a new file was created. They can then check the upload progress and even get access to the postprocessing status.

But... this needs to be compatible with the sync algorithm used by the clients.