### PR TITLE
more efficient share jail

### DIFF
--- a/changelog/unreleased/more-efficient-share-jail.md
+++ b/changelog/unreleased/more-efficient-share-jail.md
@@ -1,0 +1,5 @@
+Bugfix: more efficient share jail
+
+The share jail was stating every shared recource twice when listing the share jail root. For no good reason. And it was not sending filters when it could.
+
+https://github.com/cs3org/reva/pull/4452


### PR DESCRIPTION
The share jail was stating every shared recource twice when listing the share jail root. For no good reason. And it was not sending filters when it could.

This effectively halves all stat reqeusts made by the desktop client when the share jail changed. We could improve even further by cahcing the stat responses for 5sec. Then the client would make a `Depth: 0` PROPFIND, get a new etag and then issue a `Depth: 1` PROPFIND where we could just reuse the stats we just made. 

Furthermore ... the Client should just directly make a `Depth: 1` PROPFIND with a `If-None-Match` header set to the last known etag. That would also help. cc @TheOneRing @michaelstingl

needs backport to stable4 IMO cc @micbar 