### PR TITLE
Fix lost revisions

### DIFF
--- a/changelog/unreleased/do-not-lose-revisions.md
+++ b/changelog/unreleased/do-not-lose-revisions.md
@@ -1,0 +1,5 @@
+Bugfix: Do not lose revisions when restoring the first revision
+
+We fixed a problem where restoring the very first version of a file could delete the current version.
+
+https://github.com/cs3org/reva/pull/4456

--- a/pkg/storage/utils/decomposedfs/revisions.go
+++ b/pkg/storage/utils/decomposedfs/revisions.go
@@ -263,10 +263,6 @@ func (fs *Decomposedfs) RestoreRevision(ctx context.Context, ref *provider.Refer
 	// copy blob metadata from restored revision to node
 	restoredRevisionPath := fs.lu.InternalPath(spaceID, revisionKey)
 	err = fs.lu.CopyMetadata(ctx, restoredRevisionPath, nodePath, func(attributeName string, value []byte) (newValue []byte, copy bool) {
-		if attributeName == prefixes.MTimeAttr {
-			// update mtime
-			return []byte(time.Now().UTC().Format(time.RFC3339Nano)), true
-		}
 		return value, strings.HasPrefix(attributeName, prefixes.ChecksumPrefix) ||
 			attributeName == prefixes.TypeAttr ||
 			attributeName == prefixes.BlobIDAttr ||
@@ -275,7 +271,12 @@ func (fs *Decomposedfs) RestoreRevision(ctx context.Context, ref *provider.Refer
 	if err != nil {
 		return errtypes.InternalError("failed to copy blob xattrs to old revision to node: " + err.Error())
 	}
-
+	// always set the node mtime to the current time
+	fs.lu.MetadataBackend().SetMultiple(ctx, nodePath,
+		map[string][]byte{
+			prefixes.MTimeAttr: []byte(time.Now().UTC().Format(time.RFC3339Nano)),
+		},
+		false)
 	revisionSize, err := fs.lu.MetadataBackend().GetInt64(ctx, restoredRevisionPath, prefixes.BlobsizeAttr)
 	if err != nil {
 		return errtypes.InternalError("failed to read blob size xattr from old revision")

--- a/pkg/storage/utils/decomposedfs/revisions.go
+++ b/pkg/storage/utils/decomposedfs/revisions.go
@@ -272,11 +272,15 @@ func (fs *Decomposedfs) RestoreRevision(ctx context.Context, ref *provider.Refer
 		return errtypes.InternalError("failed to copy blob xattrs to old revision to node: " + err.Error())
 	}
 	// always set the node mtime to the current time
-	fs.lu.MetadataBackend().SetMultiple(ctx, nodePath,
+	err = fs.lu.MetadataBackend().SetMultiple(ctx, nodePath,
 		map[string][]byte{
 			prefixes.MTimeAttr: []byte(time.Now().UTC().Format(time.RFC3339Nano)),
 		},
 		false)
+	if err != nil {
+		return errtypes.InternalError("failed to set mtime attribute on node: " + err.Error())
+	}
+
 	revisionSize, err := fs.lu.MetadataBackend().GetInt64(ctx, restoredRevisionPath, prefixes.BlobsizeAttr)
 	if err != nil {
 		return errtypes.InternalError("failed to read blob size xattr from old revision")

--- a/pkg/storage/utils/decomposedfs/tree/tree.go
+++ b/pkg/storage/utils/decomposedfs/tree/tree.go
@@ -152,6 +152,11 @@ func (t *Tree) TouchFile(ctx context.Context, n *node.Node, markprocessing bool,
 		if err := n.SetMtimeString(ctx, mtime); err != nil {
 			return errors.Wrap(err, "Decomposedfs: could not set mtime")
 		}
+	} else {
+		now := time.Now()
+		if err := n.SetMtime(ctx, &now); err != nil {
+			return errors.Wrap(err, "Decomposedfs: could not set mtime")
+		}
 	}
 	err = n.SetXattrsWithContext(ctx, attributes, true)
 	if err != nil {


### PR DESCRIPTION
This fixes a problem where restoring a revision generated by `TouchFile` overwrites another version.

Fixes https://github.com/owncloud/enterprise/issues/6249