### PR TITLE
Prevent concurrent reads writes

### DIFF
--- a/changelog/unreleased/fix-concurrent-map-access.md
+++ b/changelog/unreleased/fix-concurrent-map-access.md
@@ -1,0 +1,5 @@
+Bugfix: Fix concurrent map access in sharecache
+
+We fixed a problem where the sharecache map would sometimes cause a panic when being accessed concurrently.
+
+https://github.com/cs3org/reva/pull/4457

--- a/pkg/share/manager/jsoncs3/jsoncs3_test.go
+++ b/pkg/share/manager/jsoncs3/jsoncs3_test.go
@@ -689,7 +689,8 @@ var _ = Describe("Jsoncs3", func() {
 				err = os.WriteFile(filepath.Join(tmpdir, "users/admin/created.json"), bytes, 0x755)
 				Expect(err).ToNot(HaveOccurred())
 
-				m.CreatedCache.UserShares["admin"].Etag = "reset1" // trigger reload
+				cc, _ := m.CreatedCache.UserShares.Load("admin")
+				cc.Etag = "reset1" // trigger reload
 				shares, err = m.ListShares(ctx, nil)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(len(shares)).To(Equal(2))

--- a/pkg/share/manager/jsoncs3/sharecache/sharecache_test.go
+++ b/pkg/share/manager/jsoncs3/sharecache/sharecache_test.go
@@ -71,11 +71,14 @@ var _ = Describe("Sharecache", func() {
 			})
 
 			It("updates the etag", func() {
-				oldEtag := c.UserShares[userid].Etag
+				uc, _ := c.UserShares.Load(userid)
+				oldEtag := uc.Etag
 				Expect(oldEtag).ToNot(BeEmpty())
 
 				Expect(c.Persist(ctx, userid)).To(Succeed())
-				Expect(c.UserShares[userid].Etag).ToNot(Equal(oldEtag))
+
+				uc, _ = c.UserShares.Load(userid)
+				Expect(uc.Etag).ToNot(Equal(oldEtag))
 			})
 		})
 	})


### PR DESCRIPTION
We fixed a problem where the sharecache map would sometimes cause a panic when being accessed concurrently.

Fixes https://github.com/owncloud/ocis/issues/8171