### PR TITLE
fix the resource name

### DIFF
--- a/changelog/unreleased/fix-resource-name.md
+++ b/changelog/unreleased/fix-resource-name.md
@@ -1,0 +1,6 @@
+Bugfix: Fix the resource name
+
+We fixed a problem where after renaming resource as sharer the receiver see a new name.
+
+https://github.com/cs3org/reva/pull/4463
+https://github.com/owncloud/ocis/issues/8242

--- a/internal/grpc/services/sharesstorageprovider/sharesstorageprovider.go
+++ b/internal/grpc/services/sharesstorageprovider/sharesstorageprovider.go
@@ -859,6 +859,7 @@ func (s *service) ListContainer(ctx context.Context, req *provider.ListContainer
 				OpaqueId:  share.Share.Id.OpaqueId,
 			}
 			info.Path = filepath.Base(share.MountPoint.Path)
+			info.Name = info.Path
 
 			infos = append(infos, info)
 		}


### PR DESCRIPTION
After the sharer changed the name of a shared resource, the receiver can see the new name, but cannot access it by using the new name.
We fixed a problem where after renaming the resource as sharer the receiver see a new name.
[https://github.com/owncloud/ocis/issues/8242](https://github.com/owncloud/ocis/issues/8242)
