### PR TITLE
fix `nats-js-kv` store

### DIFF
--- a/changelog/unreleased/fix-nats-store.md
+++ b/changelog/unreleased/fix-nats-store.md
@@ -1,0 +1,5 @@
+Bugfix: Fix natsjskv store
+
+Small mistake in last iteration made authorization not working.
+
+https://github.com/cs3org/reva/pull/4466

--- a/pkg/storage/utils/decomposedfs/options/options.go
+++ b/pkg/storage/utils/decomposedfs/options/options.go
@@ -91,11 +91,7 @@ type AsyncPropagatorOptions struct {
 
 // EventOptions are the configurable options for events
 type EventOptions struct {
-	NatsAddress          string `mapstructure:"natsaddress"`
-	NatsClusterID        string `mapstructure:"natsclusterid"`
-	TLSInsecure          bool   `mapstructure:"tlsinsecure"`
-	TLSRootCACertificate string `mapstructure:"tlsrootcacertificate"`
-	NumConsumers         int    `mapstructure:"numconsumers"`
+	NumConsumers int `mapstructure:"numconsumers"`
 }
 
 // TokenOptions are the configurable option for tokens

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -151,8 +151,8 @@ func Create(opts ...microstore.Option) microstore.Store {
 		}
 		return natsjskv.NewStore(
 			append(opts,
-				natsjs.NatsOptions(natsOptions), // always pass in properly initialized default nats options
-				natsjs.DefaultTTL(ttl))...,
+				natsjskv.NatsOptions(natsOptions), // always pass in properly initialized default nats options
+				natsjskv.DefaultTTL(ttl))...,
 		)
 	case TypeMemory, "mem", "": // allow existing short form and use as default
 		return microstore.NewMemoryStore(opts...)


### PR DESCRIPTION
Fixes a small mistake made during previous iteration.

Also removes some unused config.