### PR TITLE
Fix /dav/meta inconsistency

### DIFF
--- a/changelog/unreleased/fix-dav-meta.md
+++ b/changelog/unreleased/fix-dav-meta.md
@@ -1,0 +1,5 @@
+Bugfix: Make /dav/meta consistent
+
+We now also return absolute paths for shares in the share jail in the /dav/meta endpoint.
+
+https://github.com/cs3org/reva/pull/4474

--- a/internal/grpc/services/sharesstorageprovider/sharesstorageprovider.go
+++ b/internal/grpc/services/sharesstorageprovider/sharesstorageprovider.go
@@ -321,7 +321,7 @@ func (s *service) GetPath(ctx context.Context, req *provider.GetPathRequest) (*p
 
 	return &provider.GetPathResponse{
 		Status: status.NewOK(ctx),
-		Path:   receivedShare.MountPoint.Path,
+		Path:   filepath.Clean("/" + receivedShare.MountPoint.Path),
 	}, nil
 
 }


### PR DESCRIPTION
We now return absolute paths for shares in the share jail to make it consistent with all the other cases.

Fixes https://github.com/owncloud/ocis/issues/8224