### PR TITLE
upload session specific processing flag

### DIFF
--- a/changelog/unreleased/uploadsession-specific-processing-flag.md
+++ b/changelog/unreleased/uploadsession-specific-processing-flag.md
@@ -1,0 +1,5 @@
+Bugfix: upload session specific processing flag
+
+To make every upload session have a dedicated processing status, upload sessions are now treated as in processing when all bytes have been received instead of checking the node metadata.
+
+https://github.com/cs3org/reva/pull/4475

--- a/pkg/storage/utils/decomposedfs/upload/session.go
+++ b/pkg/storage/utils/decomposedfs/upload/session.go
@@ -295,13 +295,9 @@ func (s *OcisSession) MTime() time.Time {
 	return t
 }
 
-// IsProcessing returns true if the node has entered postprocessing state
+// IsProcessing returns true if all bytes have been received. The node then has entered postprocessing state.
 func (s *OcisSession) IsProcessing() bool {
-	n, err := s.Node(context.Background())
-	if err != nil {
-		return false
-	}
-	return n.IsProcessing(context.Background())
+	return s.info.Size == s.info.Offset
 }
 
 // binPath returns the path to the file storing the binary data.


### PR DESCRIPTION
To make every upload session have a dedicated processing status, upload sessions are now treated as in processing when all bytes have been received instead of checking the node metadata.
