### PR TITLE
no need to unmark postprocessing when it was not started

### DIFF
--- a/changelog/unreleased/no-need-to-unmark-postprocessing-when-it-was-not-started.md
+++ b/changelog/unreleased/no-need-to-unmark-postprocessing-when-it-was-not-started.md
@@ -1,0 +1,3 @@
+Bugfix: no need to unmark postprocessing when it was not started
+
+https://github.com/cs3org/reva/pull/4476

--- a/pkg/storage/utils/decomposedfs/upload/session.go
+++ b/pkg/storage/utils/decomposedfs/upload/session.go
@@ -295,7 +295,7 @@ func (s *OcisSession) MTime() time.Time {
 	return t
 }
 
-// IsProcessing returns true if all bytes have been received. The node then has entered postprocessing state.
+// IsProcessing returns true if all bytes have been received. The session then has entered postprocessing state.
 func (s *OcisSession) IsProcessing() bool {
 	return s.info.Size == s.info.Offset
 }

--- a/pkg/storage/utils/decomposedfs/upload/upload.go
+++ b/pkg/storage/utils/decomposedfs/upload/upload.go
@@ -191,7 +191,7 @@ func (session *OcisSession) FinishUpload(ctx context.Context) error {
 
 	n, err := session.store.CreateNodeForUpload(session, attrs)
 	if err != nil {
-		session.store.Cleanup(ctx, session, true, false, true)
+		session.store.Cleanup(ctx, session, true, false, false)
 		return err
 	}
 


### PR DESCRIPTION
to align with https://github.com/cs3org/reva/pull/4470