### PR TITLE
Extend ResumePostprocessingEvent

### DIFF
--- a/changelog/unreleased/extend-resumepp-event.md
+++ b/changelog/unreleased/extend-resumepp-event.md
@@ -1,0 +1,7 @@
+Enhancement: Extend ResumePostprocessing event
+
+Instead of just sending an uploadID, one can set a postprocessing step now to restart all uploads in this step
+Also adds a new postprocessing step - "finished" - which means that postprocessing is finished but the storage provider
+hasn't acknowledged it yet.
+
+https://github.com/cs3org/reva/pull/4477

--- a/pkg/events/postprocessing.go
+++ b/pkg/events/postprocessing.go
@@ -42,6 +42,8 @@ var (
 	PPStepPolicies Postprocessingstep = "policies"
 	// PPStepDelay is the step that processing. Useful for testing or user annoyment
 	PPStepDelay Postprocessingstep = "delay"
+	// PPStepFinished is the step that signals that postprocessing is finished, but storage provider hasn't acknowledged it yet
+	PPStepFinished Postprocessingstep = "finished"
 
 	// PPOutcomeDelete means that the file and the upload should be deleted
 	PPOutcomeDelete PostprocessingOutcome = "delete"
@@ -193,6 +195,7 @@ func (UploadReady) Unmarshal(v []byte) (interface{}, error) {
 // ResumePostprocessing can be emitted to repair broken postprocessing
 type ResumePostprocessing struct {
 	UploadID  string
+	Step      Postprocessingstep
 	Timestamp *types.Timestamp
 }
 


### PR DESCRIPTION
Instead of just sending an uploadID, one can set a postprocessing step now to restart all uploads in this step
Also adds a new postprocessing step - "finished" - which means that postprocessing is finished but the storage provider
hasn't acknowledged it yet.