### PR TITLE
distinguish failure and node metadata reversal

### DIFF
--- a/changelog/unreleased/distinguish-failure-and-node-metadata-reversal.md
+++ b/changelog/unreleased/distinguish-failure-and-node-metadata-reversal.md
@@ -1,0 +1,5 @@
+Bugfix: distinguish failure and node metadata reversal
+
+When the final blob move fails we must not remove the node metadata to be able to restart the postprocessing process.
+
+https://github.com/cs3org/reva/pull/4481


### PR DESCRIPTION
This will keep the node metadata when the final blob move failed so it can be retried.