### PR TITLE
change default for MaxConcurrency

### DIFF
--- a/changelog/unreleased/concurrence-defaults.md
+++ b/changelog/unreleased/concurrence-defaults.md
@@ -1,0 +1,6 @@
+Enhancement: Modify the concurrency default
+
+We have changed the default MaxConcurrency value from 100 to 5 to prevent too frequent gc runs on low memory systems.
+
+https://github.com/cs3org/reva/pull/4485
+https://github.com/owncloud/ocis/issues/8257

--- a/pkg/storage/utils/decomposedfs/options/options.go
+++ b/pkg/storage/utils/decomposedfs/options/options.go
@@ -149,7 +149,7 @@ func New(m map[string]interface{}) (*Options, error) {
 	}
 
 	if o.MaxConcurrency <= 0 {
-		o.MaxConcurrency = 100
+		o.MaxConcurrency = 5
 	}
 
 	if o.Propagator == "" {


### PR DESCRIPTION
Enhancement: Modify the concurrency default

We have changed the default MaxConcurrency value from 100 to 5 to prevent too frequent gc runs on low memory systems.

refs https://github.com/owncloud/ocis/issues/8257