### PR TITLE
Add filename incrementor for secret filedrops.

### DIFF
--- a/changelog/unreleased/fileincrementor-for-secret-file-drops.md
+++ b/changelog/unreleased/fileincrementor-for-secret-file-drops.md
@@ -1,0 +1,7 @@
+Enhancement: Add filename incrementor for secret filedrops
+
+We have added a function that appends a number to the filename if the file already exists in a secret filedrop. 
+This is useful if you want to upload a file with the same name multiple times.
+
+https://github.com/cs3org/reva/pull/4491
+https://github.com/owncloud/ocis/issues/8291

--- a/internal/http/services/owncloud/ocdav/context.go
+++ b/internal/http/services/owncloud/ocdav/context.go
@@ -1,0 +1,18 @@
+package ocdav
+
+import (
+	"context"
+
+	cs3storage "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+)
+
+type tokenStatInfoKey struct{}
+
+func ContextWithTokenStatInfo(ctx context.Context, info *cs3storage.ResourceInfo) context.Context {
+	return context.WithValue(ctx, tokenStatInfoKey{}, info)
+}
+
+func TokenStatInfoFromContext(ctx context.Context) (*cs3storage.ResourceInfo, bool) {
+	v, ok := ctx.Value(tokenStatInfoKey{}).(*cs3storage.ResourceInfo)
+	return v, ok
+}

--- a/internal/http/services/owncloud/ocdav/context.go
+++ b/internal/http/services/owncloud/ocdav/context.go
@@ -8,10 +8,12 @@ import (
 
 type tokenStatInfoKey struct{}
 
+// ContextWithTokenStatInfo adds the token stat info to the context
 func ContextWithTokenStatInfo(ctx context.Context, info *cs3storage.ResourceInfo) context.Context {
 	return context.WithValue(ctx, tokenStatInfoKey{}, info)
 }
 
+// TokenStatInfoFromContext returns the token stat info from the context
 func TokenStatInfoFromContext(ctx context.Context) (*cs3storage.ResourceInfo, bool) {
 	v, ok := ctx.Value(tokenStatInfoKey{}).(*cs3storage.ResourceInfo)
 	return v, ok

--- a/internal/http/services/owncloud/ocdav/dav.go
+++ b/internal/http/services/owncloud/ocdav/dav.go
@@ -318,9 +318,9 @@ func (h *DavHandler) Handler(s *svc) http.Handler {
 			}
 			log.Debug().Interface("statInfo", sRes.Info).Msg("Stat info from public link token path")
 
+			ctx := context.WithValue(ctx, tokenStatInfoKey{}, sRes.Info)
+			r = r.WithContext(ctx)
 			if sRes.Info.Type != provider.ResourceType_RESOURCE_TYPE_CONTAINER {
-				ctx := context.WithValue(ctx, tokenStatInfoKey{}, sRes.Info)
-				r = r.WithContext(ctx)
 				h.PublicFileHandler.Handler(s).ServeHTTP(w, r)
 			} else {
 				h.PublicFolderHandler.Handler(s).ServeHTTP(w, r)

--- a/internal/http/services/owncloud/ocdav/dav.go
+++ b/internal/http/services/owncloud/ocdav/dav.go
@@ -44,8 +44,6 @@ const (
 	_trashbinPath = "trash-bin"
 )
 
-type tokenStatInfoKey struct{}
-
 // DavHandler routes to the different sub handlers
 type DavHandler struct {
 	AvatarsHandler      *AvatarsHandler
@@ -318,7 +316,7 @@ func (h *DavHandler) Handler(s *svc) http.Handler {
 			}
 			log.Debug().Interface("statInfo", sRes.Info).Msg("Stat info from public link token path")
 
-			ctx := context.WithValue(ctx, tokenStatInfoKey{}, sRes.Info)
+			ctx := ContextWithTokenStatInfo(ctx, sRes.Info)
 			r = r.WithContext(ctx)
 			if sRes.Info.Type != provider.ResourceType_RESOURCE_TYPE_CONTAINER {
 				h.PublicFileHandler.Handler(s).ServeHTTP(w, r)

--- a/internal/http/services/owncloud/ocdav/errors/error.go
+++ b/internal/http/services/owncloud/ocdav/errors/error.go
@@ -159,6 +159,8 @@ var (
 	ErrNoSuchLock = errors.New("webdav: no such lock")
 	// ErrNotImplemented is returned when hitting not implemented code paths
 	ErrNotImplemented = errors.New("webdav: not implemented")
+	// ErrTokenNotFound is returned when a token is not found
+	ErrTokenStatInfoMissing = errors.New("webdav: token stat info missing")
 )
 
 // HandleErrorStatus checks the status code, logs a Debug or Error level message

--- a/internal/http/services/owncloud/ocdav/filedrop.go
+++ b/internal/http/services/owncloud/ocdav/filedrop.go
@@ -40,7 +40,7 @@ func FindName(ctx context.Context, client gatewayv1beta1.GatewayAPIClient, name 
 	// starts with two because "normal" humans begin counting with 1 and we say the existing file is the first one
 	for i := 2; i < len(itemMap)+3; i++ {
 		if _, ok := itemMap[fileName+" ("+strconv.Itoa(i)+")"+ext]; !ok {
-			return fileName + " (" + strconv.Itoa(i) + ")" + ext, nil, nil
+			return fileName + " (" + strconv.Itoa(i) + ")" + ext, lRes.GetStatus(), nil
 		}
 	}
 	return "", nil, errors.New("could not determine new filename")

--- a/internal/http/services/owncloud/ocdav/filedrop.go
+++ b/internal/http/services/owncloud/ocdav/filedrop.go
@@ -1,0 +1,47 @@
+package ocdav
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	gatewayv1beta1 "github.com/cs3org/go-cs3apis/cs3/gateway/v1beta1"
+	rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
+	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+)
+
+// FindName returns the next filename available when the current
+func FindName(ctx context.Context, client gatewayv1beta1.GatewayAPIClient, name string, parentid *provider.ResourceId) (string, *rpc.Status, error) {
+	lReq := &provider.ListContainerRequest{
+		Ref: &provider.Reference{
+			ResourceId: parentid,
+		},
+	}
+	lRes, err := client.ListContainer(ctx, lReq)
+	if err != nil {
+		return "", nil, err
+	}
+	if lRes.Status.Code != rpc.Code_CODE_OK {
+		return "", lRes.Status, nil
+	}
+	// iterate over the listing to determine next suffix
+	var itemMap = make(map[string]struct{})
+	for _, fi := range lRes.Infos {
+		itemMap[fi.GetName()] = struct{}{}
+	}
+	ext := filepath.Ext(name)
+	fileName := strings.TrimSuffix(name, ext)
+	if strings.HasSuffix(fileName, ".tar") {
+		fileName = strings.TrimSuffix(fileName, ".tar")
+		ext = filepath.Ext(fileName) + "." + ext
+	}
+	// starts with two because "normal" humans begin counting with 1 and we say the existing file is the first one
+	for i := 2; i < len(itemMap)+3; i++ {
+		if _, ok := itemMap[fileName+" ("+strconv.Itoa(i)+")"+ext]; !ok {
+			return fileName + " (" + strconv.Itoa(i) + ")" + ext, nil, nil
+		}
+	}
+	return "", nil, errors.New("could not determine new filename")
+}

--- a/internal/http/services/owncloud/ocdav/tus.go
+++ b/internal/http/services/owncloud/ocdav/tus.go
@@ -117,11 +117,11 @@ func (s *svc) handleTusPost(ctx context.Context, w http.ResponseWriter, r *http.
 		return
 	}
 
-	var isSecretFileDrop bool
 	// Test if the target is a secret filedrop
-	tokenStatInfo := r.Context().Value(tokenStatInfoKey{}).(*provider.ResourceInfo)
+	var isSecretFileDrop bool
+	tokenStatInfo, ok := TokenStatInfoFromContext(ctx)
 	// We assume that when the uploader can create containers, but is not allowed to list them, it is a secret file drop
-	if tokenStatInfo.GetPermissionSet().CreateContainer && !tokenStatInfo.GetPermissionSet().ListContainer {
+	if ok && tokenStatInfo.GetPermissionSet().CreateContainer && !tokenStatInfo.GetPermissionSet().ListContainer {
 		isSecretFileDrop = true
 	}
 

--- a/internal/http/services/owncloud/ocdav/tus.go
+++ b/internal/http/services/owncloud/ocdav/tus.go
@@ -176,12 +176,12 @@ func (s *svc) handleTusPost(ctx context.Context, w http.ResponseWriter, r *http.
 				w.WriteHeader(http.StatusInternalServerError)
 				return
 			}
-			if status.Code != rpc.Code_CODE_OK {
+			if status.GetCode() != rpc.Code_CODE_OK {
 				log.Error().Interface("status", status).Msg("error listing file")
 				errors.HandleErrorStatus(&log, w, status)
 				return
 			}
-			ref.Path = utils.MakeRelativePath(filepath.Join(filepath.Dir(ref.GetPath()), newName))
+			ref.Path = filepath.Join(filepath.Dir(ref.GetPath()), newName)
 			sRes.GetInfo().Name = newName
 		}
 	}

--- a/internal/http/services/owncloud/ocdav/tus.go
+++ b/internal/http/services/owncloud/ocdav/tus.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"net/http"
 	"path"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -115,6 +116,15 @@ func (s *svc) handleTusPost(ctx context.Context, w http.ResponseWriter, r *http.
 		w.WriteHeader(http.StatusPreconditionFailed)
 		return
 	}
+
+	var isSecretFileDrop bool
+	// Test if the target is a secret filedrop
+	tokenStatInfo := r.Context().Value(tokenStatInfoKey{}).(*provider.ResourceInfo)
+	// We assume that when the uploader can create containers, but is not allowed to list them, it is a secret file drop
+	if tokenStatInfo.GetPermissionSet().CreateContainer && !tokenStatInfo.GetPermissionSet().ListContainer {
+		isSecretFileDrop = true
+	}
+
 	// r.Header.Get(net.HeaderOCChecksum)
 	// TODO must be SHA1, ADLER32 or MD5 ... in capital letters????
 	// curl -X PUT https://demo.owncloud.com/remote.php/webdav/testcs.bin -u demo:demo -d '123' -v -H 'OC-Checksum: SHA1:40bd001563085fc35165329ea1ff5c5ecbdbbeef'
@@ -156,6 +166,43 @@ func (s *svc) handleTusPost(ctx context.Context, w http.ResponseWriter, r *http.
 				log.Warn().Str("client-etag", clientETag).Str("server-etag", serverETag).Msg("etags mismatch")
 				w.WriteHeader(http.StatusPreconditionFailed)
 				return
+			}
+		}
+		if isSecretFileDrop {
+			lReq := &provider.ListContainerRequest{
+				Ref: &provider.Reference{
+					ResourceId: sRes.GetInfo().GetParentId(),
+				},
+			}
+			lRes, err := client.ListContainer(ctx, lReq)
+			if err != nil {
+				log.Error().Err(err).Msg("error sending grpc stat request")
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			if lRes.Status.Code != rpc.Code_CODE_OK {
+				log.Debug().Err(err).Msg("error listing container")
+				errors.HandleErrorStatus(&log, w, lRes.Status)
+				return
+			}
+			// iterate over the listing to determine next suffix
+			var itemMap = make(map[string]struct{})
+			for _, fi := range lRes.Infos {
+				itemMap[fi.GetName()] = struct{}{}
+			}
+			ext := filepath.Ext(sRes.GetInfo().GetName())
+			fileName := strings.TrimSuffix(sRes.GetInfo().GetName(), ext)
+			if strings.HasSuffix(fileName, ".tar") {
+				fileName = strings.TrimSuffix(fileName, ".tar")
+				ext = filepath.Ext(fileName) + "." + ext
+			}
+			// starts with two because "normal" humans begin counting with 1 and we say the existing file is the first one
+			for i := 2; i < len(itemMap)+3; i++ {
+				if _, ok := itemMap[fileName+" ("+strconv.Itoa(i)+")"+ext]; !ok {
+					sRes.GetInfo().Name = fileName + " (" + strconv.Itoa(i) + ")" + ext
+					ref.Path = filepath.Join(filepath.Dir(ref.GetPath()), sRes.GetInfo().GetName())
+					break
+				}
 			}
 		}
 	}

--- a/internal/http/services/owncloud/ocdav/tus.go
+++ b/internal/http/services/owncloud/ocdav/tus.go
@@ -169,41 +169,20 @@ func (s *svc) handleTusPost(ctx context.Context, w http.ResponseWriter, r *http.
 			}
 		}
 		if isSecretFileDrop {
-			lReq := &provider.ListContainerRequest{
-				Ref: &provider.Reference{
-					ResourceId: sRes.GetInfo().GetParentId(),
-				},
-			}
-			lRes, err := client.ListContainer(ctx, lReq)
+			// find next filename
+			newName, status, err := FindName(ctx, client, filepath.Base(ref.Path), sRes.GetInfo().GetParentId())
 			if err != nil {
 				log.Error().Err(err).Msg("error sending grpc stat request")
 				w.WriteHeader(http.StatusInternalServerError)
 				return
 			}
-			if lRes.Status.Code != rpc.Code_CODE_OK {
-				log.Debug().Err(err).Msg("error listing container")
-				errors.HandleErrorStatus(&log, w, lRes.Status)
+			if status.Code != rpc.Code_CODE_OK {
+				log.Error().Interface("status", status).Msg("error listing file")
+				errors.HandleErrorStatus(&log, w, status)
 				return
 			}
-			// iterate over the listing to determine next suffix
-			var itemMap = make(map[string]struct{})
-			for _, fi := range lRes.Infos {
-				itemMap[fi.GetName()] = struct{}{}
-			}
-			ext := filepath.Ext(sRes.GetInfo().GetName())
-			fileName := strings.TrimSuffix(sRes.GetInfo().GetName(), ext)
-			if strings.HasSuffix(fileName, ".tar") {
-				fileName = strings.TrimSuffix(fileName, ".tar")
-				ext = filepath.Ext(fileName) + "." + ext
-			}
-			// starts with two because "normal" humans begin counting with 1 and we say the existing file is the first one
-			for i := 2; i < len(itemMap)+3; i++ {
-				if _, ok := itemMap[fileName+" ("+strconv.Itoa(i)+")"+ext]; !ok {
-					sRes.GetInfo().Name = fileName + " (" + strconv.Itoa(i) + ")" + ext
-					ref.Path = filepath.Join(filepath.Dir(ref.GetPath()), sRes.GetInfo().GetName())
-					break
-				}
-			}
+			ref.Path = utils.MakeRelativePath(filepath.Join(filepath.Dir(ref.GetPath()), newName))
+			sRes.GetInfo().Name = newName
 		}
 	}
 

--- a/tests/acceptance/expected-failures-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-on-OCIS-storage.md
@@ -75,13 +75,7 @@ Synchronization features like etag propagation, setting mtime and locking files
 
 #### [Upload-only shares must not overwrite but create a separate file](https://github.com/owncloud/ocis/issues/1267)
 
-- [coreApiSharePublicLink3/uploadToPublicLinkShare.feature:13](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiSharePublicLink3/uploadToPublicLinkShare.feature#L13)
-
-#### [Set quota over settings](https://github.com/owncloud/ocis/issues/1290)
-_requires a [CS3 user provisioning api that can update the quota for a user](https://github.com/cs3org/cs3apis/pull/95#issuecomment-772780683)_
-
-- [coreApiSharePublicLink3/uploadToPublicLinkShare.feature:91](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiSharePublicLink3/uploadToPublicLinkShare.feature#L91)
-- [coreApiSharePublicLink3/uploadToPublicLinkShare.feature:101](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiSharePublicLink3/uploadToPublicLinkShare.feature#L101)
+- [coreApiSharePublicLink2/uploadToPublicLinkShare.feature:13](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiSharePublicLink2/uploadToPublicLinkShare.feature#L13)
 
 #### [oc:privatelink property not returned in webdav responses](https://github.com/owncloud/product/issues/262)
 -   [coreApiWebdavProperties/getFileProperties.feature:295](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavProperties/getFileProperties.feature#L295)

--- a/tests/acceptance/expected-failures-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-on-OCIS-storage.md
@@ -75,8 +75,13 @@ Synchronization features like etag propagation, setting mtime and locking files
 
 #### [Upload-only shares must not overwrite but create a separate file](https://github.com/owncloud/ocis/issues/1267)
 
-- [coreApiSharePublicLink2/uploadToPublicLinkShare.feature:13](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiSharePublicLink2/uploadToPublicLinkShare.feature#L13)
-- [coreApiSharePublicLink2/uploadToPublicLinkShare.feature:121](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiSharePublicLink2/uploadToPublicLinkShare.feature#L121)
+- [coreApiSharePublicLink3/uploadToPublicLinkShare.feature:13](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiSharePublicLink3/uploadToPublicLinkShare.feature#L13)
+
+#### [Set quota over settings](https://github.com/owncloud/ocis/issues/1290)
+_requires a [CS3 user provisioning api that can update the quota for a user](https://github.com/cs3org/cs3apis/pull/95#issuecomment-772780683)_
+
+- [coreApiSharePublicLink3/uploadToPublicLinkShare.feature:91](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiSharePublicLink3/uploadToPublicLinkShare.feature#L91)
+- [coreApiSharePublicLink3/uploadToPublicLinkShare.feature:101](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiSharePublicLink3/uploadToPublicLinkShare.feature#L101)
 
 #### [oc:privatelink property not returned in webdav responses](https://github.com/owncloud/product/issues/262)
 -   [coreApiWebdavProperties/getFileProperties.feature:295](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavProperties/getFileProperties.feature#L295)

--- a/tests/acceptance/expected-failures-on-S3NG-storage.md
+++ b/tests/acceptance/expected-failures-on-S3NG-storage.md
@@ -74,8 +74,7 @@ Synchronization features like etag propagation, setting mtime and locking files
 
 #### [Upload-only shares must not overwrite but create a separate file](https://github.com/owncloud/ocis/issues/1267)
 
-- [coreApiSharePublicLink2/uploadToPublicLinkShare.feature:13](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiSharePublicLink2/uploadToPublicLinkShare.feature#L13)
-- [coreApiSharePublicLink2/uploadToPublicLinkShare.feature:121](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiSharePublicLink2/uploadToPublicLinkShare.feature#L121)
+- [coreApiSharePublicLink3/uploadToPublicLinkShare.feature:13](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiSharePublicLink3/uploadToPublicLinkShare.feature#L13)
 
 #### [Set quota over settings](https://github.com/owncloud/ocis/issues/1290)
 _requires a [CS3 user provisioning api that can update the quota for a user](https://github.com/cs3org/cs3apis/pull/95#issuecomment-772780683)_

--- a/tests/acceptance/expected-failures-on-S3NG-storage.md
+++ b/tests/acceptance/expected-failures-on-S3NG-storage.md
@@ -74,7 +74,7 @@ Synchronization features like etag propagation, setting mtime and locking files
 
 #### [Upload-only shares must not overwrite but create a separate file](https://github.com/owncloud/ocis/issues/1267)
 
-- [coreApiSharePublicLink3/uploadToPublicLinkShare.feature:13](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiSharePublicLink3/uploadToPublicLinkShare.feature#L13)
+- [coreApiSharePublicLink2/uploadToPublicLinkShare.feature:13](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiSharePublicLink2/uploadToPublicLinkShare.feature#L13)
 
 #### [Set quota over settings](https://github.com/owncloud/ocis/issues/1290)
 _requires a [CS3 user provisioning api that can update the quota for a user](https://github.com/cs3org/cs3apis/pull/95#issuecomment-772780683)_


### PR DESCRIPTION
Enhancement: Add filename incrementor for secret filedrops

We have added a function that appends a number to the filename if the file already exists in a secret filedrop. 
This is useful if you want to upload a file with the same name multiple times.

refs https://github.com/owncloud/ocis/issues/8291