### PR TITLE
Escape download name

### DIFF
--- a/internal/http/services/owncloud/ocdav/get.go
+++ b/internal/http/services/owncloud/ocdav/get.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"path"
 	"strconv"
 	"strings"
@@ -121,7 +122,7 @@ func (s *svc) handleGet(ctx context.Context, w http.ResponseWriter, r *http.Requ
 
 	w.Header().Set(HeaderContentType, info.MimeType)
 	w.Header().Set(HeaderContentDisposistion, "attachment; filename*=UTF-8''"+
-		path.Base(r.URL.Path)+"; filename=\""+path.Base(r.URL.Path)+"\"")
+		url.PathEscape(path.Base(r.URL.Path))+"; filename=\""+path.Base(r.URL.Path)+"\"")
 	w.Header().Set(HeaderETag, info.Etag)
 	w.Header().Set(HeaderOCFileID, resourceid.OwnCloudResourceIDWrap(info.Id))
 	w.Header().Set(HeaderOCETag, info.Etag)


### PR DESCRIPTION
@glpatcern Can you check if this fixes the download bug?

Other option is to port the "fix" our fork had: https://github.com/cernbox/reva/commit/3bcb3f7c4421603457458cfb3a9be51f41b2b1c3