### PR TITLE
fix content-dispostion header in dav

### DIFF
--- a/changelog/unreleased/fix-content-disposition-header.md
+++ b/changelog/unreleased/fix-content-disposition-header.md
@@ -1,0 +1,6 @@
+Bugfix: Fix Content-Disposition header in dav
+
+We have added missing quotes to the Content-Disposition header in the dav service. This fixes an issue with files containing special characters in their names.
+
+https://github.com/cs3org/reva/pull/4498
+https://github.com/owncloud/ocis/issues/8361

--- a/internal/http/services/owncloud/ocdav/net/builders.go
+++ b/internal/http/services/owncloud/ocdav/net/builders.go
@@ -27,7 +27,7 @@ import (
 
 // ContentDispositionAttachment builds a ContentDisposition Attachment header with various filename encodings
 func ContentDispositionAttachment(filename string) string {
-	return "attachment; filename*=UTF-8''" + filename + "; filename=\"" + filename + "\""
+	return "attachment; filename*=UTF-8''\"" + filename + "\"; filename=\"" + filename + "\""
 }
 
 // RFC1123Z formats a CS3 Timestamp to be used in HTTP headers like Last-Modified

--- a/tests/acceptance/expected-failures-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-on-OCIS-storage.md
@@ -287,5 +287,10 @@ _The below features have been added after I last categorized them. AFAICT they a
 - [coreApiWebdavMove2/moveFile.feature:121](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavMove2/moveFile.feature#L121)
 - [coreApiWebdavMove2/moveFile.feature:126](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavMove2/moveFile.feature#L126)
 
+### [Fix Content-Dispositon header for download requests](
+- [coreApiVersions/fileVersions.feature:158](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiVersions/fileVersions.feature#L158)
+- [coreApiVersions/fileVersions.feature:176](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiVersions/fileVersions.feature#L176)
+)
+
 - Note: always have an empty line at the end of this file.
 The bash script that processes this file may not process a scenario reference on the last line.

--- a/tests/acceptance/expected-failures-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-on-OCIS-storage.md
@@ -287,10 +287,12 @@ _The below features have been added after I last categorized them. AFAICT they a
 - [coreApiWebdavMove2/moveFile.feature:121](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavMove2/moveFile.feature#L121)
 - [coreApiWebdavMove2/moveFile.feature:126](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavMove2/moveFile.feature#L126)
 
-### [Fix Content-Dispositon header for download requests](
+### [Fix Content-Dispositon header for download requests](https://github.com/owncloud/ocis/issues/8361)
 - [coreApiVersions/fileVersions.feature:158](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiVersions/fileVersions.feature#L158)
 - [coreApiVersions/fileVersions.feature:176](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiVersions/fileVersions.feature#L176)
-)
+- [coreApiWebdavOperations/downloadFile.feature:283](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavOperations/downloadFile.feature#L283)
+- [coreApiWebdavOperations/downloadFile.feature:284](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavOperations/downloadFile.feature#L284)
+- [coreApiWebdavOperations/downloadFile.feature:289](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavOperations/downloadFile.feature#L289)
 
 - Note: always have an empty line at the end of this file.
 The bash script that processes this file may not process a scenario reference on the last line.

--- a/tests/acceptance/expected-failures-on-S3NG-storage.md
+++ b/tests/acceptance/expected-failures-on-S3NG-storage.md
@@ -290,5 +290,9 @@ _The below features have been added after I last categorized them. AFAICT they a
 - [coreApiWebdavMove2/moveFile.feature:121](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavMove2/moveFile.feature#L121)
 - [coreApiWebdavMove2/moveFile.feature:126](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavMove2/moveFile.feature#L126)
 
+### [Fix Content-Dispositon header for download requests](
+- [coreApiVersions/fileVersions.feature:158](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiVersions/fileVersions.feature#L158)
+- [coreApiVersions/fileVersions.feature:176](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiVersions/fileVersions.feature#L176)
+
 Note: always have an empty line at the end of this file.
 The bash script that processes this file may not process a scenario reference on the last line.

--- a/tests/acceptance/expected-failures-on-S3NG-storage.md
+++ b/tests/acceptance/expected-failures-on-S3NG-storage.md
@@ -290,9 +290,12 @@ _The below features have been added after I last categorized them. AFAICT they a
 - [coreApiWebdavMove2/moveFile.feature:121](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavMove2/moveFile.feature#L121)
 - [coreApiWebdavMove2/moveFile.feature:126](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavMove2/moveFile.feature#L126)
 
-### [Fix Content-Dispositon header for download requests](
+### [Fix Content-Dispositon header for download requests](https://github.com/owncloud/ocis/issues/8361)
 - [coreApiVersions/fileVersions.feature:158](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiVersions/fileVersions.feature#L158)
 - [coreApiVersions/fileVersions.feature:176](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiVersions/fileVersions.feature#L176)
+- [coreApiWebdavOperations/downloadFile.feature:283](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavOperations/downloadFile.feature#L283)
+- [coreApiWebdavOperations/downloadFile.feature:284](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavOperations/downloadFile.feature#L284)
+- [coreApiWebdavOperations/downloadFile.feature:289](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavOperations/downloadFile.feature#L289)
 
 Note: always have an empty line at the end of this file.
 The bash script that processes this file may not process a scenario reference on the last line.


### PR DESCRIPTION
Bugfix: Fix Content-Disposition header in dav

We have added missing quotes to the Content-Disposition header in the dav service. This fixes an issue with files containing special characters in their names.

https://github.com/owncloud/ocis/issues/8361
