### PR TITLE
add spaceindex.AddAll()

### DIFF
--- a/changelog/unreleased/spaceindex-addall.md
+++ b/changelog/unreleased/spaceindex-addall.md
@@ -1,0 +1,5 @@
+Enhancement: add spaceindex.AddAll()
+
+We now expose an AddAll() function that allows adding multiple entries to a space index with a single lock.
+
+https://github.com/cs3org/reva/pull/4502

--- a/pkg/storage/utils/decomposedfs/spaceidindex/spaceidindex.go
+++ b/pkg/storage/utils/decomposedfs/spaceidindex/spaceidindex.go
@@ -50,8 +50,14 @@ func (i *Index) Load(index string) (map[string]string, error) {
 }
 
 // Add adds an entry to an index
+// Consider calling AddAll() when trying to add multiple entries as every Add call has to lock the index
 func (i *Index) Add(index, key string, value string) error {
 	return i.updateIndex(index, map[string]string{key: value}, []string{})
+}
+
+// AddAll adds multiple entries to the index
+func (i *Index) AddAll(index string, m map[string]string) error {
+	return i.updateIndex(index, m, []string{})
 }
 
 // Remove removes an entry from the index


### PR DESCRIPTION
We now expose an AddAll() function that allows adding multiple entries to a space index with a single lock.

required by https://github.com/owncloud/ocis/pull/8360