### PR TITLE
allow sharemanager to disable reshares

### DIFF
--- a/changelog/unreleased/allow-disabling-resharing.md
+++ b/changelog/unreleased/allow-disabling-resharing.md
@@ -1,0 +1,5 @@
+Bugfix: the sharemanager can now reject grants with resharing permissions
+
+When disabling resharing we also need to prevent grants from allowing any grant permissions.
+
+https://github.com/cs3org/reva/pull/4516


### PR DESCRIPTION
When disabling resharing we also need to prevent grants from allowing any grant permissions.

