### PR TITLE
fix(sharesstorageprovider): Merge shares of the same resourceid

### DIFF
--- a/changelog/unreleased/fix-duplicate-sharejail-items.md
+++ b/changelog/unreleased/fix-duplicate-sharejail-items.md
@@ -1,0 +1,7 @@
+Bugfix: Fix duplicated items in the sharejail root
+
+We fixed a bug, that caused duplicate items to listed in the sharejail, when
+a user received multiple shares for the same resource.
+
+https://github.com/cs3org/reva/pull/4517  
+https://github.com/owncloud/ocis/issues/8080


### PR DESCRIPTION
When listing the sharejail root, merge shares that target the same resource into a single resource. In order to avoid the resourceId changing randomly the id will be composed from the oldest accepted share that exist for the resource.
    
Ideally we'd compose the resourceId based on the id of the shared resource, but that is currently not possible in a backwards compatible way. Some clients seem to rely on the fact that the resource ids in the sharejail contain valid shareids.
    
Fixes: https://github.com/owncloud/ocis/issues/8080

