### PR TITLE
align some ocs status codes

### DIFF
--- a/changelog/unreleased/legacy-return-code.md
+++ b/changelog/unreleased/legacy-return-code.md
@@ -1,0 +1,4 @@
+Bugfix: We aligned some OCS return codes with oc10
+
+https://github.com/cs3org/reva/pull/4529
+https://github.com/owncloud/ocis/issues/1233

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/shares.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/shares.go
@@ -693,7 +693,7 @@ func (h *Handler) GetShare(w http.ResponseWriter, r *http.Request) {
 
 	if share == nil {
 		sublog.Debug().Msg("no share found with this id")
-		response.WriteOCSError(w, r, response.MetaNotFound.StatusCode, "share not found", nil)
+		response.WriteOCSError(w, r, response.MetaPathNotFound.StatusCode, "share not found", nil) // MetaNotFount with code 998 would be cleaner, but this is a legacy api
 		return
 	}
 


### PR DESCRIPTION
Oh the inconsistency ...

fixes https://github.com/owncloud/ocis/issues/1233