### PR TITLE
jsoncs3 cache fixes

### DIFF
--- a/changelog/unreleased/jsoncs3-cache-fixes.md
+++ b/changelog/unreleased/jsoncs3-cache-fixes.md
@@ -1,0 +1,5 @@
+Bugfix: jsoncs3 cache fixes
+
+The jsoncs3 share manager now retries persisting if the file already existed and picks up the etag of the upload response in all cases.
+
+https://github.com/cs3org/reva/pull/4532


### PR DESCRIPTION
The jsoncs3 share manager now retries persisting if the file already existed and picks up the etag of the upload response in all cases.

Fixes some fallout caused by https://github.com/cs3org/reva/pull/4528 which was only detected in the ocs testsuite: https://github.com/owncloud/ocis/pull/8412#issuecomment-1954957926