### PR TITLE
fix remove/update share permissions when the file is locked

### DIFF
--- a/changelog/unreleased/fix-remove-update-share.md
+++ b/changelog/unreleased/fix-remove-update-share.md
@@ -1,0 +1,8 @@
+Bugfix: Fix remove/update share permissions
+
+This is a workaround that should prevent removing or changing the share permissions when the file is locked.
+These limitations have to be removed after the wopi server will be able to unlock the file properly.
+These limitations are not spread on the files inside the shared folder. 
+
+https://github.com/cs3org/reva/pull/4534  
+https://github.com/owncloud/ocis/issues/8273

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/shares.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/shares.go
@@ -850,8 +850,12 @@ func (h *Handler) updateShare(w http.ResponseWriter, r *http.Request, share *col
 	}
 
 	if uRes.Status.Code != rpc.Code_CODE_OK {
-		if uRes.Status.Code == rpc.Code_CODE_NOT_FOUND {
+		switch uRes.Status.Code {
+		case rpc.Code_CODE_NOT_FOUND:
 			response.WriteOCSError(w, r, response.MetaNotFound.StatusCode, "not found", nil)
+			return
+		case rpc.Code_CODE_LOCKED:
+			response.WriteOCSError(w, r, response.MetaLocked.StatusCode, uRes.GetStatus().GetMessage(), nil)
 			return
 		}
 		response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "grpc update share request failed", err)

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/user.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/user.go
@@ -293,8 +293,12 @@ func (h *Handler) removeUserShare(w http.ResponseWriter, r *http.Request, share 
 	}
 
 	if uRes.Status.Code != rpc.Code_CODE_OK {
-		if uRes.Status.Code == rpc.Code_CODE_NOT_FOUND {
+		switch uRes.Status.Code {
+		case rpc.Code_CODE_NOT_FOUND:
 			response.WriteOCSError(w, r, response.MetaNotFound.StatusCode, "not found", nil)
+			return
+		case rpc.Code_CODE_LOCKED:
+			response.WriteOCSError(w, r, response.MetaLocked.StatusCode, uRes.GetStatus().GetMessage(), nil)
 			return
 		}
 		response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "grpc delete share request failed", err)

--- a/pkg/storage/utils/decomposedfs/node/locks.go
+++ b/pkg/storage/utils/decomposedfs/node/locks.go
@@ -296,6 +296,7 @@ func readLocksIntoOpaque(ctx context.Context, n *Node, ri *provider.ResourceInfo
 		Decoder: "json",
 		Value:   b,
 	}
+	ri.Lock = lock
 	return err
 }
 


### PR DESCRIPTION
This is a workaround that should prevent removing or changing the share permissions when the file is locked.
These limitations have to be removed after the wopi server will be able to unlock the file properly.
These limitations are not spread on the files inside the shared folder. 

Related issue [https://github.com/owncloud/ocis/issues/8273](https://github.com/owncloud/ocis/issues/8273)