### PR TITLE
Kill service spanning stat cache

### DIFF
--- a/changelog/unreleased/kill-service-spanning-stat-cache.md
+++ b/changelog/unreleased/kill-service-spanning-stat-cache.md
@@ -1,0 +1,5 @@
+Change: Drop unused service spanning stat cache
+
+We removed the stat cache shared between gateway and storage providers. It is constantly invalidated and needs a different approach.
+
+https://github.com/cs3org/reva/pull/4542

--- a/internal/grpc/services/gateway/gateway.go
+++ b/internal/grpc/services/gateway/gateway.go
@@ -67,7 +67,6 @@ type config struct {
 	DataTransfersFolder            string                            `mapstructure:"data_transfers_folder"`
 	TokenManagers                  map[string]map[string]interface{} `mapstructure:"token_managers"`
 	AllowedUserAgents              map[string][]string               `mapstructure:"allowed_user_agents"` // map[path][]user-agent
-	StatCacheConfig                cache.Config                      `mapstructure:"stat_cache_config"`
 	CreatePersonalSpaceCacheConfig cache.Config                      `mapstructure:"create_personal_space_cache_config"`
 	ProviderCacheConfig            cache.Config                      `mapstructure:"provider_cache_config"`
 	UseCommonSpaceRootShareLogic   bool                              `mapstructure:"use_common_space_root_share_logic"`
@@ -117,14 +116,6 @@ func (c *config) init() {
 	}
 
 	// caching needs to be explicitly enabled
-	if c.StatCacheConfig.Store == "" {
-		c.StatCacheConfig.Store = "noop"
-	}
-
-	if c.StatCacheConfig.Database == "" {
-		c.StatCacheConfig.Database = "reva"
-	}
-
 	if c.ProviderCacheConfig.Store == "" {
 		c.ProviderCacheConfig.Store = "noop"
 	}
@@ -146,7 +137,6 @@ type svc struct {
 	c                        *config
 	dataGatewayURL           url.URL
 	tokenmgr                 token.Manager
-	statCache                cache.StatCache
 	providerCache            cache.ProviderCache
 	createPersonalSpaceCache cache.CreatePersonalSpaceCache
 }
@@ -177,7 +167,6 @@ func New(m map[string]interface{}, _ *grpc.Server) (rgrpc.Service, error) {
 		c:                        c,
 		dataGatewayURL:           *u,
 		tokenmgr:                 tokenManager,
-		statCache:                cache.GetStatCache(c.StatCacheConfig),
 		providerCache:            cache.GetProviderCache(c.ProviderCacheConfig),
 		createPersonalSpaceCache: cache.GetCreatePersonalSpaceCache(c.CreatePersonalSpaceCacheConfig),
 	}
@@ -190,7 +179,6 @@ func (s *svc) Register(ss *grpc.Server) {
 }
 
 func (s *svc) Close() error {
-	s.statCache.Close()
 	s.providerCache.Close()
 	s.createPersonalSpaceCache.Close()
 	return nil

--- a/internal/grpc/services/gateway/publicshareprovider.go
+++ b/internal/grpc/services/gateway/publicshareprovider.go
@@ -21,11 +21,9 @@ package gateway
 import (
 	"context"
 
-	userprovider "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
 	link "github.com/cs3org/go-cs3apis/cs3/sharing/link/v1beta1"
 	"github.com/cs3org/reva/v2/pkg/appctx"
-	ctxpkg "github.com/cs3org/reva/v2/pkg/ctx"
 	"github.com/cs3org/reva/v2/pkg/rgrpc/todo/pool"
 	"github.com/pkg/errors"
 )
@@ -39,15 +37,7 @@ func (s *svc) CreatePublicShare(ctx context.Context, req *link.CreatePublicShare
 		return nil, err
 	}
 
-	res, err := c.CreatePublicShare(ctx, req)
-	if err != nil {
-		return nil, err
-	}
-
-	if res.GetShare() != nil {
-		s.statCache.RemoveStatContext(ctx, ctxpkg.ContextMustGetUser(ctx).GetId(), res.Share.ResourceId)
-	}
-	return res, nil
+	return c.CreatePublicShare(ctx, req)
 }
 
 func (s *svc) RemovePublicShare(ctx context.Context, req *link.RemovePublicShareRequest) (*link.RemovePublicShareResponse, error) {
@@ -58,13 +48,7 @@ func (s *svc) RemovePublicShare(ctx context.Context, req *link.RemovePublicShare
 	if err != nil {
 		return nil, err
 	}
-	res, err := driver.RemovePublicShare(ctx, req)
-	if err != nil {
-		return nil, err
-	}
-	// TODO: How to find out the resourceId? -> get public share first, then delete
-	s.statCache.RemoveStatContext(ctx, ctxpkg.ContextMustGetUser(ctx).GetId(), nil)
-	return res, nil
+	return driver.RemovePublicShare(ctx, req)
 }
 
 func (s *svc) GetPublicShareByToken(ctx context.Context, req *link.GetPublicShareByTokenRequest) (*link.GetPublicShareByTokenResponse, error) {
@@ -137,17 +121,5 @@ func (s *svc) UpdatePublicShare(ctx context.Context, req *link.UpdatePublicShare
 		}, nil
 	}
 
-	res, err := pClient.UpdatePublicShare(ctx, req)
-	if err != nil {
-		return nil, errors.Wrap(err, "error updating share")
-	}
-	if res.GetShare() != nil {
-		s.statCache.RemoveStatContext(ctx,
-			&userprovider.UserId{
-				OpaqueId: res.Share.Owner.GetOpaqueId(),
-			},
-			res.Share.ResourceId,
-		)
-	}
-	return res, nil
+	return pClient.UpdatePublicShare(ctx, req)
 }

--- a/internal/grpc/services/gateway/storageprovider.go
+++ b/internal/grpc/services/gateway/storageprovider.go
@@ -326,7 +326,6 @@ func (s *svc) UpdateStorageSpace(ctx context.Context, req *provider.UpdateStorag
 
 	if res.Status.Code == rpc.Code_CODE_OK {
 		id := res.StorageSpace.Root
-		s.statCache.RemoveStatContext(ctx, ctxpkg.ContextMustGetUser(ctx).GetId(), id)
 		s.providerCache.RemoveListStorageProviders(id)
 	}
 	return res, nil
@@ -363,7 +362,6 @@ func (s *svc) DeleteStorageSpace(ctx context.Context, req *provider.DeleteStorag
 	}
 
 	id := &provider.ResourceId{OpaqueId: req.Id.OpaqueId}
-	s.statCache.RemoveStatContext(ctx, ctxpkg.ContextMustGetUser(ctx).GetId(), id)
 	s.providerCache.RemoveListStorageProviders(id)
 
 	if dsRes.Status.Code != rpc.Code_CODE_OK {
@@ -608,7 +606,6 @@ func (s *svc) InitiateFileUpload(ctx context.Context, req *provider.InitiateFile
 		}
 	}
 
-	s.statCache.RemoveStatContext(ctx, ctxpkg.ContextMustGetUser(ctx).GetId(), req.Ref.ResourceId)
 	return &gateway.InitiateFileUploadResponse{
 		Opaque:    storageRes.Opaque,
 		Status:    storageRes.Status,
@@ -645,7 +642,6 @@ func (s *svc) CreateContainer(ctx context.Context, req *provider.CreateContainer
 		}, nil
 	}
 
-	s.statCache.RemoveStatContext(ctx, ctxpkg.ContextMustGetUser(ctx).GetId(), req.Ref.ResourceId)
 	return res, nil
 }
 
@@ -688,7 +684,6 @@ func (s *svc) Delete(ctx context.Context, req *provider.DeleteRequest) (*provide
 		}, nil
 	}
 
-	s.statCache.RemoveStatContext(ctx, ctxpkg.ContextMustGetUser(ctx).GetId(), req.Ref.ResourceId)
 	return res, nil
 }
 
@@ -715,8 +710,6 @@ func (s *svc) Move(ctx context.Context, req *provider.MoveRequest) (*provider.Mo
 
 	req.Source = sref
 	req.Destination = dref
-	s.statCache.RemoveStatContext(ctx, ctxpkg.ContextMustGetUser(ctx).GetId(), req.Source.ResourceId)
-	s.statCache.RemoveStatContext(ctx, ctxpkg.ContextMustGetUser(ctx).GetId(), req.Destination.ResourceId)
 	return c.Move(ctx, req)
 }
 
@@ -739,7 +732,6 @@ func (s *svc) SetArbitraryMetadata(ctx context.Context, req *provider.SetArbitra
 		return nil, errors.Wrap(err, "gateway: error calling SetArbitraryMetadata")
 	}
 
-	s.statCache.RemoveStatContext(ctx, ctxpkg.ContextMustGetUser(ctx).GetId(), req.Ref.ResourceId)
 	return res, nil
 }
 
@@ -761,7 +753,6 @@ func (s *svc) UnsetArbitraryMetadata(ctx context.Context, req *provider.UnsetArb
 		}
 		return nil, errors.Wrap(err, "gateway: error calling UnsetArbitraryMetadata")
 	}
-	s.statCache.RemoveStatContext(ctx, ctxpkg.ContextMustGetUser(ctx).GetId(), req.Ref.ResourceId)
 
 	return res, nil
 }
@@ -785,7 +776,6 @@ func (s *svc) SetLock(ctx context.Context, req *provider.SetLockRequest) (*provi
 		return nil, errors.Wrap(err, "gateway: error calling SetLock")
 	}
 
-	s.statCache.RemoveStatContext(ctx, ctxpkg.ContextMustGetUser(ctx).GetId(), req.Ref.ResourceId)
 	return res, nil
 }
 
@@ -826,7 +816,6 @@ func (s *svc) RefreshLock(ctx context.Context, req *provider.RefreshLockRequest)
 		return nil, errors.Wrap(err, "gateway: error calling RefreshLock")
 	}
 
-	s.statCache.RemoveStatContext(ctx, ctxpkg.ContextMustGetUser(ctx).GetId(), req.Ref.ResourceId)
 	return res, nil
 }
 
@@ -847,12 +836,10 @@ func (s *svc) Unlock(ctx context.Context, req *provider.UnlockRequest) (*provide
 		return nil, errors.Wrap(err, "gateway: error calling Unlock")
 	}
 
-	s.statCache.RemoveStatContext(ctx, ctxpkg.ContextMustGetUser(ctx).GetId(), req.Ref.ResourceId)
 	return res, nil
 }
 
 // Stat returns the Resoure info for a given resource by forwarding the request to the responsible provider.
-// TODO cache info
 func (s *svc) Stat(ctx context.Context, req *provider.StatRequest) (*provider.StatResponse, error) {
 	c, _, ref, err := s.findAndUnwrapUnique(ctx, req.Ref)
 	if err != nil {
@@ -927,7 +914,6 @@ func (s *svc) RestoreFileVersion(ctx context.Context, req *provider.RestoreFileV
 		}, nil
 	}
 
-	s.statCache.RemoveStatContext(ctx, ctxpkg.ContextMustGetUser(ctx).GetId(), req.Ref.ResourceId)
 	return res, nil
 }
 
@@ -983,7 +969,6 @@ func (s *svc) RestoreRecycleItem(ctx context.Context, req *provider.RestoreRecyc
 		}, nil
 	}
 
-	s.statCache.RemoveStatContext(ctx, ctxpkg.ContextMustGetUser(ctx).GetId(), req.Ref.ResourceId)
 	return res, nil
 }
 
@@ -1006,7 +991,6 @@ func (s *svc) PurgeRecycle(ctx context.Context, req *provider.PurgeRecycleReques
 		}, nil
 	}
 
-	s.statCache.RemoveStatContext(ctx, ctxpkg.ContextMustGetUser(ctx).GetId(), req.Ref.ResourceId)
 	return res, nil
 }
 
@@ -1106,7 +1090,6 @@ func (s *svc) getStorageProviderClient(_ context.Context, p *registry.ProviderIn
 
 	return &cachedAPIClient{
 		c:                        c,
-		statCache:                s.statCache,
 		createPersonalSpaceCache: s.createPersonalSpaceCache,
 	}, nil
 }

--- a/internal/grpc/services/gateway/usershareprovider.go
+++ b/internal/grpc/services/gateway/usershareprovider.go
@@ -154,7 +154,6 @@ func (s *svc) updateShare(ctx context.Context, req *collaboration.UpdateShareReq
 		}
 	}
 
-	s.statCache.RemoveStatContext(ctx, ctxpkg.ContextMustGetUser(ctx).GetId(), res.Share.ResourceId)
 	return res, nil
 }
 
@@ -198,7 +197,6 @@ func (s *svc) updateSpaceShare(ctx context.Context, req *collaboration.UpdateSha
 		return res, nil
 	}
 
-	s.statCache.RemoveStatContext(ctx, ctxpkg.ContextMustGetUser(ctx).GetId(), req.GetShare().GetResourceId())
 	s.providerCache.RemoveListStorageProviders(req.GetShare().GetResourceId())
 	return res, nil
 }
@@ -282,7 +280,6 @@ func (s *svc) UpdateReceivedShare(ctx context.Context, req *collaboration.Update
 		}, nil
 	}
 
-	s.statCache.RemoveStatContext(ctx, ctxpkg.ContextMustGetUser(ctx).GetId(), req.Share.Share.ResourceId)
 	return c.UpdateReceivedShare(ctx, req)
 	/*
 		    TODO: Leftover from master merge. Do we need this?
@@ -551,7 +548,7 @@ func (s *svc) addShare(ctx context.Context, req *collaboration.CreateShareReques
 	}
 
 	if s.c.CommitShareToStorageGrant {
-		// If the share is a denial we call  denyGrant instead.
+		// If the share is a denial we call denyGrant instead.
 		var status *rpc.Status
 		if grants.PermissionsEqual(req.Grant.Permissions.Permissions, &provider.ResourcePermissions{}) {
 			status, err = s.denyGrant(ctx, req.ResourceInfo.Id, req.Grant.Grantee, nil)
@@ -569,7 +566,7 @@ func (s *svc) addShare(ctx context.Context, req *collaboration.CreateShareReques
 
 		switch status.Code {
 		case rpc.Code_CODE_OK:
-			s.statCache.RemoveStatContext(ctx, ctxpkg.ContextMustGetUser(ctx).GetId(), req.ResourceInfo.Id)
+			// ok
 		case rpc.Code_CODE_UNIMPLEMENTED:
 			appctx.GetLogger(ctx).Debug().Interface("status", status).Interface("req", req).Msg("storing grants not supported, ignoring")
 			rollBackFn(status)
@@ -613,7 +610,6 @@ func (s *svc) addSpaceShare(ctx context.Context, req *collaboration.CreateShareR
 
 	switch st.Code {
 	case rpc.Code_CODE_OK:
-		s.statCache.RemoveStatContext(ctx, ctxpkg.ContextMustGetUser(ctx).GetId(), req.ResourceInfo.Id)
 		s.providerCache.RemoveListStorageProviders(req.ResourceInfo.Id)
 	case rpc.Code_CODE_UNIMPLEMENTED:
 		appctx.GetLogger(ctx).Debug().Interface("status", st).Interface("req", req).Msg("storing grants not supported, ignoring")
@@ -692,7 +688,6 @@ func (s *svc) removeShare(ctx context.Context, req *collaboration.RemoveShareReq
 		}
 	}
 
-	s.statCache.RemoveStatContext(ctx, ctxpkg.ContextMustGetUser(ctx).GetId(), share.ResourceId)
 	return res, nil
 }
 
@@ -725,7 +720,6 @@ func (s *svc) removeSpaceShare(ctx context.Context, ref *provider.ResourceId, gr
 			Status: removeGrantStatus,
 		}, err
 	}
-	s.statCache.RemoveStatContext(ctx, ctxpkg.ContextMustGetUser(ctx).GetId(), ref)
 	s.providerCache.RemoveListStorageProviders(ref)
 	return &collaboration.RemoveShareResponse{Status: status.NewOK(ctx)}, nil
 }

--- a/pkg/rhttp/datatx/datatx.go
+++ b/pkg/rhttp/datatx/datatx.go
@@ -28,7 +28,6 @@ import (
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	"github.com/cs3org/reva/v2/pkg/events"
 	"github.com/cs3org/reva/v2/pkg/storage"
-	"github.com/cs3org/reva/v2/pkg/storage/cache"
 	"github.com/cs3org/reva/v2/pkg/utils"
 )
 
@@ -52,9 +51,4 @@ func EmitFileUploadedEvent(spaceOwnerOrManager, executant *userv1beta1.UserId, r
 	}
 
 	return events.Publish(context.Background(), publisher, uploadedEv)
-}
-
-// InvalidateCache is a helper function which invalidates the stat cache
-func InvalidateCache(owner *userv1beta1.UserId, ref *provider.Reference, statCache cache.StatCache) {
-	statCache.RemoveStatContext(context.TODO(), owner, ref.GetResourceId())
 }

--- a/pkg/rhttp/datatx/manager/simple/simple.go
+++ b/pkg/rhttp/datatx/manager/simple/simple.go
@@ -48,7 +48,6 @@ func init() {
 type manager struct {
 	conf      *cache.Config
 	publisher events.Publisher
-	statCache cache.StatCache
 }
 
 func parseConfig(m map[string]interface{}) (*cache.Config, error) {
@@ -70,7 +69,6 @@ func New(m map[string]interface{}, publisher events.Publisher) (datatx.DataTX, e
 	return &manager{
 		conf:      c,
 		publisher: publisher,
-		statCache: cache.GetStatCache(*c),
 	}, nil
 }
 
@@ -110,7 +108,6 @@ func (m *manager) Handler(fs storage.FS) (http.Handler, error) {
 				Body:   r.Body,
 				Length: r.ContentLength,
 			}, func(spaceOwner, owner *userpb.UserId, ref *provider.Reference) {
-				datatx.InvalidateCache(owner, ref, m.statCache)
 				if err := datatx.EmitFileUploadedEvent(spaceOwner, owner, ref, m.publisher); err != nil {
 					sublog.Error().Err(err).Msg("failed to publish FileUploaded event")
 				}

--- a/pkg/rhttp/datatx/manager/spaces/spaces.go
+++ b/pkg/rhttp/datatx/manager/spaces/spaces.go
@@ -50,7 +50,6 @@ func init() {
 type manager struct {
 	conf      *cache.Config
 	publisher events.Publisher
-	statCache cache.StatCache
 }
 
 func parseConfig(m map[string]interface{}) (*cache.Config, error) {
@@ -72,7 +71,6 @@ func New(m map[string]interface{}, publisher events.Publisher) (datatx.DataTX, e
 	return &manager{
 		conf:      c,
 		publisher: publisher,
-		statCache: cache.GetStatCache(*c),
 	}, nil
 }
 
@@ -117,7 +115,6 @@ func (m *manager) Handler(fs storage.FS) (http.Handler, error) {
 				Body:   r.Body,
 				Length: r.ContentLength,
 			}, func(spaceOwner, owner *userpb.UserId, ref *provider.Reference) {
-				datatx.InvalidateCache(owner, ref, m.statCache)
 				if err := datatx.EmitFileUploadedEvent(spaceOwner, owner, ref, m.publisher); err != nil {
 					sublog.Error().Err(err).Msg("failed to publish FileUploaded event")
 				}

--- a/pkg/storage/utils/decomposedfs/options/options.go
+++ b/pkg/storage/utils/decomposedfs/options/options.go
@@ -73,9 +73,10 @@ type Options struct {
 
 	Tokens TokenOptions `mapstructure:"tokens"`
 
-	StatCache         cache.Config `mapstructure:"statcache"`
+	// FileMetadataCache for file metadata
 	FileMetadataCache cache.Config `mapstructure:"filemetadatacache"`
-	IDCache           cache.Config `mapstructure:"idcache"`
+	// IDCache for symlink lookups of direntry to node id
+	IDCache cache.Config `mapstructure:"idcache"`
 
 	MaxAcquireLockCycles    int `mapstructure:"max_acquire_lock_cycles"`
 	LockCycleDurationFactor int `mapstructure:"lock_cycle_duration_factor"`

--- a/pkg/storage/utils/decomposedfs/tree/tree.go
+++ b/pkg/storage/utils/decomposedfs/tree/tree.go
@@ -70,6 +70,7 @@ type Tree struct {
 
 	options *options.Options
 
+	// used to cache symlink lookups for child names to node ids
 	idCache store.Store
 }
 


### PR DESCRIPTION
We removed the stat cache shared between gateway and storage providers. It is constantly invalidated and needs a different approach.
