### PR TITLE
Extend ServiceAccount Permissions

### DIFF
--- a/changelog/unreleased/extend-service-account-permissions.md
+++ b/changelog/unreleased/extend-service-account-permissions.md
@@ -1,0 +1,5 @@
+Enhancement: Extend service account permissions
+
+Adds CreateContainer permisson and improves cs3 storage pkg
+
+https://github.com/cs3org/reva/pull/4543

--- a/changelog/unreleased/extend-service-account-permissions.md
+++ b/changelog/unreleased/extend-service-account-permissions.md
@@ -2,4 +2,4 @@ Enhancement: Extend service account permissions
 
 Adds CreateContainer permisson and improves cs3 storage pkg
 
-https://github.com/cs3org/reva/pull/4543
+https://github.com/cs3org/reva/pull/4545

--- a/pkg/storage/utils/decomposedfs/node/permissions.go
+++ b/pkg/storage/utils/decomposedfs/node/permissions.go
@@ -99,6 +99,7 @@ func ServiceAccountPermissions() provider.ResourcePermissions {
 		PurgeRecycle:         true, // for purge-trash-bin command
 		RestoreRecycleItem:   true, // for cli restore command
 		Delete:               true, // for cli restore command with replace option
+		CreateContainer:      true, // for space provisioning
 	}
 }
 

--- a/pkg/storage/utils/metadata/storage.go
+++ b/pkg/storage/utils/metadata/storage.go
@@ -43,7 +43,8 @@ type UploadRequest struct {
 
 // UploadResponse represents a upload response
 type UploadResponse struct {
-	Etag string
+	Etag   string
+	FileID string // only for cs3 storage
 }
 
 // DownloadRequest represents a download request and its options


### PR DESCRIPTION
Adds CreateContainer permission to service accounts and allows using metadata CS3 struct directly
