### PR TITLE
fix the mount points naming

### DIFF
--- a/changelog/unreleased/fix-mount-points-naming.md
+++ b/changelog/unreleased/fix-mount-points-naming.md
@@ -1,0 +1,6 @@
+Bugfix: Fix the mount points naming
+
+We fixed a bug that caused inconsistent naming when multiple users share the resource with same name to another user.
+
+https://github.com/cs3org/reva/pull/4546  
+https://github.com/owncloud/ocis/issues/8471


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
We fixed a bug that caused inconsistent naming when multiple users share the resource with same name to another user.


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes [https://github.com/owncloud/ocis/issues/8471](https://github.com/owncloud/ocis/issues/8471)
- Related PR [https://github.com/owncloud/ocis/pull/8543](https://github.com/owncloud/ocis/pull/8543)