### PR TITLE
always select next before making calls for propfinds

### DIFF
--- a/changelog/unreleased/next-before-making-calls-for-propfind.md
+++ b/changelog/unreleased/next-before-making-calls-for-propfind.md
@@ -1,0 +1,5 @@
+Bugfix: always select next before making CS3 calls for propfinds
+
+We now select the next client more often to spread out load
+
+https://github.com/cs3org/reva/pull/4560


### PR DESCRIPTION
We now select the next client more often to spread out load

see https://github.com/owncloud/ocis/pull/8578

I don't expect a huge impact from this PR.