### PR TITLE
[full-ci] [tests-only] Bump ocis commit id to latest

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,4 +1,4 @@
 # The test runner source for API tests
-APITESTS_COMMITID=d33935c25756878c10e28b28240aade7e2b79da0
+APITESTS_COMMITID=2e7f0252f2a1b2c8200bf0931274b9e9e83f3c0a
 APITESTS_BRANCH=master
 APITESTS_REPO_GIT_URL=https://github.com/owncloud/ocis.git


### PR DESCRIPTION
Bump oCIS commit id to latest.
Part of https://github.com/owncloud/QA/issues/843