### PR TITLE
add parentcheck

### DIFF
--- a/changelog/unreleased/check-parent-on-copy.md
+++ b/changelog/unreleased/check-parent-on-copy.md
@@ -1,0 +1,6 @@
+Bugfix: Prevent copying a file to a parent folder
+
+When copying a file to a parent folder, the file would be copied to the parent folder, but the file would not be removed from the original folder.
+
+https://github.com/cs3org/reva/pull/4571
+https://github.com/owncloud/ocis/issues/1230

--- a/internal/http/services/owncloud/ocdav/copy.go
+++ b/internal/http/services/owncloud/ocdav/copy.go
@@ -559,6 +559,26 @@ func (s *svc) prepareCopy(ctx context.Context, w http.ResponseWriter, r *http.Re
 		return nil
 	}
 
+	isParent, err := s.referenceIsChildOf(ctx, s.gatewaySelector, srcRef, dstRef)
+	if err != nil {
+		switch err.(type) {
+		case errtypes.IsNotSupported:
+			log.Error().Err(err).Msg("can not detect recursive copy operation. missing machine auth configuration?")
+			w.WriteHeader(http.StatusForbidden)
+		default:
+			log.Error().Err(err).Msg("error while trying to detect recursive copy operation")
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}
+
+	if isParent {
+		w.WriteHeader(http.StatusConflict)
+		b, err := errors.Marshal(http.StatusBadRequest, "can not copy a folder into one of its parents", "")
+		errors.HandleWebdavError(log, w, b, err)
+		return nil
+
+	}
+
 	oh := r.Header.Get(net.HeaderOverwrite)
 	overwrite, err := net.ParseOverwrite(oh)
 	if err != nil {

--- a/internal/http/services/owncloud/ocdav/copy.go
+++ b/internal/http/services/owncloud/ocdav/copy.go
@@ -573,10 +573,17 @@ func (s *svc) prepareCopy(ctx context.Context, w http.ResponseWriter, r *http.Re
 
 	if isParent {
 		w.WriteHeader(http.StatusConflict)
-		b, err := errors.Marshal(http.StatusBadRequest, "can not copy a folder into one of its parents", "")
+		b, err := errors.Marshal(http.StatusBadRequest, "can not copy a folder into its parent", "")
 		errors.HandleWebdavError(log, w, b, err)
 		return nil
 
+	}
+
+	if srcRef.Path == dstRef.Path {
+		w.WriteHeader(http.StatusConflict)
+		b, err := errors.Marshal(http.StatusBadRequest, "source and destination are the same", "")
+		errors.HandleWebdavError(log, w, b, err)
+		return nil
 	}
 
 	oh := r.Header.Get(net.HeaderOverwrite)


### PR DESCRIPTION
Bugfix: Prevent copying a file to a parent folder

When copying a file to a parent folder, the file would be copied to the parent folder, but the file would not be removed from the original folder.

#refs https://github.com/owncloud/ocis/issues/1230