### PR TITLE
allow copy on self (needed for cross space copy)

### DIFF
--- a/changelog/unreleased/check-parent-on-copy.md
+++ b/changelog/unreleased/check-parent-on-copy.md
@@ -1,7 +1,8 @@
 Bugfix: Prevent copying a file to a parent folder
 
-When copying a file to a parent folder, the file would be copied to the parent folder, but the file would not be removed from the original folder.
+When copying a file to its parent folder, the file would be copied onto the parent folder, moving the original folder to the trash-bin.
 
+https://github.com/cs3org/reva/pull/4584
 https://github.com/cs3org/reva/pull/4582
 https://github.com/cs3org/reva/pull/4571
 https://github.com/owncloud/ocis/issues/1230

--- a/internal/http/services/owncloud/ocdav/copy.go
+++ b/internal/http/services/owncloud/ocdav/copy.go
@@ -583,7 +583,7 @@ func (s *svc) prepareCopy(ctx context.Context, w http.ResponseWriter, r *http.Re
 
 	}
 
-	if srcRef.Path == dstRef.Path {
+	if srcRef.Path == dstRef.Path && srcRef.ResourceId == dstRef.ResourceId {
 		w.WriteHeader(http.StatusConflict)
 		b, err := errors.Marshal(http.StatusBadRequest, "source and destination are the same", "")
 		errors.HandleWebdavError(log, w, b, err)


### PR DESCRIPTION
A minor change for https://github.com/owncloud/ocis/issues/1230 to re-enable copy on items onto themselves.