### PR TITLE
gateway(sharing-ng): Check for remaing space manager before removing grant

### DIFF
--- a/changelog/unreleased/add-remaining-manager-check.md
+++ b/changelog/unreleased/add-remaining-manager-check.md
@@ -1,0 +1,8 @@
+Enhancement: Move more consistency checks to the usershare API
+
+The gateway now checks if there will be at least one space manager remaining before
+deleting a space member. The legacy ocs based sharing implementaion already does this
+on its own. But for the future graph based sharing implementation it is better to have
+the check in a more central place.
+
+https://github.com/cs3org/reva/pull/4585


### PR DESCRIPTION
This check is already done by the ocs sharing implementaion, but for the move to the graph API base sharing implementation we'd want to have it in a more central place.