### PR TITLE
Introduce InitiatorIDs

### DIFF
--- a/changelog/unreleased/initiator_id.md
+++ b/changelog/unreleased/initiator_id.md
@@ -1,0 +1,6 @@
+Enhancement: Allow passing a initiator id
+
+Allows passing an initiator id on http request as `Initiator-ID` header. It will be passed down though ocis
+and returned with sse events (clientlog events, as userlog has its own logic)
+
+https://github.com/cs3org/reva/pull/4587

--- a/internal/grpc/interceptors/eventsmiddleware/events.go
+++ b/internal/grpc/interceptors/eventsmiddleware/events.go
@@ -185,7 +185,6 @@ func NewUnary(m map[string]interface{}) (grpc.UnaryServerInterceptor, int, error
 				ev = FileTouched(v, req.(*provider.TouchFileRequest), ownerID, executantID)
 			}
 		case *provider.SetLockResponse:
-			fmt.Println("set lock response", v)
 			if isSuccess(v) {
 				ev = FileLocked(v, req.(*provider.SetLockRequest), ownerID, executantID)
 			}

--- a/internal/grpc/interceptors/token/token.go
+++ b/internal/grpc/interceptors/token/token.go
@@ -39,6 +39,14 @@ func NewUnary() grpc.UnaryServerInterceptor {
 					ctx = metadata.AppendToOutgoingContext(ctx, ctxpkg.TokenHeader, tkn)
 				}
 			}
+
+			if val, ok := md[ctxpkg.InitiatorHeader]; ok {
+				if len(val) > 0 && val[0] != "" {
+					initiatorID := val[0]
+					ctx = ctxpkg.ContextSetInitiator(ctx, initiatorID)
+					ctx = metadata.AppendToOutgoingContext(ctx, ctxpkg.InitiatorHeader, initiatorID)
+				}
+			}
 		}
 
 		return handler(ctx, req)
@@ -59,6 +67,14 @@ func NewStream() grpc.StreamServerInterceptor {
 					tkn := val[0]
 					ctx = ctxpkg.ContextSetToken(ctx, tkn)
 					ctx = metadata.AppendToOutgoingContext(ctx, ctxpkg.TokenHeader, tkn)
+				}
+			}
+
+			if val, ok := md[ctxpkg.InitiatorHeader]; ok {
+				if len(val) > 0 && val[0] != "" {
+					initiatorID := val[0]
+					ctx = ctxpkg.ContextSetInitiator(ctx, initiatorID)
+					ctx = metadata.AppendToOutgoingContext(ctx, ctxpkg.InitiatorHeader, initiatorID)
 				}
 			}
 		}

--- a/pkg/ctx/initiatorctx.go
+++ b/pkg/ctx/initiatorctx.go
@@ -1,0 +1,35 @@
+// Copyright 2018-2021 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package ctx
+
+import "context"
+
+// InitiatorHeader is the header key used to pass the initiator id to http services and grpc calls.
+var InitiatorHeader = "initiator-id"
+
+// ContextGetInitiator returns the initiator if set in the given context.
+func ContextGetInitiator(ctx context.Context) (string, bool) {
+	i, ok := ctx.Value(initiatorKey).(string)
+	return i, ok
+}
+
+// ContextSetInitiator stores the initiator in the context.
+func ContextSetInitiator(ctx context.Context, i string) context.Context {
+	return context.WithValue(ctx, initiatorKey, i)
+}

--- a/pkg/ctx/userctx.go
+++ b/pkg/ctx/userctx.go
@@ -32,6 +32,7 @@ const (
 	idKey
 	lockIDKey
 	scopeKey
+	initiatorKey
 )
 
 // ContextGetUser returns the user if set in the given context.


### PR DESCRIPTION
Allows sending a header `Initiator-ID` on http requests. This will be passed down ocis and returned on sse events. Clients can use this to avoid unnecessary requests.

See ticket for more details: https://github.com/owncloud/ocis/issues/8677
