### PR TITLE
[tests-only][full-ci] Bump latest commit id of ocis master

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,4 +1,4 @@
 # The test runner source for API tests
-APITESTS_COMMITID=5403f5287551bdf8b089bba3195f1df8e4d6c793
+APITESTS_COMMITID=e3e0a7ae3912af84cdae51f33f946cf3c3bd25a1
 APITESTS_BRANCH=master
 APITESTS_REPO_GIT_URL=https://github.com/owncloud/ocis.git


### PR DESCRIPTION
This PR bump the lastest commit of ocis/master
Part of  https://github.com/owncloud/QA/issues/847