### PR TITLE
mask user emails in search results

### DIFF
--- a/changelog/unreleased/mask-user-email-in-output.md
+++ b/changelog/unreleased/mask-user-email-in-output.md
@@ -1,0 +1,7 @@
+Bugfix: Mask user email in output
+
+We have fixed a bug where the user email was not masked in the output and the user emails could be enumerated through
+the sharee search.
+
+https://github.com/cs3org/reva/pull/4603
+https://github.com/owncloud/ocis/issues/8726

--- a/internal/http/services/owncloud/ocs/config/config.go
+++ b/internal/http/services/owncloud/ocs/config/config.go
@@ -47,6 +47,7 @@ type Config struct {
 	ListOCMShares                         bool                              `mapstructure:"list_ocm_shares"`
 	Notifications                         map[string]interface{}            `mapstructure:"notifications"`
 	IncludeOCMSharees                     bool                              `mapstructure:"include_ocm_sharees"`
+	ShowEmailInResults                    bool                              `mapstructure:"show_email_in_results"`
 }
 
 // Init sets sane defaults

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/sharees/sharees.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/sharees/sharees.go
@@ -40,6 +40,7 @@ type Handler struct {
 	gatewayAddr             string
 	additionalInfoAttribute string
 	includeOCMSharees       bool
+	showUserEmailInResults  bool
 }
 
 // Init initializes this and any contained handlers
@@ -47,6 +48,7 @@ func (h *Handler) Init(c *config.Config) {
 	h.gatewayAddr = c.GatewaySvc
 	h.additionalInfoAttribute = c.AdditionalInfoAttribute
 	h.includeOCMSharees = c.IncludeOCMSharees
+	h.showUserEmailInResults = c.ShowEmailInResults
 }
 
 // FindSharees implements the /apps/files_sharing/api/v1/sharees endpoint
@@ -120,6 +122,21 @@ func (h *Handler) FindSharees(w http.ResponseWriter, r *http.Request) {
 			exactGroupMatches = append(exactGroupMatches, match)
 		} else {
 			groupMatches = append(groupMatches, match)
+		}
+	}
+
+	if !h.showUserEmailInResults {
+		for _, m := range userMatches {
+			m.Value.ShareWithAdditionalInfo = m.Value.ShareWith
+		}
+		for _, m := range exactUserMatches {
+			m.Value.ShareWithAdditionalInfo = m.Value.ShareWith
+		}
+		for _, m := range groupMatches {
+			m.Value.ShareWithAdditionalInfo = m.Value.ShareWith
+		}
+		for _, m := range exactGroupMatches {
+			m.Value.ShareWithAdditionalInfo = m.Value.ShareWith
 		}
 	}
 


### PR DESCRIPTION
Bugfix: Mask user email in output

We have fixed a bug where the user email was not masked in the output and the user emails could be enumerated through
the sharee search.

https://github.com/owncloud/ocis/issues/8726