### PR TITLE
jsoncs3 should use gateway selector and log from context

### DIFF
--- a/changelog/unreleased/fix-jsoncs3-gateway-client-and-logging.md
+++ b/changelog/unreleased/fix-jsoncs3-gateway-client-and-logging.md
@@ -1,0 +1,5 @@
+Bugfix: use gateway selector in jsoncs3
+
+The jsoncs3 user share manager now uses the gateway selector to get a fresh client before making requests and uses the configured logger from the context.
+
+https://github.com/cs3org/reva/pull/4608


### PR DESCRIPTION
The jsoncs3 user share manager now uses the gateway selector to get a fresh client before making requests and uses the confugired logger from the context.
