### PR TITLE
Change the default create personal space cache store to 'memory'

### DIFF
--- a/changelog/unreleased/change-cache-default-store.md
+++ b/changelog/unreleased/change-cache-default-store.md
@@ -1,0 +1,5 @@
+Enhancement: Use a memory cache for the personal space creation cache
+
+Memory is a safe default and ensures that superfluous calls to CreateStorageSpace are prevented.
+
+https://github.com/cs3org/reva/pull/4621

--- a/internal/grpc/services/gateway/gateway.go
+++ b/internal/grpc/services/gateway/gateway.go
@@ -131,7 +131,7 @@ func (c *config) init() {
 	}
 
 	if c.CreatePersonalSpaceCacheConfig.Store == "" {
-		c.CreatePersonalSpaceCacheConfig.Store = "noop"
+		c.CreatePersonalSpaceCacheConfig.Store = "memory"
 	}
 
 	if c.CreatePersonalSpaceCacheConfig.Database == "" {


### PR DESCRIPTION
Memory is a safe default and ensures that superfluous calls to `CreateStorageSpace` are prevented.