### PR TITLE
fix: permission check in public share update

### DIFF
--- a/changelog/unreleased/fix-public-share-update.md
+++ b/changelog/unreleased/fix-public-share-update.md
@@ -1,0 +1,5 @@
+Bugfix: Fix public share update
+
+We fixed the permission check for updating public shares. When updating the permissions of a public share while not providing a password, the check must be against the new permissions to take into account that users can opt out only for view permissions.
+
+https://github.com/cs3org/reva/pull/4622

--- a/internal/grpc/services/publicshareprovider/publicshareprovider.go
+++ b/internal/grpc/services/publicshareprovider/publicshareprovider.go
@@ -554,7 +554,19 @@ func (s *service) UpdatePublicShare(ctx context.Context, req *link.UpdatePublicS
 	}
 	updatePassword := req.GetUpdate().GetType() == link.UpdatePublicShareRequest_Update_TYPE_PASSWORD
 	setPassword := grant.GetPassword()
+
+	// we update permissions with an empty password and password is not set on the public share
+	emptyPasswordInPermissionUpdate := len(setPassword) == 0 && updatePermissions && !ps.PasswordProtected
+
+	// password is updated, we use the current permissions to check if the user can opt out
 	if updatePassword && !isInternalLink && enforcePassword(canOptOut, ps.GetPermissions().GetPermissions(), s.conf) && len(setPassword) == 0 {
+		return &link.UpdatePublicShareResponse{
+			Status: status.NewInvalidArg(ctx, "password protection is enforced"),
+		}, nil
+	}
+
+	// permissions are updated, we use the new permissions to check if the user can opt out
+	if emptyPasswordInPermissionUpdate && !isInternalLink && enforcePassword(canOptOut, grant.GetPermissions().GetPermissions(), s.conf) && len(setPassword) == 0 {
 		return &link.UpdatePublicShareResponse{
 			Status: status.NewInvalidArg(ctx, "password protection is enforced"),
 		}, nil


### PR DESCRIPTION
# Description

We fixed the permission check for updating public shares. When updating the permissions of a public share while not providing a password, the check must be against the new permissions to take into account that users can opt out only for view permissions.

relates to https://github.com/owncloud/enterprise/issues/6558