### PR TITLE
[tests-only][full-ci]Bump latests ocis commit to reva-edge

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,4 +1,4 @@
 # The test runner source for API tests
-APITESTS_COMMITID=d7ad04c549a1d49f085aceb84b63e7a48b026b87
+APITESTS_COMMITID=18b72a4f347a80e09142d59b586ad7b570f32e68
 APITESTS_BRANCH=master
 APITESTS_REPO_GIT_URL=https://github.com/owncloud/ocis.git


### PR DESCRIPTION
### Description
This PR bumps the latest `ocis` commit to reva edge.

### Related Issue:
 https://github.com/owncloud/QA/issues/848