### PR TITLE
test async processing cornercases

### DIFF
--- a/changelog/unreleased/test-async-processing-corner-cases.md
+++ b/changelog/unreleased/test-async-processing-corner-cases.md
@@ -1,0 +1,6 @@
+Enhancement: Test async processing cornercases
+
+We added tests to cover several bugs where file metadata or parent treesize might get corrupted when postprocessing errors occur in specific order.
+For now, the added test cases test the current behavior but contain comments and FIXMEs for the expected behavior.
+
+https://github.com/cs3org/reva/pull/4625

--- a/pkg/storage/utils/decomposedfs/upload_async_test.go
+++ b/pkg/storage/utils/decomposedfs/upload_async_test.go
@@ -62,8 +62,8 @@ var _ = Describe("Async file uploads", Ordered, func() {
 			Username: "username",
 		}
 
-		fileContent  = []byte("0123456789")
-		file2Content = []byte("01234567890123456789")
+		firstContent  = []byte("0123456789")
+		secondContent = []byte("01234567890123456789")
 
 		ctx = ruser.ContextSetUser(context.Background(), user)
 
@@ -78,6 +78,51 @@ var _ = Describe("Async file uploads", Ordered, func() {
 		cs3permissionsclient *mocks.CS3PermissionsClient
 		permissionsSelector  pool.Selectable[cs3permissions.PermissionsAPIClient]
 		bs                   *treemocks.Blobstore
+
+		succeedPostprocessing = func(uploadID string) {
+			// finish postprocessing
+			con <- events.PostprocessingFinished{
+				UploadID: uploadID,
+				Outcome:  events.PPOutcomeContinue,
+			}
+			// wait for upload to be ready
+			ev, ok := (<-pub).(events.UploadReady)
+			Expect(ok).To(BeTrue())
+			Expect(ev.Failed).To(BeFalse())
+		}
+
+		failPostprocessing = func(uploadID string, outcome events.PostprocessingOutcome) {
+			// finish postprocessing
+			con <- events.PostprocessingFinished{
+				UploadID: uploadID,
+				Outcome:  outcome,
+			}
+			// wait for upload to be ready
+			ev, ok := (<-pub).(events.UploadReady)
+			Expect(ok).To(BeTrue())
+			Expect(ev.Failed).To(BeTrue())
+		}
+
+		fileStatus = func() (bool, string, int) {
+			// check processing status
+			resources, err := fs.ListFolder(ctx, rootRef, []string{}, []string{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(len(resources)).To(BeElementOf([2]int{0, 1}), "should not have more than one child")
+
+			item := resources[0]
+			Expect(item.Path).To(Equal(ref.Path))
+			return len(resources) == 1, utils.ReadPlainFromOpaque(item.Opaque, "status"), int(item.GetSize())
+		}
+		parentSize = func() int {
+			parentInfo, err := fs.GetMD(ctx, rootRef, []string{}, []string{})
+			Expect(err).ToNot(HaveOccurred())
+			return int(parentInfo.Size)
+		}
+		revisionCount = func() int {
+			revisions, err := fs.ListRevisions(ctx, ref)
+			Expect(err).ToNot(HaveOccurred())
+			return len(revisions)
+		}
 	)
 
 	BeforeEach(func() {
@@ -162,8 +207,8 @@ var _ = Describe("Async file uploads", Ordered, func() {
 
 		_, err = fs.Upload(ctx, storage.UploadRequest{
 			Ref:    uploadRef,
-			Body:   io.NopCloser(bytes.NewReader(fileContent)),
-			Length: int64(len(fileContent)),
+			Body:   io.NopCloser(bytes.NewReader(firstContent)),
+			Length: int64(len(firstContent)),
 		}, nil)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -196,15 +241,7 @@ var _ = Describe("Async file uploads", Ordered, func() {
 			Expect(item.Path).To(Equal(ref.Path))
 			Expect(utils.ReadPlainFromOpaque(item.Opaque, "status")).To(Equal("processing"))
 
-			// finish postprocessing
-			con <- events.PostprocessingFinished{
-				UploadID: uploadID,
-				Outcome:  events.PPOutcomeContinue,
-			}
-
-			// wait for upload to be ready
-			_, ok := (<-pub).(events.UploadReady)
-			Expect(ok).To(BeTrue())
+			succeedPostprocessing(uploadID)
 
 			// blobstore called now
 			bs.AssertNumberOfCalls(GinkgoT(), "Upload", 1)
@@ -234,16 +271,7 @@ var _ = Describe("Async file uploads", Ordered, func() {
 			_, err = os.Stat(filepath.Join(o.Root, "uploads", uploadID))
 			Expect(err).To(BeNil())
 
-			// finish postprocessing
-			con <- events.PostprocessingFinished{
-				UploadID: uploadID,
-				Outcome:  events.PPOutcomeDelete,
-			}
-
-			// wait for upload to be ready
-			ev, ok := (<-pub).(events.UploadReady)
-			Expect(ok).To(BeTrue())
-			Expect(ev.Failed).To(BeTrue())
+			failPostprocessing(uploadID, events.PPOutcomeDelete)
 
 			// blobstore still not called now
 			bs.AssertNumberOfCalls(GinkgoT(), "Upload", 0)
@@ -272,16 +300,7 @@ var _ = Describe("Async file uploads", Ordered, func() {
 			_, err = os.Stat(filepath.Join(o.Root, "uploads", uploadID))
 			Expect(err).To(BeNil())
 
-			// finish postprocessing
-			con <- events.PostprocessingFinished{
-				UploadID: uploadID,
-				Outcome:  events.PPOutcomeAbort,
-			}
-
-			// wait for upload to be ready
-			ev, ok := (<-pub).(events.UploadReady)
-			Expect(ok).To(BeTrue())
-			Expect(ev.Failed).To(BeTrue())
+			failPostprocessing(uploadID, events.PPOutcomeAbort)
 
 			// blobstore still not called now
 			bs.AssertNumberOfCalls(GinkgoT(), "Upload", 0)
@@ -299,15 +318,7 @@ var _ = Describe("Async file uploads", Ordered, func() {
 
 	When("the uploaded file creates a new version", func() {
 		JustBeforeEach(func() {
-			// finish postprocessing
-			con <- events.PostprocessingFinished{
-				UploadID: uploadID,
-				Outcome:  events.PPOutcomeContinue,
-			}
-
-			// wait for upload to be ready
-			_, ok := (<-pub).(events.UploadReady)
-			Expect(ok).To(BeTrue())
+			succeedPostprocessing(uploadID)
 
 			// make sure there is no version yet
 			revs, err := fs.ListRevisions(ctx, ref)
@@ -325,15 +336,15 @@ var _ = Describe("Async file uploads", Ordered, func() {
 
 			_, err = fs.Upload(ctx, storage.UploadRequest{
 				Ref:    uploadRef,
-				Body:   io.NopCloser(bytes.NewReader(fileContent)),
-				Length: int64(len(fileContent)),
+				Body:   io.NopCloser(bytes.NewReader(firstContent)),
+				Length: int64(len(firstContent)),
 			}, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			uploadID = uploadIds["simple"]
 
 			// wait for bytes received event
-			_, ok = (<-pub).(events.BytesReceived)
+			_, ok := (<-pub).(events.BytesReceived)
 			Expect(ok).To(BeTrue())
 
 			// version already created
@@ -347,15 +358,7 @@ var _ = Describe("Async file uploads", Ordered, func() {
 		})
 
 		It("succeeds eventually, creating a new version", func() {
-			// finish postprocessing
-			con <- events.PostprocessingFinished{
-				UploadID: uploadID,
-				Outcome:  events.PPOutcomeContinue,
-			}
-			// wait for upload to be ready
-			ev, ok := (<-pub).(events.UploadReady)
-			Expect(ok).To(BeTrue())
-			Expect(ev.Failed).To(BeFalse())
+			succeedPostprocessing(uploadID)
 
 			// version still existing
 			revs, err := fs.ListRevisions(ctx, ref)
@@ -371,31 +374,13 @@ var _ = Describe("Async file uploads", Ordered, func() {
 		})
 
 		It("removes new version and restores old one when instructed", func() {
-			// node exists and is processing
-			resources, err := fs.ListFolder(ctx, rootRef, []string{}, []string{})
-			Expect(err).ToNot(HaveOccurred())
-			Expect(len(resources)).To(Equal(1))
-			item := resources[0]
-			Expect(item.Path).To(Equal(ref.Path))
-			Expect(utils.ReadPlainFromOpaque(item.Opaque, "status")).To(Equal("processing"))
+			_, status, _ := fileStatus()
+			Expect(status).To(Equal("processing"))
 
-			// finish postprocessing
-			con <- events.PostprocessingFinished{
-				UploadID: uploadID,
-				Outcome:  events.PPOutcomeDelete,
-			}
-			// wait for upload to be ready
-			ev, ok := (<-pub).(events.UploadReady)
-			Expect(ok).To(BeTrue())
-			Expect(ev.Failed).To(BeTrue())
+			failPostprocessing(uploadID, events.PPOutcomeDelete)
 
-			// node still exists as old version is restored
-			resources, err = fs.ListFolder(ctx, rootRef, []string{}, []string{})
-			Expect(err).ToNot(HaveOccurred())
-			Expect(len(resources)).To(Equal(1))
-			item = resources[0]
-			Expect(item.Path).To(Equal(ref.Path))
-			Expect(utils.ReadPlainFromOpaque(item.Opaque, "status")).To(BeEmpty())
+			_, status, _ = fileStatus()
+			Expect(status).To(Equal(""))
 
 			// version gone now
 			revs, err := fs.ListRevisions(ctx, ref)
@@ -411,7 +396,7 @@ var _ = Describe("Async file uploads", Ordered, func() {
 		})
 
 	})
-	When("Two uploads are happening in parallel", func() {
+	When("Two uploads are processed in parallel", func() {
 		var secondUploadID string
 
 		JustBeforeEach(func() {
@@ -426,8 +411,8 @@ var _ = Describe("Async file uploads", Ordered, func() {
 
 			_, err = fs.Upload(ctx, storage.UploadRequest{
 				Ref:    uploadRef,
-				Body:   io.NopCloser(bytes.NewReader(file2Content)),
-				Length: int64(len(file2Content)),
+				Body:   io.NopCloser(bytes.NewReader(secondContent)),
+				Length: int64(len(secondContent)),
 			}, nil)
 			Expect(err).ToNot(HaveOccurred())
 
@@ -439,98 +424,256 @@ var _ = Describe("Async file uploads", Ordered, func() {
 		})
 
 		It("doesn't remove processing status when first upload is finished", func() {
-			// finish postprocessing
-			con <- events.PostprocessingFinished{
-				UploadID: uploadID,
-				Outcome:  events.PPOutcomeContinue,
-			}
-			// wait for upload to be ready
-			ev, ok := (<-pub).(events.UploadReady)
-			Expect(ok).To(BeTrue())
-			Expect(ev.Failed).To(BeFalse())
+			succeedPostprocessing(uploadID)
 
+			_, status, _ := fileStatus()
 			// check processing status
-			resources, err := fs.ListFolder(ctx, rootRef, []string{}, []string{})
-			Expect(err).ToNot(HaveOccurred())
-			Expect(len(resources)).To(Equal(1))
-
-			item := resources[0]
-			Expect(item.Path).To(Equal(ref.Path))
-			Expect(utils.ReadPlainFromOpaque(item.Opaque, "status")).To(Equal("processing"))
+			Expect(status).To(Equal("processing"))
 		})
 
 		It("removes processing status when second upload is finished, even if first isn't", func() {
-			// finish postprocessing of second upload
-			con <- events.PostprocessingFinished{
-				UploadID: secondUploadID,
-				Outcome:  events.PPOutcomeContinue,
-			}
-			// wait for upload to be ready
-			ev, ok := (<-pub).(events.UploadReady)
-			Expect(ok).To(BeTrue())
-			Expect(ev.Failed).To(BeFalse())
+			succeedPostprocessing(secondUploadID)
 
-			// check processing status
-			resources, err := fs.ListFolder(ctx, rootRef, []string{}, []string{})
-			Expect(err).ToNot(HaveOccurred())
-			Expect(len(resources)).To(Equal(1))
-
-			item := resources[0]
-			Expect(item.Path).To(Equal(ref.Path))
-			Expect(utils.ReadPlainFromOpaque(item.Opaque, "status")).To(Equal(""))
+			_, status, _ := fileStatus()
+			Expect(status).To(Equal(""))
 		})
 
-		It("correctly calculates the size when the second upload is finishes, even if first is deleted", func() {
-			// finish postprocessing of second upload
-			con <- events.PostprocessingFinished{
-				UploadID: secondUploadID,
-				Outcome:  events.PPOutcomeContinue,
-			}
-			// wait for upload to be ready
-			ev, ok := (<-pub).(events.UploadReady)
-			Expect(ok).To(BeTrue())
-			Expect(ev.Failed).To(BeFalse())
+		It("correctly calculates the size when the second upload is finished, even if first is deleted", func() {
+			succeedPostprocessing(secondUploadID)
 
-			// check processing status
-			resources, err := fs.ListFolder(ctx, rootRef, []string{}, []string{})
-			Expect(err).ToNot(HaveOccurred())
-			Expect(len(resources)).To(Equal(1))
-
-			item := resources[0]
-			Expect(item.Path).To(Equal(ref.Path))
-			Expect(utils.ReadPlainFromOpaque(item.Opaque, "status")).To(Equal(""))
-
+			_, status, size := fileStatus()
+			Expect(status).To(Equal(""))
 			// size should match the second upload
-			Expect(item.Size).To(Equal(uint64(len(file2Content))))
+			Expect(size).To(Equal(len(secondContent)))
 
 			// parent size should match second upload as well
-			parentInfo, err := fs.GetMD(ctx, rootRef, []string{}, []string{})
-			Expect(err).ToNot(HaveOccurred())
-			Expect(parentInfo.Size).To(Equal(uint64(len(file2Content))))
+			Expect(parentSize()).To(Equal(len(secondContent)))
 
-			// finish postprocessing of first upload
-			con <- events.PostprocessingFinished{
-				UploadID: uploadID,
-				Outcome:  events.PPOutcomeDelete,
-				// Outcome: events.PPOutcomeAbort, // This as well ... fck
-			}
-			// wait for upload to be ready
-			ev, ok = (<-pub).(events.UploadReady)
-			Expect(ok).To(BeTrue())
-			Expect(ev.Failed).To(BeTrue())
+			failPostprocessing(uploadID, events.PPOutcomeDelete)
 
 			// check processing status
-			resources, err = fs.ListFolder(ctx, rootRef, []string{}, []string{})
-			Expect(err).ToNot(HaveOccurred())
-			Expect(len(resources)).To(Equal(1))
-
+			_, _, size = fileStatus()
 			// size should still match the second upload
-			Expect(item.Size).To(Equal(uint64(len(file2Content))))
+			Expect(size).To(Equal(len(secondContent)))
 
 			// parent size should still match second upload as well
-			parentInfo, err = fs.GetMD(ctx, rootRef, []string{}, []string{})
-			Expect(err).ToNot(HaveOccurred())
-			Expect(parentInfo.Size).To(Equal(uint64(len(file2Content))))
+			Expect(parentSize()).To(Equal(len(secondContent)))
+		})
+
+		It("the first can succeed before the second succeeds", func() {
+			succeedPostprocessing(uploadID)
+
+			_, status, size := fileStatus()
+			// check processing status
+			Expect(status).To(Equal("processing"))
+			// size should match the second upload
+			Expect(size).To(Equal((len(secondContent))))
+
+			// parent size should match the second upload
+			Expect(parentSize()).To(Equal(len(secondContent)))
+
+			succeedPostprocessing(secondUploadID)
+
+			// check processing status has been removed
+			_, status, size = fileStatus()
+			Expect(status).To(Equal(""))
+
+			// size should still match the second upload
+			Expect(size).To(Equal(len(secondContent)))
+
+			// parent size should still match second upload
+			Expect(parentSize()).To(Equal(len(secondContent)))
+
+			// file should have one revision
+			Expect(revisionCount()).To(Equal(1))
+		})
+
+		It("the first can succeed after the second succeeds", func() {
+			succeedPostprocessing(secondUploadID)
+
+			_, status, size := fileStatus()
+			// check processing status has been removed because the most recent upload finished and can be downloaded
+			Expect(status).To(Equal(""))
+			// size should match the second upload
+			Expect(size).To(Equal(len(secondContent)))
+
+			// parent size should match second upload as well
+			Expect(parentSize()).To(Equal(len(secondContent)))
+
+			succeedPostprocessing(uploadID)
+
+			_, status, size = fileStatus()
+			// check processing status is still unset
+			Expect(status).To(Equal(""))
+			// size should still match the second upload
+			Expect(size).To(Equal(len(secondContent)))
+
+			// parent size should still match second upload
+			Expect(parentSize()).To(Equal(len(secondContent)))
+
+			// file should have one revision
+			Expect(revisionCount()).To(Equal(1))
+		})
+
+		It("the first can succeed before the second fails", func() {
+			succeedPostprocessing(uploadID)
+
+			_, status, size := fileStatus()
+			// check processing status
+			Expect(status).To(Equal("processing"))
+			// size should match the second upload
+			Expect(size).To(Equal(len(secondContent)))
+
+			// parent size should match the second upload
+			Expect(parentSize()).To(Equal(len(secondContent)))
+
+			failPostprocessing(secondUploadID, events.PPOutcomeDelete)
+
+			_, status, size = fileStatus()
+			// check processing status has been removed
+			Expect(status).To(Equal(""))
+			// size should match the first upload
+			Expect(size).To(Equal(len(firstContent)))
+
+			// parent size should match first upload
+			Expect(parentSize()).To(Equal(len(firstContent)))
+
+			// file should not have any revisions
+			Expect(revisionCount()).To(Equal(0))
+		})
+
+		It("the first can succeed after the second fails", func() {
+			failPostprocessing(secondUploadID, events.PPOutcomeDelete)
+
+			_, _, size := fileStatus()
+			// check processing status has not been unset
+			// FIXME we need to fall back to the previous processing id
+			// Expect(status).To(Equal("processing"))
+			// size should match the first upload
+			Expect(size).To(Equal(len(firstContent)))
+
+			// parent size should match first upload as well
+			Expect(parentSize()).To(Equal(len(firstContent)))
+
+			succeedPostprocessing(uploadID)
+
+			_, status, size := fileStatus()
+			// check processing status is now unset
+			Expect(status).To(Equal(""))
+			// size should still match the first upload
+			Expect(size).To(Equal(len(firstContent)))
+
+			// parent size should still match first upload
+			Expect(parentSize()).To(Equal(len(firstContent)))
+
+			// file should not have any revisions
+			Expect(revisionCount()).To(Equal(0))
+		})
+
+		It("the first can fail before the second succeeds", func() {
+			failPostprocessing(uploadID, events.PPOutcomeDelete)
+
+			_, status, size := fileStatus()
+			// check processing status
+			Expect(status).To(Equal("processing"))
+			// size should match the second upload
+			Expect(size).To(Equal(len(secondContent)))
+
+			// parent size should match second upload as well
+			Expect(parentSize()).To(Equal(len(secondContent)))
+
+			succeedPostprocessing(secondUploadID)
+
+			_, status, size = fileStatus()
+			// check processing status has been removed
+			Expect(status).To(Equal(""))
+			// size should still match the second upload
+			Expect(size).To(Equal(len(secondContent)))
+
+			// parent size should still match second upload
+			Expect(parentSize()).To(Equal(len(secondContent)))
+
+			// file should not have any revisions
+			// FIXME we need to delete the revision
+			// Expect(revisionCount()).To(Equal(0))
+		})
+
+		It("the first can fail after the second succeeds", func() {
+			succeedPostprocessing(secondUploadID)
+
+			_, status, size := fileStatus()
+			// check processing status has been removed because the most recent upload finished and can be downloaded
+			Expect(status).To(Equal(""))
+			// size should match the second upload
+			Expect(size).To(Equal(len(secondContent)))
+
+			// parent size should match second upload as well
+			Expect(parentSize()).To(Equal(len(secondContent)))
+
+			failPostprocessing(uploadID, events.PPOutcomeDelete)
+
+			_, status, size = fileStatus()
+			// check processing status is still unset
+			Expect(status).To(Equal(""))
+			// size should still match the second upload
+			Expect(size).To(Equal(len(secondContent)))
+
+			// parent size should still match second upload
+			Expect(parentSize()).To(Equal(len(secondContent)))
+
+			// file should not have any revisions
+			// FIXME we need to delete the revision
+			// Expect(revisionCount()).To(Equal(0))
+		})
+
+		It("the first can fail before the second fails", func() {
+			failPostprocessing(uploadID, events.PPOutcomeDelete)
+
+			_, status, size := fileStatus()
+			// check processing status
+			Expect(status).To(Equal("processing"))
+			// size should match the second upload
+			Expect(size).To(Equal(len(secondContent)))
+
+			// parent size should match second upload as well
+			Expect(parentSize()).To(Equal(len(secondContent)))
+
+			failPostprocessing(secondUploadID, events.PPOutcomeDelete)
+
+			// check file has been removed
+			// if all uploads have been processed with outcome delete -> delete the file
+			// exists, _, _ := fileStatus()
+			// FIXME this should be false, but we are not deleting the resource
+			// Expect(exists).To(BeFalse())
+
+			// parent size should be 0
+			// FIXME we are not correctly reverting the sizediff
+			// Expect(parentSize()).To(Equal(0))
+		})
+
+		It("the first can fail after the second fails", func() {
+			failPostprocessing(secondUploadID, events.PPOutcomeDelete)
+
+			_, status, size := fileStatus()
+			// check processing status has been removed because the most recent upload finished and can be downloaded
+			Expect(status).To(Equal(""))
+			// size should match the first upload
+			Expect(size).To(Equal(len(firstContent)))
+
+			// parent size should match second first as well
+			Expect(parentSize()).To(Equal(len(firstContent)))
+
+			failPostprocessing(uploadID, events.PPOutcomeDelete)
+
+			// check file has been removed
+			// if all uploads have been processed with outcome delete -> delete the file
+			// exists, _, _ := fileStatus()
+			// FIXME this should be false, but we are not deleting the resource
+			// Expect(exists).To(BeFalse())
+
+			// parent size should be 0
+			// FIXME we are not correctly reverting the sizediff
+			// Expect(parentSize()).To(Equal(0))
 		})
 	})
 })


### PR DESCRIPTION
We added tests to cover several bugs where file metadata or parent treesize might get corrupted when postprocessing errors occur in specific order.
For now, the added test cases test the current behavior but contain comments and FIXMEs for the expected behavior.

The PR adds eight new test cases:
- the first can succeed before the second succeeds - Works!
- the first can succeed after the second succeeds - Works!
- the first can succeed before the second fails - Works!
- the first can succeed after the second fails - the file should still be in "processing" after second upload is deleted
- the first can fail before the second succeeds - list of revisions should be 0
- the first can fail after the second succeeds - list of revisions should be 0
- the first can fail before the second fails - file should be deleted, size should be correctly reverted
- the first can fail after the second fails - file should be deleted, size should be correctly reverted

I'd like to get this in so it does not get lost in an spreadsheet on my desktop.

@aduffeck And I are entertaining the idea of creating the note on the initiateFile call and keep track of all ongoing uploads in the node metadata. It will allow resolving the correct size diff and processing status. Will create an issue to track that.