### PR TITLE
use share id to identify ocm shares

### DIFF
--- a/changelog/unreleased/fix-ocm-share-id.md
+++ b/changelog/unreleased/fix-ocm-share-id.md
@@ -1,0 +1,5 @@
+Bugfix: fix ocm-share-id
+
+We now use the share id to correctly identify ocm shares.
+
+https://github.com/cs3org/reva/pull/4630

--- a/internal/grpc/interceptors/auth/scope.go
+++ b/internal/grpc/interceptors/auth/scope.go
@@ -89,7 +89,7 @@ func expandAndVerifyScope(ctx context.Context, req interface{}, tokenScope map[s
 					return nil
 				}
 			}
-			log.Err(err).Msgf("error resolving reference %s under scope %+v", ref.String(), k)
+			log.Err(err).Interface("ref", ref).Interface("scope", k).Msg("error resolving reference under scope")
 		}
 
 	} else if ref, ok := extractShareRef(req); ok {
@@ -179,6 +179,11 @@ func resolveOCMShare(ctx context.Context, ref *provider.Reference, scope *authpb
 		return err
 	}
 
+	// for ListOCMSharesRequest, the ref resource id is empty and we set path to . to indicate the root of the share
+	if ref.GetResourceId() == nil && ref.Path == "." {
+		ref.ResourceId = share.GetResourceId()
+	}
+
 	if err := checkCacheForNestedResource(ctx, ref, share.ResourceId, client, mgr); err == nil {
 		return nil
 	}
@@ -213,7 +218,7 @@ func checkRelativeReference(ctx context.Context, requested *provider.Reference, 
 	if sharedResource.ParentId == nil {
 		// Is the requested resource part of the shared space?
 		if requested.ResourceId.StorageId != sharedResource.Id.StorageId || requested.ResourceId.SpaceId != sharedResource.Id.SpaceId {
-			return errtypes.PermissionDenied("access forbidden via public link")
+			return errtypes.PermissionDenied("space access forbidden via public link")
 		}
 	} else {
 		parentID := sharedResource.ParentId
@@ -388,6 +393,11 @@ func extractRefForReaderRole(req interface{}) (*provider.Reference, bool) {
 		return v.GetRef(), true
 	case *provider.UnlockRequest:
 		return v.GetRef(), true
+
+	// OCM shares
+	case *ocmv1beta1.ListReceivedOCMSharesRequest:
+		return &provider.Reference{Path: "."}, true // we will try to stat the shared node
+
 	}
 
 	return nil, false

--- a/internal/grpc/services/ocmshareprovider/ocmshareprovider.go
+++ b/internal/grpc/services/ocmshareprovider/ocmshareprovider.go
@@ -171,9 +171,9 @@ func getResourceType(info *providerpb.ResourceInfo) string {
 	return "unknown"
 }
 
-func (s *service) webdavURL(ctx context.Context, share *ocm.Share) string {
+func (s *service) webdavURL(_ context.Context, share *ocm.Share) string {
 	// the url is in the form of https://cernbox.cern.ch/remote.php/dav/ocm/token
-	p, _ := url.JoinPath(s.conf.WebDAVEndpoint, "/dav/ocm", share.Token)
+	p, _ := url.JoinPath(s.conf.WebDAVEndpoint, "/dav/ocm", share.GetId().GetOpaqueId())
 	return p
 }
 

--- a/internal/http/services/owncloud/ocdav/dav.go
+++ b/internal/http/services/owncloud/ocdav/dav.go
@@ -185,38 +185,36 @@ func (h *DavHandler) Handler(s *svc) http.Handler {
 			}
 
 			// OC10 and Nextcloud (OCM 1.0) are using basic auth for carrying the
-			// shared token.
-			var token string
+			// ocm share id.
+			var ocmshare string
 			username, _, ok := r.BasicAuth()
 			if ok {
 				// OCM 1.0
-				token = username
-				r.URL.Path = filepath.Join("/", token, r.URL.Path)
-				ctx = context.WithValue(ctx, net.CtxOCM10, true)
+				ocmshare = username
+				r.URL.Path = filepath.Join("/", ocmshare, r.URL.Path)
 			} else {
-				token, _ = router.ShiftPath(r.URL.Path)
-				ctx = context.WithValue(ctx, net.CtxOCM10, false)
+				ocmshare, _ = router.ShiftPath(r.URL.Path)
 			}
 
-			authRes, err := handleOCMAuth(ctx, c, token)
+			authRes, err := handleOCMAuth(ctx, c, ocmshare)
 			switch {
 			case err != nil:
 				log.Error().Err(err).Msg("error during ocm authentication")
 				w.WriteHeader(http.StatusInternalServerError)
 				return
 			case authRes.Status.Code == rpc.Code_CODE_PERMISSION_DENIED:
-				log.Debug().Str("token", token).Msg("permission denied")
+				log.Debug().Str("ocmshare", ocmshare).Msg("permission denied")
 				fallthrough
 			case authRes.Status.Code == rpc.Code_CODE_UNAUTHENTICATED:
-				log.Debug().Str("token", token).Msg("unauthorized")
+				log.Debug().Str("ocmshare", ocmshare).Msg("unauthorized")
 				w.WriteHeader(http.StatusUnauthorized)
 				return
 			case authRes.Status.Code == rpc.Code_CODE_NOT_FOUND:
-				log.Debug().Str("token", token).Msg("not found")
+				log.Debug().Str("ocmshare", ocmshare).Msg("not found")
 				w.WriteHeader(http.StatusNotFound)
 				return
 			case authRes.Status.Code != rpc.Code_CODE_OK:
-				log.Error().Str("token", token).Interface("status", authRes.Status).Msg("grpc auth request failed")
+				log.Error().Str("ocmshare", ocmshare).Interface("status", authRes.Status).Msg("grpc auth request failed")
 				w.WriteHeader(http.StatusInternalServerError)
 				return
 			}
@@ -225,7 +223,7 @@ func (h *DavHandler) Handler(s *svc) http.Handler {
 			ctx = ctxpkg.ContextSetUser(ctx, authRes.User)
 			ctx = metadata.AppendToOutgoingContext(ctx, ctxpkg.TokenHeader, authRes.Token)
 
-			log.Debug().Str("token", token).Interface("user", authRes.User).Msg("OCM user authenticated")
+			log.Debug().Str("ocmshare", ocmshare).Interface("user", authRes.User).Msg("OCM user authenticated")
 
 			r = r.WithContext(ctx)
 			h.OCMSharesHandler.Handler(s).ServeHTTP(w, r)

--- a/internal/http/services/owncloud/ocdav/net/net.go
+++ b/internal/http/services/owncloud/ocdav/net/net.go
@@ -35,7 +35,6 @@ type ctxKey int
 const (
 	// CtxKeyBaseURI is the key of the base URI context field
 	CtxKeyBaseURI ctxKey = iota
-	CtxOCM10
 
 	// NsDav is the Dav ns
 	NsDav = "DAV:"

--- a/pkg/auth/manager/ocmshares/ocmshares.go
+++ b/pkg/auth/manager/ocmshares/ocmshares.go
@@ -82,10 +82,11 @@ func (m *manager) Configure(ml map[string]interface{}) error {
 	return nil
 }
 
-func (m *manager) Authenticate(ctx context.Context, token, _ string) (*userpb.User, map[string]*authpb.Scope, error) {
-	log := appctx.GetLogger(ctx).With().Str("token", token).Logger()
+func (m *manager) Authenticate(ctx context.Context, ocmshare, sharedSecret string) (*userpb.User, map[string]*authpb.Scope, error) {
+	log := appctx.GetLogger(ctx).With().Str("ocmshare", ocmshare).Logger()
+	// We need to use GetOCMShareByToken, as GetOCMShare would requir a user in the context
 	shareRes, err := m.gw.GetOCMShareByToken(ctx, &ocm.GetOCMShareByTokenRequest{
-		Token: token,
+		Token: sharedSecret,
 	})
 
 	switch {
@@ -101,6 +102,12 @@ func (m *manager) Authenticate(ctx context.Context, token, _ string) (*userpb.Us
 	case shareRes.Status.Code != rpc.Code_CODE_OK:
 		log.Error().Interface("status", shareRes.Status).Msg("got unexpected error in the grpc call to GetOCMShare")
 		return nil, nil, errtypes.InternalError(shareRes.Status.Message)
+	}
+
+	// compare ocm share id
+	if shareRes.GetShare().GetId().GetOpaqueId() != ocmshare {
+		log.Error().Str("persisted", ocmshare).Str("requested", shareRes.GetShare().GetId().GetOpaqueId()).Msg("mismatching ocm share id for existing secret")
+		return nil, nil, errtypes.InvalidCredentials("invalid shared secret")
 	}
 
 	// the user authenticated using the ocmshares authentication method

--- a/pkg/auth/manager/ocmshares/ocmshares.go
+++ b/pkg/auth/manager/ocmshares/ocmshares.go
@@ -84,7 +84,7 @@ func (m *manager) Configure(ml map[string]interface{}) error {
 
 func (m *manager) Authenticate(ctx context.Context, ocmshare, sharedSecret string) (*userpb.User, map[string]*authpb.Scope, error) {
 	log := appctx.GetLogger(ctx).With().Str("ocmshare", ocmshare).Logger()
-	// We need to use GetOCMShareByToken, as GetOCMShare would requir a user in the context
+	// We need to use GetOCMShareByToken, as GetOCMShare would require a user in the context
 	shareRes, err := m.gw.GetOCMShareByToken(ctx, &ocm.GetOCMShareByTokenRequest{
 		Token: sharedSecret,
 	})

--- a/pkg/ocm/share/repository/json/json.go
+++ b/pkg/ocm/share/repository/json/json.go
@@ -396,7 +396,7 @@ func (m *mgr) ListShares(ctx context.Context, user *userpb.User, filters []*ocm.
 	}
 
 	for _, share := range m.model.Shares {
-		if utils.UserEqual(user.Id, share.Owner) || utils.UserEqual(user.Id, share.Creator) {
+		if utils.UserEqual(user.Id, share.Owner) || utils.UserEqual(user.Id, share.Creator) || utils.UserEqual(user.Id, share.GetGrantee().GetUserId()) {
 			// no filter we return earlier
 			if len(filters) == 0 {
 				ss = append(ss, share)

--- a/pkg/utils/grpc.go
+++ b/pkg/utils/grpc.go
@@ -9,11 +9,11 @@ import (
 	gateway "github.com/cs3org/go-cs3apis/cs3/gateway/v1beta1"
 	group "github.com/cs3org/go-cs3apis/cs3/identity/group/v1beta1"
 	user "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
+	invitev1beta1 "github.com/cs3org/go-cs3apis/cs3/ocm/invite/v1beta1"
 	permissions "github.com/cs3org/go-cs3apis/cs3/permissions/v1beta1"
 	rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
 	storageprovider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	ctxpkg "github.com/cs3org/reva/v2/pkg/ctx"
-	revactx "github.com/cs3org/reva/v2/pkg/ctx"
 
 	"google.golang.org/grpc/metadata"
 )
@@ -58,7 +58,7 @@ func GetServiceUserContextWithContext(ctx context.Context, gwc gateway.GatewayAP
 		return nil, err
 	}
 
-	return metadata.AppendToOutgoingContext(ctx, revactx.TokenHeader, authRes.Token), nil
+	return metadata.AppendToOutgoingContext(ctx, ctxpkg.TokenHeader, authRes.Token), nil
 }
 
 // GetUser gets the specified user
@@ -76,9 +76,23 @@ func GetUserWithContext(ctx context.Context, userID *user.UserId, gwc gateway.Ga
 
 	if err := checkStatusCode("getting user", getUserResponse.GetStatus().GetCode()); err != nil {
 		return nil, err
+
+	}
+	return getUserResponse.GetUser(), nil
+}
+
+// GetUserWithContext gets the specified accepted user
+func GetAcceptedUserWithContext(ctx context.Context, userID *user.UserId, gwc gateway.GatewayAPIClient) (*user.User, error) {
+	getAcceptedUserResponse, err := gwc.GetAcceptedUser(ctx, &invitev1beta1.GetAcceptedUserRequest{RemoteUserId: userID})
+	if err != nil {
+		return nil, err
 	}
 
-	return getUserResponse.GetUser(), nil
+	if err := checkStatusCode("getting accepted user", getAcceptedUserResponse.GetStatus().GetCode()); err != nil {
+		return nil, err
+	}
+
+	return getAcceptedUserResponse.GetRemoteUser(), nil
 }
 
 // GetSpace returns the given space


### PR DESCRIPTION
We now use the share id to correctly identify ocm shares.