### PR TITLE
feat: add secure view share role

### DIFF
--- a/changelog/unreleased/secure-view-share-role.md
+++ b/changelog/unreleased/secure-view-share-role.md
@@ -1,0 +1,5 @@
+Enhancement: Secure view share role
+
+A new share role "Secure view" has been added. This role only allows viewing resources, no downloading, editing or deleting.
+
+https://github.com/cs3org/reva/pull/4643

--- a/pkg/conversions/role.go
+++ b/pkg/conversions/role.go
@@ -52,6 +52,8 @@ const (
 	RoleUploader = "uploader"
 	// RoleManager grants manager permissions on a resource. Semantically equivalent to co-owner.
 	RoleManager = "manager"
+	// RoleSecureView grants secure view permissions on a resource or space.
+	RoleSecureView = "secure-view"
 
 	// RoleUnknown is used for unknown roles.
 	RoleUnknown = "unknown"
@@ -159,6 +161,8 @@ func RoleFromName(name string) *Role {
 		return NewUploaderRole()
 	case RoleManager:
 		return NewManagerRole()
+	case RoleSecureView:
+		return NewSecureViewRole()
 	default:
 		return NewUnknownRole()
 	}
@@ -360,6 +364,18 @@ func NewManagerRole() *Role {
 			DenyGrant:   true, // managers can deny access to sub folders
 		},
 		ocsPermissions: PermissionAll,
+	}
+}
+
+// NewSecureViewRole creates a secure view role
+func NewSecureViewRole() *Role {
+	return &Role{
+		Name: RoleSecureView,
+		cS3ResourcePermissions: &provider.ResourcePermissions{
+			GetPath:       true,
+			ListContainer: true,
+			Stat:          true,
+		},
 	}
 }
 

--- a/pkg/conversions/role_test.go
+++ b/pkg/conversions/role_test.go
@@ -75,6 +75,21 @@ func TestSufficientPermissions(t *testing.T) {
 			Sufficient: false,
 		},
 		{
+			Existing:   RoleFromName("secure-view").CS3ResourcePermissions(),
+			Requested:  RoleFromName("secure-view").CS3ResourcePermissions(),
+			Sufficient: true,
+		},
+		{
+			Existing:   RoleFromName("secure-view").CS3ResourcePermissions(),
+			Requested:  RoleFromName("viewer").CS3ResourcePermissions(),
+			Sufficient: false,
+		},
+		{
+			Existing:   RoleFromName("secure-view").CS3ResourcePermissions(),
+			Requested:  RoleFromName("editor").CS3ResourcePermissions(),
+			Sufficient: false,
+		},
+		{
 			Existing: &providerv1beta1.ResourcePermissions{
 				// all permissions, used for personal space owners
 				AddGrant:             true,


### PR DESCRIPTION
Adds a new share role "Secure view". This role only allows viewing resources, no downloading, editing or deleting.