### PR TITLE
chore(tests): revert back to using cs3org/behat for acceptance tests

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -3,11 +3,10 @@ OC_CI_GOLANG = "owncloudci/golang:1.21"
 OC_CI_ALPINE = "owncloudci/alpine:latest"
 OSIXIA_OPEN_LDAP = "osixia/openldap:1.3.0"
 REDIS = "redis:6-alpine"
-OC_CI_PHP = "owncloudci/php:%s"
+OC_CI_PHP = "cs3org/behat:latest"
 OC_LITMUS = "owncloud/litmus:latest"
 OC_CS3_API_VALIDATOR = "owncloud/cs3api-validator:0.2.1"
 OC_CI_BAZEL_BUILDIFIER = "owncloudci/bazel-buildifier:latest"
-DEFAULT_PHP_VERSION = "8.2"
 
 # Shared step definitions
 def licenseScanStep():
@@ -253,7 +252,7 @@ def virtualViews():
             cloneApiTestReposStep(),
             {
                 "name": "APIAcceptanceTestsOcisStorage",
-                "image": OC_CI_PHP % DEFAULT_PHP_VERSION,
+                "image": OC_CI_PHP,
                 "commands": [
                     "cd /drone/src/tmp/testrunner",
                     "make test-acceptance-from-core-api",
@@ -598,7 +597,7 @@ def ocisIntegrationTests(parallelRuns, skipExceptParts = []):
                     cloneApiTestReposStep(),
                     {
                         "name": "APIAcceptanceTestsOcisStorage",
-                        "image": OC_CI_PHP % DEFAULT_PHP_VERSION,
+                        "image": OC_CI_PHP,
                         "commands": [
                             "cd /drone/src/tmp/testrunner",
                             "make test-acceptance-from-core-api",
@@ -674,7 +673,7 @@ def s3ngIntegrationTests(parallelRuns, skipExceptParts = []):
                     cloneApiTestReposStep(),
                     {
                         "name": "APIAcceptanceTestsS3ngStorage",
-                        "image": OC_CI_PHP % DEFAULT_PHP_VERSION,
+                        "image": OC_CI_PHP,
                         "commands": [
                             "cd /drone/src/tmp/testrunner",
                             "make test-acceptance-from-core-api",


### PR DESCRIPTION
In PR #4644 we changed to using owncloudci/php:8.2 for acceptance tests, because we use PHP 8.2 for testing in ocis nowadays.

I have now updated cs3org/behat https://github.com/cs3org/behat/pull/3 to have PHP 8.2

So this PR swaps back to using cs3org/behat
