### PR TITLE
gateway: improve error codes when removing space members

### DIFF
--- a/changelog/unreleased/enhance-removespacemember-returncode.md
+++ b/changelog/unreleased/enhance-removespacemember-returncode.md
@@ -1,0 +1,6 @@
+Enhancement: better error codes when removing a space member
+
+The gateway returns more specific error codes when removing a space member fails.
+
+https://github.com/cs3org/reva/pull/4652
+https://github.com/owncloud/ocis/issues/8819


### PR DESCRIPTION
We now pass through the error code from the storage provider when removing a grant fails.