### PR TITLE
fix(auth/scope): fix nested resource check when creating a new resource

### DIFF
--- a/changelog/unreleased/fix-publicshare-nested-appnew.md
+++ b/changelog/unreleased/fix-publicshare-nested-appnew.md
@@ -1,0 +1,7 @@
+Bugfix: Fix creating documents in nested folders of public shares
+
+We fixed a bug that prevented creating new documented in a nested folder
+of a public share.
+
+https://github.com/cs3org/reva/pull/4660
+https://github.com/owncloud/ocis/issues/8957

--- a/internal/grpc/interceptors/auth/scope.go
+++ b/internal/grpc/interceptors/auth/scope.go
@@ -266,7 +266,7 @@ func checkIfNestedResource(ctx context.Context, ref *provider.Reference, parent 
 	if err != nil {
 		return false, err
 	}
-	if statResponse.Status.Code != rpc.Code_CODE_OK {
+	if statResponse.GetStatus().GetCode() != rpc.Code_CODE_OK {
 		return false, statuspkg.NewErrorFromCode(statResponse.Status.Code, "auth interceptor")
 	}
 
@@ -318,14 +318,22 @@ func checkIfNestedResource(ctx context.Context, ref *provider.Reference, parent 
 	if err != nil {
 		return false, err
 	}
-	if childStat.Status.Code != rpc.Code_CODE_OK {
+	if childStat.GetStatus().GetCode() == rpc.Code_CODE_NOT_FOUND && ref.GetPath() != "" && ref.GetPath() != "." {
+		// The resource does not seem to exist (yet?). We might be part of an initiate upload request.
+		// Stat the parent to get its path and check that against the root path.
+		childStat, err = client.Stat(ctx, &provider.StatRequest{Ref: &provider.Reference{ResourceId: ref.GetResourceId()}})
+		if err != nil {
+			return false, err
+		}
+	}
+	if childStat.GetStatus().GetCode() != rpc.Code_CODE_OK {
 		return false, statuspkg.NewErrorFromCode(childStat.Status.Code, "auth interceptor")
 	}
 	pathResp, err = client.GetPath(ctx, &provider.GetPathRequest{ResourceId: childStat.GetInfo().GetId()})
 	if err != nil {
 		return false, err
 	}
-	if pathResp.Status.Code != rpc.Code_CODE_OK {
+	if pathResp.GetStatus().GetCode() != rpc.Code_CODE_OK {
 		return false, statuspkg.NewErrorFromCode(pathResp.Status.Code, "auth interceptor")
 	}
 	childPath = pathResp.Path


### PR DESCRIPTION
When creating a reource (e.g a document via the app/new endpoint) below a next folder structure of a public link, we can't stat the resource itself (it doesn't exit yet) for checking if it is a descendant of the share root. We now stat the resource's parent instead in that case.

Fixes: https://github.com/owncloud/ocis/issues/8957