### PR TITLE
fix: property Discovers() in client.go

### DIFF
--- a/pkg/ocm/client/client.go
+++ b/pkg/ocm/client/client.go
@@ -272,7 +272,7 @@ func (c *OCMClient) Discovery(ctx context.Context, endpoint string) (*Capabiliti
 	defer resp.Body.Close()
 
 	var cap Capabilities
-	if err := json.NewDecoder(resp.Body).Decode(&c); err != nil {
+	if err := json.NewDecoder(resp.Body).Decode(&cap); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
Storing json Decode() results in the client c object does not seem right. It probably silently ignores everything.

There is an unused var cap Capabilities directly above, that is returned uninitialized directly below. I assume it was meant to use this variable. Description