### PR TITLE
[backport/2.19] fix(auth/scope): fix nested resource check when creating a new resource

### DIFF
--- a/changelog/unreleased/fix-publicshare-nested-appnew.md
+++ b/changelog/unreleased/fix-publicshare-nested-appnew.md
@@ -1,0 +1,8 @@
+Bugfix: Fix creating documents in nested folders of public shares
+
+We fixed a bug that prevented creating new documented in a nested folder
+of a public share.
+
+https://github.com/cs3org/reva/pull/4665
+https://github.com/cs3org/reva/pull/4660
+https://github.com/owncloud/ocis/issues/8957


### PR DESCRIPTION
When creating a reource (e.g a document via the app/new endpoint) below a next folder structure of a public link, we can't stat the resource itself (it doesn't exit yet) for checking if it is a descendant of the share root. We now stat the resource's parent instead in that case.

Fixes: https://github.com/owncloud/ocis/issues/8957 (cherry picked from commit 5faad8dad61e25175e89f08e253feb187434a54c)