### PR TITLE
[backport/2.19] fix uploading via a public link

### DIFF
--- a/changelog/unreleased/fix-publiclink-upload.md
+++ b/changelog/unreleased/fix-publiclink-upload.md
@@ -1,0 +1,7 @@
+Bugfix: Fix uploading via a public link
+
+Fix http error when uploading via a public link
+
+https://github.com/cs3org/reva/pull/4666
+https://github.com/cs3org/reva/pull/4589
+https://github.com/owncloud/ocis/issues/8699

--- a/internal/http/services/owncloud/ocdav/tus.go
+++ b/internal/http/services/owncloud/ocdav/tus.go
@@ -319,9 +319,15 @@ func (s *svc) handleTusPost(ctx context.Context, w http.ResponseWriter, r *http.
 				w.Header().Set(net.HeaderOCMtime, httpRes.Header.Get(net.HeaderOCMtime))
 			}
 
-			if resid, err := storagespace.ParseID(httpRes.Header.Get(net.HeaderOCFileID)); err == nil {
-				sReq.Ref = &provider.Reference{
-					ResourceId: &resid,
+			if strings.HasPrefix(uReq.GetRef().GetPath(), "/public") && uReq.GetRef().GetResourceId() == nil {
+				// Use the path based request for the public link
+				sReq.Ref.Path = uReq.Ref.GetPath()
+				sReq.Ref.ResourceId = nil
+			} else {
+				if resid, err := storagespace.ParseID(httpRes.Header.Get(net.HeaderOCFileID)); err == nil {
+					sReq.Ref = &provider.Reference{
+						ResourceId: &resid,
+					}
 				}
 			}
 			finishUpload = httpRes.Header.Get(net.HeaderUploadOffset) == r.Header.Get(net.HeaderUploadLength)


### PR DESCRIPTION
(cherry picked from commit 9228b671ce1fd5018ac1185f81551979c270a5d0)