### PR TITLE
Fixed permission mapping to EOS ACLs

### DIFF
--- a/changelog/unreleased/eos-perms.md
+++ b/changelog/unreleased/eos-perms.md
@@ -1,0 +1,6 @@
+Bugfix: fixed permission mapping to EOS ACLs
+
+This is to remove "m" and "q" flags in EOS ACLs
+for regular write shares (no re-sharing).
+
+https://github.com/cs3org/reva/pull/4667

--- a/internal/http/services/owncloud/ocs/conversions/role.go
+++ b/internal/http/services/owncloud/ocs/conversions/role.go
@@ -181,7 +181,6 @@ func NewViewerRole() *Role {
 		Name: RoleViewer,
 		cS3ResourcePermissions: &provider.ResourcePermissions{
 			GetPath:              true,
-			GetQuota:             true,
 			InitiateFileDownload: true,
 			ListGrants:           true,
 			ListContainer:        true,
@@ -200,7 +199,6 @@ func NewReaderRole() *Role {
 		cS3ResourcePermissions: &provider.ResourcePermissions{
 			// read
 			GetPath:              true,
-			GetQuota:             true,
 			InitiateFileDownload: true,
 			ListGrants:           true,
 			ListContainer:        true,
@@ -218,7 +216,6 @@ func NewEditorRole() *Role {
 		Name: RoleEditor,
 		cS3ResourcePermissions: &provider.ResourcePermissions{
 			GetPath:              true,
-			GetQuota:             true,
 			InitiateFileDownload: true,
 			ListGrants:           true,
 			ListContainer:        true,
@@ -243,7 +240,6 @@ func NewFileEditorRole() *Role {
 		Name: RoleEditor,
 		cS3ResourcePermissions: &provider.ResourcePermissions{
 			GetPath:              true,
-			GetQuota:             true,
 			InitiateFileDownload: true,
 			ListGrants:           true,
 			ListContainer:        true,
@@ -368,7 +364,6 @@ func NewLegacyRoleFromOCSPermissions(p Permissions) *Role {
 		r.cS3ResourcePermissions.ListRecycle = true
 		r.cS3ResourcePermissions.Stat = true
 		r.cS3ResourcePermissions.GetPath = true
-		r.cS3ResourcePermissions.GetQuota = true
 		r.cS3ResourcePermissions.InitiateFileDownload = true
 	}
 	if p.Contain(PermissionWrite) {
@@ -424,7 +419,6 @@ func RoleFromResourcePermissions(rp *provider.ResourcePermissions) *Role {
 		rp.ListRecycle &&
 		rp.Stat &&
 		rp.GetPath &&
-		rp.GetQuota &&
 		rp.InitiateFileDownload {
 		r.ocsPermissions |= PermissionRead
 	}

--- a/pkg/storage/utils/grants/grants.go
+++ b/pkg/storage/utils/grants/grants.go
@@ -27,7 +27,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-// GetACLPerm generates a string representation of CS3APIs' ResourcePermissions
+// GetACLPerm generates a string representation of CS3APIs' ResourcePermissions,
+// modeled after the EOS ACLs.
 // TODO(labkode): fine grained permission controls.
 func GetACLPerm(set *provider.ResourcePermissions) (string, error) {
 	// resource permission is denied
@@ -37,7 +38,7 @@ func GetACLPerm(set *provider.ResourcePermissions) (string, error) {
 
 	var b strings.Builder
 
-	if set.Stat || set.InitiateFileDownload {
+	if set.Stat || set.InitiateFileDownload || set.ListGrants {
 		b.WriteString("r")
 	}
 	if set.CreateContainer || set.InitiateFileUpload || set.Delete || set.Move {
@@ -46,11 +47,8 @@ func GetACLPerm(set *provider.ResourcePermissions) (string, error) {
 	if set.ListContainer || set.ListFileVersions {
 		b.WriteString("x")
 	}
-	if set.AddGrant || set.ListGrants || set.RemoveGrant {
+	if set.AddGrant || set.RemoveGrant {
 		b.WriteString("m")
-	}
-	if set.GetQuota {
-		b.WriteString("q")
 	}
 
 	if set.Delete {
@@ -62,10 +60,10 @@ func GetACLPerm(set *provider.ResourcePermissions) (string, error) {
 	return b.String(), nil
 }
 
-// GetGrantPermissionSet converts CS3APIs' ResourcePermissions from a string
-// TODO(labkode): add more fine grained controls.
+// GetGrantPermissionSet converts CS3APIs' ResourcePermissions from a string:
 // EOS acls are a mix of ACLs and POSIX permissions. More details can be found in
-// https://github.com/cern-eos/eos/blob/master/doc/configuration/permission.rst
+// https://github.com/cern-eos/eos/blob/master/doc/citrine/configuration/permission.rst.
+// TODO(labkode): add more fine grained controls.
 func GetGrantPermissionSet(perm string) *provider.ResourcePermissions {
 	var rp provider.ResourcePermissions // default to 0 == all denied
 
@@ -73,6 +71,7 @@ func GetGrantPermissionSet(perm string) *provider.ResourcePermissions {
 		rp.GetPath = true
 		rp.Stat = true
 		rp.InitiateFileDownload = true
+		rp.ListGrants = true
 	}
 
 	if strings.Contains(perm, "w") && !strings.Contains(perm, "!w") {
@@ -98,12 +97,7 @@ func GetGrantPermissionSet(perm string) *provider.ResourcePermissions {
 
 	if strings.Contains(perm, "m") && !strings.Contains(perm, "!m") {
 		rp.AddGrant = true
-		rp.ListGrants = true
 		rp.RemoveGrant = true
-	}
-
-	if strings.Contains(perm, "q") && !strings.Contains(perm, "!q") {
-		rp.GetQuota = true
 	}
 
 	return &rp


### PR DESCRIPTION
Cf. [CERNBOX-3212](https://its.cern.ch/jira/browse/CERNBOX-3212), does this make sense?

An important side effect is that the `GetQuota` permission cannot be obtained at all, given that it is an administrative operation (and the `q` flag in EOS is for setting a quota, not for getting it anyway). To be seen how this reflects in all storage providers - do we want to keep the possibility to administer "quota" from Reva?