### PR TITLE
Support t and x in ACEs

### DIFF
--- a/changelog/unreleased/support-tx-in-aces.md
+++ b/changelog/unreleased/support-tx-in-aces.md
@@ -1,0 +1,5 @@
+Enhancement: Support t and x in ACEs
+
+To support view only shares (dowload forbidden) we added t (read attrs) and x (directory traversal) permissions to the decomposed FS ACEs. 
+
+https://github.com/cs3org/reva/pull/4685

--- a/pkg/conversions/role.go
+++ b/pkg/conversions/role.go
@@ -322,6 +322,7 @@ func NewUploaderRole() *Role {
 			GetPath:            true,
 			CreateContainer:    true,
 			InitiateFileUpload: true,
+			ListContainer:      true,
 		},
 		ocsPermissions: PermissionCreate,
 	}

--- a/pkg/conversions/role.go
+++ b/pkg/conversions/role.go
@@ -318,11 +318,13 @@ func NewUploaderRole() *Role {
 	return &Role{
 		Name: RoleUploader,
 		cS3ResourcePermissions: &provider.ResourcePermissions{
-			Stat:               true,
-			GetPath:            true,
-			CreateContainer:    true,
-			InitiateFileUpload: true,
-			ListContainer:      true,
+			Stat:                 true,
+			GetPath:              true,
+			CreateContainer:      true,
+			InitiateFileUpload:   true,
+			InitiateFileDownload: true,
+			ListContainer:        true,
+			Move:                 true,
 		},
 		ocsPermissions: PermissionCreate,
 	}

--- a/pkg/conversions/role.go
+++ b/pkg/conversions/role.go
@@ -545,6 +545,7 @@ func RoleFromResourcePermissions(rp *provider.ResourcePermissions, islink bool) 
 	if r.ocsPermissions == PermissionCreate {
 		if rp.GetPath && rp.InitiateFileDownload && rp.ListContainer && rp.Move {
 			r.Name = RoleEditorLite
+			return r
 		}
 		r.Name = RoleUploader
 		return r

--- a/pkg/storage/fs/nextcloud/nextcloud_server_mock.go
+++ b/pkg/storage/fs/nextcloud/nextcloud_server_mock.go
@@ -53,7 +53,7 @@ const serverStateMetadata = "METADATA"
 var serverState = serverStateEmpty
 
 var responses = map[string]Response{
-	`POST /apps/sciencemesh/~f7fbf8c8-139b-4376-b307-cf0a8c2d0d9c/api/storage/AddGrant {"ref":{"path":"/subdir"},"g":{"grantee":{"type":1,"Id":{"UserId":{"opaque_id":"4c510ada-c86b-4815-8820-42cdf82c3d51"}}},"permissions":{"move":true,"stat":true}}} EMPTY`: {200, ``, serverStateGrantAdded},
+	`POST /apps/sciencemesh/~f7fbf8c8-139b-4376-b307-cf0a8c2d0d9c/api/storage/AddGrant {"ref":{"path":"/subdir"},"g":{"grantee":{"type":1,"Id":{"UserId":{"opaque_id":"4c510ada-c86b-4815-8820-42cdf82c3d51"}}},"permissions":{"initiate_file_download":true,"move":true,"stat":true}}} EMPTY`: {200, ``, serverStateGrantAdded},
 
 	`POST /apps/sciencemesh/~f7fbf8c8-139b-4376-b307-cf0a8c2d0d9c/api/storage/CreateDir {"path":"/subdir"} EMPTY`:  {200, ``, serverStateSubdir},
 	`POST /apps/sciencemesh/~f7fbf8c8-139b-4376-b307-cf0a8c2d0d9c/api/storage/CreateDir {"path":"/subdir"} HOME`:   {200, ``, serverStateSubdir},
@@ -149,7 +149,7 @@ var responses = map[string]Response{
 
 	`POST /apps/sciencemesh/~f7fbf8c8-139b-4376-b307-cf0a8c2d0d9c/api/storage/UnsetArbitraryMetadata {"ref":{"path":"/subdir"},"keys":["foo"]}`: {200, ``, serverStateSubdir},
 
-	`POST /apps/sciencemesh/~f7fbf8c8-139b-4376-b307-cf0a8c2d0d9c/api/storage/UpdateGrant {"ref":{"path":"/subdir"},"g":{"grantee":{"type":1,"Id":{"UserId":{"opaque_id":"4c510ada-c86b-4815-8820-42cdf82c3d51"}}},"permissions":{"delete":true,"move":true,"stat":true}}}`: {200, ``, serverStateGrantUpdated},
+	`POST /apps/sciencemesh/~f7fbf8c8-139b-4376-b307-cf0a8c2d0d9c/api/storage/UpdateGrant {"ref":{"path":"/subdir"},"g":{"grantee":{"type":1,"Id":{"UserId":{"opaque_id":"4c510ada-c86b-4815-8820-42cdf82c3d51"}}},"permissions":{"delete":true,"initiate_file_download":true,"move":true,"stat":true}}}`: {200, ``, serverStateGrantUpdated},
 
 	`POST /apps/sciencemesh/~tester/api/storage/GetHome `:    {200, `yes we are`, serverStateHome},
 	`POST /apps/sciencemesh/~tester/api/storage/CreateHome `: {201, ``, serverStateEmpty},

--- a/pkg/storage/utils/ace/ace_test.go
+++ b/pkg/storage/utils/ace/ace_test.go
@@ -100,6 +100,21 @@ var _ = Describe("ACE", func() {
 	})
 
 	Describe("converting permissions", func() {
+		It("converts t", func() {
+			userGrant.Permissions.Stat = true
+			newGrant := ace.FromGrant(userGrant).Grant()
+			userGrant.Permissions.Stat = false
+			Expect(newGrant.Permissions.Stat).To(BeTrue())
+			Expect(newGrant.Permissions.Delete).To(BeFalse())
+
+			userGrant.Permissions.GetPath = true
+			newGrant = ace.FromGrant(userGrant).Grant()
+			fmt.Println(newGrant.Permissions)
+			userGrant.Permissions.GetPath = false
+			Expect(newGrant.Permissions.GetPath).To(BeTrue())
+			Expect(newGrant.Permissions.Delete).To(BeFalse())
+		})
+
 		It("converts r", func() {
 			userGrant.Permissions.Stat = true
 			newGrant := ace.FromGrant(userGrant).Grant()
@@ -149,6 +164,14 @@ var _ = Describe("ACE", func() {
 			newGrant := ace.FromGrant(userGrant).Grant()
 			userGrant.Permissions.CreateContainer = false
 			Expect(newGrant.Permissions.CreateContainer).To(BeTrue())
+			Expect(newGrant.Permissions.Delete).To(BeFalse())
+		})
+
+		It("converts x", func() {
+			userGrant.Permissions.ListContainer = true
+			newGrant := ace.FromGrant(userGrant).Grant()
+			userGrant.Permissions.ListContainer = false
+			Expect(newGrant.Permissions.ListContainer).To(BeTrue())
 			Expect(newGrant.Permissions.Delete).To(BeFalse())
 		})
 

--- a/pkg/storage/utils/decomposedfs/grants_test.go
+++ b/pkg/storage/utils/decomposedfs/grants_test.go
@@ -50,9 +50,10 @@ var _ = Describe("Grants", func() {
 				},
 			},
 			Permissions: &provider.ResourcePermissions{
-				Stat:   true,
-				Move:   true,
-				Delete: false,
+				Stat:                 true,
+				Move:                 true,
+				Delete:               false,
+				InitiateFileDownload: true,
 			},
 			Creator: &userpb.UserId{
 				OpaqueId: helpers.OwnerID,
@@ -130,7 +131,7 @@ var _ = Describe("Grants", func() {
 				Expect(err).ToNot(HaveOccurred())
 				attr, err := n.XattrString(env.Ctx, prefixes.GrantUserAcePrefix+grant.Grantee.GetUserId().OpaqueId)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(attr).To(Equal(fmt.Sprintf("\x00t=A:f=:p=rw:c=%s:e=0\n", o.GetOpaqueId()))) // NOTE: this tests ace package
+				Expect(attr).To(Equal(fmt.Sprintf("\x00t=A:f=:p=trw:c=%s:e=0\n", o.GetOpaqueId()))) // NOTE: this tests ace package
 			})
 
 			It("creates a storage space per created grant", func() {

--- a/tests/integration/grpc/storageprovider_test.go
+++ b/tests/integration/grpc/storageprovider_test.go
@@ -312,9 +312,10 @@ var _ = Describe("storage providers", func() {
 					},
 				},
 				Permissions: &storagep.ResourcePermissions{
-					Stat:   true,
-					Move:   true,
-					Delete: false,
+					Stat:                 true,
+					Move:                 true,
+					Delete:               false,
+					InitiateFileDownload: true,
 				},
 			}
 			addRes, err := serviceClient.AddGrant(ctx, &storagep.AddGrantRequest{Ref: subdirRef, Grant: grant})
@@ -329,6 +330,7 @@ var _ = Describe("storage providers", func() {
 			Expect(readGrant.Permissions.Stat).To(BeTrue())
 			Expect(readGrant.Permissions.Move).To(BeTrue())
 			Expect(readGrant.Permissions.Delete).To(BeFalse())
+			Expect(readGrant.Permissions.InitiateFileDownload).To(BeTrue())
 
 			By("updating the grant")
 			grant.Permissions.Delete = true
@@ -344,6 +346,7 @@ var _ = Describe("storage providers", func() {
 			Expect(readGrant.Permissions.Stat).To(BeTrue())
 			Expect(readGrant.Permissions.Move).To(BeTrue())
 			Expect(readGrant.Permissions.Delete).To(BeTrue())
+			Expect(readGrant.Permissions.InitiateFileDownload).To(BeTrue())
 
 			By("deleting a grant")
 			delRes, err := serviceClient.RemoveGrant(ctx, &storagep.RemoveGrantRequest{Ref: subdirRef, Grant: readGrant})


### PR DESCRIPTION
To support view only shares (dowload forbidden) we added t (read attrs) and x (directory traversal) permissions to the decomposed FS ACEs. 

The change is backwards compatible. an ACE with `r` permission will still grant Stat, getPath, InitiateFileDownload and ListContainer permissions. Newly written grants will explicitly set `t` and `x` permissions. If we need to be more strict, we could increase the version byte to `x02` (`x01` was used in the very early days) which can than unparse the `r` to only grant the InitiateFileDownload permission.
