### PR TITLE
fix: convert dates for propfinds from RFC3339 (ocis) to RFC1123 (ocdav)

### DIFF
--- a/changelog/unreleased/add-photo-and-image-props.md
+++ b/changelog/unreleased/add-photo-and-image-props.md
@@ -3,3 +3,4 @@ Enhancement: Add photo and image props
 Add `oc:photo` and `oc:image` props to PROPFIND responses for propall requests or when they are explicitly requested.
 
 https://github.com/cs3org/reva/pull/4684
+https://github.com/cs3org/reva/pull/4688

--- a/internal/http/services/owncloud/ocdav/propfind/propfind.go
+++ b/internal/http/services/owncloud/ocdav/propfind/propfind.go
@@ -1171,6 +1171,18 @@ func mdToPropResponse(ctx context.Context, pf *XML, md *provider.ResourceInfo, p
 		}
 	}
 
+	convertRFC3339ToRFC1123 := func(metadata map[string]string, tagNamespace string, name string, metadataPrefix string, keys []string) {
+		for _, key := range keys {
+			mdKey := fmt.Sprintf("%s.%s", metadataPrefix, key)
+			if v, ok := metadata[mdKey]; ok {
+				parsedTime, err := time.Parse(time.RFC3339, v)
+				if err == nil {
+					metadata[mdKey] = parsedTime.Format(net.RFC1123)
+				}
+			}
+		}
+	}
+
 	// when allprops has been requested
 	if pf.Allprop != nil {
 		// return all known properties
@@ -1273,6 +1285,7 @@ func mdToPropResponse(ctx context.Context, pf *XML, md *provider.ResourceInfo, p
 			appendMetadataProp(k, "oc", "audio", "libre.graph.audio", audioKeys)
 			appendMetadataProp(k, "oc", "location", "libre.graph.location", locationKeys)
 			appendMetadataProp(k, "oc", "image", "libre.graph.image", imageKeys)
+			convertRFC3339ToRFC1123(k, "oc", "photo", "libre.graph.photo", []string{"takenDateTime"})
 			appendMetadataProp(k, "oc", "photo", "libre.graph.photo", photoKeys)
 		}
 
@@ -1561,6 +1574,7 @@ func mdToPropResponse(ctx context.Context, pf *XML, md *provider.ResourceInfo, p
 					}
 				case "photo":
 					if k := md.GetArbitraryMetadata().GetMetadata(); k != nil {
+						convertRFC3339ToRFC1123(k, "oc", "photo", "libre.graph.photo", []string{"takenDateTime"})
 						appendMetadataProp(k, "oc", "photo", "libre.graph.photo", photoKeys)
 					}
 				case "name":


### PR DESCRIPTION
While oCIS uses RFC3339 time formats internally, we use RFC1123 time formats for webdav responses. Since oCIS doesn't know about the format, we now convert the time strings that arrive in reva from RFC3339 to RFC1123.