### PR TITLE
feat: give service account permission to assign initial space members

### DIFF
--- a/changelog/unreleased/extend-service-account-permissions-2.md
+++ b/changelog/unreleased/extend-service-account-permissions-2.md
@@ -1,0 +1,5 @@
+Enhancement: Extend service account permissions
+
+Adds AddGrant permisson
+
+https://github.com/cs3org/reva/pull/4689

--- a/pkg/storage/utils/decomposedfs/node/permissions.go
+++ b/pkg/storage/utils/decomposedfs/node/permissions.go
@@ -100,6 +100,7 @@ func ServiceAccountPermissions() provider.ResourcePermissions {
 		RestoreRecycleItem:   true, // for cli restore command
 		Delete:               true, // for cli restore command with replace option
 		CreateContainer:      true, // for space provisioning
+		AddGrant:             true, // for initial project space member assignment
 	}
 }
 


### PR DESCRIPTION
I'm working on a service that requires a space to be available. In order to make the deployment easier I want to create the space on startup. 
On startup there is no request context available and hence no user context.  I can use the service account to create a space, but I cannot assign a user to it - that's sort of weird. This PR gives the service account the permission to assign users as well.
