### PR TITLE
Expose secureview as 'X' in dav permissions

### DIFF
--- a/changelog/unreleased/dav-expose-secureview.md
+++ b/changelog/unreleased/dav-expose-secureview.md
@@ -1,0 +1,5 @@
+Enhancement: Expose SecureView in WebDAV permissions
+
+When a file or folder can be securely viewed we now add an `X` to the permissions.
+
+https://github.com/cs3org/reva/pull/4694

--- a/pkg/conversions/role.go
+++ b/pkg/conversions/role.go
@@ -106,6 +106,7 @@ func (r *Role) OCSPermissions() Permissions {
 // M = Mounted
 // Z = Deniable (NEW)
 // P = Purge from trashbin
+// X = SecureViewable
 func (r *Role) WebDAVPermissions(isDir, isShared, isMountpoint, isPublic bool) string {
 	var b strings.Builder
 	if !isPublic && isShared {
@@ -139,6 +140,10 @@ func (r *Role) WebDAVPermissions(isDir, isShared, isMountpoint, isPublic bool) s
 
 	if r.CS3ResourcePermissions().PurgeRecycle {
 		fmt.Fprintf(&b, "P")
+	}
+
+	if r.Name == RoleSecureViewer {
+		fmt.Fprintf(&b, "X")
 	}
 
 	return b.String()
@@ -541,6 +546,9 @@ func RoleFromResourcePermissions(rp *provider.ResourcePermissions, islink bool) 
 			r.Name = RoleViewer
 			return r
 		}
+	} else if rp.Stat && rp.GetPath && rp.ListContainer && !rp.InitiateFileUpload && !rp.Delete && !rp.AddGrant {
+		r.Name = RoleSecureViewer
+		return r
 	}
 	if r.ocsPermissions == PermissionCreate {
 		if rp.GetPath && rp.InitiateFileDownload && rp.ListContainer && rp.Move {


### PR DESCRIPTION
When a file or folder can be securely viewed we now add an `X` to the permissions.
