### PR TITLE
clean empty trash node path on delete

### DIFF
--- a/changelog/unreleased/clean-trash-node-path.md
+++ b/changelog/unreleased/clean-trash-node-path.md
@@ -1,0 +1,5 @@
+Bugfix: clean empty trash node path on delete
+
+We now delete empty directories in the trash when an item is purged or restored. This prevents old empty directories from slowing down the globbing of trash items.
+
+https://github.com/cs3org/reva/pull/4700

--- a/pkg/storage/utils/decomposedfs/tree/tree.go
+++ b/pkg/storage/utils/decomposedfs/tree/tree.go
@@ -601,9 +601,13 @@ func (t *Tree) RestoreRecycleItemFunc(ctx context.Context, spaceid, key, trashPa
 				return errors.Wrap(err, "Decomposedfs: could not resolve trash root")
 			}
 			deletePath = filepath.Join(resolvedTrashRoot, trashPath)
-		}
-		if err = os.Remove(deletePath); err != nil {
-			logger.Error().Err(err).Str("trashItem", trashItem).Msg("error deleting trash item")
+			if err = os.Remove(deletePath); err != nil {
+				logger.Error().Err(err).Str("trashItem", trashItem).Str("deletePath", deletePath).Str("trashPath", trashPath).Msg("error deleting trash item")
+			}
+		} else {
+			if err = utils.RemoveItem(deletePath); err != nil {
+				logger.Error().Err(err).Str("trashItem", trashItem).Str("deletePath", deletePath).Str("trashPath", trashPath).Msg("error recursively deleting trash item")
+			}
 		}
 
 		var sizeDiff int64
@@ -651,7 +655,7 @@ func (t *Tree) PurgeRecycleItemFunc(ctx context.Context, spaceid, key string, pa
 			}
 			deletePath = filepath.Join(resolvedTrashRoot, path)
 		}
-		if err = os.Remove(deletePath); err != nil {
+		if err = utils.RemoveItem(deletePath); err != nil {
 			logger.Error().Err(err).Str("deletePath", deletePath).Msg("error deleting trash item")
 			return err
 		}


### PR DESCRIPTION
We now delete empty directories in the trash when an item is purged or restored. This prevents old empty directories from slowing down the globbing of trash items.

~~I'll add an ocis cli cmd to clean up existing trash directories.~~
`find /var/lib/ocis/storage/users/*/*/trash/* -type d -empty -delete`