### PR TITLE
add secureview flag when listing apps via http

### DIFF
--- a/changelog/unreleased/add-providerinfo-secure-view-flag.md
+++ b/changelog/unreleased/add-providerinfo-secure-view-flag.md
@@ -1,0 +1,5 @@
+Enhancement: add secureview flag when listing apps via http
+
+To allow clients to see which application supports secure view we add a flag to the http response when the app name matches a configured secure view app.
+
+https://github.com/cs3org/reva/pull/4703


### PR DESCRIPTION
To allow clients to see which application supports secure view we add a flag to the http response when the app name matches a configured secure view app.


part of https://github.com/owncloud/ocis/issues/9272