### PR TITLE
set secureview flag based on addr

### DIFF
--- a/changelog/unreleased/add-providerinfo-secure-view-flag.md
+++ b/changelog/unreleased/add-providerinfo-secure-view-flag.md
@@ -1,5 +1,6 @@
 Enhancement: add secureview flag when listing apps via http
 
-To allow clients to see which application supports secure view we add a flag to the http response when the app name matches a configured secure view app.
+To allow clients to see which application supports secure view we add a flag to the http response when the app address matches a configured secure view app address.
 
+https://github.com/cs3org/reva/pull/4706
 https://github.com/cs3org/reva/pull/4703


### PR DESCRIPTION
To allow clients to see which application supports secure view we add a flag to the http response when the app address matches a configured secure view app address.

followup to https://github.com/cs3org/reva/pull/4703