### PR TITLE
fixed the response code when the role/permission is empty on the share update

### DIFF
--- a/changelog/unreleased/fix-share-update.md
+++ b/changelog/unreleased/fix-share-update.md
@@ -1,0 +1,7 @@
+Bugfix: Fix share update
+
+We fixed the response code when the role/permission is empty on the share update
+
+
+https://github.com/cs3org/reva/pull/4709
+https://github.com/owncloud/ocis/issues/8747

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/shares.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/shares.go
@@ -859,6 +859,9 @@ func (h *Handler) updateShare(w http.ResponseWriter, r *http.Request, share *col
 		case rpc.Code_CODE_LOCKED:
 			response.WriteOCSError(w, r, response.MetaLocked.StatusCode, uRes.GetStatus().GetMessage(), nil)
 			return
+		case rpc.Code_CODE_INVALID_ARGUMENT, rpc.Code_CODE_FAILED_PRECONDITION:
+			response.WriteOCSError(w, r, response.MetaBadRequest.StatusCode, uRes.GetStatus().GetMessage(), nil)
+			return
 		}
 		response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "grpc update share request failed", err)
 		return


### PR DESCRIPTION
We fixed the response code when the role/permission is empty on the share update

Related issue: https://github.com/owncloud/ocis/issues/8747