### PR TITLE
fix: space listing when user has no personal space

### DIFF
--- a/changelog/unreleased/fix-user-group-index.md
+++ b/changelog/unreleased/fix-user-group-index.md
@@ -1,0 +1,5 @@
+Bugfix: Tolerate missing user space index
+
+We fixed a bug where the spaces for a user were not listed if the user had no space index by user. This happens when a user has the role "User Light" and has been invited to a project space via a group.
+
+https://github.com/cs3org/reva/pull/4710

--- a/pkg/storage/utils/decomposedfs/spaces.go
+++ b/pkg/storage/utils/decomposedfs/spaces.go
@@ -325,7 +325,8 @@ func (fs *Decomposedfs) ListStorageSpaces(ctx context.Context, filter []*provide
 
 	if requestedUserID != nil {
 		allMatches, err = fs.userSpaceIndex.Load(requestedUserID.GetOpaqueId())
-		if err != nil {
+		// do not return an error if the user has no spaces
+		if err != nil && !os.IsNotExist(err) {
 			return nil, errors.Wrap(err, "error reading user index")
 		}
 


### PR DESCRIPTION
Bugfix: Tolerate missing user space index

We fixed a bug where the spaces for a user were not listed if the user had no space index by user. This happens when a user has the role "User Light" and has been invited to a project space via a group.
