### PR TITLE
fix: duplicate headers in DAV responses

### DIFF
--- a/changelog/unreleased/fix-dav-headers.md
+++ b/changelog/unreleased/fix-dav-headers.md
@@ -1,0 +1,5 @@
+Bugfix: Duplicate headers in DAV responses
+
+We fixed an issue where the DAV response headers were duplicated. This was caused by the WebDav handler which copied over all headers from the datagateways response. Now, only the relevant headers are copied over to the DAV response to prevent duplication.
+
+https://github.com/cs3org/reva/pull/4711

--- a/internal/http/services/owncloud/ocdav/get.go
+++ b/internal/http/services/owncloud/ocdav/get.go
@@ -131,7 +131,19 @@ func (s *svc) handleGet(ctx context.Context, w http.ResponseWriter, r *http.Requ
 	}
 	defer httpRes.Body.Close()
 
-	copyHeader(w.Header(), httpRes.Header)
+	// copy only the headers relevant for the content served by the datagateway
+	// more headers are already present from the GET request
+	copyHeader(w.Header(), httpRes.Header, net.HeaderContentType)
+	copyHeader(w.Header(), httpRes.Header, net.HeaderContentLength)
+	copyHeader(w.Header(), httpRes.Header, net.HeaderContentRange)
+	copyHeader(w.Header(), httpRes.Header, net.HeaderOCFileID)
+	copyHeader(w.Header(), httpRes.Header, net.HeaderOCETag)
+	copyHeader(w.Header(), httpRes.Header, net.HeaderOCChecksum)
+	copyHeader(w.Header(), httpRes.Header, net.HeaderETag)
+	copyHeader(w.Header(), httpRes.Header, net.HeaderLastModified)
+	copyHeader(w.Header(), httpRes.Header, net.HeaderAcceptRanges)
+	copyHeader(w.Header(), httpRes.Header, net.HeaderContentDisposistion)
+
 	w.WriteHeader(httpRes.StatusCode)
 
 	if httpRes.StatusCode != http.StatusOK && httpRes.StatusCode != http.StatusPartialContent {
@@ -156,11 +168,9 @@ func (s *svc) handleGet(ctx context.Context, w http.ResponseWriter, r *http.Requ
 	// TODO we need to send the If-Match etag in the GET to the datagateway to prevent race conditions between stating and reading the file
 }
 
-func copyHeader(dst, src http.Header) {
-	for key, values := range src {
-		for i := range values {
-			dst.Add(key, values[i])
-		}
+func copyHeader(dist, src http.Header, header string) {
+	if src.Get(header) != "" {
+		dist.Set(header, src.Get(header))
 	}
 }
 

--- a/internal/http/services/owncloud/ocdav/ocdav.go
+++ b/internal/http/services/owncloud/ocdav/ocdav.go
@@ -165,8 +165,6 @@ func (s *svc) Handler() http.Handler {
 		ctx := r.Context()
 		log := appctx.GetLogger(ctx)
 
-		addAccessHeaders(w, r)
-
 		// TODO(jfd): do we need this?
 		// fake litmus testing for empty namespace: see https://github.com/golang/net/blob/e514e69ffb8bc3c76a71ae40de0118d794855992/webdav/litmus_test_server.go#L58-L89
 		if r.Header.Get(net.HeaderLitmus) == "props: 3 (propfind_invalid2)" {
@@ -282,28 +280,6 @@ func (s *svc) ApplyLayout(ctx context.Context, ns string, useLoggedInUserNS bool
 	}
 
 	return templates.WithUser(u, ns), requestPath, nil
-}
-
-func addAccessHeaders(w http.ResponseWriter, r *http.Request) {
-	headers := w.Header()
-	// all resources served via the DAV endpoint should have the strictest possible as default
-	headers.Set("Content-Security-Policy", "default-src 'none';")
-	// disable sniffing the content type for IE
-	headers.Set("X-Content-Type-Options", "nosniff")
-	// https://msdn.microsoft.com/en-us/library/jj542450(v=vs.85).aspx
-	headers.Set("X-Download-Options", "noopen")
-	// Disallow iFraming from other domains
-	headers.Set("X-Frame-Options", "SAMEORIGIN")
-	// https://www.adobe.com/devnet/adobe-media-server/articles/cross-domain-xml-for-streaming.html
-	headers.Set("X-Permitted-Cross-Domain-Policies", "none")
-	// https://developers.google.com/webmasters/control-crawl-index/docs/robots_meta_tag
-	headers.Set("X-Robots-Tag", "none")
-	// enforce browser based XSS filters
-	headers.Set("X-XSS-Protection", "1; mode=block")
-
-	if r.TLS != nil {
-		headers.Set("Strict-Transport-Security", "max-age=63072000")
-	}
 }
 
 func authContextForUser(client gateway.GatewayAPIClient, userID *userpb.UserId, machineAuthAPIKey string) (context.Context, error) {


### PR DESCRIPTION
# Description

We fixed an issue where the DAV response headers were duplicated. This was caused by the WebDav handler which copied over all headers from the datagateways response. Now, only the relevant headers are copied over to the DAV response to prevent duplication.

Relates to https://github.com/owncloud/ocis/issues/9219