### PR TITLE
(posixfs) Truncate destination before uploading

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -758,7 +758,7 @@ def posixfsIntegrationTests(parallelRuns, skipExceptParts = []):
                         "environment": {
                             "TEST_SERVER_URL": "http://revad-services:20080",
                             "OCIS_REVA_DATA_ROOT": "/drone/src/tmp/reva/data/",
-                            "DELETE_USER_DATA_CMD": "rm -rf /drone/src/tmp/reva/data/users/* /drone/src/tmp/reva/data/indexes/by-type/*",
+                            "DELETE_USER_DATA_CMD": "sh -c 'i=1; while [ $i -le 60 ]; do rm -rf /drone/src/tmp/reva/data/users/* /drone/src/tmp/reva/data/indexes/by-type/* && break || sleep 5; done'",
                             "STORAGE_DRIVER": "ocis",
                             "SKELETON_DIR": "/drone/src/tmp/testing/data/apiSkeleton",
                             "TEST_WITH_LDAP": "true",

--- a/changelog/unreleased/improve-posixfs.md
+++ b/changelog/unreleased/improve-posixfs.md
@@ -2,5 +2,6 @@ Enhancement: Improve posixfs storage driver
 
 Improve the posixfs storage driver by fixing several issues and adding missing features. 
 
+https://github.com/cs3org/reva/pull/4719
 https://github.com/cs3org/reva/pull/4708
 https://github.com/cs3org/reva/pull/4562

--- a/pkg/storage/fs/posix/blobstore/blobstore.go
+++ b/pkg/storage/fs/posix/blobstore/blobstore.go
@@ -47,10 +47,11 @@ func (bs *Blobstore) Upload(node *node.Node, source string) error {
 	}
 	defer file.Close()
 
-	f, err := os.OpenFile(node.InternalPath(), os.O_CREATE|os.O_WRONLY, 0700)
+	f, err := os.OpenFile(node.InternalPath(), os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0700)
 	if err != nil {
 		return errors.Wrapf(err, "could not open blob '%s' for writing", node.InternalPath())
 	}
+	defer f.Close()
 
 	w := bufio.NewWriter(f)
 	_, err = w.ReadFrom(file)


### PR DESCRIPTION
Prevent broken uploads by truncating the destination file before uploading. Also fix the flakiness in the integration test suite.