### PR TITLE
eosfs: set initial quota depending on user type

### DIFF
--- a/changelog/unreleased/eos-userquota.md
+++ b/changelog/unreleased/eos-userquota.md
@@ -1,0 +1,6 @@
+Enhancement: differentiate quota for user types in EOS
+
+We now assign a different initial quota to users depending
+on their type, whether PRIMARY or not.
+
+https://github.com/cs3org/reva/pull/4720

--- a/pkg/storage/utils/eosfs/config.go
+++ b/pkg/storage/utils/eosfs/config.go
@@ -29,6 +29,9 @@ type Config struct {
 	// DefaultQuotaBytes sets the default maximum bytes available for a user
 	DefaultQuotaBytes uint64 `mapstructure:"default_quota_bytes"`
 
+	// DefaultSecondaryQuotaBytes sets the default maximum bytes available for a secondary user
+	DefaultSecondaryQuotaBytes uint64 `mapstructure:"default_secondary_quota_bytes"`
+
 	// DefaultQuotaFiles sets the default maximum files available for a user
 	DefaultQuotaFiles uint64 `mapstructure:"default_quota_files"`
 

--- a/pkg/storage/utils/eosfs/eosfs.go
+++ b/pkg/storage/utils/eosfs/eosfs.go
@@ -101,6 +101,9 @@ func (c *Config) ApplyDefaults() {
 	if c.DefaultQuotaBytes == 0 {
 		c.DefaultQuotaBytes = 2000000000000 // 1 TB logical
 	}
+	if c.DefaultSecondaryQuotaBytes == 0 {
+		c.DefaultSecondaryQuotaBytes = c.DefaultQuotaBytes
+	}
 	if c.DefaultQuotaFiles == 0 {
 		c.DefaultQuotaFiles = 1000000 // 1 Million
 	}
@@ -1489,12 +1492,16 @@ func (fs *eosfs) createNominalHome(ctx context.Context) error {
 		return err
 	}
 
-	// set quota for user
+	// set quota for user, depending on its type
+	quotaBytes := fs.conf.DefaultQuotaBytes
+	if u.Id.Type != userpb.UserType_USER_TYPE_PRIMARY {
+		quotaBytes = fs.conf.DefaultSecondaryQuotaBytes
+	}
 	quotaInfo := &eosclient.SetQuotaInfo{
 		Username:  u.Username,
 		UID:       auth.Role.UID,
 		GID:       auth.Role.GID,
-		MaxBytes:  fs.conf.DefaultQuotaBytes,
+		MaxBytes:  quotaBytes,
 		MaxFiles:  fs.conf.DefaultQuotaFiles,
 		QuotaNode: fs.conf.QuotaNode,
 	}


### PR DESCRIPTION
Introduced a new config parameter, `default_secondary_quota_bytes`, defaulting to the existing `default_quota_bytes`, which represents the initial volume quota given to non-primary users.