### PR TITLE
Disallow invalid filenames

### DIFF
--- a/changelog/unreleased/filename-validator.md
+++ b/changelog/unreleased/filename-validator.md
@@ -1,0 +1,7 @@
+Bugfix: Disallow illegal filenames filter
+
+We have created a validator that checks if a filename is in a list of forbidden filenames.
+This list is defined in the config file and can be extended by the administrator.
+
+https://github.com/cs3org/reva/pull/4721
+https://github.com/owncloud/ocis/issues/1002

--- a/internal/grpc/services/gateway/storageprovider.go
+++ b/internal/grpc/services/gateway/storageprovider.go
@@ -549,7 +549,7 @@ func (s *svc) InitiateFileDownload(ctx context.Context, req *provider.InitiateFi
 func (s *svc) InitiateFileUpload(ctx context.Context, req *provider.InitiateFileUploadRequest) (*gateway.InitiateFileUploadResponse, error) {
 	var c provider.ProviderAPIClient
 	var err error
-	c, _, req.Ref, err = s.findAndUnwrap(ctx, req.Ref)
+	c, _, req.Ref, err = s.findAndUnwrapUnique(ctx, req.Ref)
 	if err != nil {
 		return &gateway.InitiateFileUploadResponse{
 			Status: status.NewStatusFromErrType(ctx, fmt.Sprintf("gateway could not find space for ref=%+v", req.Ref), err),

--- a/internal/grpc/services/gateway/storageprovider.go
+++ b/internal/grpc/services/gateway/storageprovider.go
@@ -549,7 +549,7 @@ func (s *svc) InitiateFileDownload(ctx context.Context, req *provider.InitiateFi
 func (s *svc) InitiateFileUpload(ctx context.Context, req *provider.InitiateFileUploadRequest) (*gateway.InitiateFileUploadResponse, error) {
 	var c provider.ProviderAPIClient
 	var err error
-	c, _, req.Ref, err = s.findAndUnwrapUnique(ctx, req.Ref)
+	c, _, req.Ref, err = s.findAndUnwrap(ctx, req.Ref)
 	if err != nil {
 		return &gateway.InitiateFileUploadResponse{
 			Status: status.NewStatusFromErrType(ctx, fmt.Sprintf("gateway could not find space for ref=%+v", req.Ref), err),

--- a/internal/http/services/owncloud/ocdav/config/config.go
+++ b/internal/http/services/owncloud/ocdav/config/config.go
@@ -43,6 +43,7 @@ type Config struct {
 // NameValidation is the validation configuration for file and folder names
 type NameValidation struct {
 	InvalidChars []string `mapstructure:"invalid_chars"`
+	InvalidNames []string `mapstructure:"invalid_names"`
 	MaxLength    int      `mapstructure:"max_length"`
 }
 
@@ -81,6 +82,10 @@ func (c *Config) Init() {
 
 	if c.NameValidation.InvalidChars == nil {
 		c.NameValidation.InvalidChars = []string{"\f", "\r", "\n", "\\"}
+	}
+
+	if c.NameValidation.InvalidNames == nil {
+		c.NameValidation.InvalidNames = []string{"..", "."}
 	}
 
 	if c.NameValidation.MaxLength == 0 {

--- a/internal/http/services/owncloud/ocdav/config/config.go
+++ b/internal/http/services/owncloud/ocdav/config/config.go
@@ -85,7 +85,7 @@ func (c *Config) Init() {
 	}
 
 	if c.NameValidation.InvalidNames == nil {
-		c.NameValidation.InvalidNames = []string{"..", "."}
+		c.NameValidation.InvalidNames = []string{".."}
 	}
 
 	if c.NameValidation.MaxLength == 0 {

--- a/internal/http/services/owncloud/ocdav/tus.go
+++ b/internal/http/services/owncloud/ocdav/tus.go
@@ -253,6 +253,7 @@ func (s *svc) handleTusPost(ctx context.Context, w http.ResponseWriter, r *http.
 			w.WriteHeader(http.StatusPreconditionFailed)
 			return
 		}
+		log.Error().Interface("status", uRes.Status).Msg("error initiating file upload")
 		errors.HandleErrorStatus(&log, w, uRes.Status)
 		return
 	}

--- a/internal/http/services/owncloud/ocdav/validation.go
+++ b/internal/http/services/owncloud/ocdav/validation.go
@@ -22,6 +22,8 @@ func ValidatorsFromConfig(c *config.Config) []Validator {
 	// max length
 	vals = append(vals, isShorterThan(c.NameValidation.MaxLength))
 
+	vals = append(vals, invalidNames(c.NameValidation.InvalidNames))
+
 	return vals
 }
 
@@ -33,6 +35,17 @@ func ValidateName(name string, validators []Validator) error {
 		}
 	}
 	return nil
+}
+
+func invalidNames(bad []string) Validator {
+	return func(s string) error {
+		for _, b := range bad {
+			if s == b {
+				return fmt.Errorf("must not be %s", b)
+			}
+		}
+		return nil
+	}
 }
 
 func notEmpty() Validator {


### PR DESCRIPTION
Bugfix: Disallow illegal filenames filter

We have created a validator that checks if a filename is in a list of forbidden filenames.
This list is defined in the config file and can be extended by the administrator.

https://github.com/owncloud/ocis/issues/1002