### PR TITLE
The libregraph public link type representation added to the PROPFIND response

### DIFF
--- a/changelog/unreleased/ocdav-link-type.md
+++ b/changelog/unreleased/ocdav-link-type.md
@@ -1,0 +1,5 @@
+Enhancement: The public link type added
+
+The libregraph public link type representation added to the PROPFIND response.
+
+https://github.com/cs3org/reva/pull/4722

--- a/internal/http/services/owncloud/ocdav/propfind/propfind.go
+++ b/internal/http/services/owncloud/ocdav/propfind/propfind.go
@@ -1344,6 +1344,12 @@ func mdToPropResponse(ctx context.Context, pf *XML, md *provider.ResourceInfo, p
 					} else {
 						appendToNotFound(prop.NotFound("oc:public-link-permission"))
 					}
+				case "public-link-type": // only on a share root node
+					if ls != nil && md.PermissionSet != nil {
+						appendToOK(prop.Escaped("oc:public-link-type", role.OCSPermissionsToPublicLinkType(md.Type)))
+					} else {
+						appendToNotFound(prop.NotFound("oc:public-link-type"))
+					}
 				case "public-link-item-type": // only on a share root node
 					if ls != nil {
 						if md.Type == provider.ResourceType_RESOURCE_TYPE_CONTAINER {

--- a/pkg/conversions/role.go
+++ b/pkg/conversions/role.go
@@ -149,6 +149,29 @@ func (r *Role) WebDAVPermissions(isDir, isShared, isMountpoint, isPublic bool) s
 	return b.String()
 }
 
+// OCSPermissionsToPublicLinkType converts the public link OCSPermission to the sharingLinkType representation
+//
+//	VIEW            SharingLinkType = "view"
+//	UPLOAD          SharingLinkType = "upload"
+//	EDIT            SharingLinkType = "edit"
+//	CREATE_ONLY     SharingLinkType = "createOnly"
+func (r *Role) OCSPermissionsToPublicLinkType(rt provider.ResourceType) string {
+	p := r.OCSPermissions()
+	switch {
+	case p == PermissionRead:
+		return "view"
+	case p == PermissionRead|PermissionWrite && rt == provider.ResourceType_RESOURCE_TYPE_FILE:
+		return "edit"
+	case p == PermissionRead|PermissionCreate && rt == provider.ResourceType_RESOURCE_TYPE_CONTAINER:
+		return "upload"
+	case p == PermissionRead|PermissionWrite|PermissionCreate|PermissionDelete && rt == provider.ResourceType_RESOURCE_TYPE_CONTAINER:
+		return "edit"
+	case p == PermissionCreate && rt == provider.ResourceType_RESOURCE_TYPE_CONTAINER:
+		return "createOnly"
+	}
+	return ""
+}
+
 // RoleFromName creates a role from the name
 func RoleFromName(name string) *Role {
 	switch name {


### PR DESCRIPTION
The libregraph public link type representation added to the PROPFIND response
Related issue [#8740](https://github.com/owncloud/ocis/issues/8740)