### PR TITLE
enhancement: consider userid from opaque when updating received shares

### DIFF
--- a/changelog/unreleased/enhance-unique-share-mountpoint-name.md
+++ b/changelog/unreleased/enhance-unique-share-mountpoint-name.md
@@ -2,5 +2,6 @@ Enhancement: Unique share mountpoint name
 
 Accepting a received share with a mountpoint name that already exists will now append a unique suffix to the mountpoint name.
 
+https://github.com/cs3org/reva/pull/4723
 https://github.com/cs3org/reva/pull/4714
 https://github.com/owncloud/ocis/issues/8961

--- a/internal/grpc/services/usershareprovider/usershareprovider_test.go
+++ b/internal/grpc/services/usershareprovider/usershareprovider_test.go
@@ -627,7 +627,7 @@ var _ = Describe("helpers", func() {
 					}).Times(statCallCount)
 			}
 
-			availableMountpoint, err := usershareprovider.GetAvailableMountpoint(context.Background(), gatewayClient, args.withResourceId, args.withName)
+			availableMountpoint, err := usershareprovider.GetAvailableMountpoint(context.Background(), gatewayClient, args.withResourceId, args.withName, nil)
 
 			if args.listReceivedSharesError != nil {
 				Expect(err).To(HaveOccurred(), "expected error, got none")


### PR DESCRIPTION
the userId from opaque was ignored, its needed to update shares via service users