### PR TITLE
fix: ocs handles the mount_point on its own

### DIFF
--- a/changelog/unreleased/enhance-unique-share-mountpoint-name.md
+++ b/changelog/unreleased/enhance-unique-share-mountpoint-name.md
@@ -2,6 +2,7 @@ Enhancement: Unique share mountpoint name
 
 Accepting a received share with a mountpoint name that already exists will now append a unique suffix to the mountpoint name.
 
+https://github.com/cs3org/reva/pull/4725
 https://github.com/cs3org/reva/pull/4723
 https://github.com/cs3org/reva/pull/4714
 https://github.com/owncloud/ocis/issues/8961

--- a/internal/grpc/services/usershareprovider/usershareprovider_test.go
+++ b/internal/grpc/services/usershareprovider/usershareprovider_test.go
@@ -582,15 +582,15 @@ var _ = Describe("user share provider service", func() {
 })
 
 var _ = Describe("helpers", func() {
-	type GetAvailableMountpointArgs struct {
+	type GetMountpointAndUnmountedSharesArgs struct {
 		withName                   string
 		withResourceId             *providerpb.ResourceId
 		listReceivedSharesResponse *collaborationpb.ListReceivedSharesResponse
 		listReceivedSharesError    error
 		expectedName               string
 	}
-	DescribeTable("GetAvailableMountpoint",
-		func(args GetAvailableMountpointArgs) {
+	DescribeTable("GetMountpointAndUnmountedShares",
+		func(args GetMountpointAndUnmountedSharesArgs) {
 			gatewayClient := cs3mocks.NewGatewayAPIClient(GinkgoT())
 
 			gatewayClient.EXPECT().
@@ -627,7 +627,7 @@ var _ = Describe("helpers", func() {
 					}).Times(statCallCount)
 			}
 
-			availableMountpoint, err := usershareprovider.GetAvailableMountpoint(context.Background(), gatewayClient, args.withResourceId, args.withName, nil)
+			availableMountpoint, _, err := usershareprovider.GetMountpointAndUnmountedShares(context.Background(), gatewayClient, args.withResourceId, args.withName, nil)
 
 			if args.listReceivedSharesError != nil {
 				Expect(err).To(HaveOccurred(), "expected error, got none")
@@ -640,13 +640,13 @@ var _ = Describe("helpers", func() {
 		},
 		Entry(
 			"listing received shares errors",
-			GetAvailableMountpointArgs{
+			GetMountpointAndUnmountedSharesArgs{
 				listReceivedSharesError: errors.New("some error"),
 			},
 		),
 		Entry(
 			"returns the given name if no shares are found",
-			GetAvailableMountpointArgs{
+			GetMountpointAndUnmountedSharesArgs{
 				withName: "name1",
 				listReceivedSharesResponse: &collaborationpb.ListReceivedSharesResponse{
 					Status: status.NewOK(context.Background()),
@@ -656,7 +656,7 @@ var _ = Describe("helpers", func() {
 		),
 		Entry(
 			"returns the path as name if a share with the same resourceId is found",
-			GetAvailableMountpointArgs{
+			GetMountpointAndUnmountedSharesArgs{
 				withName: "name",
 				withResourceId: &providerpb.ResourceId{
 					StorageId: "1",
@@ -686,7 +686,7 @@ var _ = Describe("helpers", func() {
 		),
 		Entry(
 			"enumerates the name if a share with the same path already exists",
-			GetAvailableMountpointArgs{
+			GetMountpointAndUnmountedSharesArgs{
 				withName: "some name",
 				listReceivedSharesResponse: &collaborationpb.ListReceivedSharesResponse{
 					Status: status.NewOK(context.Background()),

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/export_test.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/export_test.go
@@ -1,3 +1,0 @@
-package shares
-
-var GetUnmountedShares = getUnmountedShares


### PR DESCRIPTION
ocs updates unmountedShares at the same time as a received share is accepted, therefore the mount_point handling is entirely done there too.