### PR TITLE
[full-ci][tests-only] Bump ocis stable commit id to latest

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,4 +1,4 @@
 # The test runner source for API tests
-APITESTS_COMMITID=846ecfd5551583035a909c5004e7242fab70eff9
+APITESTS_COMMITID=2857151f9330ee47e684bbc588b5d3138c0e85a4
 APITESTS_BRANCH=master
 APITESTS_REPO_GIT_URL=https://github.com/owncloud/ocis.git


### PR DESCRIPTION
Part of https://github.com/owncloud/QA/issues/853