### PR TITLE
always find unique providers

### DIFF
--- a/changelog/unreleased/always-find-unique-providers.md
+++ b/changelog/unreleased/always-find-unique-providers.md
@@ -1,0 +1,7 @@
+Bugfix: Always find unique providers
+
+The gateway will now always try to find a single unique provider. It has stopped aggregating multiple ListContainer responses when we removed any business logic from it. 
+
+https://github.com/cs3org/reva/pull/4741
+https://github.com/cs3org/reva/pull/4740
+https://github.com/cs3org/reva/pull/2394

--- a/pkg/storage/registry/spaces/spaces.go
+++ b/pkg/storage/registry/spaces/spaces.go
@@ -264,7 +264,7 @@ func (r *registry) GetProvider(ctx context.Context, space *providerpb.StorageSpa
 // matches = /foo/bar       <=> /foo/bar        -> list(spaceid, .)
 // below   = /foo/bar/bif   <=> /foo/bar        -> list(spaceid, ./bif)
 func (r *registry) ListProviders(ctx context.Context, filters map[string]string) ([]*registrypb.ProviderInfo, error) {
-	b, _ := strconv.ParseBool(filters["unique"])
+	unique, _ := strconv.ParseBool(filters["unique"])
 	unrestricted, _ := strconv.ParseBool(filters["unrestricted"])
 	mask := filters["mask"]
 	switch {
@@ -284,7 +284,7 @@ func (r *registry) ListProviders(ctx context.Context, filters map[string]string)
 
 		return r.findProvidersForResource(ctx, id, findMountpoint, findGrant, unrestricted, mask), nil
 	case filters["path"] != "":
-		return r.findProvidersForAbsolutePathReference(ctx, filters["path"], b, unrestricted, mask), nil
+		return r.findProvidersForAbsolutePathReference(ctx, filters["path"], unique, unrestricted, mask), nil
 	case len(filters) == 0:
 		// return all providers
 		return r.findAllProviders(ctx, mask), nil


### PR DESCRIPTION
The gateway will now always try to find a single unique provider. It has stopped aggregating multiple ListContainer responses when we removed any business logic from it. 

related:
- https://github.com/cs3org/reva/pull/4740
- https://github.com/cs3org/reva/pull/2394

