### PR TITLE
Fix same file upload

### DIFF
--- a/changelog/unreleased/fix-same-file-upload.md
+++ b/changelog/unreleased/fix-same-file-upload.md
@@ -1,0 +1,5 @@
+Bugfix: Uploading the same file multiple times leads to orphaned blobs
+
+Fixed a bug where multiple uploads of the same file would lead to orphaned blobs in the blobstore. These orphaned blobs will now be deleted.
+
+https://github.com/cs3org/reva/pull/4746


### PR DESCRIPTION
Fixes a bug where uploading the same file multiple times leads to orphaned blobs in the blobstore.


Reva part of https://github.com/owncloud/ocis/issues/9498
