### PR TITLE
fix: quotes placement in content-disposition header

### DIFF
--- a/changelog/unreleased/fix-quotes-in-content-disposition-headers.md
+++ b/changelog/unreleased/fix-quotes-in-content-disposition-headers.md
@@ -1,0 +1,6 @@
+Bugfix: Quotes in dav Content-Disposition header
+
+We've fixed the placement of the quotes in the dav `Content-Disposition` header. The misplacement caused an issue where certain browsers would decode the quotes and falsely prepend them to the filename.
+
+https://github.com/cs3org/reva/pull/4747
+https://github.com/owncloud/web/issues/11031

--- a/internal/http/services/owncloud/ocdav/net/builders.go
+++ b/internal/http/services/owncloud/ocdav/net/builders.go
@@ -27,7 +27,7 @@ import (
 
 // ContentDispositionAttachment builds a ContentDisposition Attachment header with various filename encodings
 func ContentDispositionAttachment(filename string) string {
-	return "attachment; filename*=UTF-8''\"" + filename + "\"; filename=\"" + filename + "\""
+	return "attachment; filename*=\"UTF-8''" + filename + "\"; filename=\"" + filename + "\""
 }
 
 // RFC1123Z formats a CS3 Timestamp to be used in HTTP headers like Last-Modified


### PR DESCRIPTION
Fixes the placement of the quotes in the dav `Content-Disposition` header. The misplacement caused an issue where certain browsers would decode the quotes and falsely prepend them to the filename.

refs https://github.com/owncloud/web/issues/11031