### PR TITLE
fix: quotes in content-disposition header

### DIFF
--- a/changelog/unreleased/fix-quotes-in-content-disposition-headers.md
+++ b/changelog/unreleased/fix-quotes-in-content-disposition-headers.md
@@ -1,0 +1,6 @@
+Bugfix: Quotes in dav Content-Disposition header
+
+We've fixed the the quotes in the dav `Content-Disposition` header. They caused an issue where certain browsers would decode the quotes and falsely prepend them to the filename.
+
+https://github.com/cs3org/reva/pull/4748
+https://github.com/owncloud/web/issues/11031

--- a/internal/http/services/owncloud/ocdav/net/builders.go
+++ b/internal/http/services/owncloud/ocdav/net/builders.go
@@ -19,6 +19,7 @@
 package net
 
 import (
+	"net/url"
 	"time"
 
 	cs3types "github.com/cs3org/go-cs3apis/cs3/types/v1beta1"
@@ -27,7 +28,7 @@ import (
 
 // ContentDispositionAttachment builds a ContentDisposition Attachment header with various filename encodings
 func ContentDispositionAttachment(filename string) string {
-	return "attachment; filename*=UTF-8''\"" + filename + "\"; filename=\"" + filename + "\""
+	return "attachment; filename*=UTF-8''" + url.QueryEscape(filename) + "; filename=\"" + filename + "\""
 }
 
 // RFC1123Z formats a CS3 Timestamp to be used in HTTP headers like Last-Modified

--- a/tests/acceptance/expected-failures-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-on-OCIS-storage.md
@@ -267,5 +267,10 @@ _The below features have been added after I last categorized them. AFAICT they a
 - [coreApiWebdavProperties/createFileFolder.feature:236](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavProperties/createFileFolder.feature#L236)
 - [coreApiWebdavProperties/createFileFolder.feature:237](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavProperties/createFileFolder.feature#L237)
 
+### [Fix Content-Disposition header for download requests](https://github.com/cs3org/reva/pull/4748)
+
+- [coreApiVersions/fileVersions.feature:158](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiVersions/fileVersions.feature#L158)
+- [coreApiVersions/fileVersions.feature:176](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiVersions/fileVersions.feature#L176)
+
 - Note: always have an empty line at the end of this file.
 The bash script that processes this file may not process a scenario reference on the last line.

--- a/tests/acceptance/expected-failures-on-S3NG-storage.md
+++ b/tests/acceptance/expected-failures-on-S3NG-storage.md
@@ -270,5 +270,10 @@ _The below features have been added after I last categorized them. AFAICT they a
 - [coreApiWebdavProperties/createFileFolder.feature:236](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavProperties/createFileFolder.feature#L236)
 - [coreApiWebdavProperties/createFileFolder.feature:237](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavProperties/createFileFolder.feature#L237)
 
+### [Fix Content-Disposition header for download requests](https://github.com/cs3org/reva/pull/4748)
+
+- [coreApiVersions/fileVersions.feature:158](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiVersions/fileVersions.feature#L158)
+- [coreApiVersions/fileVersions.feature:176](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiVersions/fileVersions.feature#L176)
+
 Note: always have an empty line at the end of this file.
 The bash script that processes this file may not process a scenario reference on the last line.


### PR DESCRIPTION
Replaces the quotes by actually encoding the filename in the dav `Content-Disposition` header. The value of the `filename*` parameter must not be surrounded by any quotes, but rather be encoded in the first place. See [RFC-6266](https://datatracker.ietf.org/doc/rfc6266/) for more details.

The quotes caused an issue where certain browsers would decode the quotes and falsely prepend them to the filename.

refs https://github.com/owncloud/web/issues/11031
