### PR TITLE
bump go-cs3apis to latest master

### DIFF
--- a/changelog/unreleased/bump-go-cs3apis.md
+++ b/changelog/unreleased/bump-go-cs3apis.md
@@ -1,0 +1,6 @@
+Change: Updated to the latest version of the go-cs3apis
+
+The go-cs3apis dependency was updated to the latest version
+
+https://github.com/cs3org/reva/pull/4759
+https://github.com/owncloud/ocis/issues/9554

--- a/cmd/reva/ls.go
+++ b/cmd/reva/ls.go
@@ -72,7 +72,7 @@ func lsCommand() *command {
 			}
 			if len(w) == 0 {
 				if *longFlag {
-					fmt.Printf("%s %d %d %v %s\n", info.Type, info.Mtime, info.Size, info.Id, p)
+					fmt.Printf("%s %d %d %v %s\n", info.Type, info.Mtime.GetSeconds(), info.Size, info.Id, p)
 				} else {
 					fmt.Println(p)
 				}

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/cheggaaa/pb v1.0.29
 	github.com/coreos/go-oidc/v3 v3.4.0
 	github.com/cs3org/cato v0.0.0-20200828125504-e418fc54dd5e
-	github.com/cs3org/go-cs3apis v0.0.0-20231023073225-7748710e0781
+	github.com/cs3org/go-cs3apis v0.0.0-20240425114016-d2cb31692b4e
 	github.com/dgraph-io/ristretto v0.1.1
 	github.com/emvi/iso-639-1 v1.1.0
 	github.com/eventials/go-tus v0.0.0-20220610120217-05d0564bb571

--- a/go.sum
+++ b/go.sum
@@ -916,8 +916,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46t
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/cs3org/cato v0.0.0-20200828125504-e418fc54dd5e h1:tqSPWQeueWTKnJVMJffz4pz0o1WuQxJ28+5x5JgaHD8=
 github.com/cs3org/cato v0.0.0-20200828125504-e418fc54dd5e/go.mod h1:XJEZ3/EQuI3BXTp/6DUzFr850vlxq11I6satRtz0YQ4=
-github.com/cs3org/go-cs3apis v0.0.0-20231023073225-7748710e0781 h1:BUdwkIlf8IS2FasrrPg8gGPHQPOrQ18MS1Oew2tmGtY=
-github.com/cs3org/go-cs3apis v0.0.0-20231023073225-7748710e0781/go.mod h1:UXha4TguuB52H14EMoSsCqDj7k8a/t7g4gVP+bgY5LY=
+github.com/cs3org/go-cs3apis v0.0.0-20240425114016-d2cb31692b4e h1:Cm2l8m2riLa79eh7V2wHd1Ra7wR3TbngmeLZBJ9MxTU=
+github.com/cs3org/go-cs3apis v0.0.0-20240425114016-d2cb31692b4e/go.mod h1:yyP8PRo0EZou3nSH7H4qjlzQwaydPeIRNgX50npQHpE=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -1941,7 +1941,6 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190312061237-fead79001313/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20190415081028-16da32be82c5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190502145724-3ef323f4f1fd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -2266,7 +2265,6 @@ google.golang.org/appengine v1.6.8 h1:IhEN5q69dyKagZPYMSdIjS2HqprW324FRQZJcGqPAs
 google.golang.org/appengine v1.6.8/go.mod h1:1jJ3jBArFh5pcgW8gCtRJnepW8FzD1V44FJffLiz/Ds=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20190307195333-5fe7a883aa19/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
-google.golang.org/genproto v0.0.0-20190404172233-64821d5d2107/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
 google.golang.org/genproto v0.0.0-20190418145605-e7d98fc518a7/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
 google.golang.org/genproto v0.0.0-20190425155659-357c62f0e4bb/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
 google.golang.org/genproto v0.0.0-20190502173448-54afdca5d873/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=

--- a/internal/grpc/interceptors/auth/scope.go
+++ b/internal/grpc/interceptors/auth/scope.go
@@ -142,7 +142,7 @@ func resolveLightweightScope(ctx context.Context, ref *provider.Reference, scope
 	}
 
 	for _, share := range shares.Shares {
-		shareKey := "lw:" + user.Id.OpaqueId + scopeDelimiter + storagespace.FormatResourceID(*share.Share.ResourceId)
+		shareKey := "lw:" + user.Id.OpaqueId + scopeDelimiter + storagespace.FormatResourceID(share.Share.ResourceId)
 		_ = scopeExpansionCache.SetWithExpire(shareKey, nil, scopeCacheExpiration*time.Second)
 
 		if ref.ResourceId != nil && utils.ResourceIDEqual(share.Share.ResourceId, ref.ResourceId) {
@@ -229,7 +229,7 @@ func checkRelativeReference(ctx context.Context, requested *provider.Reference, 
 		}
 	}
 
-	key := storagespace.FormatResourceID(*sharedResourceID) + scopeDelimiter + getRefKey(requested)
+	key := storagespace.FormatResourceID(sharedResourceID) + scopeDelimiter + getRefKey(requested)
 	_ = scopeExpansionCache.SetWithExpire(key, nil, scopeCacheExpiration*time.Second)
 	return nil
 }
@@ -246,7 +246,7 @@ func resolveUserShare(ctx context.Context, ref *provider.Reference, scope *authp
 
 func checkCacheForNestedResource(ctx context.Context, ref *provider.Reference, resource *provider.ResourceId, client gateway.GatewayAPIClient, mgr token.Manager) error {
 	// Check if this ref is cached
-	key := storagespace.FormatResourceID(*resource) + scopeDelimiter + getRefKey(ref)
+	key := storagespace.FormatResourceID(resource) + scopeDelimiter + getRefKey(ref)
 	if _, err := scopeExpansionCache.Get(key); err == nil {
 		return nil
 	}
@@ -520,7 +520,7 @@ func getRefKey(ref *provider.Reference) string {
 	}
 
 	if ref.GetResourceId() != nil {
-		return storagespace.FormatResourceID(*ref.ResourceId)
+		return storagespace.FormatResourceID(ref.ResourceId)
 	}
 
 	// on malicious request both path and rid could be empty

--- a/internal/grpc/services/gateway/authprovider.go
+++ b/internal/grpc/services/gateway/authprovider.go
@@ -36,6 +36,7 @@ import (
 	"github.com/cs3org/reva/v2/pkg/sharedconf"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/protobuf/proto"
 )
 
 func (s *svc) Authenticate(ctx context.Context, req *gateway.AuthenticateRequest) (*gateway.AuthenticateResponse, error) {
@@ -92,12 +93,12 @@ func (s *svc) Authenticate(ctx context.Context, req *gateway.AuthenticateRequest
 		}, nil
 	}
 
-	u := *res.User
+	u := proto.Clone(res.User).(*userpb.User)
 	if sharedconf.SkipUserGroupsInToken() {
 		u.Groups = []string{}
 	}
 
-	token, err := s.tokenmgr.MintToken(ctx, &u, res.TokenScope)
+	token, err := s.tokenmgr.MintToken(ctx, u, res.TokenScope)
 	if err != nil {
 		err = errors.Wrap(err, "authsvc: error in MintToken")
 		res := &gateway.AuthenticateResponse{

--- a/internal/grpc/services/gateway/usershareprovider.go
+++ b/internal/grpc/services/gateway/usershareprovider.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"slices"
 
+	gateway "github.com/cs3org/go-cs3apis/cs3/gateway/v1beta1"
 	rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
 	collaboration "github.com/cs3org/go-cs3apis/cs3/sharing/collaboration/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
@@ -363,6 +364,10 @@ func (s *svc) UpdateReceivedShare(ctx context.Context, req *collaboration.Update
 			}
 			return res, nil
 	*/
+}
+
+func (s *svc) ListExistingReceivedShares(_ context.Context, _ *collaboration.ListReceivedSharesRequest) (*gateway.ListExistingReceivedSharesResponse, error) {
+	return nil, errtypes.NotSupported("Unimplemented")
 }
 
 func (s *svc) denyGrant(ctx context.Context, id *provider.ResourceId, g *provider.Grantee, opaque *typesv1beta1.Opaque) (*rpc.Status, error) {

--- a/internal/grpc/services/publicshareprovider/publicshareprovider.go
+++ b/internal/grpc/services/publicshareprovider/publicshareprovider.go
@@ -350,7 +350,7 @@ func (s *service) RemovePublicShare(ctx context.Context, req *link.RemovePublicS
 			Status: status.NewInternal(ctx, "error loading public share"),
 		}, err
 	}
-	if !publicshare.IsCreatedByUser(*ps, user) {
+	if !publicshare.IsCreatedByUser(ps, user) {
 		sRes, err := gatewayClient.Stat(ctx, &provider.StatRequest{Ref: &provider.Reference{ResourceId: ps.ResourceId}})
 		if err != nil {
 			log.Err(err).Interface("resource_id", ps.ResourceId).Msg("failed to stat shared resource")
@@ -480,7 +480,7 @@ func (s *service) UpdatePublicShare(ctx context.Context, req *link.UpdatePublicS
 	// users should always be able to downgrade links to internal links
 	// when they are the creator of the link
 	// all other users should have the WritePublicLink permission
-	if !isInternalLink && !publicshare.IsCreatedByUser(*ps, user) {
+	if !isInternalLink && !publicshare.IsCreatedByUser(ps, user) {
 		canWriteLink, err := utils.CheckPermission(ctx, permission.WritePublicLink, gatewayClient)
 		if err != nil {
 			return &link.UpdatePublicShareResponse{
@@ -502,7 +502,7 @@ func (s *service) UpdatePublicShare(ctx context.Context, req *link.UpdatePublicS
 		}, err
 	}
 
-	if !publicshare.IsCreatedByUser(*ps, user) {
+	if !publicshare.IsCreatedByUser(ps, user) {
 		if !sRes.GetInfo().GetPermissionSet().UpdateGrant {
 			return &link.UpdatePublicShareResponse{
 				Status: status.NewPermissionDenied(ctx, nil, "no permission to update public share"),

--- a/internal/grpc/services/publicstorageprovider/publicstorageprovider.go
+++ b/internal/grpc/services/publicstorageprovider/publicstorageprovider.go
@@ -454,7 +454,7 @@ func (s *service) ListStorageSpaces(ctx context.Context, req *provider.ListStora
 			// we know a grant for this resource
 			space := &provider.StorageSpace{
 				Id: &provider.StorageSpaceId{
-					OpaqueId: storagespace.FormatResourceID(*root),
+					OpaqueId: storagespace.FormatResourceID(root),
 				},
 				SpaceType: "grant",
 				Owner:     &userv1beta1.User{Id: grantee},
@@ -486,7 +486,7 @@ func (s *service) ListStorageSpaces(ctx context.Context, req *provider.ListStora
 			}
 			space := &provider.StorageSpace{
 				Id: &provider.StorageSpaceId{
-					OpaqueId: storagespace.FormatResourceID(*root),
+					OpaqueId: storagespace.FormatResourceID(root),
 				},
 				SpaceType: "mountpoint",
 				Owner:     &userv1beta1.User{Id: grantee}, // FIXME actually, the mount point belongs to no one?

--- a/internal/grpc/services/publicstorageprovider/publicstorageprovider.go
+++ b/internal/grpc/services/publicstorageprovider/publicstorageprovider.go
@@ -75,6 +75,7 @@ func (s *service) UnprotectedEndpoints() []string {
 
 func (s *service) Register(ss *grpc.Server) {
 	provider.RegisterProviderAPIServer(ss, s)
+	provider.RegisterSpacesAPIServer(ss, s)
 }
 
 func parseConfig(m map[string]interface{}) (*config, error) {

--- a/internal/grpc/services/sharesstorageprovider/sharesstorageprovider.go
+++ b/internal/grpc/services/sharesstorageprovider/sharesstorageprovider.go
@@ -77,6 +77,7 @@ func (s *service) UnprotectedEndpoints() []string {
 
 func (s *service) Register(ss *grpc.Server) {
 	provider.RegisterProviderAPIServer(ss, s)
+	provider.RegisterSpacesAPIServer(ss, s)
 }
 
 // NewDefault returns a new instance of the SharesStorageProvider service with default dependencies

--- a/internal/grpc/services/sharesstorageprovider/sharesstorageprovider.go
+++ b/internal/grpc/services/sharesstorageprovider/sharesstorageprovider.go
@@ -433,7 +433,7 @@ func (s *service) ListStorageSpaces(ctx context.Context, req *provider.ListStora
 				space := &provider.StorageSpace{
 					Opaque: opaque,
 					Id: &provider.StorageSpaceId{
-						OpaqueId: storagespace.FormatResourceID(*virtualRootID),
+						OpaqueId: storagespace.FormatResourceID(virtualRootID),
 					},
 					SpaceType: "virtual",
 					//Owner:     &userv1beta1.User{Id: receivedShare.Share.Owner}, // FIXME actually, the mount point belongs to the recipient
@@ -455,7 +455,7 @@ func (s *service) ListStorageSpaces(ctx context.Context, req *provider.ListStora
 				// we know a grant for this resource
 				space := &provider.StorageSpace{
 					Id: &provider.StorageSpaceId{
-						OpaqueId: storagespace.FormatResourceID(*root),
+						OpaqueId: storagespace.FormatResourceID(root),
 					},
 					SpaceType: "grant",
 					Owner:     &userv1beta1.User{Id: receivedShare.Share.Owner},
@@ -509,7 +509,7 @@ func (s *service) ListStorageSpaces(ctx context.Context, req *provider.ListStora
 				space := &provider.StorageSpace{
 					Opaque: opaque,
 					Id: &provider.StorageSpaceId{
-						OpaqueId: storagespace.FormatResourceID(*root),
+						OpaqueId: storagespace.FormatResourceID(root),
 					},
 					SpaceType: "mountpoint",
 					Owner:     &userv1beta1.User{Id: receivedShare.Share.Owner}, // FIXME actually, the mount point belongs to the recipient
@@ -819,7 +819,7 @@ func (s *service) ListContainer(ctx context.Context, req *provider.ListContainer
 			if receivedShare.GetState() != collaboration.ShareState_SHARE_STATE_ACCEPTED {
 				continue
 			}
-			rIDStr := storagespace.FormatResourceID(*receivedShare.GetShare().GetResourceId())
+			rIDStr := storagespace.FormatResourceID(receivedShare.GetShare().GetResourceId())
 			if oldest, ok := oldestReceivedSharesByResourceID[rIDStr]; ok {
 				// replace if older than current oldest
 				if utils.TSToTime(receivedShare.GetShare().GetCtime()).Before(utils.TSToTime(oldest.GetShare().GetCtime())) {

--- a/internal/grpc/services/sharesstorageprovider/sharesstorageprovider_test.go
+++ b/internal/grpc/services/sharesstorageprovider/sharesstorageprovider_test.go
@@ -168,7 +168,7 @@ var _ = Describe("Sharesstorageprovider", func() {
 		gatewaySelector = pool.GetSelector[gateway.GatewayAPIClient](
 			"GatewaySelector",
 			"any",
-			func(cc *grpc.ClientConn) gateway.GatewayAPIClient {
+			func(cc grpc.ClientConnInterface) gateway.GatewayAPIClient {
 				return gatewayClient
 			},
 		)
@@ -178,7 +178,7 @@ var _ = Describe("Sharesstorageprovider", func() {
 		sharingCollaborationSelector = pool.GetSelector[collaboration.CollaborationAPIClient](
 			"SharingCollaborationSelector",
 			"any",
-			func(cc *grpc.ClientConn) collaboration.CollaborationAPIClient {
+			func(cc grpc.ClientConnInterface) collaboration.CollaborationAPIClient {
 				return sharingCollaborationClient
 			},
 		)

--- a/internal/grpc/services/storageprovider/storageprovider.go
+++ b/internal/grpc/services/storageprovider/storageprovider.go
@@ -116,6 +116,7 @@ func (s *Service) UnprotectedEndpoints() []string { return []string{} }
 
 func (s *Service) Register(ss *grpc.Server) {
 	provider.RegisterProviderAPIServer(ss, s)
+	provider.RegisterSpacesAPIServer(ss, s)
 }
 
 func parseXSTypes(xsTypes map[string]uint32) ([]*provider.ResourceChecksumPriority, error) {

--- a/internal/grpc/services/storageprovider/storageprovider.go
+++ b/internal/grpc/services/storageprovider/storageprovider.go
@@ -299,7 +299,7 @@ func (s *Service) InitiateFileDownload(ctx context.Context, req *provider.Initia
 	if utils.IsRelativeReference(req.Ref) {
 		s.addMissingStorageProviderID(req.GetRef().GetResourceId(), nil)
 		protocol.Protocol = "spaces"
-		u.Path = path.Join(u.Path, "spaces", storagespace.FormatResourceID(*req.Ref.ResourceId), req.Ref.Path)
+		u.Path = path.Join(u.Path, "spaces", storagespace.FormatResourceID(req.Ref.ResourceId), req.Ref.Path)
 	} else {
 		// Currently, we only support the simple protocol for GET requests
 		// Once we have multiple protocols, this would be moved to the fs layer
@@ -613,7 +613,7 @@ func (s *Service) DeleteStorageSpace(ctx context.Context, req *provider.DeleteSt
 	// FIXME: why is this string parsing necessary?
 	idraw, _ := storagespace.ParseID(req.Id.GetOpaqueId())
 	idraw.OpaqueId = idraw.GetSpaceId()
-	id := &provider.StorageSpaceId{OpaqueId: storagespace.FormatResourceID(idraw)}
+	id := &provider.StorageSpaceId{OpaqueId: storagespace.FormatResourceID(&idraw)}
 
 	spaces, err := s.Storage.ListStorageSpaces(ctx, []*provider.ListStorageSpacesRequest_Filter{{Type: provider.ListStorageSpacesRequest_Filter_TYPE_ID, Term: &provider.ListStorageSpacesRequest_Filter_Id{Id: id}}}, true)
 	if err != nil {

--- a/internal/grpc/services/usershareprovider/usershareprovider_test.go
+++ b/internal/grpc/services/usershareprovider/usershareprovider_test.go
@@ -77,7 +77,7 @@ var _ = Describe("user share provider service", func() {
 		gatewaySelector = pool.GetSelector[gateway.GatewayAPIClient](
 			"GatewaySelector",
 			"any",
-			func(cc *grpc.ClientConn) gateway.GatewayAPIClient {
+			func(cc grpc.ClientConnInterface) gateway.GatewayAPIClient {
 				return gatewayClient
 			},
 		)

--- a/internal/http/services/appprovider/appprovider.go
+++ b/internal/http/services/appprovider/appprovider.go
@@ -48,6 +48,7 @@ import (
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
+	"google.golang.org/protobuf/proto"
 )
 
 func init() {
@@ -304,7 +305,7 @@ func (s *svc) handleNew(w http.ResponseWriter, r *http.Request) {
 			writeError(w, r, appErrorInvalidParameter, "the given file id does not point to a file", nil)
 			return
 		}
-		fileid = storagespace.FormatResourceID(*statRes.Info.Id)
+		fileid = storagespace.FormatResourceID(statRes.Info.Id)
 	}
 
 	js, err := json.Marshal(
@@ -574,7 +575,8 @@ func buildApps(mimeTypes []*appregistry.MimeTypeInfo, userAgent, secureViewAppAd
 	for _, m := range mimeTypes {
 		apps := []*ProviderInfo{}
 		for _, p := range m.AppProviders {
-			ep := &ProviderInfo{ProviderInfo: *p}
+			ep := &ProviderInfo{}
+			proto.Merge(&ep.ProviderInfo, p)
 			if p.Address == secureViewAppAddr {
 				ep.SecureView = true
 			}
@@ -586,7 +588,8 @@ func buildApps(mimeTypes []*appregistry.MimeTypeInfo, userAgent, secureViewAppAd
 			}
 		}
 		if len(apps) > 0 {
-			mt := &MimeTypeInfo{MimeTypeInfo: *m}
+			mt := &MimeTypeInfo{}
+			proto.Merge(&mt.MimeTypeInfo, m)
 			mt.AppProviders = apps
 			res = append(res, mt)
 		}

--- a/internal/http/services/owncloud/ocdav/copy.go
+++ b/internal/http/services/owncloud/ocdav/copy.go
@@ -214,7 +214,7 @@ func (s *svc) executePathCopy(ctx context.Context, selector pool.Selectable[gate
 			return fmt.Errorf("status code %d", r.GetStatus().GetCode())
 		}
 
-		fileid = storagespace.FormatResourceID(*r.GetInfo().GetId())
+		fileid = storagespace.FormatResourceID(r.GetInfo().GetId())
 	} else {
 		// copy file
 
@@ -438,7 +438,7 @@ func (s *svc) executeSpacesCopy(ctx context.Context, w http.ResponseWriter, sele
 			return fmt.Errorf("stat: status code %d", r.GetStatus().GetCode())
 		}
 
-		fileid = storagespace.FormatResourceID(*r.GetInfo().GetId())
+		fileid = storagespace.FormatResourceID(r.GetInfo().GetId())
 	} else {
 		// copy file
 		// 1. get download url

--- a/internal/http/services/owncloud/ocdav/dav.go
+++ b/internal/http/services/owncloud/ocdav/dav.go
@@ -287,7 +287,7 @@ func (h *DavHandler) Handler(s *svc) http.Handler {
 				// If the link is internal then 307 redirect
 				if psRes.Status.Code == rpc.Code_CODE_OK && grants.PermissionsEqual(psRes.Share.Permissions.GetPermissions(), &provider.ResourcePermissions{}) {
 					if psRes.GetShare().GetResourceId() != nil {
-						rUrl := path.Join("/dav/spaces", storagespace.FormatResourceID(*psRes.GetShare().GetResourceId()))
+						rUrl := path.Join("/dav/spaces", storagespace.FormatResourceID(psRes.GetShare().GetResourceId()))
 						http.Redirect(w, r, rUrl, http.StatusTemporaryRedirect)
 						return
 					}

--- a/internal/http/services/owncloud/ocdav/head.go
+++ b/internal/http/services/owncloud/ocdav/head.go
@@ -85,7 +85,7 @@ func (s *svc) handleHead(ctx context.Context, w http.ResponseWriter, r *http.Req
 	info := res.Info
 	w.Header().Set(net.HeaderContentType, info.MimeType)
 	w.Header().Set(net.HeaderETag, info.Etag)
-	w.Header().Set(net.HeaderOCFileID, storagespace.FormatResourceID(*info.Id))
+	w.Header().Set(net.HeaderOCFileID, storagespace.FormatResourceID(info.Id))
 	w.Header().Set(net.HeaderOCETag, info.Etag)
 	if info.Checksum != nil {
 		w.Header().Set(net.HeaderOCChecksum, fmt.Sprintf("%s:%s", strings.ToUpper(string(storageprovider.GRPC2PKGXS(info.Checksum.Type))), info.Checksum.Sum))

--- a/internal/http/services/owncloud/ocdav/meta.go
+++ b/internal/http/services/owncloud/ocdav/meta.go
@@ -104,7 +104,7 @@ func (h *MetaHandler) handlePathForUser(w http.ResponseWriter, r *http.Request, 
 	ctx, span := appctx.GetTracerProvider(r.Context()).Tracer(tracerName).Start(r.Context(), "meta_propfind")
 	defer span.End()
 
-	id := storagespace.FormatResourceID(*rid)
+	id := storagespace.FormatResourceID(rid)
 	sublog := appctx.GetLogger(ctx).With().Str("path", r.URL.Path).Str("resourceid", id).Logger()
 	sublog.Info().Msg("calling get path for user")
 

--- a/internal/http/services/owncloud/ocdav/move.go
+++ b/internal/http/services/owncloud/ocdav/move.go
@@ -345,7 +345,7 @@ func (s *svc) handleMove(ctx context.Context, w http.ResponseWriter, r *http.Req
 	info := dstStatRes.Info
 	w.Header().Set(net.HeaderContentType, info.MimeType)
 	w.Header().Set(net.HeaderETag, info.Etag)
-	w.Header().Set(net.HeaderOCFileID, storagespace.FormatResourceID(*info.Id))
+	w.Header().Set(net.HeaderOCFileID, storagespace.FormatResourceID(info.Id))
 	w.Header().Set(net.HeaderOCETag, info.Etag)
 	w.WriteHeader(successCode)
 }

--- a/internal/http/services/owncloud/ocdav/ocdav_blackbox_test.go
+++ b/internal/http/services/owncloud/ocdav/ocdav_blackbox_test.go
@@ -172,7 +172,7 @@ var _ = Describe("ocdav", func() {
 					},
 				},
 			},
-			Id:   &cs3storageprovider.StorageSpaceId{OpaqueId: storagespace.FormatResourceID(cs3storageprovider.ResourceId{StorageId: "provider-1", SpaceId: "foospace", OpaqueId: "root"})},
+			Id:   &cs3storageprovider.StorageSpaceId{OpaqueId: storagespace.FormatResourceID(&cs3storageprovider.ResourceId{StorageId: "provider-1", SpaceId: "foospace", OpaqueId: "root"})},
 			Root: &cs3storageprovider.ResourceId{StorageId: "provider-1", SpaceId: "userspace", OpaqueId: "root"},
 			Name: "username",
 			RootInfo: &cs3storageprovider.ResourceInfo{
@@ -864,7 +864,7 @@ var _ = Describe("ocdav", func() {
 				// setup the request
 				// set the webdav endpoint to test
 				basePath = "/webdav"
-				userspace.Id = &cs3storageprovider.StorageSpaceId{OpaqueId: storagespace.FormatResourceID(cs3storageprovider.ResourceId{StorageId: "provider-1", SpaceId: "userspace", OpaqueId: "userspace"})}
+				userspace.Id = &cs3storageprovider.StorageSpaceId{OpaqueId: storagespace.FormatResourceID(&cs3storageprovider.ResourceId{StorageId: "provider-1", SpaceId: "userspace", OpaqueId: "userspace"})}
 				userspace.Root = &cs3storageprovider.ResourceId{StorageId: "provider-1", SpaceId: "userspace", OpaqueId: "userspace"}
 
 				// path based requests at the /webdav endpoint first look up the storage space
@@ -938,7 +938,7 @@ var _ = Describe("ocdav", func() {
 		BeforeEach(func() {
 			basePath = "/dav/spaces"
 
-			userspace.Id = &cs3storageprovider.StorageSpaceId{OpaqueId: storagespace.FormatResourceID(cs3storageprovider.ResourceId{StorageId: "provider-1", SpaceId: "userspace", OpaqueId: "userspace"})}
+			userspace.Id = &cs3storageprovider.StorageSpaceId{OpaqueId: storagespace.FormatResourceID(&cs3storageprovider.ResourceId{StorageId: "provider-1", SpaceId: "userspace", OpaqueId: "userspace"})}
 			userspace.Root = &cs3storageprovider.ResourceId{StorageId: "provider-1", SpaceId: "userspace", OpaqueId: "userspace"}
 			// path based requests at the /webdav endpoint first look up the storage space
 			client.On("ListStorageSpaces", mock.Anything, mock.MatchedBy(func(req *cs3storageprovider.ListStorageSpacesRequest) bool {

--- a/internal/http/services/owncloud/ocdav/ocdav_whitebox_test.go
+++ b/internal/http/services/owncloud/ocdav/ocdav_whitebox_test.go
@@ -28,7 +28,7 @@ import (
 
 func TestWrapResourceID(t *testing.T) {
 	expected := "storageid" + "$" + "spaceid" + "!" + "opaqueid"
-	wrapped := storagespace.FormatResourceID(sprovider.ResourceId{StorageId: "storageid", SpaceId: "spaceid", OpaqueId: "opaqueid"})
+	wrapped := storagespace.FormatResourceID(&sprovider.ResourceId{StorageId: "storageid", SpaceId: "spaceid", OpaqueId: "opaqueid"})
 
 	if wrapped != expected {
 		t.Errorf("wrapped id doesn't have the expected format: got %s expected %s", wrapped, expected)

--- a/internal/http/services/owncloud/ocdav/propfind/propfind.go
+++ b/internal/http/services/owncloud/ocdav/propfind/propfind.go
@@ -1177,7 +1177,7 @@ func mdToPropResponse(ctx context.Context, pf *XML, md *provider.ResourceInfo, p
 		// return all known properties
 
 		if id != nil {
-			sid := storagespace.FormatResourceID(*id)
+			sid := storagespace.FormatResourceID(id)
 			appendToOK(
 				prop.Escaped("oc:id", sid),
 				prop.Escaped("oc:fileid", sid),
@@ -1186,7 +1186,7 @@ func mdToPropResponse(ctx context.Context, pf *XML, md *provider.ResourceInfo, p
 		}
 
 		if md.ParentId != nil {
-			appendToOK(prop.Escaped("oc:file-parent", storagespace.FormatResourceID(*md.ParentId)))
+			appendToOK(prop.Escaped("oc:file-parent", storagespace.FormatResourceID(md.ParentId)))
 		} else {
 			appendToNotFound(prop.NotFound("oc:file-parent"))
 		}
@@ -1305,19 +1305,19 @@ func mdToPropResponse(ctx context.Context, pf *XML, md *provider.ResourceInfo, p
 				// I tested the desktop client and phoenix to annotate which properties are requestted, see below cases
 				case "fileid": // phoenix only
 					if id != nil {
-						appendToOK(prop.Escaped("oc:fileid", storagespace.FormatResourceID(*id)))
+						appendToOK(prop.Escaped("oc:fileid", storagespace.FormatResourceID(id)))
 					} else {
 						appendToNotFound(prop.NotFound("oc:fileid"))
 					}
 				case "id": // desktop client only
 					if id != nil {
-						appendToOK(prop.Escaped("oc:id", storagespace.FormatResourceID(*id)))
+						appendToOK(prop.Escaped("oc:id", storagespace.FormatResourceID(id)))
 					} else {
 						appendToNotFound(prop.NotFound("oc:id"))
 					}
 				case "file-parent":
 					if md.ParentId != nil {
-						appendToOK(prop.Escaped("oc:file-parent", storagespace.FormatResourceID(*md.ParentId)))
+						appendToOK(prop.Escaped("oc:file-parent", storagespace.FormatResourceID(md.ParentId)))
 					} else {
 						appendToNotFound(prop.NotFound("oc:file-parent"))
 					}
@@ -1521,7 +1521,7 @@ func mdToPropResponse(ctx context.Context, pf *XML, md *provider.ResourceInfo, p
 				case "privatelink":
 					privateURL, err := url.Parse(publicURL)
 					if err == nil && id != nil {
-						privateURL.Path = path.Join(privateURL.Path, "f", storagespace.FormatResourceID(*id))
+						privateURL.Path = path.Join(privateURL.Path, "f", storagespace.FormatResourceID(id))
 						propstatOK.Prop = append(propstatOK.Prop, prop.Escaped("oc:privatelink", privateURL.String()))
 					} else {
 						propstatNotFound.Prop = append(propstatNotFound.Prop, prop.NotFound("oc:privatelink"))

--- a/internal/http/services/owncloud/ocdav/propfind/propfind_test.go
+++ b/internal/http/services/owncloud/ocdav/propfind/propfind_test.go
@@ -128,7 +128,7 @@ var _ = Describe("PropfindWithDepthInfinity", func() {
 					},
 				},
 			},
-			Id:   &sprovider.StorageSpaceId{OpaqueId: storagespace.FormatResourceID(sprovider.ResourceId{StorageId: "provider-1", SpaceId: "foospace", OpaqueId: "root"})},
+			Id:   &sprovider.StorageSpaceId{OpaqueId: storagespace.FormatResourceID(&sprovider.ResourceId{StorageId: "provider-1", SpaceId: "foospace", OpaqueId: "root"})},
 			Root: &sprovider.ResourceId{StorageId: "provider-1", SpaceId: "foospace", OpaqueId: "root"},
 			Name: "foospace",
 		}
@@ -141,7 +141,7 @@ var _ = Describe("PropfindWithDepthInfinity", func() {
 					},
 				},
 			},
-			Id:   &sprovider.StorageSpaceId{OpaqueId: storagespace.FormatResourceID(sprovider.ResourceId{StorageId: "provider-1", SpaceId: "fooquxspace", OpaqueId: "root"})},
+			Id:   &sprovider.StorageSpaceId{OpaqueId: storagespace.FormatResourceID(&sprovider.ResourceId{StorageId: "provider-1", SpaceId: "fooquxspace", OpaqueId: "root"})},
 			Root: &sprovider.ResourceId{StorageId: "provider-1", SpaceId: "fooquxspace", OpaqueId: "root"},
 			Name: "fooquxspace",
 		}
@@ -154,7 +154,7 @@ var _ = Describe("PropfindWithDepthInfinity", func() {
 					},
 				},
 			},
-			Id:   &sprovider.StorageSpaceId{OpaqueId: storagespace.FormatResourceID(sprovider.ResourceId{StorageId: "provider-1", SpaceId: "fooFileShareSpace", OpaqueId: "sharedfile"})},
+			Id:   &sprovider.StorageSpaceId{OpaqueId: storagespace.FormatResourceID(&sprovider.ResourceId{StorageId: "provider-1", SpaceId: "fooFileShareSpace", OpaqueId: "sharedfile"})},
 			Root: &sprovider.ResourceId{StorageId: "provider-1", SpaceId: "fooFileShareSpace", OpaqueId: "sharedfile"},
 			Name: "fooFileShareSpace",
 		}
@@ -167,7 +167,7 @@ var _ = Describe("PropfindWithDepthInfinity", func() {
 					},
 				},
 			},
-			Id:   &sprovider.StorageSpaceId{OpaqueId: storagespace.FormatResourceID(sprovider.ResourceId{StorageId: "provider-1", SpaceId: "fooFileShareSpace2", OpaqueId: "sharedfile2"})},
+			Id:   &sprovider.StorageSpaceId{OpaqueId: storagespace.FormatResourceID(&sprovider.ResourceId{StorageId: "provider-1", SpaceId: "fooFileShareSpace2", OpaqueId: "sharedfile2"})},
 			Root: &sprovider.ResourceId{StorageId: "provider-1", SpaceId: "fooFileShareSpace2", OpaqueId: "sharedfile2"},
 			Name: "fooFileShareSpace2",
 		}
@@ -180,7 +180,7 @@ var _ = Describe("PropfindWithDepthInfinity", func() {
 					},
 				},
 			},
-			Id:   &sprovider.StorageSpaceId{OpaqueId: storagespace.FormatResourceID(sprovider.ResourceId{StorageId: "provider-1", SpaceId: "fooDirShareSpace", OpaqueId: "shareddir"})},
+			Id:   &sprovider.StorageSpaceId{OpaqueId: storagespace.FormatResourceID(&sprovider.ResourceId{StorageId: "provider-1", SpaceId: "fooDirShareSpace", OpaqueId: "shareddir"})},
 			Root: &sprovider.ResourceId{StorageId: "provider-1", SpaceId: "fooDirShareSpace", OpaqueId: "shareddir"},
 			Name: "fooDirShareSpace",
 		}
@@ -787,7 +787,7 @@ var _ = Describe("PropfindWithDepthInfinity", func() {
 			Expect(err).ToNot(HaveOccurred())
 			req = req.WithContext(ctx)
 
-			spaceID := storagespace.FormatResourceID(sprovider.ResourceId{StorageId: "provider-1", SpaceId: "foospace", OpaqueId: "root"})
+			spaceID := storagespace.FormatResourceID(&sprovider.ResourceId{StorageId: "provider-1", SpaceId: "foospace", OpaqueId: "root"})
 			spaceIDUrl := net.EncodePath(spaceID)
 			handler.HandleSpacesPropfind(rr, req, spaceID)
 			Expect(rr.Code).To(Equal(http.StatusMultiStatus))
@@ -822,7 +822,7 @@ var _ = Describe("PropfindWithDepthInfinity", func() {
 			Expect(err).ToNot(HaveOccurred())
 			req = req.WithContext(ctx)
 
-			spaceID := storagespace.FormatResourceID(sprovider.ResourceId{StorageId: "provider-1", SpaceId: "foospace", OpaqueId: "root"})
+			spaceID := storagespace.FormatResourceID(&sprovider.ResourceId{StorageId: "provider-1", SpaceId: "foospace", OpaqueId: "root"})
 			handler.HandleSpacesPropfind(rr, req, spaceID)
 			Expect(rr.Code).To(Equal(http.StatusMultiStatus))
 
@@ -838,7 +838,7 @@ var _ = Describe("PropfindWithDepthInfinity", func() {
 			Expect(err).ToNot(HaveOccurred())
 			req = req.WithContext(ctx)
 
-			spaceID := storagespace.FormatResourceID(sprovider.ResourceId{StorageId: "provider-1", SpaceId: "foospace", OpaqueId: "root"})
+			spaceID := storagespace.FormatResourceID(&sprovider.ResourceId{StorageId: "provider-1", SpaceId: "foospace", OpaqueId: "root"})
 			handler.HandleSpacesPropfind(rr, req, spaceID)
 			Expect(rr.Code).To(Equal(http.StatusMultiStatus))
 
@@ -855,7 +855,7 @@ var _ = Describe("PropfindWithDepthInfinity", func() {
 			Expect(err).ToNot(HaveOccurred())
 			req = req.WithContext(ctx)
 
-			spaceID := storagespace.FormatResourceID(sprovider.ResourceId{StorageId: "provider-1", SpaceId: "foospace", OpaqueId: "root"})
+			spaceID := storagespace.FormatResourceID(&sprovider.ResourceId{StorageId: "provider-1", SpaceId: "foospace", OpaqueId: "root"})
 			handler.HandleSpacesPropfind(rr, req, spaceID)
 			Expect(rr.Code).To(Equal(http.StatusMultiStatus))
 
@@ -873,7 +873,7 @@ var _ = Describe("PropfindWithDepthInfinity", func() {
 			Expect(err).ToNot(HaveOccurred())
 			req = req.WithContext(ctx)
 
-			spaceID := storagespace.FormatResourceID(sprovider.ResourceId{StorageId: "provider-1", SpaceId: "foospace", OpaqueId: "root"})
+			spaceID := storagespace.FormatResourceID(&sprovider.ResourceId{StorageId: "provider-1", SpaceId: "foospace", OpaqueId: "root"})
 			handler.HandleSpacesPropfind(rr, req, spaceID)
 			Expect(rr.Code).To(Equal(http.StatusMultiStatus))
 
@@ -959,7 +959,7 @@ var _ = Describe("PropfindWithoutDepthInfinity", func() {
 					},
 				},
 			},
-			Id:   &sprovider.StorageSpaceId{OpaqueId: storagespace.FormatResourceID(sprovider.ResourceId{StorageId: "provider-1", SpaceId: "foospace", OpaqueId: "root"})},
+			Id:   &sprovider.StorageSpaceId{OpaqueId: storagespace.FormatResourceID(&sprovider.ResourceId{StorageId: "provider-1", SpaceId: "foospace", OpaqueId: "root"})},
 			Root: &sprovider.ResourceId{StorageId: "provider-1", SpaceId: "foospace", OpaqueId: "root"},
 			Name: "foospace",
 		}
@@ -972,7 +972,7 @@ var _ = Describe("PropfindWithoutDepthInfinity", func() {
 					},
 				},
 			},
-			Id:   &sprovider.StorageSpaceId{OpaqueId: storagespace.FormatResourceID(sprovider.ResourceId{StorageId: "provider-1", SpaceId: "fooquxspace", OpaqueId: "root"})},
+			Id:   &sprovider.StorageSpaceId{OpaqueId: storagespace.FormatResourceID(&sprovider.ResourceId{StorageId: "provider-1", SpaceId: "fooquxspace", OpaqueId: "root"})},
 			Root: &sprovider.ResourceId{StorageId: "provider-1", SpaceId: "fooquxspace", OpaqueId: "root"},
 			Name: "fooquxspace",
 		}
@@ -985,7 +985,7 @@ var _ = Describe("PropfindWithoutDepthInfinity", func() {
 					},
 				},
 			},
-			Id:   &sprovider.StorageSpaceId{OpaqueId: storagespace.FormatResourceID(sprovider.ResourceId{StorageId: "provider-1", SpaceId: "fooFileShareSpace", OpaqueId: "sharedfile"})},
+			Id:   &sprovider.StorageSpaceId{OpaqueId: storagespace.FormatResourceID(&sprovider.ResourceId{StorageId: "provider-1", SpaceId: "fooFileShareSpace", OpaqueId: "sharedfile"})},
 			Root: &sprovider.ResourceId{StorageId: "provider-1", SpaceId: "fooFileShareSpace", OpaqueId: "sharedfile"},
 			Name: "fooFileShareSpace",
 		}
@@ -998,7 +998,7 @@ var _ = Describe("PropfindWithoutDepthInfinity", func() {
 					},
 				},
 			},
-			Id:   &sprovider.StorageSpaceId{OpaqueId: storagespace.FormatResourceID(sprovider.ResourceId{StorageId: "provider-1", SpaceId: "fooFileShareSpace2", OpaqueId: "sharedfile2"})},
+			Id:   &sprovider.StorageSpaceId{OpaqueId: storagespace.FormatResourceID(&sprovider.ResourceId{StorageId: "provider-1", SpaceId: "fooFileShareSpace2", OpaqueId: "sharedfile2"})},
 			Root: &sprovider.ResourceId{StorageId: "provider-1", SpaceId: "fooFileShareSpace2", OpaqueId: "sharedfile2"},
 			Name: "fooFileShareSpace2",
 		}
@@ -1011,7 +1011,7 @@ var _ = Describe("PropfindWithoutDepthInfinity", func() {
 					},
 				},
 			},
-			Id:   &sprovider.StorageSpaceId{OpaqueId: storagespace.FormatResourceID(sprovider.ResourceId{StorageId: "provider-1", SpaceId: "fooDirShareSpace", OpaqueId: "shareddir"})},
+			Id:   &sprovider.StorageSpaceId{OpaqueId: storagespace.FormatResourceID(&sprovider.ResourceId{StorageId: "provider-1", SpaceId: "fooDirShareSpace", OpaqueId: "shareddir"})},
 			Root: &sprovider.ResourceId{StorageId: "provider-1", SpaceId: "fooDirShareSpace", OpaqueId: "shareddir"},
 			Name: "fooDirShareSpace",
 		}
@@ -1598,7 +1598,7 @@ var _ = Describe("PropfindWithoutDepthInfinity", func() {
 			Expect(err).ToNot(HaveOccurred())
 			req = req.WithContext(ctx)
 
-			spaceID := storagespace.FormatResourceID(sprovider.ResourceId{StorageId: "provider-1", SpaceId: "foospace", OpaqueId: "root"})
+			spaceID := storagespace.FormatResourceID(&sprovider.ResourceId{StorageId: "provider-1", SpaceId: "foospace", OpaqueId: "root"})
 			spaceIDUrl := net.EncodePath(spaceID)
 			handler.HandleSpacesPropfind(rr, req, spaceID)
 			Expect(rr.Code).To(Equal(http.StatusMultiStatus))
@@ -1633,7 +1633,7 @@ var _ = Describe("PropfindWithoutDepthInfinity", func() {
 			Expect(err).ToNot(HaveOccurred())
 			req = req.WithContext(ctx)
 
-			spaceID := storagespace.FormatResourceID(sprovider.ResourceId{StorageId: "provider-1", SpaceId: "foospace", OpaqueId: "root"})
+			spaceID := storagespace.FormatResourceID(&sprovider.ResourceId{StorageId: "provider-1", SpaceId: "foospace", OpaqueId: "root"})
 			handler.HandleSpacesPropfind(rr, req, spaceID)
 			Expect(rr.Code).To(Equal(http.StatusMultiStatus))
 
@@ -1649,7 +1649,7 @@ var _ = Describe("PropfindWithoutDepthInfinity", func() {
 			Expect(err).ToNot(HaveOccurred())
 			req = req.WithContext(ctx)
 
-			spaceID := storagespace.FormatResourceID(sprovider.ResourceId{StorageId: "provider-1", SpaceId: "foospace", OpaqueId: "root"})
+			spaceID := storagespace.FormatResourceID(&sprovider.ResourceId{StorageId: "provider-1", SpaceId: "foospace", OpaqueId: "root"})
 			handler.HandleSpacesPropfind(rr, req, spaceID)
 			Expect(rr.Code).To(Equal(http.StatusMultiStatus))
 
@@ -1666,7 +1666,7 @@ var _ = Describe("PropfindWithoutDepthInfinity", func() {
 			Expect(err).ToNot(HaveOccurred())
 			req = req.WithContext(ctx)
 
-			spaceID := storagespace.FormatResourceID(sprovider.ResourceId{StorageId: "provider-1", SpaceId: "foospace", OpaqueId: "root"})
+			spaceID := storagespace.FormatResourceID(&sprovider.ResourceId{StorageId: "provider-1", SpaceId: "foospace", OpaqueId: "root"})
 			handler.HandleSpacesPropfind(rr, req, spaceID)
 			Expect(rr.Code).To(Equal(http.StatusMultiStatus))
 
@@ -1684,7 +1684,7 @@ var _ = Describe("PropfindWithoutDepthInfinity", func() {
 			Expect(err).ToNot(HaveOccurred())
 			req = req.WithContext(ctx)
 
-			spaceID := storagespace.FormatResourceID(sprovider.ResourceId{StorageId: "provider-1", SpaceId: "foospace", OpaqueId: "root"})
+			spaceID := storagespace.FormatResourceID(&sprovider.ResourceId{StorageId: "provider-1", SpaceId: "foospace", OpaqueId: "root"})
 			handler.HandleSpacesPropfind(rr, req, spaceID)
 			Expect(rr.Code).To(Equal(http.StatusBadRequest))
 

--- a/internal/http/services/owncloud/ocdav/put.go
+++ b/internal/http/services/owncloud/ocdav/put.go
@@ -230,7 +230,7 @@ func (s *svc) handlePut(ctx context.Context, w http.ResponseWriter, r *http.Requ
 
 			w.Header().Set(net.HeaderETag, sRes.Info.Etag)
 			w.Header().Set(net.HeaderOCETag, sRes.Info.Etag)
-			w.Header().Set(net.HeaderOCFileID, storagespace.FormatResourceID(*sRes.Info.Id))
+			w.Header().Set(net.HeaderOCFileID, storagespace.FormatResourceID(sRes.Info.Id))
 			w.Header().Set(net.HeaderLastModified, net.RFC1123Z(sRes.Info.Mtime))
 
 			w.WriteHeader(http.StatusCreated)

--- a/internal/http/services/owncloud/ocdav/spaces.go
+++ b/internal/http/services/owncloud/ocdav/spaces.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"path"
 
+	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	"github.com/cs3org/reva/v2/internal/http/services/owncloud/ocdav/config"
 	"github.com/cs3org/reva/v2/internal/http/services/owncloud/ocdav/errors"
 	"github.com/cs3org/reva/v2/internal/http/services/owncloud/ocdav/net"
@@ -30,6 +31,7 @@ import (
 	"github.com/cs3org/reva/v2/pkg/rhttp/router"
 	"github.com/cs3org/reva/v2/pkg/storagespace"
 	"github.com/cs3org/reva/v2/pkg/utils"
+	"google.golang.org/protobuf/proto"
 )
 
 // SpacesHandler handles trashbin requests
@@ -167,10 +169,10 @@ func (h *SpacesHandler) handleSpacesTrashbin(w http.ResponseWriter, r *http.Requ
 		}
 		log.Debug().Str("key", key).Str("path", r.URL.Path).Str("dst", dst).Msg("spaces restore")
 
-		dstRef := ref
+		dstRef := proto.Clone(&ref).(*provider.Reference)
 		dstRef.Path = utils.MakeRelativePath(dst)
 
-		trashbinHandler.restore(w, r, s, &ref, &dstRef, key, r.URL.Path)
+		trashbinHandler.restore(w, r, s, &ref, dstRef, key, r.URL.Path)
 	case http.MethodDelete:
 		trashbinHandler.delete(w, r, s, &ref, key, r.URL.Path)
 	default:

--- a/internal/http/services/owncloud/ocdav/trashbin.go
+++ b/internal/http/services/owncloud/ocdav/trashbin.go
@@ -601,7 +601,7 @@ func (h *TrashbinHandler) restore(w http.ResponseWriter, r *http.Request, s *svc
 	info := dstStatRes.Info
 	w.Header().Set(net.HeaderContentType, info.MimeType)
 	w.Header().Set(net.HeaderETag, info.Etag)
-	w.Header().Set(net.HeaderOCFileID, storagespace.FormatResourceID(*info.Id))
+	w.Header().Set(net.HeaderOCFileID, storagespace.FormatResourceID(info.Id))
 	w.Header().Set(net.HeaderOCETag, info.Etag)
 
 	w.WriteHeader(successCode)

--- a/internal/http/services/owncloud/ocdav/tus.go
+++ b/internal/http/services/owncloud/ocdav/tus.go
@@ -377,7 +377,7 @@ func (s *svc) handleTusPost(ctx context.Context, w http.ResponseWriter, r *http.
 			)
 
 			w.Header().Set(net.HeaderContentType, info.MimeType)
-			w.Header().Set(net.HeaderOCFileID, storagespace.FormatResourceID(*info.Id))
+			w.Header().Set(net.HeaderOCFileID, storagespace.FormatResourceID(info.Id))
 			w.Header().Set(net.HeaderOCETag, info.Etag)
 			w.Header().Set(net.HeaderETag, info.Etag)
 			w.Header().Set(net.HeaderOCPermissions, permissions)

--- a/internal/http/services/owncloud/ocdav/versions.go
+++ b/internal/http/services/owncloud/ocdav/versions.go
@@ -58,7 +58,7 @@ func (h *VersionsHandler) Handler(s *svc, rid *provider.ResourceId) http.Handler
 		}
 
 		// baseURI is encoded as part of the response payload in href field
-		baseURI := path.Join(ctx.Value(net.CtxKeyBaseURI).(string), storagespace.FormatResourceID(*rid))
+		baseURI := path.Join(ctx.Value(net.CtxKeyBaseURI).(string), storagespace.FormatResourceID(rid))
 		ctx = context.WithValue(ctx, net.CtxKeyBaseURI, baseURI)
 		r = r.WithContext(ctx)
 

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/sharees/token.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/sharees/token.go
@@ -81,7 +81,7 @@ func handleGetToken(ctx context.Context, tkn string, pw string, c gateway.Gatewa
 	}
 
 	if protected && !t.PasswordProtected {
-		space, status, err := spacelookup.LookUpStorageSpaceByID(ctx, c, storagespace.FormatResourceID(provider.ResourceId{StorageId: t.StorageID, SpaceId: t.SpaceID, OpaqueId: t.OpaqueID}))
+		space, status, err := spacelookup.LookUpStorageSpaceByID(ctx, c, storagespace.FormatResourceID(&provider.ResourceId{StorageId: t.StorageID, SpaceId: t.SpaceID, OpaqueId: t.OpaqueID}))
 		// add info only if user is able to stat
 		if err == nil && status.Code == rpc.Code_CODE_OK {
 			t.SpacePath = utils.ReadPlainFromOpaque(space.Opaque, "path")
@@ -111,7 +111,7 @@ func buildTokenInfo(owner *user.User, tkn string, token string, passProtected bo
 		return t, fmt.Errorf("can't stat resource. %+v %s", sRes, err)
 	}
 
-	t.ID = storagespace.FormatResourceID(*sRes.Share.GetResourceId())
+	t.ID = storagespace.FormatResourceID(sRes.Share.GetResourceId())
 	t.StorageID = sRes.Share.ResourceId.GetStorageId()
 	t.SpaceID = sRes.Share.ResourceId.GetSpaceId()
 	t.OpaqueID = sRes.Share.ResourceId.GetOpaqueId()

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/public.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/public.go
@@ -323,7 +323,7 @@ func (h *Handler) updatePublicShare(w http.ResponseWriter, r *http.Request, shar
 		return
 	}
 
-	createdByUser := publicshare.IsCreatedByUser(*share, user)
+	createdByUser := publicshare.IsCreatedByUser(share, user)
 
 	// NOTE: you are allowed to update a link TO a public link without the `PublicLink.Write` permission if you created it yourself
 	if (permKey != nil && *permKey != 0) || !createdByUser {
@@ -540,7 +540,7 @@ func (h *Handler) removePublicShare(w http.ResponseWriter, r *http.Request, shar
 	}
 
 	u := ctxpkg.ContextMustGetUser(ctx)
-	if !publicshare.IsCreatedByUser(*share, u) {
+	if !publicshare.IsCreatedByUser(share, u) {
 		sRes, err := c.Stat(r.Context(), &provider.StatRequest{Ref: &provider.Reference{ResourceId: share.ResourceId}})
 		if err != nil {
 			log.Err(err).Interface("resource_id", share.ResourceId).Msg("failed to stat shared resource")

--- a/pkg/app/provider/demo/demo.go
+++ b/pkg/app/provider/demo/demo.go
@@ -40,7 +40,7 @@ type demoProvider struct {
 }
 
 func (p *demoProvider) GetAppURL(ctx context.Context, resource *provider.ResourceInfo, viewMode appprovider.ViewMode, token, language string) (*appprovider.OpenInAppURL, error) {
-	url := fmt.Sprintf("<iframe src=%s/open/%s?view-mode=%s&access-token=%s />", p.iframeUIProvider, storagespace.FormatResourceID(*resource.Id), viewMode.String(), token)
+	url := fmt.Sprintf("<iframe src=%s/open/%s?view-mode=%s&access-token=%s />", p.iframeUIProvider, storagespace.FormatResourceID(resource.Id), viewMode.String(), token)
 	return &appprovider.OpenInAppURL{
 		AppUrl: url,
 		Method: "GET",

--- a/pkg/app/registry/micro/manager.go
+++ b/pkg/app/registry/micro/manager.go
@@ -190,13 +190,13 @@ func (m *manager) getProvidersFromMicroRegistry(ctx context.Context) ([]*registr
 	for _, node := range services[0].Nodes {
 		p := m.providerFromMetadata(node.Metadata)
 		p.Address = node.Address
-		providers = append(providers, &p)
+		providers = append(providers, p)
 	}
 	return providers, nil
 }
 
-func (m *manager) providerFromMetadata(metadata map[string]string) registrypb.ProviderInfo {
-	p := registrypb.ProviderInfo{
+func (m *manager) providerFromMetadata(metadata map[string]string) *registrypb.ProviderInfo {
+	p := &registrypb.ProviderInfo{
 		MimeTypes: splitMimeTypes(metadata[m.namespace+".app-provider.mime_type"]),
 		//		Address:     node.Address,
 		Name:        metadata[m.namespace+".app-provider.name"],

--- a/pkg/appauth/manager/json/json.go
+++ b/pkg/appauth/manager/json/json.go
@@ -38,6 +38,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sethvargo/go-password/password"
 	"golang.org/x/crypto/bcrypt"
+	"google.golang.org/protobuf/proto"
 )
 
 func init() {
@@ -165,9 +166,9 @@ func (mgr *jsonManager) GenerateAppPassword(ctx context.Context, scope map[strin
 		return nil, errors.Wrap(err, "error saving new token")
 	}
 
-	clonedAppPass := *appPass
+	clonedAppPass := proto.Clone(appPass).(*apppb.AppPassword)
 	clonedAppPass.Password = token
-	return &clonedAppPass, nil
+	return clonedAppPass, nil
 }
 
 func (mgr *jsonManager) ListAppPasswords(ctx context.Context) ([]*apppb.AppPassword, error) {

--- a/pkg/auth/manager/nextcloud/nextcloud.go
+++ b/pkg/auth/manager/nextcloud/nextcloud.go
@@ -180,8 +180,8 @@ func (am *Manager) Authenticate(ctx context.Context, clientID, clientSecret stri
 	}
 
 	type resultsObj struct {
-		User   user.User               `json:"user"`
-		Scopes map[string]authpb.Scope `json:"scopes"`
+		User   user.User                `json:"user"`
+		Scopes map[string]*authpb.Scope `json:"scopes"`
 	}
 	result := &resultsObj{}
 	err = json.Unmarshal(body, &result)
@@ -191,7 +191,7 @@ func (am *Manager) Authenticate(ctx context.Context, clientID, clientSecret stri
 	var pointersMap = make(map[string]*authpb.Scope)
 	for k := range result.Scopes {
 		scope := result.Scopes[k]
-		pointersMap[k] = &scope
+		pointersMap[k] = scope
 	}
 	return &result.User, pointersMap, nil
 }

--- a/pkg/auth/scope/ocmshare.go
+++ b/pkg/auth/scope/ocmshare.go
@@ -93,25 +93,25 @@ func ocmShareScope(_ context.Context, scope *authpb.Scope, resource interface{},
 
 	// editor role
 	case *provider.CreateContainerRequest:
-		return hasRoleEditor(*scope) && checkStorageRefForOCMShare(&share, v.GetRef(), ocmNamespace), nil
+		return hasRoleEditor(scope) && checkStorageRefForOCMShare(&share, v.GetRef(), ocmNamespace), nil
 	case *provider.TouchFileRequest:
-		return hasRoleEditor(*scope) && checkStorageRefForOCMShare(&share, v.GetRef(), ocmNamespace), nil
+		return hasRoleEditor(scope) && checkStorageRefForOCMShare(&share, v.GetRef(), ocmNamespace), nil
 	case *provider.DeleteRequest:
-		return hasRoleEditor(*scope) && checkStorageRefForOCMShare(&share, v.GetRef(), ocmNamespace), nil
+		return hasRoleEditor(scope) && checkStorageRefForOCMShare(&share, v.GetRef(), ocmNamespace), nil
 	case *provider.MoveRequest:
-		return hasRoleEditor(*scope) && checkStorageRefForOCMShare(&share, v.GetSource(), ocmNamespace) && checkStorageRefForOCMShare(&share, v.GetDestination(), ocmNamespace), nil
+		return hasRoleEditor(scope) && checkStorageRefForOCMShare(&share, v.GetSource(), ocmNamespace) && checkStorageRefForOCMShare(&share, v.GetDestination(), ocmNamespace), nil
 	case *provider.InitiateFileUploadRequest:
-		return hasRoleEditor(*scope) && checkStorageRefForOCMShare(&share, v.GetRef(), ocmNamespace), nil
+		return hasRoleEditor(scope) && checkStorageRefForOCMShare(&share, v.GetRef(), ocmNamespace), nil
 	case *provider.SetArbitraryMetadataRequest:
-		return hasRoleEditor(*scope) && checkStorageRefForOCMShare(&share, v.GetRef(), ocmNamespace), nil
+		return hasRoleEditor(scope) && checkStorageRefForOCMShare(&share, v.GetRef(), ocmNamespace), nil
 	case *provider.UnsetArbitraryMetadataRequest:
-		return hasRoleEditor(*scope) && checkStorageRefForOCMShare(&share, v.GetRef(), ocmNamespace), nil
+		return hasRoleEditor(scope) && checkStorageRefForOCMShare(&share, v.GetRef(), ocmNamespace), nil
 	case *provider.SetLockRequest:
-		return hasRoleEditor(*scope) && checkStorageRefForOCMShare(&share, v.GetRef(), ocmNamespace), nil
+		return hasRoleEditor(scope) && checkStorageRefForOCMShare(&share, v.GetRef(), ocmNamespace), nil
 	case *provider.RefreshLockRequest:
-		return hasRoleEditor(*scope) && checkStorageRefForOCMShare(&share, v.GetRef(), ocmNamespace), nil
+		return hasRoleEditor(scope) && checkStorageRefForOCMShare(&share, v.GetRef(), ocmNamespace), nil
 	case *provider.UnlockRequest:
-		return hasRoleEditor(*scope) && checkStorageRefForOCMShare(&share, v.GetRef(), ocmNamespace), nil
+		return hasRoleEditor(scope) && checkStorageRefForOCMShare(&share, v.GetRef(), ocmNamespace), nil
 
 	// App provider requests
 	case *appregistry.GetDefaultAppProviderForMimeTypeRequest:

--- a/pkg/auth/scope/publicshare.go
+++ b/pkg/auth/scope/publicshare.go
@@ -106,19 +106,19 @@ func publicshareScope(ctx context.Context, scope *authpb.Scope, resource interfa
 	// Editor role
 	// need to return appropriate status codes in the ocs/ocdav layers.
 	case *provider.CreateContainerRequest:
-		return hasRoleEditor(*scope) && checkStorageRef(ctx, &share, v.GetRef()), nil
+		return hasRoleEditor(scope) && checkStorageRef(ctx, &share, v.GetRef()), nil
 	case *provider.TouchFileRequest:
-		return hasRoleEditor(*scope) && checkStorageRef(ctx, &share, v.GetRef()), nil
+		return hasRoleEditor(scope) && checkStorageRef(ctx, &share, v.GetRef()), nil
 	case *provider.DeleteRequest:
-		return hasRoleEditor(*scope) && checkStorageRef(ctx, &share, v.GetRef()), nil
+		return hasRoleEditor(scope) && checkStorageRef(ctx, &share, v.GetRef()), nil
 	case *provider.MoveRequest:
-		return hasRoleEditor(*scope) && checkStorageRef(ctx, &share, v.GetSource()) && checkStorageRef(ctx, &share, v.GetDestination()), nil
+		return hasRoleEditor(scope) && checkStorageRef(ctx, &share, v.GetSource()) && checkStorageRef(ctx, &share, v.GetDestination()), nil
 	case *provider.InitiateFileUploadRequest:
-		return hasRoleEditor(*scope) && checkStorageRef(ctx, &share, v.GetRef()), nil
+		return hasRoleEditor(scope) && checkStorageRef(ctx, &share, v.GetRef()), nil
 	case *provider.SetArbitraryMetadataRequest:
-		return hasRoleEditor(*scope) && checkStorageRef(ctx, &share, v.GetRef()), nil
+		return hasRoleEditor(scope) && checkStorageRef(ctx, &share, v.GetRef()), nil
 	case *provider.UnsetArbitraryMetadataRequest:
-		return hasRoleEditor(*scope) && checkStorageRef(ctx, &share, v.GetRef()), nil
+		return hasRoleEditor(scope) && checkStorageRef(ctx, &share, v.GetRef()), nil
 
 	// App provider requests
 	case *appregistry.GetDefaultAppProviderForMimeTypeRequest:

--- a/pkg/auth/scope/resourceinfo.go
+++ b/pkg/auth/scope/resourceinfo.go
@@ -83,19 +83,19 @@ func resourceinfoScope(_ context.Context, scope *authpb.Scope, resource interfac
 	// Editor role
 	// need to return appropriate status codes in the ocs/ocdav layers.
 	case *provider.CreateContainerRequest:
-		return hasRoleEditor(*scope) && checkResourceInfo(&r, v.GetRef()), nil
+		return hasRoleEditor(scope) && checkResourceInfo(&r, v.GetRef()), nil
 	case *provider.TouchFileRequest:
-		return hasRoleEditor(*scope) && checkResourceInfo(&r, v.GetRef()), nil
+		return hasRoleEditor(scope) && checkResourceInfo(&r, v.GetRef()), nil
 	case *provider.DeleteRequest:
-		return hasRoleEditor(*scope) && checkResourceInfo(&r, v.GetRef()), nil
+		return hasRoleEditor(scope) && checkResourceInfo(&r, v.GetRef()), nil
 	case *provider.MoveRequest:
-		return hasRoleEditor(*scope) && checkResourceInfo(&r, v.GetSource()) && checkResourceInfo(&r, v.GetDestination()), nil
+		return hasRoleEditor(scope) && checkResourceInfo(&r, v.GetSource()) && checkResourceInfo(&r, v.GetDestination()), nil
 	case *provider.InitiateFileUploadRequest:
-		return hasRoleEditor(*scope) && checkResourceInfo(&r, v.GetRef()), nil
+		return hasRoleEditor(scope) && checkResourceInfo(&r, v.GetRef()), nil
 	case *provider.SetArbitraryMetadataRequest:
-		return hasRoleEditor(*scope) && checkResourceInfo(&r, v.GetRef()), nil
+		return hasRoleEditor(scope) && checkResourceInfo(&r, v.GetRef()), nil
 	case *provider.UnsetArbitraryMetadataRequest:
-		return hasRoleEditor(*scope) && checkResourceInfo(&r, v.GetRef()), nil
+		return hasRoleEditor(scope) && checkResourceInfo(&r, v.GetRef()), nil
 
 	case string:
 		return checkResourcePath(v), nil

--- a/pkg/auth/scope/scope.go
+++ b/pkg/auth/scope/scope.go
@@ -56,6 +56,6 @@ func VerifyScope(ctx context.Context, scopeMap map[string]*authpb.Scope, resourc
 	return false, nil
 }
 
-func hasRoleEditor(scope authpb.Scope) bool {
+func hasRoleEditor(scope *authpb.Scope) bool {
 	return scope.Role == authpb.Role_ROLE_OWNER || scope.Role == authpb.Role_ROLE_EDITOR || scope.Role == authpb.Role_ROLE_UPLOADER
 }

--- a/pkg/conversions/main.go
+++ b/pkg/conversions/main.go
@@ -345,7 +345,7 @@ func ReceivedOCMShare2ShareData(share *ocm.ReceivedShare, path string) (*ShareDa
 		FileTarget:   shareTarget,
 		MimeType:     mime.Detect(share.ResourceType == provider.ResourceType_RESOURCE_TYPE_CONTAINER, share.Name),
 		ItemType:     ResourceType(share.ResourceType).String(),
-		ItemSource: storagespace.FormatResourceID(provider.ResourceId{
+		ItemSource: storagespace.FormatResourceID(&provider.ResourceId{
 			StorageId: utils.OCMStorageProviderID,
 			SpaceId:   share.Id.OpaqueId,
 			OpaqueId:  opaqueid,

--- a/pkg/group/manager/json/json.go
+++ b/pkg/group/manager/json/json.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cs3org/reva/v2/pkg/group/manager/registry"
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
+	"google.golang.org/protobuf/proto"
 )
 
 func init() {
@@ -90,11 +91,11 @@ func New(m map[string]interface{}) (group.Manager, error) {
 func (m *manager) GetGroup(ctx context.Context, gid *grouppb.GroupId, skipFetchingMembers bool) (*grouppb.Group, error) {
 	for _, g := range m.groups {
 		if (g.Id.GetOpaqueId() == gid.OpaqueId || g.GroupName == gid.OpaqueId) && (gid.Idp == "" || gid.Idp == g.Id.GetIdp()) {
-			group := *g
+			group := proto.Clone(g).(*grouppb.Group)
 			if skipFetchingMembers {
 				group.Members = nil
 			}
-			return &group, nil
+			return group, nil
 		}
 	}
 	return nil, errtypes.NotFound(gid.OpaqueId)
@@ -103,11 +104,11 @@ func (m *manager) GetGroup(ctx context.Context, gid *grouppb.GroupId, skipFetchi
 func (m *manager) GetGroupByClaim(ctx context.Context, claim, value string, skipFetchingMembers bool) (*grouppb.Group, error) {
 	for _, g := range m.groups {
 		if groupClaim, err := extractClaim(g, claim); err == nil && value == groupClaim {
-			group := *g
+			group := proto.Clone(g).(*grouppb.Group)
 			if skipFetchingMembers {
 				group.Members = nil
 			}
-			return &group, nil
+			return group, nil
 		}
 	}
 	return nil, errtypes.NotFound(value)
@@ -131,11 +132,11 @@ func (m *manager) FindGroups(ctx context.Context, query string, skipFetchingMemb
 	groups := []*grouppb.Group{}
 	for _, g := range m.groups {
 		if groupContains(g, query) {
-			group := *g
+			group := proto.Clone(g).(*grouppb.Group)
 			if skipFetchingMembers {
 				group.Members = nil
 			}
-			groups = append(groups, &group)
+			groups = append(groups, group)
 		}
 	}
 	return groups, nil

--- a/pkg/group/manager/json/json_test.go
+++ b/pkg/group/manager/json/json_test.go
@@ -27,6 +27,9 @@ import (
 	grouppb "github.com/cs3org/go-cs3apis/cs3/identity/group/v1beta1"
 	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	"github.com/cs3org/reva/v2/pkg/errtypes"
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/testing/protocmp"
 )
 
 var ctx = context.Background()
@@ -112,13 +115,13 @@ func TestUserManager(t *testing.T) {
 
 	// positive test GetGroup
 	resGroup, _ := manager.GetGroup(ctx, gid, false)
-	if !reflect.DeepEqual(resGroup, group) {
+	if !proto.Equal(resGroup, group) {
 		t.Fatalf("group differs: expected=%v got=%v", group, resGroup)
 	}
 
 	// positive test GetGroup without members
 	resGroupWithoutMembers, _ := manager.GetGroup(ctx, gid, true)
-	if !reflect.DeepEqual(resGroupWithoutMembers, groupWithoutMembers) {
+	if !proto.Equal(resGroupWithoutMembers, groupWithoutMembers) {
 		t.Fatalf("group differs: expected=%v got=%v", groupWithoutMembers, resGroupWithoutMembers)
 	}
 
@@ -131,7 +134,7 @@ func TestUserManager(t *testing.T) {
 
 	// positive test GetGroupByClaim by mail
 	resGroupByEmail, _ := manager.GetGroupByClaim(ctx, "mail", "sailing-lovers@example.org", false)
-	if !reflect.DeepEqual(resGroupByEmail, group) {
+	if !proto.Equal(resGroupByEmail, group) {
 		t.Fatalf("group differs: expected=%v got=%v", group, resGroupByEmail)
 	}
 
@@ -144,7 +147,7 @@ func TestUserManager(t *testing.T) {
 
 	// test GetMembers
 	resMembers, _ := manager.GetMembers(ctx, gid)
-	if !reflect.DeepEqual(resMembers, members) {
+	if !cmp.Equal(resMembers, members, protocmp.Transform()) {
 		t.Fatalf("members differ: expected=%v got=%v", members, resMembers)
 	}
 

--- a/pkg/ocm/share/repository/nextcloud/nextcloud_test.go
+++ b/pkg/ocm/share/repository/nextcloud/nextcloud_test.go
@@ -226,16 +226,10 @@ var _ = Describe("Nextcloud", func() {
 	// 			Ctime: &types.Timestamp{
 	// 				Seconds:              1234567890,
 	// 				Nanos:                0,
-	// 				XXX_NoUnkeyedLiteral: struct{}{},
-	// 				XXX_unrecognized:     nil,
-	// 				XXX_sizecache:        0,
 	// 			},
 	// 			Mtime: &types.Timestamp{
 	// 				Seconds:              1234567890,
 	// 				Nanos:                0,
-	// 				XXX_NoUnkeyedLiteral: struct{}{},
-	// 				XXX_unrecognized:     nil,
-	// 				XXX_sizecache:        0,
 	// 			},
 	// 		}))
 	// 		checkCalled(called, `POST /apps/sciencemesh/~tester/api/ocm/addReceivedShare {"md":{"opaque_id":"fileid-/some/path"},"g":{"grantee":{"Id":{"UserId":{"idp":"0.0.0.0:19000","opaque_id":"f7fbf8c8-139b-4376-b307-cf0a8c2d0d9c","type":1}}},"permissions":{"permissions":{"get_path":true}}},"provider_domain":"cern.ch","resource_type":"file","provider_id":2,"owner_opaque_id":"einstein","owner_display_name":"Albert Einstein","protocol":{"name":"webdav","options":{"sharedSecret":"secret","permissions":"webdav-property"}}}`)
@@ -278,18 +272,12 @@ var _ = Describe("Nextcloud", func() {
 					Type:     userpb.UserType_USER_TYPE_PRIMARY,
 				},
 				Ctime: &types.Timestamp{
-					Seconds:              1234567890,
-					Nanos:                0,
-					XXX_NoUnkeyedLiteral: struct{}{},
-					XXX_unrecognized:     nil,
-					XXX_sizecache:        0,
+					Seconds: 1234567890,
+					Nanos:   0,
 				},
 				Mtime: &types.Timestamp{
-					Seconds:              1234567890,
-					Nanos:                0,
-					XXX_NoUnkeyedLiteral: struct{}{},
-					XXX_unrecognized:     nil,
-					XXX_sizecache:        0,
+					Seconds: 1234567890,
+					Nanos:   0,
 				},
 			}))
 			checkCalled(called, `POST /apps/sciencemesh/~tester/api/ocm/GetShare {"Spec":{"Id":{"opaque_id":"some-share-id"}}}`)
@@ -352,16 +340,10 @@ var _ = Describe("Nextcloud", func() {
 	// 			Ctime: &types.Timestamp{
 	// 				Seconds:              1234567890,
 	// 				Nanos:                0,
-	// 				XXX_NoUnkeyedLiteral: struct{}{},
-	// 				XXX_unrecognized:     nil,
-	// 				XXX_sizecache:        0,
 	// 			},
 	// 			Mtime: &types.Timestamp{
 	// 				Seconds:              1234567890,
 	// 				Nanos:                0,
-	// 				XXX_NoUnkeyedLiteral: struct{}{},
-	// 				XXX_unrecognized:     nil,
-	// 				XXX_sizecache:        0,
 	// 			},
 	// 		}))
 	// 		checkCalled(called, `POST /apps/sciencemesh/~tester/api/ocm/UpdateShare {"ref":{"Spec":{"Id":{"opaque_id":"some-share-id"}}},"p":{"permissions":{"add_grant":true,"create_container":true,"delete":true,"get_path":true,"get_quota":true,"initiate_file_download":true,"initiate_file_upload":true,"list_grants":true,"list_container":true,"list_file_versions":true,"list_recycle":true,"move":true,"remove_grant":true,"purge_recycle":true,"restore_file_version":true,"restore_recycle_item":true,"stat":true,"update_grant":true,"deny_grant":true}}}`)
@@ -410,18 +392,12 @@ var _ = Describe("Nextcloud", func() {
 					Type:     userpb.UserType_USER_TYPE_PRIMARY,
 				},
 				Ctime: &types.Timestamp{
-					Seconds:              1234567890,
-					Nanos:                0,
-					XXX_NoUnkeyedLiteral: struct{}{},
-					XXX_unrecognized:     nil,
-					XXX_sizecache:        0,
+					Seconds: 1234567890,
+					Nanos:   0,
 				},
 				Mtime: &types.Timestamp{
-					Seconds:              1234567890,
-					Nanos:                0,
-					XXX_NoUnkeyedLiteral: struct{}{},
-					XXX_unrecognized:     nil,
-					XXX_sizecache:        0,
+					Seconds: 1234567890,
+					Nanos:   0,
 				},
 			}))
 			checkCalled(called, `POST /apps/sciencemesh/~tester/api/ocm/ListShares [{"type":4,"Term":{"Creator":{"idp":"0.0.0.0:19000","opaque_id":"f7fbf8c8-139b-4376-b307-cf0a8c2d0d9c","type":1}}}]`)
@@ -460,18 +436,12 @@ var _ = Describe("Nextcloud", func() {
 					Type:     userpb.UserType_USER_TYPE_PRIMARY,
 				},
 				Ctime: &types.Timestamp{
-					Seconds:              1234567890,
-					Nanos:                0,
-					XXX_NoUnkeyedLiteral: struct{}{},
-					XXX_unrecognized:     nil,
-					XXX_sizecache:        0,
+					Seconds: 1234567890,
+					Nanos:   0,
 				},
 				Mtime: &types.Timestamp{
-					Seconds:              1234567890,
-					Nanos:                0,
-					XXX_NoUnkeyedLiteral: struct{}{},
-					XXX_unrecognized:     nil,
-					XXX_sizecache:        0,
+					Seconds: 1234567890,
+					Nanos:   0,
 				},
 				State: ocm.ShareState_SHARE_STATE_ACCEPTED,
 			}))
@@ -516,18 +486,12 @@ var _ = Describe("Nextcloud", func() {
 					Type:     userpb.UserType_USER_TYPE_PRIMARY,
 				},
 				Ctime: &types.Timestamp{
-					Seconds:              1234567890,
-					Nanos:                0,
-					XXX_NoUnkeyedLiteral: struct{}{},
-					XXX_unrecognized:     nil,
-					XXX_sizecache:        0,
+					Seconds: 1234567890,
+					Nanos:   0,
 				},
 				Mtime: &types.Timestamp{
-					Seconds:              1234567890,
-					Nanos:                0,
-					XXX_NoUnkeyedLiteral: struct{}{},
-					XXX_unrecognized:     nil,
-					XXX_sizecache:        0,
+					Seconds: 1234567890,
+					Nanos:   0,
 				},
 				State: ocm.ShareState_SHARE_STATE_ACCEPTED,
 			}))
@@ -565,18 +529,12 @@ var _ = Describe("Nextcloud", func() {
 						Type:     userpb.UserType_USER_TYPE_PRIMARY,
 					},
 					Ctime: &types.Timestamp{
-						Seconds:              1234567890,
-						Nanos:                0,
-						XXX_NoUnkeyedLiteral: struct{}{},
-						XXX_unrecognized:     nil,
-						XXX_sizecache:        0,
+						Seconds: 1234567890,
+						Nanos:   0,
 					},
 					Mtime: &types.Timestamp{
-						Seconds:              1234567890,
-						Nanos:                0,
-						XXX_NoUnkeyedLiteral: struct{}{},
-						XXX_unrecognized:     nil,
-						XXX_sizecache:        0,
+						Seconds: 1234567890,
+						Nanos:   0,
 					},
 					State: ocm.ShareState_SHARE_STATE_ACCEPTED,
 				},
@@ -607,18 +565,12 @@ var _ = Describe("Nextcloud", func() {
 					Type:     userpb.UserType_USER_TYPE_PRIMARY,
 				},
 				Ctime: &types.Timestamp{
-					Seconds:              1234567890,
-					Nanos:                0,
-					XXX_NoUnkeyedLiteral: struct{}{},
-					XXX_unrecognized:     nil,
-					XXX_sizecache:        0,
+					Seconds: 1234567890,
+					Nanos:   0,
 				},
 				Mtime: &types.Timestamp{
-					Seconds:              1234567890,
-					Nanos:                0,
-					XXX_NoUnkeyedLiteral: struct{}{},
-					XXX_unrecognized:     nil,
-					XXX_sizecache:        0,
+					Seconds: 1234567890,
+					Nanos:   0,
 				},
 				State: ocm.ShareState_SHARE_STATE_ACCEPTED,
 			}))

--- a/pkg/ocm/share/repository/nextcloud/nextcloud_test.go
+++ b/pkg/ocm/share/repository/nextcloud/nextcloud_test.go
@@ -34,6 +34,7 @@ import (
 	. "github.com/onsi/gomega"
 	"google.golang.org/genproto/protobuf/field_mask"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/protobuf/testing/protocmp"
 )
 
 func setUpNextcloudServer() (*nextcloud.Manager, *[]string, func()) {
@@ -250,7 +251,7 @@ var _ = Describe("Nextcloud", func() {
 				},
 			})
 			Expect(err).ToNot(HaveOccurred())
-			Expect(*share).To(Equal(ocm.Share{
+			Expect(share).To(BeComparableTo(&ocm.Share{
 				Id: &ocm.ShareId{},
 				Grantee: &provider.Grantee{
 					Id: &provider.Grantee_UserId{
@@ -279,7 +280,7 @@ var _ = Describe("Nextcloud", func() {
 					Seconds: 1234567890,
 					Nanos:   0,
 				},
-			}))
+			}, protocmp.Transform()))
 			checkCalled(called, `POST /apps/sciencemesh/~tester/api/ocm/GetShare {"Spec":{"Id":{"opaque_id":"some-share-id"}}}`)
 		})
 	})
@@ -370,7 +371,7 @@ var _ = Describe("Nextcloud", func() {
 			})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(len(shares)).To(Equal(1))
-			Expect(*shares[0]).To(Equal(ocm.Share{
+			Expect(shares[0]).To(BeComparableTo(&ocm.Share{
 				Id: &ocm.ShareId{},
 				Grantee: &provider.Grantee{
 					Id: &provider.Grantee_UserId{
@@ -399,7 +400,7 @@ var _ = Describe("Nextcloud", func() {
 					Seconds: 1234567890,
 					Nanos:   0,
 				},
-			}))
+			}, protocmp.Transform()))
 			checkCalled(called, `POST /apps/sciencemesh/~tester/api/ocm/ListShares [{"type":4,"Term":{"Creator":{"idp":"0.0.0.0:19000","opaque_id":"f7fbf8c8-139b-4376-b307-cf0a8c2d0d9c","type":1}}}]`)
 		})
 	})
@@ -413,7 +414,7 @@ var _ = Describe("Nextcloud", func() {
 			receivedShares, err := am.ListReceivedShares(ctx, user)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(len(receivedShares)).To(Equal(1))
-			Expect(*receivedShares[0]).To(Equal(ocm.ReceivedShare{
+			Expect(receivedShares[0]).To(BeComparableTo(&ocm.ReceivedShare{
 				Id:            &ocm.ShareId{},
 				RemoteShareId: "",
 				Grantee: &provider.Grantee{
@@ -444,7 +445,7 @@ var _ = Describe("Nextcloud", func() {
 					Nanos:   0,
 				},
 				State: ocm.ShareState_SHARE_STATE_ACCEPTED,
-			}))
+			}, protocmp.Transform()))
 			checkCalled(called, `POST /apps/sciencemesh/~tester/api/ocm/ListReceivedShares `)
 		})
 	})
@@ -463,7 +464,7 @@ var _ = Describe("Nextcloud", func() {
 				},
 			})
 			Expect(err).ToNot(HaveOccurred())
-			Expect(*receivedShare).To(Equal(ocm.ReceivedShare{
+			Expect(receivedShare).To(BeComparableTo(ocm.ReceivedShare{
 				Id:            &ocm.ShareId{},
 				RemoteShareId: "",
 				Grantee: &provider.Grantee{
@@ -494,7 +495,7 @@ var _ = Describe("Nextcloud", func() {
 					Nanos:   0,
 				},
 				State: ocm.ShareState_SHARE_STATE_ACCEPTED,
-			}))
+			}, protocmp.Transform()))
 			checkCalled(called, `POST /apps/sciencemesh/~tester/api/ocm/GetReceivedShare {"Spec":{"Id":{"opaque_id":"some-share-id"}}}`)
 		})
 	})
@@ -542,7 +543,7 @@ var _ = Describe("Nextcloud", func() {
 					Paths: []string{"state"},
 				})
 			Expect(err).ToNot(HaveOccurred())
-			Expect(*receivedShare).To(Equal(ocm.ReceivedShare{
+			Expect(receivedShare).To(BeComparableTo(ocm.ReceivedShare{
 				Id:            &ocm.ShareId{},
 				RemoteShareId: "",
 				Grantee: &provider.Grantee{
@@ -573,7 +574,7 @@ var _ = Describe("Nextcloud", func() {
 					Nanos:   0,
 				},
 				State: ocm.ShareState_SHARE_STATE_ACCEPTED,
-			}))
+			}, protocmp.Transform()))
 			checkCalled(called, `POST /apps/sciencemesh/~tester/api/ocm/UpdateReceivedShare {"received_share":{"id":{},"grantee":{"Id":{"UserId":{"idp":"0.0.0.0:19000","opaque_id":"f7fbf8c8-139b-4376-b307-cf0a8c2d0d9c","type":1}}},"owner":{"idp":"0.0.0.0:19000","opaque_id":"f7fbf8c8-139b-4376-b307-cf0a8c2d0d9c","type":1},"creator":{"idp":"0.0.0.0:19000","opaque_id":"f7fbf8c8-139b-4376-b307-cf0a8c2d0d9c","type":1},"ctime":{"seconds":1234567890},"mtime":{"seconds":1234567890},"state":2},"field_mask":{"paths":["state"]}}`)
 		})
 	})

--- a/pkg/ocm/storage/received/ocm.go
+++ b/pkg/ocm/storage/received/ocm.go
@@ -491,7 +491,7 @@ func (d *driver) ListStorageSpaces(ctx context.Context, filters []*provider.List
 				}
 				space := &provider.StorageSpace{
 					Id: &provider.StorageSpaceId{
-						OpaqueId: storagespace.FormatResourceID(*root),
+						OpaqueId: storagespace.FormatResourceID(root),
 					},
 					SpaceType: "mountpoint",
 					Owner: &userv1beta1.User{
@@ -510,7 +510,7 @@ func (d *driver) ListStorageSpaces(ctx context.Context, filters []*provider.List
 				}
 				space := &provider.StorageSpace{
 					Id: &provider.StorageSpaceId{
-						OpaqueId: storagespace.FormatResourceID(*root),
+						OpaqueId: storagespace.FormatResourceID(root),
 					},
 					SpaceType: "mountpoint",
 					Owner: &userv1beta1.User{

--- a/pkg/ocm/storage/received/upload.go
+++ b/pkg/ocm/storage/received/upload.go
@@ -76,23 +76,23 @@ func (d *driver) InitiateUpload(ctx context.Context, ref *provider.Reference, up
 	}, nil
 }
 
-func (d *driver) Upload(ctx context.Context, req storage.UploadRequest, _ storage.UploadFinishedFunc) (provider.ResourceInfo, error) {
+func (d *driver) Upload(ctx context.Context, req storage.UploadRequest, _ storage.UploadFinishedFunc) (*provider.ResourceInfo, error) {
 	shareID, _ := shareInfoFromReference(req.Ref)
 	u, err := d.GetUpload(ctx, shareID.OpaqueId)
 	if err != nil {
-		return provider.ResourceInfo{}, err
+		return &provider.ResourceInfo{}, err
 	}
 
 	info, err := u.GetInfo(ctx)
 	if err != nil {
-		return provider.ResourceInfo{}, err
+		return &provider.ResourceInfo{}, err
 	}
 
 	client, _, rel, err := d.webdavClient(ctx, nil, &provider.Reference{
 		Path: filepath.Join(info.MetaData["dir"], info.MetaData["filename"]),
 	})
 	if err != nil {
-		return provider.ResourceInfo{}, err
+		return &provider.ResourceInfo{}, err
 	}
 	client.SetInterceptor(func(method string, rq *http.Request) {
 		// Set the content length on the request struct directly instead of the header.
@@ -104,7 +104,7 @@ func (d *driver) Upload(ctx context.Context, req storage.UploadRequest, _ storag
 		}
 	})
 
-	return provider.ResourceInfo{}, client.WriteStream(rel, req.Body, 0)
+	return &provider.ResourceInfo{}, client.WriteStream(rel, req.Body, 0)
 }
 
 // UseIn tells the tus upload middleware which extensions it supports.

--- a/pkg/publicshare/manager/memory/memory.go
+++ b/pkg/publicshare/manager/memory/memory.go
@@ -158,7 +158,7 @@ func (m *manager) GetPublicShare(ctx context.Context, u *user.User, ref *link.Pu
 
 	// Attempt to fetch public share by Id
 	if ref.GetId() != nil {
-		share, err = m.getPublicShareByTokenID(ctx, *ref.GetId())
+		share, err = m.getPublicShareByTokenID(ctx, ref.GetId())
 		if err != nil {
 			return nil, errors.New("no shares found by id")
 		}
@@ -193,7 +193,7 @@ func (m *manager) RevokePublicShare(ctx context.Context, u *user.User, ref *link
 	// check whether the reference exists
 	switch {
 	case ref.GetId() != nil && ref.GetId().OpaqueId != "":
-		s, err := m.getPublicShareByTokenID(ctx, *ref.GetId())
+		s, err := m.getPublicShareByTokenID(ctx, ref.GetId())
 		if err != nil {
 			return errors.New("reference does not exist")
 		}
@@ -225,7 +225,7 @@ func randString(n int) string {
 	return string(b)
 }
 
-func (m *manager) getPublicShareByTokenID(ctx context.Context, targetID link.PublicShareId) (*link.PublicShare, error) {
+func (m *manager) getPublicShareByTokenID(ctx context.Context, targetID *link.PublicShareId) (*link.PublicShare, error) {
 	var found *link.PublicShare
 	m.shares.Range(func(k, v interface{}) bool {
 		id := v.(*link.PublicShare).GetId()

--- a/pkg/publicshare/publicshare.go
+++ b/pkg/publicshare/publicshare.go
@@ -131,7 +131,7 @@ func StorageIDFilter(id string) *link.ListPublicSharesRequest_Filter {
 }
 
 // MatchesFilter tests if the share passes the filter.
-func MatchesFilter(share link.PublicShare, filter *link.ListPublicSharesRequest_Filter) bool {
+func MatchesFilter(share *link.PublicShare, filter *link.ListPublicSharesRequest_Filter) bool {
 	switch filter.Type {
 	case link.ListPublicSharesRequest_Filter_TYPE_RESOURCE_ID:
 		return utils.ResourceIDEqual(share.ResourceId, filter.GetResourceId())
@@ -143,7 +143,7 @@ func MatchesFilter(share link.PublicShare, filter *link.ListPublicSharesRequest_
 }
 
 // MatchesAnyFilter checks if the share passes at least one of the given filters.
-func MatchesAnyFilter(share link.PublicShare, filters []*link.ListPublicSharesRequest_Filter) bool {
+func MatchesAnyFilter(share *link.PublicShare, filters []*link.ListPublicSharesRequest_Filter) bool {
 	for _, f := range filters {
 		if MatchesFilter(share, f) {
 			return true
@@ -156,7 +156,7 @@ func MatchesAnyFilter(share link.PublicShare, filters []*link.ListPublicSharesRe
 // Filters of the same type form a disjuntion, a logical OR. Filters of separate type form a conjunction, a logical AND.
 // Here is an example:
 // (resource_id=1 OR resource_id=2) AND (grantee_type=USER OR grantee_type=GROUP)
-func MatchesFilters(share link.PublicShare, filters []*link.ListPublicSharesRequest_Filter) bool {
+func MatchesFilters(share *link.PublicShare, filters []*link.ListPublicSharesRequest_Filter) bool {
 	if len(filters) == 0 {
 		return true
 	}
@@ -179,7 +179,7 @@ func GroupFiltersByType(filters []*link.ListPublicSharesRequest_Filter) map[link
 }
 
 // IsExpired tests whether a public share is expired
-func IsExpired(s link.PublicShare) bool {
+func IsExpired(s *link.PublicShare) bool {
 	expiration := time.Unix(int64(s.Expiration.GetSeconds()), int64(s.Expiration.GetNanos()))
 	return s.Expiration != nil && expiration.Before(time.Now())
 }
@@ -208,7 +208,7 @@ func Authenticate(share *link.PublicShare, pw string, auth *link.PublicShareAuth
 }
 
 // IsCreatedByUser checks if a share was created by the user.
-func IsCreatedByUser(share link.PublicShare, user *user.User) bool {
+func IsCreatedByUser(share *link.PublicShare, user *user.User) bool {
 	return utils.UserEqual(user.Id, share.Owner) || utils.UserEqual(user.Id, share.Creator)
 }
 

--- a/pkg/rgrpc/todo/pool/client.go
+++ b/pkg/rgrpc/todo/pool/client.go
@@ -64,6 +64,12 @@ func GetStorageProviderServiceClient(id string, opts ...Option) (storageprovider
 	return selector.Next()
 }
 
+// GetSpacesProviderServiceClient returns a SpacesProviderServiceClient.
+func GetSpacesProviderServiceClient(id string, opts ...Option) (storageprovider.SpacesAPIClient, error) {
+	selector, _ := SpacesProviderSelector(id, opts...)
+	return selector.Next()
+}
+
 // GetAuthRegistryServiceClient returns a new AuthRegistryServiceClient.
 func GetAuthRegistryServiceClient(id string, opts ...Option) (authregistry.RegistryAPIClient, error) {
 	selector, _ := AuthRegistrySelector(id, opts...)

--- a/pkg/rgrpc/todo/pool/selector.go
+++ b/pkg/rgrpc/todo/pool/selector.go
@@ -57,7 +57,7 @@ func RemoveSelector(id string) {
 	selectors.Delete(id)
 }
 
-func GetSelector[T any](k string, id string, f func(cc *grpc.ClientConn) T, options ...Option) *Selector[T] {
+func GetSelector[T any](k string, id string, f func(cc grpc.ClientConnInterface) T, options ...Option) *Selector[T] {
 	existingSelector, ok := selectors.Load(k + id)
 	if ok {
 		return existingSelector.(*Selector[T])
@@ -76,7 +76,7 @@ func GetSelector[T any](k string, id string, f func(cc *grpc.ClientConn) T, opti
 
 type Selector[T any] struct {
 	id            string
-	clientFactory func(cc *grpc.ClientConn) T
+	clientFactory func(cc grpc.ClientConnInterface) T
 	clientMap     sync.Map
 	options       []Option
 }
@@ -160,6 +160,16 @@ func StorageProviderSelector(id string, options ...Option) (*Selector[storagePro
 		"StorageProviderSelector",
 		id,
 		storageProvider.NewProviderAPIClient,
+		options...,
+	), nil
+}
+
+// SpacesProviderSelector returns a Selector[storageProvider.SpacesAPIClient].
+func SpacesProviderSelector(id string, options ...Option) (*Selector[storageProvider.SpacesAPIClient], error) {
+	return GetSelector[storageProvider.SpacesAPIClient](
+		"SpacesProviderSelector",
+		id,
+		storageProvider.NewSpacesAPIClient,
 		options...,
 	), nil
 }

--- a/pkg/rhttp/datatx/manager/simple/simple.go
+++ b/pkg/rhttp/datatx/manager/simple/simple.go
@@ -118,7 +118,7 @@ func (m *manager) Handler(fs storage.FS) (http.Handler, error) {
 				w.Header().Set(net.HeaderETag, info.Etag)
 				w.Header().Set(net.HeaderOCETag, info.Etag)
 				if info.Id != nil {
-					w.Header().Set(net.HeaderOCFileID, storagespace.FormatResourceID(*info.Id))
+					w.Header().Set(net.HeaderOCFileID, storagespace.FormatResourceID(info.Id))
 				}
 				if info.Mtime != nil {
 					t := utils.TSToTime(info.Mtime).UTC()

--- a/pkg/rhttp/datatx/manager/spaces/spaces.go
+++ b/pkg/rhttp/datatx/manager/spaces/spaces.go
@@ -109,7 +109,7 @@ func (m *manager) Handler(fs storage.FS) (http.Handler, error) {
 				ResourceId: &rid,
 				Path:       fn,
 			}
-			var info provider.ResourceInfo
+			var info *provider.ResourceInfo
 			info, err = fs.Upload(ctx, storage.UploadRequest{
 				Ref:    ref,
 				Body:   r.Body,
@@ -125,7 +125,7 @@ func (m *manager) Handler(fs storage.FS) (http.Handler, error) {
 				w.Header().Set(net.HeaderETag, info.Etag)
 				w.Header().Set(net.HeaderOCETag, info.Etag)
 				if info.Id != nil {
-					w.Header().Set(net.HeaderOCFileID, storagespace.FormatResourceID(*info.Id))
+					w.Header().Set(net.HeaderOCFileID, storagespace.FormatResourceID(info.Id))
 				}
 				if info.Mtime != nil {
 					t := utils.TSToTime(info.Mtime).UTC()

--- a/pkg/rhttp/datatx/manager/tus/tus.go
+++ b/pkg/rhttp/datatx/manager/tus/tus.go
@@ -215,7 +215,7 @@ func setHeaders(fs storage.FS, w http.ResponseWriter, r *http.Request) {
 	if expires != "" {
 		w.Header().Set(net.HeaderTusUploadExpires, expires)
 	}
-	resourceid := provider.ResourceId{
+	resourceid := &provider.ResourceId{
 		StorageId: info.MetaData["providerID"],
 		SpaceId:   info.Storage["SpaceRoot"],
 		OpaqueId:  info.Storage["NodeId"],

--- a/pkg/rhttp/datatx/utils/download/download.go
+++ b/pkg/rhttp/datatx/utils/download/download.go
@@ -228,7 +228,7 @@ func GetOrHeadFile(w http.ResponseWriter, r *http.Request, fs storage.FS, spaceI
 
 	w.Header().Set(net.HeaderContentDisposistion, net.ContentDispositionAttachment(path.Base(md.Path)))
 	w.Header().Set(net.HeaderETag, md.Etag)
-	w.Header().Set(net.HeaderOCFileID, storagespace.FormatResourceID(*md.Id))
+	w.Header().Set(net.HeaderOCFileID, storagespace.FormatResourceID(md.Id))
 	w.Header().Set(net.HeaderOCETag, md.Etag)
 	w.Header().Set(net.HeaderLastModified, net.RFC1123Z(md.Mtime))
 

--- a/pkg/share/manager/cs3/cs3.go
+++ b/pkg/share/manager/cs3/cs3.go
@@ -718,8 +718,7 @@ func (m *Manager) getShareByID(ctx context.Context, id string) (*collaboration.S
 	}
 	err = json.Unmarshal(data, userShare)
 	if err == nil && userShare.Grantee.GetUserId() != nil {
-		id := storagespace.UpdateLegacyResourceID(*userShare.GetResourceId())
-		userShare.ResourceId = &id
+		userShare.ResourceId = storagespace.UpdateLegacyResourceID(userShare.GetResourceId())
 		return userShare, nil
 	}
 
@@ -728,8 +727,7 @@ func (m *Manager) getShareByID(ctx context.Context, id string) (*collaboration.S
 	}
 	err = json.Unmarshal(data, groupShare) // try to unmarshal to a group share if the user share unmarshalling failed
 	if err == nil && groupShare.Grantee.GetGroupId() != nil {
-		id := storagespace.UpdateLegacyResourceID(*groupShare.GetResourceId())
-		groupShare.ResourceId = &id
+		groupShare.ResourceId = storagespace.UpdateLegacyResourceID(groupShare.GetResourceId())
 		return groupShare, nil
 	}
 

--- a/pkg/share/manager/cs3/cs3_test.go
+++ b/pkg/share/manager/cs3/cs3_test.go
@@ -37,6 +37,7 @@ import (
 	indexermocks "github.com/cs3org/reva/v2/pkg/storage/utils/indexer/mocks"
 	storagemocks "github.com/cs3org/reva/v2/pkg/storage/utils/metadata/mocks"
 	"github.com/stretchr/testify/mock"
+	"google.golang.org/protobuf/testing/protocmp"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -326,9 +327,9 @@ var _ = Describe("Manager", func() {
 						Expect(err).ToNot(HaveOccurred())
 						Expect(returnedShare).ToNot(BeNil())
 						Expect(returnedShare.Id.OpaqueId).To(Equal(share.Id.OpaqueId))
-						Expect(returnedShare.Owner).To(Equal(share.Owner))
-						Expect(returnedShare.Grantee).To(Equal(share.Grantee))
-						Expect(returnedShare.Permissions).To(Equal(share.Permissions))
+						Expect(returnedShare.Owner).To(BeComparableTo(share.Owner, protocmp.Transform()))
+						Expect(returnedShare.Grantee).To(BeComparableTo(share.Grantee, protocmp.Transform()))
+						Expect(returnedShare.Permissions).To(BeComparableTo(share.Permissions, protocmp.Transform()))
 					})
 				})
 
@@ -375,9 +376,9 @@ var _ = Describe("Manager", func() {
 						Expect(err).ToNot(HaveOccurred())
 						Expect(returnedShare).ToNot(BeNil())
 						Expect(returnedShare.Id.OpaqueId).To(Equal(share2.Id.OpaqueId))
-						Expect(returnedShare.Owner).To(Equal(share2.Owner))
-						Expect(returnedShare.Grantee).To(Equal(share2.Grantee))
-						Expect(returnedShare.Permissions).To(Equal(share2.Permissions))
+						Expect(returnedShare.Owner).To(BeComparableTo(share2.Owner, protocmp.Transform()))
+						Expect(returnedShare.Grantee).To(BeComparableTo(share2.Grantee, protocmp.Transform()))
+						Expect(returnedShare.Permissions).To(BeComparableTo(share2.Permissions, protocmp.Transform()))
 					})
 				})
 			})
@@ -399,8 +400,8 @@ var _ = Describe("Manager", func() {
 					Expect(err).ToNot(HaveOccurred())
 					Expect(returnedShare).ToNot(BeNil())
 					Expect(returnedShare.Id.OpaqueId).To(Equal(share.Id.OpaqueId))
-					Expect(returnedShare.Owner).To(Equal(share.Owner))
-					Expect(returnedShare.Grantee).To(Equal(share.Grantee))
+					Expect(returnedShare.Owner).To(BeComparableTo(share.Owner, protocmp.Transform()))
+					Expect(returnedShare.Grantee).To(BeComparableTo(share.Grantee, protocmp.Transform()))
 					Expect(returnedShare.Permissions).To(Equal(share.Permissions))
 				})
 			})
@@ -587,9 +588,9 @@ var _ = Describe("Manager", func() {
 						Expect(err).ToNot(HaveOccurred())
 						Expect(rshare).ToNot(BeNil())
 						Expect(rshare.Share.Id.OpaqueId).To(Equal(share2.Id.OpaqueId))
-						Expect(rshare.Share.Owner).To(Equal(share2.Owner))
-						Expect(rshare.Share.Grantee).To(Equal(share2.Grantee))
-						Expect(rshare.Share.Permissions).To(Equal(share2.Permissions))
+						Expect(rshare.Share.Owner).To(BeComparableTo(share2.Owner, protocmp.Transform()))
+						Expect(rshare.Share.Grantee).To(BeComparableTo(share2.Grantee, protocmp.Transform()))
+						Expect(rshare.Share.Permissions).To(BeComparableTo(share2.Permissions, protocmp.Transform()))
 						Expect(rshare.State).To(Equal(collaboration.ShareState_SHARE_STATE_PENDING))
 						Expect(rshare.MountPoint.ResourceId.StorageId).To(Equal("storageid"))
 						Expect(rshare.MountPoint.ResourceId.OpaqueId).To(Equal("opaqueid"))

--- a/pkg/share/manager/jsoncs3/jsoncs3.go
+++ b/pkg/share/manager/jsoncs3/jsoncs3.go
@@ -643,7 +643,7 @@ func (m *Manager) listSharesByIDs(ctx context.Context, user *userv1beta1.User, f
 				}
 
 				if !(share.IsCreatedByUser(s, user) || share.IsGrantedToUser(s, user)) {
-					key := storagespace.FormatResourceID(*resourceID)
+					key := storagespace.FormatResourceID(resourceID)
 					if _, hit := statCache[key]; !hit {
 						req := &provider.StatRequest{
 							Ref: &provider.Reference{ResourceId: resourceID},

--- a/pkg/share/manager/jsoncs3/jsoncs3_test.go
+++ b/pkg/share/manager/jsoncs3/jsoncs3_test.go
@@ -44,6 +44,7 @@ import (
 	"github.com/cs3org/reva/v2/tests/cs3mocks/mocks"
 	"github.com/stretchr/testify/mock"
 	"google.golang.org/grpc"
+	"google.golang.org/protobuf/testing/protocmp"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -161,7 +162,7 @@ var _ = Describe("Jsoncs3", func() {
 		gatewaySelector := pool.GetSelector[gatewayv1beta1.GatewayAPIClient](
 			"GatewaySelector",
 			"com.owncloud.api.gateway",
-			func(cc *grpc.ClientConn) gatewayv1beta1.GatewayAPIClient {
+			func(cc grpc.ClientConnInterface) gatewayv1beta1.GatewayAPIClient {
 				return client
 			},
 		)
@@ -417,7 +418,7 @@ var _ = Describe("Jsoncs3", func() {
 					ResourceId: sharedResource.Id,
 					Grantee:    grant.Grantee,
 				})
-				Expect(s.ResourceId).To(Equal(sharedResource.Id))
+				Expect(s.ResourceId).To(BeComparableTo(sharedResource.Id, protocmp.Transform()))
 				Expect(s.Id.OpaqueId).To(Equal(share.Id.OpaqueId))
 			})
 
@@ -730,7 +731,7 @@ var _ = Describe("Jsoncs3", func() {
 				received, err := m.ListReceivedShares(granteeCtx, []*collaboration.Filter{}, nil)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(len(received)).To(Equal(1))
-				Expect(received[0].Share.ResourceId).To(Equal(sharedResource.Id))
+				Expect(received[0].Share.ResourceId).To(BeComparableTo(sharedResource.Id, protocmp.Transform()))
 				Expect(received[0].State).To(Equal(collaboration.ShareState_SHARE_STATE_PENDING))
 			})
 
@@ -788,7 +789,7 @@ var _ = Describe("Jsoncs3", func() {
 				}, nil)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(len(received)).To(Equal(1))
-				Expect(received[0].Share.ResourceId).To(Equal(sharedResource.Id))
+				Expect(received[0].Share.ResourceId).To(BeComparableTo(sharedResource.Id, protocmp.Transform()))
 				Expect(received[0].State).To(Equal(collaboration.ShareState_SHARE_STATE_PENDING))
 				Expect(received[0].Share.Id).To(Equal(share.Id))
 
@@ -802,7 +803,7 @@ var _ = Describe("Jsoncs3", func() {
 				}, nil)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(len(received)).To(Equal(1))
-				Expect(received[0].Share.ResourceId).To(Equal(sharedResource2.Id))
+				Expect(received[0].Share.ResourceId).To(BeComparableTo(sharedResource2.Id, protocmp.Transform()))
 				Expect(received[0].State).To(Equal(collaboration.ShareState_SHARE_STATE_PENDING))
 				Expect(received[0].Share.Id).To(Equal(share2.Id))
 			})

--- a/pkg/storage/fs/nextcloud/nextcloud.go
+++ b/pkg/storage/fs/nextcloud/nextcloud.go
@@ -397,19 +397,19 @@ func (nc *StorageDriver) InitiateUpload(ctx context.Context, ref *provider.Refer
 }
 
 // Upload as defined in the storage.FS interface
-func (nc *StorageDriver) Upload(ctx context.Context, req storage.UploadRequest, _ storage.UploadFinishedFunc) (provider.ResourceInfo, error) {
+func (nc *StorageDriver) Upload(ctx context.Context, req storage.UploadRequest, _ storage.UploadFinishedFunc) (*provider.ResourceInfo, error) {
 	err := nc.doUpload(ctx, req.Ref.Path, req.Body)
 	if err != nil {
-		return provider.ResourceInfo{}, err
+		return &provider.ResourceInfo{}, err
 	}
 
 	// return id, etag and mtime
 	ri, err := nc.GetMD(ctx, req.Ref, []string{}, []string{"id", "etag", "mtime"})
 	if err != nil {
-		return provider.ResourceInfo{}, err
+		return &provider.ResourceInfo{}, err
 	}
 
-	return *ri, nil
+	return ri, nil
 }
 
 // Download as defined in the storage.FS interface

--- a/pkg/storage/fs/nextcloud/nextcloud_test.go
+++ b/pkg/storage/fs/nextcloud/nextcloud_test.go
@@ -28,6 +28,7 @@ import (
 	"strings"
 
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/protobuf/testing/protocmp"
 
 	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
@@ -227,7 +228,7 @@ var _ = Describe("Nextcloud", func() {
 			mdKeys := []string{"val1", "val2", "val3"}
 			result, err := nc.GetMD(ctx, ref, mdKeys, nil)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(*result).To(Equal(provider.ResourceInfo{
+			Expect(result).To(BeComparableTo(provider.ResourceInfo{
 				Opaque: &types.Opaque{
 					Map: nil,
 				},
@@ -277,7 +278,7 @@ var _ = Describe("Nextcloud", func() {
 				ArbitraryMetadata: &provider.ArbitraryMetadata{
 					Metadata: map[string]string{"some": "arbi", "trary": "meta", "da": "ta"},
 				},
-			}))
+			}, protocmp.Transform()))
 			checkCalled(called, `POST /apps/sciencemesh/~tester/api/storage/GetMD {"ref":{"resource_id":{"storage_id":"storage-id","opaque_id":"opaque-id"},"path":"/some/path"},"mdKeys":["val1","val2","val3"]}`)
 		})
 	})
@@ -299,7 +300,7 @@ var _ = Describe("Nextcloud", func() {
 			results, err := nc.ListFolder(ctx, ref, mdKeys, []string{})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(len(results)).To(Equal(1))
-			Expect(*results[0]).To(Equal(provider.ResourceInfo{
+			Expect(results[0]).To(BeComparableTo(&provider.ResourceInfo{
 				Opaque: &types.Opaque{
 					Map: nil,
 				},
@@ -349,7 +350,7 @@ var _ = Describe("Nextcloud", func() {
 				ArbitraryMetadata: &provider.ArbitraryMetadata{
 					Metadata: map[string]string{"some": "arbi", "trary": "meta", "da": "ta"},
 				},
-			}))
+			}, protocmp.Transform()))
 			Expect(err).ToNot(HaveOccurred())
 			checkCalled(called, `POST /apps/sciencemesh/~tester/api/storage/ListFolder {"ref":{"resource_id":{"storage_id":"storage-id","opaque_id":"opaque-id"},"path":"/some"},"mdKeys":["val1","val2","val3"]}`)
 		})
@@ -447,7 +448,7 @@ var _ = Describe("Nextcloud", func() {
 			Expect(err).ToNot(HaveOccurred())
 			// https://github.com/cs3org/go-cs3apis/blob/970eec3/cs3/storage/provider/v1beta1/resources.pb.go#L1003-L1023
 			Expect(len(results)).To(Equal(2))
-			Expect(*results[0]).To(Equal(provider.FileVersion{
+			Expect(results[0]).To(BeComparableTo(&provider.FileVersion{
 				Opaque: &types.Opaque{
 					Map: map[string]*types.OpaqueEntry{
 						"some": {
@@ -459,8 +460,8 @@ var _ = Describe("Nextcloud", func() {
 				Size:  uint64(12345),
 				Mtime: uint64(1234567890),
 				Etag:  "deadb00f",
-			}))
-			Expect(*results[1]).To(Equal(provider.FileVersion{
+			}, protocmp.Transform()))
+			Expect(results[1]).To(BeComparableTo(&provider.FileVersion{
 				Opaque: &types.Opaque{
 					Map: map[string]*types.OpaqueEntry{
 						"different": {
@@ -472,7 +473,7 @@ var _ = Describe("Nextcloud", func() {
 				Size:  uint64(12345),
 				Mtime: uint64(1234567890),
 				Etag:  "deadbeef",
-			}))
+			}, protocmp.Transform()))
 			checkCalled(called, `POST /apps/sciencemesh/~tester/api/storage/ListRevisions {"resource_id":{"storage_id":"storage-id","opaque_id":"opaque-id"},"path":"/some/path"}`)
 		})
 	})
@@ -531,7 +532,7 @@ var _ = Describe("Nextcloud", func() {
 			Expect(err).ToNot(HaveOccurred())
 			// https://github.com/cs3org/go-cs3apis/blob/970eec3/cs3/storage/provider/v1beta1/resources.pb.go#L1085-L1110
 			Expect(len(results)).To(Equal(1))
-			Expect(*results[0]).To(Equal(provider.RecycleItem{
+			Expect(results[0]).To(BeComparableTo(&provider.RecycleItem{
 				Opaque: &types.Opaque{},
 				Key:    "some-deleted-version",
 				Ref: &provider.Reference{
@@ -540,7 +541,7 @@ var _ = Describe("Nextcloud", func() {
 				},
 				Size:         uint64(12345),
 				DeletionTime: &types.Timestamp{Seconds: uint64(1234567890)},
-			}))
+			}, protocmp.Transform()))
 			checkCalled(called, `POST /apps/sciencemesh/~tester/api/storage/ListRecycle {"key":"asdf","path":"/some/file.txt"}`)
 		})
 	})
@@ -929,7 +930,7 @@ var _ = Describe("Nextcloud", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(len(spaces)).To(Equal(1))
 			// https://github.com/cs3org/go-cs3apis/blob/970eec3/cs3/storage/provider/v1beta1/resources.pb.go#L1341-L1366
-			Expect(*spaces[0]).To(Equal(provider.StorageSpace{
+			Expect(spaces[0]).To(BeComparableTo(&provider.StorageSpace{
 				Opaque: &types.Opaque{
 					Map: map[string](*types.OpaqueEntry){
 						"foo": &types.OpaqueEntry{Value: []byte("sama")},
@@ -957,7 +958,7 @@ var _ = Describe("Nextcloud", func() {
 				Mtime: &types.Timestamp{
 					Seconds: uint64(1234567890),
 				},
-			}))
+			}, protocmp.Transform()))
 			checkCalled(called, `POST /apps/sciencemesh/~tester/api/storage/ListStorageSpaces [{"type":3,"Term":{"Owner":{"idp":"0.0.0.0:19000","opaque_id":"f7fbf8c8-139b-4376-b307-cf0a8c2d0d9c","type":1}}},{"type":2,"Term":{"Id":{"opaque_id":"opaque-id"}}},{"type":4,"Term":{"SpaceType":"home"}}]`)
 		})
 	})
@@ -990,7 +991,7 @@ var _ = Describe("Nextcloud", func() {
 				Type: "home",
 			})
 			Expect(err).ToNot(HaveOccurred())
-			Expect(*result).To(Equal(provider.CreateStorageSpaceResponse{
+			Expect(result).To(BeComparableTo(&provider.CreateStorageSpaceResponse{
 				Opaque: nil,
 				Status: nil,
 				StorageSpace: &provider.StorageSpace{
@@ -1022,7 +1023,7 @@ var _ = Describe("Nextcloud", func() {
 						Seconds: uint64(1234567890),
 					},
 				},
-			}))
+			}, protocmp.Transform()))
 			checkCalled(called, `POST /apps/sciencemesh/~tester/api/storage/CreateStorageSpace {"opaque":{"map":{"bar":{"value":"c2FtYQ=="},"foo":{"value":"c2FtYQ=="}}},"owner":{"id":{"idp":"some-idp","opaque_id":"some-opaque-user-id","type":1}},"type":"home","name":"My Storage Space","quota":{"quota_max_bytes":456,"quota_max_files":123}}`)
 		})
 	})

--- a/pkg/storage/fs/nextcloud/nextcloud_test.go
+++ b/pkg/storage/fs/nextcloud/nextcloud_test.go
@@ -229,34 +229,22 @@ var _ = Describe("Nextcloud", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(*result).To(Equal(provider.ResourceInfo{
 				Opaque: &types.Opaque{
-					Map:                  nil,
-					XXX_NoUnkeyedLiteral: struct{}{},
-					XXX_unrecognized:     nil,
-					XXX_sizecache:        0,
+					Map: nil,
 				},
 				Type: provider.ResourceType_RESOURCE_TYPE_FILE,
 				Id: &provider.ResourceId{
-					StorageId:            "",
-					OpaqueId:             "fileid-/some/path",
-					XXX_NoUnkeyedLiteral: struct{}{},
-					XXX_unrecognized:     nil,
-					XXX_sizecache:        0,
+					StorageId: "",
+					OpaqueId:  "fileid-/some/path",
 				},
 				Checksum: &provider.ResourceChecksum{
-					Type:                 0,
-					Sum:                  "",
-					XXX_NoUnkeyedLiteral: struct{}{},
-					XXX_unrecognized:     nil,
-					XXX_sizecache:        0,
+					Type: 0,
+					Sum:  "",
 				},
 				Etag:     "deadbeef",
 				MimeType: "text/plain",
 				Mtime: &types.Timestamp{
-					Seconds:              1234567890,
-					Nanos:                0,
-					XXX_NoUnkeyedLiteral: struct{}{},
-					XXX_unrecognized:     nil,
-					XXX_sizecache:        0,
+					Seconds: 1234567890,
+					Nanos:   0,
 				},
 				Path: "/some/path",
 				PermissionSet: &provider.ResourcePermissions{
@@ -279,28 +267,16 @@ var _ = Describe("Nextcloud", func() {
 					Stat:                 false,
 					UpdateGrant:          false,
 					DenyGrant:            false,
-					XXX_NoUnkeyedLiteral: struct{}{},
-					XXX_unrecognized:     nil,
-					XXX_sizecache:        0,
 				},
 				Size:   12345,
 				Owner:  nil,
 				Target: "",
 				CanonicalMetadata: &provider.CanonicalMetadata{
-					Target:               nil,
-					XXX_NoUnkeyedLiteral: struct{}{},
-					XXX_unrecognized:     nil,
-					XXX_sizecache:        0,
+					Target: nil,
 				},
 				ArbitraryMetadata: &provider.ArbitraryMetadata{
-					Metadata:             map[string]string{"some": "arbi", "trary": "meta", "da": "ta"},
-					XXX_NoUnkeyedLiteral: struct{}{},
-					XXX_unrecognized:     nil,
-					XXX_sizecache:        0,
+					Metadata: map[string]string{"some": "arbi", "trary": "meta", "da": "ta"},
 				},
-				XXX_NoUnkeyedLiteral: struct{}{},
-				XXX_unrecognized:     nil,
-				XXX_sizecache:        0,
 			}))
 			checkCalled(called, `POST /apps/sciencemesh/~tester/api/storage/GetMD {"ref":{"resource_id":{"storage_id":"storage-id","opaque_id":"opaque-id"},"path":"/some/path"},"mdKeys":["val1","val2","val3"]}`)
 		})
@@ -325,34 +301,22 @@ var _ = Describe("Nextcloud", func() {
 			Expect(len(results)).To(Equal(1))
 			Expect(*results[0]).To(Equal(provider.ResourceInfo{
 				Opaque: &types.Opaque{
-					Map:                  nil,
-					XXX_NoUnkeyedLiteral: struct{}{},
-					XXX_unrecognized:     nil,
-					XXX_sizecache:        0,
+					Map: nil,
 				},
 				Type: provider.ResourceType_RESOURCE_TYPE_FILE,
 				Id: &provider.ResourceId{
-					StorageId:            "",
-					OpaqueId:             "fileid-/some/path",
-					XXX_NoUnkeyedLiteral: struct{}{},
-					XXX_unrecognized:     nil,
-					XXX_sizecache:        0,
+					StorageId: "",
+					OpaqueId:  "fileid-/some/path",
 				},
 				Checksum: &provider.ResourceChecksum{
-					Type:                 0,
-					Sum:                  "",
-					XXX_NoUnkeyedLiteral: struct{}{},
-					XXX_unrecognized:     nil,
-					XXX_sizecache:        0,
+					Type: 0,
+					Sum:  "",
 				},
 				Etag:     "deadbeef",
 				MimeType: "text/plain",
 				Mtime: &types.Timestamp{
-					Seconds:              1234567890,
-					Nanos:                0,
-					XXX_NoUnkeyedLiteral: struct{}{},
-					XXX_unrecognized:     nil,
-					XXX_sizecache:        0,
+					Seconds: 1234567890,
+					Nanos:   0,
 				},
 				Path: "/some/path",
 				PermissionSet: &provider.ResourcePermissions{
@@ -375,28 +339,16 @@ var _ = Describe("Nextcloud", func() {
 					Stat:                 false,
 					UpdateGrant:          false,
 					DenyGrant:            false,
-					XXX_NoUnkeyedLiteral: struct{}{},
-					XXX_unrecognized:     nil,
-					XXX_sizecache:        0,
 				},
 				Size:   12345,
 				Owner:  nil,
 				Target: "",
 				CanonicalMetadata: &provider.CanonicalMetadata{
-					Target:               nil,
-					XXX_NoUnkeyedLiteral: struct{}{},
-					XXX_unrecognized:     nil,
-					XXX_sizecache:        0,
+					Target: nil,
 				},
 				ArbitraryMetadata: &provider.ArbitraryMetadata{
-					Metadata:             map[string]string{"some": "arbi", "trary": "meta", "da": "ta"},
-					XXX_NoUnkeyedLiteral: struct{}{},
-					XXX_unrecognized:     nil,
-					XXX_sizecache:        0,
+					Metadata: map[string]string{"some": "arbi", "trary": "meta", "da": "ta"},
 				},
-				XXX_NoUnkeyedLiteral: struct{}{},
-				XXX_unrecognized:     nil,
-				XXX_sizecache:        0,
 			}))
 			Expect(err).ToNot(HaveOccurred())
 			checkCalled(called, `POST /apps/sciencemesh/~tester/api/storage/ListFolder {"ref":{"resource_id":{"storage_id":"storage-id","opaque_id":"opaque-id"},"path":"/some"},"mdKeys":["val1","val2","val3"]}`)
@@ -503,13 +455,10 @@ var _ = Describe("Nextcloud", func() {
 						},
 					},
 				},
-				Key:                  "version-12",
-				Size:                 uint64(12345),
-				Mtime:                uint64(1234567890),
-				Etag:                 "deadb00f",
-				XXX_NoUnkeyedLiteral: struct{}{},
-				XXX_unrecognized:     nil,
-				XXX_sizecache:        0,
+				Key:   "version-12",
+				Size:  uint64(12345),
+				Mtime: uint64(1234567890),
+				Etag:  "deadb00f",
 			}))
 			Expect(*results[1]).To(Equal(provider.FileVersion{
 				Opaque: &types.Opaque{
@@ -519,13 +468,10 @@ var _ = Describe("Nextcloud", func() {
 						},
 					},
 				},
-				Key:                  "asdf",
-				Size:                 uint64(12345),
-				Mtime:                uint64(1234567890),
-				Etag:                 "deadbeef",
-				XXX_NoUnkeyedLiteral: struct{}{},
-				XXX_unrecognized:     nil,
-				XXX_sizecache:        0,
+				Key:   "asdf",
+				Size:  uint64(12345),
+				Mtime: uint64(1234567890),
+				Etag:  "deadbeef",
 			}))
 			checkCalled(called, `POST /apps/sciencemesh/~tester/api/storage/ListRevisions {"resource_id":{"storage_id":"storage-id","opaque_id":"opaque-id"},"path":"/some/path"}`)
 		})
@@ -589,17 +535,11 @@ var _ = Describe("Nextcloud", func() {
 				Opaque: &types.Opaque{},
 				Key:    "some-deleted-version",
 				Ref: &provider.Reference{
-					ResourceId:           &provider.ResourceId{},
-					Path:                 "/some/file.txt",
-					XXX_NoUnkeyedLiteral: struct{}{},
-					XXX_unrecognized:     nil,
-					XXX_sizecache:        0,
+					ResourceId: &provider.ResourceId{},
+					Path:       "/some/file.txt",
 				},
-				Size:                 uint64(12345),
-				DeletionTime:         &types.Timestamp{Seconds: uint64(1234567890)},
-				XXX_NoUnkeyedLiteral: struct{}{},
-				XXX_unrecognized:     nil,
-				XXX_sizecache:        0,
+				Size:         uint64(12345),
+				DeletionTime: &types.Timestamp{Seconds: uint64(1234567890)},
 			}))
 			checkCalled(called, `POST /apps/sciencemesh/~tester/api/storage/ListRecycle {"key":"asdf","path":"/some/file.txt"}`)
 		})

--- a/pkg/storage/fs/posix/testhelpers/helpers.go
+++ b/pkg/storage/fs/posix/testhelpers/helpers.go
@@ -285,7 +285,7 @@ func (t *TestEnv) CreateTestStorageSpace(typ string, quota *providerv1beta1.Quot
 		Status: &v1beta11.Status{Code: v1beta11.Code_CODE_OK},
 	}, nil)
 	// Permissions required for setup below
-	t.Permissions.On("AssemblePermissions", mock.Anything, mock.Anything, mock.Anything).Return(providerv1beta1.ResourcePermissions{
+	t.Permissions.On("AssemblePermissions", mock.Anything, mock.Anything, mock.Anything).Return(&providerv1beta1.ResourcePermissions{
 		Stat:     true,
 		AddGrant: true,
 	}, nil).Times(1) //
@@ -319,7 +319,7 @@ func (t *TestEnv) CreateTestStorageSpace(typ string, quota *providerv1beta1.Quot
 	}
 
 	// Create dir1
-	t.Permissions.On("AssemblePermissions", mock.Anything, mock.Anything, mock.Anything).Return(providerv1beta1.ResourcePermissions{
+	t.Permissions.On("AssemblePermissions", mock.Anything, mock.Anything, mock.Anything).Return(&providerv1beta1.ResourcePermissions{
 		Stat:            true,
 		CreateContainer: true,
 	}, nil).Times(1) // Permissions required for setup below
@@ -335,7 +335,7 @@ func (t *TestEnv) CreateTestStorageSpace(typ string, quota *providerv1beta1.Quot
 	}
 
 	// Create subdir1 in dir1
-	t.Permissions.On("AssemblePermissions", mock.Anything, mock.Anything, mock.Anything).Return(providerv1beta1.ResourcePermissions{
+	t.Permissions.On("AssemblePermissions", mock.Anything, mock.Anything, mock.Anything).Return(&providerv1beta1.ResourcePermissions{
 		Stat:            true,
 		CreateContainer: true,
 	}, nil).Times(1) // Permissions required for setup below
@@ -351,7 +351,7 @@ func (t *TestEnv) CreateTestStorageSpace(typ string, quota *providerv1beta1.Quot
 	}
 
 	// Create emptydir
-	t.Permissions.On("AssemblePermissions", mock.Anything, mock.Anything, mock.Anything).Return(providerv1beta1.ResourcePermissions{
+	t.Permissions.On("AssemblePermissions", mock.Anything, mock.Anything, mock.Anything).Return(&providerv1beta1.ResourcePermissions{
 		Stat:            true,
 		CreateContainer: true,
 	}, nil).Times(1) // Permissions required for setup below

--- a/pkg/storage/fs/posix/testhelpers/helpers.go
+++ b/pkg/storage/fs/posix/testhelpers/helpers.go
@@ -169,7 +169,7 @@ func NewTestEnv(config map[string]interface{}) (*TestEnv, error) {
 	permissionsSelector := pool.GetSelector[cs3permissions.PermissionsAPIClient](
 		"PermissionsSelector",
 		"any",
-		func(cc *grpc.ClientConn) cs3permissions.PermissionsAPIClient {
+		func(cc grpc.ClientConnInterface) cs3permissions.PermissionsAPIClient {
 			return cs3permissionsclient
 		},
 	)

--- a/pkg/storage/registry/spaces/spaces.go
+++ b/pkg/storage/registry/spaces/spaces.go
@@ -150,17 +150,17 @@ func parseConfig(m map[string]interface{}) (*config, error) {
 
 // New creates an implementation of the storage.Registry interface that
 // uses the available storage spaces from the configured storage providers
-func New(m map[string]interface{}, getClientFunc GetStorageProviderServiceClientFunc) (storage.Registry, error) {
+func New(m map[string]interface{}, getClientFunc GetSpacesProviderServiceClientFunc) (storage.Registry, error) {
 	c, err := parseConfig(m)
 	if err != nil {
 		return nil, err
 	}
 	c.init()
 	r := &registry{
-		c:                               c,
-		resources:                       make(map[string][]*registrypb.ProviderInfo),
-		resourceNameCache:               make(map[string]string),
-		getStorageProviderServiceClient: getClientFunc,
+		c:                              c,
+		resources:                      make(map[string][]*registrypb.ProviderInfo),
+		resourceNameCache:              make(map[string]string),
+		getSpacesProviderServiceClient: getClientFunc,
 	}
 	return r, nil
 }
@@ -169,13 +169,13 @@ func New(m map[string]interface{}, getClientFunc GetStorageProviderServiceClient
 // uses the available storage spaces from the configured storage providers
 func NewDefault(m map[string]interface{}) (storage.Registry, error) {
 	getClientFunc := func(addr string) (StorageProviderClient, error) {
-		return pool.GetStorageProviderServiceClient(addr)
+		return pool.GetSpacesProviderServiceClient(addr)
 	}
 	return New(m, getClientFunc)
 }
 
 // GetStorageProviderServiceClientFunc is a callback used to pass in a StorageProviderClient during testing
-type GetStorageProviderServiceClientFunc func(addr string) (StorageProviderClient, error)
+type GetSpacesProviderServiceClientFunc func(addr string) (StorageProviderClient, error)
 
 type registry struct {
 	c *config
@@ -183,7 +183,7 @@ type registry struct {
 	resources         map[string][]*registrypb.ProviderInfo
 	resourceNameCache map[string]string
 
-	getStorageProviderServiceClient GetStorageProviderServiceClientFunc
+	getSpacesProviderServiceClient GetSpacesProviderServiceClientFunc
 }
 
 // GetProvider return the storage provider for the given spaces according to the rule configuration
@@ -719,7 +719,7 @@ func setSpaces(providerInfo *registrypb.ProviderInfo, spaces []*providerpb.Stora
 }
 
 func (r *registry) findStorageSpaceOnProvider(ctx context.Context, addr string, filters []*providerpb.ListStorageSpacesRequest_Filter, unrestricted bool) ([]*providerpb.StorageSpace, error) {
-	c, err := r.getStorageProviderServiceClient(addr)
+	c, err := r.getSpacesProviderServiceClient(addr)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/storage/registry/spaces/spaces.go
+++ b/pkg/storage/registry/spaces/spaces.go
@@ -276,7 +276,7 @@ func (r *registry) ListProviders(ctx context.Context, filters map[string]string)
 		if filters["opaque_id"] == "" {
 			filters["opaque_id"] = filters["space_id"]
 		}
-		id := storagespace.FormatResourceID(providerpb.ResourceId{
+		id := storagespace.FormatResourceID(&providerpb.ResourceId{
 			StorageId: filters["storage_id"],
 			SpaceId:   filters["space_id"],
 			OpaqueId:  filters["opaque_id"],

--- a/pkg/storage/registry/spaces/spaces_test.go
+++ b/pkg/storage/registry/spaces/spaces_test.go
@@ -65,11 +65,11 @@ var _ = Describe("Spaces", func() {
 
 		fooClient.On("ListStorageSpaces", mock.Anything, mock.Anything).Return(
 			func(_ context.Context, req *provider.ListStorageSpacesRequest, _ ...grpc.CallOption) *provider.ListStorageSpacesResponse {
-				rid := provider.ResourceId{StorageId: "provider-1", SpaceId: "foospace", OpaqueId: "foospace"}
+				rid := &provider.ResourceId{StorageId: "provider-1", SpaceId: "foospace", OpaqueId: "foospace"}
 				spaces := []*provider.StorageSpace{
 					{
 						Id:        &provider.StorageSpaceId{OpaqueId: storagespace.FormatResourceID(rid)},
-						Root:      &rid,
+						Root:      rid,
 						Name:      "Foo space",
 						SpaceType: "personal",
 						Owner:     alice,
@@ -87,11 +87,11 @@ var _ = Describe("Spaces", func() {
 			}, nil)
 		barClient.On("ListStorageSpaces", mock.Anything, mock.Anything).Return(
 			func(_ context.Context, req *provider.ListStorageSpacesRequest, _ ...grpc.CallOption) *provider.ListStorageSpacesResponse {
-				rid := provider.ResourceId{StorageId: "provider-1", SpaceId: "barspace", OpaqueId: "barspace"}
+				rid := &provider.ResourceId{StorageId: "provider-1", SpaceId: "barspace", OpaqueId: "barspace"}
 				spaces := []*provider.StorageSpace{
 					{
 						Id:        &provider.StorageSpaceId{OpaqueId: storagespace.FormatResourceID(rid)},
-						Root:      &rid,
+						Root:      rid,
 						Name:      "Bar space",
 						SpaceType: "personal",
 						Owner:     alice,
@@ -109,18 +109,18 @@ var _ = Describe("Spaces", func() {
 			}, nil)
 		bazClient.On("ListStorageSpaces", mock.Anything, mock.Anything).Return(
 			func(_ context.Context, req *provider.ListStorageSpacesRequest, _ ...grpc.CallOption) *provider.ListStorageSpacesResponse {
-				rid1 := provider.ResourceId{StorageId: "provider-1", SpaceId: "bazspace1", OpaqueId: "bazspace1"}
-				rid2 := provider.ResourceId{StorageId: "provider-1", SpaceId: "bazspace2", OpaqueId: "bazspace2"}
+				rid1 := &provider.ResourceId{StorageId: "provider-1", SpaceId: "bazspace1", OpaqueId: "bazspace1"}
+				rid2 := &provider.ResourceId{StorageId: "provider-1", SpaceId: "bazspace2", OpaqueId: "bazspace2"}
 				space1 := &provider.StorageSpace{
 					Id:        &provider.StorageSpaceId{OpaqueId: storagespace.FormatResourceID(rid1)},
-					Root:      &rid1,
+					Root:      rid1,
 					Name:      "Baz space 1",
 					SpaceType: "project",
 					Owner:     alice,
 				}
 				space2 := &provider.StorageSpace{
 					Id:        &provider.StorageSpaceId{OpaqueId: storagespace.FormatResourceID(rid2)},
-					Root:      &rid2,
+					Root:      rid2,
 					Name:      "Baz space 2",
 					SpaceType: "project",
 					Owner:     alice,

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -40,7 +40,7 @@ type FS interface {
 	GetMD(ctx context.Context, ref *provider.Reference, mdKeys, fieldMask []string) (*provider.ResourceInfo, error)
 	ListFolder(ctx context.Context, ref *provider.Reference, mdKeys, fieldMask []string) ([]*provider.ResourceInfo, error)
 	InitiateUpload(ctx context.Context, ref *provider.Reference, uploadLength int64, metadata map[string]string) (map[string]string, error)
-	Upload(ctx context.Context, req UploadRequest, uploadFunc UploadFinishedFunc) (provider.ResourceInfo, error)
+	Upload(ctx context.Context, req UploadRequest, uploadFunc UploadFinishedFunc) (*provider.ResourceInfo, error)
 	Download(ctx context.Context, ref *provider.Reference) (io.ReadCloser, error)
 	ListRevisions(ctx context.Context, ref *provider.Reference) ([]*provider.FileVersion, error)
 	DownloadRevision(ctx context.Context, ref *provider.Reference, key string) (io.ReadCloser, error)

--- a/pkg/storage/utils/ace/ace_test.go
+++ b/pkg/storage/utils/ace/ace_test.go
@@ -25,6 +25,7 @@ import (
 	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	"github.com/cs3org/reva/v2/pkg/storage/utils/ace"
+	"google.golang.org/protobuf/testing/protocmp"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -83,7 +84,7 @@ var _ = Describe("ACE", func() {
 			grant := ace.Grant()
 			// do not check opaque values
 			grant.Grantee.Opaque = nil
-			Expect(grant).To(Equal(userGrant))
+			Expect(grant).To(BeComparableTo(userGrant, protocmp.Transform()))
 		})
 	})
 

--- a/pkg/storage/utils/decomposedfs/decomposedfs.go
+++ b/pkg/storage/utils/decomposedfs/decomposedfs.go
@@ -567,7 +567,7 @@ func (fs *Decomposedfs) GetQuota(ctx context.Context, ref *provider.Reference) (
 	}
 
 	// FIXME move treesize & quota to fieldmask
-	ri, err := n.AsResourceInfo(ctx, &rp, []string{"treesize", "quota"}, []string{}, true)
+	ri, err := n.AsResourceInfo(ctx, rp, []string{"treesize", "quota"}, []string{}, true)
 	if err != nil {
 		return 0, 0, 0, err
 	}
@@ -661,7 +661,7 @@ func (fs *Decomposedfs) GetPathByID(ctx context.Context, id *provider.ResourceId
 	case err != nil:
 		return "", err
 	case !rp.GetPath:
-		f := storagespace.FormatResourceID(*id)
+		f := storagespace.FormatResourceID(id)
 		if rp.Stat {
 			return "", errtypes.PermissionDenied(f)
 		}
@@ -881,7 +881,7 @@ func (fs *Decomposedfs) GetMD(ctx context.Context, ref *provider.Reference, mdKe
 		return nil, errtypes.NotFound(f)
 	}
 
-	md, err := node.AsResourceInfo(ctx, &rp, mdKeys, fieldMask, utils.IsRelativeReference(ref))
+	md, err := node.AsResourceInfo(ctx, rp, mdKeys, fieldMask, utils.IsRelativeReference(ref))
 	if err != nil {
 		return nil, err
 	}
@@ -961,8 +961,8 @@ func (fs *Decomposedfs) ListFolder(ctx context.Context, ref *provider.Reference,
 				np := rp
 				// add this childs permissions
 				pset, _ := child.PermissionSet(ctx)
-				node.AddPermissions(&np, &pset)
-				ri, err := child.AsResourceInfo(ctx, &np, mdKeys, fieldMask, utils.IsRelativeReference(ref))
+				node.AddPermissions(np, pset)
+				ri, err := child.AsResourceInfo(ctx, np, mdKeys, fieldMask, utils.IsRelativeReference(ref))
 				if err != nil {
 					return errtypes.InternalError(err.Error())
 				}

--- a/pkg/storage/utils/decomposedfs/decomposedfs_concurrency_test.go
+++ b/pkg/storage/utils/decomposedfs/decomposedfs_concurrency_test.go
@@ -178,7 +178,7 @@ var _ = Describe("Decomposed", func() {
 
 		Describe("CreateDir", func() {
 			JustBeforeEach(func() {
-				env.Permissions.On("AssemblePermissions", mock.Anything, mock.Anything, mock.Anything).Return(provider.ResourcePermissions{
+				env.Permissions.On("AssemblePermissions", mock.Anything, mock.Anything, mock.Anything).Return(&provider.ResourcePermissions{
 					Stat:            true,
 					CreateContainer: true,
 				}, nil)

--- a/pkg/storage/utils/decomposedfs/decomposedfs_test.go
+++ b/pkg/storage/utils/decomposedfs/decomposedfs_test.go
@@ -73,7 +73,7 @@ var _ = Describe("Decomposed", func() {
 					ResourceId: env.SpaceRootRes,
 					Path:       "/dir2",
 				}
-				env.Permissions.On("AssemblePermissions", mock.Anything, mock.Anything, mock.Anything).Return(provider.ResourcePermissions{CreateContainer: true, Stat: true}, nil)
+				env.Permissions.On("AssemblePermissions", mock.Anything, mock.Anything, mock.Anything).Return(&provider.ResourcePermissions{CreateContainer: true, Stat: true}, nil)
 				err := env.Fs.CreateDir(env.Ctx, dir2)
 				Expect(err).ToNot(HaveOccurred())
 				ri, err := env.Fs.GetMD(env.Ctx, dir2, []string{}, []string{})
@@ -85,7 +85,7 @@ var _ = Describe("Decomposed", func() {
 					ResourceId: env.SpaceRootRes,
 					Path:       "/dir1/dir2",
 				}
-				env.Permissions.On("AssemblePermissions", mock.Anything, mock.Anything, mock.Anything).Return(provider.ResourcePermissions{CreateContainer: true, Stat: true}, nil)
+				env.Permissions.On("AssemblePermissions", mock.Anything, mock.Anything, mock.Anything).Return(&provider.ResourcePermissions{CreateContainer: true, Stat: true}, nil)
 				err := env.Fs.CreateDir(env.Ctx, dir2)
 				Expect(err).ToNot(HaveOccurred())
 				ri, err := env.Fs.GetMD(env.Ctx, dir2, []string{}, []string{})
@@ -93,7 +93,7 @@ var _ = Describe("Decomposed", func() {
 				Expect(ri.Path).To(Equal(dir2.Path))
 			})
 			It("dir already exists", func() {
-				env.Permissions.On("AssemblePermissions", mock.Anything, mock.Anything, mock.Anything).Return(provider.ResourcePermissions{CreateContainer: true}, nil)
+				env.Permissions.On("AssemblePermissions", mock.Anything, mock.Anything, mock.Anything).Return(&provider.ResourcePermissions{CreateContainer: true}, nil)
 				err := env.Fs.CreateDir(env.Ctx, ref)
 				Expect(err).To(HaveOccurred())
 				Expect(err).Should(MatchError(errtypes.AlreadyExists("/dir1")))
@@ -103,7 +103,7 @@ var _ = Describe("Decomposed", func() {
 					ResourceId: env.SpaceRootRes,
 					Path:       "/dir1/dir3",
 				}
-				env.Permissions.On("AssemblePermissions", mock.Anything, mock.Anything, mock.Anything).Return(provider.ResourcePermissions{CreateContainer: true}, nil)
+				env.Permissions.On("AssemblePermissions", mock.Anything, mock.Anything, mock.Anything).Return(&provider.ResourcePermissions{CreateContainer: true}, nil)
 				err := env.Fs.CreateDir(env.Ctx, dir3)
 				Expect(err).ToNot(HaveOccurred())
 				err = env.Fs.CreateDir(env.Ctx, dir3)
@@ -115,7 +115,7 @@ var _ = Describe("Decomposed", func() {
 					ResourceId: env.SpaceRootRes,
 					Path:       "/dir1/dir2/dir3",
 				}
-				env.Permissions.On("AssemblePermissions", mock.Anything, mock.Anything, mock.Anything).Return(provider.ResourcePermissions{CreateContainer: true}, nil)
+				env.Permissions.On("AssemblePermissions", mock.Anything, mock.Anything, mock.Anything).Return(&provider.ResourcePermissions{CreateContainer: true}, nil)
 				err := env.Fs.CreateDir(env.Ctx, dir2)
 				Expect(err).To(HaveOccurred())
 				Expect(err).Should(MatchError(errtypes.PreconditionFailed("/dir1/dir2")))
@@ -125,7 +125,7 @@ var _ = Describe("Decomposed", func() {
 					ResourceId: env.SpaceRootRes,
 					Path:       "/dir1/dir2/dir3/dir4",
 				}
-				env.Permissions.On("AssemblePermissions", mock.Anything, mock.Anything, mock.Anything).Return(provider.ResourcePermissions{CreateContainer: true}, nil)
+				env.Permissions.On("AssemblePermissions", mock.Anything, mock.Anything, mock.Anything).Return(&provider.ResourcePermissions{CreateContainer: true}, nil)
 				err := env.Fs.CreateDir(env.Ctx, dir2)
 				Expect(err).To(HaveOccurred())
 				Expect(err).Should(MatchError(errtypes.PreconditionFailed("error: not found: dir2")))
@@ -136,7 +136,7 @@ var _ = Describe("Decomposed", func() {
 	Describe("Delete", func() {
 		Context("with no permissions", func() {
 			It("returns an error", func() {
-				env.Permissions.On("AssemblePermissions", mock.Anything, mock.Anything, mock.Anything).Return(provider.ResourcePermissions{}, nil)
+				env.Permissions.On("AssemblePermissions", mock.Anything, mock.Anything, mock.Anything).Return(&provider.ResourcePermissions{}, nil)
 
 				err := env.Fs.Delete(env.Ctx, ref)
 
@@ -146,7 +146,7 @@ var _ = Describe("Decomposed", func() {
 
 		Context("with insufficient permissions", func() {
 			It("returns an error", func() {
-				env.Permissions.On("AssemblePermissions", mock.Anything, mock.Anything, mock.Anything).Return(provider.ResourcePermissions{
+				env.Permissions.On("AssemblePermissions", mock.Anything, mock.Anything, mock.Anything).Return(&provider.ResourcePermissions{
 					Stat:   true,
 					Delete: false,
 				}, nil)
@@ -159,7 +159,7 @@ var _ = Describe("Decomposed", func() {
 
 		Context("with sufficient permissions", func() {
 			JustBeforeEach(func() {
-				env.Permissions.On("AssemblePermissions", mock.Anything, mock.Anything, mock.Anything).Return(provider.ResourcePermissions{
+				env.Permissions.On("AssemblePermissions", mock.Anything, mock.Anything, mock.Anything).Return(&provider.ResourcePermissions{
 					Stat:   true,
 					Delete: true,
 				}, nil)

--- a/pkg/storage/utils/decomposedfs/grants_test.go
+++ b/pkg/storage/utils/decomposedfs/grants_test.go
@@ -81,7 +81,7 @@ var _ = Describe("Grants", func() {
 
 	Context("with no permissions", func() {
 		JustBeforeEach(func() {
-			env.Permissions.On("AssemblePermissions", mock.Anything, mock.Anything, mock.Anything).Return(provider.ResourcePermissions{}, nil)
+			env.Permissions.On("AssemblePermissions", mock.Anything, mock.Anything, mock.Anything).Return(&provider.ResourcePermissions{}, nil)
 		})
 
 		Describe("AddGrant", func() {
@@ -94,7 +94,7 @@ var _ = Describe("Grants", func() {
 
 	Context("with insufficient permissions", func() {
 		JustBeforeEach(func() {
-			env.Permissions.On("AssemblePermissions", mock.Anything, mock.Anything, mock.Anything).Return(provider.ResourcePermissions{
+			env.Permissions.On("AssemblePermissions", mock.Anything, mock.Anything, mock.Anything).Return(&provider.ResourcePermissions{
 				Stat: true,
 			}, nil)
 		})
@@ -109,7 +109,7 @@ var _ = Describe("Grants", func() {
 
 	Context("with sufficient permissions", func() {
 		JustBeforeEach(func() {
-			env.Permissions.On("AssemblePermissions", mock.Anything, mock.Anything, mock.Anything).Return(provider.ResourcePermissions{
+			env.Permissions.On("AssemblePermissions", mock.Anything, mock.Anything, mock.Anything).Return(&provider.ResourcePermissions{
 				Stat:        true,
 				AddGrant:    true,
 				ListGrants:  true,

--- a/pkg/storage/utils/decomposedfs/node/locks_test.go
+++ b/pkg/storage/utils/decomposedfs/node/locks_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"google.golang.org/protobuf/testing/protocmp"
 
 	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
@@ -152,7 +153,7 @@ var _ = Describe("Node locks", func() {
 			It("returns the lock", func() {
 				l, err := n.ReadLock(env.Ctx, false)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(l).To(Equal(lockByUser))
+				Expect(l).To(BeComparableTo(lockByUser, protocmp.Transform()))
 			})
 
 			It("reports an error when the node wasn't locked", func() {

--- a/pkg/storage/utils/decomposedfs/node/node_test.go
+++ b/pkg/storage/utils/decomposedfs/node/node_test.go
@@ -187,14 +187,14 @@ var _ = Describe("Node", func() {
 		Describe("the Etag field", func() {
 			It("is set", func() {
 				perms := node.OwnerPermissions()
-				ri, err := n.AsResourceInfo(env.Ctx, &perms, []string{}, []string{}, false)
+				ri, err := n.AsResourceInfo(env.Ctx, perms, []string{}, []string{}, false)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(len(ri.Etag)).To(Equal(34))
 			})
 
 			It("changes when the tmtime is set", func() {
 				perms := node.OwnerPermissions()
-				ri, err := n.AsResourceInfo(env.Ctx, &perms, []string{}, []string{}, false)
+				ri, err := n.AsResourceInfo(env.Ctx, perms, []string{}, []string{}, false)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(len(ri.Etag)).To(Equal(34))
 				before := ri.Etag
@@ -202,7 +202,7 @@ var _ = Describe("Node", func() {
 				tmtime := time.Now()
 				Expect(n.SetTMTime(env.Ctx, &tmtime)).To(Succeed())
 
-				ri, err = n.AsResourceInfo(env.Ctx, &perms, []string{}, []string{}, false)
+				ri, err = n.AsResourceInfo(env.Ctx, perms, []string{}, []string{}, false)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(len(ri.Etag)).To(Equal(34))
 				Expect(ri.Etag).ToNot(Equal(before))
@@ -218,7 +218,7 @@ var _ = Describe("Node", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				perms := node.OwnerPermissions()
-				ri, err := n.AsResourceInfo(env.Ctx, &perms, []string{}, []string{}, false)
+				ri, err := n.AsResourceInfo(env.Ctx, perms, []string{}, []string{}, false)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ri.Opaque).ToNot(BeNil())
 				Expect(ri.Opaque.Map["lock"]).ToNot(BeNil())
@@ -243,7 +243,7 @@ var _ = Describe("Node", func() {
 			nodePSpace, err := env.Lookup.NodeFromSpaceID(env.Ctx, pSpace.SpaceId)
 			Expect(err).ToNot(HaveOccurred())
 			u := ctxpkg.ContextMustGetUser(env.Ctx)
-			env.Permissions.On("AssemblePermissions", mock.Anything, mock.Anything, mock.Anything).Return(provider.ResourcePermissions{
+			env.Permissions.On("AssemblePermissions", mock.Anything, mock.Anything, mock.Anything).Return(&provider.ResourcePermissions{
 				UpdateGrant: true,
 				Stat:        true,
 			}, nil).Times(1)
@@ -264,13 +264,13 @@ var _ = Describe("Node", func() {
 			Expect(err).ToNot(HaveOccurred())
 			perms, _ := nodePSpace.PermissionSet(env.Ctx)
 			expected := ocsconv.NewManagerRole().CS3ResourcePermissions()
-			Expect(grants.PermissionsEqual(&perms, expected)).To(BeTrue())
+			Expect(grants.PermissionsEqual(perms, expected)).To(BeTrue())
 		})
 		It("Checks the Editor permissions on a project space and a denial", func() {
 			storageSpace, err := env.CreateTestStorageSpace("project", &provider.Quota{QuotaMaxBytes: 2000})
 			Expect(err).ToNot(HaveOccurred())
 			u := ctxpkg.ContextMustGetUser(env.Ctx)
-			env.Permissions.On("AssemblePermissions", mock.Anything, mock.Anything, mock.Anything).Return(provider.ResourcePermissions{
+			env.Permissions.On("AssemblePermissions", mock.Anything, mock.Anything, mock.Anything).Return(&provider.ResourcePermissions{
 				UpdateGrant: true,
 				Stat:        true,
 			}, nil).Times(1)
@@ -293,8 +293,8 @@ var _ = Describe("Node", func() {
 			Expect(err).ToNot(HaveOccurred())
 			permissionsActual, _ := spaceRoot.PermissionSet(env.Ctx)
 			permissionsExpected := ocsconv.NewEditorRole().CS3ResourcePermissions()
-			Expect(grants.PermissionsEqual(&permissionsActual, permissionsExpected)).To(BeTrue())
-			env.Permissions.On("AssemblePermissions", mock.Anything, mock.Anything, mock.Anything).Return(provider.ResourcePermissions{
+			Expect(grants.PermissionsEqual(permissionsActual, permissionsExpected)).To(BeTrue())
+			env.Permissions.On("AssemblePermissions", mock.Anything, mock.Anything, mock.Anything).Return(&provider.ResourcePermissions{
 				Stat:            true,
 				CreateContainer: true,
 			}, nil).Times(1)
@@ -307,7 +307,7 @@ var _ = Describe("Node", func() {
 			)
 			Expect(err).ToNot(HaveOccurred())
 			// adding a denial on the subpath
-			env.Permissions.On("AssemblePermissions", mock.Anything, mock.Anything, mock.Anything).Return(provider.ResourcePermissions{
+			env.Permissions.On("AssemblePermissions", mock.Anything, mock.Anything, mock.Anything).Return(&provider.ResourcePermissions{
 				DenyGrant: true,
 				Stat:      true,
 			}, nil).Times(1)
@@ -332,7 +332,7 @@ var _ = Describe("Node", func() {
 			Expect(err).ToNot(HaveOccurred())
 			subfolderActual, denied := subfolder.PermissionSet(env.Ctx)
 			subfolderExpected := ocsconv.NewDeniedRole().CS3ResourcePermissions()
-			Expect(grants.PermissionsEqual(&subfolderActual, subfolderExpected)).To(BeTrue())
+			Expect(grants.PermissionsEqual(subfolderActual, subfolderExpected)).To(BeTrue())
 			Expect(denied).To(BeTrue())
 		})
 	})

--- a/pkg/storage/utils/decomposedfs/node/node_test.go
+++ b/pkg/storage/utils/decomposedfs/node/node_test.go
@@ -31,6 +31,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/stretchr/testify/mock"
+	"google.golang.org/protobuf/testing/protocmp"
 )
 
 var _ = Describe("Node", func() {
@@ -225,7 +226,7 @@ var _ = Describe("Node", func() {
 				storedLock := &provider.Lock{}
 				err = json.Unmarshal(ri.Opaque.Map["lock"].Value, storedLock)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(storedLock).To(Equal(lock))
+				Expect(storedLock).To(BeComparableTo(lock, protocmp.Transform()))
 			})
 		})
 	})
@@ -346,7 +347,7 @@ var _ = Describe("Node", func() {
 
 			o := n.SpaceOwnerOrManager(env.Ctx)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(o).To(Equal(env.Owner.Id))
+			Expect(o).To(BeComparableTo(env.Owner.Id, protocmp.Transform()))
 		})
 
 	})

--- a/pkg/storage/utils/decomposedfs/node/permissions.go
+++ b/pkg/storage/utils/decomposedfs/node/permissions.go
@@ -42,13 +42,13 @@ var (
 )
 
 // NoPermissions represents an empty set of permissions
-func NoPermissions() provider.ResourcePermissions {
-	return provider.ResourcePermissions{}
+func NoPermissions() *provider.ResourcePermissions {
+	return &provider.ResourcePermissions{}
 }
 
 // ShareFolderPermissions defines permissions for the shared jail
-func ShareFolderPermissions() provider.ResourcePermissions {
-	return provider.ResourcePermissions{
+func ShareFolderPermissions() *provider.ResourcePermissions {
+	return &provider.ResourcePermissions{
 		// read permissions
 		ListContainer:        true,
 		Stat:                 true,
@@ -60,8 +60,8 @@ func ShareFolderPermissions() provider.ResourcePermissions {
 }
 
 // OwnerPermissions defines permissions for nodes owned by the user
-func OwnerPermissions() provider.ResourcePermissions {
-	return provider.ResourcePermissions{
+func OwnerPermissions() *provider.ResourcePermissions {
+	return &provider.ResourcePermissions{
 		// all permissions
 		AddGrant:             true,
 		CreateContainer:      true,
@@ -86,9 +86,9 @@ func OwnerPermissions() provider.ResourcePermissions {
 }
 
 // ServiceAccountPermissions defines the permissions for nodes when requested by a service account
-func ServiceAccountPermissions() provider.ResourcePermissions {
+func ServiceAccountPermissions() *provider.ResourcePermissions {
 	// TODO: Different permissions for different service accounts
-	return provider.ResourcePermissions{
+	return &provider.ResourcePermissions{
 		Stat:                 true,
 		ListContainer:        true,
 		GetPath:              true, // for search index
@@ -117,17 +117,17 @@ func NewPermissions(lu PathLookup) *Permissions {
 }
 
 // AssemblePermissions will assemble the permissions for the current user on the given node, taking into account all parent nodes
-func (p *Permissions) AssemblePermissions(ctx context.Context, n *Node) (ap provider.ResourcePermissions, err error) {
+func (p *Permissions) AssemblePermissions(ctx context.Context, n *Node) (ap *provider.ResourcePermissions, err error) {
 	return p.assemblePermissions(ctx, n, true)
 }
 
 // AssembleTrashPermissions will assemble the permissions for the current user on the given node, taking into account all parent nodes
-func (p *Permissions) AssembleTrashPermissions(ctx context.Context, n *Node) (ap provider.ResourcePermissions, err error) {
+func (p *Permissions) AssembleTrashPermissions(ctx context.Context, n *Node) (ap *provider.ResourcePermissions, err error) {
 	return p.assemblePermissions(ctx, n, false)
 }
 
 // assemblePermissions will assemble the permissions for the current user on the given node, taking into account all parent nodes
-func (p *Permissions) assemblePermissions(ctx context.Context, n *Node, failOnTrashedSubtree bool) (ap provider.ResourcePermissions, err error) {
+func (p *Permissions) assemblePermissions(ctx context.Context, n *Node, failOnTrashedSubtree bool) (ap *provider.ResourcePermissions, err error) {
 	u, ok := ctxpkg.ContextGetUser(ctx)
 	if !ok {
 		return NoPermissions(), nil
@@ -151,7 +151,7 @@ func (p *Permissions) assemblePermissions(ctx context.Context, n *Node, failOnTr
 	// determine root
 	rn := n.SpaceRoot
 	cn := n
-	ap = provider.ResourcePermissions{}
+	ap = &provider.ResourcePermissions{}
 
 	// for an efficient group lookup convert the list of groups to a map
 	// groups are just strings ... groupnames ... or group ids ??? AAARGH !!!
@@ -167,7 +167,7 @@ func (p *Permissions) assemblePermissions(ctx context.Context, n *Node, failOnTr
 			if accessDenied {
 				return np, nil
 			}
-			AddPermissions(&ap, &np)
+			AddPermissions(ap, np)
 		} else {
 			appctx.GetLogger(ctx).Error().Err(err).Str("spaceid", cn.SpaceID).Str("nodeid", cn.ID).Msg("error reading permissions")
 			// continue with next segment
@@ -193,7 +193,7 @@ func (p *Permissions) assemblePermissions(ctx context.Context, n *Node, failOnTr
 		if accessDenied {
 			return np, nil
 		}
-		AddPermissions(&ap, &np)
+		AddPermissions(ap, np)
 	} else {
 		appctx.GetLogger(ctx).Error().Err(err).Str("spaceid", cn.SpaceID).Str("nodeid", cn.ID).Msg("error reading root node permissions")
 	}

--- a/pkg/storage/utils/decomposedfs/permissions/mocks/PermissionsChecker.go
+++ b/pkg/storage/utils/decomposedfs/permissions/mocks/PermissionsChecker.go
@@ -43,22 +43,24 @@ func (_m *PermissionsChecker) EXPECT() *PermissionsChecker_Expecter {
 }
 
 // AssemblePermissions provides a mock function with given fields: ctx, n
-func (_m *PermissionsChecker) AssemblePermissions(ctx context.Context, n *node.Node) (providerv1beta1.ResourcePermissions, error) {
+func (_m *PermissionsChecker) AssemblePermissions(ctx context.Context, n *node.Node) (*providerv1beta1.ResourcePermissions, error) {
 	ret := _m.Called(ctx, n)
 
 	if len(ret) == 0 {
 		panic("no return value specified for AssemblePermissions")
 	}
 
-	var r0 providerv1beta1.ResourcePermissions
+	var r0 *providerv1beta1.ResourcePermissions
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, *node.Node) (providerv1beta1.ResourcePermissions, error)); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, *node.Node) (*providerv1beta1.ResourcePermissions, error)); ok {
 		return rf(ctx, n)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, *node.Node) providerv1beta1.ResourcePermissions); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, *node.Node) *providerv1beta1.ResourcePermissions); ok {
 		r0 = rf(ctx, n)
 	} else {
-		r0 = ret.Get(0).(providerv1beta1.ResourcePermissions)
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*providerv1beta1.ResourcePermissions)
+		}
 	}
 
 	if rf, ok := ret.Get(1).(func(context.Context, *node.Node) error); ok {
@@ -89,33 +91,35 @@ func (_c *PermissionsChecker_AssemblePermissions_Call) Run(run func(ctx context.
 	return _c
 }
 
-func (_c *PermissionsChecker_AssemblePermissions_Call) Return(ap providerv1beta1.ResourcePermissions, err error) *PermissionsChecker_AssemblePermissions_Call {
+func (_c *PermissionsChecker_AssemblePermissions_Call) Return(ap *providerv1beta1.ResourcePermissions, err error) *PermissionsChecker_AssemblePermissions_Call {
 	_c.Call.Return(ap, err)
 	return _c
 }
 
-func (_c *PermissionsChecker_AssemblePermissions_Call) RunAndReturn(run func(context.Context, *node.Node) (providerv1beta1.ResourcePermissions, error)) *PermissionsChecker_AssemblePermissions_Call {
+func (_c *PermissionsChecker_AssemblePermissions_Call) RunAndReturn(run func(context.Context, *node.Node) (*providerv1beta1.ResourcePermissions, error)) *PermissionsChecker_AssemblePermissions_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // AssembleTrashPermissions provides a mock function with given fields: ctx, n
-func (_m *PermissionsChecker) AssembleTrashPermissions(ctx context.Context, n *node.Node) (providerv1beta1.ResourcePermissions, error) {
+func (_m *PermissionsChecker) AssembleTrashPermissions(ctx context.Context, n *node.Node) (*providerv1beta1.ResourcePermissions, error) {
 	ret := _m.Called(ctx, n)
 
 	if len(ret) == 0 {
 		panic("no return value specified for AssembleTrashPermissions")
 	}
 
-	var r0 providerv1beta1.ResourcePermissions
+	var r0 *providerv1beta1.ResourcePermissions
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, *node.Node) (providerv1beta1.ResourcePermissions, error)); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, *node.Node) (*providerv1beta1.ResourcePermissions, error)); ok {
 		return rf(ctx, n)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, *node.Node) providerv1beta1.ResourcePermissions); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, *node.Node) *providerv1beta1.ResourcePermissions); ok {
 		r0 = rf(ctx, n)
 	} else {
-		r0 = ret.Get(0).(providerv1beta1.ResourcePermissions)
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*providerv1beta1.ResourcePermissions)
+		}
 	}
 
 	if rf, ok := ret.Get(1).(func(context.Context, *node.Node) error); ok {
@@ -146,12 +150,12 @@ func (_c *PermissionsChecker_AssembleTrashPermissions_Call) Run(run func(ctx con
 	return _c
 }
 
-func (_c *PermissionsChecker_AssembleTrashPermissions_Call) Return(ap providerv1beta1.ResourcePermissions, err error) *PermissionsChecker_AssembleTrashPermissions_Call {
+func (_c *PermissionsChecker_AssembleTrashPermissions_Call) Return(ap *providerv1beta1.ResourcePermissions, err error) *PermissionsChecker_AssembleTrashPermissions_Call {
 	_c.Call.Return(ap, err)
 	return _c
 }
 
-func (_c *PermissionsChecker_AssembleTrashPermissions_Call) RunAndReturn(run func(context.Context, *node.Node) (providerv1beta1.ResourcePermissions, error)) *PermissionsChecker_AssembleTrashPermissions_Call {
+func (_c *PermissionsChecker_AssembleTrashPermissions_Call) RunAndReturn(run func(context.Context, *node.Node) (*providerv1beta1.ResourcePermissions, error)) *PermissionsChecker_AssembleTrashPermissions_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/storage/utils/decomposedfs/permissions/spacepermissions.go
+++ b/pkg/storage/utils/decomposedfs/permissions/spacepermissions.go
@@ -31,8 +31,8 @@ const (
 
 // PermissionsChecker defines an interface for checking permissions on a Node
 type PermissionsChecker interface {
-	AssemblePermissions(ctx context.Context, n *node.Node) (ap provider.ResourcePermissions, err error)
-	AssembleTrashPermissions(ctx context.Context, n *node.Node) (ap provider.ResourcePermissions, err error)
+	AssemblePermissions(ctx context.Context, n *node.Node) (ap *provider.ResourcePermissions, err error)
+	AssembleTrashPermissions(ctx context.Context, n *node.Node) (ap *provider.ResourcePermissions, err error)
 }
 
 // CS3PermissionsClient defines an interface for checking permissions against the CS3 permissions service
@@ -52,14 +52,14 @@ func NewPermissions(item PermissionsChecker, permissionsSelector pool.Selectable
 }
 
 // AssemblePermissions is used to assemble file permissions
-func (p Permissions) AssemblePermissions(ctx context.Context, n *node.Node) (provider.ResourcePermissions, error) {
+func (p Permissions) AssemblePermissions(ctx context.Context, n *node.Node) (*provider.ResourcePermissions, error) {
 	ctx, span := tracer.Start(ctx, "AssemblePermissions")
 	defer span.End()
 	return p.item.AssemblePermissions(ctx, n)
 }
 
 // AssembleTrashPermissions is used to assemble file permissions
-func (p Permissions) AssembleTrashPermissions(ctx context.Context, n *node.Node) (provider.ResourcePermissions, error) {
+func (p Permissions) AssembleTrashPermissions(ctx context.Context, n *node.Node) (*provider.ResourcePermissions, error) {
 	return p.item.AssembleTrashPermissions(ctx, n)
 }
 
@@ -143,17 +143,17 @@ func (p Permissions) checkPermission(ctx context.Context, perm string, ref *prov
 }
 
 // IsManager returns true if the given resource permissions evaluate the user as "manager"
-func IsManager(rp provider.ResourcePermissions) bool {
+func IsManager(rp *provider.ResourcePermissions) bool {
 	return rp.RemoveGrant
 }
 
 // IsEditor returns true if the given resource permissions evaluate the user as "editor"
-func IsEditor(rp provider.ResourcePermissions) bool {
+func IsEditor(rp *provider.ResourcePermissions) bool {
 	return rp.InitiateFileUpload
 }
 
 // IsViewer returns true if the given resource permissions evaluate the user as "viewer"
-func IsViewer(rp provider.ResourcePermissions) bool {
+func IsViewer(rp *provider.ResourcePermissions) bool {
 	return rp.Stat
 }
 

--- a/pkg/storage/utils/decomposedfs/recycle_test.go
+++ b/pkg/storage/utils/decomposedfs/recycle_test.go
@@ -452,9 +452,9 @@ var _ = Describe("Recycle", func() {
 })
 
 func registerPermissions(m *mocks.PermissionsChecker, uid string, exp *provider.ResourcePermissions) {
-	p := provider.ResourcePermissions{}
+	p := &provider.ResourcePermissions{}
 	if exp != nil {
-		p = *exp
+		p = exp
 	}
 	m.On("AssemblePermissions",
 		mock.MatchedBy(func(ctx context.Context) bool {

--- a/pkg/storage/utils/decomposedfs/revisions.go
+++ b/pkg/storage/utils/decomposedfs/revisions.go
@@ -352,7 +352,7 @@ func (fs *Decomposedfs) getRevisionNode(ctx context.Context, ref *provider.Refer
 	switch {
 	case err != nil:
 		return nil, err
-	case !hasPermission(&p):
+	case !hasPermission(p):
 		return nil, errtypes.PermissionDenied(filepath.Join(n.ParentID, n.Name))
 	}
 

--- a/pkg/storage/utils/decomposedfs/spaces.go
+++ b/pkg/storage/utils/decomposedfs/spaces.go
@@ -1002,7 +1002,7 @@ func (fs *Decomposedfs) StorageSpaceFromNode(ctx context.Context, n *node.Node, 
 	}
 	if si := spaceAttributes.String(prefixes.SpaceImageAttr); si != "" {
 		space.Opaque = utils.AppendPlainToOpaque(space.Opaque, "image", storagespace.FormatResourceID(
-			provider.ResourceId{StorageId: space.Root.StorageId, SpaceId: space.Root.SpaceId, OpaqueId: si},
+			&provider.ResourceId{StorageId: space.Root.StorageId, SpaceId: space.Root.SpaceId, OpaqueId: si},
 		))
 	}
 	if sd := spaceAttributes.String(prefixes.SpaceDescriptionAttr); sd != "" {
@@ -1010,7 +1010,7 @@ func (fs *Decomposedfs) StorageSpaceFromNode(ctx context.Context, n *node.Node, 
 	}
 	if sr := spaceAttributes.String(prefixes.SpaceReadmeAttr); sr != "" {
 		space.Opaque = utils.AppendPlainToOpaque(space.Opaque, "readme", storagespace.FormatResourceID(
-			provider.ResourceId{StorageId: space.Root.StorageId, SpaceId: space.Root.SpaceId, OpaqueId: sr},
+			&provider.ResourceId{StorageId: space.Root.StorageId, SpaceId: space.Root.SpaceId, OpaqueId: sr},
 		))
 	}
 	if sa := spaceAttributes.String(prefixes.SpaceAliasAttr); sa != "" {
@@ -1019,7 +1019,7 @@ func (fs *Decomposedfs) StorageSpaceFromNode(ctx context.Context, n *node.Node, 
 
 	// add rootinfo
 	ps, _ := n.SpaceRoot.PermissionSet(ctx)
-	space.RootInfo, _ = n.SpaceRoot.AsResourceInfo(ctx, &ps, []string{"quota"}, nil, false)
+	space.RootInfo, _ = n.SpaceRoot.AsResourceInfo(ctx, ps, []string{"quota"}, nil, false)
 
 	// we cannot put free, used and remaining into the quota, as quota, when set would always imply a quota limit
 	// for now we use opaque properties with a 'quota.' prefix

--- a/pkg/storage/utils/decomposedfs/spaces_test.go
+++ b/pkg/storage/utils/decomposedfs/spaces_test.go
@@ -60,7 +60,7 @@ var _ = Describe("Spaces", func() {
 					return &cs3permissions.CheckPermissionResponse{Status: &rpcv1beta1.Status{Code: rpcv1beta1.Code_CODE_PERMISSION_DENIED}}
 				},
 				nil)
-			env.Permissions.On("AssemblePermissions", mock.Anything, mock.Anything, mock.Anything).Return(func(ctx context.Context, n *node.Node) provider.ResourcePermissions {
+			env.Permissions.On("AssemblePermissions", mock.Anything, mock.Anything, mock.Anything).Return(func(ctx context.Context, n *node.Node) *provider.ResourcePermissions {
 				if ctxpkg.ContextMustGetUser(ctx).Id.GetOpaqueId() == "25b69780-5f39-43be-a7ac-a9b9e9fe4230" {
 					return node.OwnerPermissions() // id of owner/admin
 				}
@@ -218,7 +218,7 @@ var _ = Describe("Spaces", func() {
 				})
 				Expect(err).ToNot(HaveOccurred())
 				env.PermissionsClient.On("CheckPermission", mock.Anything, mock.Anything, mock.Anything).Return(&cs3permissions.CheckPermissionResponse{Status: &rpcv1beta1.Status{Code: rpcv1beta1.Code_CODE_OK}}, nil)
-				env.Permissions.On("AssemblePermissions", mock.Anything, mock.Anything, mock.Anything).Return(provider.ResourcePermissions{
+				env.Permissions.On("AssemblePermissions", mock.Anything, mock.Anything, mock.Anything).Return(&provider.ResourcePermissions{
 					Stat:     true,
 					AddGrant: true,
 					GetQuota: true,
@@ -287,14 +287,14 @@ var _ = Describe("Spaces", func() {
 				}, nil)
 
 			env.Permissions.On("AssemblePermissions", mock.Anything, mock.Anything, mock.Anything).Return(
-				func(ctx context.Context, n *node.Node) provider.ResourcePermissions {
+				func(ctx context.Context, n *node.Node) *provider.ResourcePermissions {
 					switch ctxpkg.ContextMustGetUser(ctx).GetId().GetOpaqueId() {
 					case manager.GetId().GetOpaqueId():
 						return node.OwnerPermissions() // id of owner/admin
 					case editor.GetId().GetOpaqueId():
-						return provider.ResourcePermissions{InitiateFileUpload: true} // mock editor
+						return &provider.ResourcePermissions{InitiateFileUpload: true} // mock editor
 					case viewer.GetId().GetOpaqueId():
-						return provider.ResourcePermissions{Stat: true} // mock viewer
+						return &provider.ResourcePermissions{Stat: true} // mock viewer
 					default:
 						return node.NoPermissions()
 					}

--- a/pkg/storage/utils/decomposedfs/testhelpers/helpers.go
+++ b/pkg/storage/utils/decomposedfs/testhelpers/helpers.go
@@ -279,7 +279,7 @@ func (t *TestEnv) CreateTestStorageSpace(typ string, quota *providerv1beta1.Quot
 		Status: &v1beta11.Status{Code: v1beta11.Code_CODE_OK},
 	}, nil)
 	// Permissions required for setup below
-	t.Permissions.On("AssemblePermissions", mock.Anything, mock.Anything, mock.Anything).Return(providerv1beta1.ResourcePermissions{
+	t.Permissions.On("AssemblePermissions", mock.Anything, mock.Anything, mock.Anything).Return(&providerv1beta1.ResourcePermissions{
 		Stat:     true,
 		AddGrant: true,
 	}, nil).Times(1) //
@@ -313,7 +313,7 @@ func (t *TestEnv) CreateTestStorageSpace(typ string, quota *providerv1beta1.Quot
 	}
 
 	// Create dir1
-	t.Permissions.On("AssemblePermissions", mock.Anything, mock.Anything, mock.Anything).Return(providerv1beta1.ResourcePermissions{
+	t.Permissions.On("AssemblePermissions", mock.Anything, mock.Anything, mock.Anything).Return(&providerv1beta1.ResourcePermissions{
 		Stat:            true,
 		CreateContainer: true,
 	}, nil).Times(1) // Permissions required for setup below
@@ -329,7 +329,7 @@ func (t *TestEnv) CreateTestStorageSpace(typ string, quota *providerv1beta1.Quot
 	}
 
 	// Create subdir1 in dir1
-	t.Permissions.On("AssemblePermissions", mock.Anything, mock.Anything, mock.Anything).Return(providerv1beta1.ResourcePermissions{
+	t.Permissions.On("AssemblePermissions", mock.Anything, mock.Anything, mock.Anything).Return(&providerv1beta1.ResourcePermissions{
 		Stat:            true,
 		CreateContainer: true,
 	}, nil).Times(1) // Permissions required for setup below
@@ -345,7 +345,7 @@ func (t *TestEnv) CreateTestStorageSpace(typ string, quota *providerv1beta1.Quot
 	}
 
 	// Create emptydir
-	t.Permissions.On("AssemblePermissions", mock.Anything, mock.Anything, mock.Anything).Return(providerv1beta1.ResourcePermissions{
+	t.Permissions.On("AssemblePermissions", mock.Anything, mock.Anything, mock.Anything).Return(&providerv1beta1.ResourcePermissions{
 		Stat:            true,
 		CreateContainer: true,
 	}, nil).Times(1) // Permissions required for setup below

--- a/pkg/storage/utils/decomposedfs/testhelpers/helpers.go
+++ b/pkg/storage/utils/decomposedfs/testhelpers/helpers.go
@@ -164,7 +164,7 @@ func NewTestEnv(config map[string]interface{}) (*TestEnv, error) {
 	permissionsSelector := pool.GetSelector[cs3permissions.PermissionsAPIClient](
 		"PermissionsSelector",
 		"any",
-		func(cc *grpc.ClientConn) cs3permissions.PermissionsAPIClient {
+		func(cc grpc.ClientConnInterface) cs3permissions.PermissionsAPIClient {
 			return cs3permissionsclient
 		},
 	)

--- a/pkg/storage/utils/decomposedfs/tree/tree_test.go
+++ b/pkg/storage/utils/decomposedfs/tree/tree_test.go
@@ -289,7 +289,7 @@ var _ = Describe("Tree", func() {
 		var dir *node.Node
 
 		JustBeforeEach(func() {
-			env.Permissions.On("AssemblePermissions", mock.Anything, mock.Anything, mock.Anything).Return(provider.ResourcePermissions{
+			env.Permissions.On("AssemblePermissions", mock.Anything, mock.Anything, mock.Anything).Return(&provider.ResourcePermissions{
 				CreateContainer: true,
 				Stat:            true,
 			}, nil)
@@ -306,7 +306,7 @@ var _ = Describe("Tree", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				perms := node.OwnerPermissions()
-				riBefore, err := dir.AsResourceInfo(env.Ctx, &perms, []string{}, []string{}, false)
+				riBefore, err := dir.AsResourceInfo(env.Ctx, perms, []string{}, []string{}, false)
 				Expect(err).ToNot(HaveOccurred())
 
 				err = env.Tree.Propagate(env.Ctx, file, 0)
@@ -318,7 +318,7 @@ var _ = Describe("Tree", func() {
 					OpaqueId:  dir.ID,
 				})
 				Expect(err).ToNot(HaveOccurred())
-				riAfter, err := dir.AsResourceInfo(env.Ctx, &perms, []string{}, []string{}, false)
+				riAfter, err := dir.AsResourceInfo(env.Ctx, perms, []string{}, []string{}, false)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(riAfter.Etag).ToNot(Equal(riBefore.Etag))
 			})

--- a/pkg/storage/utils/decomposedfs/upload_async_test.go
+++ b/pkg/storage/utils/decomposedfs/upload_async_test.go
@@ -160,7 +160,7 @@ var _ = Describe("Async file uploads", Ordered, func() {
 
 		// for this test we don't care about permissions
 		pmock.On("AssemblePermissions", mock.Anything, mock.Anything).
-			Return(provider.ResourcePermissions{
+			Return(&provider.ResourcePermissions{
 				Stat:               true,
 				GetQuota:           true,
 				InitiateFileUpload: true,

--- a/pkg/storage/utils/decomposedfs/upload_async_test.go
+++ b/pkg/storage/utils/decomposedfs/upload_async_test.go
@@ -147,7 +147,7 @@ var _ = Describe("Async file uploads", Ordered, func() {
 		permissionsSelector = pool.GetSelector[cs3permissions.PermissionsAPIClient](
 			"PermissionsSelector",
 			"any",
-			func(cc *grpc.ClientConn) cs3permissions.PermissionsAPIClient {
+			func(cc grpc.ClientConnInterface) cs3permissions.PermissionsAPIClient {
 				return cs3permissionsclient
 			},
 		)

--- a/pkg/storage/utils/decomposedfs/upload_test.go
+++ b/pkg/storage/utils/decomposedfs/upload_test.go
@@ -130,7 +130,7 @@ var _ = Describe("File uploads", func() {
 		cs3permissionsclient.On("CheckPermission", mock.Anything, mock.Anything, mock.Anything).Return(&cs3permissions.CheckPermissionResponse{
 			Status: &v1beta11.Status{Code: v1beta11.Code_CODE_OK},
 		}, nil)
-		pmock.On("AssemblePermissions", mock.Anything, mock.Anything, mock.Anything).Return(provider.ResourcePermissions{
+		pmock.On("AssemblePermissions", mock.Anything, mock.Anything, mock.Anything).Return(&provider.ResourcePermissions{
 			Stat:     true,
 			AddGrant: true,
 		}, nil).Times(1)
@@ -155,7 +155,7 @@ var _ = Describe("File uploads", func() {
 
 	Context("the user's quota is exceeded", func() {
 		BeforeEach(func() {
-			pmock.On("AssemblePermissions", mock.Anything, mock.Anything, mock.Anything).Return(provider.ResourcePermissions{
+			pmock.On("AssemblePermissions", mock.Anything, mock.Anything, mock.Anything).Return(&provider.ResourcePermissions{
 				Stat:     true,
 				GetQuota: true,
 			}, nil)
@@ -175,7 +175,7 @@ var _ = Describe("File uploads", func() {
 
 	Context("the user has insufficient permissions", func() {
 		BeforeEach(func() {
-			pmock.On("AssemblePermissions", mock.Anything, mock.Anything, mock.Anything).Return(provider.ResourcePermissions{
+			pmock.On("AssemblePermissions", mock.Anything, mock.Anything, mock.Anything).Return(&provider.ResourcePermissions{
 				Stat: true,
 			}, nil)
 		})
@@ -197,7 +197,7 @@ var _ = Describe("File uploads", func() {
 			Expect(err).ToNot(HaveOccurred())
 			err = h.SetXattrString(ctx, prefixes.SpaceNameAttr, "username")
 			Expect(err).ToNot(HaveOccurred())
-			pmock.On("AssemblePermissions", mock.Anything, mock.Anything, mock.Anything).Return(provider.ResourcePermissions{
+			pmock.On("AssemblePermissions", mock.Anything, mock.Anything, mock.Anything).Return(&provider.ResourcePermissions{
 				Stat: true,
 			}, nil)
 		})
@@ -214,7 +214,7 @@ var _ = Describe("File uploads", func() {
 	Context("with sufficient permissions", func() {
 		BeforeEach(func() {
 			pmock.On("AssemblePermissions", mock.Anything, mock.Anything).
-				Return(provider.ResourcePermissions{
+				Return(&provider.ResourcePermissions{
 					Stat:               true,
 					GetQuota:           true,
 					InitiateFileUpload: true,

--- a/pkg/storage/utils/decomposedfs/upload_test.go
+++ b/pkg/storage/utils/decomposedfs/upload_test.go
@@ -111,7 +111,7 @@ var _ = Describe("File uploads", func() {
 		permissionsSelector = pool.GetSelector[cs3permissions.PermissionsAPIClient](
 			"PermissionsSelector",
 			"any",
-			func(cc *grpc.ClientConn) cs3permissions.PermissionsAPIClient {
+			func(cc grpc.ClientConnInterface) cs3permissions.PermissionsAPIClient {
 				return cs3permissionsclient
 			},
 		)

--- a/pkg/storage/utils/decomposedfs/usermapper/mocks/Mapper.go
+++ b/pkg/storage/utils/decomposedfs/usermapper/mocks/Mapper.go
@@ -39,69 +39,6 @@ func (_m *Mapper) EXPECT() *Mapper_Expecter {
 	return &Mapper_Expecter{mock: &_m.Mock}
 }
 
-// MapUser provides a mock function with given fields: username
-func (_m *Mapper) MapUser(username string) (int, int, error) {
-	ret := _m.Called(username)
-
-	if len(ret) == 0 {
-		panic("no return value specified for MapUser")
-	}
-
-	var r0 int
-	var r1 int
-	var r2 error
-	if rf, ok := ret.Get(0).(func(string) (int, int, error)); ok {
-		return rf(username)
-	}
-	if rf, ok := ret.Get(0).(func(string) int); ok {
-		r0 = rf(username)
-	} else {
-		r0 = ret.Get(0).(int)
-	}
-
-	if rf, ok := ret.Get(1).(func(string) int); ok {
-		r1 = rf(username)
-	} else {
-		r1 = ret.Get(1).(int)
-	}
-
-	if rf, ok := ret.Get(2).(func(string) error); ok {
-		r2 = rf(username)
-	} else {
-		r2 = ret.Error(2)
-	}
-
-	return r0, r1, r2
-}
-
-// Mapper_MapUser_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'MapUser'
-type Mapper_MapUser_Call struct {
-	*mock.Call
-}
-
-// MapUser is a helper method to define mock.On call
-//   - username string
-func (_e *Mapper_Expecter) MapUser(username interface{}) *Mapper_MapUser_Call {
-	return &Mapper_MapUser_Call{Call: _e.mock.On("MapUser", username)}
-}
-
-func (_c *Mapper_MapUser_Call) Run(run func(username string)) *Mapper_MapUser_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string))
-	})
-	return _c
-}
-
-func (_c *Mapper_MapUser_Call) Return(_a0 int, _a1 int, _a2 error) *Mapper_MapUser_Call {
-	_c.Call.Return(_a0, _a1, _a2)
-	return _c
-}
-
-func (_c *Mapper_MapUser_Call) RunAndReturn(run func(string) (int, int, error)) *Mapper_MapUser_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // RunInBaseScope provides a mock function with given fields: f
 func (_m *Mapper) RunInBaseScope(f func() error) error {
 	ret := _m.Called(f)

--- a/pkg/storage/utils/grants/grants.go
+++ b/pkg/storage/utils/grants/grants.go
@@ -24,14 +24,14 @@ import (
 
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	"github.com/cs3org/reva/v2/pkg/storage/utils/acl"
-	"github.com/google/go-cmp/cmp"
+	"google.golang.org/protobuf/proto"
 )
 
 // GetACLPerm generates a string representation of CS3APIs' ResourcePermissions
 // TODO(labkode): fine grained permission controls.
 func GetACLPerm(set *provider.ResourcePermissions) (string, error) {
 	// resource permission is denied
-	if cmp.Equal(provider.ResourcePermissions{}, *set, ignoreProtobufXxx()) {
+	if proto.Equal(&provider.ResourcePermissions{}, set) {
 		return "!r!w!x!m!u!d", nil
 	}
 
@@ -135,19 +135,10 @@ func GetGranteeType(aclType string) provider.GranteeType {
 
 // PermissionsEqual returns true if the permissions are equal
 func PermissionsEqual(p1, p2 *provider.ResourcePermissions) bool {
-	return p1 != nil && p2 != nil && cmp.Equal(*p1, *p2, ignoreProtobufXxx())
+	return p1 != nil && p2 != nil && proto.Equal(p1, p2)
 }
 
 // GranteeEqual returns true if the grantee are equal
 func GranteeEqual(g1, g2 *provider.Grantee) bool {
-	return g1 != nil && g2 != nil && cmp.Equal(*g1, *g2, ignoreProtobufXxx())
-}
-
-func ignoreProtobufXxx() cmp.Option {
-	return cmp.FilterPath(
-		func(path cmp.Path) bool {
-			return strings.HasPrefix(path.String(), "XXX")
-		},
-		cmp.Ignore(),
-	)
+	return g1 != nil && g2 != nil && proto.Equal(g1, g2)
 }

--- a/pkg/storage/utils/metadata/cs3.go
+++ b/pkg/storage/utils/metadata/cs3.go
@@ -98,7 +98,7 @@ func (cs3 *CS3) Init(ctx context.Context, spaceid string) (err error) {
 	ctx, span := tracer.Start(ctx, "Init")
 	defer span.End()
 
-	client, err := cs3.providerClient()
+	client, err := cs3.spacesClient()
 	if err != nil {
 		return err
 	}
@@ -514,6 +514,10 @@ func (cs3 *CS3) ResolveSymlink(ctx context.Context, name string) (string, error)
 
 func (cs3 *CS3) providerClient() (provider.ProviderAPIClient, error) {
 	return pool.GetStorageProviderServiceClient(cs3.providerAddr)
+}
+
+func (cs3 *CS3) spacesClient() (provider.SpacesAPIClient, error) {
+	return pool.GetSpacesProviderServiceClient(cs3.providerAddr)
 }
 
 func (cs3 *CS3) getAuthContext(ctx context.Context) (context.Context, error) {

--- a/pkg/storage/utils/middleware/middleware.go
+++ b/pkg/storage/utils/middleware/middleware.go
@@ -334,7 +334,7 @@ func (f *FS) InitiateUpload(ctx context.Context, ref *provider.Reference, upload
 	return res0, res1
 }
 
-func (f *FS) Upload(ctx context.Context, req storage.UploadRequest, uploadFunc storage.UploadFinishedFunc) (provider.ResourceInfo, error) {
+func (f *FS) Upload(ctx context.Context, req storage.UploadRequest, uploadFunc storage.UploadFinishedFunc) (*provider.ResourceInfo, error) {
 	var (
 		err     error
 		unhook  UnHook
@@ -343,7 +343,7 @@ func (f *FS) Upload(ctx context.Context, req storage.UploadRequest, uploadFunc s
 	for _, hook := range f.hooks {
 		ctx, unhook, err = hook("Upload", ctx, req.Ref.GetResourceId().GetSpaceId())
 		if err != nil {
-			return provider.ResourceInfo{}, err
+			return &provider.ResourceInfo{}, err
 		}
 		if unhook != nil {
 			unhooks = append(unhooks, unhook)
@@ -354,7 +354,7 @@ func (f *FS) Upload(ctx context.Context, req storage.UploadRequest, uploadFunc s
 
 	for _, unhook := range unhooks {
 		if err := unhook(); err != nil {
-			return provider.ResourceInfo{}, err
+			return &provider.ResourceInfo{}, err
 		}
 	}
 

--- a/pkg/storage/utils/templates/templates.go
+++ b/pkg/storage/utils/templates/templates.go
@@ -162,7 +162,7 @@ func newSpaceData(u *userpb.User, st, n, id string) *SpaceData {
 func newResourceData(i *providerv1beta1.ResourceInfo) *ResourceData {
 	rd := &ResourceData{
 		ResourceInfo: i,
-		ResourceID:   storagespace.FormatResourceID(*i.Id),
+		ResourceID:   storagespace.FormatResourceID(i.Id),
 	}
 	return rd
 }

--- a/pkg/storagespace/storagespace.go
+++ b/pkg/storagespace/storagespace.go
@@ -74,7 +74,7 @@ func SplitStorageID(sid string) (storageID, spaceID string) {
 // FormatResourceID converts a ResourceId into the string format.
 // The result format will look like:
 // <storageid>$<spaceid>!<opaqueid>
-func FormatResourceID(sid provider.ResourceId) string {
+func FormatResourceID(sid *provider.ResourceId) string {
 	if sid.OpaqueId == "" {
 		return FormatStorageID(sid.StorageId, sid.SpaceId)
 	}
@@ -140,15 +140,15 @@ func FormatReference(ref *provider.Reference) (string, error) {
 	if ref == nil || ref.ResourceId == nil || ref.ResourceId.SpaceId == "" {
 		return "", ErrInvalidSpaceReference
 	}
-	ssid := FormatResourceID(*ref.ResourceId)
+	ssid := FormatResourceID(ref.ResourceId)
 	return path.Join(ssid, ref.Path), nil
 }
 
 // UpdateLegacyResourceID checks if the given resource id contains a correct triple and will convert legacy ids without a spaceid
 // by splitting the storageid.
-func UpdateLegacyResourceID(id provider.ResourceId) provider.ResourceId {
+func UpdateLegacyResourceID(id *provider.ResourceId) *provider.ResourceId {
 	if storageid, spaceid := SplitStorageID(id.StorageId); storageid != "" && id.SpaceId == "" {
-		return provider.ResourceId{
+		return &provider.ResourceId{
 			StorageId: storageid,
 			SpaceId:   spaceid,
 			OpaqueId:  id.OpaqueId,

--- a/pkg/storagespace/storagespace_test.go
+++ b/pkg/storagespace/storagespace_test.go
@@ -66,27 +66,27 @@ func TestSplitStorageID(t *testing.T) {
 func TestParseID(t *testing.T) {
 	tests := []struct {
 		input       string
-		expected    provider.ResourceId
+		expected    *provider.ResourceId
 		expectedErr error
 	}{
 		{
 			"spaceid" + _idDelimiter + "opaqueid",
-			provider.ResourceId{SpaceId: "spaceid", OpaqueId: "opaqueid"},
+			&provider.ResourceId{SpaceId: "spaceid", OpaqueId: "opaqueid"},
 			nil,
 		},
 		{
 			"storageid" + _storageIDDelimiter + "spaceid" + _idDelimiter + "opaqueid",
-			provider.ResourceId{StorageId: "storageid", SpaceId: "spaceid", OpaqueId: "opaqueid"},
+			&provider.ResourceId{StorageId: "storageid", SpaceId: "spaceid", OpaqueId: "opaqueid"},
 			nil,
 		},
 		{
 			"",
-			provider.ResourceId{},
+			&provider.ResourceId{},
 			ErrInvalidSpaceID,
 		},
 		{
 			"spaceid",
-			provider.ResourceId{SpaceId: "spaceid"},
+			&provider.ResourceId{SpaceId: "spaceid"},
 			nil,
 		},
 	}
@@ -111,7 +111,7 @@ func TestParseID(t *testing.T) {
 
 func TestFormatResourceID(t *testing.T) {
 	expected := "spaceid" + _idDelimiter + "opaqueid"
-	wrapped := FormatResourceID(provider.ResourceId{SpaceId: "spaceid", OpaqueId: "opaqueid"})
+	wrapped := FormatResourceID(&provider.ResourceId{SpaceId: "spaceid", OpaqueId: "opaqueid"})
 
 	if wrapped != expected {
 		t.Errorf("wrapped id doesn't have the expected format: got %s expected %s", wrapped, expected)
@@ -313,29 +313,29 @@ func TestFormatAndParseReference(t *testing.T) {
 			t.Errorf("failed to parse space reference: %s error: %s", formatted, err)
 		}
 		if !(utils.ResourceIDEqual(parsed.ResourceId, tt.expected.ResourceId) && parsed.Path == tt.expected.Path) {
-			t.Errorf("Formatted then parsed references don't match the original got: %v expected %v", parsed, tt.expected)
+			t.Errorf("Formatted then parsed references don't match the original got: %s expected %s", parsed.String(), tt.expected.String())
 		}
 	}
 }
 
 func TestUpdateLegacyResourceID(t *testing.T) {
 	tests := []struct {
-		orig     provider.ResourceId
-		expected provider.ResourceId
+		orig     *provider.ResourceId
+		expected *provider.ResourceId
 	}{
 		{
-			orig:     provider.ResourceId{StorageId: "storageid", SpaceId: "spaceid", OpaqueId: "opaqueid"},
-			expected: provider.ResourceId{StorageId: "storageid", SpaceId: "spaceid", OpaqueId: "opaqueid"},
+			orig:     &provider.ResourceId{StorageId: "storageid", SpaceId: "spaceid", OpaqueId: "opaqueid"},
+			expected: &provider.ResourceId{StorageId: "storageid", SpaceId: "spaceid", OpaqueId: "opaqueid"},
 		},
 		{
-			orig:     provider.ResourceId{StorageId: "storageid$spaceid", SpaceId: "", OpaqueId: "opaqueid"},
-			expected: provider.ResourceId{StorageId: "storageid", SpaceId: "spaceid", OpaqueId: "opaqueid"},
+			orig:     &provider.ResourceId{StorageId: "storageid$spaceid", SpaceId: "", OpaqueId: "opaqueid"},
+			expected: &provider.ResourceId{StorageId: "storageid", SpaceId: "spaceid", OpaqueId: "opaqueid"},
 		},
 	}
 
 	for _, tt := range tests {
 		updated := UpdateLegacyResourceID(tt.orig)
-		if !(utils.ResourceIDEqual(&updated, &tt.expected)) {
+		if !(utils.ResourceIDEqual(updated, tt.expected)) {
 			t.Errorf("Updating resourceid failed, got: %v expected %v", updated, tt.expected)
 		}
 	}

--- a/pkg/user/manager/demo/demo.go
+++ b/pkg/user/manager/demo/demo.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cs3org/reva/v2/pkg/errtypes"
 	"github.com/cs3org/reva/v2/pkg/user"
 	"github.com/cs3org/reva/v2/pkg/user/manager/registry"
+	"google.golang.org/protobuf/proto"
 )
 
 func init() {
@@ -57,11 +58,11 @@ func (m *manager) Configure(ml map[string]interface{}) error {
 func (m *manager) GetUser(ctx context.Context, uid *userpb.UserId, skipFetchingGroups bool) (*userpb.User, error) {
 	if user, ok := m.catalog[uid.OpaqueId]; ok {
 		if uid.Idp == "" || user.Id.Idp == uid.Idp {
-			u := *user
+			u := proto.Clone(user).(*userpb.User)
 			if skipFetchingGroups {
 				u.Groups = nil
 			}
-			return &u, nil
+			return u, nil
 		}
 	}
 	return nil, errtypes.NotFound(uid.OpaqueId)
@@ -70,11 +71,11 @@ func (m *manager) GetUser(ctx context.Context, uid *userpb.UserId, skipFetchingG
 func (m *manager) GetUserByClaim(ctx context.Context, claim, value string, skipFetchingGroups bool) (*userpb.User, error) {
 	for _, u := range m.catalog {
 		if userClaim, err := extractClaim(u, claim); err == nil && value == userClaim {
-			user := *u
+			user := proto.Clone(u).(*userpb.User)
 			if skipFetchingGroups {
 				user.Groups = nil
 			}
-			return &user, nil
+			return user, nil
 		}
 	}
 	return nil, errtypes.NotFound(value)
@@ -105,11 +106,11 @@ func (m *manager) FindUsers(ctx context.Context, query string, skipFetchingGroup
 	users := []*userpb.User{}
 	for _, u := range m.catalog {
 		if userContains(u, query) {
-			user := *u
+			user := proto.Clone(u).(*userpb.User)
 			if skipFetchingGroups {
 				user.Groups = nil
 			}
-			users = append(users, &user)
+			users = append(users, user)
 		}
 	}
 	return users, nil

--- a/pkg/user/manager/demo/demo_test.go
+++ b/pkg/user/manager/demo/demo_test.go
@@ -25,6 +25,9 @@ import (
 
 	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	"github.com/cs3org/reva/v2/pkg/errtypes"
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/testing/protocmp"
 )
 
 var ctx = context.Background()
@@ -58,7 +61,7 @@ func TestUserManager(t *testing.T) {
 
 	// positive test GetUserByClaim by uid
 	resUserByUID, _ := manager.GetUserByClaim(ctx, "uid", "123", false)
-	if !reflect.DeepEqual(resUserByUID, userEinstein) {
+	if !proto.Equal(resUserByUID, userEinstein) {
 		t.Fatalf("user differs: expected=%v got=%v", userEinstein, resUserByUID)
 	}
 
@@ -71,13 +74,13 @@ func TestUserManager(t *testing.T) {
 
 	// positive test GetUserByClaim by mail
 	resUserByEmail, _ := manager.GetUserByClaim(ctx, "mail", "einstein@example.org", false)
-	if !reflect.DeepEqual(resUserByEmail, userEinstein) {
+	if !proto.Equal(resUserByEmail, userEinstein) {
 		t.Fatalf("user differs: expected=%v got=%v", userEinstein, resUserByEmail)
 	}
 
 	// positive test GetUserByClaim by uid without groups
 	resUserByUIDWithoutGroups, _ := manager.GetUserByClaim(ctx, "uid", "123", true)
-	if !reflect.DeepEqual(resUserByUIDWithoutGroups, userEinsteinWithoutGroups) {
+	if !proto.Equal(resUserByUIDWithoutGroups, userEinsteinWithoutGroups) {
 		t.Fatalf("user differs: expected=%v got=%v", userEinsteinWithoutGroups, resUserByUIDWithoutGroups)
 	}
 
@@ -96,7 +99,7 @@ func TestUserManager(t *testing.T) {
 
 	// test FindUsers
 	resUser, _ := manager.FindUsers(ctx, "einstein", false)
-	if !reflect.DeepEqual(resUser, []*userpb.User{userEinstein}) {
+	if !cmp.Equal(resUser, []*userpb.User{userEinstein}, protocmp.Transform()) {
 		t.Fatalf("user differs: expected=%v got=%v", []*userpb.User{userEinstein}, resUser)
 	}
 

--- a/pkg/user/manager/json/json.go
+++ b/pkg/user/manager/json/json.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cs3org/reva/v2/pkg/user/manager/registry"
 	"github.com/mitchellh/mapstructure"
 	"github.com/pkg/errors"
+	"google.golang.org/protobuf/proto"
 
 	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	"github.com/cs3org/reva/v2/pkg/errtypes"
@@ -97,11 +98,11 @@ func (m *manager) Configure(ml map[string]interface{}) error {
 func (m *manager) GetUser(ctx context.Context, uid *userpb.UserId, skipFetchingGroups bool) (*userpb.User, error) {
 	for _, u := range m.users {
 		if (u.Id.GetOpaqueId() == uid.OpaqueId || u.Username == uid.OpaqueId) && (uid.Idp == "" || uid.Idp == u.Id.GetIdp()) {
-			user := *u
+			user := proto.Clone(u).(*userpb.User)
 			if skipFetchingGroups {
 				user.Groups = nil
 			}
-			return &user, nil
+			return user, nil
 		}
 	}
 	return nil, errtypes.NotFound(uid.OpaqueId)
@@ -110,11 +111,11 @@ func (m *manager) GetUser(ctx context.Context, uid *userpb.UserId, skipFetchingG
 func (m *manager) GetUserByClaim(ctx context.Context, claim, value string, skipFetchingGroups bool) (*userpb.User, error) {
 	for _, u := range m.users {
 		if userClaim, err := extractClaim(u, claim); err == nil && value == userClaim {
-			user := *u
+			user := proto.Clone(u).(*userpb.User)
 			if skipFetchingGroups {
 				user.Groups = nil
 			}
-			return &user, nil
+			return user, nil
 		}
 	}
 	return nil, errtypes.NotFound(value)
@@ -147,11 +148,11 @@ func (m *manager) FindUsers(ctx context.Context, query string, skipFetchingGroup
 	users := []*userpb.User{}
 	for _, u := range m.users {
 		if userContains(u, query) {
-			user := *u
+			user := proto.Clone(u).(*userpb.User)
 			if skipFetchingGroups {
 				user.Groups = nil
 			}
-			users = append(users, &user)
+			users = append(users, user)
 		}
 	}
 	return users, nil

--- a/pkg/user/manager/json/json_test.go
+++ b/pkg/user/manager/json/json_test.go
@@ -26,6 +26,7 @@ import (
 
 	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	"github.com/cs3org/reva/v2/pkg/errtypes"
+	"google.golang.org/protobuf/proto"
 )
 
 var ctx = context.Background()
@@ -114,7 +115,7 @@ func TestUserManager(t *testing.T) {
 
 	// positive test GetUserByClaim by mail
 	resUserByEmail, _ := manager.GetUserByClaim(ctx, "mail", "einstein@example.org", false)
-	if !reflect.DeepEqual(resUserByEmail, userEinstein) {
+	if !proto.Equal(resUserByEmail, userEinstein) {
 		t.Fatalf("user differs: expected=%v got=%v", userEinstein, resUserByEmail)
 	}
 
@@ -127,7 +128,7 @@ func TestUserManager(t *testing.T) {
 
 	// positive test GetUserByClaim by mail without groups
 	resUserByEmailWithoutGroups, _ := manager.GetUserByClaim(ctx, "mail", "einstein@example.org", true)
-	if !reflect.DeepEqual(resUserByEmailWithoutGroups, userEinsteinWithoutGroups) {
+	if !proto.Equal(resUserByEmailWithoutGroups, userEinsteinWithoutGroups) {
 		t.Fatalf("user differs: expected=%v got=%v", userEinsteinWithoutGroups, resUserByEmailWithoutGroups)
 	}
 

--- a/pkg/user/manager/nextcloud/nextcloud_test.go
+++ b/pkg/user/manager/nextcloud/nextcloud_test.go
@@ -23,6 +23,7 @@ import (
 	"os"
 
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/protobuf/testing/protocmp"
 
 	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 
@@ -206,7 +207,7 @@ var _ = Describe("Nextcloud", func() {
 			users, err := um.FindUsers(ctx, "some-query", false)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(len(users)).To(Equal(1))
-			Expect(*users[0]).To(Equal(userpb.User{
+			Expect(users[0]).To(BeComparableTo(&userpb.User{
 				Id: &userpb.UserId{
 					Idp:      "some-idp",
 					OpaqueId: "some-opaque-user-id",
@@ -220,7 +221,7 @@ var _ = Describe("Nextcloud", func() {
 				Opaque:       nil,
 				UidNumber:    0,
 				GidNumber:    0,
-			}))
+			}, protocmp.Transform()))
 			checkCalled(called, `POST /apps/sciencemesh/~tester/api/user/FindUsers some-query`)
 		})
 	})

--- a/tests/cs3mocks/mocks/GatewayAPIClient.go
+++ b/tests/cs3mocks/mocks/GatewayAPIClient.go
@@ -4440,6 +4440,80 @@ func (_c *GatewayAPIClient_ListContainerStream_Call) RunAndReturn(run func(conte
 	return _c
 }
 
+// ListExistingReceivedShares provides a mock function with given fields: ctx, in, opts
+func (_m *GatewayAPIClient) ListExistingReceivedShares(ctx context.Context, in *collaborationv1beta1.ListReceivedSharesRequest, opts ...grpc.CallOption) (*gatewayv1beta1.ListExistingReceivedSharesResponse, error) {
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx, in)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ListExistingReceivedShares")
+	}
+
+	var r0 *gatewayv1beta1.ListExistingReceivedSharesResponse
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, *collaborationv1beta1.ListReceivedSharesRequest, ...grpc.CallOption) (*gatewayv1beta1.ListExistingReceivedSharesResponse, error)); ok {
+		return rf(ctx, in, opts...)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *collaborationv1beta1.ListReceivedSharesRequest, ...grpc.CallOption) *gatewayv1beta1.ListExistingReceivedSharesResponse); ok {
+		r0 = rf(ctx, in, opts...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*gatewayv1beta1.ListExistingReceivedSharesResponse)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *collaborationv1beta1.ListReceivedSharesRequest, ...grpc.CallOption) error); ok {
+		r1 = rf(ctx, in, opts...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// GatewayAPIClient_ListExistingReceivedShares_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListExistingReceivedShares'
+type GatewayAPIClient_ListExistingReceivedShares_Call struct {
+	*mock.Call
+}
+
+// ListExistingReceivedShares is a helper method to define mock.On call
+//   - ctx context.Context
+//   - in *collaborationv1beta1.ListReceivedSharesRequest
+//   - opts ...grpc.CallOption
+func (_e *GatewayAPIClient_Expecter) ListExistingReceivedShares(ctx interface{}, in interface{}, opts ...interface{}) *GatewayAPIClient_ListExistingReceivedShares_Call {
+	return &GatewayAPIClient_ListExistingReceivedShares_Call{Call: _e.mock.On("ListExistingReceivedShares",
+		append([]interface{}{ctx, in}, opts...)...)}
+}
+
+func (_c *GatewayAPIClient_ListExistingReceivedShares_Call) Run(run func(ctx context.Context, in *collaborationv1beta1.ListReceivedSharesRequest, opts ...grpc.CallOption)) *GatewayAPIClient_ListExistingReceivedShares_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		variadicArgs := make([]grpc.CallOption, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(grpc.CallOption)
+			}
+		}
+		run(args[0].(context.Context), args[1].(*collaborationv1beta1.ListReceivedSharesRequest), variadicArgs...)
+	})
+	return _c
+}
+
+func (_c *GatewayAPIClient_ListExistingReceivedShares_Call) Return(_a0 *gatewayv1beta1.ListExistingReceivedSharesResponse, _a1 error) *GatewayAPIClient_ListExistingReceivedShares_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *GatewayAPIClient_ListExistingReceivedShares_Call) RunAndReturn(run func(context.Context, *collaborationv1beta1.ListReceivedSharesRequest, ...grpc.CallOption) (*gatewayv1beta1.ListExistingReceivedSharesResponse, error)) *GatewayAPIClient_ListExistingReceivedShares_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ListFileVersions provides a mock function with given fields: ctx, in, opts
 func (_m *GatewayAPIClient) ListFileVersions(ctx context.Context, in *providerv1beta1.ListFileVersionsRequest, opts ...grpc.CallOption) (*providerv1beta1.ListFileVersionsResponse, error) {
 	_va := make([]interface{}, len(opts))

--- a/tests/integration/grpc/storageprovider_test.go
+++ b/tests/integration/grpc/storageprovider_test.go
@@ -85,7 +85,7 @@ var _ = Describe("storage providers", func() {
 
 		ctx            context.Context
 		providerClient storagep.ProviderAPIClient
-		spacesClient   storagep.SpaceAPIClient
+		spacesClient   storagep.SpacesAPIClient
 		user           = &userpb.User{
 			Id: &userpb.UserId{
 				Idp:      "0.0.0.0:19000",
@@ -121,6 +121,7 @@ var _ = Describe("storage providers", func() {
 		revads, err = startRevads(dependencies, variables)
 		Expect(err).ToNot(HaveOccurred())
 		providerClient, err = pool.GetStorageProviderServiceClient(revads["storage"].GrpcAddress)
+		Expect(err).ToNot(HaveOccurred())
 		spacesClient, err = pool.GetSpacesProviderServiceClient(revads["storage"].GrpcAddress)
 		Expect(err).ToNot(HaveOccurred())
 	})

--- a/tests/integration/grpc/storageprovider_test.go
+++ b/tests/integration/grpc/storageprovider_test.go
@@ -83,9 +83,10 @@ var _ = Describe("storage providers", func() {
 		variables    = map[string]string{}
 		revads       = map[string]*Revad{}
 
-		ctx           context.Context
-		serviceClient storagep.ProviderAPIClient
-		user          = &userpb.User{
+		ctx            context.Context
+		providerClient storagep.ProviderAPIClient
+		spacesClient   storagep.SpaceAPIClient
+		user           = &userpb.User{
 			Id: &userpb.UserId{
 				Idp:      "0.0.0.0:19000",
 				OpaqueId: "f7fbf8c8-139b-4376-b307-cf0a8c2d0d9c",
@@ -119,7 +120,8 @@ var _ = Describe("storage providers", func() {
 
 		revads, err = startRevads(dependencies, variables)
 		Expect(err).ToNot(HaveOccurred())
-		serviceClient, err = pool.GetStorageProviderServiceClient(revads["storage"].GrpcAddress)
+		providerClient, err = pool.GetStorageProviderServiceClient(revads["storage"].GrpcAddress)
+		spacesClient, err = pool.GetSpacesProviderServiceClient(revads["storage"].GrpcAddress)
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -132,11 +134,11 @@ var _ = Describe("storage providers", func() {
 	assertCreateHome := func(provider string) {
 		It("creates a home directory", func() {
 			homeRef := ref(provider, homePath)
-			statRes, err := serviceClient.Stat(ctx, &storagep.StatRequest{Ref: homeRef})
+			statRes, err := providerClient.Stat(ctx, &storagep.StatRequest{Ref: homeRef})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(statRes.Status.Code).To(Equal(rpcv1beta1.Code_CODE_NOT_FOUND))
 
-			res, err := serviceClient.CreateStorageSpace(ctx, &storagep.CreateStorageSpaceRequest{
+			res, err := spacesClient.CreateStorageSpace(ctx, &storagep.CreateStorageSpaceRequest{
 				Owner: user,
 				Type:  "personal",
 				Name:  user.Id.OpaqueId,
@@ -144,7 +146,7 @@ var _ = Describe("storage providers", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(res.Status.Code).To(Equal(rpcv1beta1.Code_CODE_OK))
 
-			statRes, err = serviceClient.Stat(ctx, &storagep.StatRequest{Ref: ref(provider, homePath)})
+			statRes, err = providerClient.Stat(ctx, &storagep.StatRequest{Ref: ref(provider, homePath)})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(statRes.Status.Code).To(Equal(rpcv1beta1.Code_CODE_OK))
 
@@ -157,15 +159,15 @@ var _ = Describe("storage providers", func() {
 	assertCreateContainer := func(provider string) {
 		It("creates a new directory", func() {
 			newRef := ref(provider, "/newdir")
-			_, err := serviceClient.Stat(ctx, &storagep.StatRequest{Ref: newRef})
+			_, err := providerClient.Stat(ctx, &storagep.StatRequest{Ref: newRef})
 			Expect(err).ToNot(HaveOccurred())
 			// Expect(statRes.Status.Code).To(Equal(rpcv1beta1.Code_CODE_NOT_FOUND))
 
-			res, err := serviceClient.CreateContainer(ctx, &storagep.CreateContainerRequest{Ref: newRef})
+			res, err := providerClient.CreateContainer(ctx, &storagep.CreateContainerRequest{Ref: newRef})
 			Expect(res.Status.Code).To(Equal(rpcv1beta1.Code_CODE_OK))
 			Expect(err).ToNot(HaveOccurred())
 
-			statRes, err := serviceClient.Stat(ctx, &storagep.StatRequest{Ref: newRef})
+			statRes, err := providerClient.Stat(ctx, &storagep.StatRequest{Ref: newRef})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(statRes.Status.Code).To(Equal(rpcv1beta1.Code_CODE_OK))
 		})
@@ -173,7 +175,7 @@ var _ = Describe("storage providers", func() {
 
 	assertListContainer := func(provider string) {
 		It("lists a directory", func() {
-			listRes, err := serviceClient.ListContainer(ctx, &storagep.ListContainerRequest{Ref: ref(provider, homePath)})
+			listRes, err := providerClient.ListContainer(ctx, &storagep.ListContainerRequest{Ref: ref(provider, homePath)})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(listRes.Status.Code).To(Equal(rpcv1beta1.Code_CODE_OK))
 
@@ -203,7 +205,7 @@ var _ = Describe("storage providers", func() {
 
 	assertFileVersions := func(provider string) {
 		It("lists file versions", func() {
-			listRes, err := serviceClient.ListFileVersions(ctx, &storagep.ListFileVersionsRequest{Ref: ref(provider, versionedFilePath)})
+			listRes, err := providerClient.ListFileVersions(ctx, &storagep.ListFileVersionsRequest{Ref: ref(provider, versionedFilePath)})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(listRes.Status.Code).To(Equal(rpcv1beta1.Code_CODE_OK))
 			Expect(len(listRes.Versions)).To(Equal(1))
@@ -213,14 +215,14 @@ var _ = Describe("storage providers", func() {
 		// FIXME flaky test?!?
 		It("restores a file version", func() {
 			vRef := ref(provider, versionedFilePath)
-			statRes, err := serviceClient.Stat(ctx, &storagep.StatRequest{Ref: vRef})
+			statRes, err := providerClient.Stat(ctx, &storagep.StatRequest{Ref: vRef})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(statRes.Status.Code).To(Equal(rpcv1beta1.Code_CODE_OK))
 			Expect(statRes.Info.Size).To(Equal(uint64(2))) // second version contains 2 bytes
 
-			listRes, err := serviceClient.ListFileVersions(ctx, &storagep.ListFileVersionsRequest{Ref: vRef})
+			listRes, err := providerClient.ListFileVersions(ctx, &storagep.ListFileVersionsRequest{Ref: vRef})
 			Expect(err).ToNot(HaveOccurred())
-			restoreRes, err := serviceClient.RestoreFileVersion(ctx,
+			restoreRes, err := providerClient.RestoreFileVersion(ctx,
 				&storagep.RestoreFileVersionRequest{
 					Ref: vRef,
 					Key: listRes.Versions[0].Key,
@@ -228,7 +230,7 @@ var _ = Describe("storage providers", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(restoreRes.Status.Code).To(Equal(rpcv1beta1.Code_CODE_OK))
 
-			statRes, err = serviceClient.Stat(ctx, &storagep.StatRequest{Ref: vRef})
+			statRes, err = providerClient.Stat(ctx, &storagep.StatRequest{Ref: vRef})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(statRes.Status.Code).To(Equal(rpcv1beta1.Code_CODE_OK))
 			Expect(statRes.Info.Size).To(Equal(uint64(1))) // initial version contains 1 byte
@@ -238,15 +240,15 @@ var _ = Describe("storage providers", func() {
 	assertDelete := func(provider string) {
 		It("deletes a directory", func() {
 			subdirRef := ref(provider, subdirPath)
-			statRes, err := serviceClient.Stat(ctx, &storagep.StatRequest{Ref: subdirRef})
+			statRes, err := providerClient.Stat(ctx, &storagep.StatRequest{Ref: subdirRef})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(statRes.Status.Code).To(Equal(rpcv1beta1.Code_CODE_OK))
 
-			res, err := serviceClient.Delete(ctx, &storagep.DeleteRequest{Ref: subdirRef})
+			res, err := providerClient.Delete(ctx, &storagep.DeleteRequest{Ref: subdirRef})
 			Expect(res.Status.Code).To(Equal(rpcv1beta1.Code_CODE_OK))
 			Expect(err).ToNot(HaveOccurred())
 
-			statRes, err = serviceClient.Stat(ctx, &storagep.StatRequest{Ref: subdirRef})
+			statRes, err = providerClient.Stat(ctx, &storagep.StatRequest{Ref: subdirRef})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(statRes.Status.Code).To(Equal(rpcv1beta1.Code_CODE_NOT_FOUND))
 		})
@@ -255,20 +257,20 @@ var _ = Describe("storage providers", func() {
 	assertMove := func(provider string) {
 		It("moves a directory", func() {
 			subdirRef := ref(provider, subdirPath)
-			statRes, err := serviceClient.Stat(ctx, &storagep.StatRequest{Ref: subdirRef})
+			statRes, err := providerClient.Stat(ctx, &storagep.StatRequest{Ref: subdirRef})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(statRes.Status.Code).To(Equal(rpcv1beta1.Code_CODE_OK))
 
 			targetRef := &storagep.Reference{ResourceId: subdirRef.ResourceId, Path: "/new_subdir"}
-			res, err := serviceClient.Move(ctx, &storagep.MoveRequest{Source: subdirRef, Destination: targetRef})
+			res, err := providerClient.Move(ctx, &storagep.MoveRequest{Source: subdirRef, Destination: targetRef})
 			Expect(res.Status.Code).To(Equal(rpcv1beta1.Code_CODE_OK))
 			Expect(err).ToNot(HaveOccurred())
 
-			statRes, err = serviceClient.Stat(ctx, &storagep.StatRequest{Ref: subdirRef})
+			statRes, err = providerClient.Stat(ctx, &storagep.StatRequest{Ref: subdirRef})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(statRes.Status.Code).To(Equal(rpcv1beta1.Code_CODE_NOT_FOUND))
 
-			statRes, err = serviceClient.Stat(ctx, &storagep.StatRequest{Ref: targetRef})
+			statRes, err = providerClient.Stat(ctx, &storagep.StatRequest{Ref: targetRef})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(statRes.Status.Code).To(Equal(rpcv1beta1.Code_CODE_OK))
 		})
@@ -277,11 +279,11 @@ var _ = Describe("storage providers", func() {
 	assertGetPath := func(provider string) {
 		It("gets the path to an ID", func() {
 			r := ref(provider, subdirPath)
-			statRes, err := serviceClient.Stat(ctx, &storagep.StatRequest{Ref: r})
+			statRes, err := providerClient.Stat(ctx, &storagep.StatRequest{Ref: r})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(statRes.Status.Code).To(Equal(rpcv1beta1.Code_CODE_OK))
 
-			res, err := serviceClient.GetPath(ctx, &storagep.GetPathRequest{ResourceId: statRes.Info.Id})
+			res, err := providerClient.GetPath(ctx, &storagep.GetPathRequest{ResourceId: statRes.Info.Id})
 			Expect(err).ToNot(HaveOccurred())
 
 			// TODO: FIXME both cases should work for all providers
@@ -297,7 +299,7 @@ var _ = Describe("storage providers", func() {
 		It("lists, adds and removes grants", func() {
 			By("there are no grants initially")
 			subdirRef := ref(provider, subdirPath)
-			listRes, err := serviceClient.ListGrants(ctx, &storagep.ListGrantsRequest{Ref: subdirRef})
+			listRes, err := providerClient.ListGrants(ctx, &storagep.ListGrantsRequest{Ref: subdirRef})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(len(listRes.Grants)).To(Equal(0))
 
@@ -318,12 +320,12 @@ var _ = Describe("storage providers", func() {
 					InitiateFileDownload: true,
 				},
 			}
-			addRes, err := serviceClient.AddGrant(ctx, &storagep.AddGrantRequest{Ref: subdirRef, Grant: grant})
+			addRes, err := providerClient.AddGrant(ctx, &storagep.AddGrantRequest{Ref: subdirRef, Grant: grant})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(addRes.Status.Code).To(Equal(rpcv1beta1.Code_CODE_OK))
 
 			By("listing the new grant")
-			listRes, err = serviceClient.ListGrants(ctx, &storagep.ListGrantsRequest{Ref: subdirRef})
+			listRes, err = providerClient.ListGrants(ctx, &storagep.ListGrantsRequest{Ref: subdirRef})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(len(listRes.Grants)).To(Equal(1))
 			readGrant := listRes.Grants[0]
@@ -334,12 +336,12 @@ var _ = Describe("storage providers", func() {
 
 			By("updating the grant")
 			grant.Permissions.Delete = true
-			updateRes, err := serviceClient.UpdateGrant(ctx, &storagep.UpdateGrantRequest{Ref: subdirRef, Grant: grant})
+			updateRes, err := providerClient.UpdateGrant(ctx, &storagep.UpdateGrantRequest{Ref: subdirRef, Grant: grant})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(updateRes.Status.Code).To(Equal(rpcv1beta1.Code_CODE_OK))
 
 			By("listing the update grant")
-			listRes, err = serviceClient.ListGrants(ctx, &storagep.ListGrantsRequest{Ref: subdirRef})
+			listRes, err = providerClient.ListGrants(ctx, &storagep.ListGrantsRequest{Ref: subdirRef})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(len(listRes.Grants)).To(Equal(1))
 			readGrant = listRes.Grants[0]
@@ -349,12 +351,12 @@ var _ = Describe("storage providers", func() {
 			Expect(readGrant.Permissions.InitiateFileDownload).To(BeTrue())
 
 			By("deleting a grant")
-			delRes, err := serviceClient.RemoveGrant(ctx, &storagep.RemoveGrantRequest{Ref: subdirRef, Grant: readGrant})
+			delRes, err := providerClient.RemoveGrant(ctx, &storagep.RemoveGrantRequest{Ref: subdirRef, Grant: readGrant})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(delRes.Status.Code).To(Equal(rpcv1beta1.Code_CODE_OK))
 
 			By("the grant is gone")
-			listRes, err = serviceClient.ListGrants(ctx, &storagep.ListGrantsRequest{Ref: subdirRef})
+			listRes, err = providerClient.ListGrants(ctx, &storagep.ListGrantsRequest{Ref: subdirRef})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(len(listRes.Grants)).To(Equal(0))
 		})
@@ -363,7 +365,7 @@ var _ = Describe("storage providers", func() {
 	assertUploads := func(provider string) {
 		It("returns upload URLs for simple and tus", func() {
 			fileRef := ref(provider, filePath)
-			res, err := serviceClient.InitiateFileUpload(ctx, &storagep.InitiateFileUploadRequest{Ref: fileRef})
+			res, err := providerClient.InitiateFileUpload(ctx, &storagep.InitiateFileUploadRequest{Ref: fileRef})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(res.Status.Code).To(Equal(rpcv1beta1.Code_CODE_OK))
 			Expect(len(res.Protocols)).To(Equal(2))
@@ -373,7 +375,7 @@ var _ = Describe("storage providers", func() {
 	assertDownloads := func(provider string) {
 		It("returns 'simple' download URLs", func() {
 			fileRef := ref(provider, filePath)
-			res, err := serviceClient.InitiateFileDownload(ctx, &storagep.InitiateFileDownloadRequest{Ref: fileRef})
+			res, err := providerClient.InitiateFileDownload(ctx, &storagep.InitiateFileDownloadRequest{Ref: fileRef})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(res.Status.Code).To(Equal(rpcv1beta1.Code_CODE_OK))
 			Expect(len(res.Protocols)).To(Equal(1))
@@ -384,13 +386,13 @@ var _ = Describe("storage providers", func() {
 		It("lists and restores resources", func() {
 			By("deleting an item")
 			subdirRef := ref(provider, subdirPath)
-			res, err := serviceClient.Delete(ctx, &storagep.DeleteRequest{Ref: subdirRef})
+			res, err := providerClient.Delete(ctx, &storagep.DeleteRequest{Ref: subdirRef})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(res.Status.Code).To(Equal(rpcv1beta1.Code_CODE_OK))
 
 			By("listing the recycle items")
 			homeRef := ref(provider, homePath)
-			listRes, err := serviceClient.ListRecycle(ctx, &storagep.ListRecycleRequest{Ref: homeRef})
+			listRes, err := providerClient.ListRecycle(ctx, &storagep.ListRecycleRequest{Ref: homeRef})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(listRes.Status.Code).To(Equal(rpcv1beta1.Code_CODE_OK))
 
@@ -399,11 +401,11 @@ var _ = Describe("storage providers", func() {
 			Expect(item.Ref.Path).To(Equal(subdirPath))
 
 			By("restoring a recycle item")
-			statRes, err := serviceClient.Stat(ctx, &storagep.StatRequest{Ref: subdirRef})
+			statRes, err := providerClient.Stat(ctx, &storagep.StatRequest{Ref: subdirRef})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(statRes.Status.Code).To(Equal(rpcv1beta1.Code_CODE_NOT_FOUND))
 
-			restoreRes, err := serviceClient.RestoreRecycleItem(ctx,
+			restoreRes, err := providerClient.RestoreRecycleItem(ctx,
 				&storagep.RestoreRecycleItemRequest{
 					Ref: homeRef,
 					Key: item.Key,
@@ -412,7 +414,7 @@ var _ = Describe("storage providers", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(restoreRes.Status.Code).To(Equal(rpcv1beta1.Code_CODE_OK))
 
-			statRes, err = serviceClient.Stat(ctx, &storagep.StatRequest{Ref: subdirRef})
+			statRes, err = providerClient.Stat(ctx, &storagep.StatRequest{Ref: subdirRef})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(statRes.Status.Code).To(Equal(rpcv1beta1.Code_CODE_OK))
 		})
@@ -423,12 +425,12 @@ var _ = Describe("storage providers", func() {
 			homeRef := ref(provider, homePath)
 
 			By("deleting an item")
-			res, err := serviceClient.Delete(ctx, &storagep.DeleteRequest{Ref: subdirRef})
+			res, err := providerClient.Delete(ctx, &storagep.DeleteRequest{Ref: subdirRef})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(res.Status.Code).To(Equal(rpcv1beta1.Code_CODE_OK))
 
 			By("listing the recycle items")
-			listRes, err := serviceClient.ListRecycle(ctx, &storagep.ListRecycleRequest{Ref: homeRef})
+			listRes, err := providerClient.ListRecycle(ctx, &storagep.ListRecycleRequest{Ref: homeRef})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(listRes.Status.Code).To(Equal(rpcv1beta1.Code_CODE_OK))
 
@@ -437,11 +439,11 @@ var _ = Describe("storage providers", func() {
 			Expect(item.Ref.Path).To(Equal(subdirPath))
 
 			By("restoring the item to a different location")
-			statRes, err := serviceClient.Stat(ctx, &storagep.StatRequest{Ref: restoreRef})
+			statRes, err := providerClient.Stat(ctx, &storagep.StatRequest{Ref: restoreRef})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(statRes.Status.Code).To(Equal(rpcv1beta1.Code_CODE_NOT_FOUND))
 
-			restoreRes, err := serviceClient.RestoreRecycleItem(ctx,
+			restoreRes, err := providerClient.RestoreRecycleItem(ctx,
 				&storagep.RestoreRecycleItemRequest{
 					Ref:        homeRef,
 					Key:        item.Key,
@@ -451,7 +453,7 @@ var _ = Describe("storage providers", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(restoreRes.Status.Code).To(Equal(rpcv1beta1.Code_CODE_OK))
 
-			statRes, err = serviceClient.Stat(ctx, &storagep.StatRequest{Ref: restoreRef})
+			statRes, err = providerClient.Stat(ctx, &storagep.StatRequest{Ref: restoreRef})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(statRes.Status.Code).To(Equal(rpcv1beta1.Code_CODE_OK))
 		})
@@ -461,12 +463,12 @@ var _ = Describe("storage providers", func() {
 			homeRef := ref(provider, homePath)
 
 			By("deleting an item")
-			res, err := serviceClient.Delete(ctx, &storagep.DeleteRequest{Ref: subdirRef})
+			res, err := providerClient.Delete(ctx, &storagep.DeleteRequest{Ref: subdirRef})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(res.Status.Code).To(Equal(rpcv1beta1.Code_CODE_OK))
 
 			By("listing recycle items")
-			listRes, err := serviceClient.ListRecycle(ctx, &storagep.ListRecycleRequest{Ref: homeRef})
+			listRes, err := providerClient.ListRecycle(ctx, &storagep.ListRecycleRequest{Ref: homeRef})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(listRes.Status.Code).To(Equal(rpcv1beta1.Code_CODE_OK))
 			Expect(len(listRes.RecycleItems)).To(Equal(1))
@@ -474,11 +476,11 @@ var _ = Describe("storage providers", func() {
 			By("purging a recycle item")
 			ref := listRes.RecycleItems[0].Ref
 			ref.ResourceId = homeRef.ResourceId
-			purgeRes, err := serviceClient.PurgeRecycle(ctx, &storagep.PurgeRecycleRequest{Ref: ref})
+			purgeRes, err := providerClient.PurgeRecycle(ctx, &storagep.PurgeRecycleRequest{Ref: ref})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(purgeRes.Status.Code).To(Equal(rpcv1beta1.Code_CODE_OK))
 
-			listRes, err = serviceClient.ListRecycle(ctx, &storagep.ListRecycleRequest{Ref: homeRef})
+			listRes, err = providerClient.ListRecycle(ctx, &storagep.ListRecycleRequest{Ref: homeRef})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(listRes.Status.Code).To(Equal(rpcv1beta1.Code_CODE_OK))
 			Expect(len(listRes.RecycleItems)).To(Equal(0))
@@ -493,12 +495,12 @@ var _ = Describe("storage providers", func() {
 			}
 
 			sharesRef := ref(provider, sharesPath)
-			listRes, err := serviceClient.ListContainer(ctx, &storagep.ListContainerRequest{Ref: sharesRef})
+			listRes, err := providerClient.ListContainer(ctx, &storagep.ListContainerRequest{Ref: sharesRef})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(listRes.Status.Code).To(Equal(rpcv1beta1.Code_CODE_NOT_FOUND))
 			Expect(len(listRes.Infos)).To(Equal(0))
 
-			res, err := serviceClient.CreateReference(ctx, &storagep.CreateReferenceRequest{
+			res, err := providerClient.CreateReference(ctx, &storagep.CreateReferenceRequest{
 				Ref: &storagep.Reference{
 					Path: "/Shares/reference",
 				},
@@ -507,7 +509,7 @@ var _ = Describe("storage providers", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(res.Status.Code).To(Equal(rpcv1beta1.Code_CODE_OK))
 
-			listRes, err = serviceClient.ListContainer(ctx, &storagep.ListContainerRequest{Ref: sharesRef})
+			listRes, err = providerClient.ListContainer(ctx, &storagep.ListContainerRequest{Ref: sharesRef})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(listRes.Status.Code).To(Equal(rpcv1beta1.Code_CODE_OK))
 			Expect(len(listRes.Infos)).To(Equal(1))
@@ -517,33 +519,33 @@ var _ = Describe("storage providers", func() {
 	assertMetadata := func(provider string) {
 		It("sets and unsets metadata", func() {
 			subdirRef := ref(provider, subdirPath)
-			statRes, err := serviceClient.Stat(ctx, &storagep.StatRequest{Ref: subdirRef})
+			statRes, err := providerClient.Stat(ctx, &storagep.StatRequest{Ref: subdirRef})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(statRes.Status.Code).To(Equal(rpcv1beta1.Code_CODE_OK))
 			Expect(statRes.Info.ArbitraryMetadata.Metadata["foo"]).To(BeEmpty())
 
 			By("setting arbitrary metadata")
-			samRes, err := serviceClient.SetArbitraryMetadata(ctx, &storagep.SetArbitraryMetadataRequest{
+			samRes, err := providerClient.SetArbitraryMetadata(ctx, &storagep.SetArbitraryMetadataRequest{
 				Ref:               subdirRef,
 				ArbitraryMetadata: &storagep.ArbitraryMetadata{Metadata: map[string]string{"foo": "bar"}},
 			})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(samRes.Status.Code).To(Equal(rpcv1beta1.Code_CODE_OK))
 
-			statRes, err = serviceClient.Stat(ctx, &storagep.StatRequest{Ref: subdirRef})
+			statRes, err = providerClient.Stat(ctx, &storagep.StatRequest{Ref: subdirRef})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(statRes.Status.Code).To(Equal(rpcv1beta1.Code_CODE_OK))
 			Expect(statRes.Info.ArbitraryMetadata.Metadata["foo"]).To(Equal("bar"))
 
 			By("unsetting arbitrary metadata")
-			uamRes, err := serviceClient.UnsetArbitraryMetadata(ctx, &storagep.UnsetArbitraryMetadataRequest{
+			uamRes, err := providerClient.UnsetArbitraryMetadata(ctx, &storagep.UnsetArbitraryMetadataRequest{
 				Ref:                   subdirRef,
 				ArbitraryMetadataKeys: []string{"foo"},
 			})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(uamRes.Status.Code).To(Equal(rpcv1beta1.Code_CODE_OK))
 
-			statRes, err = serviceClient.Stat(ctx, &storagep.StatRequest{Ref: subdirRef})
+			statRes, err = providerClient.Stat(ctx, &storagep.StatRequest{Ref: subdirRef})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(statRes.Status.Code).To(Equal(rpcv1beta1.Code_CODE_OK))
 			Expect(statRes.Info.ArbitraryMetadata.Metadata["foo"]).To(BeEmpty())
@@ -560,14 +562,14 @@ var _ = Describe("storage providers", func() {
 			}
 		)
 		It("locks, gets, refreshes and unlocks a lock", func() {
-			lockRes, err := serviceClient.SetLock(ctx, &storagep.SetLockRequest{
+			lockRes, err := providerClient.SetLock(ctx, &storagep.SetLockRequest{
 				Ref:  subdirRef,
 				Lock: lock,
 			})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(lockRes.Status.Code).To(Equal(rpcv1beta1.Code_CODE_OK))
 
-			getRes, err := serviceClient.GetLock(ctx, &storagep.GetLockRequest{
+			getRes, err := providerClient.GetLock(ctx, &storagep.GetLockRequest{
 				Ref: subdirRef,
 			})
 			Expect(err).ToNot(HaveOccurred())
@@ -581,14 +583,14 @@ var _ = Describe("storage providers", func() {
 			Expect(getRes.Lock.Expiration).To(Equal(lock.Expiration))
 			Expect(getRes.Lock.Opaque).To(Equal(lock.Opaque))
 
-			refreshRes, err := serviceClient.RefreshLock(ctx, &storagep.RefreshLockRequest{
+			refreshRes, err := providerClient.RefreshLock(ctx, &storagep.RefreshLockRequest{
 				Ref:  subdirRef,
 				Lock: lock,
 			})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(refreshRes.Status.Code).To(Equal(rpcv1beta1.Code_CODE_OK))
 
-			unlockRes, err := serviceClient.Unlock(ctx, &storagep.UnlockRequest{
+			unlockRes, err := providerClient.Unlock(ctx, &storagep.UnlockRequest{
 				Ref:  subdirRef,
 				Lock: lock,
 			})
@@ -598,7 +600,7 @@ var _ = Describe("storage providers", func() {
 
 		Context("with a locked file", func() {
 			JustBeforeEach(func() {
-				lockRes, err := serviceClient.SetLock(ctx, &storagep.SetLockRequest{
+				lockRes, err := providerClient.SetLock(ctx, &storagep.SetLockRequest{
 					Ref:  subdirRef,
 					Lock: lock,
 				})
@@ -607,20 +609,20 @@ var _ = Describe("storage providers", func() {
 			})
 
 			It("removes the lock when unlocking", func() {
-				delRes, err := serviceClient.Delete(ctx, &storagep.DeleteRequest{
+				delRes, err := providerClient.Delete(ctx, &storagep.DeleteRequest{
 					Ref: subdirRef,
 				})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(delRes.Status.Code).To(Equal(rpcv1beta1.Code_CODE_LOCKED))
 
-				unlockRes, err := serviceClient.Unlock(ctx, &storagep.UnlockRequest{
+				unlockRes, err := providerClient.Unlock(ctx, &storagep.UnlockRequest{
 					Ref:  subdirRef,
 					Lock: lock,
 				})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(unlockRes.Status.Code).To(Equal(rpcv1beta1.Code_CODE_OK))
 
-				delRes, err = serviceClient.Delete(ctx, &storagep.DeleteRequest{
+				delRes, err = providerClient.Delete(ctx, &storagep.DeleteRequest{
 					Ref: subdirRef,
 				})
 				Expect(err).ToNot(HaveOccurred())
@@ -631,7 +633,7 @@ var _ = Describe("storage providers", func() {
 			// FIXME these tests are all wrong as they use the reference of a directory, but try to lock and upload a file
 			Context("with the owner holding the lock", func() {
 				It("can not initiate an upload that would overwrite a folder", func() {
-					ulRes, err := serviceClient.InitiateFileUpload(ctx, &storagep.InitiateFileUploadRequest{
+					ulRes, err := providerClient.InitiateFileUpload(ctx, &storagep.InitiateFileUploadRequest{
 						Ref:    subdirRef,
 						LockId: lock.LockId,
 					})
@@ -640,7 +642,7 @@ var _ = Describe("storage providers", func() {
 				})
 
 				It("can delete the file", func() {
-					delRes, err := serviceClient.Delete(ctx, &storagep.DeleteRequest{
+					delRes, err := providerClient.Delete(ctx, &storagep.DeleteRequest{
 						Ref:    subdirRef,
 						LockId: lock.LockId,
 					})
@@ -651,7 +653,7 @@ var _ = Describe("storage providers", func() {
 			})
 			Context("with the owner not holding the lock", func() {
 				It("can only delete after unlocking the file", func() {
-					delRes, err := serviceClient.Delete(ctx, &storagep.DeleteRequest{
+					delRes, err := providerClient.Delete(ctx, &storagep.DeleteRequest{
 						Ref: subdirRef,
 					})
 					Expect(err).ToNot(HaveOccurred())
@@ -675,7 +677,7 @@ var _ = Describe("storage providers", func() {
 
 			Context("with a home and a subdirectory", func() {
 				JustBeforeEach(func() {
-					res, err := serviceClient.CreateStorageSpace(ctx, &storagep.CreateStorageSpaceRequest{
+					res, err := spacesClient.CreateStorageSpace(ctx, &storagep.CreateStorageSpaceRequest{
 						Owner: user,
 						Type:  "personal",
 						Name:  user.Id.OpaqueId,
@@ -683,7 +685,7 @@ var _ = Describe("storage providers", func() {
 					Expect(err).ToNot(HaveOccurred())
 					Expect(res.Status.Code).To(Equal(rpcv1beta1.Code_CODE_OK))
 
-					subdirRes, err := serviceClient.CreateContainer(ctx, &storagep.CreateContainerRequest{Ref: ref(provider, subdirPath)})
+					subdirRes, err := providerClient.CreateContainer(ctx, &storagep.CreateContainerRequest{Ref: ref(provider, subdirPath)})
 					Expect(err).ToNot(HaveOccurred())
 					Expect(subdirRes.Status.Code).To(Equal(rpcv1beta1.Code_CODE_OK))
 				})


### PR DESCRIPTION
This needed to touch quite a few unit test since the tooling to generate the go bindings was updated to a more recent version. Which causes issues with e.g. using reflect.DeepEqual on proto messages. We're basically running into the changes described here: https://github.com/protocolbuffers/protobuf-go/releases/tag/v1.20.0#v1.20-generated-code