### PR TITLE
[backport #4748] fix: quotes in content-disposition header

### DIFF
--- a/Dockerfile.revad-ceph
+++ b/Dockerfile.revad-ceph
@@ -20,10 +20,18 @@ FROM quay.io/ceph/ceph:v18
 
 # replace repo url with one that allows downloading the repo metadata
 # if http://download.ceph.com/rpm-reef/el8/x86_64/repodata/repomd.xml works again this can be dropped
-RUN sed -i 's/download.ceph.com/fr.ceph.com/' /etc/yum.repos.d/ceph.repo
-RUN mkdir -p /etc/selinux/config
+# RUN sed -i 's/download.ceph.com/fr.ceph.com/' /etc/yum.repos.d/ceph.repo
+# RUN mkdir -p /etc/selinux/config
 
-RUN dnf update --exclude=ceph-iscsi,chrony -y && dnf install -y \
+# RUN dnf update --exclude=ceph-iscsi,chrony -y && dnf install -y \
+#   git \
+#   gcc \
+#   make \
+#   libcephfs-devel \
+#   librbd-devel \
+#   librados-devel
+
+RUN dnf update --exclude=ceph-iscsi -y && dnf install -y \
   git \
   gcc \
   make \

--- a/changelog/unreleased/fix-blanks-in-content-disposition-headers.md
+++ b/changelog/unreleased/fix-blanks-in-content-disposition-headers.md
@@ -1,0 +1,6 @@
+Bugfix: Blanks in dav Content-Disposition header
+
+We've fixed the encoding of blanks in the dav `Content-Disposition` header.
+
+https://github.com/cs3org/reva/pull/4762
+https://github.com/owncloud/web/issues/11169

--- a/changelog/unreleased/fix-blanks-in-content-disposition-headers.md
+++ b/changelog/unreleased/fix-blanks-in-content-disposition-headers.md
@@ -1,6 +1,0 @@
-Bugfix: Blanks in dav Content-Disposition header
-
-We've fixed the encoding of blanks in the dav `Content-Disposition` header.
-
-https://github.com/cs3org/reva/pull/4762
-https://github.com/owncloud/web/issues/11169

--- a/changelog/unreleased/fix-quotes-in-content-disposition-headers.md
+++ b/changelog/unreleased/fix-quotes-in-content-disposition-headers.md
@@ -1,0 +1,6 @@
+Bugfix: Quotes in dav Content-Disposition header
+
+We've fixed the the quotes in the dav `Content-Disposition` header. They caused an issue where certain browsers would decode the quotes and falsely prepend them to the filename.
+
+https://github.com/cs3org/reva/pull/4748
+https://github.com/owncloud/web/issues/11031

--- a/changelog/unreleased/fix-quotes-in-content-disposition-headers.md
+++ b/changelog/unreleased/fix-quotes-in-content-disposition-headers.md
@@ -2,5 +2,5 @@ Bugfix: Quotes in dav Content-Disposition header
 
 We've fixed the the quotes in the dav `Content-Disposition` header. They caused an issue where certain browsers would decode the quotes and falsely prepend them to the filename.
 
-https://github.com/cs3org/reva/pull/4748
+https://github.com/cs3org/reva/pull/4761
 https://github.com/owncloud/web/issues/11031

--- a/changelog/unreleased/fix-quotes-in-content-disposition-headers.md
+++ b/changelog/unreleased/fix-quotes-in-content-disposition-headers.md
@@ -4,3 +4,4 @@ We've fixed the the quotes in the dav `Content-Disposition` header. They caused 
 
 https://github.com/cs3org/reva/pull/4761
 https://github.com/owncloud/web/issues/11031
+https://github.com/owncloud/web/issues/11169

--- a/internal/http/services/owncloud/ocdav/net/builders.go
+++ b/internal/http/services/owncloud/ocdav/net/builders.go
@@ -28,7 +28,7 @@ import (
 
 // ContentDispositionAttachment builds a ContentDisposition Attachment header with various filename encodings
 func ContentDispositionAttachment(filename string) string {
-	return "attachment; filename*=UTF-8''" + url.QueryEscape(filename) + "; filename=\"" + filename + "\""
+	return "attachment; filename*=UTF-8''" + url.PathEscape(filename) + "; filename=\"" + filename + "\""
 }
 
 // RFC1123Z formats a CS3 Timestamp to be used in HTTP headers like Last-Modified

--- a/internal/http/services/owncloud/ocdav/net/builders.go
+++ b/internal/http/services/owncloud/ocdav/net/builders.go
@@ -19,6 +19,7 @@
 package net
 
 import (
+	"net/url"
 	"time"
 
 	cs3types "github.com/cs3org/go-cs3apis/cs3/types/v1beta1"
@@ -27,7 +28,7 @@ import (
 
 // ContentDispositionAttachment builds a ContentDisposition Attachment header with various filename encodings
 func ContentDispositionAttachment(filename string) string {
-	return "attachment; filename*=UTF-8''\"" + filename + "\"; filename=\"" + filename + "\""
+	return "attachment; filename*=UTF-8''" + url.QueryEscape(filename) + "; filename=\"" + filename + "\""
 }
 
 // RFC1123Z formats a CS3 Timestamp to be used in HTTP headers like Last-Modified

--- a/tests/acceptance/expected-failures-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-on-OCIS-storage.md
@@ -285,6 +285,18 @@ _The below features have been added after I last categorized them. AFAICT they a
 
 - [coreApiVersions/fileVersions.feature:158](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiVersions/fileVersions.feature#L158)
 - [coreApiVersions/fileVersions.feature:176](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiVersions/fileVersions.feature#L176)
+- [coreApiWebdavOperations/downloadFile.feature:284](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavOperations/downloadFile.feature#L284)
+- [coreApiWebdavOperations/downloadFile.feature:285](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavOperations/downloadFile.feature#L285)
+- [coreApiWebdavOperations/downloadFile.feature:286](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavOperations/downloadFile.feature#L286)
+- [coreApiWebdavOperations/downloadFile.feature:287](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavOperations/downloadFile.feature#L287)
+- [coreApiWebdavOperations/downloadFile.feature:288](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavOperations/downloadFile.feature#L288)
+- [coreApiWebdavOperations/downloadFile.feature:289](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavOperations/downloadFile.feature#L289)
+- [coreApiWebdavOperations/downloadFile.feature:294](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavOperations/downloadFile.feature#L294)
+- [coreApiWebdavOperations/downloadFile.feature:295](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavOperations/downloadFile.feature#L295)
+- [coreApiWebdavOperations/downloadFile.feature:296](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavOperations/downloadFile.feature#L296)
+- [coreApiWebdavOperations/downloadFile.feature:317](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavOperations/downloadFile.feature#L317)
+- [coreApiWebdavOperations/downloadFile.feature:318](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavOperations/downloadFile.feature#L318)
+- [coreApiWebdavOperations/downloadFile.feature:323](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavOperations/downloadFile.feature#L323)
 
 - Note: always have an empty line at the end of this file.
 The bash script that processes this file may not process a scenario reference on the last line.

--- a/tests/acceptance/expected-failures-on-OCIS-storage.md
+++ b/tests/acceptance/expected-failures-on-OCIS-storage.md
@@ -281,5 +281,10 @@ _The below features have been added after I last categorized them. AFAICT they a
 - [coreApiWebdavMove2/moveFile.feature:121](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavMove2/moveFile.feature#L121)
 - [coreApiWebdavMove2/moveFile.feature:126](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavMove2/moveFile.feature#L126)
 
+### [Fix Content-Disposition header for download requests](https://github.com/cs3org/reva/pull/4748)
+
+- [coreApiVersions/fileVersions.feature:158](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiVersions/fileVersions.feature#L158)
+- [coreApiVersions/fileVersions.feature:176](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiVersions/fileVersions.feature#L176)
+
 - Note: always have an empty line at the end of this file.
 The bash script that processes this file may not process a scenario reference on the last line.

--- a/tests/acceptance/expected-failures-on-S3NG-storage.md
+++ b/tests/acceptance/expected-failures-on-S3NG-storage.md
@@ -284,5 +284,10 @@ _The below features have been added after I last categorized them. AFAICT they a
 - [coreApiWebdavMove2/moveFile.feature:121](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavMove2/moveFile.feature#L121)
 - [coreApiWebdavMove2/moveFile.feature:126](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavMove2/moveFile.feature#L126)
 
+### [Fix Content-Disposition header for download requests](https://github.com/cs3org/reva/pull/4748)
+
+- [coreApiVersions/fileVersions.feature:158](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiVersions/fileVersions.feature#L158)
+- [coreApiVersions/fileVersions.feature:176](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiVersions/fileVersions.feature#L176)
+
 Note: always have an empty line at the end of this file.
 The bash script that processes this file may not process a scenario reference on the last line.

--- a/tests/acceptance/expected-failures-on-S3NG-storage.md
+++ b/tests/acceptance/expected-failures-on-S3NG-storage.md
@@ -288,6 +288,18 @@ _The below features have been added after I last categorized them. AFAICT they a
 
 - [coreApiVersions/fileVersions.feature:158](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiVersions/fileVersions.feature#L158)
 - [coreApiVersions/fileVersions.feature:176](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiVersions/fileVersions.feature#L176)
+- [coreApiWebdavOperations/downloadFile.feature:284](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavOperations/downloadFile.feature#L284)
+- [coreApiWebdavOperations/downloadFile.feature:285](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavOperations/downloadFile.feature#L285)
+- [coreApiWebdavOperations/downloadFile.feature:286](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavOperations/downloadFile.feature#L286)
+- [coreApiWebdavOperations/downloadFile.feature:287](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavOperations/downloadFile.feature#L287)
+- [coreApiWebdavOperations/downloadFile.feature:288](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavOperations/downloadFile.feature#L288)
+- [coreApiWebdavOperations/downloadFile.feature:289](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavOperations/downloadFile.feature#L289)
+- [coreApiWebdavOperations/downloadFile.feature:294](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavOperations/downloadFile.feature#L294)
+- [coreApiWebdavOperations/downloadFile.feature:295](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavOperations/downloadFile.feature#L295)
+- [coreApiWebdavOperations/downloadFile.feature:296](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavOperations/downloadFile.feature#L296)
+- [coreApiWebdavOperations/downloadFile.feature:317](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavOperations/downloadFile.feature#L317)
+- [coreApiWebdavOperations/downloadFile.feature:318](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavOperations/downloadFile.feature#L318)
+- [coreApiWebdavOperations/downloadFile.feature:323](https://github.com/owncloud/ocis/blob/master/tests/acceptance/features/coreApiWebdavOperations/downloadFile.feature#L323)
 
 Note: always have an empty line at the end of this file.
 The bash script that processes this file may not process a scenario reference on the last line.


### PR DESCRIPTION
Backports https://github.com/cs3org/reva/pull/4748 to `stable-2.19`.

Needs to wait for https://github.com/cs3org/reva/pull/4762.