### PR TITLE
fix: blanks in dav Content-Disposition header

### DIFF
--- a/changelog/unreleased/fix-blanks-in-content-disposition-headers.md
+++ b/changelog/unreleased/fix-blanks-in-content-disposition-headers.md
@@ -1,0 +1,6 @@
+Bugfix: Blanks in dav Content-Disposition header
+
+We've fixed the encoding of blanks in the dav `Content-Disposition` header.
+
+https://github.com/cs3org/reva/pull/4762
+https://github.com/owncloud/web/issues/11169

--- a/internal/http/services/owncloud/ocdav/net/builders.go
+++ b/internal/http/services/owncloud/ocdav/net/builders.go
@@ -28,7 +28,7 @@ import (
 
 // ContentDispositionAttachment builds a ContentDisposition Attachment header with various filename encodings
 func ContentDispositionAttachment(filename string) string {
-	return "attachment; filename*=UTF-8''" + url.QueryEscape(filename) + "; filename=\"" + filename + "\""
+	return "attachment; filename*=UTF-8''" + url.PathEscape(filename) + "; filename=\"" + filename + "\""
 }
 
 // RFC1123Z formats a CS3 Timestamp to be used in HTTP headers like Last-Modified


### PR DESCRIPTION
Fixes the encoding of blanks in the dav `Content-Disposition` header. `QueryEscape` doesn't encode all special chars like e.g. blanks ` `. Hence we need to use `PathEscape`.

This is a regression caused by #4748.

See Web issue https://github.com/owncloud/web/issues/11169.