### PR TITLE
[tests-only][full-ci] bump latest ocis commit id

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,4 +1,4 @@
 # The test runner source for API tests
-APITESTS_COMMITID=d57ff92ea629a037c2f8ca934821a020faa2bdda
+APITESTS_COMMITID=9fc37e7b8173884231d3f7bda671ff81984dc960
 APITESTS_BRANCH=master
 APITESTS_REPO_GIT_URL=https://github.com/owncloud/ocis.git


### PR DESCRIPTION
### Description
Bump latest ocis commit id.

part of: https://github.com/owncloud/QA/issues/856