### PR TITLE
fix: dav delete via resource id

### DIFF
--- a/changelog/unreleased/fix-dav-id-based-delete.md
+++ b/changelog/unreleased/fix-dav-id-based-delete.md
@@ -1,0 +1,6 @@
+Bugfix: Deleting resources via their id
+
+We fixed a bug where deleting resources by using their id via the `/dav/spaces/` endpoint would not work.
+
+https://github.com/cs3org/reva/pull/4771
+https://github.com/owncloud/ocis/issues/9619

--- a/internal/http/services/owncloud/ocdav/delete.go
+++ b/internal/http/services/owncloud/ocdav/delete.go
@@ -137,8 +137,11 @@ func (s *svc) handleSpacesDelete(w http.ResponseWriter, r *http.Request, spaceID
 
 	// do not allow deleting spaces via dav endpoint - use graph endpoint instead
 	// we get a relative reference coming from the space root
-	// so if the path is "empty" we a referencing the space
-	if ref.GetPath() == "." {
+	// so if the path is "empty" and no opaque id is present or the opaque id equals
+	// the space id, we are referencing the space
+	rid := ref.GetResourceId()
+	if ref.GetPath() == "." &&
+		(rid.GetOpaqueId() == "" || rid.GetOpaqueId() == rid.GetSpaceId()) {
 		return http.StatusMethodNotAllowed, errors.New("deleting spaces via dav is not allowed")
 	}
 


### PR DESCRIPTION
Fixes an issue where deleting a resource via its id, using the `/dav/spaces/{fileId}` endpoint, wouldn't work.

The issue was happening because the code was checking for an empty path to prevent spaces from being deleted this way (because spaces have an empty path). When only providing a resource id however, the path will be empty for regular resources as well. For this reason we now additionally check for the resource's `opaqueId`. If the resource doesn't have such and the path is empty, we can assume that it's a space and prevent deletion via the dav endpoint.

fixes https://github.com/owncloud/ocis/issues/9619
