### PR TITLE
allow configuring grpc max connection age

### DIFF
--- a/changelog/unreleased/add-grpc-max-connection-age-env.md
+++ b/changelog/unreleased/add-grpc-max-connection-age-env.md
@@ -1,0 +1,5 @@
+Enhancement: Allow configuring grpc max connection age
+
+We added a GRPC_MAX_CONNECTION_AGE env var that allows limiting the lifespan of connections. A closed connection triggers grpc clients to do a new DNS lookup to pick up new IPs.
+
+https://github.com/cs3org/reva/pull/4772

--- a/pkg/rgrpc/keepalive.go
+++ b/pkg/rgrpc/keepalive.go
@@ -1,0 +1,24 @@
+package rgrpc
+
+import (
+	"math"
+	"os"
+	"time"
+)
+
+const (
+	_serverMaxConnectionAgeEnv = "GRPC_MAX_CONNECTION_AGE"
+
+	// same default as grpc
+	infinity                 = time.Duration(math.MaxInt64)
+	_defaultMaxConnectionAge = infinity
+)
+
+// GetMaxConnectionAge returns the maximum grpc connection age.
+func GetMaxConnectionAge() time.Duration {
+	d, err := time.ParseDuration(os.Getenv(_serverMaxConnectionAgeEnv))
+	if err != nil {
+		return _defaultMaxConnectionAge
+	}
+	return d
+}

--- a/pkg/rgrpc/rgrpc.go
+++ b/pkg/rgrpc/rgrpc.go
@@ -42,6 +42,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/reflection"
 )
 
@@ -245,6 +246,9 @@ func (s *Server) registerServices() error {
 	if s.conf.TLSSettings.tlsConfig != nil {
 		opts = append(opts, grpc.Creds(credentials.NewTLS(s.conf.TLSSettings.tlsConfig)))
 	}
+	opts = append(opts, grpc.KeepaliveParams(keepalive.ServerParameters{
+		MaxConnectionAge: GetMaxConnectionAge(), // this forces clients to reconnect after 30 seconds, triggering a new DNS lookup to pick up new IPs
+	}))
 
 	grpcServer := grpc.NewServer(opts...)
 


### PR DESCRIPTION
We added a GRPC_MAX_CONNECTION_AGE env var that allows limiting the lifespan of connections. A closed connection triggers grpc clients to do a new DNS lookup to pick up new IPs.

counterpart to https://github.com/owncloud/ocis/pull/9657

part of https://github.com/owncloud/ocis/pull/9488