### PR TITLE
fix micro ocdav service

### DIFF
--- a/changelog/unreleased/bump-ocis.md
+++ b/changelog/unreleased/bump-ocis.md
@@ -1,4 +1,4 @@
-Change: Ocis bumped.
+Change: Ocis bumped
 
 Ocis bumped. The expected failures removed.
 

--- a/changelog/unreleased/fix-micro-ocdav-registry.md
+++ b/changelog/unreleased/fix-micro-ocdav-registry.md
@@ -1,0 +1,5 @@
+Bugfix: Fix micro ocdav service init and registration
+
+We no longer call Init to configure default options because it was replacing the existing options.
+
+https://github.com/cs3org/reva/pull/4774

--- a/pkg/micro/ocdav/option.go
+++ b/pkg/micro/ocdav/option.go
@@ -21,6 +21,7 @@ package ocdav
 import (
 	"context"
 	"crypto/tls"
+	"time"
 
 	gateway "github.com/cs3org/go-cs3apis/cs3/gateway/v1beta1"
 	"github.com/cs3org/reva/v2/internal/http/services/owncloud/ocdav"
@@ -70,6 +71,9 @@ type Options struct {
 	AllowedHeaders     []string
 	AllowedMethods     []string
 	AllowDepthInfinity bool
+
+	RegisterTTL      time.Duration
+	RegisterInterval time.Duration
 }
 
 // newOptions initializes the available default options.
@@ -381,5 +385,19 @@ func ItemNameInvalidChars(chars []string) Option {
 func ItemNameMaxLength(i int) Option {
 	return func(o *Options) {
 		o.config.NameValidation.MaxLength = i
+	}
+}
+
+// RegisterTTL provides a function to set the RegisterTTL option.
+func RegisterTTL(ttl time.Duration) Option {
+	return func(o *Options) {
+		o.RegisterTTL = ttl
+	}
+}
+
+// RegisterInterval provides a function to set the RegisterInterval option.
+func RegisterInterval(interval time.Duration) Option {
+	return func(o *Options) {
+		o.RegisterInterval = interval
 	}
 }

--- a/pkg/micro/ocdav/service.go
+++ b/pkg/micro/ocdav/service.go
@@ -78,6 +78,8 @@ func Service(opts ...Option) (micro.Service, error) {
 		server.Name(sopts.Name),
 		server.Address(sopts.Address), // Address defaults to ":0" and will pick any free port
 		server.Version(sopts.config.VersionString),
+		server.RegisterTTL(sopts.RegisterTTL),
+		server.RegisterInterval(sopts.RegisterInterval),
 	)
 
 	revaService, err := ocdav.NewWith(&sopts.config, sopts.FavoriteManager, sopts.lockSystem, &sopts.Logger, sopts.GatewaySelector)
@@ -124,9 +126,6 @@ func Service(opts ...Option) (micro.Service, error) {
 		micro.Server(srv),
 		micro.Registry(registry.GetRegistry()),
 	)
-
-	// Init the service? make that optional?
-	service.Init()
 
 	// finally, return the service so it can be Run() by the caller himself
 	return service, nil


### PR DESCRIPTION
We no longer call Init to configure default options because it was replacing the existing options.
