### PR TITLE
Dont postprocess 0 byte files

### DIFF
--- a/changelog/unreleased/zero-byte-uploads.md
+++ b/changelog/unreleased/zero-byte-uploads.md
@@ -1,0 +1,5 @@
+Bugfix: Zero byte uploads
+
+Zero byte uploads would trigger postprocessing which lead to breaking pipelines.
+
+https://github.com/cs3org/reva/pull/4778

--- a/pkg/storage/utils/decomposedfs/upload/upload.go
+++ b/pkg/storage/utils/decomposedfs/upload/upload.go
@@ -171,7 +171,7 @@ func (session *OcisSession) FinishUpload(ctx context.Context) error {
 	metrics.UploadProcessing.Inc()
 	metrics.UploadSessionsBytesReceived.Inc()
 
-	if session.store.pub != nil {
+	if session.store.pub != nil && session.info.Size > 0 {
 		u, _ := ctxpkg.ContextGetUser(ctx)
 		s, err := session.URL(ctx)
 		if err != nil {


### PR DESCRIPTION
Tackles https://github.com/owncloud/ocis/issues/9573

I can't reproduce this locally. But `decomposedfs` will call `FinishUpload` directly if it is a 0 byte upload. https://github.com/cs3org/reva/blob/edge/pkg/storage/utils/decomposedfs/upload.go#L322-L328
But it would still send a `BytesReceived` event. This is wrong imho, because it didn't receive any bytes.

Anyways I hope this also fixes the attached issue.
