### PR TITLE
OCM: Fix open driver

### DIFF
--- a/changelog/unreleased/fix-ocm-open-driver.md
+++ b/changelog/unreleased/fix-ocm-open-driver.md
@@ -1,0 +1,8 @@
+Bugfix: ocm: fixed domain not having a protocol scheme
+
+This PR fixes a bug in the OCM open driver that causes it to be unable to probe
+OCM services at the remote server due to the domain having an unsupported
+protocol scheme. in this case domain doesn't have a scheme and the changes in
+this PR add a scheme to the domain before doing the probe.
+
+https://github.com/cs3org/reva/pull/4788

--- a/changelog/unreleased/fix-ocm-open-driver.md
+++ b/changelog/unreleased/fix-ocm-open-driver.md
@@ -5,4 +5,4 @@ OCM services at the remote server due to the domain having an unsupported
 protocol scheme. in this case domain doesn't have a scheme and the changes in
 this PR add a scheme to the domain before doing the probe.
 
-https://github.com/cs3org/reva/pull/4788
+https://github.com/cs3org/reva/pull/4790

--- a/pkg/ocm/provider/authorizer/open/open.go
+++ b/pkg/ocm/provider/authorizer/open/open.go
@@ -72,7 +72,7 @@ func (a *authorizer) GetInfoByDomain(ctx context.Context, domain string) (*ocmpr
 	// to ocmClient.Discover would fail.
 
 	// convert domain into lowercase to avoid adding scheme if the domain
-	//looks like this: HtTpS://domain.docker
+	// looks like this: HtTpS://domain.docker
 	domain = strings.ToLower(domain)
 
 	// add a scheme to domain if it doesn't have one.

--- a/pkg/ocm/provider/authorizer/open/open.go
+++ b/pkg/ocm/provider/authorizer/open/open.go
@@ -70,7 +70,12 @@ func (a *authorizer) GetInfoByDomain(ctx context.Context, domain string) (*ocmpr
 	// there is a possibility that domain doesn't contain a scheme
 	// for example resource={"domain":"reva.docker"} and the call
 	// to ocmClient.Discover would fail.
-	// add scheme to domain if it doesn't have one.
+
+	// convert domain into lowercase to avoid adding scheme if the domain
+	//looks like this: HtTpS://domain.docker
+	domain = strings.ToLower(domain)
+
+	// add a scheme to domain if it doesn't have one.
 	if !strings.HasPrefix(domain, "http://") && !strings.HasPrefix(domain, "https://") {
 		domain = "https://" + domain
 	}

--- a/pkg/ocm/provider/authorizer/open/open.go
+++ b/pkg/ocm/provider/authorizer/open/open.go
@@ -67,6 +67,14 @@ func (a *authorizer) GetInfoByDomain(ctx context.Context, domain string) (*ocmpr
 		}
 	}
 
+	// there is a possibility that domain doesn't contain a scheme
+	// for example resource={"domain":"reva.docker"} and the call
+	// to ocmClient.Discover would fail.
+	// add scheme to domain if it doesn't have one.
+	if !strings.HasPrefix(domain, "http://") && !strings.HasPrefix(domain, "https://") {
+		domain = "https://" + domain
+	}
+
 	// not yet known: try to discover the remote OCM endpoint
 	ocmClient := client.NewClient(time.Duration(10)*time.Second, true)
 	ocmCaps, err := ocmClient.Discover(ctx, domain)

--- a/pkg/ocm/provider/authorizer/open/open.go
+++ b/pkg/ocm/provider/authorizer/open/open.go
@@ -67,22 +67,16 @@ func (a *authorizer) GetInfoByDomain(ctx context.Context, domain string) (*ocmpr
 		}
 	}
 
-	// there is a possibility that domain doesn't contain a scheme
-	// for example resource={"domain":"reva.docker"} and the call
-	// to ocmClient.Discover would fail.
-
-	// convert domain into lowercase to avoid adding scheme if the domain
-	// looks like this: HtTpS://domain.docker
-	domain = strings.ToLower(domain)
-
-	// add a scheme to domain if it doesn't have one.
+	var endpoint string
 	if !strings.HasPrefix(domain, "http://") && !strings.HasPrefix(domain, "https://") {
-		domain = "https://" + domain
+		endpoint = "https://" + domain
+	} else {
+		endpoint = domain
 	}
 
 	// not yet known: try to discover the remote OCM endpoint
 	ocmClient := client.NewClient(time.Duration(10)*time.Second, true)
-	ocmCaps, err := ocmClient.Discover(ctx, domain)
+	ocmCaps, err := ocmClient.Discover(ctx, endpoint)
 	if err != nil {
 		return nil, errors.Wrap(err, "error probing OCM services at remote server")
 	}


### PR DESCRIPTION
The error happens because of an error probing OCM services at the remote server:
`error doing request: Get \"revaowncloud1.docker/ocm-provider\": unsupported protocol scheme \"\"`
since the provider domain doesn't have `http://` or `https://`.

The changes in this PR add a scheme to the domain before the probing.

Fixes: #4791 