### PR TITLE
tests: bump openldap and deprecate HOSTNAME variable

### DIFF
--- a/tests/docker/docker-compose.yml
+++ b/tests/docker/docker-compose.yml
@@ -170,13 +170,12 @@ services:
       storage-local-2:
         condition: service_healthy
   ldap:
-    image: osixia/openldap:1.3.0
+    image: osixia/openldap:1.5.0
     environment:
       LDAP_DOMAIN: owncloud.com
       LDAP_ORGANISATION: ownCloud
       LDAP_ADMIN_PASSWORD: admin
       LDAP_TLS_VERIFY_CLIENT: never
-      HOSTNAME: ldap
     healthcheck:
       test: ldapsearch -x -h localhost -b dc=owncloud,dc=com -D "cn=admin,dc=owncloud,dc=com" -w admin
       interval: 5s


### PR DESCRIPTION
This PR unblocks the recurrent errors on the CI tests where the ldap container is not available.