### PR TITLE
owncloudsql: fix path, naming and listing spaces

### DIFF
--- a/changelog/unreleased/fix-owncloudsql.md
+++ b/changelog/unreleased/fix-owncloudsql.md
@@ -1,0 +1,3 @@
+Bugfix: Fixed bugs in the owncloudsql storage driver
+
+https://github.com/cs3org/reva/pull/4808

--- a/go.sum
+++ b/go.sum
@@ -916,8 +916,6 @@ github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46t
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/cs3org/cato v0.0.0-20200828125504-e418fc54dd5e h1:tqSPWQeueWTKnJVMJffz4pz0o1WuQxJ28+5x5JgaHD8=
 github.com/cs3org/cato v0.0.0-20200828125504-e418fc54dd5e/go.mod h1:XJEZ3/EQuI3BXTp/6DUzFr850vlxq11I6satRtz0YQ4=
-github.com/cs3org/go-cs3apis v0.0.0-20240425114016-d2cb31692b4e h1:Cm2l8m2riLa79eh7V2wHd1Ra7wR3TbngmeLZBJ9MxTU=
-github.com/cs3org/go-cs3apis v0.0.0-20240425114016-d2cb31692b4e/go.mod h1:yyP8PRo0EZou3nSH7H4qjlzQwaydPeIRNgX50npQHpE=
 github.com/cs3org/go-cs3apis v0.0.0-20240724121416-062c4e3046cb h1:KmYZDReplv/yfwc1LNYpDcVhVujC3Pasv6WjXx1haSU=
 github.com/cs3org/go-cs3apis v0.0.0-20240724121416-062c4e3046cb/go.mod h1:yyP8PRo0EZou3nSH7H4qjlzQwaydPeIRNgX50npQHpE=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/pkg/user/manager/owncloudsql/owncloudsql.go
+++ b/pkg/user/manager/owncloudsql/owncloudsql.go
@@ -167,6 +167,11 @@ func (m *manager) convertToCS3User(ctx context.Context, a *accounts.Account, ski
 		GidNumber: m.c.Nobody,
 		UidNumber: m.c.Nobody,
 	}
+	// https://github.com/cs3org/reva/pull/4135
+	// fall back to userid
+	if u.Id.OpaqueId == "" {
+		u.Id.OpaqueId = a.UserID
+	}
 	if u.Username == "" {
 		u.Username = u.Id.OpaqueId
 	}


### PR DESCRIPTION
@dragotin owncloudsql has bitrotted. uploads are still broken, even with this PR. oCIS seems to equire the storage driver to implement listing upload sessions and using the event handler to integrate with postprocessing.

This PR is just the basic fixes to get listing spaces and basic file navigation working again.

why do I still do this? I think being able to switch from oc10 / nc to ocis effortless is a worthwile thing. It would be great if clients could deal with multiple 'personal' spaces, then we could just deploy an owncloudsql storage alongside decomposedfs and then users could migrate at will. 

For that a readonly owncloudsql might make sense ... hm ... we could list the owncloudsql spaces as projects ... that only the one user has access to ... 🤔 

it any case pls give me a +1 so I can start working on the upload sessions ...