### PR TITLE
Ignore Resharing instead of Erroring

### DIFF
--- a/changelog/unreleased/ignore-resharing-requests.md
+++ b/changelog/unreleased/ignore-resharing-requests.md
@@ -1,0 +1,5 @@
+Enhancement: Ignore resharing requests
+
+We now ignore resharing permissions. Instead of returning BadRequest we just reduce the permissions.
+
+https://github.com/cs3org/reva/pull/4816


### PR DESCRIPTION
Ignores resharing. See https://github.com/owncloud/ocis/issues/9681


Also changes the default from `Manager` to `Viewer` as `Manager` would result in a bad request.