### PR TITLE
Fix response code when upload a file over locked

### DIFF
--- a/changelog/unreleased/fix-upload-response-code.md
+++ b/changelog/unreleased/fix-upload-response-code.md
@@ -1,0 +1,6 @@
+Bugfix: Fix response code when upload a file over locked
+
+We fixed a bug where the response code was incorrect when uploading a file over a locked file.
+
+https://github.com/cs3org/reva/pull/4820  
+https://github.com/owncloud/ocis/issues/7638

--- a/internal/grpc/services/storageprovider/storageprovider.go
+++ b/internal/grpc/services/storageprovider/storageprovider.go
@@ -436,6 +436,8 @@ func (s *Service) InitiateFileUpload(ctx context.Context, req *provider.Initiate
 			st = status.NewInsufficientStorage(ctx, err, "insufficient storage")
 		case errtypes.PreconditionFailed:
 			st = status.NewFailedPrecondition(ctx, err, "failed precondition")
+		case errtypes.Locked:
+			st = status.NewLocked(ctx, "locked")
 		default:
 			st = status.NewInternal(ctx, "error getting upload id: "+err.Error())
 		}

--- a/internal/http/services/owncloud/ocdav/put.go
+++ b/internal/http/services/owncloud/ocdav/put.go
@@ -325,8 +325,6 @@ func (s *svc) handlePut(ctx context.Context, w http.ResponseWriter, r *http.Requ
 			w.WriteHeader(http.StatusPreconditionFailed)
 		case rpc.Code_CODE_FAILED_PRECONDITION:
 			w.WriteHeader(http.StatusConflict)
-		case rpc.Code_CODE_NOT_FOUND:
-			w.WriteHeader(http.StatusNotFound)
 		default:
 			errors.HandleErrorStatus(&log, w, uRes.Status)
 		}


### PR DESCRIPTION
Bugfix: Fix response code when uploading a file over locked

We fixed a bug where the response code was incorrect when uploading a file over a locked file.


https://github.com/owncloud/ocis/issues/7638