### PR TITLE
ocm: return remote etag

### DIFF
--- a/changelog/unreleased/ocm-return-etag.md
+++ b/changelog/unreleased/ocm-return-etag.md
@@ -1,0 +1,6 @@
+Bugfix: return etag for ocm shares
+
+The ocm remote storage now passes on the etag returned in the PROPFIND response.
+
+https://github.com/cs3org/reva/pull/4823
+https://github.com/owncloud/ocis/issues/9534

--- a/pkg/ocm/storage/received/ocm.go
+++ b/pkg/ocm/storage/received/ocm.go
@@ -285,6 +285,7 @@ func convertStatToResourceInfo(ref *provider.Reference, f fs.FileInfo, share *oc
 		Mtime: &typepb.Timestamp{
 			Seconds: uint64(f.ModTime().Unix()),
 		},
+		Etag:          webdavFile.ETag(),
 		Owner:         share.Creator,
 		PermissionSet: webdavProtocol.Permissions.Permissions,
 		Checksum: &provider.ResourceChecksum{


### PR DESCRIPTION
The ocm remote storage now passes on the etag returned in the PROPFIND response.

related: https://github.com/owncloud/ocis/issues/9534
