### PR TITLE
enhancement: add minimal test setup for the ocm-json-provider

### DIFF
--- a/pkg/ocm/provider/authorizer/json/json.go
+++ b/pkg/ocm/provider/authorizer/json/json.go
@@ -28,17 +28,22 @@ import (
 	"sync"
 
 	ocmprovider "github.com/cs3org/go-cs3apis/cs3/ocm/provider/v1beta1"
+	"github.com/pkg/errors"
+
 	"github.com/cs3org/reva/v2/pkg/appctx"
 	"github.com/cs3org/reva/v2/pkg/errtypes"
 	"github.com/cs3org/reva/v2/pkg/ocm/provider"
 	"github.com/cs3org/reva/v2/pkg/ocm/provider/authorizer/registry"
 	"github.com/cs3org/reva/v2/pkg/utils/cfg"
-	"github.com/pkg/errors"
 )
 
 func init() {
 	registry.Register("json", New)
 }
+
+var (
+	ErrNoIP = errtypes.NotSupported("No IP provided")
+)
 
 // New returns a new authorizer object.
 func New(m map[string]interface{}) (provider.Authorizer, error) {
@@ -102,7 +107,7 @@ func normalizeDomain(d string) (string, error) {
 	return u.Hostname(), nil
 }
 
-func (a *authorizer) GetInfoByDomain(ctx context.Context, domain string) (*ocmprovider.ProviderInfo, error) {
+func (a *authorizer) GetInfoByDomain(_ context.Context, domain string) (*ocmprovider.ProviderInfo, error) {
 	normalizedDomain, err := normalizeDomain(domain)
 	if err != nil {
 		return nil, err
@@ -140,7 +145,7 @@ func (a *authorizer) IsProviderAllowed(ctx context.Context, pi *ocmprovider.Prov
 	case !a.conf.VerifyRequestHostname:
 		return nil
 	case len(pi.Services) == 0:
-		return errtypes.NotSupported("No IP provided")
+		return ErrNoIP
 	}
 
 	var ocmHost string

--- a/pkg/ocm/provider/authorizer/json/json_test.go
+++ b/pkg/ocm/provider/authorizer/json/json_test.go
@@ -1,0 +1,83 @@
+package json_test
+
+import (
+	"context"
+	"testing"
+
+	ocmprovider "github.com/cs3org/go-cs3apis/cs3/ocm/provider/v1beta1"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cs3org/reva/v2/pkg/errtypes"
+	"github.com/cs3org/reva/v2/pkg/ocm/provider/authorizer/json"
+)
+
+func TestAuthorizer_GetInfoByDomain(t *testing.T) {
+	authorizer, err := json.New(map[string]interface{}{
+		"providers": "./testdata/providers.json",
+	})
+	assert.NotNil(t, authorizer)
+	assert.Nil(t, err)
+
+	{ // implicit normalizeDomain
+		for name, env := range map[string]struct {
+			givenDomain    string
+			expectedDomain string
+			expectedError  error
+		}{
+			"domain only":      {givenDomain: "server-one:9200", expectedDomain: "server-one"},
+			"domain with port": {givenDomain: "server-two:9200", expectedDomain: "server-two:9200"},
+			"unknown domain":   {givenDomain: "unknown-domain", expectedError: errtypes.NotFound("unknown-domain")},
+		} {
+			t.Run(name, func(t *testing.T) {
+				info, err := authorizer.GetInfoByDomain(context.Background(), env.givenDomain)
+				assert.ErrorIs(t, err, env.expectedError)
+				assert.Equal(t, info.GetDomain(), env.expectedDomain)
+			})
+		}
+	}
+}
+
+func TestAuthorizer_IsProviderAllowed(t *testing.T) {
+	{ // implicit normalizeDomain
+		for name, env := range map[string]struct {
+			providerInfo          *ocmprovider.ProviderInfo
+			verifyRequestHostname bool
+			expectedError         error
+		}{
+			"not authorized": {
+				providerInfo: &ocmprovider.ProviderInfo{
+					Domain: "some.unknown.domain",
+				},
+				expectedError: errtypes.NotFound("some.unknown.domain"),
+			},
+			"authorized without host name verification": {
+				providerInfo: &ocmprovider.ProviderInfo{
+					Domain: "server-one",
+				},
+			},
+			"no services and host name verification enabled": {
+				providerInfo:          &ocmprovider.ProviderInfo{},
+				verifyRequestHostname: true,
+				expectedError:         json.ErrNoIP,
+			},
+			"fails if the domain contains a port": {
+				providerInfo: &ocmprovider.ProviderInfo{
+					Domain: "server-two",
+				},
+				expectedError: error(errtypes.NotFound("server-two")),
+			},
+		} {
+			t.Run(name, func(t *testing.T) {
+				authorizer, err := json.New(map[string]interface{}{
+					"providers":               "./testdata/providers.json",
+					"verify_request_hostname": env.verifyRequestHostname,
+				})
+				assert.NotNil(t, authorizer)
+				assert.Nil(t, err)
+
+				err = authorizer.IsProviderAllowed(context.Background(), env.providerInfo)
+				assert.ErrorIs(t, err, env.expectedError)
+			})
+		}
+	}
+}

--- a/pkg/ocm/provider/authorizer/json/testdata/providers.json
+++ b/pkg/ocm/provider/authorizer/json/testdata/providers.json
@@ -1,0 +1,29 @@
+[
+  {
+    "domain": "server-one",
+    "services": [
+      {
+        "endpoint": {
+          "type": {
+            "name": "OCM"
+          },
+          "path": "https://server-one:9200/ocm/"
+        },
+        "host": "server-one:9200"
+      }
+    ]
+  },
+  {
+    "domain": "server-two:9200",
+    "services": [
+      {
+        "endpoint": {
+          "type": {
+            "name": "OCM"
+          },
+          "path": "https://server-two:9200/ocm/"
+        }
+      }
+    ]
+  }
+]


### PR DESCRIPTION
start writing tests for ocm related stuff...

@butonic after reading the code, it looks like its intended to not provide a port!
The invitation popup now also only contains one institute as expected!

![Screenshot 2024-08-30 at 14 52 36](https://github.com/user-attachments/assets/eb016124-b67f-480e-a1ef-ceb69dc4c26b)
