### PR TITLE
ocm: fix federated userid

### DIFF
--- a/changelog/unreleased/ocm-fix-federated-userid.md
+++ b/changelog/unreleased/ocm-fix-federated-userid.md
@@ -1,0 +1,6 @@
+Bugfix: fix OCM userid encoding
+
+We now base64 encode the remote userid and provider as the local federated user id. This allows us to always differentiate them from local users and unpack the encoded user id and provider when making requests to the remote ocm provider.
+
+https://github.com/cs3org/reva/pull/4833
+https://github.com/owncloud/ocis/issues/9927

--- a/internal/grpc/services/gateway/ocmshareprovider.go
+++ b/internal/grpc/services/gateway/ocmshareprovider.go
@@ -51,11 +51,15 @@ func (s *svc) CreateOCMShare(ctx context.Context, req *ocm.CreateOCMShareRequest
 		}, nil
 	}
 
+	// persist the OCM share in the ocm share provider
 	res, err := c.CreateOCMShare(ctx, req)
 	if err != nil {
 		return nil, errors.Wrap(err, "gateway: error calling CreateOCMShare")
 	}
 
+	// add a grant to the storage provider so the share can efficiently be listed
+	// the grant does not grant any permissions. access is granted by the OCM link token
+	// that is used by the public storage provider to impersonate the resource owner
 	status, err := s.addGrant(ctx, req.ResourceId, req.Grantee, req.AccessMethods[0].GetWebdavOptions().Permissions, req.Expiration, nil)
 	switch {
 	case err != nil:

--- a/pkg/ocm/user/user.go
+++ b/pkg/ocm/user/user.go
@@ -1,0 +1,55 @@
+package user
+
+import (
+	"encoding/base64"
+	"fmt"
+	"net/url"
+	"strings"
+
+	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
+)
+
+// FederatedID creates a federated user id by
+// 1. stripping the protocol from the domain and
+// 2. base64 encoding the opaque id with the domain to get a unique identifier that cannot collide with other users
+func FederatedID(id *userpb.UserId) *userpb.UserId {
+	// strip protocol from the domain
+	domain := id.Idp
+	if u, err := url.Parse(domain); err == nil && u.Host != "" {
+		domain = u.Host
+	}
+	return &userpb.UserId{
+		Type:     userpb.UserType_USER_TYPE_FEDERATED,
+		Idp:      domain,
+		OpaqueId: base64.URLEncoding.EncodeToString([]byte(id.OpaqueId + "@" + domain)),
+	}
+}
+
+// RemoteID creates a remote user id by
+// 1. decoding the base64 encoded opaque id
+// 2. splitting the opaque id at the last @ to get the opaque id and the domain
+func RemoteID(id *userpb.UserId) *userpb.UserId {
+	remoteId := &userpb.UserId{
+		Type:     userpb.UserType_USER_TYPE_PRIMARY,
+		Idp:      id.Idp,
+		OpaqueId: id.OpaqueId,
+	}
+	bytes, err := base64.URLEncoding.DecodeString(id.GetOpaqueId())
+	if err != nil {
+		return remoteId
+	}
+	remote := string(bytes)
+	last := strings.LastIndex(remote, "@")
+	if last == -1 {
+		return remoteId
+	}
+	remoteId.OpaqueId = remote[:last]
+	remoteId.Idp = remote[last+1:]
+
+	return remoteId
+}
+
+// FormatOCMUser formats a user id in the form of <opaque-id>@<idp> used by the OCM API in shareWith, owner and creator fields
+func FormatOCMUser(u *userpb.UserId) string {
+	return fmt.Sprintf("%s@%s", u.OpaqueId, u.Idp)
+}

--- a/tests/integration/grpc/fixtures/ocm-share/ocm-users.demo.json
+++ b/tests/integration/grpc/fixtures/ocm-share/ocm-users.demo.json
@@ -2,7 +2,7 @@
 	{
 		"id": {
 			"opaque_id": "4c510ada-c86b-4815-8820-42cdf82c3d51",
-			"idp": "cernbox.cern.ch",
+			"idp": "https://cernbox.cern.ch",
 			"type": 1
 		},
 		"username": "einstein",
@@ -32,7 +32,7 @@
 	{
 		"id": {
 			"opaque_id": "f7fbf8c8-139b-4376-b307-cf0a8c2d0d9c",
-			"idp": "cesnet.cz",
+			"idp": "https://cesnet.cz",
 			"type": 1
 		},
 		"username": "marie",

--- a/tests/integration/grpc/fixtures/ocm-users.demo.json
+++ b/tests/integration/grpc/fixtures/ocm-users.demo.json
@@ -2,7 +2,7 @@
 	{
 		"id": {
 			"opaque_id": "4c510ada-c86b-4815-8820-42cdf82c3d51",
-			"idp": "cernbox.cern.ch",
+			"idp": "https://cernbox.cern.ch",
 			"type": 1
 		},
 		"username": "einstein",
@@ -32,7 +32,7 @@
 	{
 		"id": {
 			"opaque_id": "f7fbf8c8-139b-4376-b307-cf0a8c2d0d9c",
-			"idp": "cesnet.cz",
+			"idp": "https://cesnet.cz",
 			"type": 1
 		},
 		"username": "marie",


### PR DESCRIPTION

We now base64 encode the remote userid and provider as the local federated user id. This allows us to always differentiate them from local users and unpack the encoded user id and provider when making requests to the remote ocm provider.

related: https://github.com/owncloud/ocis/issues/9927