### PR TITLE
Fix sharejail stat

### DIFF
--- a/changelog/unreleased/fix-sharejail-stat-id.md
+++ b/changelog/unreleased/fix-sharejail-stat-id.md
@@ -1,0 +1,6 @@
+Bugfix: Fix sharejail stat id
+
+Stating a share jail mountpoint now returns the same resourceid as in the directory listing of the share jail root.
+
+https://github.com/cs3org/reva/pull/4835
+https://github.com/owncloud/ocis/issues/9933


### PR DESCRIPTION
Stating a share jail mountpoint now returns the same resourceid as in the directory listing of the share jail root.

This needs to be tested with WOPI, as I fear the web client might now try to use the sharejail id to access a resource ...

see https://github.com/owncloud/ocis/issues/9933