### PR TITLE
OCM: write body after header

### DIFF
--- a/changelog/unreleased/ocm-generate-invite-event.md
+++ b/changelog/unreleased/ocm-generate-invite-event.md
@@ -3,5 +3,6 @@ Enhancement: Publish an event when an OCM invite is generated
 The ocm generate-invite endpoint now publishes an event whenever an invitation is requested and generated.
 This event can be subscribed to by other services to react to the generated invitation.
 
+https://github.com/cs3org/reva/pull/4836
 https://github.com/cs3org/reva/pull/4832
 https://github.com/owncloud/ocis/issues/9583

--- a/internal/http/services/sciencemesh/token.go
+++ b/internal/http/services/sciencemesh/token.go
@@ -100,10 +100,12 @@ func (h *tokenHandler) Generate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK) // FIXME this should be a 201 created status. Tracked in https://github.com/cs3org/reva/issues/4838
+
 	tknRes := h.prepareGenerateTokenResponse(genTokenRes.GetInviteToken())
 	if err := json.NewEncoder(w).Encode(tknRes); err != nil {
 		reqres.WriteError(w, r, reqres.APIErrorServerError, "error marshalling token data", err)
-		return
 	}
 
 	if h.eventStream != nil {
@@ -122,8 +124,6 @@ func (h *tokenHandler) Generate(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
 }
 
 // generateRequest is the request body for the Generate endpoint.


### PR DESCRIPTION
the order of writing body and header is wrong

also creating something should return a 201 status

finally, we still want to emit the event even if we could not render the body, because the email should still be sent.