### PR TITLE
fix: persist updated share

### DIFF
--- a/changelog/unreleased/allow-update-ocm-shares.md
+++ b/changelog/unreleased/allow-update-ocm-shares.md
@@ -2,5 +2,6 @@ Bugfix: Allow update of ocm shares
 
 We fixed a bug that prevented ocm shares to be updated or removed.
 
+https://github.com/cs3org/reva/pull/4843/
 https://github.com/cs3org/reva/pull/4840/
 https://github.com/owncloud/ocis/issues/9926


### PR DESCRIPTION
persists the share after applying all mutations