### PR TITLE
Add specific application/x-binary mime type for bin extension files to mime type mapping

### DIFF
--- a/changelog/unreleased/enhancement-add-specific-mime-type-for-bin-files.md
+++ b/changelog/unreleased/enhancement-add-specific-mime-type-for-bin-files.md
@@ -1,0 +1,5 @@
+Enhancement: Add specific mime type for bin files
+
+We've added the specific mime type 'application/x-binary' for bin files to the list of mime types.
+
+https://github.com/cs3org/reva/pull/4846

--- a/pkg/mime/mime.go
+++ b/pkg/mime/mime.go
@@ -88,7 +88,7 @@ var mimeTypes = map[string]string{
 	"bdoc":                     "application/x-bdoc",
 	"bed":                      "application/vnd.realvnc.bed",
 	"bh2":                      "application/vnd.fujitsu.oasysprs",
-	"bin":                      "application/octet-stream",
+	"bin":                      "application/x-binary",
 	"blb":                      "application/x-blorb",
 	"blorb":                    "application/x-blorb",
 	"bmi":                      "application/vnd.bmi",


### PR DESCRIPTION
Enhancement: Add specific mime type for bin files

We've added the specific mime type 'application/x-binary' for bin files to the list of mime types.