### PR TITLE
stable 2.19 - backport write upload session info atomically

### DIFF
--- a/changelog/unreleased/write-upload-sessions-atomically.md
+++ b/changelog/unreleased/write-upload-sessions-atomically.md
@@ -1,0 +1,7 @@
+Bugfix: Write upload session info atomically
+
+We now use a lock and atomic write on upload session metadata to prevent empty reads. A virus scan event might cause the file to be truncated and then a finished event might try to read the file, just getting an empty string.
+
+Backport of https://github.com/cs3org/reva/pull/4850
+
+https://github.com/cs3org/reva/pull/4853

--- a/pkg/storage/utils/decomposedfs/upload/store.go
+++ b/pkg/storage/utils/decomposedfs/upload/store.go
@@ -110,7 +110,7 @@ func (store OcisStore) List(ctx context.Context) ([]*OcisSession, error) {
 
 // Get returns the upload session for the given upload id
 func (store OcisStore) Get(ctx context.Context, id string) (*OcisSession, error) {
-	sessionPath := filepath.Join(store.root, "uploads", id+".info")
+	sessionPath := sessionPath(store.root, id)
 	match := _idRegexp.FindStringSubmatch(sessionPath)
 	if match == nil || len(match) < 2 {
 		return nil, fmt.Errorf("invalid upload path")
@@ -120,6 +120,15 @@ func (store OcisStore) Get(ctx context.Context, id string) (*OcisSession, error)
 		store: store,
 		info:  tusd.FileInfo{},
 	}
+	lock, err := lockedfile.Open(sessionPath + ".lock")
+	if err != nil {
+		if errors.Is(err, iofs.ErrNotExist) {
+			// Interpret os.ErrNotExist as 404 Not Found
+			err = tusd.ErrNotFound
+		}
+		return nil, err
+	}
+	defer lock.Close()
 	data, err := os.ReadFile(sessionPath)
 	if err != nil {
 		if errors.Is(err, iofs.ErrNotExist) {
@@ -128,6 +137,8 @@ func (store OcisStore) Get(ctx context.Context, id string) (*OcisSession, error)
 		}
 		return nil, err
 	}
+	lock.Close() // release lock asap
+
 	if err := json.Unmarshal(data, &session.info); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
We now use a lock and atomic write on upload session metadata to prevent empty reads. A virus scan event might cause the file to be truncated and then a finished event might try to read the file, just getting an empty string.

Backport of https://github.com/cs3org/reva/pull/4850