### PR TITLE
fix: return proper responses on app/new

### DIFF
--- a/changelog/unreleased/fix-app-new-response.md
+++ b/changelog/unreleased/fix-app-new-response.md
@@ -1,0 +1,5 @@
+Bugfix: Better response codes for app new endpoint
+
+We fixed the response codes for the app new endpoint.
+
+https://github.com/cs3org/reva/pull/4858

--- a/internal/http/services/appprovider/appprovider.go
+++ b/internal/http/services/appprovider/appprovider.go
@@ -251,8 +251,16 @@ func (s *svc) handleNew(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if createRes.Status.Code != rpc.Code_CODE_OK {
-		writeError(w, r, appErrorServerError, "error calling InitiateFileUpload", nil)
-		return
+		switch createRes.Status.Code {
+		case rpc.Code_CODE_PERMISSION_DENIED:
+			writeError(w, r, appErrorPermissionDenied, "permission denied to create the file", nil)
+		case rpc.Code_CODE_NOT_FOUND:
+			writeError(w, r, appErrorNotFound, "parent container does not exist", nil)
+			return
+		default:
+			writeError(w, r, appErrorServerError, "error calling InitiateFileUpload", nil)
+			return
+		}
 	}
 
 	// Do a HTTP PUT with an empty body


### PR DESCRIPTION
Bugfix: Better response codes for app new endpoint

We fixed the response codes for the app new endpoint.

Fixes https://github.com/owncloud/ocis/issues/10126
