### PR TITLE
Fixed an issue when the collaboration service registers apps also for binary and unknown mime types

### DIFF
--- a/changelog/unreleased/fix-registers-app.md
+++ b/changelog/unreleased/fix-registers-app.md
@@ -1,0 +1,6 @@
+Bugfix: Fixed the collaboration service registration
+
+Fixed an issue when the collaboration service registers apps also for binary and unknown mime types.
+
+https://github.com/cs3org/reva/pull/4859   
+https://github.com/owncloud/ocis/issues/10086

--- a/pkg/mime/mime.go
+++ b/pkg/mime/mime.go
@@ -1054,6 +1054,7 @@ var mimeTypes = map[string]string{
 	"wmz":                      "application/x-msmetafile",
 	"woff":                     "font/woff",
 	"woff2":                    "font/woff2",
+	"wopitest":                 "text/plain", // The dummy extension for the WOPI validator https://learn.microsoft.com/en-us/microsoft-365/cloud-storage-partner-program/online/build-test-ship/validator
 	"wpd":                      "application/vnd.wordperfect",
 	"wpl":                      "application/vnd.ms-wpl",
 	"wps":                      "application/vnd.ms-works",


### PR DESCRIPTION
Related Issue https://github.com/owncloud/ocis/issues/10086