### PR TITLE
fix(store): encode nats-js-kv keys

### DIFF
--- a/changelog/unreleased/fix-nats-encoding.md
+++ b/changelog/unreleased/fix-nats-encoding.md
@@ -1,0 +1,6 @@
+Bugfix: Fix nats encoding
+
+Encode nats-js-kv keys. This got lost by a dependency bump.
+
+https://github.com/cs3org/reva/pull/4862
+https://github.com/cs3org/reva/pull/4678

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -152,6 +152,7 @@ func Create(opts ...microstore.Option) microstore.Store {
 		return natsjskv.NewStore(
 			append(opts,
 				natsjskv.NatsOptions(natsOptions), // always pass in properly initialized default nats options
+				natsjskv.EncodeKeys(),
 				natsjskv.DefaultTTL(ttl))...,
 		)
 	case TypeMemory, "mem", "": // allow existing short form and use as default


### PR DESCRIPTION
Encode nats-js-kv keys. This got lost by a dependency bump.

complicated thing .... https://github.com/cs3org/reva/pull/4842#discussion_r1761003987 ... don't ask

in case someone has to dig in again:

nats-js-kv used to always encode the keys. we changed that upstream to make it configurable ... as a good citizen ... you know ... then we had to make ocis always encode the key ... which led to https://github.com/cs3org/reva/pull/4678#issue-2289684740

so yea ... we always encode the key ...