### PR TITLE
Add option to disable versioning in EOS upon PUT request

### DIFF
--- a/changelog/unreleased/disable-versioning.md
+++ b/changelog/unreleased/disable-versioning.md
@@ -1,0 +1,4 @@
+Enhancement: Add HTTP header to disable versioning on EOS
+
+This enhancement introduces a new header, `X-Disable-Versioning`, on PUT requests. EOS will not version this file save whenever this header is set with a truthy value.
+See also: https://github.com/cs3org/reva/pull/4864

--- a/internal/http/services/appprovider/appprovider.go
+++ b/internal/http/services/appprovider/appprovider.go
@@ -27,6 +27,7 @@ import (
 	"net/url"
 	"path"
 	"path/filepath"
+	"strconv"
 
 	apppb "github.com/cs3org/go-cs3apis/cs3/app/provider/v1beta1"
 	appregistry "github.com/cs3org/go-cs3apis/cs3/app/registry/v1beta1"
@@ -35,6 +36,7 @@ import (
 	storagepb "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	typespb "github.com/cs3org/go-cs3apis/cs3/types/v1beta1"
 	"github.com/cs3org/reva/internal/http/services/datagateway"
+	"github.com/cs3org/reva/internal/http/services/owncloud/ocdav"
 	"github.com/cs3org/reva/pkg/appctx"
 	"github.com/cs3org/reva/pkg/httpclient"
 	"github.com/cs3org/reva/pkg/rgrpc/status"
@@ -251,6 +253,7 @@ func (s *svc) handleNew(w http.ResponseWriter, r *http.Request) {
 	}
 
 	httpReq.Header.Set(datagateway.TokenTransportHeader, token)
+	httpReq.Header.Set(ocdav.HeaderContentLength, strconv.Itoa(0))
 
 	tr := &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: s.conf.Insecure}}
 	httpRes, err := httpclient.New(httpclient.RoundTripper(tr)).Do(httpReq)

--- a/internal/http/services/datagateway/datagateway.go
+++ b/internal/http/services/datagateway/datagateway.go
@@ -332,6 +332,7 @@ func (s *svc) doPut(w http.ResponseWriter, r *http.Request) {
 
 	copyHeader(w.Header(), httpRes.Header)
 	if httpRes.StatusCode != http.StatusOK {
+		log.Warn().Int("StatusCode", httpRes.StatusCode).Msg("Non-OK Status Code when sending request to internal data server")
 		// swallow the body and set content-length to 0 to prevent reverse proxies from trying to read from it
 		w.Header().Set("Content-Length", "0")
 		w.WriteHeader(httpRes.StatusCode)

--- a/internal/http/services/owncloud/ocdav/put.go
+++ b/internal/http/services/owncloud/ocdav/put.go
@@ -280,6 +280,14 @@ func (s *svc) handlePut(ctx context.Context, w http.ResponseWriter, r *http.Requ
 		httpReq.Header.Set(HeaderLockHolder, lockholder)
 	}
 
+	// Propagate X-Disable-Versioning header
+	// Used to disable versioning for applications that do not expect this behaviour
+	// See reva#4855 for more info
+	disableVersioning, err := strconv.ParseBool(r.Header.Get(HeaderDisableVersioning))
+	if err == nil && disableVersioning {
+		httpReq.Header.Set(HeaderDisableVersioning, strconv.FormatBool(true))
+	}
+
 	httpRes, err := s.client.Do(httpReq)
 	if err != nil {
 		log.Error().Err(err).Msg("error doing PUT request to data service")

--- a/internal/http/services/owncloud/ocdav/put.go
+++ b/internal/http/services/owncloud/ocdav/put.go
@@ -280,6 +280,14 @@ func (s *svc) handlePut(ctx context.Context, w http.ResponseWriter, r *http.Requ
 		httpReq.Header.Set(HeaderLockHolder, lockholder)
 	}
 
+	// We need to pass Content-Length to the storage backend (e.g. EOS).
+	// However, the Go HTTP Client library may arbitrarily modify or drop
+	// the Content-Length header, for example when it compresses the data
+	// See: https://pkg.go.dev/net/http#Request
+	// Therefore, we use another header to pass it through the internal
+	// data server
+	httpReq.Header.Set(HeaderUploadLength, strconv.FormatInt(length, 10))
+
 	// Propagate X-Disable-Versioning header
 	// Used to disable versioning for applications that do not expect this behaviour
 	// See reva#4855 for more info

--- a/internal/http/services/owncloud/ocdav/put_test.go
+++ b/internal/http/services/owncloud/ocdav/put_test.go
@@ -1,0 +1,94 @@
+// Copyright 2018-2024 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package ocdav
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	gateway "github.com/cs3org/go-cs3apis/cs3/gateway/v1beta1"
+	rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
+	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+	mockgateway "github.com/cs3org/go-cs3apis/mocks/github.com/cs3org/go-cs3apis/cs3/gateway/v1beta1"
+	"github.com/cs3org/reva/pkg/httpclient"
+	"github.com/cs3org/reva/pkg/rgrpc/todo/pool"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/mock"
+)
+
+// Test that when calls come in to the PUT endpoint with a X-Disable-Versioning header,
+// this header is propagated to the actual upload endpoint
+func TestDisableVersioningHeaderPassedAlong(t *testing.T) {
+
+	gatewayAPIEndpoint := "my-api-endpoint"
+	incomingPath := "http://my-reva.com/myfile.txt"
+	input := "Hello world!"
+
+	// create HTTP request
+	request := httptest.NewRequest(http.MethodPut, incomingPath, strings.NewReader(input))
+	request.Header.Add(HeaderContentLength, strconv.Itoa(len(input)))
+	request.Header.Add(HeaderDisableVersioning, "true")
+
+	// Create fake HTTP server for upload endpoint
+	// Here we will check whether the header was correctly set
+	calls := 0
+	w := httptest.NewRecorder()
+	mockServerUpload := httptest.NewServer(
+		http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				if header := r.Header.Get(HeaderDisableVersioning); header == "" {
+					t.Errorf("expected header %s but header was not set", HeaderDisableVersioning)
+				}
+				calls++
+			},
+		),
+	)
+	endpointPath := mockServerUpload.URL
+
+	// Set up mocked GatewayAPIClient
+	gatewayClient := mockgateway.NewMockGatewayAPIClient(t)
+	gatewayClient.On("Stat", mock.Anything, mock.Anything).Return(&provider.StatResponse{Status: &rpc.Status{Code: rpc.Code_CODE_NOT_FOUND}}, nil)
+	gatewayClient.On("InitiateFileUpload", mock.Anything, mock.Anything).Return(&gateway.InitiateFileUploadResponse{
+		Status: &rpc.Status{Code: rpc.Code_CODE_OK},
+		Protocols: []*gateway.FileUploadProtocol{
+			{Protocol: "simple", UploadEndpoint: endpointPath, Token: "my-secret-token"},
+		}}, nil)
+	pool.RegisterGatewayServiceClient(gatewayClient, gatewayAPIEndpoint)
+
+	// Set up OCDAV Service
+	service := svc{
+		c: &Config{
+			GatewaySvc: gatewayAPIEndpoint,
+		},
+		client: httpclient.New(),
+	}
+	ref := provider.Reference{}
+
+	// Do the actual call
+	service.handlePut(context.Background(), w, request, &ref, zerolog.Logger{})
+
+	// If no connection was made to the upload endpoint, something is also wrong
+	if calls == 0 {
+		t.Errorf("Upload endpoint was not called. ")
+	}
+}

--- a/internal/http/services/owncloud/ocdav/webdav.go
+++ b/internal/http/services/owncloud/ocdav/webdav.go
@@ -78,6 +78,7 @@ const (
 	HeaderTransferAuth         = "TransferHeaderAuthorization"
 	HeaderLockID               = "X-Lock-Id"
 	HeaderLockHolder           = "X-Lock-Holder"
+	HeaderDisableVersioning    = "X-Disable-Versioning"
 )
 
 // WebDavHandler implements a dav endpoint.

--- a/pkg/eosclient/eosbinary/eosbinary.go
+++ b/pkg/eosclient/eosbinary/eosbinary.go
@@ -747,7 +747,7 @@ func (c *Client) Read(ctx context.Context, auth eosclient.Authorization, path st
 }
 
 // Write writes a stream to the mgm.
-func (c *Client) Write(ctx context.Context, auth eosclient.Authorization, path string, stream io.ReadCloser, app string, disableVersioning bool) error {
+func (c *Client) Write(ctx context.Context, auth eosclient.Authorization, path string, stream io.ReadCloser, length int64, app string, disableVersioning bool) error {
 	fd, err := os.CreateTemp(c.opt.CacheDirectory, "eoswrite-")
 	if err != nil {
 		return err

--- a/pkg/eosclient/eosclient.go
+++ b/pkg/eosclient/eosclient.go
@@ -52,7 +52,7 @@ type EOSClient interface {
 	List(ctx context.Context, auth Authorization, path string) ([]*FileInfo, error)
 	ListWithRegex(ctx context.Context, auth Authorization, path string, depth uint, regex string) ([]*FileInfo, error)
 	Read(ctx context.Context, auth Authorization, path string) (io.ReadCloser, error)
-	Write(ctx context.Context, auth Authorization, path string, stream io.ReadCloser, app string, disableVersioning bool) error
+	Write(ctx context.Context, auth Authorization, path string, stream io.ReadCloser, length int64, app string, disableVersioning bool) error
 	ListDeletedEntries(ctx context.Context, auth Authorization, maxentries int, from, to time.Time) ([]*DeletedEntry, error)
 	RestoreDeletedEntry(ctx context.Context, auth Authorization, key string) error
 	PurgeDeletedEntries(ctx context.Context, auth Authorization) error

--- a/pkg/eosclient/eosclient.go
+++ b/pkg/eosclient/eosclient.go
@@ -52,7 +52,7 @@ type EOSClient interface {
 	List(ctx context.Context, auth Authorization, path string) ([]*FileInfo, error)
 	ListWithRegex(ctx context.Context, auth Authorization, path string, depth uint, regex string) ([]*FileInfo, error)
 	Read(ctx context.Context, auth Authorization, path string) (io.ReadCloser, error)
-	Write(ctx context.Context, auth Authorization, path string, stream io.ReadCloser, app string) error
+	Write(ctx context.Context, auth Authorization, path string, stream io.ReadCloser, app string, disableVersioning bool) error
 	ListDeletedEntries(ctx context.Context, auth Authorization, maxentries int, from, to time.Time) ([]*DeletedEntry, error)
 	RestoreDeletedEntry(ctx context.Context, auth Authorization, key string) error
 	PurgeDeletedEntries(ctx context.Context, auth Authorization) error

--- a/pkg/eosclient/eosgrpc/eosgrpc.go
+++ b/pkg/eosclient/eosgrpc/eosgrpc.go
@@ -284,11 +284,9 @@ func (c *Client) Read(ctx context.Context, auth eosclient.Authorization, path st
 
 // Write writes a file to the mgm
 // Somehow the same considerations as Read apply.
-func (c *Client) Write(ctx context.Context, auth eosclient.Authorization, path string, stream io.ReadCloser, app string, disableVersioning bool) error {
+func (c *Client) Write(ctx context.Context, auth eosclient.Authorization, path string, stream io.ReadCloser, length int64, app string, disableVersioning bool) error {
 	log := appctx.GetLogger(ctx)
 	log.Info().Str("func", "Write").Str("uid,gid", auth.Role.UID+","+auth.Role.GID).Str("path", path).Msg("")
-	var length int64
-	length = -1
 
 	u, err := utils.GetUser(ctx)
 	if err != nil {

--- a/pkg/eosclient/eosgrpc/eosgrpc.go
+++ b/pkg/eosclient/eosgrpc/eosgrpc.go
@@ -284,7 +284,7 @@ func (c *Client) Read(ctx context.Context, auth eosclient.Authorization, path st
 
 // Write writes a file to the mgm
 // Somehow the same considerations as Read apply.
-func (c *Client) Write(ctx context.Context, auth eosclient.Authorization, path string, stream io.ReadCloser, app string) error {
+func (c *Client) Write(ctx context.Context, auth eosclient.Authorization, path string, stream io.ReadCloser, app string, disableVersioning bool) error {
 	log := appctx.GetLogger(ctx)
 	log.Info().Str("func", "Write").Str("uid,gid", auth.Role.UID+","+auth.Role.GID).Str("path", path).Msg("")
 	var length int64
@@ -317,10 +317,10 @@ func (c *Client) Write(ctx context.Context, auth eosclient.Authorization, path s
 		defer wfd.Close()
 		defer os.RemoveAll(fd.Name())
 
-		return c.httpcl.PUTFile(ctx, u.Username, auth, path, wfd, length, app)
+		return c.httpcl.PUTFile(ctx, u.Username, auth, path, wfd, length, app, disableVersioning)
 	}
 
-	return c.httpcl.PUTFile(ctx, u.Username, auth, path, stream, length, app)
+	return c.httpcl.PUTFile(ctx, u.Username, auth, path, stream, length, app, disableVersioning)
 }
 
 func (c *Client) getOrCreateVersionFolderInode(ctx context.Context, ownerAuth eosclient.Authorization, p string) (uint64, error) {

--- a/pkg/eosclient/eosgrpc/eoshttp.go
+++ b/pkg/eosclient/eosgrpc/eoshttp.go
@@ -385,10 +385,6 @@ func (c *EOSHTTPClient) PUTFile(ctx context.Context, remoteuser string, auth eos
 	base.RawQuery = queryValues.Encode()
 	finalurl := base.String()
 
-	if err != nil {
-		log.Error().Str("func", "PUTFile").Str("url", finalurl).Str("err", err.Error()).Msg("can't create request")
-		return err
-	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodPut, finalurl, nil)
 	if err != nil {
 		log.Error().Str("func", "PUTFile").Str("url", finalurl).Str("err", err.Error()).Msg("can't create request")
@@ -444,7 +440,8 @@ func (c *EOSHTTPClient) PUTFile(ctx context.Context, remoteuser string, auth eos
 			}
 			if length >= 0 {
 				log.Debug().Str("func", "PUTFile").Int64("Content-Length", length).Msg("setting header")
-				req.Header.Set("Content-Length", strconv.FormatInt(length, 10))
+				req.ContentLength = length
+				req.Header.Set("Content-Length", fmt.Sprintf("%d", length))
 			}
 
 			log.Debug().Str("func", "PUTFile").Str("location", loc.String()).Msg("redirection")

--- a/pkg/eosclient/eosgrpc/eoshttp_test.go
+++ b/pkg/eosclient/eosgrpc/eoshttp_test.go
@@ -1,0 +1,59 @@
+package eosgrpc
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/cs3org/reva/pkg/eosclient"
+)
+
+// Test that, when the PUTFile method is called with disableVersioning
+// set to true, the url for the EOS endpoint contains the right query param
+func TestDisableVersioningLeadsToCorrectQueryParams(t *testing.T) {
+
+	stream := io.NopCloser(strings.NewReader("Hello world!"))
+	length := int64(12)
+	app := "my-app"
+	urlpath := "/my-file.txt?queryparam=1"
+	token := "my-secret-token"
+
+	// Create fake HTTP server that acts as the EOS endpoint
+	calls := 0
+	mockServerUpload := httptest.NewServer(
+		http.HandlerFunc(
+			func(w http.ResponseWriter, r *http.Request) {
+				calls++
+				queryValues := r.URL.Query()
+				if queryValues.Get("eos.versioning") == "" {
+					t.Errorf("Query parameter eos.versioning not set")
+				}
+				if q := queryValues.Get("eos.versioning"); q != strconv.Itoa(0) {
+					t.Errorf("Query parameter eos.versioning set to wrong value; got %s, expected 0", q)
+				}
+			},
+		),
+	)
+
+	// Create EOS HTTP Client
+	// TODO: right now, expects files to be on the FS
+	client, err := NewEOSHTTPClient(&HTTPOptions{
+		BaseURL: mockServerUpload.URL,
+	})
+	if err != nil {
+		t.Errorf("Failed to construct client: %s", err.Error())
+	}
+
+	// Test actual PUTFile call
+	client.PUTFile(context.Background(), "remote-user", eosclient.Authorization{
+		Token: token}, urlpath, stream, length, app, true)
+
+	// If no connection was made to the EOS endpoint, something is wrong
+	if calls == 0 {
+		t.Errorf("EOS endpoint was not called. ")
+	}
+}

--- a/pkg/rgrpc/todo/pool/pool.go
+++ b/pkg/rgrpc/todo/pool/pool.go
@@ -98,6 +98,13 @@ func NewConn(options Options) (*grpc.ClientConn, error) {
 	return conn, nil
 }
 
+func RegisterGatewayServiceClient(client gateway.GatewayAPIClient, endpoint string) {
+	gatewayProviders.m.Lock()
+	defer gatewayProviders.m.Unlock()
+
+	gatewayProviders.conn[endpoint] = client
+}
+
 // GetGatewayServiceClient returns a GatewayServiceClient.
 func GetGatewayServiceClient(opts ...Option) (gateway.GatewayAPIClient, error) {
 	gatewayProviders.m.Lock()

--- a/pkg/rhttp/datatx/manager/simple/simple.go
+++ b/pkg/rhttp/datatx/manager/simple/simple.go
@@ -21,6 +21,7 @@ package simple
 import (
 	"context"
 	"net/http"
+	"strconv"
 
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	"github.com/cs3org/reva/internal/http/services/owncloud/ocdav"
@@ -86,6 +87,12 @@ func (m *manager) Handler(fs storage.FS) (http.Handler, error) {
 
 			if disableVersioning := r.Header.Get(ocdav.HeaderDisableVersioning); disableVersioning != "" {
 				metadata["disableVersioning"] = disableVersioning
+			}
+
+			contentLength := r.Header.Get(ocdav.HeaderUploadLength)
+
+			if _, err := strconv.ParseInt(contentLength, 10, 64); err == nil {
+				metadata[ocdav.HeaderContentLength] = contentLength
 			}
 
 			err := fs.Upload(ctx, ref, r.Body, metadata)

--- a/pkg/rhttp/datatx/manager/simple/simple.go
+++ b/pkg/rhttp/datatx/manager/simple/simple.go
@@ -84,6 +84,10 @@ func (m *manager) Handler(fs storage.FS) (http.Handler, error) {
 				metadata["lockholder"] = lockholder
 			}
 
+			if disableVersioning := r.Header.Get(ocdav.HeaderDisableVersioning); disableVersioning != "" {
+				metadata["disableVersioning"] = disableVersioning
+			}
+
 			err := fs.Upload(ctx, ref, r.Body, metadata)
 			switch v := err.(type) {
 			case nil:

--- a/pkg/storage/utils/eosfs/upload.go
+++ b/pkg/storage/utils/eosfs/upload.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"os"
 	"path"
+	"strconv"
 
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	"github.com/cs3org/reva/pkg/errtypes"
@@ -83,7 +84,13 @@ func (fs *Eosfs) Upload(ctx context.Context, ref *provider.Reference, r io.ReadC
 		// if we have a lock context, the app for EOS must match the lock holder
 		app = fs.EncodeAppName(app)
 	}
-	return fs.c.Write(ctx, auth, fn, r, app)
+
+	disableVersioning, err := strconv.ParseBool(metadata["disableVersioning"])
+	if err != nil {
+		disableVersioning = false
+	}
+
+	return fs.c.Write(ctx, auth, fn, r, app, disableVersioning)
 }
 
 func (fs *Eosfs) InitiateUpload(ctx context.Context, ref *provider.Reference, uploadLength int64, metadata map[string]string) (map[string]string, error) {

--- a/pkg/storage/utils/eosfs/upload.go
+++ b/pkg/storage/utils/eosfs/upload.go
@@ -26,6 +26,7 @@ import (
 	"strconv"
 
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+	"github.com/cs3org/reva/internal/http/services/owncloud/ocdav"
 	"github.com/cs3org/reva/pkg/errtypes"
 	"github.com/cs3org/reva/pkg/storage/utils/chunking"
 	"github.com/cs3org/reva/pkg/utils"
@@ -90,7 +91,13 @@ func (fs *Eosfs) Upload(ctx context.Context, ref *provider.Reference, r io.ReadC
 		disableVersioning = false
 	}
 
-	return fs.c.Write(ctx, auth, fn, r, app, disableVersioning)
+	contentLength := metadata[ocdav.HeaderContentLength]
+	len, err := strconv.ParseInt(contentLength, 10, 64)
+	if err != nil {
+		return errors.New("No content length specified in EOS upload, got: " + contentLength)
+	}
+
+	return fs.c.Write(ctx, auth, fn, r, len, app, disableVersioning)
 }
 
 func (fs *Eosfs) InitiateUpload(ctx context.Context, ref *provider.Reference, uploadLength int64, metadata map[string]string) (map[string]string, error) {

--- a/tests/helpers/helpers.go
+++ b/tests/helpers/helpers.go
@@ -28,6 +28,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 
 	"github.com/pkg/errors"
 
@@ -35,6 +36,7 @@ import (
 	rpcv1beta1 "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	"github.com/cs3org/reva/internal/http/services/datagateway"
+	"github.com/cs3org/reva/internal/http/services/owncloud/ocdav"
 	"github.com/cs3org/reva/pkg/httpclient"
 	"github.com/cs3org/reva/pkg/storage"
 	"github.com/studio-b12/gowebdav"
@@ -105,7 +107,9 @@ func Upload(ctx context.Context, fs storage.FS, ref *provider.Reference, content
 		return errors.New("simple upload method not available")
 	}
 	uploadRef := &provider.Reference{Path: "/" + uploadID}
-	err = fs.Upload(ctx, uploadRef, io.NopCloser(bytes.NewReader(content)), map[string]string{})
+	err = fs.Upload(ctx, uploadRef, io.NopCloser(bytes.NewReader(content)), map[string]string{
+		ocdav.HeaderUploadLength: strconv.FormatInt(int64(len(content)), 10),
+	})
 	return err
 }
 


### PR DESCRIPTION
Fixes #4855 

This PR introduces a new HTTP header for PUT requests, `X-Disable-Versioning`. When this header is added to a PUT request, the EOS storage driver will turn off versioning for this particular save. This is particularly useful for applications that perform automatic saves every x minutes: disabling versioning on these automatic saves ensures that the version history of these files is not polluted