### PR TITLE
fix(decomposedfs): available space calculation

### DIFF
--- a/changelog/unreleased/fix-available-diskspace.md
+++ b/changelog/unreleased/fix-available-diskspace.md
@@ -1,0 +1,6 @@
+Bugfix: Fix remaining space calculation for S3 blobstore
+
+The calculation of the remaining space in the S3 blobstore was incorrectly using
+the remaining space of the local disk instead.
+
+https://github.com/cs3org/reva/pull/4867

--- a/pkg/storage/fs/ocis/blobstore/blobstore.go
+++ b/pkg/storage/fs/ocis/blobstore/blobstore.go
@@ -116,6 +116,11 @@ func (bs *Blobstore) Delete(node *node.Node) error {
 	return nil
 }
 
+// GetAvailableSize returns the available size in the blobstore in bytes
+func (bs *Blobstore) GetAvailableSize(n *node.Node) (uint64, error) {
+	return node.GetAvailableSize(n.InternalPath())
+}
+
 // List lists all blobs in the Blobstore
 func (bs *Blobstore) List() ([]*node.Node, error) {
 	dirs, err := filepath.Glob(filepath.Join(bs.root, "spaces", "*", "*", "blobs", "*", "*", "*", "*", "*"))

--- a/pkg/storage/fs/posix/blobstore/blobstore.go
+++ b/pkg/storage/fs/posix/blobstore/blobstore.go
@@ -88,3 +88,8 @@ func (bs *Blobstore) Download(node *node.Node) (io.ReadCloser, error) {
 func (bs *Blobstore) Delete(node *node.Node) error {
 	return nil
 }
+
+// GetAvailableSize returns the available size in the blobstore in bytes
+func (bs *Blobstore) GetAvailableSize(n *node.Node) (uint64, error) {
+	return node.GetAvailableSize(n.InternalPath())
+}

--- a/pkg/storage/fs/posix/posix.go
+++ b/pkg/storage/fs/posix/posix.go
@@ -126,6 +126,7 @@ func New(m map[string]interface{}, stream events.Stream) (storage.FS, error) {
 	aspects := aspects.Aspects{
 		Lookup:            lu,
 		Tree:              tp,
+		Blobstore:         bs,
 		Permissions:       p,
 		EventStream:       stream,
 		UserMapper:        um,

--- a/pkg/storage/fs/posix/testhelpers/helpers.go
+++ b/pkg/storage/fs/posix/testhelpers/helpers.go
@@ -178,6 +178,7 @@ func NewTestEnv(config map[string]interface{}) (*TestEnv, error) {
 	)
 
 	bs := &treemocks.Blobstore{}
+	bs.On("GetAvailableSize", mock.Anything).Return(uint64(1000000000), nil)
 	tree, err := tree.New(lu, bs, um, &trashbin.Trashbin{}, o, nil, store.Create())
 	if err != nil {
 		return nil, err
@@ -189,6 +190,7 @@ func NewTestEnv(config map[string]interface{}) (*TestEnv, error) {
 	aspects := aspects.Aspects{
 		Lookup:      lu,
 		Tree:        tree,
+		Blobstore:   bs,
 		Permissions: permissions.NewPermissions(pmock, permissionsSelector),
 		Trashbin:    tb,
 	}

--- a/pkg/storage/fs/s3ng/blobstore/blobstore.go
+++ b/pkg/storage/fs/s3ng/blobstore/blobstore.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/lookup"
 	"github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/node"
+	"github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/tree"
 	"github.com/minio/minio-go/v7"
 	"github.com/minio/minio-go/v7/pkg/credentials"
 	"github.com/pkg/errors"
@@ -126,6 +127,12 @@ func (bs *Blobstore) Delete(node *node.Node) error {
 		return errors.Wrapf(err, "could not delete object '%s' from bucket '%s'", bs.Path(node), bs.bucket)
 	}
 	return nil
+}
+
+// GetAvailableSize returns the available size in the blobstore in bytes
+func (bs *Blobstore) GetAvailableSize(n *node.Node) (uint64, error) {
+	// S3 doen't have a concept of available size
+	return 0, tree.ErrSizeUnlimited
 }
 
 // List lists all blobs in the Blobstore

--- a/pkg/storage/utils/decomposedfs/aspects/aspects.go
+++ b/pkg/storage/utils/decomposedfs/aspects/aspects.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/node"
 	"github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/permissions"
 	"github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/trashbin"
+	"github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/tree"
 	"github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/usermapper"
 )
 
@@ -30,6 +31,7 @@ import (
 type Aspects struct {
 	Lookup            node.PathLookup
 	Tree              node.Tree
+	Blobstore         tree.Blobstore
 	Trashbin          trashbin.Trashbin
 	Permissions       permissions.Permissions
 	EventStream       events.Stream

--- a/pkg/storage/utils/decomposedfs/decomposedfs_test.go
+++ b/pkg/storage/utils/decomposedfs/decomposedfs_test.go
@@ -58,6 +58,7 @@ var _ = Describe("Decomposed", func() {
 	Describe("NewDefault", func() {
 		It("works", func() {
 			bs := &treemocks.Blobstore{}
+			bs.On("GetAvailableSize", mock.Anything).Return(uint64(1000000000), nil)
 			_, err := decomposedfs.NewDefault(map[string]interface{}{
 				"root":           env.Root,
 				"permissionssvc": "any",

--- a/pkg/storage/utils/decomposedfs/spaces.go
+++ b/pkg/storage/utils/decomposedfs/spaces.go
@@ -45,6 +45,7 @@ import (
 	"github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/metadata/prefixes"
 	"github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/node"
 	"github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/permissions"
+	"github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/tree"
 	"github.com/cs3org/reva/v2/pkg/storage/utils/templates"
 	"github.com/cs3org/reva/v2/pkg/storagespace"
 	"github.com/cs3org/reva/v2/pkg/utils"
@@ -1028,9 +1029,11 @@ func (fs *Decomposedfs) StorageSpaceFromNode(ctx context.Context, n *node.Node, 
 		quotaStr = quotaInOpaque
 	}
 
-	// FIXME this reads remaining disk size from the local disk, not the blobstore
-	remaining, err := node.GetAvailableSize(n.InternalPath())
-	if err != nil {
+	remaining, err := fs.bs.GetAvailableSize(n)
+	switch {
+	case errors.Is(err, tree.ErrSizeUnlimited):
+		remaining = math.MaxUint64
+	case err != nil:
 		return nil, err
 	}
 	total, used, remaining, err := fs.calculateTotalUsedRemaining(quotaStr, space.GetRootInfo().GetSize(), remaining)
@@ -1039,7 +1042,9 @@ func (fs *Decomposedfs) StorageSpaceFromNode(ctx context.Context, n *node.Node, 
 	}
 	space.Opaque = utils.AppendPlainToOpaque(space.Opaque, "quota.total", strconv.FormatUint(total, 10))
 	space.Opaque = utils.AppendPlainToOpaque(space.Opaque, "quota.used", strconv.FormatUint(used, 10))
-	space.Opaque = utils.AppendPlainToOpaque(space.Opaque, "quota.remaining", strconv.FormatUint(remaining, 10))
+	if remaining != math.MaxUint64 {
+		space.Opaque = utils.AppendPlainToOpaque(space.Opaque, "quota.remaining", strconv.FormatUint(remaining, 10))
+	}
 
 	return space, nil
 }

--- a/pkg/storage/utils/decomposedfs/testhelpers/helpers.go
+++ b/pkg/storage/utils/decomposedfs/testhelpers/helpers.go
@@ -175,6 +175,7 @@ func NewTestEnv(config map[string]interface{}) (*TestEnv, error) {
 	aspects := aspects.Aspects{
 		Lookup:      lu,
 		Tree:        tree,
+		Blobstore:   bs,
 		Permissions: permissions.NewPermissions(pmock, permissionsSelector),
 		Trashbin:    &decomposedfs.DecomposedfsTrashbin{},
 	}
@@ -290,6 +291,7 @@ func (t *TestEnv) CreateTestStorageSpace(typ string, quota *providerv1beta1.Quot
 	if typ == "personal" {
 		owner = t.Owner
 	}
+	t.Blobstore.On("GetAvailableSize", mock.Anything).Return(uint64(1000000000), nil)
 	space, err := t.Fs.CreateStorageSpace(t.Ctx, &providerv1beta1.CreateStorageSpaceRequest{
 		Owner: owner,
 		Type:  typ,

--- a/pkg/storage/utils/decomposedfs/tree/mocks/Blobstore.go
+++ b/pkg/storage/utils/decomposedfs/tree/mocks/Blobstore.go
@@ -144,6 +144,62 @@ func (_c *Blobstore_Download_Call) RunAndReturn(run func(*node.Node) (io.ReadClo
 	return _c
 }
 
+// GetAvailableSize provides a mock function with given fields: _a0
+func (_m *Blobstore) GetAvailableSize(_a0 *node.Node) (uint64, error) {
+	ret := _m.Called(_a0)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetAvailableSize")
+	}
+
+	var r0 uint64
+	var r1 error
+	if rf, ok := ret.Get(0).(func(*node.Node) (uint64, error)); ok {
+		return rf(_a0)
+	}
+	if rf, ok := ret.Get(0).(func(*node.Node) uint64); ok {
+		r0 = rf(_a0)
+	} else {
+		r0 = ret.Get(0).(uint64)
+	}
+
+	if rf, ok := ret.Get(1).(func(*node.Node) error); ok {
+		r1 = rf(_a0)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// Blobstore_GetAvailableSize_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetAvailableSize'
+type Blobstore_GetAvailableSize_Call struct {
+	*mock.Call
+}
+
+// GetAvailableSize is a helper method to define mock.On call
+//   - _a0 *node.Node
+func (_e *Blobstore_Expecter) GetAvailableSize(_a0 interface{}) *Blobstore_GetAvailableSize_Call {
+	return &Blobstore_GetAvailableSize_Call{Call: _e.mock.On("GetAvailableSize", _a0)}
+}
+
+func (_c *Blobstore_GetAvailableSize_Call) Run(run func(_a0 *node.Node)) *Blobstore_GetAvailableSize_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(*node.Node))
+	})
+	return _c
+}
+
+func (_c *Blobstore_GetAvailableSize_Call) Return(_a0 uint64, _a1 error) *Blobstore_GetAvailableSize_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *Blobstore_GetAvailableSize_Call) RunAndReturn(run func(*node.Node) (uint64, error)) *Blobstore_GetAvailableSize_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Upload provides a mock function with given fields: _a0, source
 func (_m *Blobstore) Upload(_a0 *node.Node, source string) error {
 	ret := _m.Called(_a0, source)

--- a/pkg/storage/utils/decomposedfs/tree/tree.go
+++ b/pkg/storage/utils/decomposedfs/tree/tree.go
@@ -48,7 +48,10 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-var tracer trace.Tracer
+var (
+	tracer           trace.Tracer
+	ErrSizeUnlimited = errors.New("blobstore size unlimited")
+)
 
 func init() {
 	tracer = otel.Tracer("github.com/cs3org/reva/pkg/storage/utils/decomposedfs/tree")
@@ -59,6 +62,7 @@ type Blobstore interface {
 	Upload(node *node.Node, source string) error
 	Download(node *node.Node) (io.ReadCloser, error)
 	Delete(node *node.Node) error
+	GetAvailableSize(node *node.Node) (uint64, error)
 }
 
 // Tree manages a hierarchical tree

--- a/pkg/storage/utils/decomposedfs/upload_async_test.go
+++ b/pkg/storage/utils/decomposedfs/upload_async_test.go
@@ -153,6 +153,7 @@ var _ = Describe("Async file uploads", Ordered, func() {
 			},
 		)
 		bs = &treemocks.Blobstore{}
+		bs.On("GetAvailableSize", mock.Anything).Return(uint64(1000000000), nil)
 
 		// create space uses CheckPermission endpoint
 		cs3permissionsclient.On("CheckPermission", mock.Anything, mock.Anything, mock.Anything).Return(&cs3permissions.CheckPermissionResponse{
@@ -176,6 +177,7 @@ var _ = Describe("Async file uploads", Ordered, func() {
 		aspects := aspects.Aspects{
 			Lookup:      lu,
 			Tree:        tree,
+			Blobstore:   bs,
 			Permissions: permissions.NewPermissions(pmock, permissionsSelector),
 			EventStream: stream.Chan{pub, con},
 			Trashbin:    &DecomposedfsTrashbin{},

--- a/pkg/storage/utils/decomposedfs/upload_test.go
+++ b/pkg/storage/utils/decomposedfs/upload_test.go
@@ -136,11 +136,13 @@ var _ = Describe("File uploads", func() {
 			AddGrant: true,
 		}, nil).Times(1)
 		var err error
+		bs.On("GetAvailableSize", mock.Anything).Return(uint64(1000000000), nil).Times(1)
 		tree := tree.New(lu, bs, o, store.Create())
 
 		aspects := aspects.Aspects{
 			Lookup:      lu,
 			Tree:        tree,
+			Blobstore:   bs,
 			Permissions: permissions.NewPermissions(pmock, permissionsSelector),
 			Trashbin:    &decomposedfs.DecomposedfsTrashbin{},
 		}


### PR DESCRIPTION
Move the calculation of the available size to the blobstore interface. We were just returning the available size of the local disk, which is wrong when using the S3 blobstore.

Also, as the S3 blobstore doesn't have a concept of available size, we don't return a 'remaining' for S3 backed spaces with unlimited quota.

Fixes: https://github.com/owncloud/ocis/issues/9245