### PR TITLE
improve metadata client errors

### DIFF
--- a/changelog/unreleased/improve-metadata-client-log.md
+++ b/changelog/unreleased/improve-metadata-client-log.md
@@ -1,0 +1,5 @@
+Enhancement: Improve metadata client errors
+
+We now return a more descripive error message when the metadata client cannot create a space because it already exists.
+
+https://github.com/cs3org/reva/pull/4868


### PR DESCRIPTION
We now return a more descripive error message when the metadata client cannot create a space because it already exists.

related https://github.com/owncloud/ocis/issues/10161