### PR TITLE
return 409 conflict when a file was already created

### DIFF
--- a/changelog/unreleased/fix-return-code-on-upload-error.md
+++ b/changelog/unreleased/fix-return-code-on-upload-error.md
@@ -1,0 +1,5 @@
+Bugfix: return 409 conflict when a file was already created
+
+We now return the correct 409 conflict status code when a file was already created by another upload.
+
+https://github.com/cs3org/reva/pull/4872


### PR DESCRIPTION

We now return the correct 409 conflict status code when a file was already created by another upload.
