### PR TITLE
fix share jail mountpoint parent id

### DIFF
--- a/changelog/unreleased/fix-sharejail-mountpoint-parentid.md
+++ b/changelog/unreleased/fix-sharejail-mountpoint-parentid.md
@@ -1,0 +1,6 @@
+Bugfix: Fix share jail mountpoint parent id
+
+Stating a share jail mountpoint now returns the share jail root as the parent id.
+
+https://github.com/cs3org/reva/pull/4876
+https://github.com/owncloud/ocis/issues/9933

--- a/internal/grpc/services/sharesstorageprovider/sharesstorageprovider.go
+++ b/internal/grpc/services/sharesstorageprovider/sharesstorageprovider.go
@@ -798,13 +798,19 @@ func (s *service) Stat(ctx context.Context, req *provider.StatRequest) (*provide
 		return nil, err
 	}
 
-	// when stating a share jail mountpoint we need to rewrite the id and use the share
-	// jail space id as the mountpoint has a different id than the grant
+	// when stating a share jail mountpoint we need to rewrite the ids
 	if statRes.GetStatus().GetCode() == rpc.Code_CODE_OK && receivedShare.MountPoint.Path == strings.TrimPrefix(req.Ref.Path, "./") && statRes.Info != nil {
+		// overwrite id with the share jail mountpoint id
 		statRes.Info.Id = &provider.ResourceId{
 			StorageId: utils.ShareStorageProviderID,
 			SpaceId:   utils.ShareStorageSpaceID,
 			OpaqueId:  receivedShare.GetShare().GetId().GetOpaqueId(),
+		}
+		// overwrite parent id with the share jail root
+		statRes.Info.ParentId = &provider.ResourceId{
+			StorageId: utils.ShareStorageProviderID,
+			SpaceId:   utils.ShareStorageSpaceID,
+			OpaqueId:  utils.ShareStorageSpaceID,
 		}
 	}
 


### PR DESCRIPTION
Stating a share jail mountpoint now returns the share jail root as the parent id.

ref https://github.com/owncloud/ocis/issues/9933