### PR TITLE
Kept historical resource naming after renaming in activity for shares and public links.

### DIFF
--- a/changelog/unreleased/fix-activity-keep-naming.md
+++ b/changelog/unreleased/fix-activity-keep-naming.md
@@ -1,0 +1,6 @@
+Bugfix: Kept historical resource naming in activity
+
+Kept historical resource naming after renaming in activity for shares and public links.     
+
+https://github.com/cs3org/reva/pull/4880    
+https://github.com/owncloud/ocis/issues/10210

--- a/internal/grpc/interceptors/eventsmiddleware/conversion.go
+++ b/internal/grpc/interceptors/eventsmiddleware/conversion.go
@@ -51,6 +51,7 @@ func ShareCreated(r *collaboration.CreateShareResponse, executant *user.User) ev
 		GranteeUserID:  r.Share.GetGrantee().GetUserId(),
 		GranteeGroupID: r.Share.GetGrantee().GetGroupId(),
 		ItemID:         r.Share.ResourceId,
+		ResourceName:   utils.ReadPlainFromOpaque(r.Opaque, "resourcename"),
 		CTime:          r.Share.Ctime,
 		Permissions:    r.Share.Permissions,
 	}
@@ -73,6 +74,7 @@ func ShareRemoved(r *collaboration.RemoveShareResponse, req *collaboration.Remov
 		GranteeUserID:  userid,
 		GranteeGroupID: groupid,
 		ItemID:         rid,
+		ResourceName:   utils.ReadPlainFromOpaque(r.Opaque, "resourcename"),
 		Timestamp:      time.Now(),
 	}
 }
@@ -83,6 +85,7 @@ func ShareUpdated(r *collaboration.UpdateShareResponse, req *collaboration.Updat
 		Executant:      executant.GetId(),
 		ShareID:        r.Share.Id,
 		ItemID:         r.Share.ResourceId,
+		ResourceName:   utils.ReadPlainFromOpaque(r.Opaque, "resourcename"),
 		Permissions:    r.Share.Permissions,
 		GranteeUserID:  r.Share.GetGrantee().GetUserId(),
 		GranteeGroupID: r.Share.GetGrantee().GetGroupId(),
@@ -114,6 +117,7 @@ func LinkCreated(r *link.CreatePublicShareResponse, executant *user.User) events
 		ShareID:           r.Share.Id,
 		Sharer:            r.Share.Creator,
 		ItemID:            r.Share.ResourceId,
+		ResourceName:      utils.ReadPlainFromOpaque(r.Opaque, "resourcename"),
 		Permissions:       r.Share.Permissions,
 		DisplayName:       r.Share.DisplayName,
 		Expiration:        r.Share.Expiration,
@@ -130,6 +134,7 @@ func LinkUpdated(r *link.UpdatePublicShareResponse, req *link.UpdatePublicShareR
 		ShareID:           r.Share.Id,
 		Sharer:            r.Share.Creator,
 		ItemID:            r.Share.ResourceId,
+		ResourceName:      utils.ReadPlainFromOpaque(r.Opaque, "resourcename"),
 		Permissions:       r.Share.Permissions,
 		DisplayName:       r.Share.DisplayName,
 		Expiration:        r.Share.Expiration,
@@ -177,11 +182,12 @@ func LinkRemoved(r *link.RemovePublicShareResponse, req *link.RemovePublicShareR
 	var rid *provider.ResourceId
 	_ = utils.ReadJSONFromOpaque(r.Opaque, "resourceid", &rid)
 	return events.LinkRemoved{
-		Executant:  executant.GetId(),
-		ShareID:    req.Ref.GetId(),
-		ShareToken: req.Ref.GetToken(),
-		Timestamp:  utils.TSNow(),
-		ItemID:     rid,
+		Executant:    executant.GetId(),
+		ShareID:      req.Ref.GetId(),
+		ShareToken:   req.Ref.GetToken(),
+		Timestamp:    utils.TSNow(),
+		ItemID:       rid,
+		ResourceName: utils.ReadPlainFromOpaque(r.Opaque, "resourcename"),
 	}
 }
 

--- a/internal/grpc/services/publicshareprovider/publicshareprovider_test.go
+++ b/internal/grpc/services/publicshareprovider/publicshareprovider_test.go
@@ -763,6 +763,9 @@ var _ = Describe("PublicShareProvider", func() {
 				Once().
 				Return(
 					createdLink, nil)
+
+			gatewayClient.EXPECT().Stat(mock.Anything, mock.Anything).Return(statResourceResponse, nil)
+
 			manager.
 				EXPECT().
 				RevokePublicShare(

--- a/internal/grpc/services/usershareprovider/usershareprovider.go
+++ b/internal/grpc/services/usershareprovider/usershareprovider.go
@@ -248,6 +248,7 @@ func (s *service) CreateShare(ctx context.Context, req *collaboration.CreateShar
 	return &collaboration.CreateShareResponse{
 		Status: status.NewOK(ctx),
 		Share:  createdShare,
+		Opaque: utils.AppendPlainToOpaque(nil, "resourcename", sRes.GetInfo().GetName()),
 	}, nil
 }
 
@@ -296,6 +297,7 @@ func (s *service) RemoveShare(ctx context.Context, req *collaboration.RemoveShar
 	}
 
 	o := utils.AppendJSONToOpaque(nil, "resourceid", share.GetResourceId())
+	o = utils.AppendPlainToOpaque(o, "resourcename", sRes.GetInfo().GetName())
 	if user := share.GetGrantee().GetUserId(); user != nil {
 		o = utils.AppendJSONToOpaque(o, "granteeuserid", user)
 	} else {
@@ -447,6 +449,7 @@ func (s *service) UpdateShare(ctx context.Context, req *collaboration.UpdateShar
 	res := &collaboration.UpdateShareResponse{
 		Status: status.NewOK(ctx),
 		Share:  share,
+		Opaque: utils.AppendPlainToOpaque(nil, "resourcename", sRes.GetInfo().GetName()),
 	}
 	return res, nil
 }

--- a/pkg/events/sharing.go
+++ b/pkg/events/sharing.go
@@ -41,6 +41,7 @@ type ShareCreated struct {
 	GranteeGroupID *group.GroupId
 	Sharee         *provider.Grantee
 	ItemID         *provider.ResourceId
+	ResourceName   string
 	Permissions    *collaboration.SharePermissions
 	CTime          *types.Timestamp
 }
@@ -62,8 +63,9 @@ type ShareRemoved struct {
 	GranteeUserID  *user.UserId
 	GranteeGroupID *group.GroupId
 
-	ItemID    *provider.ResourceId
-	Timestamp time.Time
+	ItemID       *provider.ResourceId
+	ResourceName string
+	Timestamp    time.Time
 }
 
 // Unmarshal to fulfill umarshaller interface
@@ -78,6 +80,7 @@ type ShareUpdated struct {
 	Executant      *user.UserId
 	ShareID        *collaboration.ShareId
 	ItemID         *provider.ResourceId
+	ResourceName   string
 	Permissions    *collaboration.SharePermissions
 	GranteeUserID  *user.UserId
 	GranteeGroupID *group.GroupId
@@ -101,6 +104,7 @@ type ShareExpired struct {
 	ShareID    *collaboration.ShareId
 	ShareOwner *user.UserId
 	ItemID     *provider.ResourceId
+	Path       string
 	ExpiredAt  time.Time
 	// split the protobuf Grantee oneof so we can use stdlib encoding/json
 	GranteeUserID  *user.UserId
@@ -119,6 +123,7 @@ type ReceivedShareUpdated struct {
 	Executant      *user.UserId
 	ShareID        *collaboration.ShareId
 	ItemID         *provider.ResourceId
+	Path           string
 	Permissions    *collaboration.SharePermissions
 	GranteeUserID  *user.UserId
 	GranteeGroupID *group.GroupId
@@ -141,6 +146,7 @@ type LinkCreated struct {
 	ShareID           *link.PublicShareId
 	Sharer            *user.UserId
 	ItemID            *provider.ResourceId
+	ResourceName      string
 	Permissions       *link.PublicSharePermissions
 	DisplayName       string
 	Expiration        *types.Timestamp
@@ -162,6 +168,7 @@ type LinkUpdated struct {
 	ShareID           *link.PublicShareId
 	Sharer            *user.UserId
 	ItemID            *provider.ResourceId
+	ResourceName      string
 	Permissions       *link.PublicSharePermissions
 	DisplayName       string
 	Expiration        *types.Timestamp
@@ -185,6 +192,7 @@ type LinkAccessed struct {
 	ShareID           *link.PublicShareId
 	Sharer            *user.UserId
 	ItemID            *provider.ResourceId
+	Path              string
 	Permissions       *link.PublicSharePermissions
 	DisplayName       string
 	Expiration        *types.Timestamp
@@ -221,10 +229,11 @@ func (LinkAccessFailed) Unmarshal(v []byte) (interface{}, error) {
 type LinkRemoved struct {
 	Executant *user.UserId
 	// split protobuf Ref
-	ShareID    *link.PublicShareId
-	ShareToken string
-	Timestamp  *types.Timestamp
-	ItemID     *provider.ResourceId
+	ShareID      *link.PublicShareId
+	ShareToken   string
+	Timestamp    *types.Timestamp
+	ItemID       *provider.ResourceId
+	ResourceName string
 }
 
 // Unmarshal to fulfill umarshaller interface


### PR DESCRIPTION
Related issue https://github.com/owncloud/ocis/issues/10210
