### PR TITLE
fix: usershareprovider log level

### DIFF
--- a/changelog/unreleased/fix-log-level.md
+++ b/changelog/unreleased/fix-log-level.md
@@ -1,0 +1,7 @@
+Bugfix: Log levels
+
+We changed the following log levels:
+
+- `ERROR` to `DEBUG` in `internal/grpc/services/usershareprovider` when getting received shares
+
+https://github.com/cs3org/reva/pull/4881

--- a/internal/grpc/services/usershareprovider/usershareprovider.go
+++ b/internal/grpc/services/usershareprovider/usershareprovider.go
@@ -485,7 +485,7 @@ func (s *service) GetReceivedShare(ctx context.Context, req *collaboration.GetRe
 
 	share, err := s.sm.GetReceivedShare(ctx, req.Ref)
 	if err != nil {
-		log.Err(err).Msg("error getting received share")
+		log.Debug().Err(err).Msg("error getting received share")
 		switch err.(type) {
 		case errtypes.NotFound:
 			return &collaboration.GetReceivedShareResponse{


### PR DESCRIPTION
`ERROR` to `DEBUG` log level in `internal/grpc/services/usershareprovider` when getting received shares