### PR TITLE
fix upload session bugs

### DIFF
--- a/changelog/unreleased/fix-upload-session-bugs.md
+++ b/changelog/unreleased/fix-upload-session-bugs.md
@@ -1,0 +1,5 @@
+Bugfix: Fix upload session bugs
+
+We fixed an issue that caused a panic when we could not open a file to calculate checksums. Furthermore, we now delete the upload session .lock file on cleanup.
+
+https://github.com/cs3org/reva/pull/4888

--- a/pkg/storage/utils/decomposedfs/upload/session.go
+++ b/pkg/storage/utils/decomposedfs/upload/session.go
@@ -86,7 +86,10 @@ func (s *OcisSession) Purge(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	defer f.Close()
+	defer func() {
+		f.Close()
+		os.Remove(sessionPath + ".lock")
+	}()
 	if err := os.Remove(sessionPath); err != nil {
 		return err
 	}

--- a/pkg/storage/utils/decomposedfs/upload/upload.go
+++ b/pkg/storage/utils/decomposedfs/upload/upload.go
@@ -115,7 +115,7 @@ func (session *OcisSession) FinishUpload(ctx context.Context) error {
 
 	sha1h, md5h, adler32h, err := node.CalculateChecksums(ctx, session.binPath())
 	if err != nil {
-		log.Info().Err(err).Msg("error copying checksums")
+		return err
 	}
 
 	// compare if they match the sent checksum


### PR DESCRIPTION
We fixed an issue that caused a panic when we could not open a file to calculate checksums. Furthermore, we now delete the upload session .lock file on cleanup.

fixes https://github.com/owncloud/ocis/issues/10320

This requites us to be able to calculate checksumes ... which I think is the case anyway. Waiting on the CI.