### PR TITLE
Fix stuck 0 byte uploads

### DIFF
--- a/changelog/unreleased/improve-posixfs.md
+++ b/changelog/unreleased/improve-posixfs.md
@@ -2,5 +2,6 @@ Enhancement: Improve posixfs stability and performance
 
 The posixfs storage driver saw a number of bugfixes and optimizations.
 
+https://github.com/cs3org/reva/pull/4889
 https://github.com/cs3org/reva/pull/4877
 

--- a/pkg/storage/utils/decomposedfs/upload/upload.go
+++ b/pkg/storage/utils/decomposedfs/upload/upload.go
@@ -178,7 +178,6 @@ func (session *OcisSession) FinishUpload(ctx context.Context) error {
 			return err
 		}
 	}
-
 	// increase the processing counter for every started processing
 	// will be decreased in Cleanup()
 	metrics.UploadProcessing.Inc()
@@ -213,7 +212,9 @@ func (session *OcisSession) FinishUpload(ctx context.Context) error {
 		}
 	}
 
-	if !session.store.async {
+	// if the upload is synchronous or the upload is empty, finalize it now
+	// for 0-byte uploads we take a shortcut and finalize isn't called elsewhere
+	if !session.store.async || session.info.Size == 0 {
 		// handle postprocessing synchronously
 		err = session.Finalize()
 		session.store.Cleanup(ctx, session, err != nil, false, err == nil)


### PR DESCRIPTION
The postprocessing flag was never cleared for 0-byte uploads for posixfs because it (rightfully) enables async uploads for both the storageprovider and the dataprovider, in contrast to decomposedfs. See https://github.com/owncloud/ocis/issues/10327 for more details on the underlying problem.