### PR TITLE
Do not include HTTPS cert in EOS HTTP Client

### DIFF
--- a/changelog/unreleased/no-certs-eos-http-client.md
+++ b/changelog/unreleased/no-certs-eos-http-client.md
@@ -1,0 +1,8 @@
+Bugfix: no certs in EOS HTTP client
+
+Omit HTTPS cert in EOS HTTP Client, as this causes authentication issues on EOS < 5.2.28. 
+When EOS receives a certificate, it will look for this cert in the gridmap file. 
+If it is not found there, the whole authn flow is aborted and the user is mapped to nobody.
+
+
+https://github.com/cs3org/reva/pull/4894

--- a/pkg/eosclient/eosgrpc/eoshttp.go
+++ b/pkg/eosclient/eosgrpc/eoshttp.go
@@ -21,8 +21,6 @@ package eosgrpc
 import (
 	"bytes"
 	"context"
-	"crypto/tls"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -148,10 +146,6 @@ func NewEOSHTTPClient(opt *HTTPOptions) (*EOSHTTPClient, error) {
 	}
 
 	opt.init()
-	baseUrl, err := url.Parse(opt.BaseURL)
-	if err != nil {
-		return nil, errors.New("Failed to parse BaseURL")
-	}
 
 	t := &http.Transport{
 		MaxIdleConns:        opt.MaxIdleConns,
@@ -160,21 +154,6 @@ func NewEOSHTTPClient(opt *HTTPOptions) (*EOSHTTPClient, error) {
 		IdleConnTimeout:     time.Duration(opt.IdleConnTimeout) * time.Second,
 		DisableCompression:  true,
 	}
-
-	if baseUrl.Scheme == "https" {
-		cert, err := tls.LoadX509KeyPair(opt.ClientCertFile, opt.ClientKeyFile)
-		if err != nil {
-			return nil, err
-		}
-		t.TLSClientConfig = &tls.Config{
-			Certificates: []tls.Certificate{cert},
-		}
-	}
-
-	// TODO: the error reporting of http.transport is insufficient
-	// we may want to check manually at least the existence of the certfiles
-	// The point is that also the error reporting of the context that calls this function
-	// is weak
 
 	cl := &http.Client{
 		Transport: t,


### PR DESCRIPTION
Omit HTTPS cert in EOS HTTP Client, as this causes authentication issues on EOS < 5.2.28. When EOS receives a certificate, it will look for this cert in the gridmap file. If it is not found there, the whole authn flow is aborted and the user is mapped to nobody.