### PR TITLE
eos/grpc: Fix RestoreFileVersion

### DIFF
--- a/changelog/unreleased/restorefileversion-nilptr.md
+++ b/changelog/unreleased/restorefileversion-nilptr.md
@@ -1,0 +1,3 @@
+Bugfix: fix nilpointer error in RollbackToVersion
+
+https://github.com/cs3org/reva/pull/4896

--- a/pkg/eosclient/eosgrpc/eosgrpc.go
+++ b/pkg/eosclient/eosgrpc/eosgrpc.go
@@ -1544,8 +1544,9 @@ func (c *Client) RollbackToVersion(ctx context.Context, auth eosclient.Authoriza
 		return errtypes.InternalError(fmt.Sprintf("nil response for uid: '%s' ", auth.Role.UID))
 	}
 
-	log.Info().Str("func", "RollbackToVersion").Int64("errcode", resp.GetError().Code).Str("errmsg", resp.GetError().Msg).Msg("grpc response")
-
+	if resp.GetError() != nil {
+		log.Info().Str("func", "RollbackToVersion").Int64("errcode", resp.GetError().Code).Str("errmsg", resp.GetError().Msg).Msg("grpc response")
+	}
 	return err
 }
 


### PR DESCRIPTION
Calls to RestoreFileVersion would fail due to a nilpointer error:
```
2024-10-21 15:57:23.062 ERR github.com/cs3org/reva@v1.28.0/internal/grpc/interceptors/recovery/recovery.go:49 > runtime error: invalid memory address or nil pointer dereference; stack: goroutine 103 [running]:
runtime/debug.Stack()
        runtime/debug/stack.go:24 +0x5e
github.com/cs3org/reva/internal/grpc/interceptors/recovery.recoveryFunc({0x1453608, 0xc019158cc0}, {0x10f3180?, 0x1c58af0})
        github.com/cs3org/reva@v1.28.0/internal/grpc/interceptors/recovery/recovery.go:49 +0x65
github.com/grpc-ecosystem/go-grpc-middleware/recovery.recoverFrom({0x1453608?, 0xc019158cc0?}, {0x10f3180?, 0x1c58af0?}, 0xc00007f260?)
        github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/recovery/interceptors.go:61 +0x30
github.com/grpc-ecosystem/go-grpc-middleware/recovery.UnaryServerInterceptor.func1.1()
        github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/recovery/interceptors.go:29 +0x75
panic({0x10f3180?, 0x1c58af0?})
        runtime/panic.go:914 +0x21f
github.com/cs3org/reva/pkg/eosclient/eosgrpc.(*Client).RollbackToVersion(0xc00004e3c0, {0x1453608, 0xc019159200}, {{{0xc01b026218, 0x6}, {0xc01b026270, 0x4}}, {0x0, 0x0}}, {0xc018e14d20, ...}, ...)
        github.com/cs3org/reva@v1.28.0/pkg/eosclient/eosgrpc/eosgrpc.go:1547 +0x426
github.com/cs3org/reva/pkg/storage/utils/eosfs.(*eosfs).RestoreRevision(0xc00041c850, {0x1453608, 0xc019159200}, 0x602677?, {0xc01a1b8678, 0x13})
        github.com/cs3org/reva@v1.28.0/pkg/storage/utils/eosfs/eosfs.go:1923 +0x27b
github.com/cernbox/reva-plugins/storage/eoswrapper.(*wrapper).RestoreRevision(0xc0001c19a0, {0x1453608, 0xc019159200}, 0x30?, {0xc01a1b8678, 0x13})
        github.com/cernbox/reva-plugins@v0.0.12/storage/eoswrapper/eoswrapper.go:160 +0x6a
github.com/cs3org/reva/internal/grpc/services/storageprovider.(*service).RestoreFileVersion(0xc00041c8c0, {0x1453608, 0xc019159200}, 0xc000356c00)
        github.com/cs3org/reva@v1.28.0/internal/grpc/services/storageprovider/storageprovider.go:1093 +0x199
github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1._ProviderAPI_RestoreFileVersion_Handler.func1({0x1453608, 0xc019159200}, {0x11ed240?, 0xc000356c00})
        github.com/cs3org/go-cs3apis@v0.0.0-20240927085705-d50e291cbf4c/cs3/storage/provider/v1beta1/provider_api_grpc.pb.go:1141 +0x75
github.com/cs3org/reva/internal/grpc/interceptors/auth.NewUnary.func1({0x1453608, 0xc019158cc0}, {0x11ed240, 0xc000356c00}, 0xc000684640, 0xc003e63818)
        github.com/cs3org/reva@v1.28.0/internal/grpc/interceptors/auth/auth.go:125 +0x4bd
github.com/cs3org/reva/pkg/rgrpc.(*Server).getInterceptors.ChainUnaryServer.func2.1({0x1453608?, 0xc019158cc0?}, {0x11ed240?, 0xc000356c00?})
        github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:48 +0x45
github.com/grpc-ecosystem/go-grpc-middleware/recovery.UnaryServerInterceptor.func1({0x1453608?, 0xc019158cc0?}, {0x11ed240?, 0xc000356c00?}, 0xc000577138?, 0x4d594f?)
        github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/recovery/interceptors.go:33 +0xb0
github.com/cs3org/reva/pkg/rgrpc.(*Server).getInterceptors.ChainUnaryServer.func2.1({0x1453608?, 0xc019158cc0?}, {0x11ed240?, 0xc000356c00?})
        github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:48 +0x45
github.com/cs3org/reva/cmd/revad/runtime.initGRPCInterceptors.NewUnary.func7({0x1453608, 0xc019158cc0}, {0x11ed240, 0xc000356c00}, 0xc000684640, 0xc003e74880)
        github.com/cs3org/reva@v1.28.0/internal/grpc/interceptors/log/log.go:38 +0x8e
github.com/cs3org/reva/pkg/rgrpc.(*Server).getInterceptors.ChainUnaryServer.func2.1({0x1453608?, 0xc019158cc0?}, {0x11ed240?, 0xc000356c00?})
        github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:48 +0x45
github.com/cs3org/reva/cmd/revad/runtime.initGRPCInterceptors.NewUnary.func6({0x1453608, 0xc019158ba0}, {0x11ed240, 0xc000356c00}, 0x1?, 0xc003e748c0)
        github.com/cs3org/reva@v1.28.0/internal/grpc/interceptors/useragent/useragent.go:38 +0xf0
github.com/cs3org/reva/pkg/rgrpc.(*Server).getInterceptors.ChainUnaryServer.func2.1({0x1453608?, 0xc019158ba0?}, {0x11ed240?, 0xc000356c00?})
        github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:48 +0x45
github.com/cs3org/reva/cmd/revad/runtime.initGRPCInterceptors.NewUnary.func5({0x1453608, 0xc019158a80}, {0x11ed240, 0xc000356c00}, 0x0?, 0xc003e74900)
        github.com/cs3org/reva@v1.28.0/internal/grpc/interceptors/token/token.go:44 +0x14a
github.com/cs3org/reva/pkg/rgrpc.(*Server).getInterceptors.ChainUnaryServer.func2.1({0x1453608?, 0xc019158a80?}, {0x11ed240?, 0xc000356c00?})
        github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:48 +0x45
github.com/cs3org/reva/cmd/revad/runtime.initGRPCInterceptors.NewUnary.func4({0x1453608, 0xc019158a20}, {0x11ed240, 0xc000356c00}, 0x12e043e?, 0xc003e74940)
        github.com/cs3org/reva@v1.28.0/internal/grpc/interceptors/appctx/appctx.go:36 +0x197
github.com/cs3org/reva/pkg/rgrpc.(*Server).getInterceptors.ChainUnaryServer.func2.1({0x1453608?, 0xc019158a20?}, {0x11ed240?, 0xc000356c00?})
        github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:48 +0x45
github.com/cs3org/reva/cmd/revad/runtime.initGRPCInterceptors.NewUnary.(*ServerMetrics).UnaryServerInterceptor.UnaryServerInterceptor.func13({0x1453608, 0xc019158a20}, {0x11ed240, 0xc000356c00}, 0x0?, 0xc003e74980)
        github.com/grpc-ecosystem/go-grpc-middleware/v2@v2.1.0/interceptors/server.go:22 +0x28a
github.com/cs3org/reva/pkg/rgrpc.(*Server).getInterceptors.ChainUnaryServer.func2.1({0x1453608?, 0xc019158a20?}, {0x11ed240?, 0xc000356c00?})
        github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:48 +0x45
github.com/cs3org/reva/cmd/revad/runtime.initGRPCInterceptors.NewUnary.func3({0x1453608?, 0xc019158960?}, {0x11ed240, 0xc000356c00}, 0xc003e63818?, 0xc003e749c0)
        github.com/cs3org/reva@v1.28.0/internal/grpc/interceptors/trace/trace.go:57 +0x43
github.com/cs3org/reva/pkg/rgrpc.(*Server).getInterceptors.ChainUnaryServer.func2({0x1453608, 0xc019158960}, {0x11ed240, 0xc000356c00}, 0xc000684640, 0x10f3ae0?)
        github.com/grpc-ecosystem/go-grpc-middleware@v1.4.0/chain.go:53 +0x135
github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1._ProviderAPI_RestoreFileVersion_Handler({0x12741c0?, 0xc00041c8c0}, {0x1453608, 0xc019158960}, 0xc0006bfe00, 0xc0001421b0)
        github.com/cs3org/go-cs3apis@v0.0.0-20240927085705-d50e291cbf4c/cs3/storage/provider/v1beta1/provider_api_grpc.pb.go:1143 +0x135
google.golang.org/grpc.(*Server).processUnaryRPC(0xc000456800, {0x1453608, 0xc019158840}, {0x1459f00, 0xc01ddc2900}, 0xc019f4fb00, 0xc0001423f0, 0x1c70c00, 0x0)
        google.golang.org/grpc@v1.65.0/server.go:1379 +0xe23
google.golang.org/grpc.(*Server).handleStream(0xc000456800, {0x1459f00, 0xc01ddc2900}, 0xc019f4fb00)
        google.golang.org/grpc@v1.65.0/server.go:1790 +0x1016
google.golang.org/grpc.(*Server).serveStreams.func2.1()
        google.golang.org/grpc@v1.65.0/server.go:1029 +0x8b
created by google.golang.org/grpc.(*Server).serveStreams.func2 in goroutine 139
        google.golang.org/grpc@v1.65.0/server.go:1040 +0x135
```

This PR fixes this by adding a nil check for `resp.GetError()` in the EOS gRPC client.