### PR TITLE
Fix bug in ListDeletedEntries where the PurgeDate was not set correctly

### DIFF
--- a/changelog/unreleased/trashbin-grpc.md
+++ b/changelog/unreleased/trashbin-grpc.md
@@ -1,0 +1,5 @@
+Bugfix: PurgeDate in ListDeletedEntries was ignored
+
+The date range that can be passed to ListDeletedEntries was not taken into account due to a bug in reva: the Purgedate argument was set, which only works for PURGE requests, and not for LIST requests. Instead, the Listflag argument must be used. Additionally, there was a bug in the loop that is used to iterate over all days in the date range.
+
+https://github.com/cs3org/reva/pull/4905

--- a/pkg/eosclient/eosgrpc/eosgrpc.go
+++ b/pkg/eosclient/eosgrpc/eosgrpc.go
@@ -47,8 +47,8 @@ import (
 )
 
 const (
-	versionPrefix  = ".sys.v#."
-	favoritesKey   = "http://owncloud.org/ns/favorite"
+	versionPrefix = ".sys.v#."
+	favoritesKey  = "http://owncloud.org/ns/favorite"
 )
 
 const (
@@ -1416,14 +1416,13 @@ func (c *Client) ListDeletedEntries(ctx context.Context, auth eosclient.Authoriz
 
 	ret := make([]*eosclient.DeletedEntry, 0)
 	count := 0
-	for d := to; !d.Before(to); d = d.AddDate(0, 0, -1) {
+	for d := to; !d.Before(from); d = d.AddDate(0, 0, -1) {
 		msg := new(erpc.NSRequest_RecycleRequest)
 		msg.Cmd = erpc.NSRequest_RecycleRequest_RECYCLE_CMD(erpc.NSRequest_RecycleRequest_RECYCLE_CMD_value["LIST"])
-		msg.Purgedate = new(erpc.NSRequest_RecycleRequest_PurgeDate)
-		msg.Purgedate.Day = int32(d.Day())
-		msg.Purgedate.Month = int32(d.Month())
-		msg.Purgedate.Year = int32(d.Year())
 		msg.Listflag = new(erpc.NSRequest_RecycleRequest_ListFlags)
+		msg.Listflag.Day = int32(d.Day())
+		msg.Listflag.Month = int32(d.Month())
+		msg.Listflag.Year = int32(d.Year())
 		msg.Listflag.Maxentries = int32(maxentries + 1)
 		rq.Command = &erpc.NSRequest_Recycle{Recycle: msg}
 


### PR DESCRIPTION
The date range that can be passed to `ListDeletedEntries` was not taken into account due to a bug in reva: the `Purgedate` argument was set, which only works for `PURGE` requests, and not for `LIST` requests. Instead, the `Listflag` argument must be used.  Additionally, there was a bug in the loop that is used to iterate over all days in the date range.