### PR TITLE
public links: return error when owner could not be resolved

### DIFF
--- a/changelog/unreleased/publink-fix.md
+++ b/changelog/unreleased/publink-fix.md
@@ -1,0 +1,3 @@
+Bugfix: public links: return error when owner could not be resolved
+
+https://github.com/cs3org/reva/pull/4907

--- a/pkg/auth/manager/publicshares/publicshares.go
+++ b/pkg/auth/manager/publicshares/publicshares.go
@@ -128,6 +128,9 @@ func (m *manager) Authenticate(ctx context.Context, token, secret string) (*user
 	if err != nil {
 		return nil, nil, err
 	}
+	if getUserResponse.Status.Code != rpcv1beta1.Code_CODE_OK {
+		return nil, nil, errtypes.NotFound(getUserResponse.Status.Message)
+	}
 
 	share := publicShareResponse.GetShare()
 	role := authpb.Role_ROLE_VIEWER


### PR DESCRIPTION
Fixes panic in case the owner of a public link was not resolved