### PR TITLE
fix: fix app templates

### DIFF
--- a/changelog/unreleased/fix-app-templates.md
+++ b/changelog/unreleased/fix-app-templates.md
@@ -1,0 +1,5 @@
+Bugfix: Fix app templates
+
+We fixed the app templates by using the product name of the providerinfo instead of the provider name.
+
+https://github.com/cs3org/reva/pull/4918

--- a/internal/http/services/appprovider/templates.go
+++ b/internal/http/services/appprovider/templates.go
@@ -75,7 +75,7 @@ var tl = TemplateList{
 
 func addTemplateInfo(mt *appregistry.MimeTypeInfo, apps []*ProviderInfo) {
 	for _, app := range apps {
-		if tls, ok := tl.Templates[strings.ToLower(app.Name)]; ok {
+		if tls, ok := tl.Templates[strings.ToLower(app.ProductName)]; ok {
 			for _, tmpl := range tls {
 				if tmpl.Extension != "" && tmpl.Extension == mt.Ext {
 					app.TargetExt = tmpl.TargetExtension


### PR DESCRIPTION
Bugfix: Fix app templates

We fixed the app templates by using the product name of the providerinfo instead of the provider name.