### PR TITLE
fix simple upload status code

### DIFF
--- a/changelog/unreleased/fix-simple-upload.md
+++ b/changelog/unreleased/fix-simple-upload.md
@@ -1,0 +1,6 @@
+Bugfix: Return correct status codes for simple uploads
+
+Decomposedfs now returns the correct precondition failed status code when the etag does not match. This allows the jsoncs3 share managers optimistic locking to handle concurrent writes correctly
+
+https://github.com/cs3org/reva/pull/4920
+

--- a/pkg/storage/utils/decomposedfs/upload.go
+++ b/pkg/storage/utils/decomposedfs/upload.go
@@ -26,10 +26,11 @@ import (
 	"strings"
 	"time"
 
+	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	"github.com/google/uuid"
+	"github.com/pkg/errors"
 	tusd "github.com/tus/tusd/v2/pkg/handler"
 
-	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	"github.com/cs3org/reva/v2/pkg/appctx"
 	ctxpkg "github.com/cs3org/reva/v2/pkg/ctx"
 	"github.com/cs3org/reva/v2/pkg/errtypes"
@@ -40,7 +41,6 @@ import (
 	"github.com/cs3org/reva/v2/pkg/storage/utils/decomposedfs/upload"
 	"github.com/cs3org/reva/v2/pkg/storagespace"
 	"github.com/cs3org/reva/v2/pkg/utils"
-	"github.com/pkg/errors"
 )
 
 // Upload uploads data to the given resource
@@ -90,7 +90,7 @@ func (fs *Decomposedfs) Upload(ctx context.Context, req storage.UploadRequest, u
 		}
 	}
 
-	if err := session.FinishUpload(ctx); err != nil {
+	if err := session.FinishUploadDecomposed(ctx); err != nil {
 		return &provider.ResourceInfo{}, err
 	}
 
@@ -321,7 +321,7 @@ func (fs *Decomposedfs) InitiateUpload(ctx context.Context, ref *provider.Refere
 
 	if uploadLength == 0 {
 		// Directly finish this upload
-		err = session.FinishUpload(ctx)
+		err = session.FinishUploadDecomposed(ctx)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Decomposedfs now returns the correct precondition failed status code when the etag does not match. This allows the jsoncs3 share managers optimistic locking to handle concurrent writes correctly
