### PR TITLE
Cephfs kafka

### DIFF
--- a/pkg/storage/fs/posix/options/options.go
+++ b/pkg/storage/fs/posix/options/options.go
@@ -35,6 +35,7 @@ type Options struct {
 
 	WatchFS                 bool   `mapstructure:"watch_fs"`
 	WatchType               string `mapstructure:"watch_type"`
+	WatchMountPoint         string `mapstructure:"watch_mount_point"`
 	WatchPath               string `mapstructure:"watch_path"`
 	WatchFolderKafkaBrokers string `mapstructure:"watch_folder_kafka_brokers"`
 }

--- a/pkg/storage/fs/posix/tree/cephfswatcher.go
+++ b/pkg/storage/fs/posix/tree/cephfswatcher.go
@@ -1,0 +1,113 @@
+// Copyright 2018-2024 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package tree
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"path/filepath"
+
+	kafka "github.com/segmentio/kafka-go"
+)
+
+const (
+	CEPH_MDS_NOTIFY_ACCESS        = 0x0000000000000001
+	CEPH_MDS_NOTIFY_ATTRIB        = 0x0000000000000002
+	CEPH_MDS_NOTIFY_CLOSE_WRITE   = 0x0000000000000004
+	CEPH_MDS_NOTIFY_CLOSE_NOWRITE = 0x0000000000000008
+	CEPH_MDS_NOTIFY_CREATE        = 0x0000000000000010
+	CEPH_MDS_NOTIFY_DELETE        = 0x0000000000000020
+	CEPH_MDS_NOTIFY_DELETE_SELF   = 0x0000000000000040
+	CEPH_MDS_NOTIFY_MODIFY        = 0x0000000000000080
+	CEPH_MDS_NOTIFY_MOVE_SELF     = 0x0000000000000100
+	CEPH_MDS_NOTIFY_MOVED_FROM    = 0x0000000000000200
+	CEPH_MDS_NOTIFY_MOVED_TO      = 0x0000000000000400
+	CEPH_MDS_NOTIFY_OPEN          = 0x0000000000000800
+	CEPH_MDS_NOTIFY_CLOSE         = 0x0000000000001000
+	CEPH_MDS_NOTIFY_MOVE          = 0x0000000000002000
+	CEPH_MDS_NOTIFY_ONESHOT       = 0x0000000000004000
+	CEPH_MDS_NOTIFY_IGNORED       = 0x0000000000008000
+	CEPH_MDS_NOTIFY_ONLYDIR       = 0x0000000000010000
+)
+
+type CephfsWatcher struct {
+	tree        *Tree
+	mount_point string
+	brokers     []string
+}
+
+func NewCephfsWatcher(tree *Tree, kafkaBrokers []string) (*CephfsWatcher, error) {
+	return &CephfsWatcher{
+		tree:        tree,
+		mount_point: tree.options.WatchMountPoint,
+		brokers:     kafkaBrokers,
+	}, nil
+}
+
+type event struct {
+	Path string `json:"path"`
+	Mask int    `json:"mask"`
+}
+
+func (w *CephfsWatcher) Watch(topic string) {
+	r := kafka.NewReader(kafka.ReaderConfig{
+		Brokers: w.brokers,
+		GroupID: "ocis-posixfs",
+		Topic:   topic,
+	})
+
+	for {
+		m, err := r.ReadMessage(context.Background())
+		if err != nil {
+			fmt.Println("error reading message", err)
+			break
+		}
+
+		ev := &event{}
+		err = json.Unmarshal(m.Value, ev)
+		if err != nil {
+			fmt.Println("error unmarshalling message", err)
+			continue
+		}
+
+		if isLockFile(ev.Path) || isTrash(ev.Path) || w.tree.isUpload(ev.Path) {
+			continue
+		}
+
+		isDir := ev.Mask&CEPH_MDS_NOTIFY_ONLYDIR > 0
+		path := filepath.Join(w.mount_point, ev.Path)
+		go func() {
+			switch {
+			case ev.Mask&CEPH_MDS_NOTIFY_DELETE > 0:
+				_ = w.tree.HandleFileDelete(path)
+			case ev.Mask&CEPH_MDS_NOTIFY_CREATE > 0:
+				_ = w.tree.Scan(path, ActionCreate, isDir)
+			case ev.Mask&CEPH_MDS_NOTIFY_CLOSE_WRITE > 0:
+				_ = w.tree.Scan(path, ActionUpdate, isDir)
+			case ev.Mask&CEPH_MDS_NOTIFY_MOVED_TO > 0:
+				_ = w.tree.Scan(path, ActionMove, isDir)
+			}
+		}()
+	}
+	if err := r.Close(); err != nil {
+		log.Fatal("failed to close reader:", err)
+	}
+}

--- a/pkg/storage/fs/posix/tree/tree.go
+++ b/pkg/storage/fs/posix/tree/tree.go
@@ -132,6 +132,11 @@ func New(lu node.PathLookup, bs Blobstore, um usermapper.Mapper, trashbin *trash
 		if err != nil {
 			return nil, err
 		}
+	case "cephfs":
+		t.watcher, err = NewCephfsWatcher(t, strings.Split(o.WatchFolderKafkaBrokers, ","))
+		if err != nil {
+			return nil, err
+		}
 	default:
 		t.watcher = NewInotifyWatcher(t)
 		watchPath = o.Root


### PR DESCRIPTION
This PR adds a posixfs watcher for cephfs. It depends on the kafka connector implemented by croit to receive the required fs events.

During a k6 test with a POC cluster it reached 100% success rate and a decent performance despite being a VM-based test instance only.

The configuration used was
```
      STORAGE_USERS_DRIVER: posix
      STORAGE_USERS_POSIX_ROOT: /var/lib/cephfs/ocis-data/storage-users/
      STORAGE_USERS_POSIX_WATCH_MOUNT_POINT: /var/lib/cephfs
      STORAGE_USERS_POSIX_USE_SPACE_GROUPS: false

      STORAGE_USERS_POSIX_WATCH_TYPE: cephfs
      STORAGE_USERS_POSIX_WATCH_PATH: ocis
      STORAGE_USERS_POSIX_WATCH_FOLDER_KAFKA_BROKERS: 172.31.105.4:909

      STORAGE_USERS_ID_CACHE_STORE: nats-js-kv
      STORAGE_USERS_ID_CACHE_STORE_NODES: localhost:9233
```

The result of the k6 tests:
```
     checks.........................: 100.00% ✓ 3644     ✗ 0   
     data_received..................: 1.6 GB  4.1 MB/s
     data_sent......................: 833 MB  2.1 MB/s
     http_req_blocked...............: avg=539.47µs min=1.18µs  med=5.08µs   max=36.02ms p(90)=6.73µs   p(95)=7.68µs  
     http_req_connecting............: avg=205.64µs min=0s      med=0s       max=16.7ms  p(90)=0s       p(95)=0s      
     http_req_duration..............: avg=223.14ms min=21.92ms med=113.1ms  max=13.51s  p(90)=427.67ms p(95)=678.19ms
       { expected_response:true }...: avg=223.14ms min=21.92ms med=113.1ms  max=13.51s  p(90)=427.67ms p(95)=678.19ms
     http_req_failed................: 0.00%   ✓ 0        ✗ 3620
     http_req_receiving.............: avg=10.75ms  min=17.22µs med=79.16µs  max=2.94s   p(90)=129.22µs p(95)=966.74µs
     http_req_sending...............: avg=24.89ms  min=7.94µs  med=29.87µs  max=12.47s  p(90)=40.47µs  p(95)=47.13µs 
     http_req_tls_handshaking.......: avg=327.31µs min=0s      med=0s       max=26.39ms p(90)=0s       p(95)=0s      
     http_req_waiting...............: avg=187.49ms min=21.82ms med=108.95ms max=2.56s   p(90)=382.81ms p(95)=611.5ms 
     http_reqs......................: 3620    9.282039/s
     iteration_duration.............: avg=7.17s    min=2.04s   med=2.12s    max=1m16s   p(90)=30.08s   p(95)=30.72s  
     iterations.....................: 2851    7.310246/s
     vus............................: 3       min=0      max=75
     vus_max........................: 75      min=75     max=75
```

**Note:** Depends on https://github.com/owncloud/ocis/pull/10519