### PR TITLE
fix error type

### DIFF
--- a/changelog/unreleased/fix-download-consistency.md
+++ b/changelog/unreleased/fix-download-consistency.md
@@ -1,6 +1,7 @@
-Bugfix: make etag always matche content on downloads
+Bugfix: make etag always match content on downloads
 
 We added an openReaderfunc to the Download interface to give drivers a way to guarantee that the reader matches the etag returned in a previous GetMD call.
 
+https://github.com/cs3org/reva/pull/4926
 https://github.com/cs3org/reva/pull/4923
 

--- a/pkg/storage/utils/decomposedfs/decomposedfs.go
+++ b/pkg/storage/utils/decomposedfs/decomposedfs.go
@@ -1065,7 +1065,7 @@ func (fs *Decomposedfs) Download(ctx context.Context, ref *provider.Reference, o
 
 	n, err := fs.lu.NodeFromResource(ctx, ref)
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "Decomposedfs: error resolving ref")
+		return nil, nil, err
 	}
 
 	if !n.Exists {


### PR DESCRIPTION
we must not use the `errors.Wrap(` ... as tho handleError in download.go does a typecast. This may also be fragile in other cases, but this one is reproducible in the ocis full-ci.