### PR TITLE
Fix flaky posixfs tests

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -761,7 +761,7 @@ def posixfsIntegrationTests(parallelRuns, skipExceptParts = []):
                         "environment": {
                             "TEST_SERVER_URL": "http://revad-services:20080",
                             "OCIS_REVA_DATA_ROOT": "/drone/src/tmp/reva/data/",
-                            "DELETE_USER_DATA_CMD": "bash -cx 'for i in {1..30}; do rm -rf /drone/src/tmp/reva/data/users/* /drone/src/tmp/reva/data/indexes/by-type/* && break || sleep 5; done'",
+                            "DELETE_USER_DATA_CMD": "bash -cx 'for i in {1..30}; do rm -rf /drone/src/tmp/reva/data/users/* /drone/src/tmp/reva/data/indexes/by-type/* && break || sleep 5; done; sleep 0.1'",
                             "STORAGE_DRIVER": "ocis",
                             "SKELETON_DIR": "/drone/src/tmp/testing/data/apiSkeleton",
                             "TEST_WITH_LDAP": "true",

--- a/changelog/unreleased/fix-flaky-posixfs-tests.md
+++ b/changelog/unreleased/fix-flaky-posixfs-tests.md
@@ -1,0 +1,6 @@
+Bugfix: Fix flaky posixfs integration tests
+
+We fixed a problem with the posixfs integration tests where the in-memory id cache sometimes hadn't caught up with the cleanup between test runs leading to flaky failures.
+
+https://github.com/cs3org/reva/pull/4929
+


### PR DESCRIPTION
Fix flaky posixfs tests. The in-memory id cache sometimes hadn't caught up with the clean up on disk when running the next test.