### PR TITLE
eosgrpc: fixed tree metadata following fix in EOS

### DIFF
--- a/changelog/unreleased/fix-eosgrpc-stat.md
+++ b/changelog/unreleased/fix-eosgrpc-stat.md
@@ -1,0 +1,5 @@
+Bugfix: fixed tree metadata following fix in EOS
+
+The treecount is now populated from the EOS response.
+
+https://github.com/cs3org/reva/pull/4931

--- a/pkg/eosclient/eosgrpc/eosgrpc.go
+++ b/pkg/eosclient/eosgrpc/eosgrpc.go
@@ -1677,8 +1677,7 @@ func (c *Client) grpcMDResponseToFileInfo(ctx context.Context, st *erpc.MDRespon
 
 		fi.TreeSize = uint64(st.Cmd.TreeSize)
 		fi.Size = fi.TreeSize
-		// TODO(lopresti) this info is missing in the EOS Protobuf, cf. EOS-5974
-		// fi.TreeCount = uint64(st.Cmd.TreeCount)
+		fi.TreeCount = st.Cmd.Files + st.Cmd.Containers
 
 		log.Debug().Str("stat info - path", fi.File).Uint64("inode", fi.Inode).Uint64("uid", fi.UID).Uint64("gid", fi.GID).Str("etag", fi.ETag).Msg("grpc response")
 	} else {


### PR DESCRIPTION
Found while reviewing remaining TODOs in EOS GRPC.