### PR TITLE
fix: make TUS POST more robust

### DIFF
--- a/changelog/unreleased/fix-uploads.md
+++ b/changelog/unreleased/fix-uploads.md
@@ -1,0 +1,5 @@
+Bugfix: Make TUS POST more robust
+
+We improved the handling of TUS POST uploads when the metadata can not be read directly after sucessfully uploading the file to the storage.
+
+https://github.com/cs3org/reva/pull/4932


### PR DESCRIPTION
Bugfix: Make TUS POST more robust

We improved the handling of TUS POST uploads when the metadata can not be read directly after sucessfully uploading the file to the storage.