### PR TITLE
pass proper logger down to datatx handler and tus

### DIFF
--- a/changelog/unreleased/log-uploads.md
+++ b/changelog/unreleased/log-uploads.md
@@ -1,0 +1,6 @@
+Bugfix: enable datatx log
+
+We now pass a properly initialized logger to the datatx implementations, allowing the tus handler to log with the same level as the rest of reva.
+
+https://github.com/cs3org/reva/pull/4935
+

--- a/pkg/rhttp/datatx/manager/registry/registry.go
+++ b/pkg/rhttp/datatx/manager/registry/registry.go
@@ -19,13 +19,15 @@
 package registry
 
 import (
+	"github.com/rs/zerolog"
+
 	"github.com/cs3org/reva/v2/pkg/events"
 	"github.com/cs3org/reva/v2/pkg/rhttp/datatx"
 )
 
 // NewFunc is the function that data transfer implementations
 // should register at init time.
-type NewFunc func(map[string]interface{}, events.Publisher) (datatx.DataTX, error)
+type NewFunc func(map[string]interface{}, events.Publisher, *zerolog.Logger) (datatx.DataTX, error)
 
 // NewFuncs is a map containing all the registered data transfers.
 var NewFuncs = map[string]NewFunc{}

--- a/pkg/rhttp/datatx/manager/simple/simple.go
+++ b/pkg/rhttp/datatx/manager/simple/simple.go
@@ -22,11 +22,12 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/mitchellh/mapstructure"
-	"github.com/pkg/errors"
-
 	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+	"github.com/mitchellh/mapstructure"
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog"
+
 	"github.com/cs3org/reva/v2/internal/http/services/owncloud/ocdav/net"
 	"github.com/cs3org/reva/v2/pkg/appctx"
 	"github.com/cs3org/reva/v2/pkg/errtypes"
@@ -48,6 +49,7 @@ func init() {
 type manager struct {
 	conf      *cache.Config
 	publisher events.Publisher
+	log       *zerolog.Logger
 }
 
 func parseConfig(m map[string]interface{}) (*cache.Config, error) {
@@ -60,22 +62,26 @@ func parseConfig(m map[string]interface{}) (*cache.Config, error) {
 }
 
 // New returns a datatx manager implementation that relies on HTTP PUT/GET.
-func New(m map[string]interface{}, publisher events.Publisher) (datatx.DataTX, error) {
+func New(m map[string]interface{}, publisher events.Publisher, log *zerolog.Logger) (datatx.DataTX, error) {
 	c, err := parseConfig(m)
 	if err != nil {
 		return nil, err
 	}
 
+	l := log.With().Str("datatx", "simple").Logger()
+
 	return &manager{
 		conf:      c,
 		publisher: publisher,
+		log:       &l,
 	}, nil
 }
 
 func (m *manager) Handler(fs storage.FS) (http.Handler, error) {
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sublog := m.log.With().Str("path", r.URL.Path).Logger()
+		r = r.WithContext(appctx.WithLogger(r.Context(), &sublog))
 		ctx := r.Context()
-		sublog := appctx.GetLogger(ctx).With().Str("datatx", "simple").Logger()
 
 		switch r.Method {
 		case "GET", "HEAD":


### PR DESCRIPTION
pass a properly initialized logger to tus.

it will log sth like:
```
2024-11-14T11:55:27+01:00 WRN NetworkControlError datatx=tus line=/home/jfd/Repositories/reva/pkg/rhttp/datatx/manager/tus/tus.go:251 method={} path={} pkg=rhttp requestId={} service=storage-users
2024-11-14T11:55:27+01:00 INF RequestIncoming datatx=tus line=/home/jfd/Repositories/reva/pkg/rhttp/datatx/manager/tus/tus.go:249 method={} path={} pkg=rhttp requestId={} service=storage-users
2024-11-14T11:55:27+01:00 INF ChunkWriteStart datatx=tus id={} line=/home/jfd/Repositories/reva/pkg/rhttp/datatx/manager/tus/tus.go:249 method={} path={} pkg=rhttp requestId={} service=storage-users
2024-11-14T11:55:27+01:00 WRN NetworkTimeoutError datatx=tus id={} line=/home/jfd/Repositories/reva/pkg/rhttp/datatx/manager/tus/tus.go:251 method={} path={} pkg=rhttp requestId={} service=storage-users
2024-11-14T11:55:27+01:00 INF ChunkWriteComplete datatx=tus id={} line=/home/jfd/Repositories/reva/pkg/rhttp/datatx/manager/tus/tus.go:249 method={} path={} pkg=rhttp requestId={} service=storage-users
2024-11-14T11:55:27+01:00 INF UploadFinished datatx=tus id={} line=/home/jfd/Repositories/reva/pkg/rhttp/datatx/manager/tus/tus.go:249 method={} path={} pkg=rhttp requestId={} service=storage-users
2024-11-14T11:55:27+01:00 INF ResponseOutgoing datatx=tus id={} line=/home/jfd/Repositories/reva/pkg/rhttp/datatx/manager/tus/tus.go:249 method={} path={} pkg=rhttp requestId={} service=storage-users
2024-11-14T11:55:27+01:00 DBG http end="14/Nov/2024:11:55:27 +0100" host=127.0.0.1 line=/home/jfd/Repositories/reva/internal/http/interceptors/log/log.go:112 method=PATCH pkg=rhttp proto=HTTP/1.1 service=storage-users size=0 start="14/Nov/2024:11:55:27 +0100" status=204 time_ns=25707586 traceid=07b8bc72a6bb2f9df54baf8a494c32e6 uri=/data/tus/d4817c6b-dd30-4f02-b4fb-183f703384d4 url=/d4817c6b-dd30-4f02-b4fb-183f703384d4
```

not perfect, but we should at least see errors in the logs now.