### PR TITLE
do not delete mlock files after update

### DIFF
--- a/changelog/unreleased/no-delete-lock.md
+++ b/changelog/unreleased/no-delete-lock.md
@@ -1,0 +1,6 @@
+Bugfix: Do not delete mlock files
+
+To prevent stale NFS file handles we no longer delete empty mlock files after updating the metadata.
+
+https://github.com/cs3org/reva/pull/4936
+https://github.com/cs3org/reva/pull/4924

--- a/pkg/storage/utils/decomposedfs/upload/store.go
+++ b/pkg/storage/utils/decomposedfs/upload/store.go
@@ -312,11 +312,8 @@ func (store OcisStore) updateExistingNode(ctx context.Context, session *OcisSess
 	}
 
 	unlock := func() error {
-		err := f.Close()
-		if err != nil {
-			return err
-		}
-		return os.Remove(store.lu.MetadataBackend().LockfilePath(targetPath))
+		// NOTE: to prevent stale NFS file handles do not remove lock file!
+		return f.Close()
 	}
 
 	old, _ := node.ReadNode(ctx, store.lu, spaceID, n.ID, false, nil, false)


### PR DESCRIPTION

To prevent stale NFS file handles we no longer delete empty mlock files after updating the metadata.

related https://github.com/cs3org/reva/pull/4924