### PR TITLE
Fix Gateway Panics

### DIFF
--- a/changelog/unreleased/fix-gateway-panic.md
+++ b/changelog/unreleased/fix-gateway-panic.md
@@ -1,0 +1,5 @@
+Bugfix: Avoid gateway panics
+
+The gateway would panic if there is a missing user in the context. Now it errors instead.
+
+https://github.com/cs3org/reva/issues/4953

--- a/internal/grpc/services/gateway/appprovider.go
+++ b/internal/grpc/services/gateway/appprovider.go
@@ -197,7 +197,11 @@ func buildOpenInAppRequest(ctx context.Context, ri *storageprovider.ResourceInfo
 		}
 
 		// build a fake user object for the token
-		currentuser := ctxpkg.ContextMustGetUser(ctx)
+		currentuser, ok := ctxpkg.ContextGetUser(ctx)
+		if !ok {
+			return nil, errors.New("user not found in context")
+		}
+
 		scopedUser := &userpb.User{
 			Id:          ri.GetOwner(), // the owner of the resource is always set, right?
 			DisplayName: "View Only user for " + currentuser.GetUsername(),

--- a/internal/grpc/services/gateway/storageprovider.go
+++ b/internal/grpc/services/gateway/storageprovider.go
@@ -428,7 +428,10 @@ func (s *svc) DeleteStorageSpace(ctx context.Context, req *provider.DeleteStorag
 }
 
 func (s *svc) GetHome(ctx context.Context, _ *provider.GetHomeRequest) (*provider.GetHomeResponse, error) {
-	currentUser := ctxpkg.ContextMustGetUser(ctx)
+	currentUser, ok := ctxpkg.ContextGetUser(ctx)
+	if !ok {
+		return nil, errors.New("user not found in context")
+	}
 
 	srClient, err := s.getStorageRegistryClient(ctx, s.c.StorageRegistryEndpoint)
 	if err != nil {

--- a/internal/grpc/services/gateway/usershareprovider.go
+++ b/internal/grpc/services/gateway/usershareprovider.go
@@ -139,7 +139,11 @@ func (s *svc) updateShare(ctx context.Context, req *collaboration.UpdateShareReq
 	}
 
 	if s.c.CommitShareToStorageGrant {
-		creator := ctxpkg.ContextMustGetUser(ctx)
+		creator, ok := ctxpkg.ContextGetUser(ctx)
+		if !ok {
+			return nil, errors.New("user not found in context")
+		}
+
 		grant := &provider.Grant{
 			Grantee:     res.GetShare().GetGrantee(),
 			Permissions: res.GetShare().GetPermissions().GetPermissions(),
@@ -198,11 +202,16 @@ func (s *svc) updateSpaceShare(ctx context.Context, req *collaboration.UpdateSha
 			req.Share.Expiration = existsGrant.GetExpiration()
 		}
 
+		u, ok := ctxpkg.ContextGetUser(ctx)
+		if !ok {
+			return nil, errors.New("user not found in context")
+		}
+
 		grant := &provider.Grant{
 			Grantee:     req.GetShare().GetGrantee(),
 			Permissions: req.GetShare().GetPermissions().GetPermissions(),
 			Expiration:  req.GetShare().GetExpiration(),
-			Creator:     ctxpkg.ContextMustGetUser(ctx).GetId(),
+			Creator:     u.GetId(),
 		}
 
 		if grant.GetPermissions() == nil {
@@ -410,7 +419,11 @@ func (s *svc) addGrant(ctx context.Context, id *provider.ResourceId, g *provider
 		ResourceId: id,
 	}
 
-	creator := ctxpkg.ContextMustGetUser(ctx)
+	creator, ok := ctxpkg.ContextGetUser(ctx)
+	if !ok {
+		return nil, errors.New("user not found in context")
+	}
+
 	grantReq := &provider.AddGrantRequest{
 		Ref: ref,
 		Grant: &provider.Grant{


### PR DESCRIPTION
Avoid `ContextMustGetUser` calls in gateway service as they could potentially panic.


reva part for https://github.com/owncloud/ocis/issues/10594