### PR TITLE
Revert sse fix

### DIFF
--- a/changelog/unreleased/change-touch-on-office-create.md
+++ b/changelog/unreleased/change-touch-on-office-create.md
@@ -1,0 +1,7 @@
+Bugfix: Revert and adapt touch on office file create
+
+We have reverted https://github.com/cs3org/reva/pull/4959 and
+instead implemented added a touch file bevore the file is uploaded.
+
+https://github.com/cs3org/reva/pull/4962
+https://github.com/owncloud/ocis/issues/8950

--- a/internal/http/services/appprovider/appprovider.go
+++ b/internal/http/services/appprovider/appprovider.go
@@ -230,6 +230,16 @@ func (s *svc) handleNew(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	touchFileReq := &provider.TouchFileRequest{
+		Ref: fileRef,
+	}
+
+	_, err = client.TouchFile(ctx, touchFileReq)
+	if err != nil {
+		writeError(w, r, appErrorServerError, "error sending a grpc touchfile request", err)
+		return
+	}
+
 	// Create empty file via storageprovider
 	createReq := &provider.InitiateFileUploadRequest{
 		Ref: fileRef,


### PR DESCRIPTION
Bugfix: Revert and adapt touch on office file create

We have reverted https://github.com/cs3org/reva/pull/4959 and
instead implemented added a touch file bevore the file is uploaded.

https://github.com/owncloud/ocis/issues/8950