### PR TITLE
fix sharecache exists case

### DIFF
--- a/changelog/unreleased/jsoncs3-cache-fixes.md
+++ b/changelog/unreleased/jsoncs3-cache-fixes.md
@@ -1,0 +1,6 @@
+Bugfix: jsoncs3 cache fixes
+
+The jsoncs3 share manager now retries persisting if the file already existed and picks up the etag of the upload response in all cases.
+
+https://github.com/cs3org/reva/pull/4968
+https://github.com/cs3org/reva/pull/4532

--- a/pkg/share/manager/jsoncs3/sharecache/sharecache.go
+++ b/pkg/share/manager/jsoncs3/sharecache/sharecache.go
@@ -214,6 +214,11 @@ func (c *Cache) Remove(ctx context.Context, userid, shareID string) error {
 			log.Debug().Msg("precondition failed when persisting removed share: etag changed. retrying...")
 			// actually, this is the wrong status code and we treat it like errtypes.Aborted because of inconsistencies on the server side
 			// continue with sync below
+		case errtypes.AlreadyExists:
+			log.Debug().Msg("file already existed when persisting removed share. retrying...")
+			// CS3 uses an already exists error instead of precondition failed when using an If-None-Match=* header / IfExists flag in the InitiateFileUpload call.
+			// Thas happens when the cache thinks there is no file.
+			// continue with sync below
 		default:
 			span.SetStatus(codes.Error, fmt.Sprintf("persisting removed share failed. giving up: %s", err.Error()))
 			log.Error().Err(err).Msg("persisting removed share failed")


### PR DESCRIPTION
The jsoncs3 share manager now retries persisting if the file already existed and picks up the etag of the upload response in all cases.

related https://github.com/cs3org/reva/pull/4532