### PR TITLE
Use manager to list shares

### DIFF
--- a/changelog/unreleased/usershareprovider-list-with-manager.md
+++ b/changelog/unreleased/usershareprovider-list-with-manager.md
@@ -1,0 +1,5 @@
+Bugfix: Use manager to list shares
+
+When updating a received share the usershareprovider now uses the share manager directly to list received shares instead of going through the gateway again.
+
+https://github.com/cs3org/reva/pull/4971


### PR DESCRIPTION
When updating a received share the usershareprovider now uses the share manager directly to list received shares instead of going through the gateway again.

fixes https://github.com/owncloud/ocis/issues/10646