### PR TITLE
Backward compatible WebDAV lock token HTTP header (ie. for Windows)

### DIFF
--- a/internal/http/services/owncloud/ocdav/locks.go
+++ b/internal/http/services/owncloud/ocdav/locks.go
@@ -649,5 +649,9 @@ func (s *svc) unlockReference(ctx context.Context, _ http.ResponseWriter, r *htt
 }
 
 func requestLockToken(r *http.Request) string {
-	return strings.TrimSuffix(strings.TrimPrefix(r.Header.Get(net.HeaderLockToken), "<"), ">")
+	h := r.Header.Get(net.HeaderLockToken)
+	if len(h) == 0 {
+		h = strings.TrimSuffix(strings.TrimPrefix(r.Header.Get(net.HeaderIf), "("), ")")
+	}
+	return strings.TrimSuffix(strings.TrimPrefix(h, "<"), ">")
 }


### PR DESCRIPTION
Parses lock token from HTTP If header (as has been done in some past versions) in addition to the new Lock-Token header. This enables clients that use the header (ie. Windows) to work and create files.

This is a follow-up to #4928.

There may be a good reason for the header change I am not aware of. Therefore I am not entirely sure this is a proper modification.