### PR TITLE
Bugfix: handle parsing of favorites on gRPC

### DIFF
--- a/changelog/unreleased/parse-favs-grpc.md
+++ b/changelog/unreleased/parse-favs-grpc.md
@@ -1,0 +1,5 @@
+Bugfix: handle parsing of favs over gRPC
+
+To store user favorites, the key `user.http://owncloud.org/ns/favorite` maps to a list of users, in the format `u:username=1`. Right now, extracting the "correct" user doesn't happen in gRPC, while it is implemented in the EOS binary client. This feature has now been moved to the higher-level call in eosfs.
+
+https://github.com/cs3org/reva/pull/4973

--- a/internal/http/services/owncloud/ocdav/proppatch.go
+++ b/internal/http/services/owncloud/ocdav/proppatch.go
@@ -228,7 +228,7 @@ func (s *svc) handleProppatch(ctx context.Context, w http.ResponseWriter, r *htt
 					HandleErrorStatus(&log, w, res.Status)
 					return nil, nil, false
 				}
-				if key == "http://owncloud.org/ns/favorite" {
+				if key == _propOcFavorite {
 					statRes, err := c.Stat(ctx, &provider.StatRequest{Ref: ref})
 					if err != nil {
 						w.WriteHeader(http.StatusInternalServerError)
@@ -269,7 +269,7 @@ func (s *svc) handleProppatch(ctx context.Context, w http.ResponseWriter, r *htt
 				acceptedProps = append(acceptedProps, propNameXML)
 				delete(sreq.ArbitraryMetadata.Metadata, key)
 
-				if key == "http://owncloud.org/ns/favorite" {
+				if key == _propOcFavorite {
 					statRes, err := c.Stat(ctx, &provider.StatRequest{Ref: ref})
 					if err != nil {
 						w.WriteHeader(http.StatusInternalServerError)


### PR DESCRIPTION
To store user favorites, the key `user.http://owncloud.org/ns/favorite` maps to a list of users, in the format `u:username=1`. Right now, extracting the "correct" user doesn't happen in gRPC, while it is implemented in the EOS binary client. This feature has now been moved to the higher-level call in eosfs.
