### PR TITLE
Refactor EOSFS to use cbox / daemon instead of root

### DIFF
--- a/changelog/unreleased/no-more-shadow-ns.md
+++ b/changelog/unreleased/no-more-shadow-ns.md
@@ -1,0 +1,14 @@
+Enhancement: drop shadow namespaces
+
+This comes as part of the effort to operate EOS without being root, see https://github.com/cs3org/reva/pull/4977
+
+In this PR the post-home creation hook (and corresponding flag) is replaced by a create_home_hook, and the following configuration parameters are suppressed:
+
+    shadow_namespace
+    share_folder
+    default_quota_bytes
+    default_secondary_quota_bytes
+    default_quota_files
+    uploads_namespace (unused)
+
+https://github.com/cs3org/reva/pull/4984

--- a/changelog/unreleased/rootless-auth.md
+++ b/changelog/unreleased/rootless-auth.md
@@ -1,0 +1,10 @@
+Enhancement: do not use root on EOS
+
+Currently, the EOS drivers use root authentication for many different operations. This has now been changed to use one of the following:
+* cbox, which is a sudo'er
+* daemon, for read-only operations
+* the user himselft
+
+Note that home creation is excluded here as this will be tackled in a different PR.
+
+https://github.com/cs3org/reva/pull/4977/

--- a/pkg/eosclient/eosgrpc/eosgrpc.go
+++ b/pkg/eosclient/eosgrpc/eosgrpc.go
@@ -853,13 +853,9 @@ func (c *Client) GetQuota(ctx context.Context, username string, rootAuth eosclie
 		return nil, errtypes.InternalError(fmt.Sprintf("Quota error from eos. info: '%#v'", resp.Quota))
 	}
 
-	qi := new(eosclient.QuotaInfo)
-	if resp == nil {
-		return nil, errtypes.InternalError("Out of memory")
-	}
-
 	// Let's loop on all the quotas that match this uid (apparently there can be many)
 	// If there are many for this node, we sum them up
+	qi := new(eosclient.QuotaInfo)
 	for i := 0; i < len(resp.Quota.Quotanode); i++ {
 		log.Debug().Str("func", "GetQuota").Str("quotanode:", fmt.Sprintf("%d: %#v", i, resp.Quota.Quotanode[i])).Msg("")
 

--- a/pkg/eosclient/eosgrpc/eoshttp.go
+++ b/pkg/eosclient/eosgrpc/eoshttp.go
@@ -429,14 +429,6 @@ func (c *EOSHTTPClient) PUTFile(ctx context.Context, remoteuser string, auth eos
 				log.Debug().Str("func", "PUTFile").Int64("Content-Length", length).Msg("setting header")
 				req.Header.Set("Content-Length", strconv.FormatInt(length, 10))
 			}
-			if err != nil {
-				log.Error().Str("func", "PUTFile").Str("url", loc.String()).Str("err", err.Error()).Msg("can't create redirected request")
-				return err
-			}
-			if length >= 0 {
-				log.Debug().Str("func", "PUTFile").Int64("Content-Length", length).Msg("setting header")
-				req.Header.Set("Content-Length", strconv.FormatInt(length, 10))
-			}
 
 			log.Debug().Str("func", "PUTFile").Str("location", loc.String()).Msg("redirection")
 			nredirs++

--- a/pkg/storage/utils/eosfs/config.go
+++ b/pkg/storage/utils/eosfs/config.go
@@ -26,25 +26,6 @@ type Config struct {
 	// QuotaNode for storing quota information
 	QuotaNode string `mapstructure:"quota_node"`
 
-	// DefaultQuotaBytes sets the default maximum bytes available for a user
-	DefaultQuotaBytes uint64 `mapstructure:"default_quota_bytes"`
-
-	// DefaultSecondaryQuotaBytes sets the default maximum bytes available for a secondary user
-	DefaultSecondaryQuotaBytes uint64 `mapstructure:"default_secondary_quota_bytes"`
-
-	// DefaultQuotaFiles sets the default maximum files available for a user
-	DefaultQuotaFiles uint64 `mapstructure:"default_quota_files"`
-
-	// ShadowNamespace for storing shadow data
-	ShadowNamespace string `mapstructure:"shadow_namespace"`
-
-	// UploadsNamespace for storing upload data
-	UploadsNamespace string `mapstructure:"uploads_namespace"`
-
-	// ShareFolder defines the name of the folder in the
-	// shadowed namespace. Ex: /eos/user/.shadow/h/hugo/MyShares
-	ShareFolder string `mapstructure:"share_folder"`
-
 	// Location of the eos binary.
 	// Default is /usr/bin/eos.
 	EosBinary string `mapstructure:"eos_binary"`
@@ -149,9 +130,6 @@ type Config struct {
 	// revisions-related operations.
 	ImpersonateOwnerforRevisions bool `mapstructure:"impersonate_owner_for_revisions"`
 
-	// Whether to enable the post create home hook
-	EnablePostCreateHomeHook bool `mapstructure:"enable_post_create_home_hook"`
-
 	// HTTP connections to EOS: max number of idle conns
 	MaxIdleConns int `mapstructure:"max_idle_conns"`
 
@@ -177,8 +155,9 @@ type Config struct {
 	// Default is 3600
 	TokenExpiry int
 
-	// Path of the script to run after an user home folder has been created
-	OnPostCreateHomeHook string `mapstructure:"on_post_create_home_hook"`
+	// Path of the script to run in order to create a user home folder
+	// TODO(lopresti): to be replaced by a call to the Resource Lifecycle API being developed
+	CreateHomeHook string `mapstructure:"create_home_hook"`
 
 	// Maximum entries count a ListRecycle call may return: if exceeded, ListRecycle
 	// will return a BadRequest error

--- a/pkg/storage/utils/eosfs/upload.go
+++ b/pkg/storage/utils/eosfs/upload.go
@@ -36,10 +36,6 @@ func (fs *eosfs) Upload(ctx context.Context, ref *provider.Reference, r io.ReadC
 		return errors.Wrap(err, "eos: error resolving reference")
 	}
 
-	if fs.isShareFolder(ctx, p) {
-		return errtypes.PermissionDenied("eos: cannot upload under the virtual share folder")
-	}
-
 	ok, err := chunking.IsChunked(p)
 	if err != nil {
 		return errors.Wrap(err, "eos: error checking path")

--- a/pkg/storage/utils/eosfs/upload.go
+++ b/pkg/storage/utils/eosfs/upload.go
@@ -27,6 +27,7 @@ import (
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	"github.com/cs3org/reva/pkg/errtypes"
 	"github.com/cs3org/reva/pkg/storage/utils/chunking"
+	"github.com/cs3org/reva/pkg/utils"
 	"github.com/pkg/errors"
 )
 
@@ -60,7 +61,7 @@ func (fs *eosfs) Upload(ctx context.Context, ref *provider.Reference, r io.ReadC
 
 	fn := fs.wrap(ctx, p)
 
-	u, err := getUser(ctx)
+	u, err := utils.GetUser(ctx)
 	if err != nil {
 		return errors.Wrap(err, "eos: no user in ctx")
 	}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -37,6 +37,7 @@ import (
 	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	types "github.com/cs3org/go-cs3apis/cs3/types/v1beta1"
+	"github.com/cs3org/reva/pkg/eosclient"
 	"github.com/cs3org/reva/pkg/registry"
 	"github.com/cs3org/reva/pkg/registry/memory"
 	"go.step.sm/crypto/randutil"
@@ -423,9 +424,9 @@ func HasPermissions(target, toCheck *provider.ResourcePermissions) bool {
 	return true
 }
 
-// UserIsLightweight returns true if the user is a lightweight
+// IsLightweightUser returns true if the user is a lightweight
 // or federated account.
-func UserIsLightweight(u *userpb.User) bool {
+func IsLightweightUser(u *userpb.User) bool {
 	return u.Id.Type == userpb.UserType_USER_TYPE_FEDERATED ||
 		u.Id.Type == userpb.UserType_USER_TYPE_LIGHTWEIGHT
 }
@@ -442,4 +443,16 @@ func Cast(v any, to any) {
 	}
 	toVal = toVal.Elem()
 	toVal.Set(reflect.ValueOf(v))
+}
+
+func GetDaemonAuth() eosclient.Authorization {
+	return eosclient.Authorization{Role: eosclient.Role{UID: "2", GID: "2"}}
+}
+
+// This function is used when we don't want to pass any additional auth info.
+// Because we later populate the secret key for gRPC, we will be automatically
+// mapped to cbox.
+// So, in other words, use this function if you want to use the cbox account.
+func GetEmptyAuth() eosclient.Authorization {
+	return eosclient.Authorization{}
 }


### PR DESCRIPTION
Currently, the EOS drivers use root authentication for many different operations. This has now been changed to use one of the following, depending on the operation:
* cbox, which is a sudo'er
* daemon, for read-only operations
* the user himselft

Note that home creation was tackled in sub-PR #4984