### PR TITLE
Cleanup stale shares

### DIFF
--- a/pkg/share/manager/jsoncs3/jsoncs3.go
+++ b/pkg/share/manager/jsoncs3/jsoncs3.go
@@ -936,7 +936,13 @@ func (m *Manager) ListReceivedShares(ctx context.Context, filters []*collaborati
 				}
 				for shareID, state := range w.rspace.States {
 					s, err := m.Cache.Get(ctx, storageID, spaceID, shareID, true)
-					if err != nil || s == nil {
+					if err != nil {
+						sublogr.Error().Err(err).Msg("could not retrieve share")
+						continue
+					}
+					if s == nil {
+						sublogr.Warn().Str("shareid", shareID).Msg("share not found. cleaning up")
+						_ = m.UserReceivedStates.Remove(ctx, user.Id.OpaqueId, w.ssid, shareID)
 						continue
 					}
 					sublogr = sublogr.With().Str("shareid", shareID).Logger()

--- a/pkg/share/manager/jsoncs3/providercache/providercache.go
+++ b/pkg/share/manager/jsoncs3/providercache/providercache.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -317,6 +318,36 @@ func (c *Cache) Get(ctx context.Context, storageID, spaceID, shareID string, ski
 		return nil, nil
 	}
 	return space.Shares[shareID], nil
+}
+
+// All returns all entries in the storage
+func (c *Cache) All(ctx context.Context) (*mtimesyncedcache.Map[string, *Spaces], error) {
+	ctx, span := tracer.Start(ctx, "All")
+	defer span.End()
+
+	providers, err := c.storage.ListDir(ctx, "/storages")
+	if err != nil {
+		return nil, err
+	}
+	for _, provider := range providers {
+		storageID := provider.Name
+		spaces, err := c.storage.ListDir(ctx, path.Join("/storages", storageID))
+		if err != nil {
+			return nil, err
+		}
+		for _, space := range spaces {
+			spaceID := strings.TrimSuffix(space.Name, ".json")
+
+			unlock := c.LockSpace(spaceID)
+			span.AddEvent("got lock for space " + spaceID)
+			if err := c.syncWithLock(ctx, storageID, spaceID); err != nil {
+				return nil, err
+			}
+			unlock()
+		}
+	}
+
+	return &c.Providers, nil
 }
 
 // ListSpace returns the list of shares in a given space

--- a/pkg/share/manager/jsoncs3/providercache/providercache.go
+++ b/pkg/share/manager/jsoncs3/providercache/providercache.go
@@ -469,7 +469,11 @@ func (c *Cache) PurgeSpace(ctx context.Context, storageID, spaceID string) error
 	if !ok {
 		return nil
 	}
-	spaces.Spaces.Store(spaceID, &Shares{})
+	newShares := &Shares{}
+	if space, ok := spaces.Spaces.Load(spaceID); ok {
+		newShares.Etag = space.Etag // keep the etag to allow overwriting the state on the server
+	}
+	spaces.Spaces.Store(spaceID, newShares)
 
 	return c.Persist(ctx, storageID, spaceID)
 }

--- a/pkg/share/manager/jsoncs3/providercache/providercache_test.go
+++ b/pkg/share/manager/jsoncs3/providercache/providercache_test.go
@@ -191,5 +191,13 @@ var _ = Describe("Cache", func() {
 				Expect(s).To(BeNil())
 			})
 		})
+
+		Describe("All", func() {
+			It("returns all entries", func() {
+				entries, err := c.All(ctx)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(entries.Count()).To(Equal(1))
+			})
+		})
 	})
 })

--- a/pkg/storage/utils/decomposedfs/mtimesyncedcache/map.go
+++ b/pkg/storage/utils/decomposedfs/mtimesyncedcache/map.go
@@ -34,3 +34,12 @@ func (m *Map[K, V]) Range(f func(key K, value V) bool) {
 }
 
 func (m *Map[K, V]) Store(key K, value V) { m.m.Store(key, value) }
+
+func (m *Map[K, V]) Count() int {
+	l := 0
+	m.Range(func(_ K, _ V) bool {
+		l++
+		return true
+	})
+	return l
+}

--- a/pkg/storage/utils/metadata/cs3.go
+++ b/pkg/storage/utils/metadata/cs3.go
@@ -552,7 +552,11 @@ func (cs3 *CS3) getAuthContext(ctx context.Context) (context.Context, error) {
 	authCtx, span := tracer.Start(authCtx, "getAuthContext", trace.WithLinks(trace.LinkFromContext(ctx)))
 	defer span.End()
 
-	client, err := pool.GetGatewayServiceClient(cs3.gatewayAddr)
+	selector, err := pool.GatewaySelector(cs3.gatewayAddr)
+	if err != nil {
+		return nil, err
+	}
+	client, err := selector.Next()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR adds a method for cleanin up stale shares. It also cleans up received shares that don't have an according share anymore, e.g. when a group share was removed.