### PR TITLE
eosfs: use external script for home creation + drop support for shadow namespace

### DIFF
--- a/pkg/storage/utils/eosfs/config.go
+++ b/pkg/storage/utils/eosfs/config.go
@@ -35,15 +35,8 @@ type Config struct {
 	// DefaultQuotaFiles sets the default maximum files available for a user
 	DefaultQuotaFiles uint64 `mapstructure:"default_quota_files"`
 
-	// ShadowNamespace for storing shadow data
-	ShadowNamespace string `mapstructure:"shadow_namespace"`
-
 	// UploadsNamespace for storing upload data
 	UploadsNamespace string `mapstructure:"uploads_namespace"`
-
-	// ShareFolder defines the name of the folder in the
-	// shadowed namespace. Ex: /eos/user/.shadow/h/hugo/MyShares
-	ShareFolder string `mapstructure:"share_folder"`
 
 	// Location of the eos binary.
 	// Default is /usr/bin/eos.
@@ -149,9 +142,6 @@ type Config struct {
 	// revisions-related operations.
 	ImpersonateOwnerforRevisions bool `mapstructure:"impersonate_owner_for_revisions"`
 
-	// Whether to enable the post create home hook
-	EnablePostCreateHomeHook bool `mapstructure:"enable_post_create_home_hook"`
-
 	// HTTP connections to EOS: max number of idle conns
 	MaxIdleConns int `mapstructure:"max_idle_conns"`
 
@@ -177,8 +167,9 @@ type Config struct {
 	// Default is 3600
 	TokenExpiry int
 
-	// Path of the script to run after an user home folder has been created
-	OnPostCreateHomeHook string `mapstructure:"on_post_create_home_hook"`
+	// Path of the script to run in order to create a user home folder
+	// TODO(lopresti): to be replaced by a call to the Resource Lifecycle API being developed
+	CreateHomeHook string `mapstructure:"create_home_hook"`
 
 	// Maximum entries count a ListRecycle call may return: if exceeded, ListRecycle
 	// will return a BadRequest error

--- a/pkg/storage/utils/eosfs/config.go
+++ b/pkg/storage/utils/eosfs/config.go
@@ -26,15 +26,6 @@ type Config struct {
 	// QuotaNode for storing quota information
 	QuotaNode string `mapstructure:"quota_node"`
 
-	// DefaultQuotaBytes sets the default maximum bytes available for a user
-	DefaultQuotaBytes uint64 `mapstructure:"default_quota_bytes"`
-
-	// DefaultSecondaryQuotaBytes sets the default maximum bytes available for a secondary user
-	DefaultSecondaryQuotaBytes uint64 `mapstructure:"default_secondary_quota_bytes"`
-
-	// DefaultQuotaFiles sets the default maximum files available for a user
-	DefaultQuotaFiles uint64 `mapstructure:"default_quota_files"`
-
 	// UploadsNamespace for storing upload data
 	UploadsNamespace string `mapstructure:"uploads_namespace"`
 

--- a/pkg/storage/utils/eosfs/config.go
+++ b/pkg/storage/utils/eosfs/config.go
@@ -26,9 +26,6 @@ type Config struct {
 	// QuotaNode for storing quota information
 	QuotaNode string `mapstructure:"quota_node"`
 
-	// UploadsNamespace for storing upload data
-	UploadsNamespace string `mapstructure:"uploads_namespace"`
-
 	// Location of the eos binary.
 	// Default is /usr/bin/eos.
 	EosBinary string `mapstructure:"eos_binary"`

--- a/pkg/storage/utils/eosfs/upload.go
+++ b/pkg/storage/utils/eosfs/upload.go
@@ -36,10 +36,6 @@ func (fs *eosfs) Upload(ctx context.Context, ref *provider.Reference, r io.ReadC
 		return errors.Wrap(err, "eos: error resolving reference")
 	}
 
-	if fs.isShareFolder(ctx, p) {
-		return errtypes.PermissionDenied("eos: cannot upload under the virtual share folder")
-	}
-
 	ok, err := chunking.IsChunked(p)
 	if err != nil {
 		return errors.Wrap(err, "eos: error checking path")


### PR DESCRIPTION
This comes as part of the effort to operate EOS without being root, see https://github.com/cs3org/reva/pull/4977/

In this PR the post-home creation hook (and corresponding flag) is replaced by a `create_home_hook`, and the following configuration parameters are suppressed:
* `shadow_namespace`
* `share_folder`
* `default_quota_bytes`
* `default_secondary_quota_bytes`
* `default_quota_files`
* `uploads_namespace` (unused)