### PR TITLE
Fix ListStorageSpaces for ocm

### DIFF
--- a/changelog/unreleased/fix-ocm-liststoragespace.md
+++ b/changelog/unreleased/fix-ocm-liststoragespace.md
@@ -1,0 +1,7 @@
+Bugfix: Fix ListStorageSpaces for OCM shares
+
+There are no mount points for OCM shares currently. So the ListStorageSpaces
+does not return any for them anymore.
+
+https://github.com/cs3org/reva/pull/4986
+https://github.com/owncloud/ocis/issues/10689


### PR DESCRIPTION
Currently there are no mountpoints for federated shares. We just return an empty list on the ListStorageSpaces request.

Related: https://github.com/owncloud/ocis/issues/10689