### PR TITLE
eos: fixed error reporting in the gRPC client

### DIFF
--- a/changelog/unreleased/fix-eos-grpc-errors.md
+++ b/changelog/unreleased/fix-eos-grpc-errors.md
@@ -1,0 +1,5 @@
+Bugfix: fixed error reporting in the EOS gRPC client
+
+This in particular fixes the lock-related errors
+
+https://github.com/cs3org/reva/pull/5015

--- a/pkg/eosclient/eosgrpc/eosgrpc.go
+++ b/pkg/eosclient/eosgrpc/eosgrpc.go
@@ -216,7 +216,14 @@ func (c *Client) getRespError(rsp *erpc.NSResponse, err error) error {
 		return nil
 	}
 
-	return errtypes.InternalError("Err from EOS: " + fmt.Sprintf("%#v", rsp.Error))
+	switch rsp.Error.Code {
+	case 16: // EBUSY
+		return eosclient.FileIsLockedError
+	case 17: // EEXIST
+		return eosclient.AttrAlreadyExistsError
+	default:
+		return errtypes.InternalError(fmt.Sprintf("%s (code: %d)", rsp.Error.Msg, rsp.Error.Code))
+	}
 }
 
 // Common code to create and initialize a NSRequest.


### PR DESCRIPTION
With this we have a correct error reporting when locks come into play, however the wopi test suite still fails because it seems EOS does not honor the request payload (that includes the "app" name) when handling a PUT or a SetAttr (lock refresh) operation.