### PR TITLE
Allow Wildcards in OCM Domains

### DIFF
--- a/changelog/unreleased/allow-wildcard-ocm.md
+++ b/changelog/unreleased/allow-wildcard-ocm.md
@@ -1,0 +1,5 @@
+Enhancement: Allow wildcards in OCM domains
+
+When verifiying domains, allow wildcards in the domain name. This will not work when using `verify-request-hostname`
+
+https://github.com/cs3org/reva/pull/5025

--- a/pkg/ocm/provider/authorizer/json/json.go
+++ b/pkg/ocm/provider/authorizer/json/json.go
@@ -24,6 +24,7 @@ import (
 	"net"
 	"net/url"
 	"os"
+	"regexp"
 	"strings"
 	"sync"
 
@@ -130,7 +131,7 @@ func (a *authorizer) IsProviderAllowed(ctx context.Context, pi *ocmprovider.Prov
 	var providerAuthorized bool
 	if normalizedDomain != "" {
 		for _, p := range a.providers {
-			if p.Domain == normalizedDomain {
+			if ok, err := regexp.MatchString(p.Domain, normalizedDomain); ok && err == nil {
 				providerAuthorized = true
 				break
 			}


### PR DESCRIPTION
Allows using wildcards when defining ocm domains.