### PR TITLE
eosclient: handle empty traces

### DIFF
--- a/changelog/unreleased/better-eos-traces.md
+++ b/changelog/unreleased/better-eos-traces.md
@@ -1,0 +1,3 @@
+Enhancement: Handle empty EOS traces
+
+https://github.com/cs3org/reva/pull/5028

--- a/pkg/eosclient/eosbinary/eosbinary.go
+++ b/pkg/eosclient/eosbinary/eosbinary.go
@@ -247,7 +247,10 @@ func (c *Client) executeEOS(ctx context.Context, cmdArgs []string, auth eosclien
 
 	cmd.Args = append(cmd.Args, cmdArgs...)
 
-	cmd.Args = append(cmd.Args, "--comment", trace.Get(ctx))
+	t := trace.Get(ctx)
+	if t != "" {
+		cmd.Args = append(cmd.Args, "--comment", t)
+	}
 
 	err := cmd.Run()
 

--- a/pkg/storage/fs/cephfs/errors.go
+++ b/pkg/storage/fs/cephfs/errors.go
@@ -28,8 +28,8 @@ package cephfs
 */
 import "C"
 import (
-	"fmt"
 	"context"
+	"fmt"
 	"github.com/cs3org/reva/pkg/appctx"
 	"github.com/cs3org/reva/pkg/errtypes"
 )


### PR DESCRIPTION
Empty traces (i.e not defined in `ctx`) cause the eosclient to fail commands that set the `--comment` flag.