### PR TITLE
[tests-only][full-ci]Bump ocis to reva edge

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,4 +1,4 @@
 # The test runner source for API tests
-APITESTS_COMMITID=d32d3f126b6560c4737e36871fabc852d69c28f3
+APITESTS_COMMITID=b13a3a3a92545b46d834ff4560194888667bd97b
 APITESTS_BRANCH=master
 APITESTS_REPO_GIT_URL=https://github.com/owncloud/ocis.git


### PR DESCRIPTION
### Description
Bump latest `master-ocis` commit to `reva-edge`

Part of:
https://github.com/owncloud/QA/issues/872