### PR TITLE
[tests-only][full-ci]Bump ocis commit id

### DIFF
--- a/.drone.env
+++ b/.drone.env
@@ -1,4 +1,4 @@
 # The test runner source for API tests
-APITESTS_COMMITID=b13a3a3a92545b46d834ff4560194888667bd97b
+APITESTS_COMMITID=c73d253868c86277bf703dc6be481962793b5d23
 APITESTS_BRANCH=master
 APITESTS_REPO_GIT_URL=https://github.com/owncloud/ocis.git


### PR DESCRIPTION
## Description
Bumps ocis latest commit id.

Part of: https://github.com/owncloud/QA/issues/872