### PR TITLE
fix: SpaceMembershipExpired unmarshal

### DIFF
--- a/changelog/unreleased/fix-space-membership-expired-unmarshal.md
+++ b/changelog/unreleased/fix-space-membership-expired-unmarshal.md
@@ -1,0 +1,5 @@
+Bugfix: Fix SpaceMembershipExpired unmarshal
+
+SpaceMembershipExpired events can now be unmarshalled correctly
+
+https://github.com/cs3org/reva/pull/5043

--- a/pkg/events/spaces.go
+++ b/pkg/events/spaces.go
@@ -186,7 +186,7 @@ type SpaceMembershipExpired struct {
 
 // Unmarshal to fulfill umarshaller interface
 func (SpaceMembershipExpired) Unmarshal(v []byte) (interface{}, error) {
-	e := ShareExpired{}
+	e := SpaceMembershipExpired{}
 	err := json.Unmarshal(v, &e)
 	return e, err
 }


### PR DESCRIPTION
Fix SpaceMembershipExpired unmarshal

SpaceMembershipExpired events can now be unmarshalled correctly