### PR TITLE
Fix for broken ListRevision in EOS Projects

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -50,7 +50,7 @@ jobs:
           push: ${{ inputs.push }}
           platforms: ${{ inputs.platforms }}
       - name: Upload ${{ steps.build.outputs.imageid }} Docker image to artifacts
-        uses: ishworkh/docker-image-artifact-upload@v1
+        uses: ishworkh/container-image-artifact-upload@v2.0.0
         if: inputs.load
         with:
           image: ${{ steps.build.outputs.imageid }}

--- a/changelog/unreleased/listrevisions-impersonate.md
+++ b/changelog/unreleased/listrevisions-impersonate.md
@@ -1,5 +1,5 @@
 Bugfix: impersonate owner on ListRevisions
 
-ListRevisions is currently broken for projects, because this happens on behalf of the user, instead of the owner of the file. This behaviour is changed to, if so configured, do the call on behalf of the owner.
+ListRevisions is currently broken for projects, because this happens on behalf of the user, instead of the owner of the file. This behaviour is changed to do the call on behalf of the owner (if we are in a non-home space).
 
 https://github.com/cs3org/reva/pull/5064

--- a/changelog/unreleased/listrevisions-impersonate.md
+++ b/changelog/unreleased/listrevisions-impersonate.md
@@ -1,0 +1,5 @@
+Bugfix: impersonate owner on ListRevisions
+
+ListRevisions is currently broken for projects, because this happens on behalf of the user, instead of the owner of the file. This behaviour is changed to, if so configured, do the call on behalf of the owner.
+
+https://github.com/cs3org/reva/pull/5064


### PR DESCRIPTION
ListRevisions is currently broken for projects, because this happens on behalf of the user, instead of the owner of the file. This PR changes this behaviour to do the call on behalf of the owner (if we are in a non-home space).

Additionally, some unused code was removed.