### PR TITLE
Fix ocm auth manager

### DIFF
--- a/changelog/unreleased/fix-ocm-auth-manager.md
+++ b/changelog/unreleased/fix-ocm-auth-manager.md
@@ -1,0 +1,5 @@
+Enhancement: Fix ocm auth manager
+
+OCM auth manager had the Gatewayselector caching issue
+
+https://github.com/cs3org/reva/pull/5101


### PR DESCRIPTION
Calls `gwc.Next()` on each request to avoid issues with restarting services
