### PR TITLE
Temporary workaround for removing favorited folders

### DIFF
--- a/changelog/unreleased/broken-remove-favs
+++ b/changelog/unreleased/broken-remove-favs
@@ -1,0 +1,6 @@
+Bugfix: allow folders to be un-favorited
+
+Currently, removing a folder from your favorites is broken, if you are the only one who has favorited it.
+This is because the UnsetAttr call to EOS over gRPC is failing. As a temporary workaround, we now always set it to empty.
+
+https://github.com/cs3org/reva/pull/5120

--- a/internal/grpc/services/storageprovider/storageprovider.go
+++ b/internal/grpc/services/storageprovider/storageprovider.go
@@ -242,6 +242,7 @@ func (s *service) SetArbitraryMetadata(ctx context.Context, req *provider.SetArb
 }
 
 func (s *service) UnsetArbitraryMetadata(ctx context.Context, req *provider.UnsetArbitraryMetadataRequest) (*provider.UnsetArbitraryMetadataResponse, error) {
+	log := appctx.GetLogger(ctx)
 	newRef, err := s.unwrap(ctx, req.Ref)
 	if err != nil {
 		err := errors.Wrap(err, "storageprovidersvc: error unwrapping path")
@@ -258,6 +259,7 @@ func (s *service) UnsetArbitraryMetadata(ctx context.Context, req *provider.Unse
 		case errtypes.PermissionDenied:
 			st = status.NewPermissionDenied(ctx, err, "permission denied")
 		default:
+			log.Error().Err(err).Str("ref", req.Ref.String()).Any("keys", req.ArbitraryMetadataKeys).Msg("error unsetting arbitrary metadata")
 			st = status.NewInternal(ctx, err, "error unsetting arbitrary metadata: "+req.Ref.String())
 		}
 		return &provider.UnsetArbitraryMetadataResponse{

--- a/pkg/eosclient/eosgrpc/eosgrpc.go
+++ b/pkg/eosclient/eosgrpc/eosgrpc.go
@@ -604,11 +604,18 @@ func (c *Client) handleFavAttr(ctx context.Context, auth eosclient.Authorization
 		favs.DeleteEntry(acl.TypeUser, u.Id.OpaqueId)
 	}
 	attr.Val = favs.Serialize()
-	if attr.Val == "" {
-		return c.unsetEOSAttr(ctx, auth, attr, recursive, path, "", true)
-	} else {
-		return c.setEOSAttr(ctx, auth, attr, false, recursive, path, "")
-	}
+
+	// If the value is empty, we should actually unset it
+	// However, for some reason, for folders, we currently get
+	// permission denied from EOS when removing the attr.
+	// So, as a temporary workaround, we now set to empty
+	// See CERNBOX-3793
+
+	// if attr.Val == "" {
+	// 	return c.unsetEOSAttr(ctx, auth, attr, recursive, path, "", true)
+	// } else {
+	return c.setEOSAttr(ctx, auth, attr, false, recursive, path, "")
+	// }
 }
 
 // UnsetAttr unsets an extended attribute on a path.


### PR DESCRIPTION
Currently, removing a folder from your favorites is broken, if you are the only one who has favorited it.
This is because the UnsetAttr call to EOS over gRPC is failing. As a temporary workaround, we now always set it to empty.