### PR TITLE
Use binary client for Set / UnsetAttr

### DIFF
--- a/changelog/unreleased/eos-bc-for-attrs
+++ b/changelog/unreleased/eos-bc-for-attrs
@@ -1,0 +1,9 @@
+Bugfix: Use binary client for Attrs
+
+EOS < 5.3 has a couple of bugs related to attributes:
+* Attributes can only be removed as root or the owner, but over gRPC we cannot become root
+* The recursive property is ignored on set attributes
+
+For these two issues, we circumvent them by calling the binary client until we have deployed EOS 5.3
+
+https://github.com/cs3org/reva/pull/5123

--- a/pkg/eosclient/eosgrpc/eosgrpc.go
+++ b/pkg/eosclient/eosgrpc/eosgrpc.go
@@ -605,17 +605,11 @@ func (c *Client) handleFavAttr(ctx context.Context, auth eosclient.Authorization
 	}
 	attr.Val = favs.Serialize()
 
-	// If the value is empty, we should actually unset it
-	// However, for some reason, for folders, we currently get
-	// permission denied from EOS when removing the attr.
-	// So, as a temporary workaround, we now set to empty
-	// See CERNBOX-3793
-
-	// if attr.Val == "" {
-	// 	return c.unsetEOSAttr(ctx, auth, attr, recursive, path, "", true)
-	// } else {
-	return c.setEOSAttr(ctx, auth, attr, false, recursive, path, "")
-	// }
+	if attr.Val == "" {
+		return c.unsetEOSAttr(ctx, auth, attr, recursive, path, "", true)
+	} else {
+		return c.setEOSAttr(ctx, auth, attr, false, recursive, path, "")
+	}
 }
 
 // UnsetAttr unsets an extended attribute on a path.

--- a/pkg/storage/utils/eosfs/eosfs.go
+++ b/pkg/storage/utils/eosfs/eosfs.go
@@ -932,7 +932,13 @@ func (fs *eosfs) AddGrant(ctx context.Context, ref *provider.Reference, g *provi
 			Key:  fmt.Sprintf("%s.%s", lwShareAttrKey, eosACL.Qualifier),
 			Val:  eosACL.Permissions,
 		}
-		if err := fs.c.SetAttr(ctx, cboxAuth, attr, false, true, fn, ""); err != nil {
+
+		// Temporary workaround (See #5123)
+		// EOS < 5.3 gRPC does not recognize the "recursive" attribute
+		// So we use the binary client for now
+
+		if err := fs.binaryClient.SetAttr(ctx, cboxAuth, attr, false, true, fn, ""); err != nil {
+			// if err := fs.c.SetAttr(ctx, cboxAuth, attr, false, true, fn, ""); err != nil {
 			return errors.Wrap(err, "eosfs: error adding acl for lightweight account")
 		}
 		return nil


### PR DESCRIPTION
EOS < 5.3 has a couple of bugs related to attributes:
* Attributes can only be removed as root or the owner, but over gRPC we cannot become root
* The recursive property is ignored on set attributes over gRPC

We circumvent these two issues by calling the binary client until we have deployed EOS 5.3\

That means that **this PR has to be reverted once EOS 5.3 is live**