### PR TITLE
Fix handling Range requests for storages which are not seekable

### DIFF
--- a/changelog/unreleased/fix-range-req.md
+++ b/changelog/unreleased/fix-range-req.md
@@ -1,0 +1,13 @@
+Bugfix: fix broken handling of range requests
+
+Currently, the video preview in public links is broken, because the browser sends a "Range: bytes=0-" request. Since EOS over gRPC returns a ReadCloser on the file, which is not seekable, Reva currently returns a 416 RequestedRangeNotSatisfiable response, breaking the video preview.
+
+This PR modifies this behaviour to ignore the Range request in such cases.
+
+Additionally, some errors where removed. For example, when the request does not contain bytes=, Reva currently returns an error. However, RFC 7233 states:
+
+> An origin server MUST ignore a Range header field that contains a range unit it does not understand
+
+Thus, we now ignore these requests instead of returning a 416.
+
+https://github.com/cs3org/reva/pull/5133

--- a/pkg/rhttp/datatx/utils/download/download.go
+++ b/pkg/rhttp/datatx/utils/download/download.go
@@ -138,13 +138,9 @@ func GetOrHeadFile(w http.ResponseWriter, r *http.Request, fs storage.FS, spaceI
 		w.Header().Set("Accept-Ranges", "bytes")
 	}
 
-	if len(ranges) > 0 {
+	// If we want to adhere to the Range request, the content must be seekable
+	if s != nil && len(ranges) > 0 {
 		sublog.Debug().Int64("start", ranges[0].Start).Int64("length", ranges[0].Length).Msg("range request")
-		if s == nil {
-			sublog.Error().Int64("start", ranges[0].Start).Int64("length", ranges[0].Length).Msg("ReadCloser is not seekable")
-			w.WriteHeader(http.StatusRequestedRangeNotSatisfiable)
-			return
-		}
 
 		switch {
 		case len(ranges) == 1:

--- a/pkg/rhttp/datatx/utils/download/download.go
+++ b/pkg/rhttp/datatx/utils/download/download.go
@@ -139,6 +139,8 @@ func GetOrHeadFile(w http.ResponseWriter, r *http.Request, fs storage.FS, spaceI
 	}
 
 	// If we want to adhere to the Range request, the content must be seekable
+	// If the storage provider does not support seeking the content,
+	// we ignore the Range request
 	if s != nil && len(ranges) > 0 {
 		sublog.Debug().Int64("start", ranges[0].Start).Int64("length", ranges[0].Length).Msg("range request")
 

--- a/pkg/rhttp/datatx/utils/download/range.go
+++ b/pkg/rhttp/datatx/utils/download/range.go
@@ -65,7 +65,10 @@ func ParseRange(s string, size int64) ([]HTTPRange, error) {
 	}
 	const b = "bytes="
 	if !strings.HasPrefix(s, b) {
-		return nil, errors.New("invalid range")
+		// We do not return an error, because RFC 7233 states:
+		// An origin server MUST ignore a Range header field that contains a
+		// range unit it does not understand
+		return nil, nil
 	}
 	ranges := []HTTPRange{}
 	noOverlap := false
@@ -76,7 +79,7 @@ func ParseRange(s string, size int64) ([]HTTPRange, error) {
 		}
 		i := strings.Index(ra, "-")
 		if i < 0 {
-			return nil, errors.New("invalid range")
+			return nil, nil
 		}
 		start, end := textproto.TrimString(ra[:i]), textproto.TrimString(ra[i+1:])
 		var r HTTPRange

--- a/pkg/rhttp/datatx/utils/download/range_test.go
+++ b/pkg/rhttp/datatx/utils/download/range_test.go
@@ -1,0 +1,23 @@
+package download
+
+import "testing"
+
+func TestParseRange(t *testing.T) {
+	testRange := "bytes=0-"
+	size := int64(64)
+
+	resRange, err := ParseRange(testRange, size)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if len(resRange) != 1 {
+		t.Error("Expected only one range to be returned")
+	}
+
+	singleResRange := resRange[0]
+	if singleResRange.Start != 0 || singleResRange.Length != size {
+		t.Errorf("Excpected range to start at %d and end at %d; but got %d-%d", 0, size, singleResRange.Start, singleResRange.Length)
+	}
+
+}


### PR DESCRIPTION
Currently, the video preview in public links is broken, because the browser sends a `Range: bytes=0-` request. Since EOS over gRPC returns a `ReadCloser` on the file, which is not seekable, Reva currently returns a `416`  `RequestedRangeNotSatisfiable` response, breaking the video preview. 

This PR modifies this behaviour to ignore the `Range` request in such cases.

Additionally, some errors where removed. For example, when the request does not contain `bytes=`, Reva currently returns an error. However, RFC 7233 states:

> An origin server MUST ignore a Range header field that contains a range unit it does not understand

Thus, we now ignore these requests instead of returning a `416`.