### PR TITLE
eosgrpc: fixed panic with ACLs handling

### DIFF
--- a/changelog/unreleased/fix-eosgrpc-panic.md
+++ b/changelog/unreleased/fix-eosgrpc-panic.md
@@ -1,0 +1,6 @@
+Bugfix: eosgrpc: fixed panic with ACLs handling
+
+Fixes a panic that happens when listing a folder where
+files have no SysACLs, parent == nil and versionFolder has ACLs.
+
+https://github.com/cs3org/reva/pull/5143


### PR DESCRIPTION
This PR fixes a panic that happens when listing a folder where files have no SysACLs, parent == nil and versionFolder has ACLs.

Also an incorrect log was removed.