### PR TITLE
Fix for spaces bug related to opening apps

### DIFF
--- a/changelog/unreleased/spaces-apps-bug.md
+++ b/changelog/unreleased/spaces-apps-bug.md
@@ -1,0 +1,5 @@
+Bugfix: spaces + apps broken
+
+There were still some places where Reva assumed that we are running spaces; while not verifying this. This caused non-spaces WebUIs to break. This is fixed now.
+
+https://github.com/cs3org/reva/pull/5151

--- a/internal/http/services/appprovider/appprovider.go
+++ b/internal/http/services/appprovider/appprovider.go
@@ -43,6 +43,7 @@ import (
 	"github.com/cs3org/reva/pkg/spaces"
 	"github.com/cs3org/reva/pkg/utils"
 	"github.com/cs3org/reva/pkg/utils/cfg"
+	"github.com/cs3org/reva/pkg/utils/resourceid"
 	"github.com/go-chi/chi/v5"
 	ua "github.com/mileusna/useragent"
 	"github.com/pkg/errors"
@@ -353,8 +354,12 @@ func (s *svc) handleOpen(w http.ResponseWriter, r *http.Request) {
 	} else {
 		resourceID, ok := spaces.ParseResourceID(fileID)
 		if !ok {
-			writeError(w, r, appErrorInvalidParameter, "invalid file ID", nil)
-			return
+			// we try to fall back for non-spaces requests
+			resourceID = resourceid.OwnCloudResourceIDUnwrap(fileID)
+			if resourceID == nil {
+				writeError(w, r, appErrorInvalidParameter, "invalid file ID", nil)
+				return
+			}
 		}
 		fileRef.ResourceId = resourceID
 	}

--- a/pkg/spaces/utils.go
+++ b/pkg/spaces/utils.go
@@ -82,6 +82,10 @@ func EncodeResourceID(r *provider.ResourceId) string {
 // EncodeSpaceID encodes storage ID and path to create a space ID,
 // in the format <storage_id>$base32(<path>).
 func EncodeSpaceID(storageID, path string) string {
+	if path == "" {
+		return storageID
+	}
+
 	encodedPath := base32.StdEncoding.EncodeToString([]byte(path))
 	return fmt.Sprintf("%s$%s", storageID, encodedPath)
 }


### PR DESCRIPTION
There were still some places where Reva assumed that we are running spaces; while not verifying this. This caused non-spaces WebUIs to break. This PR fixes this.