### PR TITLE
fix: ocdav/put response compatible with spaces

### DIFF
--- a/changelog/unreleased/fix-put-response-spaces.md
+++ b/changelog/unreleased/fix-put-response-spaces.md
@@ -1,0 +1,5 @@
+Bugfix: ocdav/put response compatible with spaces
+
+Checks if `spaces` is enabled before returning the `fileid` after a PUT request.
+
+https://github.com/cs3org/reva/pull/5153


### PR DESCRIPTION
Checks if `spaces` is enabled before returning the `fileid` after a PUT request.