### PR TITLE
fix: shares parentReference

### DIFF
--- a/changelog/unreleased/fix-shares-parent-reference.md
+++ b/changelog/unreleased/fix-shares-parent-reference.md
@@ -1,0 +1,13 @@
+Bugfix: shares parent reference
+
+- change: replace `md.Id.SpaceID` with `<storage-id>?<space-id>`
+- fix: parentReference
+  - add space info to id
+  - removes double encoding of driveId
+  - new function to return relative path inside a space root
+- refactor space utils:
+  - reorder functions (Encode > Decode > Parse)
+  - returns `SpaceID` instead of `path` in `DecodeResourceID`
+  - new comments
+
+https://github.com/cs3org/reva/pull/5189

--- a/internal/http/services/owncloud/ocdav/propfind.go
+++ b/internal/http/services/owncloud/ocdav/propfind.go
@@ -518,21 +518,19 @@ func spaceHref(ctx context.Context, baseURI string, md *provider.ResourceInfo) (
 	if md.Id == nil || md.Id.SpaceId == "" {
 		return "", errors.New("Space ID must be set to calculate Href")
 	}
+	storageSpaceID := spaces.ConcatStorageSpaceID(md.Id.StorageId, md.Id.SpaceId)
 
-	spacePath, ok := ctx.Value(ctxSpacePath).(string)
+	_, spacePath, ok := spaces.DecodeStorageSpaceID(storageSpaceID)
 	if !ok {
-		// If no space path is set in the context, we calculate it
-		_, spacePath, ok = spaces.DecodeStorageSpaceID(fmt.Sprintf("%s$%s", md.Id.StorageId, md.Id.SpaceId))
-		if !ok {
-			return "", errors.New("Failed to decode space ID")
-		}
+		return "", errors.New("Failed to decode space ID")
 	}
 
 	relativePath, err := filepath.Rel(spacePath, md.Path)
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to calculate path relative to space root: %v", spacePath)
 	}
-	return path.Join(baseURI, md.Id.SpaceId, relativePath), nil
+
+	return path.Join(baseURI, storageSpaceID, relativePath), nil
 }
 
 func appendSlash(path string) string {

--- a/internal/http/services/owncloud/ocgraph/drives.go
+++ b/internal/http/services/owncloud/ocgraph/drives.go
@@ -143,6 +143,8 @@ func libregraphShareID(shareID *collaborationv1beta1.ShareId) string {
 
 func (s *svc) convertShareToSpace(rsi *gateway.ReceivedShareResourceInfo) *libregraph.Drive {
 	// the prefix of the remote_item.id and rootid
+	resourceRelativePath, _ := spaces.PathRelativeToSpaceRoot(rsi.ResourceInfo)
+
 	return &libregraph.Drive{
 		Id:         libregraph.PtrString(libregraphShareID(rsi.ReceivedShare.Share.Id)),
 		DriveType:  libregraph.PtrString("mountpoint"),
@@ -158,7 +160,7 @@ func (s *svc) convertShareToSpace(rsi *gateway.ReceivedShareResourceInfo) *libre
 			Id:        libregraph.PtrString(fmt.Sprintf("%s$%s!%s", ShareJailID, ShareJailID, rsi.ReceivedShare.Share.Id.OpaqueId)),
 			WebDavUrl: libregraph.PtrString(fullURL(s.c.WebDavBase, rsi.ResourceInfo.Path)),
 			RemoteItem: &libregraph.RemoteItem{
-				DriveAlias: libregraph.PtrString(strings.TrimSuffix(strings.TrimPrefix(rsi.ResourceInfo.Path, "/"), spaces.RelativePathToSpaceID(rsi.ResourceInfo))), // the drive alias must not start with /
+				DriveAlias: libregraph.PtrString(rsi.ResourceInfo.Id.StorageId),
 				ETag:       libregraph.PtrString(rsi.ResourceInfo.Etag),
 				Folder:     &libregraph.Folder{},
 				// The Id must correspond to the id in the OCS response, for the time being
@@ -166,7 +168,7 @@ func (s *svc) convertShareToSpace(rsi *gateway.ReceivedShareResourceInfo) *libre
 				Id:                   libregraph.PtrString(spaces.EncodeResourceID(rsi.ResourceInfo.Id)),
 				LastModifiedDateTime: libregraph.PtrTime(time.Unix(int64(rsi.ResourceInfo.Mtime.Seconds), int64(rsi.ResourceInfo.Mtime.Nanos))),
 				Name:                 libregraph.PtrString(filepath.Base(rsi.ResourceInfo.Path)),
-				Path:                 libregraph.PtrString(spaces.RelativePathToSpaceID(rsi.ResourceInfo)),
+				Path:                 libregraph.PtrString(resourceRelativePath),
 				// RootId must have the same token before ! as Id
 				// the second part for the time being is not used
 				RootId: libregraph.PtrString(fmt.Sprintf("%s!unused_root_id", spaces.EncodeStorageSpaceID(rsi.ResourceInfo.Id.StorageId, rsi.ResourceInfo.Id.SpaceId))),

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/shares.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/shares.go
@@ -1194,8 +1194,12 @@ func (h *Handler) addFileInfo(ctx context.Context, s *conversions.ShareData, inf
 		s.FileSource = s.ItemSource
 		switch {
 		case h.sharePrefix == "/":
-			s.FileTarget = spaces.RelativePathToSpaceID(info)
-			s.Path = spaces.RelativePathToSpaceID(info)
+			relativePath, err := spaces.PathRelativeToSpaceRoot(info)
+			if err != nil {
+				return err
+			}
+			s.FileTarget = relativePath
+			s.Path = relativePath
 		case s.ShareType == conversions.ShareTypePublicLink:
 			s.FileTarget = path.Join("/", path.Base(info.Path))
 			s.Path = path.Join("/", path.Base(info.Path))

--- a/pkg/spaces/utils.go
+++ b/pkg/spaces/utils.go
@@ -29,6 +29,18 @@ import (
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 )
 
+// EncodeStorageSpaceID encodes storage ID and space ID.
+// In case of empty space ID, the path is used to create an identifier
+// in the format <storage_id>$base32(<path>), where base32(<path>) is the space ID.
+func EncodeStorageSpaceID(storageID, path string) string {
+	if path == "" {
+		return storageID
+	}
+
+	encodedPath := PathToSpaceID(path)
+	return ConcatStorageSpaceID(storageID, encodedPath)
+}
+
 // DecodeStorageSpaceID returns the components of the storage + space ID.
 // This ID is expected to be in the format <storage_id>$base32(<path>).
 func DecodeStorageSpaceID(raw string) (storageID, path string, ok bool) {
@@ -47,6 +59,10 @@ func DecodeStorageSpaceID(raw string) (storageID, path string, ok bool) {
 	return storageID, path, true
 }
 
+func ConcatStorageSpaceID(storageID, spaceID string) string {
+	return fmt.Sprintf("%s$%s", storageID, spaceID)
+}
+
 func EncodeSpaceID(spacePath string) string {
 	return base32.StdEncoding.EncodeToString([]byte(spacePath))
 }
@@ -57,6 +73,19 @@ func DecodeSpaceID(spaceId string) (string, error) {
 		return "", err
 	}
 	return string(res), nil
+}
+
+// EncodeResourceID encodes the provided resource ID as a string,
+// in the format <storage_id>$<space_id>!<item_id>.
+// If space_id or opaque_id is not set on the ResourceId,
+// then this part will not be encoded
+func EncodeResourceID(r *provider.ResourceId) string {
+	if r.SpaceId == "" {
+		return fmt.Sprintf("%s!%s", r.StorageId, r.OpaqueId)
+	} else if r.OpaqueId == "" {
+		return fmt.Sprintf("%s$%s", r.StorageId, r.SpaceId)
+	}
+	return fmt.Sprintf("%s$%s!%s", r.StorageId, r.SpaceId, r.OpaqueId)
 }
 
 // Decode resourceID returns the components of the space ID.
@@ -78,50 +107,29 @@ func ParseResourceID(raw string) (*provider.ResourceId, bool) {
 	if !ok {
 		return nil, false
 	}
+
+	spaceID := PathToSpaceID(path)
+
 	return &provider.ResourceId{
 		StorageId: storageID,
-		SpaceId:   path,
+		SpaceId:   spaceID,
 		OpaqueId:  itemID,
 	}, true
 }
 
-// EncodeResourceID encodes the provided resource ID as a string,
-// in the format <storage_id>$<space_id>!<item_id>.
-// If space_id or opaque_id is not set on the ResourceId,
-// then this part will not be encoded
-func EncodeResourceID(r *provider.ResourceId) string {
-	if r.SpaceId == "" {
-		return fmt.Sprintf("%s!%s", r.StorageId, r.OpaqueId)
-	} else if r.OpaqueId == "" {
-		return fmt.Sprintf("%s$%s", r.StorageId, r.SpaceId)
-	}
-	return fmt.Sprintf("%s$%s!%s", r.StorageId, r.SpaceId, r.OpaqueId)
-}
-
-// EncodeResourceID encodes the provided resource ID as a string,
+// EncodeResourceInfo encodes the provided resource ID as a string,
 // in the format <storage_id>$<space_id>!<item_id>.
 // If space_id is not set, it will be calculated from the path.
 // If no path or space_id is set, an error will be returned
-func EncodeResourceInfo(md *provider.ResourceInfo) (spaceId string, err error) {
-	if md.Id.SpaceId != "" {
-		return fmt.Sprintf("%s$%s!%s", md.Id.StorageId, md.Id.SpaceId, md.Id.OpaqueId), nil
-	} else if md.Path != "" {
-		encodedPath := PathToSpaceID(md.Path)
-		return fmt.Sprintf("%s$%s!%s", md.Id.StorageId, encodedPath, md.Id.OpaqueId), nil
+func EncodeResourceInfo(info *provider.ResourceInfo) (spaceId string, err error) {
+	if info.Id.SpaceId != "" {
+		return fmt.Sprintf("%s$%s!%s", info.Id.StorageId, info.Id.SpaceId, info.Id.OpaqueId), nil
+	} else if info.Path != "" {
+		encodedPath := PathToSpaceID(info.Path)
+		return fmt.Sprintf("%s$%s!%s", info.Id.StorageId, encodedPath, info.Id.OpaqueId), nil
 	} else {
 		return "", errors.New("resourceInfo must contain a spaceID or a path")
 	}
-}
-
-// EncodeStorageSpaceID encodes storage ID and path to create an identifier
-// in the format <storage_id>$base32(<path>), where base32(<path>) is the space ID.
-func EncodeStorageSpaceID(storageID, path string) string {
-	if path == "" {
-		return storageID
-	}
-
-	encodedPath := PathToSpaceID(path)
-	return fmt.Sprintf("%s$%s", storageID, encodedPath)
 }
 
 // If the path given is a subfolder of a space,
@@ -153,11 +161,6 @@ func spacesLevel(path string) int {
 		// a safe default for all other eos paths (e.g. /eos/experiment etc)
 		return 3
 	}
-}
-
-// Removes the Space ID from the path of a resource info, preserving the leading slash.
-func RelativePathToSpaceID(info *provider.ResourceInfo) string {
-	return strings.TrimPrefix(info.Path, info.Id.SpaceId)
 }
 
 // Returns the path relative to the space root.

--- a/pkg/spaces/utils.go
+++ b/pkg/spaces/utils.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
@@ -154,8 +155,22 @@ func spacesLevel(path string) int {
 	}
 }
 
+// Removes the Space ID from the path of a resource info, preserving the leading slash.
 func RelativePathToSpaceID(info *provider.ResourceInfo) string {
 	return strings.TrimPrefix(info.Path, info.Id.SpaceId)
+}
+
+// Returns the path relative to the space root.
+func PathRelativeToSpaceRoot(info *provider.ResourceInfo) (relativePath string, err error) {
+	if info.Id.SpaceId == "" {
+		return "", errors.New("resourceInfo must contain a space ID")
+	}
+	_, spacePath, ok := DecodeStorageSpaceID(fmt.Sprintf("%s$%s", info.Id.StorageId, info.Id.SpaceId))
+	if !ok {
+		return "", fmt.Errorf("failed to decode storage space ID: %s", fmt.Sprintf("%s$%s", info.Id.StorageId, info.Id.SpaceId))
+	}
+
+	return filepath.Rel(spacePath, info.Path)
 }
 
 func ResourceIdToString(id *provider.ResourceId) string {


### PR DESCRIPTION
- rollback change: replace `md.Id.SpaceID` with the `storageSpaceID`.
  - instead of `<space-id>`, it should use `<storage-id>$<space-id>`
- fix: parentReference
  - add space info to `id`
  - removes double encoding of `driveId`
  - new function to return relative path inside a space root