### PR TITLE
Revert "Upgrade jwt library to v5"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/go-playground/validator/v10 v10.26.0
 	github.com/go-sql-driver/mysql v1.9.3
 	github.com/gofrs/uuid v4.4.0+incompatible
-	github.com/golang-jwt/jwt/v5 v5.2.2
+	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/golang/protobuf v1.5.4
 	github.com/gomodule/redigo v1.9.2
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -1027,8 +1027,8 @@ github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7a
 github.com/gogo/protobuf v1.2.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
-github.com/golang-jwt/jwt/v5 v5.2.2 h1:Rl4B7itRWVtYIHFrSNd7vhTiz9UpLdi6gZhZ3wEeDy8=
-github.com/golang-jwt/jwt/v5 v5.2.2/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
+github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
+github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
 github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe h1:lXe2qZdvpiX5WZkZR4hgp4KJVfY3nMkvmwbVkpv1rVY=
 github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe/go.mod h1:8vg3r2VgvsThLBIFL93Qb5yWzgyZWhEmBwUJWevAkK0=
 github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0/go.mod h1:E/TSTwGwJL78qG/PmXZO1EjYhfJinVAhrmmHX6Z8B9k=

--- a/internal/grpc/services/gateway/storageprovider.go
+++ b/internal/grpc/services/gateway/storageprovider.go
@@ -31,13 +31,13 @@ import (
 	registry "github.com/cs3org/go-cs3apis/cs3/storage/registry/v1beta1"
 	types "github.com/cs3org/go-cs3apis/cs3/types/v1beta1"
 	"github.com/cs3org/reva/pkg/appctx"
-	"github.com/golang-jwt/jwt/v5"
 
 	"github.com/cs3org/reva/pkg/errtypes"
 	"github.com/cs3org/reva/pkg/rgrpc/status"
 	"github.com/cs3org/reva/pkg/rgrpc/todo/pool"
 	"github.com/cs3org/reva/pkg/storage/utils/templates"
 	"github.com/cs3org/reva/pkg/utils"
+	"github.com/golang-jwt/jwt"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc/codes"
@@ -46,7 +46,7 @@ import (
 
 // transferClaims are custom claims for a JWT token to be used between the metadata and data gateways.
 type transferClaims struct {
-	jwt.RegisteredClaims
+	jwt.StandardClaims
 	Target     string `json:"target"`
 	VersionKey string `json:"version_key,omitempty"`
 }
@@ -56,10 +56,10 @@ func (s *svc) sign(_ context.Context, target, versionKey string) (string, error)
 	// For large files, this can take a long time, so we extend the expiration
 	ttl := time.Duration(s.c.TransferExpires) * time.Second
 	claims := transferClaims{
-		RegisteredClaims: jwt.RegisteredClaims{
-			ExpiresAt: jwt.NewNumericDate(time.Now().Add(ttl)),
-			Audience:  jwt.ClaimStrings{"reva"},
-			IssuedAt:  jwt.NewNumericDate(time.Now()),
+		StandardClaims: jwt.StandardClaims{
+			ExpiresAt: time.Now().Add(ttl).Unix(),
+			Audience:  "reva",
+			IssuedAt:  time.Now().Unix(),
 		},
 		Target:     target,
 		VersionKey: versionKey,

--- a/internal/http/services/datagateway/datagateway.go
+++ b/internal/http/services/datagateway/datagateway.go
@@ -34,7 +34,7 @@ import (
 	"github.com/cs3org/reva/pkg/rhttp/global"
 	"github.com/cs3org/reva/pkg/sharedconf"
 	"github.com/cs3org/reva/pkg/utils/cfg"
-	"github.com/golang-jwt/jwt/v5"
+	"github.com/golang-jwt/jwt"
 	"github.com/pkg/errors"
 )
 
@@ -51,7 +51,7 @@ func init() {
 
 // transferClaims are custom claims for a JWT token to be used between the metadata and data gateways.
 type transferClaims struct {
-	jwt.RegisteredClaims
+	jwt.StandardClaims
 	Target     string `json:"target"`
 	VersionKey string `json:"version_key,omitempty"`
 }
@@ -211,7 +211,7 @@ func (s *svc) doHead(w http.ResponseWriter, r *http.Request) {
 	copyHeader(w.Header(), httpRes.Header)
 
 	// add upload expiry / transfer token expiry header for tus https://tus.io/protocols/resumable-upload.html#expiration
-	w.Header().Set(UploadExpiresHeader, time.Unix(claims.ExpiresAt.Unix(), 0).Format(time.RFC1123))
+	w.Header().Set(UploadExpiresHeader, time.Unix(claims.ExpiresAt, 0).Format(time.RFC1123))
 
 	if httpRes.StatusCode != http.StatusOK {
 		// swallow the body and set content-length to 0 to prevent reverse proxies from trying to read from it

--- a/pkg/app/provider/wopi/wopi.go
+++ b/pkg/app/provider/wopi/wopi.go
@@ -53,7 +53,7 @@ import (
 	"github.com/cs3org/reva/pkg/utils"
 	"github.com/cs3org/reva/pkg/utils/cfg"
 	gomime "github.com/glpatcern/go-mime"
-	"github.com/golang-jwt/jwt/v5"
+	"github.com/golang-jwt/jwt"
 	"github.com/pkg/errors"
 )
 
@@ -442,16 +442,16 @@ func getAppURLs(c *config) (map[string]map[string]string, error) {
 
 func (p *wopiProvider) getAccessTokenTTL(ctx context.Context) (string, error) {
 	tkn := appctx.ContextMustGetToken(ctx)
-	token, err := jwt.ParseWithClaims(tkn, &jwt.RegisteredClaims{}, func(token *jwt.Token) (interface{}, error) {
+	token, err := jwt.ParseWithClaims(tkn, &jwt.StandardClaims{}, func(token *jwt.Token) (interface{}, error) {
 		return []byte(p.conf.JWTSecret), nil
 	})
 	if err != nil {
 		return "", err
 	}
 
-	if claims, ok := token.Claims.(*jwt.RegisteredClaims); ok && token.Valid {
+	if claims, ok := token.Claims.(*jwt.StandardClaims); ok && token.Valid {
 		// milliseconds since Jan 1, 1970 UTC as required in https://learn.microsoft.com/en-us/microsoft-365/cloud-storage-partner-program/rest/concepts#the-access_token_ttl-property
-		return strconv.FormatInt(claims.ExpiresAt.UnixMicro()*1000, 10), nil
+		return strconv.FormatInt(claims.ExpiresAt*1000, 10), nil
 	}
 
 	return "", errtypes.InvalidCredentials("wopi: invalid token present in ctx")

--- a/pkg/auth/manager/ldap/ldap.go
+++ b/pkg/auth/manager/ldap/ldap.go
@@ -192,7 +192,7 @@ func (am *mgr) Authenticate(ctx context.Context, clientID, clientSecret string) 
 	}
 	u := &user.User{
 		Id: userID,
-		// TODO add more claims from the RegisteredClaims, eg EmailVerified
+		// TODO add more claims from the StandardClaims, eg EmailVerified
 		Username: sr.Entries[0].GetEqualFoldAttributeValue(am.c.Schema.UID),
 		// TODO groups
 		Groups:      getGroupsResp.Groups,

--- a/pkg/auth/manager/oidc/oidc.go
+++ b/pkg/auth/manager/oidc/oidc.go
@@ -44,7 +44,7 @@ import (
 	"github.com/cs3org/reva/pkg/rgrpc/todo/pool"
 	"github.com/cs3org/reva/pkg/sharedconf"
 	"github.com/cs3org/reva/pkg/utils/cfg"
-	"github.com/golang-jwt/jwt/v5"
+	"github.com/golang-jwt/jwt"
 	"github.com/juliangruber/go-intersect"
 	"github.com/pkg/errors"
 	"golang.org/x/oauth2"

--- a/pkg/token/manager/jwt/jwt.go
+++ b/pkg/token/manager/jwt/jwt.go
@@ -29,7 +29,7 @@ import (
 	"github.com/cs3org/reva/pkg/token"
 	"github.com/cs3org/reva/pkg/token/manager/registry"
 	"github.com/cs3org/reva/pkg/utils/cfg"
-	"github.com/golang-jwt/jwt/v5"
+	"github.com/golang-jwt/jwt"
 	"github.com/pkg/errors"
 )
 
@@ -51,7 +51,7 @@ type manager struct {
 
 // claims are custom claims for the JWT token.
 type claims struct {
-	jwt.RegisteredClaims
+	jwt.StandardClaims
 	User  *user.User             `json:"user"`
 	Scope map[string]*auth.Scope `json:"scope"`
 }
@@ -81,11 +81,11 @@ func New(m map[string]interface{}) (token.Manager, error) {
 
 func (m *manager) MintToken(ctx context.Context, u *user.User, scope map[string]*auth.Scope) (string, error) {
 	claims := claims{
-		RegisteredClaims: jwt.RegisteredClaims{
-			ExpiresAt: jwt.NewNumericDate(getExpirationDate(m.conf.ExpiresNextWeekend, time.Duration(m.conf.Expires)*time.Second)),
+		StandardClaims: jwt.StandardClaims{
+			ExpiresAt: getExpirationDate(m.conf.ExpiresNextWeekend, time.Duration(m.conf.Expires)*time.Second).Unix(),
 			Issuer:    u.Id.Idp,
-			Audience:  jwt.ClaimStrings{"reva"},
-			IssuedAt:  jwt.NewNumericDate(time.Now()),
+			Audience:  "reva",
+			IssuedAt:  time.Now().Unix(),
 		},
 		User:  u,
 		Scope: scope,


### PR DESCRIPTION
Temporarily reverting cs3org/reva#5174 to ease next production upgrade. The JWT v5 upgrade will be targeted in the next build.