### PR TITLE
feat: resource private link

### DIFF
--- a/changelog/unreleased/feat-resource-private-link.md
+++ b/changelog/unreleased/feat-resource-private-link.md
@@ -1,0 +1,6 @@
+Enhancement: add private link to propfind response
+
+- new `privatelink` property in the PROPFIND response
+- `privatelink` is NOT a "permanent link", as it's a path based link to the resource
+
+https://github.com/cs3org/reva/pull/5215

--- a/internal/http/services/owncloud/ocdav/propfind.go
+++ b/internal/http/services/owncloud/ocdav/propfind.go
@@ -660,7 +660,6 @@ func (s *svc) mdToPropResponse(ctx context.Context, pf *propfindXML, md *provide
 	// when allprops has been requested
 	if pf.Allprop != nil {
 		// return all known properties
-
 		if md.Id != nil {
 			if spacesEnabled {
 				id := spaces.EncodeResourceID(md.Id)
@@ -1014,8 +1013,16 @@ func (s *svc) mdToPropResponse(ctx context.Context, pf *propfindXML, md *provide
 							propstatNotFound.Prop = append(propstatNotFound.Prop, s.newProp("oc:signature-auth", ""))
 						}
 					}
-				case "privatelink": // phoenix only
-					// <oc:privatelink>https://phoenix.owncloud.com/f/9</oc:privatelink>
+				case "privatelink":
+					privateURL, err := url.Parse(s.c.PublicURL)
+					if err == nil {
+						// privateURL.Path = path.Join("f", spaces.EncodeResourceID(md.Id))
+						// TODO: create a choice between id based and path based links
+						privateURL.Path = path.Join("files", "spaces", md.Path)
+						propstatOK.Prop = append(propstatOK.Prop, s.newProp("oc:privatelink", privateURL.String()))
+					} else {
+						propstatNotFound.Prop = append(propstatNotFound.Prop, s.newProp("oc:privatelink", ""))
+					}
 					fallthrough
 				case "dDC": // desktop
 					fallthrough


### PR DESCRIPTION
- add private link property to propfind response
- not configurable to choose between id or path based links (path only)

in order to `s.c.PublicURL` have a value, a config in puppet is needed.