### PR TITLE
feat: inode to path reverse resolution in the cephfs driver

### DIFF
--- a/changelog/unreleased/inode-to-path-reverse-resolution-ceph.md
+++ b/changelog/unreleased/inode-to-path-reverse-resolution-ceph.md
@@ -1,0 +1,5 @@
+Enhancement: Cephfs - inode to path reverse resolution
+
+This enhancement introduces a way to do inode to path reverse resolution. This implementation first queries the ceph monitor to find the active ceph MDS (metadata server), and then queries the MDS to find the path from an inode using the dump inode command.
+
+https://github.com/cs3org/reva/pull/5222


### PR DESCRIPTION
A proof of concept for the inode to path reverse resolution in the cephfs driver.

The main function is `GetPathByID` which does the following:
1. Query the Ceph monitor and parse the active mds (`getFSStatus()` & `parseActiveMDS()`)
2. Convert the `opaque_id` to an `integer` (to be seen if needed in the future, for testing it was required)
3. Query the Ceph MDS (Metadata Server) to "dump inode" to get the path (`dumpInode()` & `extractPathFromInodeOutput()`)
4. Trim the Reva mount path from the full path.

The path we get from the mds is the full path on the ceph cluster e.g. `/volumes/_nogroup/rasmus/welander`,  however Reva mounts at the root `/volumes/_nogroup/rasmus`, so the corresponding cephfs driver path is `/rasmus/welander`. 

**_Note:_** _this proof of concept uses a powerful admin key to the ceph cluster, which will need to be generated for the production ceph cluster with the required permissions, and has only been tested on a test ceph cluster._ 

**Line 215 -  224 should be removed since it's only there for testing purposes.**