### PR TITLE
fix: valid download url in public links

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,16 +53,16 @@ gaia:
 
 .PHONY: cernbox-revad
 cernbox-revad: gaia
-	gaia build --with github.com/cernbox/reva-plugins --with github.com/cs3org/reva=$(shell pwd) --debug -o ./cmd/revad/revad
+	gaia build --with github.com/cernbox/reva-plugins --with github.com/cs3org/reva/v3=$(shell pwd) --debug -o ./cmd/revad/revad
 
 .PHONY: cernbox-revad-local
 cernbox-revad-local: gaia
-	gaia build --with github.com/cernbox/reva-plugins=$(shell pwd)/../reva-plugins --with github.com/cs3org/reva=$(shell pwd) --debug -o ./cmd/revad/revad
+	gaia build --with github.com/cernbox/reva-plugins=$(shell pwd)/../reva-plugins --with github.com/cs3org/reva/v3=$(shell pwd) --debug -o ./cmd/revad/revad
 
 
 .PHONY: cernbox-revad-ceph
 cernbox-revad-ceph: cernbox-revad
-	gaia build --tags ceph --with github.com/cernbox/reva-plugins --with github.com/cs3org/reva=$(shell pwd) --debug -o ./cmd/revad/revad-ceph
+	gaia build --tags ceph --with github.com/cernbox/reva-plugins --with github.com/cs3org/reva/v3=$(shell pwd) --debug -o ./cmd/revad/revad-ceph
 
 .PHONY: revad-ceph
 revad-ceph:

--- a/changelog/unreleased/feat-resource-private-link.md
+++ b/changelog/unreleased/feat-resource-private-link.md
@@ -1,0 +1,6 @@
+Enhancement: add private link to propfind response
+
+- new `privatelink` property in the PROPFIND response
+- `privatelink` is NOT a "permanent link", as it's a path based link to the resource
+
+https://github.com/cs3org/reva/pull/5215

--- a/changelog/unreleased/fix-public-download-url.md
+++ b/changelog/unreleased/fix-public-download-url.md
@@ -1,0 +1,5 @@
+Bugfix: public link downloadURL
+
+removes `/public` prefix from resource path when building the download URL.
+
+https://github.com/cs3org/reva/pull/5232

--- a/internal/http/services/owncloud/ocdav/propfind.go
+++ b/internal/http/services/owncloud/ocdav/propfind.go
@@ -660,7 +660,6 @@ func (s *svc) mdToPropResponse(ctx context.Context, pf *propfindXML, md *provide
 	// when allprops has been requested
 	if pf.Allprop != nil {
 		// return all known properties
-
 		if md.Id != nil {
 			if spacesEnabled {
 				id := spaces.EncodeResourceID(md.Id)
@@ -1014,8 +1013,16 @@ func (s *svc) mdToPropResponse(ctx context.Context, pf *propfindXML, md *provide
 							propstatNotFound.Prop = append(propstatNotFound.Prop, s.newProp("oc:signature-auth", ""))
 						}
 					}
-				case "privatelink": // phoenix only
-					// <oc:privatelink>https://phoenix.owncloud.com/f/9</oc:privatelink>
+				case "privatelink":
+					privateURL, err := url.Parse(s.c.PublicURL)
+					if err == nil {
+						// privateURL.Path = path.Join("f", spaces.EncodeResourceID(md.Id))
+						// TODO: create a choice between id based and path based links
+						privateURL.Path = path.Join("files", "spaces", md.Path)
+						propstatOK.Prop = append(propstatOK.Prop, s.newProp("oc:privatelink", privateURL.String()))
+					} else {
+						propstatNotFound.Prop = append(propstatNotFound.Prop, s.newProp("oc:privatelink", ""))
+					}
 					fallthrough
 				case "dDC": // desktop
 					fallthrough

--- a/internal/http/services/owncloud/ocdav/propfind.go
+++ b/internal/http/services/owncloud/ocdav/propfind.go
@@ -991,7 +991,8 @@ func (s *svc) mdToPropResponse(ctx context.Context, pf *propfindXML, md *provide
 
 							path = sb.String()
 						}
-						propstatOK.Prop = append(propstatOK.Prop, s.newProp("oc:downloadURL", s.c.PublicURL+baseURI+path))
+						relativePath := strings.TrimPrefix(path, "/public")
+						propstatOK.Prop = append(propstatOK.Prop, s.newProp("oc:downloadURL", s.c.PublicURL+baseURI+relativePath))
 					} else {
 						propstatNotFound.Prop = append(propstatNotFound.Prop, s.newProp("oc:"+pf.Prop[i].Local, ""))
 					}


### PR DESCRIPTION
Downloading files doesn't work with
`GET https://cbox-ocisdev-rodrigo.cern.ch/remote.php/dav/public-files/public/<public-link-token>/<filename>`
instead, it should be:
`GET https://cbox-ocisdev-rodrigo.cern.ch/remote.php/dav/public-files/<public-link-token>/<filename>`

The other properties, as `href` and `privatelink` for example, do work with the resource path starting with `/public`, so there seems to be no reason to remove this from the path itself. The exception is only for `downloadURL`.