### PR TITLE
Allow POST to /shares endpoint to send multiple users at once

### DIFF
--- a/changelog/unreleased/multiple-users-share.md
+++ b/changelog/unreleased/multiple-users-share.md
@@ -1,0 +1,5 @@
+Enhancement: allow multi-user share in OCS
+
+Sending multiple POST requests for multiple users leads to parallel calls to EOS, which suffers from a critical race condition when setting ACLs. So, now the reva OCS endpoint supports sending multiple comma-seperated users.
+
+https://github.com/cs3org/reva/pull/5235


### PR DESCRIPTION
Sending multiple POST requests for multiple users leads to parallel calls to EOS, which suffers from a critical race condition when setting ACLs. So, now the reva OCS endpoint supports sending multiple comma-seperated users.