### PR TITLE
Fix file creation via AppProvider

### DIFF
--- a/changelog/unreleased/fix-approvider.md
+++ b/changelog/unreleased/fix-approvider.md
@@ -1,0 +1,5 @@
+Bugfix: approvider failed to create files
+
+In https://github.com/cs3org/reva/pull/4864, a new header was introduced for sending content lengths to the datagateway. This header was missing in the appprovider, causing it to fail when creating new files.
+
+https://github.com/cs3org/reva/pull/5236

--- a/internal/http/services/appprovider/appprovider.go
+++ b/internal/http/services/appprovider/appprovider.go
@@ -219,7 +219,7 @@ func (s *svc) handleNew(w http.ResponseWriter, r *http.Request) {
 		Ref: fileRef,
 		Opaque: &typespb.Opaque{
 			Map: map[string]*typespb.OpaqueEntry{
-				"Upload-Length": {
+				ocdav.HeaderUploadLength: {
 					Decoder: "plain",
 					Value:   []byte("0"),
 				},
@@ -254,6 +254,7 @@ func (s *svc) handleNew(w http.ResponseWriter, r *http.Request) {
 
 	httpReq.Header.Set(datagateway.TokenTransportHeader, token)
 	httpReq.Header.Set(ocdav.HeaderContentLength, strconv.Itoa(0))
+	httpReq.Header.Set(ocdav.HeaderUploadLength, strconv.Itoa(0))
 
 	tr := &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: s.conf.Insecure}}
 	httpRes, err := httpclient.New(httpclient.RoundTripper(tr)).Do(httpReq)

--- a/pkg/rhttp/datatx/manager/simple/simple.go
+++ b/pkg/rhttp/datatx/manager/simple/simple.go
@@ -93,6 +93,12 @@ func (m *manager) Handler(fs storage.FS) (http.Handler, error) {
 
 			if _, err := strconv.ParseInt(contentLength, 10, 64); err == nil {
 				metadata[ocdav.HeaderContentLength] = contentLength
+			} else {
+				contentLength := r.Header.Get(ocdav.HeaderContentLength)
+				if _, err := strconv.ParseInt(contentLength, 10, 64); err == nil {
+					metadata[ocdav.HeaderContentLength] = contentLength
+				}
+
 			}
 
 			err := fs.Upload(ctx, ref, r.Body, metadata)


### PR DESCRIPTION
In https://github.com/cs3org/reva/pull/4864, a new header was introduced for sending content lengths to the datagateway. This header was missing in the appprovider, causing it to fail when creating new files.