### PR TITLE
Use TLS by default on EOS gRPC connections

### DIFF
--- a/changelog/unreleased/eosgrpc-tls.md
+++ b/changelog/unreleased/eosgrpc-tls.md
@@ -1,0 +1,5 @@
+Enhancement: use TLS for EOS gRPC connections
+
+By default, we now use TLS for EOS gRPC connections. Falling back to non-TLS connections is only allowed when allow_insecure is set to true.
+
+https://github.com/cs3org/reva/pull/5253

--- a/pkg/storage/utils/eosfs/config.go
+++ b/pkg/storage/utils/eosfs/config.go
@@ -165,4 +165,8 @@ type Config struct {
 	// Maximum time span in days a ListRecycle call may return: if exceeded, ListRecycle
 	// will override the "to" date with "from" + this value
 	MaxDaysInRecycleList int `mapstructure:"max_days_in_recycle_list"`
+
+	// AllowInsecure determines whether EOS can fall back to no TLS
+	// Default is false
+	AllowInsecure bool `mapstructure:"allow_insecure"`
 }

--- a/pkg/storage/utils/eosfs/eosfs.go
+++ b/pkg/storage/utils/eosfs/eosfs.go
@@ -174,6 +174,7 @@ func NewEOSFS(ctx context.Context, c *Config) (storage.FS, error) {
 			ReadUsesLocalTemp:  c.ReadUsesLocalTemp,
 			WriteUsesLocalTemp: c.WriteUsesLocalTemp,
 			TokenExpiry:        c.TokenExpiry,
+			AllowInsecure:      c.AllowInsecure,
 		}
 		eosHTTPOpts := &eosgrpc.HTTPOptions{
 			BaseURL:             c.MasterURL,


### PR DESCRIPTION
By default, we now use TLS  for EOS gRPC connections. Falling back to non-TLS connections is only allowed when `allow_insecure` is set to `true`.