### PR TITLE
Allow from and to for trashbin listing to be set in headers

### DIFF
--- a/changelog/unreleased/trashbin-dateheaders.md
+++ b/changelog/unreleased/trashbin-dateheaders.md
@@ -1,0 +1,5 @@
+Enhancement: allow from and to for trashbin in headers
+
+Currently, from and to values for trashbin listing are passed as query parameters. With the new DAV library on the frontend, it is easier to send these as headers. Reva now accepts both, with query parameters having priority.
+
+https://github.com/cs3org/reva/pull/5254

--- a/internal/http/services/owncloud/ocdav/trashbin.go
+++ b/internal/http/services/owncloud/ocdav/trashbin.go
@@ -47,6 +47,11 @@ type TrashbinHandler struct {
 	gatewaySvc string
 }
 
+const (
+	DateFromHeader = "X-Trashbin-From"
+	DateToHeader   = "X-Trashbin-To"
+)
+
 func (h *TrashbinHandler) init(c *Config) error {
 	h.gatewaySvc = c.GatewaySvc
 	return nil
@@ -272,6 +277,14 @@ func (h *TrashbinHandler) listTrashbin(w http.ResponseWriter, r *http.Request, s
 	// resolve date boundaries, ignore if invalid/missing
 	fromTS, _ := conversions.ParseTimestamp(r.URL.Query().Get("from"))
 	toTS, _ := conversions.ParseTimestamp(r.URL.Query().Get("to"))
+
+	if fromTS == nil {
+		fromTS, _ = conversions.ParseTimestamp(r.Header.Get(DateFromHeader))
+	}
+
+	if toTS == nil {
+		toTS, _ = conversions.ParseTimestamp(r.Header.Get(DateToHeader))
+	}
 
 	// ask gateway for recycle items
 	getRecycleRes, err := gc.ListRecycle(ctx, &provider.ListRecycleRequest{


### PR DESCRIPTION
Currently, from and to values for trashbin listing are passed as query parameters. With the new DAV library on the frontend, it is easier to send these as headers. Reva now accepts both, with query parameters having priority.