### PR TITLE
Add support for updating readme, thumbnail in spaces

### DIFF
--- a/changelog/unreleased/spaces-readme.md
+++ b/changelog/unreleased/spaces-readme.md
@@ -1,0 +1,6 @@
+Enhancement: support for updating space
+
+This PR adds support for updating spaces to libregraph, specifically the description and thumbnail of a space.
+Additionally, the projects catalogue now directly implements the methods of the spaces registry.
+
+https://github.com/cs3org/reva/pull/5260

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/coreos/go-oidc/v3 v3.14.1
 	github.com/creasty/defaults v1.8.0
 	github.com/cs3org/cato v0.0.0-20200828125504-e418fc54dd5e
-	github.com/cs3org/go-cs3apis v0.0.0-20250626104136-a0b31b323c48
+	github.com/cs3org/go-cs3apis v0.0.0-20250811135935-5147e5c98678
 	github.com/dgraph-io/ristretto v0.2.0
 	github.com/dolthub/go-mysql-server v0.14.0
 	github.com/gdexlab/go-render v1.0.1

--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/nats-io/nats.go v1.43.0
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.38.0
-	github.com/owncloud/libre-graph-api-go v1.0.5-0.20240425090020-dba6d1507c38
+	github.com/owncloud/libre-graph-api-go v1.0.5-0.20250217093259-fa3804be6c27
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.22.0
 	github.com/rs/cors v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -895,8 +895,8 @@ github.com/creasty/defaults v1.8.0 h1:z27FJxCAa0JKt3utc0sCImAEb+spPucmKoOdLHvHYK
 github.com/creasty/defaults v1.8.0/go.mod h1:iGzKe6pbEHnpMPtfDXZEr0NVxWnPTjb1bbDy08fPzYM=
 github.com/cs3org/cato v0.0.0-20200828125504-e418fc54dd5e h1:tqSPWQeueWTKnJVMJffz4pz0o1WuQxJ28+5x5JgaHD8=
 github.com/cs3org/cato v0.0.0-20200828125504-e418fc54dd5e/go.mod h1:XJEZ3/EQuI3BXTp/6DUzFr850vlxq11I6satRtz0YQ4=
-github.com/cs3org/go-cs3apis v0.0.0-20250626104136-a0b31b323c48 h1:ia8WkfK+9quVDRZzEXmjV9vmdwVbVyX26uVTIJlJm0o=
-github.com/cs3org/go-cs3apis v0.0.0-20250626104136-a0b31b323c48/go.mod h1:DedpcqXl193qF/08Y04IO0PpxyyMu8+GrkD6kWK2MEQ=
+github.com/cs3org/go-cs3apis v0.0.0-20250811135935-5147e5c98678 h1:MVTpLBAmZMvDY+5TW1LYCSlitKikwX0/Sor8LSqeCJ4=
+github.com/cs3org/go-cs3apis v0.0.0-20250811135935-5147e5c98678/go.mod h1:DedpcqXl193qF/08Y04IO0PpxyyMu8+GrkD6kWK2MEQ=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/go.sum
+++ b/go.sum
@@ -1405,8 +1405,8 @@ github.com/openzipkin-contrib/zipkin-go-opentracing v0.4.5/go.mod h1:/wsWhb9smxS
 github.com/openzipkin/zipkin-go v0.1.6/go.mod h1:QgAqvLzwWbR/WpD4A3cGpPtJrZXNIiJc5AZX7/PBEpw=
 github.com/openzipkin/zipkin-go v0.2.1/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
 github.com/openzipkin/zipkin-go v0.2.2/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
-github.com/owncloud/libre-graph-api-go v1.0.5-0.20240425090020-dba6d1507c38 h1:Ld9bPh0c4y1H22mhiWZBw4AoupWjg8L0WLKX0hfbJho=
-github.com/owncloud/libre-graph-api-go v1.0.5-0.20240425090020-dba6d1507c38/go.mod h1:yXI+rmE8yYx+ZsGVrnCpprw/gZMcxjwntnX2y2+VKxY=
+github.com/owncloud/libre-graph-api-go v1.0.5-0.20250217093259-fa3804be6c27 h1:ID8s5lGBntmrlI6TbDAjTzRyHucn3bVM2wlW+HBplv4=
+github.com/owncloud/libre-graph-api-go v1.0.5-0.20250217093259-fa3804be6c27/go.mod h1:+gT+x62AS9u2Farh9wE2uYmgdvTg0MQgsSI62D+xoRg=
 github.com/pact-foundation/pact-go v1.0.4/go.mod h1:uExwJY4kCzNPcHRj+hCR/HBbOOIwwtUjcrb0b5/5kLM=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=

--- a/internal/grpc/services/spacesregistry/spacesregistry.go
+++ b/internal/grpc/services/spacesregistry/spacesregistry.go
@@ -181,10 +181,15 @@ func (s *service) listSpacesByType(ctx context.Context, user *userpb.User, space
 			sp = append(sp, space)
 		}
 	} else if spaceType == spaces.SpaceTypeProject {
-		projects, err := s.projects.ListProjects(ctx, user)
+		resp, err := s.projects.ListStorageSpaces(ctx, &provider.ListStorageSpacesRequest{})
 		if err != nil {
 			return nil, err
 		}
+		if resp.Status.Code != rpcv1beta1.Code_CODE_OK {
+			return nil, fmt.Errorf("%s: %s", resp.Status.Code.String(), resp.Status.Message)
+		}
+
+		projects := resp.StorageSpaces
 		if err := s.decorateProjects(ctx, projects); err != nil {
 			return nil, err
 		}
@@ -305,7 +310,7 @@ func (s *service) userSpace(ctx context.Context, user *userpb.User) (*provider.S
 }
 
 func (s *service) UpdateStorageSpace(ctx context.Context, req *provider.UpdateStorageSpaceRequest) (*provider.UpdateStorageSpaceResponse, error) {
-	return nil, errors.New("not yet implemented")
+	return s.projects.UpdateStorageSpace(ctx, req)
 }
 
 func (s *service) DeleteStorageSpace(ctx context.Context, req *provider.DeleteStorageSpaceRequest) (*provider.DeleteStorageSpaceResponse, error) {

--- a/internal/http/services/owncloud/ocdav/dav.go
+++ b/internal/http/services/owncloud/ocdav/dav.go
@@ -194,21 +194,27 @@ func (h *DavHandler) Handler(s *svc) http.Handler {
 				r = r.WithContext(ctx)
 				h.TrashbinHandler.Handler(s).ServeHTTP(w, r)
 			default:
-				// path is of type: space_id/relative/path/from/space
-				// the space_id is the base64 encode of the path where
-				// the space is located
+				// there are two possible types of path
+				// 1) path is of type: space_id/relative/path/from/space
+				//    the space_id is the base64 encode of the path where
+				//    the space is located
+				// 2) path is of type: resource_id/relative/path
+				//    here, resource_id is the encoded resource id of a folder
+				//    i.e. in the form of storage$space_id!inode
+				//    and the relative path is relative to this folder
 
 				_, base, ok := spaces.DecodeStorageSpaceID(head)
 				if ok {
-					fullPath := filepath.Join(base, r.URL.Path)
-					r.URL.Path = fullPath
-					ctx = context.WithValue(ctx, ctxSpaceFullPath, fullPath)
-					ctx = context.WithValue(ctx, ctxSpaceRelativePath, r.URL.Path)
+					// this is case (1)
 					ctx = context.WithValue(ctx, ctxSpaceID, head)
+					fullPath := filepath.Join(base, r.URL.Path)
+					// like this, we can use the existing DAV handler
+					// we replace the space id with it's actual path in the URL
+					r.URL.Path = fullPath
 
 					// We support doing a PUT and a PROPFIND on a resource ID (eg eos$space!inode/file.txt)
 				} else if r.Method == http.MethodPut || r.Method == MethodPropfind {
-					// If it's not a space ID, we try to parse it as a resource ID
+					// If it's not a space ID, we try to parse it as a resource ID, i.e. case (2)
 					var storageId, itemId string
 					storageId, base, itemId, ok = spaces.DecodeResourceID(head)
 					if !ok {

--- a/internal/http/services/owncloud/ocdav/ocdav.go
+++ b/internal/http/services/owncloud/ocdav/ocdav.go
@@ -57,6 +57,8 @@ const (
 	ctxSpaceRelativePath
 	ctxOCM
 	ctxPublicLink
+	ctxStorageId
+	ctxResourceOpaqueId
 )
 
 var (

--- a/internal/http/services/owncloud/ocdav/ocdav.go
+++ b/internal/http/services/owncloud/ocdav/ocdav.go
@@ -53,8 +53,6 @@ const (
 	ctxKeyBaseURI ctxKey = iota
 	ctxSpaceID
 	ctxSpacePath
-	ctxSpaceFullPath
-	ctxSpaceRelativePath
 	ctxOCM
 	ctxPublicLink
 	ctxStorageId

--- a/internal/http/services/owncloud/ocdav/put.go
+++ b/internal/http/services/owncloud/ocdav/put.go
@@ -122,7 +122,6 @@ func (s *svc) handlePathPut(w http.ResponseWriter, r *http.Request, ns string) {
 
 func (s *svc) handlePut(ctx context.Context, w http.ResponseWriter, r *http.Request, ref *provider.Reference, log zerolog.Logger) {
 	spacesEnabled := s.c.SpacesEnabled
-
 	if !checkPreconditions(w, r, log) {
 		// checkPreconditions handles error returns
 		return

--- a/internal/http/services/owncloud/ocdav/put.go
+++ b/internal/http/services/owncloud/ocdav/put.go
@@ -115,6 +115,8 @@ func (s *svc) handlePathPut(w http.ResponseWriter, r *http.Request, ns string) {
 
 	sublog := appctx.GetLogger(ctx).With().Str("path", fn).Logger()
 
+	sublog.Error().Msg("FindMe")
+
 	ref := &provider.Reference{Path: fn}
 
 	s.handlePut(ctx, w, r, ref, sublog)
@@ -122,6 +124,7 @@ func (s *svc) handlePathPut(w http.ResponseWriter, r *http.Request, ns string) {
 
 func (s *svc) handlePut(ctx context.Context, w http.ResponseWriter, r *http.Request, ref *provider.Reference, log zerolog.Logger) {
 	spacesEnabled := s.c.SpacesEnabled
+
 	if !checkPreconditions(w, r, log) {
 		// checkPreconditions handles error returns
 		return

--- a/internal/http/services/owncloud/ocdav/put.go
+++ b/internal/http/services/owncloud/ocdav/put.go
@@ -111,29 +111,20 @@ func isContentRange(r *http.Request) bool {
 
 func (s *svc) handlePathPut(w http.ResponseWriter, r *http.Request, ns string) {
 	ctx := r.Context()
-	ref := &provider.Reference{}
-	sublog := appctx.GetLogger(ctx).With().Any("ref", ref).Logger()
 
 	fn := path.Join(ns, r.URL.Path)
-	ref.Path = fn
+	ref := &provider.Reference{}
 
-	// First, we check if the PUT was made to a resource ID instead of a path
-	if opaqueId := ctx.Value(ctxResourceOpaqueId); opaqueId != nil {
-		storageId := ctx.Value(ctxStorageId)
-		if storageId != nil {
-			// We make the path relative
-			ref.Path = path.Join(".", fn)
-			ref.ResourceId = &provider.ResourceId{
-				StorageId: storageId.(string),
-				OpaqueId:  opaqueId.(string),
-			}
-			s.handlePut(ctx, w, r, ref, sublog)
-			return
-		}
+	// We check if the PUT was made to a resource ID instead of a path
+	if r, ok := requestWasMadeToResourceId(ctx, fn); ok {
+		ref = r
+	} else {
+		ref.Path = fn
 	}
 
-	s.handlePut(ctx, w, r, ref, sublog)
+	sublog := appctx.GetLogger(ctx).With().Any("ref", ref).Logger()
 
+	s.handlePut(ctx, w, r, ref, sublog)
 }
 
 func (s *svc) handlePut(ctx context.Context, w http.ResponseWriter, r *http.Request, ref *provider.Reference, log zerolog.Logger) {

--- a/internal/http/services/owncloud/ocdav/spaces.go
+++ b/internal/http/services/owncloud/ocdav/spaces.go
@@ -22,8 +22,10 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"path"
 
 	rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
+	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	storageProvider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	"github.com/cs3org/reva/v3/pkg/rhttp/router"
 	"github.com/cs3org/reva/v3/pkg/utils"
@@ -129,4 +131,22 @@ func (s *svc) lookUpStorageSpaceReference(ctx context.Context, spaceID string, r
 		ResourceId: space.Root,
 		Path:       utils.MakeRelativePath(relativePath),
 	}, lSSRes.Status, nil
+}
+
+func requestWasMadeToResourceId(ctx context.Context, fn string) (ref *provider.Reference, ok bool) {
+	if opaqueId := ctx.Value(ctxResourceOpaqueId); opaqueId != nil {
+		storageId := ctx.Value(ctxStorageId)
+		if storageId != nil {
+			ref := &provider.Reference{
+				// We make the path relative
+				Path: path.Join(".", fn),
+				ResourceId: &provider.ResourceId{
+					StorageId: storageId.(string),
+					OpaqueId:  opaqueId.(string),
+				},
+			}
+			return ref, true
+		}
+	}
+	return nil, false
 }

--- a/internal/http/services/owncloud/ocgraph/drives.go
+++ b/internal/http/services/owncloud/ocgraph/drives.go
@@ -380,8 +380,6 @@ func (s *svc) patchSpace(w http.ResponseWriter, r *http.Request) {
 	user := appctx.ContextMustGetUser(ctx)
 	space := s.cs3StorageSpaceToDrive(user, res.StorageSpace)
 	_ = json.NewEncoder(w).Encode(space)
-	return
-
 }
 
 func isShareJail(spaceID string) bool {

--- a/internal/http/services/owncloud/ocgraph/ocgraph.go
+++ b/internal/http/services/owncloud/ocgraph/ocgraph.go
@@ -103,6 +103,7 @@ func (s *svc) initRouter() {
 		})
 		r.Route("/drives", func(r chi.Router) {
 			r.Get("/{space-id}", s.getSpace)
+			r.Patch("/{space-id}", s.patchSpace)
 		})
 		r.Route("/users", func(r chi.Router) {
 			r.Get("/", s.listUsers)
@@ -111,6 +112,7 @@ func (s *svc) initRouter() {
 			r.Get("/", s.listGroups)
 		})
 	})
+
 	s.router.Route("/v1beta1", func(r chi.Router) {
 		r.Route("/me", func(r chi.Router) {
 			r.Route("/drives", func(r chi.Router) {

--- a/internal/http/services/owncloud/ocgraph/users.go
+++ b/internal/http/services/owncloud/ocgraph/users.go
@@ -64,9 +64,9 @@ func (s UserSelectableProperty) Valid() bool {
 func (s *svc) getMe(w http.ResponseWriter, r *http.Request) {
 	user := appctx.ContextMustGetUser(r.Context())
 	me := &libregraph.User{
-		DisplayName:              &user.DisplayName,
+		DisplayName:              user.DisplayName,
 		Mail:                     &user.Mail,
-		OnPremisesSamAccountName: &user.Username,
+		OnPremisesSamAccountName: user.Username,
 		Id:                       &user.Id.OpaqueId,
 	}
 	_ = json.NewEncoder(w).Encode(me)
@@ -174,8 +174,8 @@ func mapToLibregraphUsers(users []*userpb.User, selection []UserSelectableProper
 			lgUser = libregraph.User{
 				Id:                       &u.Id.OpaqueId,
 				Mail:                     &u.Mail,
-				OnPremisesSamAccountName: &u.Username,
-				DisplayName:              &u.DisplayName,
+				OnPremisesSamAccountName: u.Username,
+				DisplayName:              u.DisplayName,
 			}
 		} else {
 			for _, prop := range selection {
@@ -197,11 +197,11 @@ func appendPropToLgUser(u *userpb.User, lgUser libregraph.User, prop UserSelecta
 	case propUserId:
 		lgUser.Id = &u.Id.OpaqueId
 	case propUserDisplayName:
-		lgUser.DisplayName = &u.DisplayName
+		lgUser.DisplayName = u.DisplayName
 	case propUserMail:
 		lgUser.Mail = &u.Mail
 	case propUserOnPremisesSamAccountName:
-		lgUser.OnPremisesSamAccountName = &u.Username
+		lgUser.OnPremisesSamAccountName = u.Username
 	}
 	return lgUser
 }
@@ -217,7 +217,7 @@ func sortUsers(ctx context.Context, users []libregraph.User, sortKey string) ([]
 	switch UserSelectableProperty(sortKey) {
 	case propUserDisplayName:
 		slices.SortFunc(users, func(a, b libregraph.User) int {
-			return cmp.Compare(*a.DisplayName, *b.DisplayName)
+			return cmp.Compare(a.DisplayName, b.DisplayName)
 		})
 	case propUserId:
 		slices.SortFunc(users, func(a, b libregraph.User) int {
@@ -229,7 +229,7 @@ func sortUsers(ctx context.Context, users []libregraph.User, sortKey string) ([]
 		})
 	case propUserOnPremisesSamAccountName:
 		slices.SortFunc(users, func(a, b libregraph.User) int {
-			return cmp.Compare(*a.OnPremisesSamAccountName, *b.OnPremisesSamAccountName)
+			return cmp.Compare(a.OnPremisesSamAccountName, b.OnPremisesSamAccountName)
 		})
 	}
 	return users, nil

--- a/pkg/projects/manager/memory/memory.go
+++ b/pkg/projects/manager/memory/memory.go
@@ -108,7 +108,6 @@ func (s *service) ListStorageSpaces(ctx context.Context, req *provider.ListStora
 	}, nil
 }
 
-// TODO: at least this should be implemented
 func (s *service) UpdateStorageSpace(ctx context.Context, req *provider.UpdateStorageSpaceRequest) (*provider.UpdateStorageSpaceResponse, error) {
 	return nil, errors.New("Unsupported")
 }

--- a/pkg/projects/manager/sql/sql.go
+++ b/pkg/projects/manager/sql/sql.go
@@ -206,14 +206,15 @@ func (m *mgr) GetStorageSpaces(ctx context.Context, name string) (*provider.Stor
 
 func (m *mgr) UpdateStorageSpace(ctx context.Context, req *provider.UpdateStorageSpaceRequest) (*provider.UpdateStorageSpaceResponse, error) {
 	log := appctx.GetLogger(ctx)
-	log.Debug().Any("space", req.StorageSpace).Any("update", req.Field).Any("type", req.Field.GetMetadata().Type).Msg("Updating storage space")
-	if req.StorageSpace == nil || req.StorageSpace.Id == nil {
+	if req == nil || req.StorageSpace == nil || req.StorageSpace.Id == nil {
+		log.Error().Msg("UpdateStorageSpace called without valid request")
 		return &provider.UpdateStorageSpaceResponse{
 			Status: &rpcv1beta1.Status{
 				Code: rpcv1beta1.Code_CODE_INVALID,
 			},
 		}, errors.New("Must provide an ID when updating a storage space")
 	}
+	log.Debug().Any("space", req.StorageSpace).Any("update", req.Field).Msg("Updating storage space")
 
 	if req.Field == nil {
 		return &provider.UpdateStorageSpaceResponse{

--- a/pkg/projects/manager/sql/sql_test.go
+++ b/pkg/projects/manager/sql/sql_test.go
@@ -28,6 +28,7 @@ import (
 	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	"github.com/cs3org/reva/v3/internal/http/services/owncloud/ocs/conversions"
+	"github.com/cs3org/reva/v3/pkg/appctx"
 	projects_catalogue "github.com/cs3org/reva/v3/pkg/projects"
 	"github.com/cs3org/reva/v3/pkg/spaces"
 )
@@ -267,13 +268,14 @@ func TestListProjects(t *testing.T) {
 				catmgr.db.Create(&proj)
 			}
 
-			got, err := catalogue.ListProjects(ctx, tt.user)
+			ctx = appctx.ContextSetUser(ctx, tt.user)
+			got, err := catalogue.ListStorageSpaces(ctx, &provider.ListStorageSpacesRequest{})
 			if err != nil {
 				t.Fatalf("not expected error while listing projects: %+v", err)
 			}
 
-			if !reflect.DeepEqual(got, tt.expected) {
-				t.Fatalf("projects' list do not match. got=%#v expected=%#v", got, tt.expected)
+			if !reflect.DeepEqual(got.StorageSpaces, tt.expected) {
+				t.Fatalf("projects' list do not match. got=%#v expected=%#v", got.StorageSpaces, tt.expected)
 			}
 
 			err = teardown(t)

--- a/pkg/projects/projects.go
+++ b/pkg/projects/projects.go
@@ -21,11 +21,13 @@ package projects
 import (
 	"context"
 
-	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 )
 
 // Catalogue is the interface that stores the project spaces.
 type Catalogue interface {
-	ListProjects(ctx context.Context, user *userpb.User) ([]*provider.StorageSpace, error)
+	CreateStorageSpace(ctx context.Context, req *provider.CreateStorageSpaceRequest) (*provider.CreateStorageSpaceResponse, error)
+	ListStorageSpaces(ctx context.Context, req *provider.ListStorageSpacesRequest) (*provider.ListStorageSpacesResponse, error)
+	UpdateStorageSpace(ctx context.Context, req *provider.UpdateStorageSpaceRequest) (*provider.UpdateStorageSpaceResponse, error)
+	DeleteStorageSpace(ctx context.Context, req *provider.DeleteStorageSpaceRequest) (*provider.DeleteStorageSpaceResponse, error)
 }

--- a/pkg/spaces/utils.go
+++ b/pkg/spaces/utils.go
@@ -90,15 +90,15 @@ func EncodeResourceID(r *provider.ResourceId) string {
 
 // Decode resourceID returns the components of the space ID.
 // The resource ID is expected to be in the form of <storage_id>$base32(<path>)!<item_id>.
-func DecodeResourceID(raw string) (storageID, path, itemID string, ok bool) {
+func DecodeResourceID(raw string) (storageID, spacePath, itemID string, ok bool) {
 	// The input is expected to be in the form of <storage_id>$base32(<path>)!<item_id>
 	s := strings.SplitN(raw, "!", 2)
 	if len(s) != 2 {
 		return "", "", "", false
 	}
 	itemID = s[1]
-	storageID, path, ok = DecodeStorageSpaceID(s[0])
-	return storageID, path, itemID, ok
+	storageID, spacePath, ok = DecodeStorageSpaceID(s[0])
+	return storageID, spacePath, itemID, ok
 }
 
 // ParseResourceID converts the encoded resource id in a CS3API ResourceId.


### PR DESCRIPTION
This PR adds support for:
* displaying description (called readme in the backend), subtitle (called description in the backend) and thumbnail of a space.
*  updating the thumbnail and readme (support for the description has also been added to the CS3API, but not used at the moment as we don't support users updating it)

This required:
* An update of the libregraph API
* An update of the CS3APIs (https://github.com/cs3org/cs3apis/pull/245, https://github.com/cs3org/cs3apis/pull/246)
* Hooking up the project catalogue to the spaces registry

Additionally, the projects catalogue now directly implements the methods of the spaces registry.