### PR TITLE
Fix COPY requests

### DIFF
--- a/changelog/unreleased/fix-copy.md
+++ b/changelog/unreleased/fix-copy.md
@@ -1,0 +1,5 @@
+Bugfix: make COPY requests work again
+
+COPY requests were broken, because during the upload-part of the copy, no Content-Length header was set.
+
+https://github.com/cs3org/reva/pull/5264

--- a/pkg/rhttp/datatx/manager/simple/simple.go
+++ b/pkg/rhttp/datatx/manager/simple/simple.go
@@ -89,16 +89,16 @@ func (m *manager) Handler(fs storage.FS) (http.Handler, error) {
 				metadata["disableVersioning"] = disableVersioning
 			}
 
+			// Check that Content-Length or Upload-Length is set
 			contentLength := r.Header.Get(ocdav.HeaderUploadLength)
+			if contentLength == "" {
+				contentLength = r.Header.Get(ocdav.HeaderContentLength)
+			}
 
 			if _, err := strconv.ParseInt(contentLength, 10, 64); err == nil {
 				metadata[ocdav.HeaderContentLength] = contentLength
 			} else {
-				contentLength := r.Header.Get(ocdav.HeaderContentLength)
-				if _, err := strconv.ParseInt(contentLength, 10, 64); err == nil {
-					metadata[ocdav.HeaderContentLength] = contentLength
-				}
-
+				sublog.Warn().Msg("Internal data server got PUT request without valid Content-Length or Upload-Length header")
 			}
 
 			err := fs.Upload(ctx, ref, r.Body, metadata)

--- a/pkg/storage/utils/eosfs/upload.go
+++ b/pkg/storage/utils/eosfs/upload.go
@@ -92,9 +92,12 @@ func (fs *Eosfs) Upload(ctx context.Context, ref *provider.Reference, r io.ReadC
 	}
 
 	contentLength := metadata[ocdav.HeaderContentLength]
+	if contentLength == "" {
+		contentLength = metadata[ocdav.HeaderUploadLength]
+	}
 	len, err := strconv.ParseInt(contentLength, 10, 64)
 	if err != nil {
-		return errors.New("No content length specified in EOS upload, got: " + contentLength)
+		return errtypes.BadRequest("no content length specified in EOS upload")
 	}
 
 	return fs.c.Write(ctx, auth, fn, r, len, app, disableVersioning)

--- a/tests/helpers/helpers.go
+++ b/tests/helpers/helpers.go
@@ -137,6 +137,7 @@ func UploadGateway(ctx context.Context, gw gatewayv1beta1.GatewayAPIClient, ref 
 	}
 
 	httpReq.Header.Set(datagateway.TokenTransportHeader, token)
+	httpReq.Header.Set(ocdav.HeaderUploadLength, strconv.Itoa(len(content)))
 
 	httpRes, err := httpclient.New().Do(httpReq)
 	if err != nil {
@@ -246,6 +247,7 @@ func CreateFile(ctx context.Context, gw gatewayv1beta1.GatewayAPIClient, path st
 	}
 
 	httpReq.Header.Set(datagateway.TokenTransportHeader, token)
+	httpReq.Header.Set(ocdav.HeaderUploadLength, strconv.Itoa(len(content)))
 
 	httpRes, err := httpclient.New().Do(httpReq)
 	if err != nil {


### PR DESCRIPTION
COPY requests were broken, because during the upload-part of the copy, no Content-Length header was set.