### PR TITLE
add version dir root to propfind response of /v

### DIFF
--- a/changelog/unreleased/fix-show-version.md
+++ b/changelog/unreleased/fix-show-version.md
@@ -1,0 +1,6 @@
+Bugfix: add version directory to propfind response
+
+PROPFINDs to <resource>/v return a list of all versions of a resource. This list should start with a reference to the version directory itself,
+which in turn is filtered out by the front-end. This entry was missing after a refactor of the versions to make them spaces-compatible. This change now fixes this.
+
+https://github.com/cs3org/reva/pull/5265

--- a/internal/http/services/owncloud/ocdav/versions.go
+++ b/internal/http/services/owncloud/ocdav/versions.go
@@ -161,7 +161,9 @@ func (h *VersionsHandler) doListVersions(w http.ResponseWriter, r *http.Request,
 
 	versions := lvRes.GetVersions()
 	infos := make([]*provider.ResourceInfo, 0, len(versions)+1)
+
 	// add version dir . entry, derived from file info
+	infos = append(infos, info)
 
 	var spacePath string
 	var ok bool


### PR DESCRIPTION
`PROPFIND`s to `<resource>/v` return a list of all versions of a resource. This list should start with a reference to the version directory itself, which in turn is filtered out by the front-end. This entry was missing after a refactor of the versions to make them spaces-compatible. This PR now fixes this.