### PR TITLE
Add support for new EOS Project Quota Nodes

### DIFF
--- a/changelog/unreleased/new-quota-nodes.md
+++ b/changelog/unreleased/new-quota-nodes.md
@@ -1,0 +1,11 @@
+Enhancement: add support for new EOS project quota nodes
+
+For EOS projects, quota nodes used to be set under the service
+account of the project on the path /eos/project
+
+This has been changed to using GID=99 and having the path of the
+project be the quota node
+
+This change introduces support for the new system
+
+https://github.com/cs3org/reva/pull/5278

--- a/pkg/eosclient/eosbinary/eosbinary.go
+++ b/pkg/eosclient/eosbinary/eosbinary.go
@@ -635,8 +635,15 @@ func deserializeAttribute(attrStr string) (*eosclient.Attribute, error) {
 }
 
 // GetQuota gets the quota of a user on the quota node defined by path.
-func (c *Client) GetQuota(ctx context.Context, username string, rootAuth eosclient.Authorization, path string) (*eosclient.QuotaInfo, error) {
-	args := []string{"quota", "ls", "-u", username, "-m"}
+func (c *Client) GetQuota(ctx context.Context, user eosclient.Authorization, rootAuth eosclient.Authorization, path string) (*eosclient.QuotaInfo, error) {
+	var args []string
+	// NewStyle project quota
+	if user.Role.GID == "99" {
+		args = []string{"quota", "ls", "-g", "99", "-p", path}
+	} else {
+		// Old style quota
+		args = []string{"quota", "ls", "-u", user.Role.UID, "-m"}
+	}
 	stdout, _, err := c.executeEOS(ctx, args, rootAuth)
 	if err != nil {
 		return nil, err

--- a/pkg/eosclient/eosclient.go
+++ b/pkg/eosclient/eosclient.go
@@ -41,7 +41,7 @@ type EOSClient interface {
 	UnsetAttr(ctx context.Context, auth Authorization, attr *Attribute, recursive bool, path, app string) error
 	GetAttr(ctx context.Context, auth Authorization, key, path string) (*Attribute, error)
 	GetAttrs(ctx context.Context, auth Authorization, path string) ([]*Attribute, error)
-	GetQuota(ctx context.Context, username string, rootAuth Authorization, path string) (*QuotaInfo, error)
+	GetQuota(ctx context.Context, user Authorization, rootAuth Authorization, path string) (*QuotaInfo, error)
 	SetQuota(ctx context.Context, rooAuth Authorization, info *SetQuotaInfo) error
 	Touch(ctx context.Context, auth Authorization, path string) error
 	Chown(ctx context.Context, auth, chownauth Authorization, path string) error

--- a/pkg/storage/utils/eosfs/eosfs.go
+++ b/pkg/storage/utils/eosfs/eosfs.go
@@ -1274,14 +1274,17 @@ func (fs *Eosfs) GetQuota(ctx context.Context, ref *provider.Reference) (totalby
 		return 0, 0, errors.Wrap(err, "eosfs: no user in ctx")
 	}
 	// lightweight accounts don't have quota nodes, so we're passing an empty string as path
-	auth, err := fs.getUserAuth(ctx, u, "")
+	userAuth, err := fs.getUserAuth(ctx, u, "")
 	if err != nil {
 		return 0, 0, err
 	}
-
 	cboxAuth := utils.GetEmptyAuth()
 
-	qi, err := fs.c.GetQuota(ctx, auth.Role.UID, cboxAuth, fs.conf.QuotaNode)
+	if ref.Path != fs.conf.QuotaNode && ref.Path != "" {
+		ref.Path = fs.wrap(ctx, ref.Path)
+	}
+
+	qi, err := fs.c.GetQuota(ctx, userAuth, cboxAuth, ref.Path)
 	if err != nil {
 		err := errors.Wrap(err, "eosfs: error getting quota")
 		return 0, 0, err


### PR DESCRIPTION
For EOS projects, quota nodes used to be set under the service account of the project on the path /eos/project. This has been changed to using GID=99 and having the path of the project be the quota node. This change introduces support for the new system, while still being compatible with the old system.