### PR TITLE
No home creation for machine auth

### DIFF
--- a/changelog/unreleased/fix-machine-nohome.md
+++ b/changelog/unreleased/fix-machine-nohome.md
@@ -1,0 +1,5 @@
+Bugfix: No home creation for machine auth
+
+When you sign in with auth type `machine`, no home should be created for the user
+
+https://github.com/cs3org/reva/pull/5288

--- a/internal/grpc/services/gateway/authprovider.go
+++ b/internal/grpc/services/gateway/authprovider.go
@@ -152,7 +152,8 @@ func (s *svc) Authenticate(ctx context.Context, req *gateway.AuthenticateRequest
 	ctx = metadata.AppendToOutgoingContext(ctx, appctx.TokenHeader, token) // TODO(jfd): hardcoded metadata key. use  PerRPCCredentials?
 
 	// create home directory
-	if _, err = s.createHomeCache.Get(res.User.Id.OpaqueId); err != nil {
+	// This is not necessary when you sign in with the 'machine' type
+	if _, err = s.createHomeCache.Get(res.User.Id.OpaqueId); req.Type != "machine" && err != nil {
 		statRes, err := s.Stat(ctx, &storageprovider.StatRequest{
 			Ref: &storageprovider.Reference{
 				Path: s.getHome(ctx),


### PR DESCRIPTION
When you sign in with auth type `machine`, no home should be created for the user