### PR TITLE
Remove codacy coverage check

### DIFF
--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -21,10 +21,3 @@ jobs:
         run: make test-go
         env:
           COVER_PROFILE: ${{ github.event_name == 'push' && 'coverage.out' || '' }}
-      - name: Run codacy-coverage-reporter
-        uses: codacy/codacy-coverage-reporter-action@v1
-        if: github.event_name == 'push'
-        with:
-          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
-          coverage-reports: coverage.out
-          force-coverage-parser: go


### PR DESCRIPTION
Following @labkode 's removal of the codacy app, we also remove the coverage check from the test pipeline