### PR TITLE
dynamic router: do not fail if a mount configuration is missing

### DIFF
--- a/changelog/unreleased/fix-missing-routes-registry.md
+++ b/changelog/unreleased/fix-missing-routes-registry.md
@@ -3,3 +3,4 @@ Bugfix: skip missing routes in dynamic router
 Skip missing routes from logic.
 
 https://github.com/cs3org/reva/pull/5314
+https://github.com/cs3org/reva/pull/5318

--- a/pkg/storage/registry/dynamic/dynamic.go
+++ b/pkg/storage/registry/dynamic/dynamic.go
@@ -217,13 +217,10 @@ func (d *dynamic) FindProviders(ctx context.Context, ref *provider.Reference) ([
 				Address:      address,
 			})
 		} else {
-			err := errtypes.InternalError("storage provider address not configured for mountID " + p.ProviderId)
-			l.Error().Err(err).Send()
-			return nil, err
+			l.Error().Str("mount", p.ProviderId).Msg("Storage provider address not configured for mount, skipping")
 		}
 	}
 
-	l.Debug().Msgf("resolved storage providers %+v", providers)
-
+	l.Debug().Msgf("resolved storage providers %+v for the given ref", providers)
 	return providers, nil
 }


### PR DESCRIPTION
Continuation of #5314