### PR TITLE
Config cleanup: add database config to sharedconf

### DIFF
--- a/changelog/unreleased/db-sharedconf.md
+++ b/changelog/unreleased/db-sharedconf.md
@@ -1,0 +1,5 @@
+Enhancement: add database config to sharedconf
+
+Add database configuration to `sharedconf`, so that it doesn't have to be repeated for every driver
+
+https://github.com/cs3org/reva/pull/5323

--- a/cmd/revad/pkg/config/config.go
+++ b/cmd/revad/pkg/config/config.go
@@ -56,6 +56,16 @@ type Shared struct {
 	DataGateway           string   `default:"http://0.0.0.0:19001/datagateway" key:"datagateway"                        mapstructure:"datagateway"`
 	SkipUserGroupsInToken bool     `key:"skip_user_groups_in_token"            mapstructure:"skip_user_groups_in_token"`
 	BlockedUsers          []string `default:"[]"                               key:"blocked_users"                      mapstructure:"blocked_users"`
+	Database
+}
+
+type Database struct {
+	Engine     string `mapstructure:"engine"` // mysql | sqlite
+	DBUsername string `mapstructure:"db_username"`
+	DBPassword string `mapstructure:"db_password"`
+	DBHost     string `mapstructure:"db_host"`
+	DBPort     int    `mapstructure:"db_port"`
+	DBName     string `mapstructure:"db_name"`
 }
 
 // Core holds the core configuration.

--- a/cmd/revad/pkg/config/config_test.go
+++ b/cmd/revad/pkg/config/config_test.go
@@ -490,6 +490,14 @@ func TestDump(t *testing.T) {
 			"datagateway":               "",
 			"skip_user_groups_in_token": false,
 			"blocked_users":             []any{},
+			"Database": map[string]any{
+				"DBHost":     "",
+				"DBName":     "",
+				"DBPassword": "",
+				"DBPort":     0,
+				"DBUsername": "",
+				"Engine":     "",
+			},
 		},
 		"log": map[string]any{
 			"output": "/var/log/revad/revad-gateway.log",

--- a/pkg/notification/manager/sql/sql.go
+++ b/pkg/notification/manager/sql/sql.go
@@ -23,8 +23,10 @@ import (
 	"database/sql"
 	"fmt"
 
+	"github.com/cs3org/reva/v3/cmd/revad/pkg/config"
 	"github.com/cs3org/reva/v3/pkg/notification"
 	"github.com/cs3org/reva/v3/pkg/notification/manager/registry"
+	"github.com/cs3org/reva/v3/pkg/sharedconf"
 	"github.com/cs3org/reva/v3/pkg/utils/cfg"
 )
 
@@ -32,12 +34,12 @@ func init() {
 	registry.Register("sql", NewMysql)
 }
 
-type config struct {
-	DBUsername string `mapstructure:"db_username"`
-	DBPassword string `mapstructure:"db_password"`
-	DBHost     string `mapstructure:"db_host"`
-	DBPort     int    `mapstructure:"db_port"`
-	DBName     string `mapstructure:"db_name"`
+type Config struct {
+	config.Database `mapstructure:",squash"`
+}
+
+func (c *Config) ApplyDefaults() {
+	c.Database = sharedconf.GetDBInfo(c.Database)
 }
 
 type mgr struct {
@@ -47,10 +49,11 @@ type mgr struct {
 
 // NewMysql returns an instance of the sql notifications manager.
 func NewMysql(ctx context.Context, m map[string]interface{}) (notification.Manager, error) {
-	var c config
+	var c Config
 	if err := cfg.Decode(m, &c); err != nil {
 		return nil, err
 	}
+	c.ApplyDefaults()
 
 	db, err := sql.Open("mysql", fmt.Sprintf("%s:%s@tcp(%s:%d)/%s", c.DBUsername, c.DBPassword, c.DBHost, c.DBPort, c.DBName))
 	if err != nil {

--- a/pkg/projects/manager/sql/sql_test.go
+++ b/pkg/projects/manager/sql/sql_test.go
@@ -37,7 +37,7 @@ import (
 func setupSuite(tb testing.TB) (projects_catalogue.Catalogue, error, func(tb testing.TB) error) {
 	ctx := context.Background()
 	dbName := "test_db.sqlite"
-	cfg := map[string]interface{}{
+	cfg := map[string]any{
 		"engine":  "sqlite",
 		"db_name": dbName,
 	}

--- a/pkg/share/manager/sql/ocm_shares.go
+++ b/pkg/share/manager/sql/ocm_shares.go
@@ -44,14 +44,14 @@ import (
 )
 
 type mgr struct {
-	c  *config
+	c  *Config
 	db *gorm.DB
 }
 
 func NewOCMShareManager(ctx context.Context, m map[string]interface{}) (share.Repository, error) {
 	log := appctx.GetLogger(ctx)
 	log.Debug().Interface("config", m).Msg("creating OCM share manager")
-	var c config
+	var c Config
 	if err := cfg.Decode(m, &c); err != nil {
 		return nil, err
 	}

--- a/pkg/share/manager/sql/public_link.go
+++ b/pkg/share/manager/sql/public_link.go
@@ -45,7 +45,7 @@ import (
 )
 
 type PublicShareMgr struct {
-	c  *config
+	c  *Config
 	db *gorm.DB
 }
 
@@ -54,11 +54,12 @@ type ExpiryRange struct {
 	To   time.Time
 }
 
-func NewPublicShareManager(ctx context.Context, m map[string]interface{}) (publicshare.Manager, error) {
-	var c config
+func NewPublicShareManager(ctx context.Context, m map[string]any) (publicshare.Manager, error) {
+	var c Config
 	if err := cfg.Decode(m, &c); err != nil {
 		return nil, err
 	}
+	c.ApplyDefaults()
 
 	db, err := getDb(c)
 	if err != nil {

--- a/pkg/share/manager/sql/share.go
+++ b/pkg/share/manager/sql/share.go
@@ -37,7 +37,6 @@ import (
 	"github.com/cs3org/reva/v3/pkg/rgrpc/todo/pool"
 	revashare "github.com/cs3org/reva/v3/pkg/share"
 	"github.com/cs3org/reva/v3/pkg/share/manager/sql/model"
-	"github.com/cs3org/reva/v3/pkg/sharedconf"
 	"github.com/cs3org/reva/v3/pkg/utils"
 	"github.com/cs3org/reva/v3/pkg/utils/cfg"
 	"google.golang.org/genproto/protobuf/field_mask"
@@ -50,19 +49,16 @@ import (
 )
 
 type ShareMgr struct {
-	c  *config
+	c  *Config
 	db *gorm.DB
 }
 
-func (c *config) ApplyDefaults() {
-	c.GatewaySvc = sharedconf.GetGatewaySVC(c.GatewaySvc)
-}
-
-func NewShareManager(ctx context.Context, m map[string]interface{}) (revashare.Manager, error) {
-	var c config
+func NewShareManager(ctx context.Context, m map[string]any) (revashare.Manager, error) {
+	var c Config
 	if err := cfg.Decode(m, &c); err != nil {
 		return nil, err
 	}
+	c.ApplyDefaults()
 
 	db, err := getDb(c)
 	if err != nil {

--- a/pkg/sharedconf/sharedconf.go
+++ b/pkg/sharedconf/sharedconf.go
@@ -66,3 +66,28 @@ func SkipUserGroupsInToken() bool {
 func GetBlockedUsers() []string {
 	return sharedConf.BlockedUsers
 }
+
+func GetDBInfo(in config.Database) config.Database {
+	c := in
+
+	if c.Engine == "" {
+		c.Engine = sharedConf.Engine
+	}
+	if c.DBHost == "" {
+		c.DBHost = sharedConf.DBHost
+	}
+	if c.DBUsername == "" {
+		c.DBUsername = sharedConf.DBUsername
+	}
+	if c.DBPassword == "" {
+		c.DBPassword = sharedConf.DBPassword
+	}
+	if c.DBName == "" {
+		c.DBName = sharedConf.DBName
+	}
+	if c.DBPort == 0 {
+		c.DBPort = sharedConf.DBPort
+	}
+
+	return c
+}

--- a/pkg/storage/favorite/sql/sql.go
+++ b/pkg/storage/favorite/sql/sql.go
@@ -26,8 +26,10 @@ import (
 	user "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 
+	"github.com/cs3org/reva/v3/cmd/revad/pkg/config"
 	"github.com/cs3org/reva/v3/pkg/appctx"
 	"github.com/cs3org/reva/v3/pkg/cbox/utils"
+	"github.com/cs3org/reva/v3/pkg/sharedconf"
 	"github.com/cs3org/reva/v3/pkg/storage/favorite"
 	"github.com/cs3org/reva/v3/pkg/storage/favorite/registry"
 	"github.com/cs3org/reva/v3/pkg/utils/cfg"
@@ -37,25 +39,26 @@ func init() {
 	registry.Register("sql", New)
 }
 
-type config struct {
-	DBUsername string `mapstructure:"db_username"`
-	DBPassword string `mapstructure:"db_password"`
-	DBHost     string `mapstructure:"db_host"`
-	DBPort     int    `mapstructure:"db_port"`
-	DBName     string `mapstructure:"db_name"`
+type Config struct {
+	config.Database `mapstructure:",squash"`
+}
+
+func (c *Config) ApplyDefaults() {
+	c.Database = sharedconf.GetDBInfo(c.Database)
 }
 
 type mgr struct {
-	c  *config
+	c  *Config
 	db *sql.DB
 }
 
 // New returns an instance of the cbox sql favorites manager.
 func New(m map[string]interface{}) (favorite.Manager, error) {
-	var c config
+	var c Config
 	if err := cfg.Decode(m, &c); err != nil {
 		return nil, err
 	}
+	c.ApplyDefaults()
 
 	db, err := sql.Open("mysql", fmt.Sprintf("%s:%s@tcp(%s:%d)/%s", c.DBUsername, c.DBPassword, c.DBHost, c.DBPort, c.DBName))
 	if err != nil {


### PR DESCRIPTION
 Add database configuration to `sharedconf`, so that it doesn't have to be repeated for every driver

Depends on https://github.com/cs3org/reva/pull/5322 being merged