### PR TITLE
Add support for thumbnails in Public spaces

### DIFF
--- a/changelog/unreleased/feat-thumb-pub-spaces
+++ b/changelog/unreleased/feat-thumb-pub-spaces
@@ -1,0 +1,5 @@
+Enhancement: Add support for thumbnails in Public spaces
+
+To be configured with an extra thumbnail_path property in the public_space map.
+
+https://github.com/cs3org/reva/pull/5331

--- a/internal/grpc/services/spacesregistry/spacesregistry.go
+++ b/internal/grpc/services/spacesregistry/spacesregistry.go
@@ -429,6 +429,9 @@ func (s *service) getPublicSpaces(ctx context.Context) ([]*provider.StorageSpace
 		if description, ok := content["description"]; ok {
 			space.Description = description
 		}
+		if thumbnailPath, ok := content["thumbnail_path"]; ok {
+			space.ThumbnailId = thumbnailPath
+		}
 
 		publicSpaces = append(publicSpaces, space)
 	}


### PR DESCRIPTION
To be configured with an extra `thumbnail_path` property in the `public_space` map.