### PR TITLE
add user filter to OCS listSharesWithOthers

### DIFF
--- a/changelog/unreleased/fix-memleak.md
+++ b/changelog/unreleased/fix-memleak.md
@@ -1,0 +1,5 @@
+Bugfix: add user filter to OCS listSharesWithOthers
+
+Fixes a memory leak where an OCS function would load all shares, because no filter for the current user was set
+
+https://github.com/cs3org/reva/pull/5333

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/shares.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/shares.go
@@ -1051,9 +1051,22 @@ func findMatch(shareJailInfos []*provider.ResourceInfo, id *provider.ResourceId)
 func (h *Handler) listSharesWithOthers(w http.ResponseWriter, r *http.Request) {
 	shares := make([]*conversions.ShareData, 0)
 
-	log := appctx.GetLogger(r.Context())
+	ctx := r.Context()
+	log := appctx.GetLogger(ctx)
+	user, ok := appctx.ContextGetUser(ctx)
 
-	filters := []*collaboration.Filter{}
+	if !ok {
+		return
+	}
+
+	filters := []*collaboration.Filter{
+		&collaboration.Filter{
+			Type: collaboration.Filter_TYPE_CREATOR,
+			Term: &collaboration.Filter_Creator{
+				Creator: user.Id,
+			},
+		},
+	}
 	linkFilters := []*link.ListPublicSharesRequest_Filter{}
 	var e error
 


### PR DESCRIPTION
Fixes a memory leak where an OCS function would load all shares, because no filter for the current user was set