### PR TITLE
sharedByMe works with deleted accounts

### DIFF
--- a/changelog/unreleased/fix-sharedbyme-deleted.md
+++ b/changelog/unreleased/fix-sharedbyme-deleted.md
@@ -1,0 +1,6 @@
+Bugfix: sharedByMe works with deleted accounts
+
+The `/sharedByMe` endpoint now works, even if the user has
+shares with users that no longer exist
+
+https://github.com/cs3org/reva/pull/5336

--- a/internal/http/services/owncloud/ocgraph/conversions.go
+++ b/internal/http/services/owncloud/ocgraph/conversions.go
@@ -544,12 +544,14 @@ func (s *svc) cs3sharesToPermissions(ctx context.Context, shares []*GenericShare
 
 			creator, err := s.getUserByID(ctx, e.share.Creator)
 			if err != nil {
-				return nil, err
+				log.Error().Err(err).Msg("Failed to convert cs3 share to permission in ocgraph - ignoring this share")
+				continue
 			}
 
 			grantee, err := s.cs3GranteeToSharePointIdentitySet(ctx, e.share.Grantee)
 			if err != nil {
-				return nil, err
+				log.Error().Err(err).Msg("Failed to convert cs3 share to permission in ocgraph - ignoring this share")
+				continue
 			}
 
 			roles := make([]string, 0, 1)


### PR DESCRIPTION
The `/sharedByMe` endpoint now works, even if the user has shares with users that no longer exist