### PR TITLE
Fix permission check for MOVE for LW accs

### DIFF
--- a/changelog/unreleased/fix-rename-lw.md
+++ b/changelog/unreleased/fix-rename-lw.md
@@ -1,0 +1,7 @@
+Bugfix: fix permission check for MOVE for LW accs
+
+The permission check for MOVE requests for lightweight accounts
+was broken: it checked whether the user has permission on the destination
+(which does not exist yet), instead of the destination's parent
+
+https://github.com/cs3org/reva/pull/5337

--- a/internal/grpc/interceptors/auth/scope.go
+++ b/internal/grpc/interceptors/auth/scope.go
@@ -20,6 +20,7 @@ package auth
 
 import (
 	"context"
+	"path"
 	"path/filepath"
 	"strings"
 	"time"
@@ -164,9 +165,10 @@ func checkLightweightScope(ctx context.Context, req interface{}, tokenScope map[
 			Delete: true,
 		})
 	case *provider.MoveRequest:
+		destinationParent := path.Dir(r.Destination.Path)
 		return hasPermissions(ctx, client, r.Source, &provider.ResourcePermissions{
 			InitiateFileDownload: true,
-		}) && hasPermissions(ctx, client, r.Destination, &provider.ResourcePermissions{
+		}) && hasPermissions(ctx, client, &provider.Reference{Path: destinationParent}, &provider.ResourcePermissions{
 			InitiateFileUpload: true,
 		})
 	case *provider.InitiateFileUploadRequest:


### PR DESCRIPTION
The permission check for MOVE requests for lightweight accounts was broken: it checked whether the user has permission on the destination (which does not exist yet), instead of the destination's parent