### PR TITLE
Ensure links cannot expire in the past

### DIFF
--- a/changelog/unreleased/disallow-expiry-past
+++ b/changelog/unreleased/disallow-expiry-past
@@ -1,3 +1,0 @@
-Bugfix: disallow setting link expiry in the past
-
-https://github.com/cs3org/reva/pull/5346

--- a/changelog/unreleased/disallow-expiry-past.md
+++ b/changelog/unreleased/disallow-expiry-past.md
@@ -1,0 +1,6 @@
+Bugfix: disallow setting link expiry in the past
+
+Aditionally, in some cases an earlier expiration date was accidentally overwritten by a later one.
+This is also now fixed.
+
+https://github.com/cs3org/reva/pull/5346

--- a/internal/http/services/owncloud/ocgraph/drive_permissions.go
+++ b/internal/http/services/owncloud/ocgraph/drive_permissions.go
@@ -810,7 +810,7 @@ func (s *svc) getLinkUpdates(ctx context.Context, link *linkv1beta1.PublicShare,
 		if exp := permission.ExpirationDateTime.Get(); exp.Before(time.Now().AddDate(0, 0, -1)) {
 			return nil, errtypes.BadRequest("links cannot expire in the past")
 		}
-		// For editor links, a max expiration is defined
+		// For editor links, a default expiration is set
 		finalExpiration := permission.ExpirationDateTime
 		if isEditorLink && isExpirationEnforced {
 			if permission.ExpirationDateTime.Get() == nil {
@@ -854,7 +854,7 @@ func (s *svc) getLinkUpdates(ctx context.Context, link *linkv1beta1.PublicShare,
 					finalExpiration.Set(&maxExpiration)
 				}
 			} else if link.Expiration != nil {
-				if endOfDay.Add(time.Second * time.Duration(link.Expiration.Seconds)).After(maxExpiration) {
+				if time.Unix(int64(link.Expiration.GetSeconds()), 0).After(maxExpiration) {
 					finalExpiration.Set(&maxExpiration)
 				}
 			}


### PR DESCRIPTION
* Reva's libregraph API now ensures that link expiration dates cannot be set in the past
* Aditionally, in some cases an earlier expiration date was accidentally overwritten by a later one. This is also now fixed.