### PR TITLE
temp fix to make eosatlas and eosmedia work

### DIFF
--- a/changelog/unreleased/fix-eosmedia.md
+++ b/changelog/unreleased/fix-eosmedia.md
@@ -1,0 +1,8 @@
+Bugfix: make eosmedia work with new space structure
+
+We have added a special case to the `spacesLevel` function
+to make eosmedia's spaces work. This is temporary, since we
+plan to get rid of this function and just use the SpaceID that
+comes from the projects database.
+
+https://github.com/cs3org/reva/pull/5347

--- a/pkg/spaces/utils.go
+++ b/pkg/spaces/utils.go
@@ -158,7 +158,7 @@ func PathToSpaceID(path string) string {
 func spacesLevel(path string) int {
 	if strings.HasPrefix(path, "/eos/user") || strings.HasPrefix(path, "/eos/project") {
 		return 5
-	} else if strings.HasPrefix(path, "/winspaces") {
+	} else if strings.HasPrefix(path, "/winspaces") || strings.HasPrefix(path, "/eos/media") || strings.HasPrefix(path, "/eos/atlas") {
 		// e.g. /winspaces/c/copstest-doyle
 		return 4
 	} else {


### PR DESCRIPTION
We have added a special case to the `spacesLevel` function
to make eosmedia and eosatlas's spaces work. This is temporary, since we
plan to get rid of this function and just use the SpaceID that
comes from the projects database.