### PR TITLE
Rewrite handling of listing spaces with an ID filter

### DIFF
--- a/changelog/unreleased/fix-filter-spaces-id.md
+++ b/changelog/unreleased/fix-filter-spaces-id.md
@@ -1,0 +1,7 @@
+Bugfix: fix filtering spaces by ID
+
+Rewrite handling of listing spaces with an ID filter. We now handle one or
+multiple filters properly, and the db driver supports querying both by
+SpaceID and StorageSpaceID
+
+https://github.com/cs3org/reva/pull/5349

--- a/internal/http/services/owncloud/ocgraph/drives.go
+++ b/internal/http/services/owncloud/ocgraph/drives.go
@@ -312,6 +312,7 @@ func (s *svc) getSpace(w http.ResponseWriter, r *http.Request) {
 				},
 			},
 		})
+
 		if err != nil {
 			log.Error().Err(err).Msg("error getting space by id")
 			handleError(ctx, err, w)

--- a/pkg/projects/manager/sql/sql.go
+++ b/pkg/projects/manager/sql/sql.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"fmt"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/ReneKroon/ttlcache/v2"
@@ -358,10 +359,18 @@ func (m *ProjectsManager) appendFiltersToQuery(ctx context.Context, query *gorm.
 		case provider.ListStorageSpacesRequest_Filter_TYPE_ID:
 			innerQuery := m.db
 			for i, filter := range filters {
+				// ID could be both normal SpaceID and StorageSpaceID
+				id := filter.GetId().OpaqueId
+				if strings.Contains(id, "$") {
+					parts := strings.Split(id, "$")
+					if len(parts) == 2 {
+						id = parts[1]
+					}
+				}
 				if i == 0 {
-					innerQuery = innerQuery.Where("space_id = ?", filter.GetId().OpaqueId)
+					innerQuery = innerQuery.Where("space_id = ?", id)
 				} else {
-					innerQuery = innerQuery.Or("space_id = ?", filter.GetId().OpaqueId)
+					innerQuery = innerQuery.Or("space_id = ?", id)
 				}
 			}
 			query = query.Where(innerQuery)


### PR DESCRIPTION
Rewrite handling of listing spaces with an ID filter. We now handle one or multiple filters properly, and the db driver supports querying both by SpaceID and StorageSpaceID
