### PR TITLE
OCM: Bugfix when searching for federated users

### DIFF
--- a/changelog/unreleased/searching-for-federated-users.md
+++ b/changelog/unreleased/searching-for-federated-users.md
@@ -1,0 +1,9 @@
+Bugfix: Searching for federated users
+
+Since the "sm:" prefix is no longer given by the frontend when searching
+for federated users this is removed and the if is replaced with a flag to 
+perform the search only when OCM is enabled.
+
+https://github.com/cs3org/reva/pull/5350
+
+

--- a/internal/grpc/services/gateway/gateway.go
+++ b/internal/grpc/services/gateway/gateway.go
@@ -78,6 +78,7 @@ type config struct {
 	ResourceInfoCacheTTL     int                               `mapstructure:"resource_info_cache_ttl"`
 	ResourceInfoCacheDrivers map[string]map[string]interface{} `mapstructure:"resource_info_caches"`
 	HomeLayout               string                            `mapstructure:"home_layout"`
+	OCMEnabled               bool                              `mapstructure:"ocm_enabled"`
 }
 
 // sets defaults.

--- a/internal/grpc/services/gateway/userprovider.go
+++ b/internal/grpc/services/gateway/userprovider.go
@@ -20,7 +20,6 @@ package gateway
 
 import (
 	"context"
-	"strings"
 
 	user "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	invitepb "github.com/cs3org/go-cs3apis/cs3/ocm/invite/v1beta1"
@@ -63,7 +62,7 @@ func (s *svc) GetUserByClaim(ctx context.Context, req *user.GetUserByClaimReques
 }
 
 func (s *svc) FindUsers(ctx context.Context, req *user.FindUsersRequest) (*user.FindUsersResponse, error) {
-	if strings.HasPrefix(req.Query, "sm:") {
+	if s.c.OCMEnabled {
 		c, err := pool.GetOCMInviteManagerClient(pool.Endpoint(s.c.OCMInviteManagerEndpoint))
 		if err != nil {
 			return &user.FindUsersResponse{
@@ -71,10 +70,8 @@ func (s *svc) FindUsers(ctx context.Context, req *user.FindUsersRequest) (*user.
 			}, nil
 		}
 
-		term := strings.TrimPrefix(req.Query, "sm:")
-
 		res, err := c.FindAcceptedUsers(ctx, &invitepb.FindAcceptedUsersRequest{
-			Filter: term,
+			Filter: req.Query,
 		})
 		if err != nil {
 			return nil, errors.Wrap(err, "gateway: error calling FindAcceptedUsers")


### PR DESCRIPTION
Since we no longer have the button for account-type the 'sm:' prefix is no longer needed automatically prefixed and the search wasn't working unless you manually added this. 

We however don't want to do this search if ocm is not enabled, so a config flag has been added.