### PR TITLE
Remove trash and versions from OCS role

### DIFF
--- a/changelog/unreleased/fix-ocs-roles.md
+++ b/changelog/unreleased/fix-ocs-roles.md
@@ -1,0 +1,6 @@
+Bugfix: Remove trash and versions from OCS role
+
+Remove trashbin and version-related permissions from conversion to OCS role, as some
+space types do not support these, leading to invalid roles
+
+https://github.com/cs3org/reva/pull/5364

--- a/internal/grpc/services/spacesregistry/spacesregistry.go
+++ b/internal/grpc/services/spacesregistry/spacesregistry.go
@@ -449,6 +449,7 @@ func (s *service) getAllPublicSpaces(ctx context.Context) ([]*provider.StorageSp
 				QuotaMaxBytes:  uint64(math.Pow10(18)),
 				RemainingBytes: uint64(math.Pow10(18)) - resourceInfo.Size,
 			},
+			PermissionSet: resourceInfo.PermissionSet,
 		}
 
 		if description, ok := content["description"]; ok {

--- a/internal/http/services/owncloud/ocs/conversions/role.go
+++ b/internal/http/services/owncloud/ocs/conversions/role.go
@@ -291,16 +291,12 @@ func RoleFromResourcePermissions(rp *provider.ResourcePermissions) *Role {
 		return r
 	}
 	if rp.ListContainer &&
-		rp.ListFileVersions &&
-		rp.ListRecycle &&
 		rp.Stat &&
 		rp.GetPath &&
 		rp.InitiateFileDownload {
 		r.ocsPermissions |= PermissionRead
 	}
-	if rp.InitiateFileUpload &&
-		rp.RestoreFileVersion &&
-		rp.RestoreRecycleItem {
+	if rp.InitiateFileUpload {
 		r.ocsPermissions |= PermissionWrite
 	}
 	if rp.ListContainer &&
@@ -308,8 +304,7 @@ func RoleFromResourcePermissions(rp *provider.ResourcePermissions) *Role {
 		rp.InitiateFileUpload {
 		r.ocsPermissions |= PermissionCreate
 	}
-	if rp.Delete &&
-		rp.PurgeRecycle {
+	if rp.Delete {
 		r.ocsPermissions |= PermissionDelete
 	}
 	if rp.AddGrant &&


### PR DESCRIPTION
Remove trashbin and version-related permissions from conversion to OCS role, as some space types do not support these, leading to invalid roles