### PR TITLE
Proper support of Range requests

### DIFF
--- a/changelog/unreleased/fix-range-reqs.md
+++ b/changelog/unreleased/fix-range-reqs.md
@@ -1,0 +1,9 @@
+Enhancement: Proper support of Range requests
+
+Up to now, Reva supported Range requests only when the requested content
+was copied into Reva's memory. This has now been improved: the ranges can
+be propagated upto the storage provider, which only returns the requested
+content, instead of first copying everything into memory and then only
+returning the requested ranges
+
+https://github.com/cs3org/reva/pull/5367

--- a/internal/http/services/owncloud/ocdav/get.go
+++ b/internal/http/services/owncloud/ocdav/get.go
@@ -155,22 +155,3 @@ func (s *svc) handleGet(ctx context.Context, w http.ResponseWriter, r *http.Requ
 	}
 	// TODO we need to send the If-Match etag in the GET to the datagateway to prevent race conditions between stating and reading the file
 }
-
-func (s *svc) handleSpacesGet(w http.ResponseWriter, r *http.Request, spaceID string) {
-	ctx := r.Context()
-	sublog := appctx.GetLogger(ctx).With().Str("path", r.URL.Path).Str("spaceid", spaceID).Str("handler", "get").Logger()
-
-	// retrieve a specific storage space
-	ref, rpcStatus, err := s.lookUpStorageSpaceReference(ctx, spaceID, r.URL.Path)
-	if err != nil {
-		sublog.Error().Err(err).Msg("error sending a grpc request")
-		w.WriteHeader(http.StatusInternalServerError)
-		return
-	}
-
-	if rpcStatus.Code != rpc.Code_CODE_OK {
-		HandleErrorStatus(&sublog, w, rpcStatus)
-		return
-	}
-	s.handleGet(ctx, w, r, ref, "spaces", sublog)
-}

--- a/pkg/eosclient/eosbinary/eosbinary.go
+++ b/pkg/eosclient/eosbinary/eosbinary.go
@@ -34,6 +34,7 @@ import (
 
 	"github.com/ReneKroon/ttlcache/v2"
 	"github.com/cs3org/reva/v3/pkg/appctx"
+	"github.com/cs3org/reva/v3/pkg/storage"
 
 	"github.com/cs3org/reva/v3/pkg/eosclient"
 	"github.com/cs3org/reva/v3/pkg/errtypes"
@@ -735,7 +736,10 @@ func (c *Client) List(ctx context.Context, auth eosclient.Authorization, path st
 }
 
 // Read reads a file from the mgm.
-func (c *Client) Read(ctx context.Context, auth eosclient.Authorization, path string) (io.ReadCloser, error) {
+func (c *Client) Read(ctx context.Context, auth eosclient.Authorization, path string, ranges []storage.Range) (io.ReadCloser, error) {
+	if len(ranges) > 0 {
+		return nil, errtypes.NotSupported("Download with ranges is not supported with this storage driver")
+	}
 	rand := "eosread-" + uuid.New().String()
 	localTarget := fmt.Sprintf("%s/%s", c.opt.CacheDirectory, rand)
 	defer os.RemoveAll(localTarget)
@@ -866,7 +870,7 @@ func (c *Client) RollbackToVersion(ctx context.Context, auth eosclient.Authoriza
 // ReadVersion reads the version for the given file.
 func (c *Client) ReadVersion(ctx context.Context, auth eosclient.Authorization, p, version string) (io.ReadCloser, error) {
 	versionFile := path.Join(eosclient.GetVersionFolder(p), version)
-	return c.Read(ctx, auth, versionFile)
+	return c.Read(ctx, auth, versionFile, nil)
 }
 
 // GenerateToken returns a token on behalf of the resource owner to be used by lightweight accounts.

--- a/pkg/eosclient/eosclient.go
+++ b/pkg/eosclient/eosclient.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/cs3org/reva/v3/pkg/errtypes"
+	"github.com/cs3org/reva/v3/pkg/storage"
 	"github.com/cs3org/reva/v3/pkg/storage/utils/acl"
 )
 
@@ -51,7 +52,7 @@ type EOSClient interface {
 	Rename(ctx context.Context, auth Authorization, oldPath, newPath string) error
 	List(ctx context.Context, auth Authorization, path string) ([]*FileInfo, error)
 	ListWithRegex(ctx context.Context, auth Authorization, path string, depth uint, regex string) ([]*FileInfo, error)
-	Read(ctx context.Context, auth Authorization, path string) (io.ReadCloser, error)
+	Read(ctx context.Context, auth Authorization, path string, ranges []storage.Range) (io.ReadCloser, error)
 	Write(ctx context.Context, auth Authorization, path string, stream io.ReadCloser, length int64, app string, disableVersioning bool) error
 	ListDeletedEntries(ctx context.Context, auth Authorization, maxentries int, from, to time.Time) ([]*DeletedEntry, error)
 	RestoreDeletedEntry(ctx context.Context, auth Authorization, key string) error

--- a/pkg/eosclient/eosgrpc/eosgrpc.go
+++ b/pkg/eosclient/eosgrpc/eosgrpc.go
@@ -34,6 +34,7 @@ import (
 	"github.com/cs3org/reva/v3/pkg/appctx"
 	"github.com/cs3org/reva/v3/pkg/eosclient"
 	"github.com/cs3org/reva/v3/pkg/errtypes"
+	"github.com/cs3org/reva/v3/pkg/storage"
 	"github.com/cs3org/reva/v3/pkg/trace"
 	"github.com/cs3org/reva/v3/pkg/utils"
 	"github.com/google/uuid"
@@ -269,9 +270,9 @@ func (c *Client) initMDRequest(ctx context.Context, auth eosclient.Authorization
 //
 // Let's consider this experimental for the moment, maybe I'll like to add a config
 // parameter to choose between the two behaviours.
-func (c *Client) Read(ctx context.Context, auth eosclient.Authorization, path string) (io.ReadCloser, error) {
+func (c *Client) Read(ctx context.Context, auth eosclient.Authorization, path string, ranges []storage.Range) (io.ReadCloser, error) {
 	log := appctx.GetLogger(ctx)
-	log.Info().Str("func", "Read").Str("uid,gid", auth.Role.UID+","+auth.Role.GID).Str("path", path).Msg("")
+	log.Info().Str("func", "Read").Any("Ranges", ranges).Str("uid,gid", auth.Role.UID+","+auth.Role.GID).Str("path", path).Msg("")
 
 	var localTarget string
 	var err error
@@ -296,7 +297,7 @@ func (c *Client) Read(ctx context.Context, auth eosclient.Authorization, path st
 		}
 	}
 
-	bodystream, err := c.httpcl.GETFile(ctx, u.Username, auth, path, localfile)
+	bodystream, err := c.httpcl.GETFile(ctx, u.Username, auth, path, localfile, ranges)
 	if err != nil {
 		log.Error().Str("func", "Read").Str("path", path).Str("uid,gid", auth.Role.UID+","+auth.Role.GID).Str("err", err.Error()).Msg("")
 		return nil, errtypes.InternalError(fmt.Sprintf("can't GET local cache file '%s'", localTarget))

--- a/pkg/eosclient/eosgrpc/versions.go
+++ b/pkg/eosclient/eosgrpc/versions.go
@@ -68,5 +68,5 @@ func (c *Client) ReadVersion(ctx context.Context, auth eosclient.Authorization, 
 	log.Info().Str("func", "ReadVersion").Str("uid,gid", auth.Role.UID+","+auth.Role.GID).Str("p", p).Str("version", version).Msg("")
 
 	versionFile := path.Join(eosclient.GetVersionFolder(p), version)
-	return c.Read(ctx, auth, versionFile)
+	return c.Read(ctx, auth, versionFile, nil)
 }

--- a/pkg/ocm/storage/outcoming/ocm.go
+++ b/pkg/ocm/storage/outcoming/ocm.go
@@ -462,7 +462,10 @@ func getDownloadProtocol(protocols []*gateway.FileDownloadProtocol, lst []string
 	return "", "", false
 }
 
-func (d *driver) Download(ctx context.Context, ref *provider.Reference) (io.ReadCloser, error) {
+func (d *driver) Download(ctx context.Context, ref *provider.Reference, ranges []storage.Range) (io.ReadCloser, error) {
+	if len(ranges) > 0 {
+		return nil, errtypes.NotSupported("Download with ranges is not supported with this storage driver")
+	}
 	share, rel, err := d.shareAndRelativePathFromRef(ctx, ref)
 	if err != nil {
 		return nil, err

--- a/pkg/ocm/storage/received/ocm.go
+++ b/pkg/ocm/storage/received/ocm.go
@@ -334,7 +334,10 @@ func (d *driver) Upload(ctx context.Context, ref *provider.Reference, r io.ReadC
 	return client.WriteStream(rel, r, 0)
 }
 
-func (d *driver) Download(ctx context.Context, ref *provider.Reference) (io.ReadCloser, error) {
+func (d *driver) Download(ctx context.Context, ref *provider.Reference, ranges []storage.Range) (io.ReadCloser, error) {
+	if len(ranges) > 0 {
+		return nil, errtypes.NotSupported("Download with ranges is not supported with this storage driver")
+	}
 	client, _, rel, err := d.webdavClient(ctx, ref)
 	if err != nil {
 		return nil, err

--- a/pkg/storage/fs/cephfs/cephfs.go
+++ b/pkg/storage/fs/cephfs/cephfs.go
@@ -275,7 +275,10 @@ func (fs *cephfs) ListFolder(ctx context.Context, ref *provider.Reference, mdKey
 	return files, getRevaError(ctx, err)
 }
 
-func (fs *cephfs) Download(ctx context.Context, ref *provider.Reference) (rc io.ReadCloser, err error) {
+func (fs *cephfs) Download(ctx context.Context, ref *provider.Reference, ranges []storage.Range) (rc io.ReadCloser, err error) {
+	if len(ranges) > 0 {
+		return nil, errtypes.NotSupported("Download with ranges is not supported with this storage driver")
+	}
 	var path string
 	user := fs.makeUser(ctx)
 	if path, err = user.resolveRef(ref); err != nil {

--- a/pkg/storage/fs/cephmount/cephmount.go
+++ b/pkg/storage/fs/cephmount/cephmount.go
@@ -721,7 +721,11 @@ func (fs *cephmountfs) ListFolder(ctx context.Context, ref *provider.Reference, 
 	return files, nil
 }
 
-func (fs *cephmountfs) Download(ctx context.Context, ref *provider.Reference) (rc io.ReadCloser, err error) {
+func (fs *cephmountfs) Download(ctx context.Context, ref *provider.Reference, ranges []storage.Range) (rc io.ReadCloser, err error) {
+	if len(ranges) > 0 {
+		return nil, errtypes.NotSupported("Download with ranges is not supported with this storage driver")
+	}
+
 	// Capture the original received path for logging
 	var receivedPath string
 	if ref != nil && ref.Path != "" {

--- a/pkg/storage/fs/nextcloud/nextcloud.go
+++ b/pkg/storage/fs/nextcloud/nextcloud.go
@@ -334,7 +334,10 @@ func (nc *StorageDriver) Upload(ctx context.Context, ref *provider.Reference, r 
 }
 
 // Download as defined in the storage.FS interface.
-func (nc *StorageDriver) Download(ctx context.Context, ref *provider.Reference) (io.ReadCloser, error) {
+func (nc *StorageDriver) Download(ctx context.Context, ref *provider.Reference, ranges []storage.Range) (io.ReadCloser, error) {
+	if len(ranges) > 0 {
+		return nil, errtypes.NotSupported("Download with ranges is not supported with this storage driver")
+	}
 	req, err := nc.prepareRequest(ctx, http.MethodGet, filepath.Join("/Download", ref.Path), nil)
 	if err != nil {
 		return nil, err

--- a/pkg/storage/fs/nextcloud/nextcloud_test.go
+++ b/pkg/storage/fs/nextcloud/nextcloud_test.go
@@ -360,7 +360,7 @@ var _ = Describe("Nextcloud", func() {
 				},
 				Path: "some/file/path.txt",
 			}
-			reader, err := nc.Download(ctx, ref)
+			reader, err := nc.Download(ctx, ref, nil)
 			Expect(err).ToNot(HaveOccurred())
 			checkCalled(called, `GET /apps/sciencemesh/~tester/api/storage/Download/some/file/path.txt `)
 			defer reader.Close()

--- a/pkg/storage/utils/eosfs/eosfs.go
+++ b/pkg/storage/utils/eosfs/eosfs.go
@@ -1478,13 +1478,13 @@ func (fs *Eosfs) Move(ctx context.Context, oldRef, newRef *provider.Reference) e
 	return fs.c.Rename(ctx, auth, oldFn, newFn)
 }
 
-func (fs *Eosfs) Download(ctx context.Context, ref *provider.Reference) (io.ReadCloser, error) {
+func (fs *Eosfs) Download(ctx context.Context, ref *provider.Reference, ranges []storage.Range) (io.ReadCloser, error) {
 	fn, auth, err := fs.resolveRefAndGetAuth(ctx, ref)
 	if err != nil {
 		return nil, err
 	}
 
-	return fs.c.Read(ctx, auth, fn)
+	return fs.c.Read(ctx, auth, fn, ranges)
 }
 
 func (fs *Eosfs) ListRevisions(ctx context.Context, ref *provider.Reference) ([]*provider.FileVersion, error) {

--- a/pkg/storage/utils/localfs/localfs.go
+++ b/pkg/storage/utils/localfs/localfs.go
@@ -1065,7 +1065,10 @@ func (fs *localfs) listShareFolderRoot(ctx context.Context, home string, mdKeys 
 	return finfos, nil
 }
 
-func (fs *localfs) Download(ctx context.Context, ref *provider.Reference) (io.ReadCloser, error) {
+func (fs *localfs) Download(ctx context.Context, ref *provider.Reference, ranges []storage.Range) (io.ReadCloser, error) {
+	if len(ranges) > 0 {
+		return nil, errtypes.NotSupported("Download with ranges is not supported with this storage driver")
+	}
 	fn, err := fs.resolve(ctx, ref)
 	log := appctx.GetLogger(ctx)
 


### PR DESCRIPTION
Up to now, Reva supported Range requests only when the requested content was copied into Reva's memory. This has now been improved: the ranges can be propagated upto the storage provider, which only returns the requested content, instead of first copying everything into memory and then only returning the requested ranges