### PR TITLE
Return 201 as opposed to 200 when creating a new OCM invite

### DIFF
--- a/internal/http/services/sciencemesh/token.go
+++ b/internal/http/services/sciencemesh/token.go
@@ -115,7 +115,7 @@ func (h *tokenHandler) Generate(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
+	w.WriteHeader(http.StatusCreated)
 }
 
 func (h *tokenHandler) prepareGenerateTokenResponse(tkn *invitepb.InviteToken) *token {

--- a/tests/integration/grpc/ocm_invitation_test.go
+++ b/tests/integration/grpc/ocm_invitation_test.go
@@ -484,7 +484,7 @@ var _ = Describe("ocm invitation workflow", func() {
 					Expect(ocmUsersEqual(list.Map(users, remoteToCs3User), []*userpb.User{})).To(BeTrue())
 
 					ocmToken, code := generateToken(tknEinstein, cernboxURL)
-					Expect(code).To(Equal(http.StatusOK))
+					Expect(code).To(Equal(http.StatusCreated))
 
 					code = acceptInvite(tknMarie, cesnetURL, "cernbox.cern.ch", ocmToken.Token)
 					Expect(code).To(Equal(http.StatusOK))


### PR DESCRIPTION
A trivial fix for #4838¸ but to merge this we need the frontend to accept a HTTP 201 along with 200.