### PR TITLE
Revert "Remove trashbin and version-related permissions from (#5364)"

### DIFF
--- a/internal/grpc/services/spacesregistry/spacesregistry.go
+++ b/internal/grpc/services/spacesregistry/spacesregistry.go
@@ -462,7 +462,6 @@ func (s *service) getAllPublicSpaces(ctx context.Context) ([]*provider.StorageSp
 				QuotaMaxBytes:  uint64(math.Pow10(18)),
 				RemainingBytes: uint64(math.Pow10(18)) - resourceInfo.Size,
 			},
-			PermissionSet: resourceInfo.PermissionSet,
 		}
 
 		if description, ok := content["description"]; ok {

--- a/internal/http/services/owncloud/ocs/conversions/role.go
+++ b/internal/http/services/owncloud/ocs/conversions/role.go
@@ -291,12 +291,16 @@ func RoleFromResourcePermissions(rp *provider.ResourcePermissions) *Role {
 		return r
 	}
 	if rp.ListContainer &&
+		rp.ListFileVersions &&
+		rp.ListRecycle &&
 		rp.Stat &&
 		rp.GetPath &&
 		rp.InitiateFileDownload {
 		r.ocsPermissions |= PermissionRead
 	}
-	if rp.InitiateFileUpload {
+	if rp.InitiateFileUpload &&
+		rp.RestoreFileVersion &&
+		rp.RestoreRecycleItem {
 		r.ocsPermissions |= PermissionWrite
 	}
 	if rp.ListContainer &&
@@ -304,7 +308,8 @@ func RoleFromResourcePermissions(rp *provider.ResourcePermissions) *Role {
 		rp.InitiateFileUpload {
 		r.ocsPermissions |= PermissionCreate
 	}
-	if rp.Delete {
+	if rp.Delete &&
+		rp.PurgeRecycle {
 		r.ocsPermissions |= PermissionDelete
 	}
 	if rp.AddGrant &&


### PR DESCRIPTION
This reverts commit 21c4627256746a8379f2cebfa636fc391eb6d775.

This branch was used as a temporary work-around to build a release without that change, as it impacted the public upload-only links. The expectation however is to fix them in a different way, therefore this PR shall not be merged.