### PR TITLE
feat(ocm): Strengthen OCM client security

### DIFF
--- a/changelog/unreleased/add-ocm-security-measures.md
+++ b/changelog/unreleased/add-ocm-security-measures.md
@@ -1,0 +1,12 @@
+Enhancement: Strengthen OCM Client Security
+
+Introduces several new security measures for the OCM client:
+
+- Blocks requests to private or local network addresses.
+- Limits the number of allowed redirects and validates target IPs to prevent redirection to private ranges.
+- Adds configurable timeouts for connection establishment, TLS handshake, data read operations, and overall request duration.
+- Enforces a maximum response size, halting reads after a specified byte limit.
+
+All parameters are configurable through YAML or TOML config files on a per-service basis.
+
+https://github.com/cs3org/reva/pull/5389

--- a/changelog/unreleased/ocm-client-hardening.md
+++ b/changelog/unreleased/ocm-client-hardening.md
@@ -1,0 +1,22 @@
+Security: harden OCM outbound HTTP clients after public-only client
+
+Following the public-only client work merged in #5752, outbound OCM HTTP
+calls now share tighter limits and one untrusted transport path. Discovery,
+share, and ExchangeToken response bodies are capped at 1 MiB with
+io.LimitReader. NewPublicOnlyClient enforces HTTPS-only URLs, limits
+redirects to three hops, and sets TLS 1.2 as the minimum on OCM client
+transports.
+
+ScienceMesh gained flat ocm_client_response_limit and ocm_client_timeout
+config fields. The unauthenticated /discover (WAYF) flow uses the untrusted
+public-only client. Body-supplied discovery in the open authorizer and on
+received Discover/ExchangeToken requests is routed through NewPublicOnlyClient,
+closing a redirect-to-link-local SSRF on received Discover.
+
+An exported UntrustedHTTPTransport helper lets gowebdav callers use the same
+dial rules. That transport is installed on WebDAV ingest-stat, received-share
+WebDAV access, and embedded srcURL fetch. A cohesive public-only dial-refusal
+test matrix covers the refusal cases.
+
+https://github.com/cs3org/reva/pull/5389
+https://github.com/cs3org/reva/pull/5752

--- a/changelog/unreleased/ocm-client-hardening.md
+++ b/changelog/unreleased/ocm-client-hardening.md
@@ -1,22 +1,19 @@
-Security: harden OCM outbound HTTP clients after public-only client
+Security: extend OCM untrusted HTTP client hardening
 
-Following the public-only client work merged in #5752, outbound OCM HTTP
-calls now share tighter limits and one untrusted transport path. Discovery,
-share, and ExchangeToken response bodies are capped at 1 MiB with
-io.LimitReader. NewPublicOnlyClient enforces HTTPS-only URLs, limits
-redirects to three hops, and sets TLS 1.2 as the minimum on OCM client
-transports.
-
-ScienceMesh gained flat ocm_client_response_limit and ocm_client_timeout
-config fields. The unauthenticated /discover (WAYF) flow uses the untrusted
-public-only client. Body-supplied discovery in the open authorizer and on
-received Discover/ExchangeToken requests is routed through NewPublicOnlyClient,
-closing a redirect-to-link-local SSRF on received Discover.
-
-An exported UntrustedHTTPTransport helper lets gowebdav callers use the same
-dial rules. That transport is installed on WebDAV ingest-stat, received-share
-WebDAV access, and embedded srcURL fetch. A cohesive public-only dial-refusal
-test matrix covers the refusal cases.
+Outbound OCM HTTP clients for peer-supplied URLs now share the additive
+UntrustedClientSecurity type and a public-only transport. net.Dialer.Control
+refuses non-public dial targets against SSRF, DNS rebinding, and cloud
+metadata access; URLs must be HTTPS; redirect chains default to three hops;
+OCM JSON response bodies default to 1 MiB; and TLS defaults to 1.2.
+The ocm_client_security block and ocm_client_response_limit,
+ocm_client_tls_min_version, ocm_client_dial_timeout, and ocm_client_timeout
+knobs remain configurable. Received storage split WebDAV metadata clients from
+WebDAV streaming clients, with webdav_dial_timeout for dial deadlines and
+webdav_timeout for metadata request deadlines (streams stay uncapped);
+webdav_transfer_timeout is reserved for a follow-up idle stall monitor and
+does not cap streams. ocm_allow_loopback_federation adds
+an off-by-default, WebDAV-only loopback hatch. ScienceMesh reuses the ocmd
+public-only client, regression tests cover the hardening paths, and unused
+gateway WebDAV storage provider code was removed.
 
 https://github.com/cs3org/reva/pull/5389
-https://github.com/cs3org/reva/pull/5752

--- a/internal/grpc/services/gateway/webdavstorageprovider.go
+++ b/internal/grpc/services/gateway/webdavstorageprovider.go
@@ -20,197 +20,20 @@ package gateway
 
 import (
 	"context"
-	"fmt"
 	"net/url"
 	"path"
 	"strings"
 
 	ocmprovider "github.com/cs3org/go-cs3apis/cs3/ocm/provider/v1beta1"
-	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
-	types "github.com/cs3org/go-cs3apis/cs3/types/v1beta1"
 
-	"github.com/cs3org/reva/v3/pkg/appctx"
 	"github.com/cs3org/reva/v3/pkg/errtypes"
 	"github.com/pkg/errors"
-	"github.com/studio-b12/gowebdav"
 )
 
 type webdavEndpoint struct {
 	filePath string
 	endpoint string
 	token    string
-}
-
-func (s *svc) webdavRefStat(ctx context.Context, targetURL string, nameQueries ...string) (*provider.ResourceInfo, error) {
-	targetURL, err := appendNameQuery(targetURL, nameQueries...)
-	if err != nil {
-		return nil, err
-	}
-
-	ep, err := s.extractEndpointInfo(ctx, targetURL)
-	if err != nil {
-		return nil, err
-	}
-	webdavEP, err := s.getWebdavEndpoint(ctx, ep.endpoint)
-	if err != nil {
-		return nil, err
-	}
-
-	c := gowebdav.NewClient(webdavEP, "", "")
-	c.SetHeader(appctx.TokenHeader, ep.token)
-
-	// TODO(ishank011): We need to call PROPFIND ourselves as we need to retrieve
-	// ownloud-specific fields to get the resource ID and permissions.
-	info, err := c.Stat(ep.filePath)
-	if err != nil {
-		return nil, errors.Wrap(err, fmt.Sprintf("gateway: error statting %s at the webdav endpoint: %s", ep.filePath, webdavEP))
-	}
-	return normalize(info.(*gowebdav.File)), nil
-}
-
-func (s *svc) webdavRefLs(ctx context.Context, targetURL string, nameQueries ...string) ([]*provider.ResourceInfo, error) {
-	targetURL, err := appendNameQuery(targetURL, nameQueries...)
-	if err != nil {
-		return nil, err
-	}
-
-	ep, err := s.extractEndpointInfo(ctx, targetURL)
-	if err != nil {
-		return nil, err
-	}
-	webdavEP, err := s.getWebdavEndpoint(ctx, ep.endpoint)
-	if err != nil {
-		return nil, err
-	}
-
-	c := gowebdav.NewClient(webdavEP, "", "")
-	c.SetHeader(appctx.TokenHeader, ep.token)
-
-	// TODO(ishank011): We need to call PROPFIND ourselves as we need to retrieve
-	// ownloud-specific fields to get the resource ID and permissions.
-	infos, err := c.ReadDir(ep.filePath)
-	if err != nil {
-		return nil, errors.Wrap(err, fmt.Sprintf("gateway: error listing %s at the webdav endpoint: %s", ep.filePath, webdavEP))
-	}
-
-	mds := []*provider.ResourceInfo{}
-	for _, fi := range infos {
-		info := fi.(gowebdav.File)
-		mds = append(mds, normalize(&info))
-	}
-	return mds, nil
-}
-
-func (s *svc) webdavRefMkdir(ctx context.Context, targetURL string, nameQueries ...string) error {
-	targetURL, err := appendNameQuery(targetURL, nameQueries...)
-	if err != nil {
-		return err
-	}
-
-	ep, err := s.extractEndpointInfo(ctx, targetURL)
-	if err != nil {
-		return err
-	}
-	webdavEP, err := s.getWebdavEndpoint(ctx, ep.endpoint)
-	if err != nil {
-		return err
-	}
-
-	c := gowebdav.NewClient(webdavEP, "", "")
-	c.SetHeader(appctx.TokenHeader, ep.token)
-
-	err = c.Mkdir(ep.filePath, 0700)
-	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("gateway: error creating dir %s at the webdav endpoint: %s", ep.filePath, webdavEP))
-	}
-	return nil
-}
-
-func (s *svc) webdavRefMove(ctx context.Context, targetURL, src, destination string) error {
-	srcURL, err := appendNameQuery(targetURL, src)
-	if err != nil {
-		return err
-	}
-	srcEP, err := s.extractEndpointInfo(ctx, srcURL)
-	if err != nil {
-		return err
-	}
-	srcWebdavEP, err := s.getWebdavEndpoint(ctx, srcEP.endpoint)
-	if err != nil {
-		return err
-	}
-
-	destURL, err := appendNameQuery(targetURL, destination)
-	if err != nil {
-		return err
-	}
-	destEP, err := s.extractEndpointInfo(ctx, destURL)
-	if err != nil {
-		return err
-	}
-
-	c := gowebdav.NewClient(srcWebdavEP, "", "")
-	c.SetHeader(appctx.TokenHeader, srcEP.token)
-
-	err = c.Rename(srcEP.filePath, destEP.filePath, true)
-	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("gateway: error renaming %s to %s at the webdav endpoint: %s", srcEP.filePath, destEP.filePath, srcWebdavEP))
-	}
-	return nil
-}
-
-func (s *svc) webdavRefDelete(ctx context.Context, targetURL string, nameQueries ...string) error {
-	targetURL, err := appendNameQuery(targetURL, nameQueries...)
-	if err != nil {
-		return err
-	}
-
-	ep, err := s.extractEndpointInfo(ctx, targetURL)
-	if err != nil {
-		return err
-	}
-	webdavEP, err := s.getWebdavEndpoint(ctx, ep.endpoint)
-	if err != nil {
-		return err
-	}
-
-	c := gowebdav.NewClient(webdavEP, "", "")
-	c.SetHeader(appctx.TokenHeader, ep.token)
-
-	err = c.Remove(ep.filePath)
-	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("gateway: error removing %s at the webdav endpoint: %s", ep.filePath, webdavEP))
-	}
-	return nil
-}
-
-func (s *svc) webdavRefTransferEndpoint(ctx context.Context, targetURL string, nameQueries ...string) (string, *types.Opaque, error) {
-	targetURL, err := appendNameQuery(targetURL, nameQueries...)
-	if err != nil {
-		return "", nil, err
-	}
-
-	ep, err := s.extractEndpointInfo(ctx, targetURL)
-	if err != nil {
-		return "", nil, err
-	}
-	webdavEP, err := s.getWebdavEndpoint(ctx, ep.endpoint)
-	if err != nil {
-		return "", nil, err
-	}
-
-	return webdavEP, &types.Opaque{
-		Map: map[string]*types.OpaqueEntry{
-			"webdav-file-path": {
-				Decoder: "plain",
-				Value:   []byte(ep.filePath),
-			},
-			"webdav-token": {
-				Decoder: "plain",
-				Value:   []byte(ep.token),
-			},
-		},
-	}, nil
 }
 
 func (s *svc) extractEndpointInfo(ctx context.Context, targetURL string) (*webdavEndpoint, error) {
@@ -266,27 +89,6 @@ func (s *svc) getWebdavHost(ctx context.Context, domain string) (string, error) 
 		}
 	}
 	return "", errtypes.NotFound(domain)
-}
-
-func normalize(info *gowebdav.File) *provider.ResourceInfo {
-	return &provider.ResourceInfo{
-		// TODO(ishank011): Add Id, PermissionSet, Owner
-		Path:     info.Path(),
-		Type:     getResourceType(info.IsDir()),
-		Etag:     info.ETag(),
-		MimeType: info.ContentType(),
-		Size:     uint64(info.Size()),
-		Mtime: &types.Timestamp{
-			Seconds: uint64(info.ModTime().Unix()),
-		},
-	}
-}
-
-func getResourceType(isDir bool) provider.ResourceType {
-	if isDir {
-		return provider.ResourceType_RESOURCE_TYPE_CONTAINER
-	}
-	return provider.ResourceType_RESOURCE_TYPE_FILE
 }
 
 func appendNameQuery(targetURL string, nameQueries ...string) (string, error) {

--- a/internal/grpc/services/ocminvitemanager/ocminvitemanager.go
+++ b/internal/grpc/services/ocminvitemanager/ocminvitemanager.go
@@ -113,7 +113,7 @@ func New(ctx context.Context, m map[string]any) (rgrpc.Service, error) {
 	service := &service{
 		conf:      &c,
 		repo:      repo,
-		ocmClient: ocmd.NewClient(time.Duration(c.OCMClientTimeout)*time.Second, c.OCMClientInsecure),
+		ocmClient: ocmd.NewClient(time.Duration(c.OCMClientTimeout)*time.Second, c.OCMClientInsecure, 0),
 	}
 	return service, nil
 }

--- a/internal/grpc/services/ocmshareprovider/ocmshareprovider.go
+++ b/internal/grpc/services/ocmshareprovider/ocmshareprovider.go
@@ -146,7 +146,7 @@ func New(ctx context.Context, m map[string]any) (rgrpc.Service, error) {
 
 	walker := walker.NewWalker(gateway)
 
-	ocmcl := ocmd.NewClient(time.Duration(c.ClientTimeout)*time.Second, c.ClientInsecure)
+	ocmcl := ocmd.NewClient(time.Duration(c.ClientTimeout)*time.Second, c.ClientInsecure, 0)
 	service := &service{
 		conf:        &c,
 		repo:        repo,

--- a/internal/http/services/opencloudmesh/ocmd/client.go
+++ b/internal/http/services/opencloudmesh/ocmd/client.go
@@ -280,7 +280,7 @@ func validateURL(u *url.URL, cfg *ClientSecurityConfig) error {
 
 	ips, err := net.LookupIP(host)
 	if err != nil {
-		return errors.Wrapf(ErrURLValidationFailed, "DNS resolution failed: %w", err)
+		return errors.Wrapf(ErrURLValidationFailed, "DNS resolution failed: %v", err)
 	}
 
 	for _, ip := range ips {
@@ -359,7 +359,7 @@ func (c *OCMClient) Discover(ctx context.Context, endpoint string) (*wellknown.O
 
 	endpointURL, err := url.Parse(endpoint)
 	if err != nil {
-		return nil, errors.Wrapf(ErrURLValidationFailed, "invalid endpoint URL: %w", err)
+		return nil, errors.Wrapf(ErrURLValidationFailed, "invalid endpoint URL: %v", err)
 	}
 	if err := validateURL(endpointURL, c.cfg); err != nil {
 		return nil, errors.Wrapf(err, "endpoint URL validation failed")
@@ -437,7 +437,7 @@ func (c *OCMClient) NewShare(ctx context.Context, endpoint string, r *NewShareRe
 
 	endpointURL, err := url.Parse(endpoint)
 	if err != nil {
-		return nil, errors.Wrapf(ErrURLValidationFailed, "invalid endpoint URL: %w", err)
+		return nil, errors.Wrapf(ErrURLValidationFailed, "invalid endpoint URL: %v", err)
 	}
 	if err := validateURL(endpointURL, c.cfg); err != nil {
 		return nil, errors.Wrapf(err, "endpoint URL validation failed")
@@ -528,7 +528,7 @@ func (c *OCMClient) InviteAccepted(ctx context.Context, endpoint string, r *Invi
 
 	endpointURL, err := url.Parse(endpoint)
 	if err != nil {
-		return nil, errors.Wrapf(ErrURLValidationFailed, "invalid endpoint URL: %w", err)
+		return nil, errors.Wrapf(ErrURLValidationFailed, "invalid endpoint URL: %v", err)
 	}
 	if err := validateURL(endpointURL, c.cfg); err != nil {
 		return nil, errors.Wrapf(err, "endpoint URL validation failed")
@@ -627,7 +627,7 @@ func (c *OCMClient) GetDirectoryService(ctx context.Context, directoryURL string
 
 	endpointURL, err := url.Parse(directoryURL)
 	if err != nil {
-		return nil, errors.Wrapf(ErrURLValidationFailed, "invalid directory service URL: %w", err)
+		return nil, errors.Wrapf(ErrURLValidationFailed, "invalid directory service URL: %v", err)
 	}
 	if err := validateURL(endpointURL, c.cfg); err != nil {
 		return nil, errors.Wrapf(err, "directory service URL validation failed")

--- a/internal/http/services/opencloudmesh/ocmd/client.go
+++ b/internal/http/services/opencloudmesh/ocmd/client.go
@@ -24,8 +24,11 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/cs3org/reva/v3/internal/http/services/wellknown"
@@ -50,21 +53,301 @@ var ErrUserAlreadyAccepted = errors.New("invitation already accepted")
 // when the request does not contain required properties.
 var ErrInvalidParameters = errors.New("invalid parameters")
 
+// ErrURLValidationFailed is returned when URL validation fails.
+var ErrURLValidationFailed = errors.New("URL validation failed")
+
+// ErrResponseTooLarge is returned when response exceeds maximum allowed size.
+var ErrResponseTooLarge = errors.New("response exceeds maximum allowed size")
+
+// ClientSecurityConfig holds all security configuration options for the OCM client.
+type ClientSecurityConfig struct {
+	// Response limits
+	MaxDiscoveryResponseBytes int64
+	MaxShareResponseBytes     int64
+	MaxErrorResponseBytes     int64
+	MaxResponseHeaderBytes    int64
+
+	// Timeouts
+	ConnectionTimeout     time.Duration
+	TLSHandshakeTimeout   time.Duration
+	ResponseHeaderTimeout time.Duration
+	IdleConnTimeout       time.Duration
+	OverallTimeout        time.Duration
+
+	// Redirect control
+	MaxRedirects               int
+	ValidateRedirectTargets    bool
+	AllowRedirectsToPrivateIPs bool
+
+	// SSRF prevention
+	BlockPrivateIPs  bool
+	BlockLinkLocal   bool
+	BlockLoopback    bool
+	AllowedSchemes   []string
+	AllowedPorts     []int
+	ValidateIPAtDial bool
+
+	// TLS
+	MinTLSVersion      uint16
+	InsecureSkipVerify bool
+}
+
+// ApplyDefaults sets default values for unset configuration options.
+func (c *ClientSecurityConfig) ApplyDefaults() {
+	// TODO(@MahdiBaghbani): default values are up for debate!
+	if c.MaxDiscoveryResponseBytes == 0 {
+		c.MaxDiscoveryResponseBytes = 25 * 1024 // 10 KB
+	}
+	if c.MaxShareResponseBytes == 0 {
+		c.MaxShareResponseBytes = 50 * 1024 // 50 KB
+	}
+	if c.MaxErrorResponseBytes == 0 {
+		c.MaxErrorResponseBytes = 50 * 1024 // 50 KB
+	}
+	if c.MaxResponseHeaderBytes == 0 {
+		c.MaxResponseHeaderBytes = 4 * 1024 // 4 KB
+	}
+	if c.ConnectionTimeout == 0 {
+		c.ConnectionTimeout = 5 * time.Second
+	}
+	if c.TLSHandshakeTimeout == 0 {
+		c.TLSHandshakeTimeout = 5 * time.Second
+	}
+	if c.ResponseHeaderTimeout == 0 {
+		c.ResponseHeaderTimeout = 10 * time.Second
+	}
+	if c.IdleConnTimeout == 0 {
+		c.IdleConnTimeout = 30 * time.Second
+	}
+	if c.OverallTimeout == 0 {
+		c.OverallTimeout = 30 * time.Second
+	}
+	if c.MaxRedirects == 0 {
+		c.MaxRedirects = 3
+	}
+	c.ValidateRedirectTargets = true
+
+	if len(c.AllowedSchemes) == 0 {
+		// TODO(@MahdiBaghbani): @gplatcern we can allow http as well in dev env
+		c.AllowedSchemes = []string{"https"}
+	}
+	if c.MinTLSVersion == 0 {
+		c.MinTLSVersion = tls.VersionTLS12
+	}
+	c.ValidateIPAtDial = true
+
+	// TODO(@MahdiBaghbani): @gplatcern we can allow these in dev env
+	// BlockPrivateIPs, BlockLinkLocal, BlockLoopback default to true
+	if !c.BlockPrivateIPs && !c.BlockLinkLocal && !c.BlockLoopback {
+		// If none were set, apply secure defaults
+		c.BlockPrivateIPs = true
+		c.BlockLinkLocal = true
+		c.BlockLoopback = true
+	}
+}
+
 // OCMClient is the client for an OCM provider.
 type OCMClient struct {
 	client *http.Client
+	cfg    *ClientSecurityConfig
 }
 
-// NewClient returns a new OCMClient.
-func NewClient(timeout time.Duration, insecure bool) *OCMClient {
-	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: insecure},
+// NewClientWithConfig creates a new OCMClient with security configuration.
+func NewClientWithConfig(cfg *ClientSecurityConfig) *OCMClient {
+	if cfg == nil {
+		cfg = &ClientSecurityConfig{}
 	}
-	return &OCMClient{
-		client: &http.Client{
-			Transport: tr,
-			Timeout:   timeout,
+	cfg.ApplyDefaults()
+
+	baseDialer := &net.Dialer{
+		Timeout:   cfg.ConnectionTimeout,
+		KeepAlive: 30 * time.Second,
+	}
+
+	tr := &http.Transport{
+		DialContext:            secureDialContext(cfg, baseDialer),
+		TLSHandshakeTimeout:    cfg.TLSHandshakeTimeout,
+		ResponseHeaderTimeout:  cfg.ResponseHeaderTimeout,
+		IdleConnTimeout:        cfg.IdleConnTimeout,
+		MaxResponseHeaderBytes: cfg.MaxResponseHeaderBytes,
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: cfg.InsecureSkipVerify,
+			MinVersion:         cfg.MinTLSVersion,
 		},
+	}
+
+	client := &OCMClient{
+		cfg: cfg,
+	}
+	client.client = &http.Client{
+		Transport:     tr,
+		Timeout:       cfg.OverallTimeout,
+		CheckRedirect: redirectChecker(cfg, client),
+	}
+
+	return client
+}
+
+// NewClient returns a new OCMClient with backward compatible API.
+// It creates a secure client with defaults, using the provided timeout and insecure settings.
+func NewClient(timeout time.Duration, insecure bool) *OCMClient {
+	cfg := &ClientSecurityConfig{
+		OverallTimeout:     timeout,
+		InsecureSkipVerify: insecure,
+	}
+	return NewClientWithConfig(cfg)
+}
+
+// isPrivateIP checks if an IP address is in a private/internal range based on configuration.
+func isPrivateIP(ip net.IP, cfg *ClientSecurityConfig) bool {
+	if ip == nil {
+		return false
+	}
+
+	if cfg.BlockLoopback && ip.IsLoopback() {
+		return true
+	}
+
+	if cfg.BlockLinkLocal && (ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast()) {
+		return true
+	}
+
+	// RFC 1918 and IPv6 private
+	if cfg.BlockPrivateIPs {
+		privateBlocks := []string{
+			"10.0.0.0/8",
+			"172.16.0.0/12",
+			"192.168.0.0/16",
+			"fc00::/7",
+		}
+
+		for _, block := range privateBlocks {
+			_, subnet, err := net.ParseCIDR(block)
+			if err != nil {
+				continue
+			}
+			if subnet.Contains(ip) {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+// validateURL validates a URL against security configuration to prevent SSRF attacks.
+func validateURL(u *url.URL, cfg *ClientSecurityConfig) error {
+	if u == nil {
+		return errors.Wrap(ErrURLValidationFailed, "nil URL")
+	}
+
+	schemeAllowed := false
+	for _, allowedScheme := range cfg.AllowedSchemes {
+		if strings.EqualFold(u.Scheme, allowedScheme) {
+			schemeAllowed = true
+			break
+		}
+	}
+	if !schemeAllowed {
+		return errors.Wrapf(ErrURLValidationFailed, "scheme %s not allowed", u.Scheme)
+	}
+
+	if len(cfg.AllowedPorts) > 0 {
+		portStr := u.Port()
+		if portStr != "" {
+			port, err := strconv.Atoi(portStr)
+			if err != nil {
+				return errors.Wrapf(ErrURLValidationFailed, "invalid port: %s", portStr)
+			}
+			portAllowed := false
+			for _, allowedPort := range cfg.AllowedPorts {
+				if port == allowedPort {
+					portAllowed = true
+					break
+				}
+			}
+			if !portAllowed {
+				return errors.Wrapf(ErrURLValidationFailed, "port %d not allowed", port)
+			}
+		}
+	}
+
+	host := u.Hostname()
+	if host == "" {
+		return errors.Wrap(ErrURLValidationFailed, "empty hostname")
+	}
+
+	ips, err := net.LookupIP(host)
+	if err != nil {
+		return errors.Wrapf(ErrURLValidationFailed, "DNS resolution failed: %w", err)
+	}
+
+	for _, ip := range ips {
+		if isPrivateIP(ip, cfg) {
+			return errors.Wrapf(ErrURLValidationFailed, "private/internal IP address blocked: %s", ip)
+		}
+	}
+
+	return nil
+}
+
+// secureDialContext creates a dialer that validates IPs at connection time to prevent DNS rebinding.
+func secureDialContext(cfg *ClientSecurityConfig, baseDialer *net.Dialer) func(context.Context, string, string) (net.Conn, error) {
+	return func(ctx context.Context, network, addr string) (net.Conn, error) {
+		if cfg.ValidateIPAtDial {
+			host, _, err := net.SplitHostPort(addr)
+			if err != nil {
+				return nil, errors.Wrap(err, "failed to split host:port")
+			}
+
+			ip := net.ParseIP(host)
+			if ip != nil {
+				if isPrivateIP(ip, cfg) {
+					return nil, errors.Errorf("private IP blocked at dial time: %s", ip)
+				}
+			} else {
+				// Resolve hostname and validate all IPs
+				ips, err := net.LookupIP(host)
+				if err != nil {
+					return nil, errors.Wrapf(err, "DNS resolution failed at dial time: %s", host)
+				}
+				for _, resolvedIP := range ips {
+					if isPrivateIP(resolvedIP, cfg) {
+						return nil, errors.Errorf("private IP blocked at dial time: %s (resolved from %s)", resolvedIP, host)
+					}
+				}
+			}
+		}
+
+		return baseDialer.DialContext(ctx, network, addr)
+	}
+}
+
+// redirectChecker creates a CheckRedirect function that validates redirect targets.
+func redirectChecker(cfg *ClientSecurityConfig, client *OCMClient) func(*http.Request, []*http.Request) error {
+	return func(req *http.Request, via []*http.Request) error {
+		// Enforce redirect count limit
+		if len(via) >= cfg.MaxRedirects {
+			return errors.Errorf("stopped after %d redirects", cfg.MaxRedirects)
+		}
+
+		// Validate redirect target if enabled
+		if cfg.ValidateRedirectTargets {
+			// Create a temporary config for redirect validation
+			// Allow private IPs if AllowRedirectsToPrivateIPs is true
+			redirectCfg := *cfg
+			if cfg.AllowRedirectsToPrivateIPs {
+				redirectCfg.BlockPrivateIPs = false
+				redirectCfg.BlockLinkLocal = false
+				redirectCfg.BlockLoopback = false
+			}
+
+			if err := validateURL(req.URL, &redirectCfg); err != nil {
+				return errors.Wrapf(err, "redirect blocked: %s", req.URL)
+			}
+		}
+
+		return nil
 	}
 }
 
@@ -72,6 +355,17 @@ func NewClient(timeout time.Duration, insecure bool) *OCMClient {
 // https://cs3org.github.io/OCM-API/docs.html?branch=develop&repo=OCM-API&user=cs3org#/paths/~1ocm-provider/get
 func (c *OCMClient) Discover(ctx context.Context, endpoint string) (*wellknown.OcmDiscoveryData, error) {
 	log := appctx.GetLogger(ctx)
+
+	endpointURL, err := url.Parse(endpoint)
+	if err != nil {
+		return nil, errors.Wrapf(ErrURLValidationFailed, "invalid endpoint URL: %w", err)
+	}
+	if err := validateURL(endpointURL, c.cfg); err != nil {
+		return nil, errors.Wrapf(err, "endpoint URL validation failed")
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, c.cfg.OverallTimeout)
+	defer cancel()
 
 	remoteurl, _ := url.JoinPath(endpoint, "/.well-known/ocm")
 	body, err := c.discover(ctx, remoteurl)
@@ -97,10 +391,10 @@ func (c *OCMClient) Discover(ctx context.Context, endpoint string) (*wellknown.O
 	return &disco, nil
 }
 
-func (c *OCMClient) discover(ctx context.Context, url string) ([]byte, error) {
+func (c *OCMClient) discover(ctx context.Context, urlStr string) ([]byte, error) {
 	log := appctx.GetLogger(ctx)
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, urlStr, nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "error creating OCM discovery request")
 	}
@@ -117,21 +411,40 @@ func (c *OCMClient) discover(ctx context.Context, url string) ([]byte, error) {
 		}
 	}(resp.Body)
 	if resp.StatusCode != http.StatusOK {
-		log.Warn().Str("sender", url).Int("status", resp.StatusCode).Msg("discovery returned")
+		log.Warn().Str("sender", urlStr).Int("status", resp.StatusCode).Msg("discovery returned")
 		return nil, errtypes.InternalError("Remote does not offer a valid OCM discovery endpoint")
 	}
 
-	body, err := io.ReadAll(resp.Body)
+	limitedBody := io.LimitReader(resp.Body, c.cfg.MaxShareResponseBytes+1)
+	body, err := io.ReadAll(limitedBody)
 	if err != nil {
 		return nil, errors.Wrap(err, "malformed remote OCM discovery")
 	}
+	// TODO(@MahdiBaghbani): @glpatcern so this would be only 1 byte bigger, should we tolerate it?
+	if int64(len(body)) > c.cfg.MaxShareResponseBytes {
+		return nil, ErrResponseTooLarge
+	}
+
 	return body, nil
 }
 
 // NewShare sends a new OCM share to the remote system.
 // https://cs3org.github.io/OCM-API/docs.html?branch=develop&repo=OCM-API&user=cs3org#/paths/~1shares/post
 func (c *OCMClient) NewShare(ctx context.Context, endpoint string, r *NewShareRequest) (*NewShareResponse, error) {
-	url, err := url.JoinPath(endpoint, "shares")
+	log := appctx.GetLogger(ctx)
+
+	endpointURL, err := url.Parse(endpoint)
+	if err != nil {
+		return nil, errors.Wrapf(ErrURLValidationFailed, "invalid endpoint URL: %w", err)
+	}
+	if err := validateURL(endpointURL, c.cfg); err != nil {
+		return nil, errors.Wrapf(err, "endpoint URL validation failed")
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, c.cfg.OverallTimeout)
+	defer cancel()
+
+	urlStr, err := url.JoinPath(endpoint, "shares")
 	if err != nil {
 		return nil, err
 	}
@@ -140,9 +453,8 @@ func (c *OCMClient) NewShare(ctx context.Context, endpoint string, r *NewShareRe
 		return nil, err
 	}
 
-	log := appctx.GetLogger(ctx)
-	log.Info().Str("url", url).Str("payload", string(body)).Msg("Sending OCM share")
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	log.Info().Str("url", urlStr).Str("payload", string(body)).Msg("Sending OCM share")
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, urlStr, bytes.NewReader(body))
 	if err != nil {
 		return nil, errors.Wrap(err, "error creating request")
 	}
@@ -152,7 +464,12 @@ func (c *OCMClient) NewShare(ctx context.Context, endpoint string, r *NewShareRe
 	if err != nil {
 		return nil, errors.Wrap(err, "error sending request")
 	}
-	defer resp.Body.Close()
+	defer func(body io.ReadCloser) {
+		err := body.Close()
+		if err != nil {
+			log.Warn().Err(err).Msg("error closing response body")
+		}
+	}(resp.Body)
 
 	sresp, err := c.parseNewShareResponse(resp)
 	if sresp != nil {
@@ -166,26 +483,59 @@ func (c *OCMClient) NewShare(ctx context.Context, endpoint string, r *NewShareRe
 func (c *OCMClient) parseNewShareResponse(r *http.Response) (*NewShareResponse, error) {
 	switch r.StatusCode {
 	case http.StatusOK, http.StatusCreated:
+		// Apply response size limit for successful responses
+		limitedBody := io.LimitReader(r.Body, c.cfg.MaxShareResponseBytes+1)
+		data, err := io.ReadAll(limitedBody)
+		if err != nil {
+			return nil, errors.Wrap(err, "error reading response body")
+		}
+		if int64(len(data)) > c.cfg.MaxShareResponseBytes {
+			return nil, ErrResponseTooLarge
+		}
+
 		var res NewShareResponse
-		err := json.NewDecoder(r.Body).Decode(&res)
-		return &res, err
+		err = json.NewDecoder(limitedBody).Decode(&res)
+
+		if err != nil {
+			return nil, errors.Wrap(err, "error decoding response body")
+		}
+		return &res, nil
 	case http.StatusBadRequest:
 		return nil, ErrInvalidParameters
 	case http.StatusUnauthorized, http.StatusForbidden:
 		return nil, ErrServiceNotTrusted
 	}
 
-	body, err := io.ReadAll(r.Body)
+	limitedBody := io.LimitReader(r.Body, c.cfg.MaxErrorResponseBytes+1)
+	body, err := io.ReadAll(limitedBody)
 	if err != nil {
 		return nil, errors.Wrap(err, "error decoding response body")
 	}
+	// TODO(@MahdiBaghbani): @glpatcern so this would be only 1 byte bigger, should we tolerate it?
+	if int64(len(body)) > c.cfg.MaxErrorResponseBytes {
+		return nil, ErrResponseTooLarge
+	}
+	// TODO(@MahdiBaghbani): @glpatcern is string() necessary here?
 	return nil, errtypes.InternalError(string(body))
 }
 
 // InviteAccepted informs the remote end that the invitation was accepted
 // https://cs3org.github.io/OCM-API/docs.html?branch=develop&repo=OCM-API&user=cs3org#/paths/~1invite-accepted/post
 func (c *OCMClient) InviteAccepted(ctx context.Context, endpoint string, r *InviteAcceptedRequest) (*RemoteUser, error) {
-	url, err := url.JoinPath(endpoint, "invite-accepted")
+	log := appctx.GetLogger(ctx)
+
+	endpointURL, err := url.Parse(endpoint)
+	if err != nil {
+		return nil, errors.Wrapf(ErrURLValidationFailed, "invalid endpoint URL: %w", err)
+	}
+	if err := validateURL(endpointURL, c.cfg); err != nil {
+		return nil, errors.Wrapf(err, "endpoint URL validation failed")
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, c.cfg.OverallTimeout)
+	defer cancel()
+
+	urlStr, err := url.JoinPath(endpoint, "invite-accepted")
 	if err != nil {
 		return nil, err
 	}
@@ -194,9 +544,8 @@ func (c *OCMClient) InviteAccepted(ctx context.Context, endpoint string, r *Invi
 		return nil, err
 	}
 
-	log := appctx.GetLogger(ctx)
-	log.Info().Str("url", url).Str("payload", string(body)).Msg("Sending OCM invite-accepted")
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	log.Info().Str("url", urlStr).Str("payload", string(body)).Msg("Sending OCM invite-accepted")
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, urlStr, bytes.NewReader(body))
 	if err != nil {
 		return nil, errors.Wrap(err, "error creating request")
 	}
@@ -206,7 +555,12 @@ func (c *OCMClient) InviteAccepted(ctx context.Context, endpoint string, r *Invi
 	if err != nil {
 		return nil, errors.Wrap(err, "error sending request")
 	}
-	defer resp.Body.Close()
+	defer func(body io.ReadCloser) {
+		err := body.Close()
+		if err != nil {
+			log.Warn().Err(err).Msg("error closing response body")
+		}
+	}(resp.Body)
 
 	u, err := c.parseInviteAcceptedResponse(resp)
 	if u != nil {
@@ -220,8 +574,20 @@ func (c *OCMClient) InviteAccepted(ctx context.Context, endpoint string, r *Invi
 func (c *OCMClient) parseInviteAcceptedResponse(r *http.Response) (*RemoteUser, error) {
 	switch r.StatusCode {
 	case http.StatusOK:
+		// Apply response size limit for successful responses
+		limitedBody := io.LimitReader(r.Body, c.cfg.MaxShareResponseBytes+1)
+		data, err := io.ReadAll(limitedBody)
+		if err != nil {
+			return nil, errors.Wrap(err, "error reading response body")
+		}
+		if int64(len(data)) > c.cfg.MaxShareResponseBytes {
+			return nil, ErrResponseTooLarge
+		}
+
 		var u RemoteUser
-		if err := json.NewDecoder(r.Body).Decode(&u); err != nil {
+		err = json.NewDecoder(limitedBody).Decode(&u)
+
+		if err != nil {
 			return nil, errors.Wrap(err, "error decoding response body")
 		}
 		return &u, nil
@@ -233,10 +599,17 @@ func (c *OCMClient) parseInviteAcceptedResponse(r *http.Response) (*RemoteUser, 
 		return nil, ErrServiceNotTrusted
 	}
 
-	body, err := io.ReadAll(r.Body)
+	// Apply response size limit for error responses
+	limitedBody := io.LimitReader(r.Body, c.cfg.MaxErrorResponseBytes+1)
+	body, err := io.ReadAll(limitedBody)
 	if err != nil {
 		return nil, errors.Wrap(err, "error decoding response body")
 	}
+	// TODO(@MahdiBaghbani): @glpatcern so this would be only 1 byte bigger, should we tolerate it?
+	if int64(len(body)) > c.cfg.MaxErrorResponseBytes {
+		return nil, ErrResponseTooLarge
+	}
+	// TODO(@MahdiBaghbani): @glpatcern is string() necessary here?
 	return nil, errtypes.InternalError(string(body))
 }
 

--- a/internal/http/services/opencloudmesh/ocmd/client.go
+++ b/internal/http/services/opencloudmesh/ocmd/client.go
@@ -63,34 +63,34 @@ var ErrResponseTooLarge = errors.New("response exceeds maximum allowed size")
 // ClientSecurityConfig holds all security configuration options for the OCM client.
 type ClientSecurityConfig struct {
 	// Response limits
-	MaxDiscoveryResponseBytes int64
-	MaxShareResponseBytes     int64
-	MaxErrorResponseBytes     int64
-	MaxResponseHeaderBytes    int64
+	MaxDiscoveryResponseBytes int64 `mapstructure:"max_discovery_response_bytes"`
+	MaxShareResponseBytes     int64 `mapstructure:"max_share_response_bytes"`
+	MaxErrorResponseBytes     int64 `mapstructure:"max_error_response_bytes"`
+	MaxResponseHeaderBytes    int64 `mapstructure:"max_response_header_bytes"`
 
 	// Timeouts
-	ConnectionTimeout     time.Duration
-	TLSHandshakeTimeout   time.Duration
-	ResponseHeaderTimeout time.Duration
-	IdleConnTimeout       time.Duration
-	OverallTimeout        time.Duration
+	ConnectionTimeout     time.Duration `mapstructure:"connection_timeout"`
+	TLSHandshakeTimeout   time.Duration `mapstructure:"tls_handshake_timeout"`
+	ResponseHeaderTimeout time.Duration `mapstructure:"response_header_timeout"`
+	IdleConnTimeout       time.Duration `mapstructure:"idle_conn_timeout"`
+	OverallTimeout        time.Duration `mapstructure:"overall_timeout"`
 
 	// Redirect control
-	MaxRedirects               int
-	ValidateRedirectTargets    bool
-	AllowRedirectsToPrivateIPs bool
+	MaxRedirects               int  `mapstructure:"max_redirects"`
+	ValidateRedirectTargets    bool `mapstructure:"validate_redirect_targets"`
+	AllowRedirectsToPrivateIPs bool `mapstructure:"allow_redirects_to_private_ips"`
 
 	// SSRF prevention
-	BlockPrivateIPs  bool
-	BlockLinkLocal   bool
-	BlockLoopback    bool
-	AllowedSchemes   []string
-	AllowedPorts     []int
-	ValidateIPAtDial bool
+	BlockPrivateIPs  bool     `mapstructure:"block_private_ips"`
+	BlockLinkLocal   bool     `mapstructure:"block_link_local"`
+	BlockLoopback    bool     `mapstructure:"block_loopback"`
+	AllowedSchemes   []string `mapstructure:"allowed_schemes"`
+	AllowedPorts     []int    `mapstructure:"allowed_ports"`
+	ValidateIPAtDial bool     `mapstructure:"validate_ip_at_dial"`
 
 	// TLS
-	MinTLSVersion      uint16
-	InsecureSkipVerify bool
+	MinTLSVersion      uint16 `mapstructure:"min_tls_version"`
+	InsecureSkipVerify bool   `mapstructure:"insecure_skip_verify"`
 }
 
 // ApplyDefaults sets default values for unset configuration options.

--- a/internal/http/services/opencloudmesh/ocmd/client.go
+++ b/internal/http/services/opencloudmesh/ocmd/client.go
@@ -176,6 +176,14 @@ func (c *OCMClient) HTTPTransport() http.RoundTripper {
 	return c.client.Transport
 }
 
+// RequestTimeout returns the outbound HTTP client timeout.
+func (c *OCMClient) RequestTimeout() time.Duration {
+	if c == nil || c.client == nil {
+		return 0
+	}
+	return c.client.Timeout
+}
+
 // publicOnlyTransport refuses disallowed schemes and excess redirect hops
 // before the inner dialer runs. Proxy stays nil on the inner transport.
 type publicOnlyTransport struct {

--- a/internal/http/services/opencloudmesh/ocmd/client.go
+++ b/internal/http/services/opencloudmesh/ocmd/client.go
@@ -75,7 +75,9 @@ func resolveOCMResponseLimit(limit int64) int64 {
 // newOCMTransport returns the HTTP transport used for outbound OCM requests.
 // It honors the standard HTTP_PROXY, HTTPS_PROXY, and NO_PROXY environment
 // variables and optionally skips TLS certificate verification.
-func newOCMTransport(insecure bool) *http.Transport {
+// minVersion is the TLS minimum; 0 means TLS 1.2. Values below TLS 1.2 are
+// rejected. The per-service knob defaults to TLS 1.2 and may raise to 1.3.
+func newOCMTransport(insecure bool, minVersion uint16) *http.Transport {
 	var tr *http.Transport
 	if dt, ok := http.DefaultTransport.(*http.Transport); ok {
 		tr = dt.Clone()
@@ -86,7 +88,7 @@ func newOCMTransport(insecure bool) *http.Transport {
 	}
 	tr.TLSClientConfig = &tls.Config{
 		InsecureSkipVerify: insecure,
-		MinVersion:         tls.VersionTLS12,
+		MinVersion:         resolveTLSMinVersion(minVersion),
 	}
 	return tr
 }
@@ -96,7 +98,7 @@ func newOCMTransport(insecure bool) *http.Transport {
 func NewClient(timeout time.Duration, insecure bool, responseLimit int64) *OCMClient {
 	return &OCMClient{
 		client: &http.Client{
-			Transport: newOCMTransport(insecure),
+			Transport: newOCMTransport(insecure, 0),
 			Timeout:   timeout,
 		},
 		responseLimit: resolveOCMResponseLimit(responseLimit),
@@ -110,7 +112,8 @@ func NewClient(timeout time.Duration, insecure bool, responseLimit int64) *OCMCl
 // Transport-layer guarantees:
 //   - dials only addresses allowed by sec (PIN or public-only)
 //   - Proxy is nil (no ProxyFromEnvironment)
-//   - TLS 1.2 minimum; InsecureSkipVerify only when insecure is true
+//   - TLS minimum is configurable and defaults to 1.2 via the service knob;
+//     InsecureSkipVerify only when insecure is true
 //   - requireScheme on every RoundTrip
 //   - redirect-cap walker via req.Response so SetTransport-only clients
 //     (gowebdav) still enforce sec.maxRedirects()
@@ -120,9 +123,14 @@ func NewClient(timeout time.Duration, insecure bool, responseLimit int64) *OCMCl
 // The timeout option applies only to dialing, specifically net.Dialer.Timeout
 // on the Control path. Request-level deadlines require http.Client.Timeout or
 // gowebdav SetTimeout. sec must already be compiled; this constructor
-// returns no error.
-func UntrustedHTTPTransport(timeout time.Duration, insecure bool, sec UntrustedClientSecurity) http.RoundTripper {
-	tr := newOCMTransport(insecure)
+// returns no error. minVersion 0 means TLS 1.2; the knob may raise to 1.3.
+func UntrustedHTTPTransport(
+	timeout time.Duration,
+	insecure bool,
+	sec UntrustedClientSecurity,
+	minVersion uint16,
+) http.RoundTripper {
+	tr := newOCMTransport(insecure, minVersion)
 	// with a proxy the dial goes to the proxy, so Control never sees the target
 	tr.Proxy = nil
 	tr.DialContext = (&net.Dialer{
@@ -143,15 +151,29 @@ func NewPublicOnlyClient(
 	insecure bool,
 	sec UntrustedClientSecurity,
 	responseLimit int64,
+	minVersion uint16,
 ) *OCMClient {
 	return &OCMClient{
 		client: &http.Client{
-			Transport:     UntrustedHTTPTransport(timeout, insecure, sec),
+			Transport: UntrustedHTTPTransport(
+				timeout,
+				insecure,
+				sec,
+				minVersion,
+			),
 			Timeout:       timeout,
 			CheckRedirect: sec.CheckRedirect,
 		},
 		responseLimit: resolveOCMResponseLimit(responseLimit),
 	}
+}
+
+// HTTPTransport returns the live outbound RoundTripper.
+func (c *OCMClient) HTTPTransport() http.RoundTripper {
+	if c == nil || c.client == nil {
+		return nil
+	}
+	return c.client.Transport
 }
 
 // publicOnlyTransport refuses disallowed schemes and excess redirect hops

--- a/internal/http/services/opencloudmesh/ocmd/client.go
+++ b/internal/http/services/opencloudmesh/ocmd/client.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
+	stderrors "errors"
 	"fmt"
 	"io"
 	"net"
@@ -53,6 +54,11 @@ var ErrUserAlreadyAccepted = errors.New("invitation already accepted")
 // ErrInvalidParameters is the error returned by the shares endpoint
 // when the request does not contain required properties.
 var ErrInvalidParameters = errors.New("invalid parameters")
+
+// maxOCMResponseBytes caps attacker-influenced OCM HTTP response bodies.
+const maxOCMResponseBytes = 1 << 20 // 1 MiB
+
+var errOCMResponseTooLarge = errors.New("ocm response body exceeds size limit")
 
 // OCMClient is the client for an OCM provider.
 type OCMClient struct {
@@ -153,10 +159,16 @@ func (c *OCMClient) Discover(ctx context.Context, endpoint string) (*wellknown.O
 	}
 	remoteurl, _ := url.JoinPath(endpoint, "/.well-known/ocm")
 	body, err := c.httpget(ctx, remoteurl)
+	if stderrors.Is(err, errOCMResponseTooLarge) {
+		return nil, err
+	}
 	if err != nil || len(body) == 0 {
 		log.Debug().Err(err).Any("remote", remoteurl).Str("response", string(body)).Msg("invalid or empty response, falling back to legacy discovery")
 		remoteurl, _ := url.JoinPath(endpoint, "/ocm-provider") // legacy discovery endpoint
 		body, err = c.httpget(ctx, remoteurl)
+		if stderrors.Is(err, errOCMResponseTooLarge) {
+			return nil, err
+		}
 		if err != nil || len(body) == 0 {
 			log.Warn().Err(err).Any("remote", remoteurl).Str("response", string(body)).Msg("invalid or empty response")
 			return nil, errtypes.InternalError("Invalid response on OCM discovery")
@@ -197,9 +209,35 @@ func (c *OCMClient) httpget(ctx context.Context, url string) ([]byte, error) {
 		return nil, errtypes.InternalError("Remote does not offer a valid OCM discovery endpoint")
 	}
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := readOCMBody(resp.Body)
 	if err != nil {
 		return nil, errors.Wrap(err, "malformed remote OCM discovery")
+	}
+	return body, nil
+}
+
+func decodeOCMJSON(r io.Reader, v any) error {
+	limited := io.LimitReader(r, maxOCMResponseBytes+1)
+	err := json.NewDecoder(limited).Decode(v)
+	// Drain leftover limited bytes. Decode can stop after a valid JSON value
+	// while the body still exceeds the cap.
+	_, drainErr := io.Copy(io.Discard, limited)
+	if limited.(*io.LimitedReader).N == 0 {
+		return errOCMResponseTooLarge
+	}
+	if err != nil {
+		return err
+	}
+	return drainErr
+}
+
+func readOCMBody(r io.Reader) ([]byte, error) {
+	body, err := io.ReadAll(io.LimitReader(r, maxOCMResponseBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(body)) > maxOCMResponseBytes {
+		return nil, errOCMResponseTooLarge
 	}
 	return body, nil
 }
@@ -243,15 +281,17 @@ func (c *OCMClient) parseNewShareResponse(r *http.Response) (*NewShareResponse, 
 	switch r.StatusCode {
 	case http.StatusOK, http.StatusCreated:
 		var res NewShareResponse
-		err := json.NewDecoder(r.Body).Decode(&res)
-		return &res, err
+		if err := decodeOCMJSON(r.Body, &res); err != nil {
+			return nil, errors.Wrap(err, "error decoding response body")
+		}
+		return &res, nil
 	case http.StatusBadRequest:
 		return nil, ErrInvalidParameters
 	case http.StatusUnauthorized, http.StatusForbidden:
 		return nil, ErrServiceNotTrusted
 	}
 
-	body, err := io.ReadAll(r.Body)
+	body, err := readOCMBody(r.Body)
 	if err != nil {
 		return nil, errors.Wrap(err, "error decoding response body")
 	}
@@ -351,7 +391,13 @@ func (c *OCMClient) ExchangeToken(ctx context.Context, tokenEndpoint, code, clie
 		var errBody struct {
 			Error string `json:"error"`
 		}
-		if err := json.NewDecoder(resp.Body).Decode(&errBody); err == nil && errBody.Error == "invalid_grant" {
+		if err := decodeOCMJSON(resp.Body, &errBody); err != nil {
+			if stderrors.Is(err, errOCMResponseTooLarge) {
+				return "", 0, errors.Wrap(err, "error decoding token exchange response")
+			}
+			return "", 0, errtypes.InternalError("token exchange returned HTTP 400 (sender contract error)")
+		}
+		if errBody.Error == "invalid_grant" {
 			return "", 0, errtypes.InvalidCredentials("token exchange: invalid_grant")
 		}
 		return "", 0, errtypes.InternalError("token exchange returned HTTP 400 (sender contract error)")
@@ -365,7 +411,7 @@ func (c *OCMClient) ExchangeToken(ctx context.Context, tokenEndpoint, code, clie
 		AccessToken string `json:"access_token"`
 		ExpiresIn   int64  `json:"expires_in"`
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+	if err := decodeOCMJSON(resp.Body, &result); err != nil {
 		return "", 0, errors.Wrap(err, "error decoding token exchange response")
 	}
 	if result.AccessToken == "" {

--- a/internal/http/services/opencloudmesh/ocmd/client.go
+++ b/internal/http/services/opencloudmesh/ocmd/client.go
@@ -58,7 +58,15 @@ var ErrInvalidParameters = errors.New("invalid parameters")
 // maxOCMResponseBytes caps attacker-influenced OCM HTTP response bodies.
 const maxOCMResponseBytes = 1 << 20 // 1 MiB
 
+// maxPublicOnlyRedirects caps hops on the untrusted public-only client.
+// Do not rely on Go's default of 10.
+const maxPublicOnlyRedirects = 3
+
 var errOCMResponseTooLarge = errors.New("ocm response body exceeds size limit")
+
+var errPublicOnlyNonHTTPS = errors.New("public-only OCM client requires https")
+
+var errPublicOnlyTooManyRedirects = fmt.Errorf("public-only OCM client stopped after %d redirects", maxPublicOnlyRedirects)
 
 // OCMClient is the client for an OCM provider.
 type OCMClient struct {
@@ -93,7 +101,8 @@ func NewClient(timeout time.Duration, insecure bool) *OCMClient {
 
 // NewPublicOnlyClient returns an OCMClient that only dials public addresses, for
 // discovery of hosts named by an untrusted caller. The check is in the dialer so
-// it also covers redirects and DNS rebinding.
+// it also covers redirects and DNS rebinding. Redirects are capped and both the
+// initial URL and every hop must use https.
 func NewPublicOnlyClient(timeout time.Duration, insecure bool) *OCMClient {
 	tr := newOCMTransport(insecure)
 	// with a proxy the dial goes to the proxy, so Control never sees the target
@@ -105,10 +114,42 @@ func NewPublicOnlyClient(timeout time.Duration, insecure bool) *OCMClient {
 	}).DialContext
 	return &OCMClient{
 		client: &http.Client{
-			Transport: tr,
-			Timeout:   timeout,
+			Transport:     &publicOnlyTransport{Transport: tr},
+			Timeout:       timeout,
+			CheckRedirect: publicOnlyCheckRedirect,
 		},
 	}
+}
+
+// publicOnlyTransport refuses non-https URLs on the initial request and on
+// every redirect hop, before the inner dialer runs.
+type publicOnlyTransport struct {
+	*http.Transport
+}
+
+func (t *publicOnlyTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if err := requirePublicOnlyHTTPS(req.URL); err != nil {
+		return nil, err
+	}
+	return t.Transport.RoundTrip(req)
+}
+
+func requirePublicOnlyHTTPS(u *url.URL) error {
+	if u != nil && u.Scheme == "https" {
+		return nil
+	}
+	scheme := ""
+	if u != nil {
+		scheme = u.Scheme
+	}
+	return fmt.Errorf("public-only OCM client refuses non-https scheme %q: %w", scheme, errPublicOnlyNonHTTPS)
+}
+
+func publicOnlyCheckRedirect(req *http.Request, via []*http.Request) error {
+	if len(via) > maxPublicOnlyRedirects {
+		return errPublicOnlyTooManyRedirects
+	}
+	return requirePublicOnlyHTTPS(req.URL)
 }
 
 func refuseNonPublicAddr(_, address string, _ syscall.RawConn) error {

--- a/internal/http/services/opencloudmesh/ocmd/client.go
+++ b/internal/http/services/opencloudmesh/ocmd/client.go
@@ -72,11 +72,10 @@ func resolveOCMResponseLimit(limit int64) int64 {
 	return limit
 }
 
-// newOCMTransport returns the HTTP transport used for outbound OCM requests.
-// It honors the standard HTTP_PROXY, HTTPS_PROXY, and NO_PROXY environment
-// variables and optionally skips TLS certificate verification.
-// minVersion is the TLS minimum; 0 means TLS 1.2. Values below TLS 1.2 are
-// rejected. The per-service knob defaults to TLS 1.2 and may raise to 1.3.
+// newOCMTransport builds the outbound OCM transport. It honors HTTP_PROXY,
+// HTTPS_PROXY, and NO_PROXY. minVersion is the TLS floor from the service
+// knob; 0 selects that knob's default. Values below the enforced floor are
+// rejected.
 func newOCMTransport(insecure bool, minVersion uint16) *http.Transport {
 	var tr *http.Transport
 	if dt, ok := http.DefaultTransport.(*http.Transport); ok {
@@ -93,8 +92,9 @@ func newOCMTransport(insecure bool, minVersion uint16) *http.Transport {
 	return tr
 }
 
-// NewClient returns a new OCMClient.
-// responseLimit caps OCM response bodies in bytes; values <= 0 select the 1 MiB default.
+// NewClient returns an OCM client for trusted, operator-configured endpoints.
+// It does not apply public-only dial or redirect policy. responseLimit caps
+// OCM response bodies; values <= 0 select the package default.
 func NewClient(timeout time.Duration, insecure bool, responseLimit int64) *OCMClient {
 	return &OCMClient{
 		client: &http.Client{
@@ -107,23 +107,20 @@ func NewClient(timeout time.Duration, insecure bool, responseLimit int64) *OCMCl
 
 // UntrustedHTTPTransport returns a RoundTripper with the same untrusted-client
 // hardening as NewPublicOnlyClient. Use it with gowebdav.Client.SetTransport
-// (or any http.Client.Transport) when the URL is untrusted or peer-supplied.
-//
-// Transport-layer guarantees:
-//   - dials only addresses allowed by sec (PIN or public-only)
-//   - Proxy is nil (no ProxyFromEnvironment)
-//   - TLS minimum is configurable and defaults to 1.2 via the service knob;
-//     InsecureSkipVerify only when insecure is true
-//   - requireScheme on every RoundTrip
-//   - redirect-cap walker via req.Response so SetTransport-only clients
-//     (gowebdav) still enforce sec.maxRedirects()
-//
+// when the URL is peer-supplied: gowebdav cannot install CheckRedirect, so
+// the RoundTripper walks req.Response and enforces the redirect cap itself.
 // Owned http.Client callers should also set CheckRedirect to sec.CheckRedirect.
 //
-// The timeout option applies only to dialing, specifically net.Dialer.Timeout
-// on the Control path. Request-level deadlines require http.Client.Timeout or
-// gowebdav SetTimeout. sec must already be compiled; this constructor
-// returns no error. minVersion 0 means TLS 1.2; the knob may raise to 1.3.
+// Proxy is forced to nil. An environment proxy would make the dialer inspect
+// the proxy address rather than the peer target, so the public-only Control
+// guard could not enforce the target-IP policy.
+//
+// timeout is net.Dialer.Timeout: it bounds the TCP dial (DNS resolution +
+// TCP connect). Control is the post-resolution, pre-dial policy gate that
+// runs within that TCP dial. TLS is bounded separately by the transport's
+// TLS handshake timeout. Request-level deadlines need http.Client.Timeout
+// or gowebdav SetTimeout. minVersion 0 selects the TLS-knob default. sec
+// must already be compiled.
 func UntrustedHTTPTransport(
 	timeout time.Duration,
 	insecure bool,
@@ -131,7 +128,7 @@ func UntrustedHTTPTransport(
 	minVersion uint16,
 ) http.RoundTripper {
 	tr := newOCMTransport(insecure, minVersion)
-	// with a proxy the dial goes to the proxy, so Control never sees the target
+	// An env proxy would make Control inspect the proxy, not the peer target.
 	tr.Proxy = nil
 	tr.DialContext = (&net.Dialer{
 		Timeout:   timeout,
@@ -141,11 +138,11 @@ func UntrustedHTTPTransport(
 	return &publicOnlyTransport{Transport: tr, sec: sec}
 }
 
-// NewPublicOnlyClient returns an OCMClient that only dials addresses allowed
-// by sec, for discovery of hosts named by an untrusted caller. The check is in
-// the dialer so it also covers redirects and DNS rebinding. Redirects are
-// capped and both the initial URL and every hop must satisfy requireScheme.
-// responseLimit caps OCM response bodies in bytes; values <= 0 select the 1 MiB default.
+// NewPublicOnlyClient returns an OCMClient for hosts named by an untrusted
+// caller. Dial Control enforces sec's address policy on every hop, including
+// redirects, so DNS rebinding cannot sneak a private target past the first
+// lookup. The initial URL and each redirect must satisfy requireScheme.
+// responseLimit caps OCM response bodies; values <= 0 select the package default.
 func NewPublicOnlyClient(
 	timeout time.Duration,
 	insecure bool,
@@ -184,8 +181,9 @@ func (c *OCMClient) RequestTimeout() time.Duration {
 	return c.client.Timeout
 }
 
-// publicOnlyTransport refuses disallowed schemes and excess redirect hops
-// before the inner dialer runs. Proxy stays nil on the inner transport.
+// publicOnlyTransport enforces scheme and redirect-cap before the inner
+// dialer. SetTransport-only clients (gowebdav) cannot install CheckRedirect,
+// so RoundTrip walks req.Response as the redirect backstop.
 type publicOnlyTransport struct {
 	*http.Transport
 	sec UntrustedClientSecurity
@@ -460,7 +458,6 @@ func (c *OCMClient) ExchangeToken(ctx context.Context, tokenEndpoint, code, clie
 
 	switch resp.StatusCode {
 	case http.StatusOK:
-		// success, decode below
 	case http.StatusBadRequest:
 		var errBody struct {
 			Error string `json:"error"`
@@ -510,7 +507,6 @@ func (c *OCMClient) GetDirectoryService(ctx context.Context, directoryURL string
 		return nil, errors.Wrap(err, "invalid directory service payload")
 	}
 
-	// Validate required fields
 	if dirService.Federation == "" {
 		return nil, errtypes.InternalError("directory service missing required 'federation' field")
 	}

--- a/internal/http/services/opencloudmesh/ocmd/client.go
+++ b/internal/http/services/opencloudmesh/ocmd/client.go
@@ -61,7 +61,15 @@ var errOCMResponseTooLarge = errors.New("ocm response body exceeds size limit")
 
 // OCMClient is the client for an OCM provider.
 type OCMClient struct {
-	client *http.Client
+	client        *http.Client
+	responseLimit int64
+}
+
+func resolveOCMResponseLimit(limit int64) int64 {
+	if limit <= 0 {
+		return maxOCMResponseBytes
+	}
+	return limit
 }
 
 // newOCMTransport returns the HTTP transport used for outbound OCM requests.
@@ -84,12 +92,14 @@ func newOCMTransport(insecure bool) *http.Transport {
 }
 
 // NewClient returns a new OCMClient.
-func NewClient(timeout time.Duration, insecure bool) *OCMClient {
+// responseLimit caps OCM response bodies in bytes; values <= 0 select the 1 MiB default.
+func NewClient(timeout time.Duration, insecure bool, responseLimit int64) *OCMClient {
 	return &OCMClient{
 		client: &http.Client{
 			Transport: newOCMTransport(insecure),
 			Timeout:   timeout,
 		},
+		responseLimit: resolveOCMResponseLimit(responseLimit),
 	}
 }
 
@@ -127,13 +137,20 @@ func UntrustedHTTPTransport(timeout time.Duration, insecure bool, sec UntrustedC
 // by sec, for discovery of hosts named by an untrusted caller. The check is in
 // the dialer so it also covers redirects and DNS rebinding. Redirects are
 // capped and both the initial URL and every hop must satisfy requireScheme.
-func NewPublicOnlyClient(timeout time.Duration, insecure bool, sec UntrustedClientSecurity) *OCMClient {
+// responseLimit caps OCM response bodies in bytes; values <= 0 select the 1 MiB default.
+func NewPublicOnlyClient(
+	timeout time.Duration,
+	insecure bool,
+	sec UntrustedClientSecurity,
+	responseLimit int64,
+) *OCMClient {
 	return &OCMClient{
 		client: &http.Client{
 			Transport:     UntrustedHTTPTransport(timeout, insecure, sec),
 			Timeout:       timeout,
 			CheckRedirect: sec.CheckRedirect,
 		},
+		responseLimit: resolveOCMResponseLimit(responseLimit),
 	}
 }
 
@@ -236,15 +253,15 @@ func (c *OCMClient) httpget(ctx context.Context, url string) ([]byte, error) {
 		return nil, errtypes.InternalError("Remote does not offer a valid OCM discovery endpoint")
 	}
 
-	body, err := readOCMBody(resp.Body)
+	body, err := c.readOCMBody(resp.Body)
 	if err != nil {
 		return nil, errors.Wrap(err, "malformed remote OCM discovery")
 	}
 	return body, nil
 }
 
-func decodeOCMJSON(r io.Reader, v any) error {
-	limited := io.LimitReader(r, maxOCMResponseBytes+1)
+func (c *OCMClient) decodeOCMJSON(r io.Reader, v any) error {
+	limited := io.LimitReader(r, c.responseLimit+1)
 	err := json.NewDecoder(limited).Decode(v)
 	// Drain leftover limited bytes. Decode can stop after a valid JSON value
 	// while the body still exceeds the cap.
@@ -258,12 +275,12 @@ func decodeOCMJSON(r io.Reader, v any) error {
 	return drainErr
 }
 
-func readOCMBody(r io.Reader) ([]byte, error) {
-	body, err := io.ReadAll(io.LimitReader(r, maxOCMResponseBytes+1))
+func (c *OCMClient) readOCMBody(r io.Reader) ([]byte, error) {
+	body, err := io.ReadAll(io.LimitReader(r, c.responseLimit+1))
 	if err != nil {
 		return nil, err
 	}
-	if int64(len(body)) > maxOCMResponseBytes {
+	if int64(len(body)) > c.responseLimit {
 		return nil, errOCMResponseTooLarge
 	}
 	return body, nil
@@ -308,7 +325,7 @@ func (c *OCMClient) parseNewShareResponse(r *http.Response) (*NewShareResponse, 
 	switch r.StatusCode {
 	case http.StatusOK, http.StatusCreated:
 		var res NewShareResponse
-		if err := decodeOCMJSON(r.Body, &res); err != nil {
+		if err := c.decodeOCMJSON(r.Body, &res); err != nil {
 			return nil, errors.Wrap(err, "error decoding response body")
 		}
 		return &res, nil
@@ -318,7 +335,7 @@ func (c *OCMClient) parseNewShareResponse(r *http.Response) (*NewShareResponse, 
 		return nil, ErrServiceNotTrusted
 	}
 
-	body, err := readOCMBody(r.Body)
+	body, err := c.readOCMBody(r.Body)
 	if err != nil {
 		return nil, errors.Wrap(err, "error decoding response body")
 	}
@@ -364,7 +381,7 @@ func (c *OCMClient) parseInviteAcceptedResponse(r *http.Response) (*RemoteUser, 
 	switch r.StatusCode {
 	case http.StatusOK:
 		var u RemoteUser
-		if err := json.NewDecoder(r.Body).Decode(&u); err != nil {
+		if err := c.decodeOCMJSON(r.Body, &u); err != nil {
 			return nil, errors.Wrap(err, "error decoding response body")
 		}
 		return &u, nil
@@ -376,7 +393,7 @@ func (c *OCMClient) parseInviteAcceptedResponse(r *http.Response) (*RemoteUser, 
 		return nil, ErrServiceNotTrusted
 	}
 
-	body, err := io.ReadAll(r.Body)
+	body, err := c.readOCMBody(r.Body)
 	if err != nil {
 		return nil, errors.Wrap(err, "error decoding response body")
 	}
@@ -418,7 +435,7 @@ func (c *OCMClient) ExchangeToken(ctx context.Context, tokenEndpoint, code, clie
 		var errBody struct {
 			Error string `json:"error"`
 		}
-		if err := decodeOCMJSON(resp.Body, &errBody); err != nil {
+		if err := c.decodeOCMJSON(resp.Body, &errBody); err != nil {
 			if stderrors.Is(err, errOCMResponseTooLarge) {
 				return "", 0, errors.Wrap(err, "error decoding token exchange response")
 			}
@@ -438,7 +455,7 @@ func (c *OCMClient) ExchangeToken(ctx context.Context, tokenEndpoint, code, clie
 		AccessToken string `json:"access_token"`
 		ExpiresIn   int64  `json:"expires_in"`
 	}
-	if err := decodeOCMJSON(resp.Body, &result); err != nil {
+	if err := c.decodeOCMJSON(resp.Body, &result); err != nil {
 		return "", 0, errors.Wrap(err, "error decoding token exchange response")
 	}
 	if result.AccessToken == "" {

--- a/internal/http/services/opencloudmesh/ocmd/client.go
+++ b/internal/http/services/opencloudmesh/ocmd/client.go
@@ -30,7 +30,6 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/cs3org/reva/v3/internal/http/services/wellknown"
@@ -58,15 +57,7 @@ var ErrInvalidParameters = errors.New("invalid parameters")
 // maxOCMResponseBytes caps attacker-influenced OCM HTTP response bodies.
 const maxOCMResponseBytes = 1 << 20 // 1 MiB
 
-// maxPublicOnlyRedirects caps hops on the untrusted public-only client.
-// Do not rely on Go's default of 10.
-const maxPublicOnlyRedirects = 3
-
 var errOCMResponseTooLarge = errors.New("ocm response body exceeds size limit")
-
-var errPublicOnlyNonHTTPS = errors.New("public-only OCM client requires https")
-
-var errPublicOnlyTooManyRedirects = fmt.Errorf("public-only OCM client stopped after %d redirects", maxPublicOnlyRedirects)
 
 // OCMClient is the client for an OCM provider.
 type OCMClient struct {
@@ -102,117 +93,82 @@ func NewClient(timeout time.Duration, insecure bool) *OCMClient {
 	}
 }
 
-// UntrustedHTTPTransport returns a RoundTripper with the same public-only
+// UntrustedHTTPTransport returns a RoundTripper with the same untrusted-client
 // hardening as NewPublicOnlyClient. Use it with gowebdav.Client.SetTransport
 // (or any http.Client.Transport) when the URL is untrusted or peer-supplied.
 //
 // Transport-layer guarantees:
-//   - dials only public addresses (refuseNonPublicAddr / isPublicIP), including
-//     redirect hops and DNS-rebinding races
+//   - dials only addresses allowed by sec (PIN or public-only)
 //   - Proxy is nil (no ProxyFromEnvironment)
 //   - TLS 1.2 minimum; InsecureSkipVerify only when insecure is true
-//   - https-only scheme on every RoundTrip
+//   - requireScheme on every RoundTrip
+//   - redirect-cap walker via req.Response so SetTransport-only clients
+//     (gowebdav) still enforce sec.maxRedirects()
 //
-// Redirect limiting is an http.Client CheckRedirect concern, not a property of
-// http.Transport. gowebdav.Client keeps its own CheckRedirect (10 hops).
-// Callers that own the http.Client should set CheckRedirect to
-// PublicOnlyCheckRedirect to apply the 3-redirect cap used by
-// NewPublicOnlyClient.
+// Owned http.Client callers should also set CheckRedirect to sec.CheckRedirect.
 //
 // The timeout option applies only to dialing, specifically net.Dialer.Timeout
 // on the Control path. Request-level deadlines require http.Client.Timeout or
-// gowebdav SetTimeout.
-func UntrustedHTTPTransport(timeout time.Duration, insecure bool) http.RoundTripper {
+// gowebdav SetTimeout. sec must already be compiled; this constructor
+// returns no error.
+func UntrustedHTTPTransport(timeout time.Duration, insecure bool, sec UntrustedClientSecurity) http.RoundTripper {
 	tr := newOCMTransport(insecure)
 	// with a proxy the dial goes to the proxy, so Control never sees the target
 	tr.Proxy = nil
 	tr.DialContext = (&net.Dialer{
 		Timeout:   timeout,
 		KeepAlive: 30 * time.Second,
-		Control:   refuseNonPublicAddr,
+		Control:   sec.dialControl,
 	}).DialContext
-	return &publicOnlyTransport{Transport: tr}
+	return &publicOnlyTransport{Transport: tr, sec: sec}
 }
 
-// NewPublicOnlyClient returns an OCMClient that only dials public addresses, for
-// discovery of hosts named by an untrusted caller. The check is in the dialer so
-// it also covers redirects and DNS rebinding. Redirects are capped and both the
-// initial URL and every hop must use https.
-func NewPublicOnlyClient(timeout time.Duration, insecure bool) *OCMClient {
+// NewPublicOnlyClient returns an OCMClient that only dials addresses allowed
+// by sec, for discovery of hosts named by an untrusted caller. The check is in
+// the dialer so it also covers redirects and DNS rebinding. Redirects are
+// capped and both the initial URL and every hop must satisfy requireScheme.
+func NewPublicOnlyClient(timeout time.Duration, insecure bool, sec UntrustedClientSecurity) *OCMClient {
 	return &OCMClient{
 		client: &http.Client{
-			Transport:     UntrustedHTTPTransport(timeout, insecure),
+			Transport:     UntrustedHTTPTransport(timeout, insecure, sec),
 			Timeout:       timeout,
-			CheckRedirect: PublicOnlyCheckRedirect,
+			CheckRedirect: sec.CheckRedirect,
 		},
 	}
 }
 
-// publicOnlyTransport refuses non-https URLs on the initial request and on
-// every redirect hop, before the inner dialer runs.
+// publicOnlyTransport refuses disallowed schemes and excess redirect hops
+// before the inner dialer runs. Proxy stays nil on the inner transport.
 type publicOnlyTransport struct {
 	*http.Transport
+	sec UntrustedClientSecurity
 }
 
 func (t *publicOnlyTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	if err := requirePublicOnlyHTTPS(req.URL); err != nil {
+	var u *url.URL
+	if req != nil {
+		u = req.URL
+	}
+	if err := t.sec.requireScheme(u); err != nil {
 		return nil, err
+	}
+	if redirectHopCount(req) > t.sec.maxRedirects() {
+		return nil, t.sec.tooManyRedirectsError()
 	}
 	return t.Transport.RoundTrip(req)
 }
 
-func requirePublicOnlyHTTPS(u *url.URL) error {
-	if u != nil && u.Scheme == "https" {
-		return nil
+func redirectHopCount(req *http.Request) int {
+	n := 0
+	for req != nil && req.Response != nil {
+		n++
+		next := req.Response.Request
+		if next == req {
+			break
+		}
+		req = next
 	}
-	scheme := ""
-	if u != nil {
-		scheme = u.Scheme
-	}
-	return fmt.Errorf("public-only OCM client refuses non-https scheme %q: %w", scheme, errPublicOnlyNonHTTPS)
-}
-
-// PublicOnlyCheckRedirect is the 3-redirect, https-only CheckRedirect used by
-// NewPublicOnlyClient. Assign it on an http.Client that uses
-// UntrustedHTTPTransport when the caller owns that client.
-func PublicOnlyCheckRedirect(req *http.Request, via []*http.Request) error {
-	if len(via) > maxPublicOnlyRedirects {
-		return errPublicOnlyTooManyRedirects
-	}
-	return requirePublicOnlyHTTPS(req.URL)
-}
-
-func refuseNonPublicAddr(_, address string, _ syscall.RawConn) error {
-	host, _, err := net.SplitHostPort(address)
-	if err != nil {
-		return err
-	}
-	ip := net.ParseIP(host)
-	if ip == nil || !isPublicIP(ip) {
-		return errtypes.BadRequest("refusing to connect to non-public address " + address)
-	}
-	return nil
-}
-
-// 64:ff9b::/96 embeds an IPv4 address in its low 32 bits (RFC 6052), so on a
-// NAT64 network it can still reach internal hosts.
-var nat64WellKnownPrefix = net.IPNet{IP: net.ParseIP("64:ff9b::"), Mask: net.CIDRMask(96, 128)}
-
-func isPublicIP(ip net.IP) bool {
-	if nat64WellKnownPrefix.Contains(ip) {
-		v6 := ip.To16()
-		return isPublicIP(net.IPv4(v6[12], v6[13], v6[14], v6[15]))
-	}
-	if ip.IsLoopback() || ip.IsPrivate() || ip.IsUnspecified() ||
-		ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() ||
-		ip.IsMulticast() || ip.IsInterfaceLocalMulticast() {
-		return false
-	}
-	// 100.64.0.0/10 is carrier-grade NAT, which net.IP.IsPrivate does not cover
-	if ip4 := ip.To4(); ip4 != nil && ip4[0] == 100 && ip4[1]&0xc0 == 64 {
-		return false
-	}
-	return true
+	return n
 }
 
 // Discover returns a number of properties used to discover the capabilities offered by a remote cloud storage.

--- a/internal/http/services/opencloudmesh/ocmd/client.go
+++ b/internal/http/services/opencloudmesh/ocmd/client.go
@@ -102,11 +102,27 @@ func NewClient(timeout time.Duration, insecure bool) *OCMClient {
 	}
 }
 
-// NewPublicOnlyClient returns an OCMClient that only dials public addresses, for
-// discovery of hosts named by an untrusted caller. The check is in the dialer so
-// it also covers redirects and DNS rebinding. Redirects are capped and both the
-// initial URL and every hop must use https.
-func NewPublicOnlyClient(timeout time.Duration, insecure bool) *OCMClient {
+// UntrustedHTTPTransport returns a RoundTripper with the same public-only
+// hardening as NewPublicOnlyClient. Use it with gowebdav.Client.SetTransport
+// (or any http.Client.Transport) when the URL is untrusted or peer-supplied.
+//
+// Transport-layer guarantees:
+//   - dials only public addresses (refuseNonPublicAddr / isPublicIP), including
+//     redirect hops and DNS-rebinding races
+//   - Proxy is nil (no ProxyFromEnvironment)
+//   - TLS 1.2 minimum; InsecureSkipVerify only when insecure is true
+//   - https-only scheme on every RoundTrip
+//
+// Redirect limiting is an http.Client CheckRedirect concern, not a property of
+// http.Transport. gowebdav.Client keeps its own CheckRedirect (10 hops).
+// Callers that own the http.Client should set CheckRedirect to
+// PublicOnlyCheckRedirect to apply the 3-redirect cap used by
+// NewPublicOnlyClient.
+//
+// The timeout option applies only to dialing, specifically net.Dialer.Timeout
+// on the Control path. Request-level deadlines require http.Client.Timeout or
+// gowebdav SetTimeout.
+func UntrustedHTTPTransport(timeout time.Duration, insecure bool) http.RoundTripper {
 	tr := newOCMTransport(insecure)
 	// with a proxy the dial goes to the proxy, so Control never sees the target
 	tr.Proxy = nil
@@ -115,11 +131,19 @@ func NewPublicOnlyClient(timeout time.Duration, insecure bool) *OCMClient {
 		KeepAlive: 30 * time.Second,
 		Control:   refuseNonPublicAddr,
 	}).DialContext
+	return &publicOnlyTransport{Transport: tr}
+}
+
+// NewPublicOnlyClient returns an OCMClient that only dials public addresses, for
+// discovery of hosts named by an untrusted caller. The check is in the dialer so
+// it also covers redirects and DNS rebinding. Redirects are capped and both the
+// initial URL and every hop must use https.
+func NewPublicOnlyClient(timeout time.Duration, insecure bool) *OCMClient {
 	return &OCMClient{
 		client: &http.Client{
-			Transport:     &publicOnlyTransport{Transport: tr},
+			Transport:     UntrustedHTTPTransport(timeout, insecure),
 			Timeout:       timeout,
-			CheckRedirect: publicOnlyCheckRedirect,
+			CheckRedirect: PublicOnlyCheckRedirect,
 		},
 	}
 }
@@ -148,7 +172,10 @@ func requirePublicOnlyHTTPS(u *url.URL) error {
 	return fmt.Errorf("public-only OCM client refuses non-https scheme %q: %w", scheme, errPublicOnlyNonHTTPS)
 }
 
-func publicOnlyCheckRedirect(req *http.Request, via []*http.Request) error {
+// PublicOnlyCheckRedirect is the 3-redirect, https-only CheckRedirect used by
+// NewPublicOnlyClient. Assign it on an http.Client that uses
+// UntrustedHTTPTransport when the caller owns that client.
+func PublicOnlyCheckRedirect(req *http.Request, via []*http.Request) error {
 	if len(via) > maxPublicOnlyRedirects {
 		return errPublicOnlyTooManyRedirects
 	}

--- a/internal/http/services/opencloudmesh/ocmd/client.go
+++ b/internal/http/services/opencloudmesh/ocmd/client.go
@@ -85,7 +85,10 @@ func newOCMTransport(insecure bool) *http.Transport {
 			Proxy: http.ProxyFromEnvironment,
 		}
 	}
-	tr.TLSClientConfig = &tls.Config{InsecureSkipVerify: insecure}
+	tr.TLSClientConfig = &tls.Config{
+		InsecureSkipVerify: insecure,
+		MinVersion:         tls.VersionTLS12,
+	}
 	return tr
 }
 

--- a/internal/http/services/opencloudmesh/ocmd/client_refusal_matrix_test.go
+++ b/internal/http/services/opencloudmesh/ocmd/client_refusal_matrix_test.go
@@ -89,10 +89,10 @@ func doPublicOnlyURL(t *testing.T, surface, rawURL string) (bool, error) {
 	var resp *http.Response
 	switch surface {
 	case "NewPublicOnlyClient":
-		resp, err = NewPublicOnlyClient(2*time.Second, true).client.Do(req)
+		resp, err = NewPublicOnlyClient(2*time.Second, true, testSec()).client.Do(req)
 	case "UntrustedHTTPTransport":
 		resp, err = (&http.Client{
-			Transport: UntrustedHTTPTransport(2*time.Second, true),
+			Transport: UntrustedHTTPTransport(2*time.Second, true, testSec()),
 		}).Do(req)
 	default:
 		t.Fatalf("unknown public-only surface %q", surface)

--- a/internal/http/services/opencloudmesh/ocmd/client_refusal_matrix_test.go
+++ b/internal/http/services/opencloudmesh/ocmd/client_refusal_matrix_test.go
@@ -94,10 +94,11 @@ func doPublicOnlyURL(t *testing.T, surface, rawURL string) (bool, error) {
 			true,
 			testSec(),
 			0,
+			0,
 		).client.Do(req)
 	case "UntrustedHTTPTransport":
 		resp, err = (&http.Client{
-			Transport: UntrustedHTTPTransport(2*time.Second, true, testSec()),
+			Transport: UntrustedHTTPTransport(2*time.Second, true, testSec(), 0),
 		}).Do(req)
 	default:
 		t.Fatalf("unknown public-only surface %q", surface)

--- a/internal/http/services/opencloudmesh/ocmd/client_refusal_matrix_test.go
+++ b/internal/http/services/opencloudmesh/ocmd/client_refusal_matrix_test.go
@@ -1,0 +1,113 @@
+// Copyright 2018-2026 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package ocmd
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptrace"
+	"testing"
+	"time"
+
+	"github.com/cs3org/reva/v3/pkg/errtypes"
+)
+
+// publicOnlySurfaces are the two constructors that must refuse untrusted
+// destinations.
+var publicOnlySurfaces = []string{
+	"NewPublicOnlyClient",
+	"UntrustedHTTPTransport",
+}
+
+// TestPublicOnlyClientRefusalMatrix covers the new public-only dial-refusal
+// categories. HTTP-scheme and redirect-cap refusals live in client_test.go.
+func TestPublicOnlyClientRefusalMatrix(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		rawURL string
+	}{
+		{name: "rfc1918 10/8", rawURL: "https://10.1.2.3/"},
+		{name: "rfc1918 172.16/12", rawURL: "https://172.16.5.4/"},
+		{name: "rfc1918 192.168/16", rawURL: "https://192.168.1.1/"},
+		{name: "cgnat 100.64/10", rawURL: "https://100.64.0.1/"},
+		{name: "nat64 well-known prefix", rawURL: "https://[64:ff9b::a9fe:a9fe]/"},
+		{name: "link-local 169.254/16", rawURL: "https://169.254.1.1/"},
+		{name: "cloud metadata 169.254.169.254", rawURL: "https://169.254.169.254/"},
+		{name: "multicast", rawURL: "https://224.0.0.1/"},
+		{name: "unspecified", rawURL: "https://0.0.0.0/"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			for _, surface := range publicOnlySurfaces {
+				t.Run(surface, func(t *testing.T) {
+					t.Parallel()
+					gotConn, err := doPublicOnlyURL(t, surface, tt.rawURL)
+					if gotConn {
+						t.Fatalf("%s established a connection to %s", surface, tt.rawURL)
+					}
+					assertPublicOnlyDialRefusal(t, err)
+				})
+			}
+		})
+	}
+}
+
+func doPublicOnlyURL(t *testing.T, surface, rawURL string) (bool, error) {
+	t.Helper()
+	var established bool
+	ctx := httptrace.WithClientTrace(context.Background(), &httptrace.ClientTrace{
+		GotConn: func(httptrace.GotConnInfo) {
+			established = true
+		},
+	})
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var resp *http.Response
+	switch surface {
+	case "NewPublicOnlyClient":
+		resp, err = NewPublicOnlyClient(2*time.Second, true).client.Do(req)
+	case "UntrustedHTTPTransport":
+		resp, err = (&http.Client{
+			Transport: UntrustedHTTPTransport(2*time.Second, true),
+		}).Do(req)
+	default:
+		t.Fatalf("unknown public-only surface %q", surface)
+	}
+	closeResponse(resp)
+	return established, err
+}
+
+func assertPublicOnlyDialRefusal(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected public-only dial refusal")
+	}
+	var br errtypes.BadRequest
+	if !errors.As(err, &br) {
+		t.Fatalf("got %T %v, want errtypes.BadRequest in the chain", err, err)
+	}
+}

--- a/internal/http/services/opencloudmesh/ocmd/client_refusal_matrix_test.go
+++ b/internal/http/services/opencloudmesh/ocmd/client_refusal_matrix_test.go
@@ -89,7 +89,12 @@ func doPublicOnlyURL(t *testing.T, surface, rawURL string) (bool, error) {
 	var resp *http.Response
 	switch surface {
 	case "NewPublicOnlyClient":
-		resp, err = NewPublicOnlyClient(2*time.Second, true, testSec()).client.Do(req)
+		resp, err = NewPublicOnlyClient(
+			2*time.Second,
+			true,
+			testSec(),
+			0,
+		).client.Do(req)
 	case "UntrustedHTTPTransport":
 		resp, err = (&http.Client{
 			Transport: UntrustedHTTPTransport(2*time.Second, true, testSec()),

--- a/internal/http/services/opencloudmesh/ocmd/client_test.go
+++ b/internal/http/services/opencloudmesh/ocmd/client_test.go
@@ -21,11 +21,13 @@ package ocmd
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -367,5 +369,179 @@ func TestPublicOnlyClientRefusesInternalHosts(t *testing.T) {
 				t.Errorf("Discover() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
+	}
+}
+
+// 2 MiB is above the 1 MiB OCM response cap; using a fixed oversize keeps the
+// tests valid before the named constant exists and after it is added.
+const testOversizedOCMBody = 2 << 20
+
+func oversizedJSON(t *testing.T, extra map[string]any, largeField string) []byte {
+	t.Helper()
+	payload := map[string]any{}
+	for k, v := range extra {
+		payload[k] = v
+	}
+	payload[largeField] = strings.Repeat("a", testOversizedOCMBody)
+	body, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return body
+}
+
+func testNewShareRequest() *NewShareRequest {
+	return &NewShareRequest{
+		ShareWith:    "einstein@remote.example",
+		Name:         "notes.txt",
+		ProviderID:   "id-1",
+		Owner:        "marie@local.example",
+		Sender:       "marie@local.example",
+		ShareType:    "user",
+		ResourceType: "file",
+		Protocols: Protocols{
+			&WebDAV{
+				SharedSecret: "secret",
+				Permissions:  []string{"read"},
+				URI:          "https://local.example/dav/notes.txt",
+			},
+		},
+	}
+}
+
+func assertOCMResponseTooLarge(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected oversized OCM response to be rejected")
+	}
+	if !errors.Is(err, errOCMResponseTooLarge) {
+		t.Fatalf("got error %q, want errOCMResponseTooLarge", err)
+	}
+}
+
+func TestDiscoverNormalSizedBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"enabled":    true,
+			"apiVersion": "1.1",
+			"provider":   "reva",
+		})
+	}))
+	defer srv.Close()
+
+	c := NewClient(10*time.Second, true)
+	disco, err := c.Discover(context.Background(), srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if disco == nil || !disco.Enabled || disco.APIVersion != "1.1" {
+		t.Fatalf("unexpected discovery payload: %+v", disco)
+	}
+}
+
+func TestDiscoverOversizedBody(t *testing.T) {
+	body := oversizedJSON(t, map[string]any{
+		"enabled":    true,
+		"apiVersion": "1.1",
+	}, "provider")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(body)
+	}))
+	defer srv.Close()
+
+	c := NewClient(10*time.Second, true)
+	disco, err := c.Discover(context.Background(), srv.URL)
+	assertOCMResponseTooLarge(t, err)
+	if disco != nil {
+		t.Fatalf("oversized discovery body must not be decoded, got %+v", disco)
+	}
+}
+
+func TestNewShareNormalSizedBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"recipientDisplayName": "Alice",
+		})
+	}))
+	defer srv.Close()
+
+	c := NewClient(10*time.Second, true)
+	resp, err := c.NewShare(context.Background(), srv.URL, testNewShareRequest())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp == nil || resp.RecipientDisplayName != "Alice" {
+		t.Fatalf("unexpected share response: %+v", resp)
+	}
+}
+
+func TestNewShareOversizedBody(t *testing.T) {
+	body := oversizedJSON(t, nil, "recipientDisplayName")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write(body)
+	}))
+	defer srv.Close()
+
+	c := NewClient(10*time.Second, true)
+	resp, err := c.NewShare(context.Background(), srv.URL, testNewShareRequest())
+	assertOCMResponseTooLarge(t, err)
+	if resp != nil {
+		t.Fatalf("oversized share body must not be decoded, got %+v", resp)
+	}
+}
+
+func TestNewShareOversizedTrailingBody(t *testing.T) {
+	body := []byte(`{"recipientDisplayName":"Alice"}` + strings.Repeat(" ", testOversizedOCMBody))
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write(body)
+	}))
+	defer srv.Close()
+
+	c := NewClient(10*time.Second, true)
+	resp, err := c.NewShare(context.Background(), srv.URL, testNewShareRequest())
+	assertOCMResponseTooLarge(t, err)
+	if resp != nil {
+		t.Fatalf("oversized trailing body must not return a decoded share, got %+v", resp)
+	}
+}
+
+func TestExchangeTokenOversizedBody(t *testing.T) {
+	body := oversizedJSON(t, map[string]any{"expires_in": 3600}, "access_token")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(body)
+	}))
+	defer srv.Close()
+
+	c := NewClient(10*time.Second, true)
+	tok, exp, err := c.ExchangeToken(context.Background(), srv.URL, "code123", "client1")
+	assertOCMResponseTooLarge(t, err)
+	if tok != "" || exp != 0 {
+		t.Fatalf("oversized token body must not be decoded, got token %q expires_in %d", tok, exp)
+	}
+}
+
+func TestExchangeTokenHTTP400OversizedBody(t *testing.T) {
+	body := oversizedJSON(t, map[string]any{"error": "invalid_grant"}, "error_description")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write(body)
+	}))
+	defer srv.Close()
+
+	c := NewClient(10*time.Second, true)
+	tok, exp, err := c.ExchangeToken(context.Background(), srv.URL, "code123", "client1")
+	assertOCMResponseTooLarge(t, err)
+	if tok != "" || exp != 0 {
+		t.Fatalf("oversized HTTP 400 token body must not be decoded, got token %q expires_in %d", tok, exp)
 	}
 }

--- a/internal/http/services/opencloudmesh/ocmd/client_test.go
+++ b/internal/http/services/opencloudmesh/ocmd/client_test.go
@@ -23,6 +23,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"errors"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -62,7 +63,7 @@ func TestExchangeTokenSuccess(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := NewClient(10*time.Second, true)
+	c := NewClient(10*time.Second, true, 0)
 	tok, exp, err := c.ExchangeToken(context.Background(), srv.URL, "code123", "client1")
 	if err != nil {
 		t.Fatal(err)
@@ -83,7 +84,7 @@ func TestExchangeTokenInvalidGrant(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := NewClient(10*time.Second, true)
+	c := NewClient(10*time.Second, true, 0)
 	_, _, err := c.ExchangeToken(context.Background(), srv.URL, "bad-code", "")
 	if err == nil {
 		t.Fatal("expected error for invalid_grant")
@@ -101,7 +102,7 @@ func TestExchangeTokenUnsupportedGrantType(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := NewClient(10*time.Second, true)
+	c := NewClient(10*time.Second, true, 0)
 	_, _, err := c.ExchangeToken(context.Background(), srv.URL, "code", "")
 	if err == nil {
 		t.Fatal("expected error for unsupported_grant_type")
@@ -117,7 +118,7 @@ func TestExchangeTokenForbidden(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := NewClient(10*time.Second, true)
+	c := NewClient(10*time.Second, true, 0)
 	_, _, err := c.ExchangeToken(context.Background(), srv.URL, "code", "")
 	if err == nil {
 		t.Fatal("expected error for 403")
@@ -133,7 +134,7 @@ func TestExchangeTokenUnauthorized(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := NewClient(10*time.Second, true)
+	c := NewClient(10*time.Second, true, 0)
 	_, _, err := c.ExchangeToken(context.Background(), srv.URL, "code", "")
 	if err == nil {
 		t.Fatal("expected error for 401")
@@ -149,7 +150,7 @@ func TestExchangeTokenServerError(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := NewClient(10*time.Second, true)
+	c := NewClient(10*time.Second, true, 0)
 	_, _, err := c.ExchangeToken(context.Background(), srv.URL, "code", "")
 	if err == nil {
 		t.Fatal("expected error for 500")
@@ -169,7 +170,7 @@ func TestExchangeTokenMissingAccessToken(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := NewClient(10*time.Second, true)
+	c := NewClient(10*time.Second, true, 0)
 	_, _, err := c.ExchangeToken(context.Background(), srv.URL, "code", "")
 	if err == nil {
 		t.Fatal("expected error for missing access_token")
@@ -186,7 +187,7 @@ func TestExchangeTokenMalformedJSON(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := NewClient(10*time.Second, true)
+	c := NewClient(10*time.Second, true, 0)
 	_, _, err := c.ExchangeToken(context.Background(), srv.URL, "code", "")
 	if err == nil {
 		t.Fatal("expected error for malformed JSON response")
@@ -216,7 +217,12 @@ func TestNewOCMTransportUsesProxyFromEnvironment(t *testing.T) {
 // The untrusted transport must not proxy, or the dial Control would see the
 // proxy address instead of the target.
 func TestNewPublicOnlyClientTransportProxyNil(t *testing.T) {
-	c := NewPublicOnlyClient(5*time.Second, true, testSec())
+	c := NewPublicOnlyClient(
+		5*time.Second,
+		true,
+		testSec(),
+		0,
+	)
 	tr := publicOnlyHTTPTransport(t, c)
 	if tr.Proxy != nil {
 		t.Error("untrusted client must not use a proxy")
@@ -260,7 +266,7 @@ func TestNewOCMTransportFallback(t *testing.T) {
 // TestNewClientUsesOCMTransport confirms the public constructor wires the
 // proxy-aware transport and request timeout into the HTTP client.
 func TestNewClientUsesOCMTransport(t *testing.T) {
-	c := NewClient(7*time.Second, true)
+	c := NewClient(7*time.Second, true, 0)
 	if c.client.Timeout != 7*time.Second {
 		t.Errorf("client timeout: got %v, want %v", c.client.Timeout, 7*time.Second)
 	}
@@ -279,8 +285,13 @@ func TestOCMClientTransportsRequireTLS12(t *testing.T) {
 		name   string
 		client *OCMClient
 	}{
-		{name: "NewClient", client: NewClient(5*time.Second, false)},
-		{name: "NewPublicOnlyClient", client: NewPublicOnlyClient(5*time.Second, false, testSec())},
+		{name: "NewClient", client: NewClient(5*time.Second, false, 0)},
+		{name: "NewPublicOnlyClient", client: NewPublicOnlyClient(
+			5*time.Second,
+			false,
+			testSec(),
+			0,
+		)},
 	}
 
 	for _, tt := range tests {
@@ -379,8 +390,13 @@ func TestPublicOnlyClientRefusesInternalHosts(t *testing.T) {
 		client  *OCMClient
 		wantErr bool
 	}{
-		{name: "public-only client refuses the loopback target", client: NewPublicOnlyClient(5*time.Second, true, testSec()), wantErr: true},
-		{name: "plain client still reaches it", client: NewClient(5*time.Second, true), wantErr: false},
+		{name: "public-only client refuses the loopback target", client: NewPublicOnlyClient(
+			5*time.Second,
+			true,
+			testSec(),
+			0,
+		), wantErr: true},
+		{name: "plain client still reaches it", client: NewClient(5*time.Second, true, 0), wantErr: false},
 	}
 
 	for _, tt := range tests {
@@ -451,7 +467,7 @@ func TestDiscoverNormalSizedBody(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := NewClient(10*time.Second, true)
+	c := NewClient(10*time.Second, true, 0)
 	disco, err := c.Discover(context.Background(), srv.URL)
 	if err != nil {
 		t.Fatal(err)
@@ -472,7 +488,7 @@ func TestDiscoverOversizedBody(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := NewClient(10*time.Second, true)
+	c := NewClient(10*time.Second, true, 0)
 	disco, err := c.Discover(context.Background(), srv.URL)
 	assertOCMResponseTooLarge(t, err)
 	if disco != nil {
@@ -490,7 +506,7 @@ func TestNewShareNormalSizedBody(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := NewClient(10*time.Second, true)
+	c := NewClient(10*time.Second, true, 0)
 	resp, err := c.NewShare(context.Background(), srv.URL, testNewShareRequest())
 	if err != nil {
 		t.Fatal(err)
@@ -509,7 +525,7 @@ func TestNewShareOversizedBody(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := NewClient(10*time.Second, true)
+	c := NewClient(10*time.Second, true, 0)
 	resp, err := c.NewShare(context.Background(), srv.URL, testNewShareRequest())
 	assertOCMResponseTooLarge(t, err)
 	if resp != nil {
@@ -526,7 +542,7 @@ func TestNewShareOversizedTrailingBody(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := NewClient(10*time.Second, true)
+	c := NewClient(10*time.Second, true, 0)
 	resp, err := c.NewShare(context.Background(), srv.URL, testNewShareRequest())
 	assertOCMResponseTooLarge(t, err)
 	if resp != nil {
@@ -542,7 +558,7 @@ func TestExchangeTokenOversizedBody(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := NewClient(10*time.Second, true)
+	c := NewClient(10*time.Second, true, 0)
 	tok, exp, err := c.ExchangeToken(context.Background(), srv.URL, "code123", "client1")
 	assertOCMResponseTooLarge(t, err)
 	if tok != "" || exp != 0 {
@@ -559,11 +575,112 @@ func TestExchangeTokenHTTP400OversizedBody(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := NewClient(10*time.Second, true)
+	c := NewClient(10*time.Second, true, 0)
 	tok, exp, err := c.ExchangeToken(context.Background(), srv.URL, "code123", "client1")
 	assertOCMResponseTooLarge(t, err)
 	if tok != "" || exp != 0 {
 		t.Fatalf("oversized HTTP 400 token body must not be decoded, got token %q expires_in %d", tok, exp)
+	}
+}
+
+func TestOCMClientResolvesResponseLimit(t *testing.T) {
+	tests := []struct {
+		name  string
+		limit int64
+		want  int64
+	}{
+		{name: "zero uses default", limit: 0, want: maxOCMResponseBytes},
+		{name: "negative uses default", limit: -1, want: maxOCMResponseBytes},
+		{name: "positive is stored", limit: 64, want: 64},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := NewClient(time.Second, true, tt.limit)
+			if c.responseLimit != tt.want {
+				t.Errorf("NewClient responseLimit = %d, want %d", c.responseLimit, tt.want)
+			}
+			p := NewPublicOnlyClient(
+				time.Second,
+				true,
+				testSec(),
+				tt.limit,
+			)
+			if p.responseLimit != tt.want {
+				t.Errorf("NewPublicOnlyClient responseLimit = %d, want %d", p.responseLimit, tt.want)
+			}
+		})
+	}
+}
+
+func TestConfiguredResponseLimitRejectsLargeBody(t *testing.T) {
+	payload := map[string]any{
+		"enabled":    true,
+		"apiVersion": "1.1",
+		"provider":   strings.Repeat("a", 80),
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(body) <= 64 {
+		t.Fatalf("fixture body is %d bytes, want more than 64", len(body))
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(body)
+	}))
+	defer srv.Close()
+
+	c := NewClient(10*time.Second, true, 64)
+	disco, err := c.Discover(context.Background(), srv.URL)
+	assertOCMResponseTooLarge(t, err)
+	if disco != nil {
+		t.Fatalf("body over the configured limit must not be decoded, got %+v", disco)
+	}
+}
+
+func TestInviteAcceptedOversizedBody(t *testing.T) {
+	body := oversizedJSON(t, map[string]any{"email": "a@b.c"}, "name")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(body)
+	}))
+	defer srv.Close()
+
+	c := NewClient(10*time.Second, true, 0)
+	u, err := c.InviteAccepted(context.Background(), srv.URL, &InviteAcceptedRequest{
+		UserID: "alice",
+		Token:  "tok",
+	})
+	assertOCMResponseTooLarge(t, err)
+	if u != nil {
+		t.Fatalf("oversized invite-accepted body must not be decoded, got %+v", u)
+	}
+}
+
+func TestParseInviteAcceptedResponseOversizedBody(t *testing.T) {
+	c := NewClient(10*time.Second, true, 64)
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(`{"userID":"` + strings.Repeat("a", 80) + `"}`)),
+	}
+	u, err := c.parseInviteAcceptedResponse(resp)
+	assertOCMResponseTooLarge(t, err)
+	if u != nil {
+		t.Fatalf("oversized invite-accepted JSON must not be decoded, got %+v", u)
+	}
+}
+
+func TestParseInviteAcceptedResponseOversizedErrorBody(t *testing.T) {
+	c := NewClient(10*time.Second, true, 64)
+	resp := &http.Response{
+		StatusCode: http.StatusInternalServerError,
+		Body:       io.NopCloser(strings.NewReader(strings.Repeat("x", 80))),
+	}
+	u, err := c.parseInviteAcceptedResponse(resp)
+	assertOCMResponseTooLarge(t, err)
+	if u != nil {
+		t.Fatalf("oversized invite-accepted error body must not be returned, got %+v", u)
 	}
 }
 
@@ -600,7 +717,12 @@ func TestPublicOnlyClientRedirectCapAndHTTPSScheme(t *testing.T) {
 		}))
 		defer srv.Close()
 
-		c := NewPublicOnlyClient(5*time.Second, true, testSec())
+		c := NewPublicOnlyClient(
+			5*time.Second,
+			true,
+			testSec(),
+			0,
+		)
 		allowPublicOnlyLoopback(t, c)
 		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
 		if err != nil {
@@ -623,7 +745,12 @@ func TestPublicOnlyClientRedirectCapAndHTTPSScheme(t *testing.T) {
 		}))
 		defer srv.Close()
 
-		c := NewPublicOnlyClient(5*time.Second, true, testSec())
+		c := NewPublicOnlyClient(
+			5*time.Second,
+			true,
+			testSec(),
+			0,
+		)
 		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
 		if err != nil {
 			t.Fatal(err)
@@ -651,7 +778,12 @@ func TestPublicOnlyClientRedirectCapAndHTTPSScheme(t *testing.T) {
 		}))
 		defer tlsSrv.Close()
 
-		c := NewPublicOnlyClient(5*time.Second, true, testSec())
+		c := NewPublicOnlyClient(
+			5*time.Second,
+			true,
+			testSec(),
+			0,
+		)
 		allowPublicOnlyLoopback(t, c)
 		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, tlsSrv.URL, nil)
 		if err != nil {
@@ -683,7 +815,12 @@ func TestPublicOnlyClientRedirectCapAndHTTPSScheme(t *testing.T) {
 		}))
 		defer srv.Close()
 
-		c := NewPublicOnlyClient(5*time.Second, true, testSec())
+		c := NewPublicOnlyClient(
+			5*time.Second,
+			true,
+			testSec(),
+			0,
+		)
 		allowPublicOnlyLoopback(t, c)
 		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
 		if err != nil {
@@ -713,7 +850,7 @@ func TestNewClientAllowsHTTPAndFollowsMoreThanThreeRedirects(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := NewClient(5*time.Second, true)
+	c := NewClient(5*time.Second, true, 0)
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -772,7 +909,12 @@ func TestPublicOnlyDiscoverSucceedsOnAllowedHTTPSHost(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := NewPublicOnlyClient(5*time.Second, true, testSec())
+	c := NewPublicOnlyClient(
+		5*time.Second,
+		true,
+		testSec(),
+		0,
+	)
 	allowPublicOnlyTestServer(t, c, srv.Listener.Addr().String())
 	disco, err := c.Discover(context.Background(), srv.URL)
 	if err != nil {
@@ -790,7 +932,12 @@ func TestPublicOnlyDiscoverRefusesRedirectToLinkLocal(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := NewPublicOnlyClient(5*time.Second, true, testSec())
+	c := NewPublicOnlyClient(
+		5*time.Second,
+		true,
+		testSec(),
+		0,
+	)
 	allowed := srv.Listener.Addr().String()
 	allowedHost, allowedPort, err := net.SplitHostPort(allowed)
 	if err != nil {
@@ -839,7 +986,12 @@ func TestPublicOnlyExchangeTokenSucceedsOnAllowedHTTPSHost(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := NewPublicOnlyClient(5*time.Second, true, testSec())
+	c := NewPublicOnlyClient(
+		5*time.Second,
+		true,
+		testSec(),
+		0,
+	)
 	allowPublicOnlyTestServer(t, c, srv.Listener.Addr().String())
 	tok, exp, err := c.ExchangeToken(context.Background(), srv.URL, "code123", "client1")
 	if err != nil {
@@ -857,7 +1009,12 @@ func TestPublicOnlyClientStillRefusesHTTPSLoopback(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := NewPublicOnlyClient(5*time.Second, true, testSec())
+	c := NewPublicOnlyClient(
+		5*time.Second,
+		true,
+		testSec(),
+		0,
+	)
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -1150,7 +1307,12 @@ func TestPublicOnlyCheckRedirectCapsAtThree(t *testing.T) {
 }
 
 func TestNewPublicOnlyClientKeepsPublicOnlyPolicy(t *testing.T) {
-	c := NewPublicOnlyClient(5*time.Second, true, testSec())
+	c := NewPublicOnlyClient(
+		5*time.Second,
+		true,
+		testSec(),
+		0,
+	)
 	if c.client.Timeout != 5*time.Second {
 		t.Errorf("client timeout: got %v, want %v", c.client.Timeout, 5*time.Second)
 	}

--- a/internal/http/services/opencloudmesh/ocmd/client_test.go
+++ b/internal/http/services/opencloudmesh/ocmd/client_test.go
@@ -572,24 +572,12 @@ func TestExchangeTokenHTTP400OversizedBody(t *testing.T) {
 // and Proxy=nil, and only drop Control so the TLS server is reachable.
 func allowPublicOnlyLoopback(t *testing.T, c *OCMClient) {
 	t.Helper()
-	tr := publicOnlyHTTPTransport(t, c)
-	tr.DialContext = (&net.Dialer{Timeout: 5 * time.Second}).DialContext
+	allowUntrustedLoopback(t, c.client.Transport)
 }
 
 func publicOnlyHTTPTransport(t *testing.T, c *OCMClient) *http.Transport {
 	t.Helper()
-	switch tr := c.client.Transport.(type) {
-	case *http.Transport:
-		return tr
-	case *publicOnlyTransport:
-		if tr.Transport == nil {
-			t.Fatal("public-only client is missing an inner *http.Transport")
-		}
-		return tr.Transport
-	default:
-		t.Fatalf("public-only client transport: got %T, want *http.Transport or *publicOnlyTransport", c.client.Transport)
-		return nil
-	}
+	return innerUntrustedTransport(t, c.client.Transport)
 }
 
 func closeResponse(resp *http.Response) {
@@ -880,5 +868,212 @@ func TestPublicOnlyClientStillRefusesHTTPSLoopback(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "non-public") {
 		t.Fatalf("got %v, want the existing non-public dial error", err)
+	}
+}
+
+func doUntrustedRequest(t *testing.T, rt http.RoundTripper, rawURL string) (*http.Response, error) {
+	t.Helper()
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, rawURL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return (&http.Client{Transport: rt}).Do(req)
+}
+
+func innerUntrustedTransport(t *testing.T, rt http.RoundTripper) *http.Transport {
+	t.Helper()
+	switch tr := rt.(type) {
+	case *http.Transport:
+		return tr
+	case *publicOnlyTransport:
+		if tr.Transport == nil {
+			t.Fatal("untrusted transport is missing an inner *http.Transport")
+		}
+		return tr.Transport
+	default:
+		t.Fatalf("untrusted transport: got %T, want *http.Transport or *publicOnlyTransport", rt)
+		return nil
+	}
+}
+
+func allowUntrustedLoopback(t *testing.T, rt http.RoundTripper) {
+	t.Helper()
+	tr := innerUntrustedTransport(t, rt)
+	tr.DialContext = (&net.Dialer{Timeout: 5 * time.Second}).DialContext
+}
+
+func TestUntrustedHTTPTransportRefusesNonPublicHosts(t *testing.T) {
+	t.Parallel()
+
+	t.Run("https loopback is refused at dial", func(t *testing.T) {
+		srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			t.Error("untrusted transport must not connect to loopback")
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer srv.Close()
+
+		resp, err := doUntrustedRequest(t, UntrustedHTTPTransport(5*time.Second, true), srv.URL)
+		closeResponse(resp)
+		if err == nil {
+			t.Fatal("expected untrusted transport to refuse https loopback at dial")
+		}
+		if !strings.Contains(err.Error(), "non-public") {
+			t.Fatalf("got %v, want the existing non-public dial error", err)
+		}
+	})
+
+	t.Run("cloud metadata host is refused at dial", func(t *testing.T) {
+		resp, err := doUntrustedRequest(t, UntrustedHTTPTransport(5*time.Second, true), "https://169.254.169.254/")
+		closeResponse(resp)
+		if err == nil {
+			t.Fatal("expected untrusted transport to refuse the metadata host at dial")
+		}
+		if !strings.Contains(err.Error(), "non-public") {
+			t.Fatalf("got %v, want the existing non-public dial error", err)
+		}
+	})
+}
+
+func TestUntrustedHTTPTransportRefusesHTTP(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("untrusted transport must not fetch a non-https URL")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	resp, err := doUntrustedRequest(t, UntrustedHTTPTransport(5*time.Second, true), srv.URL)
+	closeResponse(resp)
+	if err == nil {
+		t.Fatal("expected untrusted transport to refuse a non-https URL")
+	}
+	if !errors.Is(err, errPublicOnlyNonHTTPS) {
+		t.Fatalf("got %v, want errPublicOnlyNonHTTPS", err)
+	}
+}
+
+func TestUntrustedHTTPTransportRequiresTLS12(t *testing.T) {
+	rt := UntrustedHTTPTransport(5*time.Second, false)
+	tr := innerUntrustedTransport(t, rt)
+	if tr.TLSClientConfig == nil {
+		t.Fatal("TLSClientConfig is nil")
+	}
+	if tr.TLSClientConfig.MinVersion < tls.VersionTLS12 {
+		t.Errorf("MinVersion = %#x, want at least TLS 1.2 (%#x)", tr.TLSClientConfig.MinVersion, tls.VersionTLS12)
+	}
+	if tr.TLSClientConfig.InsecureSkipVerify {
+		t.Error("insecure=false must not set InsecureSkipVerify")
+	}
+
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("TLS 1.1 handshake must not succeed")
+		w.WriteHeader(http.StatusOK)
+	}))
+	srv.TLS = &tls.Config{
+		MinVersion: tls.VersionTLS11,
+		MaxVersion: tls.VersionTLS11,
+	}
+	srv.StartTLS()
+	defer srv.Close()
+
+	insecureRT := UntrustedHTTPTransport(5*time.Second, true)
+	allowUntrustedLoopback(t, insecureRT)
+	resp, err := doUntrustedRequest(t, insecureRT, srv.URL)
+	closeResponse(resp)
+	if err == nil {
+		t.Fatal("expected untrusted transport to refuse a TLS 1.1 handshake")
+	}
+	errMsg := strings.ToLower(err.Error())
+	mentionsTLS := strings.Contains(errMsg, "tls")
+	mentionsProtocol := strings.Contains(errMsg, "protocol")
+	mentionsHandshake := strings.Contains(errMsg, "handshake")
+	if !mentionsTLS && !mentionsProtocol && !mentionsHandshake {
+		t.Fatalf("got %v, want a TLS-version or handshake failure", err)
+	}
+}
+
+func TestUntrustedHTTPTransportMirrorsInsecureFlag(t *testing.T) {
+	for _, insecure := range []bool{false, true} {
+		tr := innerUntrustedTransport(t, UntrustedHTTPTransport(5*time.Second, insecure))
+		if tr.TLSClientConfig == nil {
+			t.Fatalf("insecure=%v: TLSClientConfig is nil", insecure)
+		}
+		if tr.TLSClientConfig.InsecureSkipVerify != insecure {
+			t.Errorf("insecure=%v: InsecureSkipVerify = %v, want %v", insecure, tr.TLSClientConfig.InsecureSkipVerify, insecure)
+		}
+		if tr.Proxy != nil {
+			t.Errorf("insecure=%v: untrusted transport must not use a proxy", insecure)
+		}
+	}
+}
+
+func TestUntrustedHTTPTransportFitsGowebdavSetTransport(t *testing.T) {
+	var rt http.RoundTripper = UntrustedHTTPTransport(5*time.Second, false)
+	if rt == nil {
+		t.Fatal("UntrustedHTTPTransport returned nil")
+	}
+}
+
+func TestPublicOnlyCheckRedirectCapsAtThree(t *testing.T) {
+	hops := 0
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hops++
+		if hops <= 4 {
+			http.Redirect(w, r, "/hop", http.StatusFound)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	rt := UntrustedHTTPTransport(5*time.Second, true)
+	allowUntrustedLoopback(t, rt)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := (&http.Client{
+		Transport:     rt,
+		CheckRedirect: PublicOnlyCheckRedirect,
+	}).Do(req)
+	closeResponse(resp)
+	if err == nil {
+		t.Fatal("expected PublicOnlyCheckRedirect to refuse more than 3 redirects")
+	}
+	if !errors.Is(err, errPublicOnlyTooManyRedirects) {
+		t.Fatalf("got %v, want errPublicOnlyTooManyRedirects", err)
+	}
+}
+
+func TestNewPublicOnlyClientKeepsPublicOnlyPolicy(t *testing.T) {
+	c := NewPublicOnlyClient(5*time.Second, true)
+	if c.client.Timeout != 5*time.Second {
+		t.Errorf("client timeout: got %v, want %v", c.client.Timeout, 5*time.Second)
+	}
+	if _, ok := c.client.Transport.(*publicOnlyTransport); !ok {
+		t.Fatalf("transport: got %T, want *publicOnlyTransport", c.client.Transport)
+	}
+	if c.client.CheckRedirect == nil {
+		t.Fatal("NewPublicOnlyClient must keep CheckRedirect")
+	}
+	got := reflect.ValueOf(c.client.CheckRedirect).Pointer()
+	want := reflect.ValueOf(PublicOnlyCheckRedirect).Pointer()
+	if got != want {
+		t.Error("NewPublicOnlyClient CheckRedirect must stay PublicOnlyCheckRedirect")
+	}
+
+	tr := publicOnlyHTTPTransport(t, c)
+	if tr.Proxy != nil {
+		t.Error("public-only client must not use a proxy")
+	}
+	if tr.TLSClientConfig == nil {
+		t.Fatal("TLSClientConfig is nil")
+	}
+	if tr.TLSClientConfig.MinVersion < tls.VersionTLS12 {
+		t.Errorf("MinVersion = %#x, want at least TLS 1.2 (%#x)", tr.TLSClientConfig.MinVersion, tls.VersionTLS12)
+	}
+	if !tr.TLSClientConfig.InsecureSkipVerify {
+		t.Error("insecure=true must set InsecureSkipVerify")
 	}
 }

--- a/internal/http/services/opencloudmesh/ocmd/client_test.go
+++ b/internal/http/services/opencloudmesh/ocmd/client_test.go
@@ -739,6 +739,128 @@ func TestNewClientAllowsHTTPAndFollowsMoreThanThreeRedirects(t *testing.T) {
 	}
 }
 
+// allowPublicOnlyTestServer keeps the public-only HTTPS gate, redirect cap, and
+// non-public dial refusal, and only permits the httptest listener so the first
+// hop is reachable. Redirects to other addresses still hit refuseNonPublicAddr.
+func allowPublicOnlyTestServer(t *testing.T, c *OCMClient, allowed string) {
+	t.Helper()
+	allowedHost, allowedPort, err := net.SplitHostPort(allowed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tr := publicOnlyHTTPTransport(t, c)
+	tr.DialContext = func(ctx context.Context, network, address string) (net.Conn, error) {
+		host, port, err := net.SplitHostPort(address)
+		if err != nil {
+			return nil, err
+		}
+		if host == allowedHost && port == allowedPort {
+			return (&net.Dialer{Timeout: 5 * time.Second}).DialContext(ctx, network, address)
+		}
+		if err := refuseNonPublicAddr(network, address, nil); err != nil {
+			return nil, err
+		}
+		return (&net.Dialer{Timeout: 5 * time.Second}).DialContext(ctx, network, address)
+	}
+}
+
+func TestPublicOnlyDiscoverSucceedsOnAllowedHTTPSHost(t *testing.T) {
+	var srv *httptest.Server
+	srv = httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/.well-known/ocm" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"enabled":       true,
+			"apiVersion":    "1.2.0",
+			"endPoint":      srv.URL + "/ocm",
+			"provider":      "reva",
+			"resourceTypes": []any{},
+			"tokenEndPoint": srv.URL + "/ocm/token",
+		})
+	}))
+	defer srv.Close()
+
+	c := NewPublicOnlyClient(5*time.Second, true)
+	allowPublicOnlyTestServer(t, c, srv.Listener.Addr().String())
+	disco, err := c.Discover(context.Background(), srv.URL)
+	if err != nil {
+		t.Fatalf("Discover() on an allowed HTTPS host: %v", err)
+	}
+	if disco == nil || disco.TokenEndPoint != srv.URL+"/ocm/token" {
+		t.Fatalf("unexpected discovery payload: %+v", disco)
+	}
+}
+
+func TestPublicOnlyDiscoverRefusesRedirectToLinkLocal(t *testing.T) {
+	var dialed []string
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "https://169.254.169.254/.well-known/ocm", http.StatusFound)
+	}))
+	defer srv.Close()
+
+	c := NewPublicOnlyClient(5*time.Second, true)
+	allowed := srv.Listener.Addr().String()
+	allowedHost, allowedPort, err := net.SplitHostPort(allowed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tr := publicOnlyHTTPTransport(t, c)
+	tr.DialContext = func(ctx context.Context, network, address string) (net.Conn, error) {
+		dialed = append(dialed, address)
+		host, port, err := net.SplitHostPort(address)
+		if err != nil {
+			return nil, err
+		}
+		if host == allowedHost && port == allowedPort {
+			return (&net.Dialer{Timeout: 5 * time.Second}).DialContext(ctx, network, address)
+		}
+		if err := refuseNonPublicAddr(network, address, nil); err != nil {
+			return nil, err
+		}
+		return (&net.Dialer{Timeout: 5 * time.Second}).DialContext(ctx, network, address)
+	}
+
+	_, err = c.Discover(context.Background(), srv.URL)
+	if err == nil {
+		t.Fatal("expected Discover to refuse a redirect to a link-local address")
+	}
+	sawLinkLocal := false
+	for _, address := range dialed {
+		if strings.HasPrefix(address, "169.254.169.254:") {
+			sawLinkLocal = true
+			break
+		}
+	}
+	if !sawLinkLocal {
+		t.Fatalf("expected a redirect-hop dial to 169.254.169.254, dialed %v", dialed)
+	}
+}
+
+func TestPublicOnlyExchangeTokenSucceedsOnAllowedHTTPSHost(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token": "jwt-tok",
+			"token_type":   "Bearer",
+			"expires_in":   3600,
+		})
+	}))
+	defer srv.Close()
+
+	c := NewPublicOnlyClient(5*time.Second, true)
+	allowPublicOnlyTestServer(t, c, srv.Listener.Addr().String())
+	tok, exp, err := c.ExchangeToken(context.Background(), srv.URL, "code123", "client1")
+	if err != nil {
+		t.Fatalf("ExchangeToken() on an allowed HTTPS host: %v", err)
+	}
+	if tok != "jwt-tok" || exp != 3600 {
+		t.Fatalf("got token %q expires_in %d, want jwt-tok / 3600", tok, exp)
+	}
+}
+
 func TestPublicOnlyClientStillRefusesHTTPSLoopback(t *testing.T) {
 	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Error("public-only dial guard must not connect to loopback")

--- a/internal/http/services/opencloudmesh/ocmd/client_test.go
+++ b/internal/http/services/opencloudmesh/ocmd/client_test.go
@@ -203,7 +203,7 @@ func (f roundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) { r
 // The trusted transport must keep http.ProxyFromEnvironment: some deployments
 // only reach their peers through a corporate proxy.
 func TestNewOCMTransportUsesProxyFromEnvironment(t *testing.T) {
-	tr := newOCMTransport(false)
+	tr := newOCMTransport(false, 0)
 	if tr.Proxy == nil {
 		t.Fatal("transport Proxy must not be nil")
 	}
@@ -222,6 +222,7 @@ func TestNewPublicOnlyClientTransportProxyNil(t *testing.T) {
 		true,
 		testSec(),
 		0,
+		0,
 	)
 	tr := publicOnlyHTTPTransport(t, c)
 	if tr.Proxy != nil {
@@ -232,7 +233,7 @@ func TestNewPublicOnlyClientTransportProxyNil(t *testing.T) {
 // TestNewOCMTransportInsecureSkipVerify checks the TLS contract is preserved.
 func TestNewOCMTransportInsecureSkipVerify(t *testing.T) {
 	for _, insecure := range []bool{false, true} {
-		tr := newOCMTransport(insecure)
+		tr := newOCMTransport(insecure, 0)
 		if tr.TLSClientConfig == nil {
 			t.Fatalf("insecure=%v: TLSClientConfig is nil", insecure)
 		}
@@ -251,7 +252,7 @@ func TestNewOCMTransportFallback(t *testing.T) {
 		return nil, nil
 	})
 
-	tr := newOCMTransport(true)
+	tr := newOCMTransport(true, 0)
 	if tr.Proxy == nil {
 		t.Fatal("fallback transport Proxy must not be nil")
 	}
@@ -291,6 +292,7 @@ func TestOCMClientTransportsRequireTLS12(t *testing.T) {
 			false,
 			testSec(),
 			0,
+			0,
 		)},
 	}
 
@@ -305,6 +307,104 @@ func TestOCMClientTransportsRequireTLS12(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestNewOCMTransportMinVersion(t *testing.T) {
+	t.Run("zero defaults to TLS 1.2", func(t *testing.T) {
+		tr := newOCMTransport(false, 0)
+		if tr.TLSClientConfig == nil {
+			t.Fatal("TLSClientConfig is nil")
+		}
+		if tr.TLSClientConfig.MinVersion != tls.VersionTLS12 {
+			t.Fatalf("MinVersion = %#x, want TLS 1.2 (%#x)", tr.TLSClientConfig.MinVersion, tls.VersionTLS12)
+		}
+		if tr.TLSClientConfig.InsecureSkipVerify {
+			t.Error("insecure=false must not set InsecureSkipVerify")
+		}
+	})
+
+	t.Run("1.3 raises the floor", func(t *testing.T) {
+		tr := newOCMTransport(false, tls.VersionTLS13)
+		if tr.TLSClientConfig == nil {
+			t.Fatal("TLSClientConfig is nil")
+		}
+		if tr.TLSClientConfig.MinVersion != tls.VersionTLS13 {
+			t.Fatalf("MinVersion = %#x, want TLS 1.3 (%#x)", tr.TLSClientConfig.MinVersion, tls.VersionTLS13)
+		}
+	})
+}
+
+func TestNewOCMTransportRejectsBelowFloor(t *testing.T) {
+	tests := []struct {
+		name       string
+		minVersion uint16
+	}{
+		{name: "TLS 1.0", minVersion: tls.VersionTLS10},
+		{name: "TLS 1.1", minVersion: tls.VersionTLS11},
+		{name: "nonzero below floor", minVersion: 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			defer func() {
+				if recover() == nil {
+					t.Fatalf("newOCMTransport(false, %#x) must reject below TLS 1.2", tt.minVersion)
+				}
+			}()
+			tr := newOCMTransport(false, tt.minVersion)
+			t.Fatalf("newOCMTransport returned MinVersion %#x instead of rejecting", tr.TLSClientConfig.MinVersion)
+		})
+	}
+}
+
+func TestUntrustedConstructorsHonorTLSMinVersion(t *testing.T) {
+	t.Run("default 0 is TLS 1.2", func(t *testing.T) {
+		c := NewPublicOnlyClient(
+			5*time.Second,
+			false,
+			testSec(),
+			0,
+			0,
+		)
+		tr := publicOnlyHTTPTransport(t, c)
+		if tr.TLSClientConfig.MinVersion != tls.VersionTLS12 {
+			t.Fatalf("NewPublicOnlyClient MinVersion = %#x, want TLS 1.2", tr.TLSClientConfig.MinVersion)
+		}
+		rt := UntrustedHTTPTransport(
+			5*time.Second,
+			false,
+			testSec(),
+			0,
+		)
+		got := innerUntrustedTransport(t, rt)
+		if got.TLSClientConfig.MinVersion != tls.VersionTLS12 {
+			t.Fatalf("UntrustedHTTPTransport MinVersion = %#x, want TLS 1.2", got.TLSClientConfig.MinVersion)
+		}
+	})
+
+	t.Run("1.3 reaches the transport", func(t *testing.T) {
+		c := NewPublicOnlyClient(
+			5*time.Second,
+			false,
+			testSec(),
+			0,
+			tls.VersionTLS13,
+		)
+		tr := publicOnlyHTTPTransport(t, c)
+		if tr.TLSClientConfig.MinVersion != tls.VersionTLS13 {
+			t.Fatalf("NewPublicOnlyClient MinVersion = %#x, want TLS 1.3", tr.TLSClientConfig.MinVersion)
+		}
+		rt := UntrustedHTTPTransport(
+			5*time.Second,
+			false,
+			testSec(),
+			tls.VersionTLS13,
+		)
+		got := innerUntrustedTransport(t, rt)
+		if got.TLSClientConfig.MinVersion != tls.VersionTLS13 {
+			t.Fatalf("UntrustedHTTPTransport MinVersion = %#x, want TLS 1.3", got.TLSClientConfig.MinVersion)
+		}
+	})
 }
 
 func TestIsPublicIP(t *testing.T) {
@@ -394,6 +494,7 @@ func TestPublicOnlyClientRefusesInternalHosts(t *testing.T) {
 			5*time.Second,
 			true,
 			testSec(),
+			0,
 			0,
 		), wantErr: true},
 		{name: "plain client still reaches it", client: NewClient(5*time.Second, true, 0), wantErr: false},
@@ -604,6 +705,7 @@ func TestOCMClientResolvesResponseLimit(t *testing.T) {
 				true,
 				testSec(),
 				tt.limit,
+				0,
 			)
 			if p.responseLimit != tt.want {
 				t.Errorf("NewPublicOnlyClient responseLimit = %d, want %d", p.responseLimit, tt.want)
@@ -722,6 +824,7 @@ func TestPublicOnlyClientRedirectCapAndHTTPSScheme(t *testing.T) {
 			true,
 			testSec(),
 			0,
+			0,
 		)
 		allowPublicOnlyLoopback(t, c)
 		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
@@ -749,6 +852,7 @@ func TestPublicOnlyClientRedirectCapAndHTTPSScheme(t *testing.T) {
 			5*time.Second,
 			true,
 			testSec(),
+			0,
 			0,
 		)
 		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
@@ -782,6 +886,7 @@ func TestPublicOnlyClientRedirectCapAndHTTPSScheme(t *testing.T) {
 			5*time.Second,
 			true,
 			testSec(),
+			0,
 			0,
 		)
 		allowPublicOnlyLoopback(t, c)
@@ -819,6 +924,7 @@ func TestPublicOnlyClientRedirectCapAndHTTPSScheme(t *testing.T) {
 			5*time.Second,
 			true,
 			testSec(),
+			0,
 			0,
 		)
 		allowPublicOnlyLoopback(t, c)
@@ -914,6 +1020,7 @@ func TestPublicOnlyDiscoverSucceedsOnAllowedHTTPSHost(t *testing.T) {
 		true,
 		testSec(),
 		0,
+		0,
 	)
 	allowPublicOnlyTestServer(t, c, srv.Listener.Addr().String())
 	disco, err := c.Discover(context.Background(), srv.URL)
@@ -936,6 +1043,7 @@ func TestPublicOnlyDiscoverRefusesRedirectToLinkLocal(t *testing.T) {
 		5*time.Second,
 		true,
 		testSec(),
+		0,
 		0,
 	)
 	allowed := srv.Listener.Addr().String()
@@ -991,6 +1099,7 @@ func TestPublicOnlyExchangeTokenSucceedsOnAllowedHTTPSHost(t *testing.T) {
 		true,
 		testSec(),
 		0,
+		0,
 	)
 	allowPublicOnlyTestServer(t, c, srv.Listener.Addr().String())
 	tok, exp, err := c.ExchangeToken(context.Background(), srv.URL, "code123", "client1")
@@ -1013,6 +1122,7 @@ func TestPublicOnlyClientStillRefusesHTTPSLoopback(t *testing.T) {
 		5*time.Second,
 		true,
 		testSec(),
+		0,
 		0,
 	)
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
@@ -1070,7 +1180,7 @@ func TestUntrustedHTTPTransportRefusesNonPublicHosts(t *testing.T) {
 		}))
 		defer srv.Close()
 
-		resp, err := doUntrustedRequest(t, UntrustedHTTPTransport(5*time.Second, true, testSec()), srv.URL)
+		resp, err := doUntrustedRequest(t, UntrustedHTTPTransport(5*time.Second, true, testSec(), 0), srv.URL)
 		closeResponse(resp)
 		if err == nil {
 			t.Fatal("expected untrusted transport to refuse https loopback at dial")
@@ -1081,7 +1191,7 @@ func TestUntrustedHTTPTransportRefusesNonPublicHosts(t *testing.T) {
 	})
 
 	t.Run("cloud metadata host is refused at dial", func(t *testing.T) {
-		resp, err := doUntrustedRequest(t, UntrustedHTTPTransport(5*time.Second, true, testSec()), "https://169.254.169.254/")
+		resp, err := doUntrustedRequest(t, UntrustedHTTPTransport(5*time.Second, true, testSec(), 0), "https://169.254.169.254/")
 		closeResponse(resp)
 		if err == nil {
 			t.Fatal("expected untrusted transport to refuse the metadata host at dial")
@@ -1101,7 +1211,7 @@ func TestUntrustedHTTPTransportRefusesHTTP(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	resp, err := doUntrustedRequest(t, UntrustedHTTPTransport(5*time.Second, true, testSec()), srv.URL)
+	resp, err := doUntrustedRequest(t, UntrustedHTTPTransport(5*time.Second, true, testSec(), 0), srv.URL)
 	closeResponse(resp)
 	if err == nil {
 		t.Fatal("expected untrusted transport to refuse a non-https URL")
@@ -1112,7 +1222,7 @@ func TestUntrustedHTTPTransportRefusesHTTP(t *testing.T) {
 }
 
 func TestUntrustedHTTPTransportRequiresTLS12(t *testing.T) {
-	rt := UntrustedHTTPTransport(5*time.Second, false, testSec())
+	rt := UntrustedHTTPTransport(5*time.Second, false, testSec(), 0)
 	tr := innerUntrustedTransport(t, rt)
 	if tr.TLSClientConfig == nil {
 		t.Fatal("TLSClientConfig is nil")
@@ -1135,7 +1245,7 @@ func TestUntrustedHTTPTransportRequiresTLS12(t *testing.T) {
 	srv.StartTLS()
 	defer srv.Close()
 
-	insecureRT := UntrustedHTTPTransport(5*time.Second, true, testSec())
+	insecureRT := UntrustedHTTPTransport(5*time.Second, true, testSec(), 0)
 	allowUntrustedLoopback(t, insecureRT)
 	resp, err := doUntrustedRequest(t, insecureRT, srv.URL)
 	closeResponse(resp)
@@ -1153,7 +1263,7 @@ func TestUntrustedHTTPTransportRequiresTLS12(t *testing.T) {
 
 func TestUntrustedHTTPTransportMirrorsInsecureFlag(t *testing.T) {
 	for _, insecure := range []bool{false, true} {
-		tr := innerUntrustedTransport(t, UntrustedHTTPTransport(5*time.Second, insecure, testSec()))
+		tr := innerUntrustedTransport(t, UntrustedHTTPTransport(5*time.Second, insecure, testSec(), 0))
 		if tr.TLSClientConfig == nil {
 			t.Fatalf("insecure=%v: TLSClientConfig is nil", insecure)
 		}
@@ -1167,7 +1277,7 @@ func TestUntrustedHTTPTransportMirrorsInsecureFlag(t *testing.T) {
 }
 
 func TestUntrustedHTTPTransportFitsGowebdavSetTransport(t *testing.T) {
-	var rt http.RoundTripper = UntrustedHTTPTransport(5*time.Second, false, testSec())
+	var rt http.RoundTripper = UntrustedHTTPTransport(5*time.Second, false, testSec(), 0)
 	if rt == nil {
 		t.Fatal("UntrustedHTTPTransport returned nil")
 	}
@@ -1215,7 +1325,7 @@ func TestPublicOnlyTransportRedirectWalkerHonorsConfiguredCap(t *testing.T) {
 		defer srv.Close()
 
 		sec := receivedLoopbackHTTPSec(t, redirectCap, srv.Listener.Addr())
-		rt := UntrustedHTTPTransport(5*time.Second, true, sec)
+		rt := UntrustedHTTPTransport(5*time.Second, true, sec, 0)
 		pot, ok := rt.(*publicOnlyTransport)
 		if !ok {
 			t.Fatalf("transport: got %T, want *publicOnlyTransport", rt)
@@ -1254,7 +1364,7 @@ func TestPublicOnlyTransportRedirectWalkerHonorsConfiguredCap(t *testing.T) {
 		defer srv.Close()
 
 		sec := receivedLoopbackHTTPSec(t, redirectCap, srv.Listener.Addr())
-		rt := UntrustedHTTPTransport(5*time.Second, true, sec)
+		rt := UntrustedHTTPTransport(5*time.Second, true, sec, 0)
 		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
 		if err != nil {
 			t.Fatal(err)
@@ -1287,7 +1397,7 @@ func TestPublicOnlyCheckRedirectCapsAtThree(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	rt := UntrustedHTTPTransport(5*time.Second, true, testSec())
+	rt := UntrustedHTTPTransport(5*time.Second, true, testSec(), 0)
 	allowUntrustedLoopback(t, rt)
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
 	if err != nil {
@@ -1311,6 +1421,7 @@ func TestNewPublicOnlyClientKeepsPublicOnlyPolicy(t *testing.T) {
 		5*time.Second,
 		true,
 		testSec(),
+		0,
 		0,
 	)
 	if c.client.Timeout != 5*time.Second {

--- a/internal/http/services/opencloudmesh/ocmd/client_test.go
+++ b/internal/http/services/opencloudmesh/ocmd/client_test.go
@@ -213,13 +213,13 @@ func TestNewOCMTransportUsesProxyFromEnvironment(t *testing.T) {
 	}
 }
 
-// The public-only transport must not proxy, or the dial Control would see the
+// The untrusted transport must not proxy, or the dial Control would see the
 // proxy address instead of the target.
 func TestNewPublicOnlyClientTransportProxyNil(t *testing.T) {
-	c := NewPublicOnlyClient(5*time.Second, true)
+	c := NewPublicOnlyClient(5*time.Second, true, testSec())
 	tr := publicOnlyHTTPTransport(t, c)
 	if tr.Proxy != nil {
-		t.Error("public-only client must not use a proxy")
+		t.Error("untrusted client must not use a proxy")
 	}
 }
 
@@ -280,7 +280,7 @@ func TestOCMClientTransportsRequireTLS12(t *testing.T) {
 		client *OCMClient
 	}{
 		{name: "NewClient", client: NewClient(5*time.Second, false)},
-		{name: "NewPublicOnlyClient", client: NewPublicOnlyClient(5*time.Second, false)},
+		{name: "NewPublicOnlyClient", client: NewPublicOnlyClient(5*time.Second, false, testSec())},
 	}
 
 	for _, tt := range tests {
@@ -379,7 +379,7 @@ func TestPublicOnlyClientRefusesInternalHosts(t *testing.T) {
 		client  *OCMClient
 		wantErr bool
 	}{
-		{name: "public-only client refuses the loopback target", client: NewPublicOnlyClient(5*time.Second, true), wantErr: true},
+		{name: "public-only client refuses the loopback target", client: NewPublicOnlyClient(5*time.Second, true, testSec()), wantErr: true},
 		{name: "plain client still reaches it", client: NewClient(5*time.Second, true), wantErr: false},
 	}
 
@@ -567,9 +567,10 @@ func TestExchangeTokenHTTP400OversizedBody(t *testing.T) {
 	}
 }
 
-// httptest servers bind loopback, which the public-only dial guard refuses.
-// Redirect and scheme tests keep the constructor's CheckRedirect, https gate,
-// and Proxy=nil, and only drop Control so the TLS server is reachable.
+// httptest servers bind loopback, which the untrusted dial guard refuses
+// when the hatch is empty. Redirect and scheme tests keep the constructor's
+// CheckRedirect, https gate, and Proxy=nil, and only drop Control so the
+// TLS server is reachable.
 func allowPublicOnlyLoopback(t *testing.T, c *OCMClient) {
 	t.Helper()
 	allowUntrustedLoopback(t, c.client.Transport)
@@ -599,7 +600,7 @@ func TestPublicOnlyClientRedirectCapAndHTTPSScheme(t *testing.T) {
 		}))
 		defer srv.Close()
 
-		c := NewPublicOnlyClient(5*time.Second, true)
+		c := NewPublicOnlyClient(5*time.Second, true, testSec())
 		allowPublicOnlyLoopback(t, c)
 		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
 		if err != nil {
@@ -610,8 +611,8 @@ func TestPublicOnlyClientRedirectCapAndHTTPSScheme(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected public-only client to refuse more than 3 redirects")
 		}
-		if !errors.Is(err, errPublicOnlyTooManyRedirects) {
-			t.Fatalf("got %v, want errPublicOnlyTooManyRedirects", err)
+		if !errors.Is(err, ErrTooManyRedirects) {
+			t.Fatalf("got %v, want ErrTooManyRedirects", err)
 		}
 	})
 
@@ -622,7 +623,7 @@ func TestPublicOnlyClientRedirectCapAndHTTPSScheme(t *testing.T) {
 		}))
 		defer srv.Close()
 
-		c := NewPublicOnlyClient(5*time.Second, true)
+		c := NewPublicOnlyClient(5*time.Second, true, testSec())
 		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
 		if err != nil {
 			t.Fatal(err)
@@ -632,8 +633,8 @@ func TestPublicOnlyClientRedirectCapAndHTTPSScheme(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected public-only client to refuse a non-https URL")
 		}
-		if !errors.Is(err, errPublicOnlyNonHTTPS) {
-			t.Fatalf("got %v, want errPublicOnlyNonHTTPS", err)
+		if !errors.Is(err, ErrNonHTTPS) {
+			t.Fatalf("got %v, want ErrNonHTTPS", err)
 		}
 	})
 
@@ -650,7 +651,7 @@ func TestPublicOnlyClientRedirectCapAndHTTPSScheme(t *testing.T) {
 		}))
 		defer tlsSrv.Close()
 
-		c := NewPublicOnlyClient(5*time.Second, true)
+		c := NewPublicOnlyClient(5*time.Second, true, testSec())
 		allowPublicOnlyLoopback(t, c)
 		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, tlsSrv.URL, nil)
 		if err != nil {
@@ -664,8 +665,8 @@ func TestPublicOnlyClientRedirectCapAndHTTPSScheme(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected public-only client to refuse an http redirect hop")
 		}
-		if !errors.Is(err, errPublicOnlyNonHTTPS) {
-			t.Fatalf("got %v, want errPublicOnlyNonHTTPS", err)
+		if !errors.Is(err, ErrNonHTTPS) {
+			t.Fatalf("got %v, want ErrNonHTTPS", err)
 		}
 	})
 
@@ -682,7 +683,7 @@ func TestPublicOnlyClientRedirectCapAndHTTPSScheme(t *testing.T) {
 		}))
 		defer srv.Close()
 
-		c := NewPublicOnlyClient(5*time.Second, true)
+		c := NewPublicOnlyClient(5*time.Second, true, testSec())
 		allowPublicOnlyLoopback(t, c)
 		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
 		if err != nil {
@@ -727,9 +728,9 @@ func TestNewClientAllowsHTTPAndFollowsMoreThanThreeRedirects(t *testing.T) {
 	}
 }
 
-// allowPublicOnlyTestServer keeps the public-only HTTPS gate, redirect cap, and
-// non-public dial refusal, and only permits the httptest listener so the first
-// hop is reachable. Redirects to other addresses still hit refuseNonPublicAddr.
+// allowPublicOnlyTestServer keeps the configured HTTPS gate, redirect cap, and
+// dial policy, and only permits the httptest listener so the first hop is
+// reachable. Redirects to other addresses still hit refuseNonPublicAddr.
 func allowPublicOnlyTestServer(t *testing.T, c *OCMClient, allowed string) {
 	t.Helper()
 	allowedHost, allowedPort, err := net.SplitHostPort(allowed)
@@ -771,7 +772,7 @@ func TestPublicOnlyDiscoverSucceedsOnAllowedHTTPSHost(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := NewPublicOnlyClient(5*time.Second, true)
+	c := NewPublicOnlyClient(5*time.Second, true, testSec())
 	allowPublicOnlyTestServer(t, c, srv.Listener.Addr().String())
 	disco, err := c.Discover(context.Background(), srv.URL)
 	if err != nil {
@@ -789,7 +790,7 @@ func TestPublicOnlyDiscoverRefusesRedirectToLinkLocal(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := NewPublicOnlyClient(5*time.Second, true)
+	c := NewPublicOnlyClient(5*time.Second, true, testSec())
 	allowed := srv.Listener.Addr().String()
 	allowedHost, allowedPort, err := net.SplitHostPort(allowed)
 	if err != nil {
@@ -838,7 +839,7 @@ func TestPublicOnlyExchangeTokenSucceedsOnAllowedHTTPSHost(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := NewPublicOnlyClient(5*time.Second, true)
+	c := NewPublicOnlyClient(5*time.Second, true, testSec())
 	allowPublicOnlyTestServer(t, c, srv.Listener.Addr().String())
 	tok, exp, err := c.ExchangeToken(context.Background(), srv.URL, "code123", "client1")
 	if err != nil {
@@ -856,7 +857,7 @@ func TestPublicOnlyClientStillRefusesHTTPSLoopback(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	c := NewPublicOnlyClient(5*time.Second, true)
+	c := NewPublicOnlyClient(5*time.Second, true, testSec())
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -866,8 +867,8 @@ func TestPublicOnlyClientStillRefusesHTTPSLoopback(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected public-only dial guard to refuse https loopback")
 	}
-	if !strings.Contains(err.Error(), "non-public") {
-		t.Fatalf("got %v, want the existing non-public dial error", err)
+	if !errors.Is(err, ErrNonPublicAddr) {
+		t.Fatalf("got %v, want ErrNonPublicAddr", err)
 	}
 }
 
@@ -912,24 +913,24 @@ func TestUntrustedHTTPTransportRefusesNonPublicHosts(t *testing.T) {
 		}))
 		defer srv.Close()
 
-		resp, err := doUntrustedRequest(t, UntrustedHTTPTransport(5*time.Second, true), srv.URL)
+		resp, err := doUntrustedRequest(t, UntrustedHTTPTransport(5*time.Second, true, testSec()), srv.URL)
 		closeResponse(resp)
 		if err == nil {
 			t.Fatal("expected untrusted transport to refuse https loopback at dial")
 		}
-		if !strings.Contains(err.Error(), "non-public") {
-			t.Fatalf("got %v, want the existing non-public dial error", err)
+		if !errors.Is(err, ErrNonPublicAddr) {
+			t.Fatalf("got %v, want ErrNonPublicAddr", err)
 		}
 	})
 
 	t.Run("cloud metadata host is refused at dial", func(t *testing.T) {
-		resp, err := doUntrustedRequest(t, UntrustedHTTPTransport(5*time.Second, true), "https://169.254.169.254/")
+		resp, err := doUntrustedRequest(t, UntrustedHTTPTransport(5*time.Second, true, testSec()), "https://169.254.169.254/")
 		closeResponse(resp)
 		if err == nil {
 			t.Fatal("expected untrusted transport to refuse the metadata host at dial")
 		}
-		if !strings.Contains(err.Error(), "non-public") {
-			t.Fatalf("got %v, want the existing non-public dial error", err)
+		if !errors.Is(err, ErrNonPublicAddr) {
+			t.Fatalf("got %v, want ErrNonPublicAddr", err)
 		}
 	})
 }
@@ -943,18 +944,18 @@ func TestUntrustedHTTPTransportRefusesHTTP(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	resp, err := doUntrustedRequest(t, UntrustedHTTPTransport(5*time.Second, true), srv.URL)
+	resp, err := doUntrustedRequest(t, UntrustedHTTPTransport(5*time.Second, true, testSec()), srv.URL)
 	closeResponse(resp)
 	if err == nil {
 		t.Fatal("expected untrusted transport to refuse a non-https URL")
 	}
-	if !errors.Is(err, errPublicOnlyNonHTTPS) {
-		t.Fatalf("got %v, want errPublicOnlyNonHTTPS", err)
+	if !errors.Is(err, ErrNonHTTPS) {
+		t.Fatalf("got %v, want ErrNonHTTPS", err)
 	}
 }
 
 func TestUntrustedHTTPTransportRequiresTLS12(t *testing.T) {
-	rt := UntrustedHTTPTransport(5*time.Second, false)
+	rt := UntrustedHTTPTransport(5*time.Second, false, testSec())
 	tr := innerUntrustedTransport(t, rt)
 	if tr.TLSClientConfig == nil {
 		t.Fatal("TLSClientConfig is nil")
@@ -977,7 +978,7 @@ func TestUntrustedHTTPTransportRequiresTLS12(t *testing.T) {
 	srv.StartTLS()
 	defer srv.Close()
 
-	insecureRT := UntrustedHTTPTransport(5*time.Second, true)
+	insecureRT := UntrustedHTTPTransport(5*time.Second, true, testSec())
 	allowUntrustedLoopback(t, insecureRT)
 	resp, err := doUntrustedRequest(t, insecureRT, srv.URL)
 	closeResponse(resp)
@@ -995,7 +996,7 @@ func TestUntrustedHTTPTransportRequiresTLS12(t *testing.T) {
 
 func TestUntrustedHTTPTransportMirrorsInsecureFlag(t *testing.T) {
 	for _, insecure := range []bool{false, true} {
-		tr := innerUntrustedTransport(t, UntrustedHTTPTransport(5*time.Second, insecure))
+		tr := innerUntrustedTransport(t, UntrustedHTTPTransport(5*time.Second, insecure, testSec()))
 		if tr.TLSClientConfig == nil {
 			t.Fatalf("insecure=%v: TLSClientConfig is nil", insecure)
 		}
@@ -1009,10 +1010,112 @@ func TestUntrustedHTTPTransportMirrorsInsecureFlag(t *testing.T) {
 }
 
 func TestUntrustedHTTPTransportFitsGowebdavSetTransport(t *testing.T) {
-	var rt http.RoundTripper = UntrustedHTTPTransport(5*time.Second, false)
+	var rt http.RoundTripper = UntrustedHTTPTransport(5*time.Second, false, testSec())
 	if rt == nil {
 		t.Fatal("UntrustedHTTPTransport returned nil")
 	}
+}
+
+func receivedLoopbackHTTPSec(t *testing.T, maxRedirects int, listener net.Addr) UntrustedClientSecurity {
+	t.Helper()
+	host, _, err := net.SplitHostPort(listener.String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		t.Fatalf("listener host is not an IP: %q", host)
+	}
+	cidr := host + "/32"
+	if ip.To4() == nil {
+		cidr = host + "/128"
+	}
+	s := UntrustedClientSecurity{
+		MaxRedirects: maxRedirects,
+		AllowHTTP:    true,
+		AllowedCIDRs: []string{cidr},
+	}
+	s.ApplyDefaults()
+	if err := s.Compile(); err != nil {
+		t.Fatal(err)
+	}
+	return s
+}
+
+func TestPublicOnlyTransportRedirectWalkerHonorsConfiguredCap(t *testing.T) {
+	const redirectCap = 2
+
+	t.Run("refuses above configured cap", func(t *testing.T) {
+		hops := 0
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			hops++
+			if hops <= redirectCap+2 {
+				http.Redirect(w, r, "/hop", http.StatusFound)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer srv.Close()
+
+		sec := receivedLoopbackHTTPSec(t, redirectCap, srv.Listener.Addr())
+		rt := UntrustedHTTPTransport(5*time.Second, true, sec)
+		pot, ok := rt.(*publicOnlyTransport)
+		if !ok {
+			t.Fatalf("transport: got %T, want *publicOnlyTransport", rt)
+		}
+
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp, err := (&http.Client{
+			Transport: pot,
+			CheckRedirect: func(*http.Request, []*http.Request) error {
+				return nil
+			},
+		}).Do(req)
+		closeResponse(resp)
+		if err == nil {
+			t.Fatal("expected transport walker to refuse after the configured cap")
+		}
+		if !errors.Is(err, ErrTooManyRedirects) {
+			t.Fatalf("got %v, want ErrTooManyRedirects", err)
+		}
+	})
+
+	t.Run("allows exactly the configured cap", func(t *testing.T) {
+		hops := 0
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			hops++
+			if hops <= redirectCap {
+				http.Redirect(w, r, "/hop", http.StatusFound)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("ok"))
+		}))
+		defer srv.Close()
+
+		sec := receivedLoopbackHTTPSec(t, redirectCap, srv.Listener.Addr())
+		rt := UntrustedHTTPTransport(5*time.Second, true, sec)
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp, err := (&http.Client{
+			Transport: rt,
+			CheckRedirect: func(*http.Request, []*http.Request) error {
+				return nil
+			},
+		}).Do(req)
+		if err != nil {
+			t.Fatalf("expected transport walker to allow %d redirects: %v", redirectCap, err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("status = %d, want 200", resp.StatusCode)
+		}
+	})
 }
 
 func TestPublicOnlyCheckRedirectCapsAtThree(t *testing.T) {
@@ -1027,7 +1130,7 @@ func TestPublicOnlyCheckRedirectCapsAtThree(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	rt := UntrustedHTTPTransport(5*time.Second, true)
+	rt := UntrustedHTTPTransport(5*time.Second, true, testSec())
 	allowUntrustedLoopback(t, rt)
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
 	if err != nil {
@@ -1041,13 +1144,13 @@ func TestPublicOnlyCheckRedirectCapsAtThree(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected PublicOnlyCheckRedirect to refuse more than 3 redirects")
 	}
-	if !errors.Is(err, errPublicOnlyTooManyRedirects) {
-		t.Fatalf("got %v, want errPublicOnlyTooManyRedirects", err)
+	if !errors.Is(err, ErrTooManyRedirects) {
+		t.Fatalf("got %v, want ErrTooManyRedirects", err)
 	}
 }
 
 func TestNewPublicOnlyClientKeepsPublicOnlyPolicy(t *testing.T) {
-	c := NewPublicOnlyClient(5*time.Second, true)
+	c := NewPublicOnlyClient(5*time.Second, true, testSec())
 	if c.client.Timeout != 5*time.Second {
 		t.Errorf("client timeout: got %v, want %v", c.client.Timeout, 5*time.Second)
 	}
@@ -1057,15 +1160,15 @@ func TestNewPublicOnlyClientKeepsPublicOnlyPolicy(t *testing.T) {
 	if c.client.CheckRedirect == nil {
 		t.Fatal("NewPublicOnlyClient must keep CheckRedirect")
 	}
-	got := reflect.ValueOf(c.client.CheckRedirect).Pointer()
-	want := reflect.ValueOf(PublicOnlyCheckRedirect).Pointer()
-	if got != want {
-		t.Error("NewPublicOnlyClient CheckRedirect must stay PublicOnlyCheckRedirect")
+	if err := c.client.CheckRedirect(&http.Request{}, []*http.Request{{}, {}, {}, {}}); err == nil {
+		t.Error("NewPublicOnlyClient CheckRedirect must refuse more than 3 hops")
+	} else if !errors.Is(err, ErrTooManyRedirects) {
+		t.Errorf("got %v, want ErrTooManyRedirects", err)
 	}
 
 	tr := publicOnlyHTTPTransport(t, c)
 	if tr.Proxy != nil {
-		t.Error("public-only client must not use a proxy")
+		t.Error("untrusted client must not use a proxy")
 	}
 	if tr.TLSClientConfig == nil {
 		t.Fatal("TLSClientConfig is nil")

--- a/internal/http/services/opencloudmesh/ocmd/client_test.go
+++ b/internal/http/services/opencloudmesh/ocmd/client_test.go
@@ -216,10 +216,7 @@ func TestNewOCMTransportUsesProxyFromEnvironment(t *testing.T) {
 // proxy address instead of the target.
 func TestNewPublicOnlyClientTransportProxyNil(t *testing.T) {
 	c := NewPublicOnlyClient(5*time.Second, true)
-	tr, ok := c.client.Transport.(*http.Transport)
-	if !ok {
-		t.Fatal("public-only client must use an *http.Transport")
-	}
+	tr := publicOnlyHTTPTransport(t, c)
 	if tr.Proxy != nil {
 		t.Error("public-only client must not use a proxy")
 	}
@@ -543,5 +540,199 @@ func TestExchangeTokenHTTP400OversizedBody(t *testing.T) {
 	assertOCMResponseTooLarge(t, err)
 	if tok != "" || exp != 0 {
 		t.Fatalf("oversized HTTP 400 token body must not be decoded, got token %q expires_in %d", tok, exp)
+	}
+}
+
+// httptest servers bind loopback, which the public-only dial guard refuses.
+// Redirect and scheme tests keep the constructor's CheckRedirect, https gate,
+// and Proxy=nil, and only drop Control so the TLS server is reachable.
+func allowPublicOnlyLoopback(t *testing.T, c *OCMClient) {
+	t.Helper()
+	tr := publicOnlyHTTPTransport(t, c)
+	tr.DialContext = (&net.Dialer{Timeout: 5 * time.Second}).DialContext
+}
+
+func publicOnlyHTTPTransport(t *testing.T, c *OCMClient) *http.Transport {
+	t.Helper()
+	switch tr := c.client.Transport.(type) {
+	case *http.Transport:
+		return tr
+	case *publicOnlyTransport:
+		if tr.Transport == nil {
+			t.Fatal("public-only client is missing an inner *http.Transport")
+		}
+		return tr.Transport
+	default:
+		t.Fatalf("public-only client transport: got %T, want *http.Transport or *publicOnlyTransport", c.client.Transport)
+		return nil
+	}
+}
+
+func closeResponse(resp *http.Response) {
+	if resp != nil {
+		resp.Body.Close()
+	}
+}
+
+func TestPublicOnlyClientRedirectCapAndHTTPSScheme(t *testing.T) {
+	t.Run("https redirecting more than 3 times is refused", func(t *testing.T) {
+		hops := 0
+		srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			hops++
+			if hops <= 4 {
+				http.Redirect(w, r, "/hop", http.StatusFound)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer srv.Close()
+
+		c := NewPublicOnlyClient(5*time.Second, true)
+		allowPublicOnlyLoopback(t, c)
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp, err := c.client.Do(req)
+		closeResponse(resp)
+		if err == nil {
+			t.Fatal("expected public-only client to refuse more than 3 redirects")
+		}
+		if !errors.Is(err, errPublicOnlyTooManyRedirects) {
+			t.Fatalf("got %v, want errPublicOnlyTooManyRedirects", err)
+		}
+	})
+
+	t.Run("http non-https initial URL is refused", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			t.Error("public-only client must not fetch a non-https URL")
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer srv.Close()
+
+		c := NewPublicOnlyClient(5*time.Second, true)
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp, err := c.client.Do(req)
+		closeResponse(resp)
+		if err == nil {
+			t.Fatal("expected public-only client to refuse a non-https URL")
+		}
+		if !errors.Is(err, errPublicOnlyNonHTTPS) {
+			t.Fatalf("got %v, want errPublicOnlyNonHTTPS", err)
+		}
+	})
+
+	t.Run("redirect to http is refused at the hop", func(t *testing.T) {
+		httpFetched := false
+		httpSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			httpFetched = true
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer httpSrv.Close()
+
+		tlsSrv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Redirect(w, r, httpSrv.URL, http.StatusFound)
+		}))
+		defer tlsSrv.Close()
+
+		c := NewPublicOnlyClient(5*time.Second, true)
+		allowPublicOnlyLoopback(t, c)
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, tlsSrv.URL, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp, err := c.client.Do(req)
+		closeResponse(resp)
+		if httpFetched {
+			t.Error("public-only client followed a redirect to http")
+		}
+		if err == nil {
+			t.Fatal("expected public-only client to refuse an http redirect hop")
+		}
+		if !errors.Is(err, errPublicOnlyNonHTTPS) {
+			t.Fatalf("got %v, want errPublicOnlyNonHTTPS", err)
+		}
+	})
+
+	t.Run("https with at most 3 redirects succeeds", func(t *testing.T) {
+		hops := 0
+		srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			hops++
+			if hops <= 3 {
+				http.Redirect(w, r, "/hop", http.StatusFound)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("ok"))
+		}))
+		defer srv.Close()
+
+		c := NewPublicOnlyClient(5*time.Second, true)
+		allowPublicOnlyLoopback(t, c)
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp, err := c.client.Do(req)
+		if err != nil {
+			t.Fatalf("expected public-only client to follow <=3 https redirects: %v", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("status = %d, want 200", resp.StatusCode)
+		}
+	})
+}
+
+func TestNewClientAllowsHTTPAndFollowsMoreThanThreeRedirects(t *testing.T) {
+	hops := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hops++
+		if hops <= 4 {
+			http.Redirect(w, r, "/hop", http.StatusFound)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer srv.Close()
+
+	c := NewClient(5*time.Second, true)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := c.client.Do(req)
+	if err != nil {
+		t.Fatalf("trusted client must still allow http and more than 3 redirects: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+}
+
+func TestPublicOnlyClientStillRefusesHTTPSLoopback(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("public-only dial guard must not connect to loopback")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := NewPublicOnlyClient(5*time.Second, true)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := c.client.Do(req)
+	closeResponse(resp)
+	if err == nil {
+		t.Fatal("expected public-only dial guard to refuse https loopback")
+	}
+	if !strings.Contains(err.Error(), "non-public") {
+		t.Fatalf("got %v, want the existing non-public dial error", err)
 	}
 }

--- a/internal/http/services/opencloudmesh/ocmd/client_test.go
+++ b/internal/http/services/opencloudmesh/ocmd/client_test.go
@@ -20,6 +20,7 @@ package ocmd
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"net"
@@ -269,6 +270,29 @@ func TestNewClientUsesOCMTransport(t *testing.T) {
 	}
 	if tr.Proxy == nil {
 		t.Fatal("client transport Proxy must not be nil")
+	}
+}
+
+// Both constructors must set a TLS 1.2 floor on the outbound transport.
+func TestOCMClientTransportsRequireTLS12(t *testing.T) {
+	tests := []struct {
+		name   string
+		client *OCMClient
+	}{
+		{name: "NewClient", client: NewClient(5*time.Second, false)},
+		{name: "NewPublicOnlyClient", client: NewPublicOnlyClient(5*time.Second, false)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tr := publicOnlyHTTPTransport(t, tt.client)
+			if tr.TLSClientConfig == nil {
+				t.Fatal("TLSClientConfig is nil")
+			}
+			if tr.TLSClientConfig.MinVersion < tls.VersionTLS12 {
+				t.Errorf("MinVersion = %#x, want at least TLS 1.2 (%#x)", tr.TLSClientConfig.MinVersion, tls.VersionTLS12)
+			}
+		})
 	}
 }
 

--- a/internal/http/services/opencloudmesh/ocmd/ocm.go
+++ b/internal/http/services/opencloudmesh/ocmd/ocm.go
@@ -55,11 +55,15 @@ type config struct {
 	// OCMClientResponseLimit caps outbound OCM JSON response bodies in bytes.
 	// Zero means 1 MiB.
 	OCMClientResponseLimit int64 `mapstructure:"ocm_client_response_limit"`
+	// OCMClientTLSMinVersion is the untrusted-client TLS minimum enum string.
+	// Empty means TLS 1.2. Accepted values are "1.2" and "1.3".
+	OCMClientTLSMinVersion string `mapstructure:"ocm_client_tls_min_version"`
 	// UntrustedClientSecurity is the shared hatch and redirect policy for
 	// untrusted outbound clients used by this service (TOML block
 	// ocm_client_security). Non-received consumers must keep the hatch closed
 	// (no allow_http / allowed_cidrs).
 	UntrustedClientSecurity UntrustedClientSecurity `mapstructure:"ocm_client_security"`
+	ocmClientTLSMin         uint16
 }
 
 func (c *config) ApplyDefaults() {
@@ -78,6 +82,7 @@ func (c *config) ApplyDefaults() {
 type svc struct {
 	Conf   *config
 	router chi.Router
+	shares *sharesHandler
 }
 
 // New returns a new ocmd object, that implements
@@ -94,6 +99,11 @@ func New(ctx context.Context, m map[string]any) (global.Service, error) {
 	if err := c.UntrustedClientSecurity.RejectHatch(); err != nil {
 		return nil, err
 	}
+	minVersion, err := ParseTLSMinVersion(c.OCMClientTLSMinVersion)
+	if err != nil {
+		return nil, err
+	}
+	c.ocmClientTLSMin = minVersion
 
 	r := chi.NewRouter()
 	s := &svc{
@@ -116,6 +126,7 @@ func (s *svc) routerInit() error {
 	if err := sharesHandler.init(s.Conf); err != nil {
 		return err
 	}
+	s.shares = sharesHandler
 	if err := invitesHandler.init(s.Conf); err != nil {
 		return err
 	}

--- a/internal/http/services/opencloudmesh/ocmd/ocm.go
+++ b/internal/http/services/opencloudmesh/ocmd/ocm.go
@@ -52,6 +52,9 @@ type config struct {
 	// OCMClientInsecure skips TLS verification when probing a remote provider's
 	// discovery endpoint. Off by default; turning it on exposes discovery to MITM.
 	OCMClientInsecure bool `mapstructure:"ocm_client_insecure"`
+	// OCMClientResponseLimit caps outbound OCM JSON response bodies in bytes.
+	// Zero means 1 MiB.
+	OCMClientResponseLimit int64 `mapstructure:"ocm_client_response_limit"`
 	// UntrustedClientSecurity is the shared hatch and redirect policy for
 	// untrusted outbound clients used by this service (TOML block
 	// ocm_client_security). Non-received consumers must keep the hatch closed
@@ -66,6 +69,9 @@ func (c *config) ApplyDefaults() {
 	}
 	if c.TokenManager == "" {
 		c.TokenManager = "jwt"
+	}
+	if c.OCMClientResponseLimit == 0 {
+		c.OCMClientResponseLimit = 1 << 20
 	}
 }
 

--- a/internal/http/services/opencloudmesh/ocmd/ocm.go
+++ b/internal/http/services/opencloudmesh/ocmd/ocm.go
@@ -52,6 +52,11 @@ type config struct {
 	// OCMClientInsecure skips TLS verification when probing a remote provider's
 	// discovery endpoint. Off by default; turning it on exposes discovery to MITM.
 	OCMClientInsecure bool `mapstructure:"ocm_client_insecure"`
+	// UntrustedClientSecurity is the shared hatch and redirect policy for
+	// untrusted outbound clients used by this service (TOML block
+	// ocm_client_security). Non-received consumers must keep the hatch closed
+	// (no allow_http / allowed_cidrs).
+	UntrustedClientSecurity UntrustedClientSecurity `mapstructure:"ocm_client_security"`
 }
 
 func (c *config) ApplyDefaults() {
@@ -74,6 +79,13 @@ type svc struct {
 func New(ctx context.Context, m map[string]any) (global.Service, error) {
 	var c config
 	if err := cfg.Decode(m, &c); err != nil {
+		return nil, err
+	}
+	c.UntrustedClientSecurity.ApplyDefaults()
+	if err := c.UntrustedClientSecurity.Compile(); err != nil {
+		return nil, err
+	}
+	if err := c.UntrustedClientSecurity.RejectHatch(); err != nil {
 		return nil, err
 	}
 

--- a/internal/http/services/opencloudmesh/ocmd/ocm.go
+++ b/internal/http/services/opencloudmesh/ocmd/ocm.go
@@ -63,7 +63,15 @@ type config struct {
 	// ocm_client_security). Non-received consumers must keep the hatch closed
 	// (no allow_http / allowed_cidrs).
 	UntrustedClientSecurity UntrustedClientSecurity `mapstructure:"ocm_client_security"`
-	ocmClientTLSMin         uint16
+	// OCMClientDialTimeout is the untrusted-transport net.Dialer timeout
+	// in seconds for peer-supplied WebDAV ingest URLs. Zero or negative
+	// means 10s.
+	OCMClientDialTimeout int `mapstructure:"ocm_client_dial_timeout"`
+	// OCMClientTimeout is the outbound OCM JSON/metadata request timeout
+	// in seconds (Discover, ingest PROPFIND SetTimeout). Zero or negative
+	// means 10s.
+	OCMClientTimeout int `mapstructure:"ocm_client_timeout"`
+	ocmClientTLSMin  uint16
 }
 
 func (c *config) ApplyDefaults() {
@@ -76,6 +84,12 @@ func (c *config) ApplyDefaults() {
 	}
 	if c.OCMClientResponseLimit == 0 {
 		c.OCMClientResponseLimit = 1 << 20
+	}
+	if c.OCMClientDialTimeout <= 0 {
+		c.OCMClientDialTimeout = 10
+	}
+	if c.OCMClientTimeout <= 0 {
+		c.OCMClientTimeout = 10
 	}
 }
 

--- a/internal/http/services/opencloudmesh/ocmd/ocm_test.go
+++ b/internal/http/services/opencloudmesh/ocmd/ocm_test.go
@@ -19,6 +19,9 @@
 package ocmd
 
 import (
+	"context"
+	"crypto/tls"
+	"errors"
 	"testing"
 
 	"github.com/cs3org/reva/v3/pkg/utils/cfg"
@@ -57,6 +60,109 @@ func TestConfigOCMClientResponseLimit(t *testing.T) {
 			}
 			if c.OCMClientResponseLimit != tt.wantLimit {
 				t.Errorf("OCMClientResponseLimit = %d, want %d", c.OCMClientResponseLimit, tt.wantLimit)
+			}
+		})
+	}
+}
+
+func TestNewWiresTLSMinVersionToSharesTransport(t *testing.T) {
+	t.Parallel()
+
+	got, err := New(context.Background(), map[string]any{
+		"gatewaysvc":                 "gateway:9142",
+		"ocm_client_tls_min_version": "1.3",
+		"token_managers": map[string]any{
+			"jwt": map[string]any{
+				"secret": "test-secret-for-ocm-new",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	s, ok := got.(*svc)
+	if !ok {
+		t.Fatalf("got %T, want *svc", got)
+	}
+	if s.shares == nil || s.shares.untrustedTransport == nil {
+		t.Fatal("shares untrusted transport is nil")
+	}
+	tr := innerUntrustedTransport(t, s.shares.untrustedTransport)
+	if tr.TLSClientConfig == nil || tr.TLSClientConfig.MinVersion != tls.VersionTLS13 {
+		t.Fatalf("shares handler transport MinVersion = %v, want TLS 1.3", tr.TLSClientConfig)
+	}
+}
+
+func TestNewRejectsInvalidTLSMinVersion(t *testing.T) {
+	t.Parallel()
+
+	_, err := New(context.Background(), map[string]any{
+		"gatewaysvc":                 "gateway:9142",
+		"ocm_client_tls_min_version": "1.1",
+	})
+	if err == nil {
+		t.Fatal("expected ocmd.New to reject TLS min version 1.1")
+	}
+	if !errors.Is(err, ErrInvalidTLSMinVersion) {
+		t.Fatalf("got %v, want ErrInvalidTLSMinVersion", err)
+	}
+}
+
+func TestConfigOCMClientTLSMinVersion(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		extra   map[string]any
+		want    uint16
+		wantErr bool
+	}{
+		{name: "empty defaults to TLS 1.2", extra: map[string]any{}, want: tls.VersionTLS12},
+		{
+			name:  "configured 1.3",
+			extra: map[string]any{"ocm_client_tls_min_version": "1.3"},
+			want:  tls.VersionTLS13,
+		},
+		{
+			name:    "bogus rejected",
+			extra:   map[string]any{"ocm_client_tls_min_version": "bogus"},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			input := map[string]any{"gatewaysvc": "gateway:9142"}
+			for k, v := range tt.extra {
+				input[k] = v
+			}
+
+			var c config
+			if err := cfg.Decode(input, &c); err != nil {
+				t.Fatalf("cfg.Decode: %v", err)
+			}
+			got, err := ParseTLSMinVersion(c.OCMClientTLSMinVersion)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected invalid TLS min version to fail")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tt.want {
+				t.Fatalf("ParseTLSMinVersion(%q) = %#x, want %#x", c.OCMClientTLSMinVersion, got, tt.want)
+			}
+			tr := innerUntrustedTransport(t, UntrustedHTTPTransport(
+				0,
+				false,
+				testSec(),
+				got,
+			))
+			if tr.TLSClientConfig.MinVersion != tt.want {
+				t.Fatalf("transport MinVersion = %#x, want %#x", tr.TLSClientConfig.MinVersion, tt.want)
 			}
 		})
 	}

--- a/internal/http/services/opencloudmesh/ocmd/ocm_test.go
+++ b/internal/http/services/opencloudmesh/ocmd/ocm_test.go
@@ -1,0 +1,63 @@
+// Copyright 2018-2026 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package ocmd
+
+import (
+	"testing"
+
+	"github.com/cs3org/reva/v3/pkg/utils/cfg"
+)
+
+func TestConfigOCMClientResponseLimit(t *testing.T) {
+	tests := []struct {
+		name      string
+		extra     map[string]any
+		wantLimit int64
+	}{
+		{
+			name: "parses configured limit",
+			extra: map[string]any{
+				"ocm_client_response_limit": 2097152,
+			},
+			wantLimit: 2097152,
+		},
+		{
+			name:      "defaults when unset",
+			extra:     map[string]any{},
+			wantLimit: 1 << 20,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input := map[string]any{"gatewaysvc": "gateway:9142"}
+			for k, v := range tt.extra {
+				input[k] = v
+			}
+
+			var c config
+			if err := cfg.Decode(input, &c); err != nil {
+				t.Fatalf("cfg.Decode: %v", err)
+			}
+			if c.OCMClientResponseLimit != tt.wantLimit {
+				t.Errorf("OCMClientResponseLimit = %d, want %d", c.OCMClientResponseLimit, tt.wantLimit)
+			}
+		})
+	}
+}

--- a/internal/http/services/opencloudmesh/ocmd/ocm_test.go
+++ b/internal/http/services/opencloudmesh/ocmd/ocm_test.go
@@ -23,6 +23,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/cs3org/reva/v3/pkg/utils/cfg"
 )
@@ -62,6 +63,122 @@ func TestConfigOCMClientResponseLimit(t *testing.T) {
 				t.Errorf("OCMClientResponseLimit = %d, want %d", c.OCMClientResponseLimit, tt.wantLimit)
 			}
 		})
+	}
+}
+
+func TestConfigOCMClientTimeouts(t *testing.T) {
+	tests := []struct {
+		name        string
+		extra       map[string]any
+		wantDial    int
+		wantRequest int
+	}{
+		{
+			name:        "defaults when unset",
+			extra:       map[string]any{},
+			wantDial:    10,
+			wantRequest: 10,
+		},
+		{
+			name: "parses configured timeouts",
+			extra: map[string]any{
+				"ocm_client_dial_timeout": 2,
+				"ocm_client_timeout":      7,
+			},
+			wantDial:    2,
+			wantRequest: 7,
+		},
+		{
+			name: "negative timeouts use defaults",
+			extra: map[string]any{
+				"ocm_client_dial_timeout": -1,
+				"ocm_client_timeout":      -5,
+			},
+			wantDial:    10,
+			wantRequest: 10,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input := map[string]any{"gatewaysvc": "gateway:9142"}
+			for k, v := range tt.extra {
+				input[k] = v
+			}
+
+			var c config
+			if err := cfg.Decode(input, &c); err != nil {
+				t.Fatalf("cfg.Decode: %v", err)
+			}
+			if c.OCMClientDialTimeout != tt.wantDial {
+				t.Errorf("OCMClientDialTimeout = %d, want %d", c.OCMClientDialTimeout, tt.wantDial)
+			}
+			if c.OCMClientTimeout != tt.wantRequest {
+				t.Errorf("OCMClientTimeout = %d, want %d", c.OCMClientTimeout, tt.wantRequest)
+			}
+		})
+	}
+}
+
+func TestNewWiresClientTimeoutsToSharesHandler(t *testing.T) {
+	t.Parallel()
+
+	got, err := New(context.Background(), map[string]any{
+		"gatewaysvc":              "gateway:9142",
+		"ocm_client_dial_timeout": 2,
+		"ocm_client_timeout":      7,
+		"token_managers": map[string]any{
+			"jwt": map[string]any{
+				"secret": "test-secret-for-ocm-timeouts",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	s, ok := got.(*svc)
+	if !ok {
+		t.Fatalf("got %T, want *svc", got)
+	}
+	if s.shares == nil {
+		t.Fatal("shares handler is nil")
+	}
+	if s.shares.ocmClientDialTimeout != 2*time.Second {
+		t.Fatalf("dial timeout = %v, want 2s", s.shares.ocmClientDialTimeout)
+	}
+	if s.shares.ocmClientTimeout != 7*time.Second {
+		t.Fatalf("request timeout = %v, want 7s", s.shares.ocmClientTimeout)
+	}
+}
+
+func TestNewNormalizesNegativeClientTimeouts(t *testing.T) {
+	t.Parallel()
+
+	got, err := New(context.Background(), map[string]any{
+		"gatewaysvc":              "gateway:9142",
+		"ocm_client_dial_timeout": -1,
+		"ocm_client_timeout":      -5,
+		"token_managers": map[string]any{
+			"jwt": map[string]any{
+				"secret": "test-secret-for-ocm-timeouts",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	s, ok := got.(*svc)
+	if !ok {
+		t.Fatalf("got %T, want *svc", got)
+	}
+	if s.shares == nil {
+		t.Fatal("shares handler is nil")
+	}
+	if s.shares.ocmClientDialTimeout != 10*time.Second {
+		t.Fatalf("dial timeout = %v, want 10s", s.shares.ocmClientDialTimeout)
+	}
+	if s.shares.ocmClientTimeout != 10*time.Second {
+		t.Fatalf("request timeout = %v, want 10s", s.shares.ocmClientTimeout)
 	}
 }
 

--- a/internal/http/services/opencloudmesh/ocmd/shares.go
+++ b/internal/http/services/opencloudmesh/ocmd/shares.go
@@ -63,7 +63,9 @@ type sharesHandler struct {
 	trustForwardedFor          bool
 	ocmClientInsecure          bool
 	ocmClientResponseLimit     int64
+	ocmClientTLSMin            uint16
 	untrustedSec               UntrustedClientSecurity
+	untrustedTransport         http.RoundTripper
 }
 
 func (h *sharesHandler) init(c *config) error {
@@ -77,7 +79,14 @@ func (h *sharesHandler) init(c *config) error {
 	h.trustForwardedFor = c.TrustForwardedFor
 	h.ocmClientInsecure = c.OCMClientInsecure
 	h.ocmClientResponseLimit = c.OCMClientResponseLimit
+	h.ocmClientTLSMin = c.ocmClientTLSMin
 	h.untrustedSec = c.UntrustedClientSecurity
+	h.untrustedTransport = UntrustedHTTPTransport(
+		10*time.Second,
+		h.ocmClientInsecure,
+		h.untrustedSec,
+		h.ocmClientTLSMin,
+	)
 	for _, p := range c.AutoAcceptProviders {
 		re, err := regexp.Compile(p)
 		if err != nil {
@@ -120,10 +129,14 @@ func (h *sharesHandler) isAcceptedUser(ctx context.Context, recipient *userpb.Us
 }
 
 // statIngestWebDAV PROPFINDs a peer-supplied WebDAV source URL before ingest.
-// The URL is attacker-influenced, so the client uses UntrustedHTTPTransport.
-func statIngestWebDAV(uri, sharedSecret string, timeout time.Duration, insecure bool, sec UntrustedClientSecurity) (os.FileInfo, error) {
+// The URL is attacker-influenced, so the caller must pass the handler-owned
+// untrusted transport (or an equivalent test transport).
+func statIngestWebDAV(
+	uri, sharedSecret string,
+	rt http.RoundTripper,
+) (os.FileInfo, error) {
 	c := gowebdav.NewClient(uri, "", "")
-	c.SetTransport(UntrustedHTTPTransport(timeout, insecure, sec))
+	c.SetTransport(rt)
 	c.SetHeader("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(sharedSecret+":")))
 	return c.Stat("")
 }
@@ -225,9 +238,7 @@ func (h *sharesHandler) CreateShare(w http.ResponseWriter, r *http.Request) {
 		target, err := statIngestWebDAV(
 			protocols[0].GetWebdavOptions().Uri,
 			protocols[0].GetWebdavOptions().SharedSecret,
-			10*time.Second,
-			h.ocmClientInsecure,
-			h.untrustedSec,
+			h.untrustedTransport,
 		)
 		if err != nil {
 			log.Info().Err(err).Str("endpoint", protocols[0].GetWebdavOptions().Uri).Msg("error stating remote resource, assuming file")

--- a/internal/http/services/opencloudmesh/ocmd/shares.go
+++ b/internal/http/services/opencloudmesh/ocmd/shares.go
@@ -62,6 +62,7 @@ type sharesHandler struct {
 	autoAcceptProviders        []*regexp.Regexp
 	trustForwardedFor          bool
 	ocmClientInsecure          bool
+	untrustedSec               UntrustedClientSecurity
 }
 
 func (h *sharesHandler) init(c *config) error {
@@ -74,6 +75,7 @@ func (h *sharesHandler) init(c *config) error {
 	h.machineSecret = c.MachineSecret
 	h.trustForwardedFor = c.TrustForwardedFor
 	h.ocmClientInsecure = c.OCMClientInsecure
+	h.untrustedSec = c.UntrustedClientSecurity
 	for _, p := range c.AutoAcceptProviders {
 		re, err := regexp.Compile(p)
 		if err != nil {
@@ -117,9 +119,9 @@ func (h *sharesHandler) isAcceptedUser(ctx context.Context, recipient *userpb.Us
 
 // statIngestWebDAV PROPFINDs a peer-supplied WebDAV source URL before ingest.
 // The URL is attacker-influenced, so the client uses UntrustedHTTPTransport.
-func statIngestWebDAV(uri, sharedSecret string, timeout time.Duration, insecure bool) (os.FileInfo, error) {
+func statIngestWebDAV(uri, sharedSecret string, timeout time.Duration, insecure bool, sec UntrustedClientSecurity) (os.FileInfo, error) {
 	c := gowebdav.NewClient(uri, "", "")
-	c.SetTransport(UntrustedHTTPTransport(timeout, insecure))
+	c.SetTransport(UntrustedHTTPTransport(timeout, insecure, sec))
 	c.SetHeader("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(sharedSecret+":")))
 	return c.Stat("")
 }
@@ -217,12 +219,13 @@ func (h *sharesHandler) CreateShare(w http.ResponseWriter, r *http.Request) {
 		// in case of legacy OCM v1.0 shares, we have to PROPFIND the remote resource to check the type,
 		// because remote systems such as Nextcloud may send "file" even if the resource is a folder.
 		// The WebDAV URI is peer-supplied, so the gowebdav client must use the
-		// public-only transport (https + public dial only).
+		// untrusted transport (scheme and dial policy from sec).
 		target, err := statIngestWebDAV(
 			protocols[0].GetWebdavOptions().Uri,
 			protocols[0].GetWebdavOptions().SharedSecret,
 			10*time.Second,
 			h.ocmClientInsecure,
+			h.untrustedSec,
 		)
 		if err != nil {
 			log.Info().Err(err).Str("endpoint", protocols[0].GetWebdavOptions().Uri).Msg("error stating remote resource, assuming file")

--- a/internal/http/services/opencloudmesh/ocmd/shares.go
+++ b/internal/http/services/opencloudmesh/ocmd/shares.go
@@ -62,6 +62,7 @@ type sharesHandler struct {
 	autoAcceptProviders        []*regexp.Regexp
 	trustForwardedFor          bool
 	ocmClientInsecure          bool
+	ocmClientResponseLimit     int64
 	untrustedSec               UntrustedClientSecurity
 }
 
@@ -75,6 +76,7 @@ func (h *sharesHandler) init(c *config) error {
 	h.machineSecret = c.MachineSecret
 	h.trustForwardedFor = c.TrustForwardedFor
 	h.ocmClientInsecure = c.OCMClientInsecure
+	h.ocmClientResponseLimit = c.OCMClientResponseLimit
 	h.untrustedSec = c.UntrustedClientSecurity
 	for _, p := range c.AutoAcceptProviders {
 		re, err := regexp.Compile(p)
@@ -510,7 +512,7 @@ func (h *sharesHandler) getAndResolveProtocols(ctx context.Context, p Protocols,
 }
 
 func (h *sharesHandler) discoverOcmResourceTypes(ctx context.Context, ownerServer string) ([]wellknown.ResourceTypes, string, error) {
-	ocmClient := NewClient(time.Duration(10)*time.Second, h.ocmClientInsecure)
+	ocmClient := NewClient(time.Duration(10)*time.Second, h.ocmClientInsecure, h.ocmClientResponseLimit)
 	ocmCaps, err := ocmClient.Discover(ctx, ownerServer)
 	if err != nil {
 		return nil, "", err

--- a/internal/http/services/opencloudmesh/ocmd/shares.go
+++ b/internal/http/services/opencloudmesh/ocmd/shares.go
@@ -148,8 +148,11 @@ func (h *sharesHandler) requestTimeout() time.Duration {
 
 // statIngestWebDAV PROPFINDs a peer-supplied WebDAV source URL before ingest.
 // The URL is attacker-influenced, so the caller must pass the handler-owned
-// untrusted transport (or an equivalent test transport). requestTimeout is
-// applied via gowebdav SetTimeout so a connected peer cannot hang the worker.
+// untrusted transport (or an equivalent test double): that transport applies
+// scheme and dial policy. gowebdav only accepts SetTransport, not
+// CheckRedirect, so the transport-level redirect walker is the hop backstop.
+// requestTimeout, when set, is applied via SetTimeout so a connected peer
+// cannot hang the worker.
 func statIngestWebDAV(
 	uri, sharedSecret string,
 	rt http.RoundTripper,
@@ -256,8 +259,6 @@ func (h *sharesHandler) CreateShare(w http.ResponseWriter, r *http.Request) {
 	if legacy && req.ResourceType == "file" {
 		// in case of legacy OCM v1.0 shares, we have to PROPFIND the remote resource to check the type,
 		// because remote systems such as Nextcloud may send "file" even if the resource is a folder.
-		// The WebDAV URI is peer-supplied, so the gowebdav client must use the
-		// untrusted transport (scheme and dial policy from sec).
 		target, err := statIngestWebDAV(
 			protocols[0].GetWebdavOptions().Uri,
 			protocols[0].GetWebdavOptions().SharedSecret,

--- a/internal/http/services/opencloudmesh/ocmd/shares.go
+++ b/internal/http/services/opencloudmesh/ocmd/shares.go
@@ -64,6 +64,8 @@ type sharesHandler struct {
 	ocmClientInsecure          bool
 	ocmClientResponseLimit     int64
 	ocmClientTLSMin            uint16
+	ocmClientDialTimeout       time.Duration
+	ocmClientTimeout           time.Duration
 	untrustedSec               UntrustedClientSecurity
 	untrustedTransport         http.RoundTripper
 }
@@ -80,9 +82,11 @@ func (h *sharesHandler) init(c *config) error {
 	h.ocmClientInsecure = c.OCMClientInsecure
 	h.ocmClientResponseLimit = c.OCMClientResponseLimit
 	h.ocmClientTLSMin = c.ocmClientTLSMin
+	h.ocmClientDialTimeout = time.Duration(c.OCMClientDialTimeout) * time.Second
+	h.ocmClientTimeout = time.Duration(c.OCMClientTimeout) * time.Second
 	h.untrustedSec = c.UntrustedClientSecurity
 	h.untrustedTransport = UntrustedHTTPTransport(
-		10*time.Second,
+		h.dialTimeout(),
 		h.ocmClientInsecure,
 		h.untrustedSec,
 		h.ocmClientTLSMin,
@@ -128,15 +132,34 @@ func (h *sharesHandler) isAcceptedUser(ctx context.Context, recipient *userpb.Us
 	return err == nil && res.Status.Code == rpc.Code_CODE_OK
 }
 
+func (h *sharesHandler) dialTimeout() time.Duration {
+	if h != nil && h.ocmClientDialTimeout > 0 {
+		return h.ocmClientDialTimeout
+	}
+	return 10 * time.Second
+}
+
+func (h *sharesHandler) requestTimeout() time.Duration {
+	if h != nil && h.ocmClientTimeout > 0 {
+		return h.ocmClientTimeout
+	}
+	return 10 * time.Second
+}
+
 // statIngestWebDAV PROPFINDs a peer-supplied WebDAV source URL before ingest.
 // The URL is attacker-influenced, so the caller must pass the handler-owned
-// untrusted transport (or an equivalent test transport).
+// untrusted transport (or an equivalent test transport). requestTimeout is
+// applied via gowebdav SetTimeout so a connected peer cannot hang the worker.
 func statIngestWebDAV(
 	uri, sharedSecret string,
 	rt http.RoundTripper,
+	requestTimeout time.Duration,
 ) (os.FileInfo, error) {
 	c := gowebdav.NewClient(uri, "", "")
 	c.SetTransport(rt)
+	if requestTimeout > 0 {
+		c.SetTimeout(requestTimeout)
+	}
 	c.SetHeader("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(sharedSecret+":")))
 	return c.Stat("")
 }
@@ -239,6 +262,7 @@ func (h *sharesHandler) CreateShare(w http.ResponseWriter, r *http.Request) {
 			protocols[0].GetWebdavOptions().Uri,
 			protocols[0].GetWebdavOptions().SharedSecret,
 			h.untrustedTransport,
+			h.requestTimeout(),
 		)
 		if err != nil {
 			log.Info().Err(err).Str("endpoint", protocols[0].GetWebdavOptions().Uri).Msg("error stating remote resource, assuming file")
@@ -523,7 +547,7 @@ func (h *sharesHandler) getAndResolveProtocols(ctx context.Context, p Protocols,
 }
 
 func (h *sharesHandler) discoverOcmResourceTypes(ctx context.Context, ownerServer string) ([]wellknown.ResourceTypes, string, error) {
-	ocmClient := NewClient(time.Duration(10)*time.Second, h.ocmClientInsecure, h.ocmClientResponseLimit)
+	ocmClient := NewClient(h.requestTimeout(), h.ocmClientInsecure, h.ocmClientResponseLimit)
 	ocmCaps, err := ocmClient.Discover(ctx, ownerServer)
 	if err != nil {
 		return nil, "", err

--- a/internal/http/services/opencloudmesh/ocmd/shares.go
+++ b/internal/http/services/opencloudmesh/ocmd/shares.go
@@ -26,6 +26,7 @@ import (
 	"mime"
 	"net/http"
 	"net/url"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -112,6 +113,15 @@ func (h *sharesHandler) isAcceptedUser(ctx context.Context, recipient *userpb.Us
 		},
 	})
 	return err == nil && res.Status.Code == rpc.Code_CODE_OK
+}
+
+// statIngestWebDAV PROPFINDs a peer-supplied WebDAV source URL before ingest.
+// The URL is attacker-influenced, so the client uses UntrustedHTTPTransport.
+func statIngestWebDAV(uri, sharedSecret string, timeout time.Duration, insecure bool) (os.FileInfo, error) {
+	c := gowebdav.NewClient(uri, "", "")
+	c.SetTransport(UntrustedHTTPTransport(timeout, insecure))
+	c.SetHeader("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(sharedSecret+":")))
+	return c.Stat("")
 }
 
 // CreateShare implements the OCM /shares call and stores an incoming share
@@ -206,9 +216,14 @@ func (h *sharesHandler) CreateShare(w http.ResponseWriter, r *http.Request) {
 	if legacy && req.ResourceType == "file" {
 		// in case of legacy OCM v1.0 shares, we have to PROPFIND the remote resource to check the type,
 		// because remote systems such as Nextcloud may send "file" even if the resource is a folder.
-		c := gowebdav.NewClient(protocols[0].GetWebdavOptions().Uri, "", "")
-		c.SetHeader("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(protocols[0].GetWebdavOptions().SharedSecret+":")))
-		target, err := c.Stat("")
+		// The WebDAV URI is peer-supplied, so the gowebdav client must use the
+		// public-only transport (https + public dial only).
+		target, err := statIngestWebDAV(
+			protocols[0].GetWebdavOptions().Uri,
+			protocols[0].GetWebdavOptions().SharedSecret,
+			10*time.Second,
+			h.ocmClientInsecure,
+		)
 		if err != nil {
 			log.Info().Err(err).Str("endpoint", protocols[0].GetWebdavOptions().Uri).Msg("error stating remote resource, assuming file")
 		} else if target.IsDir() {

--- a/internal/http/services/opencloudmesh/ocmd/shares_test.go
+++ b/internal/http/services/opencloudmesh/ocmd/shares_test.go
@@ -28,7 +28,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"regexp"
-	"strings"
 	"testing"
 	"time"
 
@@ -365,7 +364,13 @@ func TestIngestWebDAVStatPublicHTTPSHostSucceeds(t *testing.T) {
 	contacted := false
 	srv := startPublicTLSServer(t, ingestWebDAVHandler(t, &contacted))
 
-	info, err := statIngestWebDAV(srv.URL, "secret", 5*time.Second, true)
+	info, err := statIngestWebDAV(
+		srv.URL,
+		"secret",
+		5*time.Second,
+		true,
+		testSec(),
+	)
 	if err != nil {
 		t.Fatalf("ingest stat to a public HTTPS WebDAV host: %v", err)
 	}
@@ -379,12 +384,18 @@ func TestIngestWebDAVStatPublicHTTPSHostSucceeds(t *testing.T) {
 
 func TestIngestWebDAVStatRefusesPrivateHost(t *testing.T) {
 	t.Run("metadata host is refused at dial", func(t *testing.T) {
-		_, err := statIngestWebDAV("https://169.254.169.254/remote.php/dav/ocm", "secret", 5*time.Second, true)
+		_, err := statIngestWebDAV(
+			"https://169.254.169.254/remote.php/dav/ocm",
+			"secret",
+			5*time.Second,
+			true,
+			testSec(),
+		)
 		if err == nil {
 			t.Fatal("expected ingest stat to refuse the metadata host at dial")
 		}
-		if !strings.Contains(err.Error(), "non-public") {
-			t.Fatalf("got %v, want the existing non-public dial error", err)
+		if !errors.Is(err, ErrNonPublicAddr) {
+			t.Fatalf("got %v, want ErrNonPublicAddr", err)
 		}
 	})
 
@@ -393,15 +404,21 @@ func TestIngestWebDAVStatRefusesPrivateHost(t *testing.T) {
 		srv := httptest.NewTLSServer(ingestWebDAVHandler(t, &contacted))
 		defer srv.Close()
 
-		_, err := statIngestWebDAV(srv.URL, "secret", 5*time.Second, true)
+		_, err := statIngestWebDAV(
+			srv.URL,
+			"secret",
+			5*time.Second,
+			true,
+			testSec(),
+		)
 		if contacted {
 			t.Fatal("ingest stat contacted a private WebDAV host; the untrusted transport must refuse it at dial")
 		}
 		if err == nil {
 			t.Fatal("expected ingest stat to a private host to fail")
 		}
-		if !strings.Contains(err.Error(), "non-public") {
-			t.Fatalf("got %v, want the existing non-public dial error", err)
+		if !errors.Is(err, ErrNonPublicAddr) {
+			t.Fatalf("got %v, want ErrNonPublicAddr", err)
 		}
 	})
 }
@@ -411,14 +428,20 @@ func TestIngestWebDAVStatRefusesHTTP(t *testing.T) {
 	srv := httptest.NewServer(ingestWebDAVHandler(t, &contacted))
 	defer srv.Close()
 
-	_, err := statIngestWebDAV(srv.URL, "secret", 5*time.Second, true)
+	_, err := statIngestWebDAV(
+		srv.URL,
+		"secret",
+		5*time.Second,
+		true,
+		testSec(),
+	)
 	if contacted {
 		t.Fatal("ingest stat contacted an http WebDAV host; the untrusted transport must refuse it")
 	}
 	if err == nil {
 		t.Fatal("expected ingest stat to refuse a non-https URL")
 	}
-	if !errors.Is(err, errPublicOnlyNonHTTPS) {
-		t.Fatalf("got %v, want errPublicOnlyNonHTTPS", err)
+	if !errors.Is(err, ErrNonHTTPS) {
+		t.Fatalf("got %v, want ErrNonHTTPS", err)
 	}
 }

--- a/internal/http/services/opencloudmesh/ocmd/shares_test.go
+++ b/internal/http/services/opencloudmesh/ocmd/shares_test.go
@@ -22,11 +22,15 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"regexp"
+	"strings"
 	"testing"
+	"time"
 
 	gateway "github.com/cs3org/go-cs3apis/cs3/gateway/v1beta1"
 	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
@@ -283,5 +287,138 @@ func TestDiscoverVerifiesTLSUnlessInsecure(t *testing.T) {
 				t.Errorf("discoverOcmResourceTypes() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
+	}
+}
+
+const ingestWebDAVPropfindXML = `<?xml version="1.0" encoding="utf-8"?>
+<d:multistatus xmlns:d="DAV:">
+  <d:response>
+    <d:href>/</d:href>
+    <d:propstat>
+      <d:prop>
+        <d:displayname>legacy-share</d:displayname>
+        <d:getcontentlength>4</d:getcontentlength>
+        <d:getcontenttype>text/plain</d:getcontenttype>
+        <d:getetag>"abc"</d:getetag>
+        <d:getlastmodified>Mon, 02 Jan 2006 15:04:05 GMT</d:getlastmodified>
+      </d:prop>
+      <d:status>HTTP/1.1 200 OK</d:status>
+    </d:propstat>
+  </d:response>
+</d:multistatus>`
+
+func ingestWebDAVHandler(t *testing.T, contacted *bool) http.Handler {
+	t.Helper()
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		*contacted = true
+		if r.Method != "PROPFIND" {
+			t.Errorf("unexpected method %s", r.Method)
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		w.Header().Set("Content-Type", "application/xml")
+		w.WriteHeader(207)
+		_, _ = w.Write([]byte(ingestWebDAVPropfindXML))
+	})
+}
+
+func firstPublicIPv4() (string, bool) {
+	addrs, err := net.InterfaceAddrs()
+	if err != nil {
+		return "", false
+	}
+	for _, a := range addrs {
+		n, ok := a.(*net.IPNet)
+		if !ok || n.IP == nil {
+			continue
+		}
+		ip := n.IP.To4()
+		if ip == nil || !isPublicIP(ip) {
+			continue
+		}
+		return ip.String(), true
+	}
+	return "", false
+}
+
+func startPublicTLSServer(t *testing.T, h http.Handler) *httptest.Server {
+	t.Helper()
+	ip, ok := firstPublicIPv4()
+	if !ok {
+		t.Skip("no public IPv4 address available for public-only httptest")
+	}
+	ln, err := net.Listen("tcp", net.JoinHostPort(ip, "0"))
+	if err != nil {
+		t.Skipf("cannot listen on public IP %s: %v", ip, err)
+	}
+	srv := httptest.NewUnstartedServer(h)
+	if srv.Listener != nil {
+		_ = srv.Listener.Close()
+	}
+	srv.Listener = ln
+	srv.StartTLS()
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestIngestWebDAVStatPublicHTTPSHostSucceeds(t *testing.T) {
+	contacted := false
+	srv := startPublicTLSServer(t, ingestWebDAVHandler(t, &contacted))
+
+	info, err := statIngestWebDAV(srv.URL, "secret", 5*time.Second, true)
+	if err != nil {
+		t.Fatalf("ingest stat to a public HTTPS WebDAV host: %v", err)
+	}
+	if info == nil {
+		t.Fatal("expected WebDAV stat info for a public HTTPS host")
+	}
+	if !contacted {
+		t.Fatal("expected ingest stat to reach the public HTTPS WebDAV host")
+	}
+}
+
+func TestIngestWebDAVStatRefusesPrivateHost(t *testing.T) {
+	t.Run("metadata host is refused at dial", func(t *testing.T) {
+		_, err := statIngestWebDAV("https://169.254.169.254/remote.php/dav/ocm", "secret", 5*time.Second, true)
+		if err == nil {
+			t.Fatal("expected ingest stat to refuse the metadata host at dial")
+		}
+		if !strings.Contains(err.Error(), "non-public") {
+			t.Fatalf("got %v, want the existing non-public dial error", err)
+		}
+	})
+
+	t.Run("reachable private host is not contacted", func(t *testing.T) {
+		contacted := false
+		srv := httptest.NewTLSServer(ingestWebDAVHandler(t, &contacted))
+		defer srv.Close()
+
+		_, err := statIngestWebDAV(srv.URL, "secret", 5*time.Second, true)
+		if contacted {
+			t.Fatal("ingest stat contacted a private WebDAV host; the untrusted transport must refuse it at dial")
+		}
+		if err == nil {
+			t.Fatal("expected ingest stat to a private host to fail")
+		}
+		if !strings.Contains(err.Error(), "non-public") {
+			t.Fatalf("got %v, want the existing non-public dial error", err)
+		}
+	})
+}
+
+func TestIngestWebDAVStatRefusesHTTP(t *testing.T) {
+	contacted := false
+	srv := httptest.NewServer(ingestWebDAVHandler(t, &contacted))
+	defer srv.Close()
+
+	_, err := statIngestWebDAV(srv.URL, "secret", 5*time.Second, true)
+	if contacted {
+		t.Fatal("ingest stat contacted an http WebDAV host; the untrusted transport must refuse it")
+	}
+	if err == nil {
+		t.Fatal("expected ingest stat to refuse a non-https URL")
+	}
+	if !errors.Is(err, errPublicOnlyNonHTTPS) {
+		t.Fatalf("got %v, want errPublicOnlyNonHTTPS", err)
 	}
 }

--- a/internal/http/services/opencloudmesh/ocmd/shares_test.go
+++ b/internal/http/services/opencloudmesh/ocmd/shares_test.go
@@ -28,6 +28,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"regexp"
+	"sync"
 	"testing"
 	"time"
 
@@ -265,6 +266,26 @@ func tlsOcmDiscoveryServer(t *testing.T) *httptest.Server {
 	return httptest.NewTLSServer(mux)
 }
 
+func TestDiscoverOcmResourceTypesHonorsRequestTimeout(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(2 * time.Second)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"enabled":true}`))
+	}))
+	defer srv.Close()
+
+	h := &sharesHandler{ocmClientInsecure: true, ocmClientTimeout: 400 * time.Millisecond}
+	start := time.Now()
+	_, _, err := h.discoverOcmResourceTypes(context.Background(), srv.URL)
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatal("expected Discover to fail when the metadata peer is slow")
+	}
+	if elapsed > 1500*time.Millisecond {
+		t.Fatalf("Discover request timeout was not applied; elapsed %v", elapsed)
+	}
+}
+
 func TestDiscoverOcmResourceTypesHonorsResponseLimit(t *testing.T) {
 	body := oversizedJSON(t, map[string]any{
 		"enabled":    true,
@@ -384,6 +405,7 @@ func TestIngestWebDAVStatPublicHTTPSHostSucceeds(t *testing.T) {
 		srv.URL,
 		"secret",
 		UntrustedHTTPTransport(5*time.Second, true, testSec(), 0),
+		5*time.Second,
 	)
 	if err != nil {
 		t.Fatalf("ingest stat to a public HTTPS WebDAV host: %v", err)
@@ -402,6 +424,7 @@ func TestIngestWebDAVStatRefusesPrivateHost(t *testing.T) {
 			"https://169.254.169.254/remote.php/dav/ocm",
 			"secret",
 			UntrustedHTTPTransport(5*time.Second, true, testSec(), 0),
+			5*time.Second,
 		)
 		if err == nil {
 			t.Fatal("expected ingest stat to refuse the metadata host at dial")
@@ -420,6 +443,7 @@ func TestIngestWebDAVStatRefusesPrivateHost(t *testing.T) {
 			srv.URL,
 			"secret",
 			UntrustedHTTPTransport(5*time.Second, true, testSec(), 0),
+			5*time.Second,
 		)
 		if contacted {
 			t.Fatal("ingest stat contacted a private WebDAV host; the untrusted transport must refuse it at dial")
@@ -442,6 +466,7 @@ func TestIngestWebDAVStatRefusesHTTP(t *testing.T) {
 		srv.URL,
 		"secret",
 		UntrustedHTTPTransport(5*time.Second, true, testSec(), 0),
+		5*time.Second,
 	)
 	if contacted {
 		t.Fatal("ingest stat contacted an http WebDAV host; the untrusted transport must refuse it")
@@ -451,5 +476,75 @@ func TestIngestWebDAVStatRefusesHTTP(t *testing.T) {
 	}
 	if !errors.Is(err, ErrNonHTTPS) {
 		t.Fatalf("got %v, want ErrNonHTTPS", err)
+	}
+}
+
+func TestIngestWebDAVStatHonorsRequestTimeout(t *testing.T) {
+	var startOnce sync.Once
+	started := make(chan struct{})
+	srv := startPublicTLSServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		startOnce.Do(func() { close(started) })
+		time.Sleep(2 * time.Second)
+		w.Header().Set("Content-Type", "application/xml")
+		w.WriteHeader(207)
+		_, _ = w.Write([]byte(ingestWebDAVPropfindXML))
+	}))
+
+	start := time.Now()
+	_, err := statIngestWebDAV(
+		srv.URL,
+		"secret",
+		UntrustedHTTPTransport(5*time.Second, true, testSec(), 0),
+		400*time.Millisecond,
+	)
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatal("expected ingest Stat to fail when the metadata peer is slow")
+	}
+	if elapsed > 1500*time.Millisecond {
+		t.Fatalf("ingest SetTimeout was not honored; elapsed %v", elapsed)
+	}
+	select {
+	case <-started:
+	default:
+		t.Fatal("expected the slow metadata peer to accept the connection")
+	}
+}
+
+func TestIngestWebDAVDialTimeoutBoundsNonResponsiveDial(t *testing.T) {
+	got, err := New(context.Background(), map[string]any{
+		"gatewaysvc":              "gateway:9142",
+		"ocm_client_dial_timeout": 1,
+		"ocm_client_timeout":      30,
+		"token_managers": map[string]any{
+			"jwt": map[string]any{
+				"secret": "test-secret-for-ocm-dial-timeout",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	s, ok := got.(*svc)
+	if !ok {
+		t.Fatalf("got %T, want *svc", got)
+	}
+	if s.shares == nil || s.shares.untrustedTransport == nil {
+		t.Fatal("shares untrusted transport is nil")
+	}
+
+	start := time.Now()
+	_, err = statIngestWebDAV(
+		"https://240.0.0.1/remote.php/dav/ocm",
+		"secret",
+		s.shares.untrustedTransport,
+		s.shares.requestTimeout(),
+	)
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatal("expected ingest stat to a non-responsive public address to fail")
+	}
+	if elapsed > 5*time.Second {
+		t.Fatalf("dial timeout was not wired; elapsed %v", elapsed)
 	}
 }

--- a/internal/http/services/opencloudmesh/ocmd/shares_test.go
+++ b/internal/http/services/opencloudmesh/ocmd/shares_test.go
@@ -265,6 +265,22 @@ func tlsOcmDiscoveryServer(t *testing.T) *httptest.Server {
 	return httptest.NewTLSServer(mux)
 }
 
+func TestDiscoverOcmResourceTypesHonorsResponseLimit(t *testing.T) {
+	body := oversizedJSON(t, map[string]any{
+		"enabled":    true,
+		"apiVersion": "1.1",
+	}, "provider")
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(body)
+	}))
+	defer srv.Close()
+
+	h := &sharesHandler{ocmClientInsecure: true, ocmClientResponseLimit: 64}
+	_, _, err := h.discoverOcmResourceTypes(context.Background(), srv.URL)
+	assertOCMResponseTooLarge(t, err)
+}
+
 // discovery must verify certs by default, and skip only when asked.
 func TestDiscoverVerifiesTLSUnlessInsecure(t *testing.T) {
 	srv := tlsOcmDiscoveryServer(t) // self-signed, https://127.0.0.1:port

--- a/internal/http/services/opencloudmesh/ocmd/shares_test.go
+++ b/internal/http/services/opencloudmesh/ocmd/shares_test.go
@@ -383,9 +383,7 @@ func TestIngestWebDAVStatPublicHTTPSHostSucceeds(t *testing.T) {
 	info, err := statIngestWebDAV(
 		srv.URL,
 		"secret",
-		5*time.Second,
-		true,
-		testSec(),
+		UntrustedHTTPTransport(5*time.Second, true, testSec(), 0),
 	)
 	if err != nil {
 		t.Fatalf("ingest stat to a public HTTPS WebDAV host: %v", err)
@@ -403,9 +401,7 @@ func TestIngestWebDAVStatRefusesPrivateHost(t *testing.T) {
 		_, err := statIngestWebDAV(
 			"https://169.254.169.254/remote.php/dav/ocm",
 			"secret",
-			5*time.Second,
-			true,
-			testSec(),
+			UntrustedHTTPTransport(5*time.Second, true, testSec(), 0),
 		)
 		if err == nil {
 			t.Fatal("expected ingest stat to refuse the metadata host at dial")
@@ -423,9 +419,7 @@ func TestIngestWebDAVStatRefusesPrivateHost(t *testing.T) {
 		_, err := statIngestWebDAV(
 			srv.URL,
 			"secret",
-			5*time.Second,
-			true,
-			testSec(),
+			UntrustedHTTPTransport(5*time.Second, true, testSec(), 0),
 		)
 		if contacted {
 			t.Fatal("ingest stat contacted a private WebDAV host; the untrusted transport must refuse it at dial")
@@ -447,9 +441,7 @@ func TestIngestWebDAVStatRefusesHTTP(t *testing.T) {
 	_, err := statIngestWebDAV(
 		srv.URL,
 		"secret",
-		5*time.Second,
-		true,
-		testSec(),
+		UntrustedHTTPTransport(5*time.Second, true, testSec(), 0),
 	)
 	if contacted {
 		t.Fatal("ingest stat contacted an http WebDAV host; the untrusted transport must refuse it")

--- a/internal/http/services/opencloudmesh/ocmd/tls_min.go
+++ b/internal/http/services/opencloudmesh/ocmd/tls_min.go
@@ -1,0 +1,52 @@
+// Copyright 2018-2026 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package ocmd
+
+import (
+	"crypto/tls"
+	"errors"
+	"fmt"
+)
+
+// ErrInvalidTLSMinVersion is returned when a per-service TLS minimum
+// enum string is not empty, "1.2", or "1.3".
+var ErrInvalidTLSMinVersion = errors.New("invalid TLS min version")
+
+// ParseTLSMinVersion maps a per-service TLS minimum enum string to a
+// crypto/tls version. Empty and "1.2" mean TLS 1.2; "1.3" means TLS 1.3.
+func ParseTLSMinVersion(s string) (uint16, error) {
+	switch s {
+	case "", "1.2":
+		return tls.VersionTLS12, nil
+	case "1.3":
+		return tls.VersionTLS13, nil
+	default:
+		return 0, fmt.Errorf("%w %q: want \"1.2\" or \"1.3\"", ErrInvalidTLSMinVersion, s)
+	}
+}
+
+func resolveTLSMinVersion(minVersion uint16) uint16 {
+	if minVersion == 0 {
+		return tls.VersionTLS12
+	}
+	if minVersion < tls.VersionTLS12 {
+		panic(fmt.Sprintf("ocm transport TLS min version %#x is below TLS 1.2", minVersion))
+	}
+	return minVersion
+}

--- a/internal/http/services/opencloudmesh/ocmd/tls_min_test.go
+++ b/internal/http/services/opencloudmesh/ocmd/tls_min_test.go
@@ -1,0 +1,65 @@
+// Copyright 2018-2026 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package ocmd
+
+import (
+	"crypto/tls"
+	"errors"
+	"testing"
+)
+
+func TestParseTLSMinVersion(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		in      string
+		want    uint16
+		wantErr bool
+	}{
+		{name: "empty defaults to TLS 1.2", in: "", want: tls.VersionTLS12},
+		{name: "1.2", in: "1.2", want: tls.VersionTLS12},
+		{name: "1.3", in: "1.3", want: tls.VersionTLS13},
+		{name: "1.1 rejected", in: "1.1", wantErr: true},
+		{name: "1.0 rejected", in: "1.0", wantErr: true},
+		{name: "bogus rejected", in: "bogus", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := ParseTLSMinVersion(tt.in)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("ParseTLSMinVersion(%q) = %#x, want error", tt.in, got)
+				}
+				if !errors.Is(err, ErrInvalidTLSMinVersion) {
+					t.Fatalf("ParseTLSMinVersion(%q) error = %v, want ErrInvalidTLSMinVersion", tt.in, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseTLSMinVersion(%q) unexpected error: %v", tt.in, err)
+			}
+			if got != tt.want {
+				t.Fatalf("ParseTLSMinVersion(%q) = %#x, want %#x", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/http/services/opencloudmesh/ocmd/untrusted_hardening_regression_test.go
+++ b/internal/http/services/opencloudmesh/ocmd/untrusted_hardening_regression_test.go
@@ -1,0 +1,925 @@
+// Copyright 2018-2026 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package ocmd
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/http/httptrace"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/studio-b12/gowebdav"
+)
+
+const (
+	regressionPropfindMethod = "PROPFIND"
+	regressionMetadataIP     = "169.254.169.254"
+	regressionRebindHost     = "rebind.test"
+	regressionTestNet3IP     = "203.0.113.1"
+)
+
+// TestUntrustedHardeningRegression is the T8 integrated sweep over the
+// shared untrusted-client contract. Per-surface constructor proofs live
+// next to received.New, open.New, embedded.New, and sciencemesh.New;
+// this file stitches the ocmd-owned invariants those constructors share.
+func TestUntrustedHardeningRegression(t *testing.T) {
+	t.Run("public-only dial guard", testRegressionPublicOnlyDialGuard)
+	t.Run("untrusted https redirect tls timeouts", testRegressionUntrustedClientContract)
+	t.Run("trusted NewClient TLS isolation", testRegressionTrustedTLSIsolation)
+	t.Run("sticky-IP reuse", testRegressionStickyIPReuse)
+	t.Run("gowebdav HTTP redirect before dial", testRegressionGowebdavHTTPRedirect)
+	t.Run("gowebdav HTTPS 307 redirect cap", testRegressionGowebdavHTTPSRedirectCap)
+	t.Run("public HTTPS redirect cap", testRegressionPublicHTTPSRedirectCap)
+	t.Run("hatch pin and link-local", testRegressionHatchPinLinkLocal)
+	t.Run("response limit and F2 invite", testRegressionResponseLimitInvite)
+}
+
+func regressionPublicOnlyClient(timeout time.Duration) *OCMClient {
+	return NewPublicOnlyClient(
+		timeout,
+		true,
+		testSec(),
+		0,
+		0,
+	)
+}
+
+func regressionWalkerClient(rt http.RoundTripper) *http.Client {
+	return &http.Client{
+		Transport: rt,
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return nil
+		},
+	}
+}
+
+func testRegressionPublicOnlyDialGuard(t *testing.T) {
+	t.Parallel()
+	sec := testSec()
+
+	refuse := []struct {
+		name string
+		addr string
+	}{
+		{name: "private 10/8", addr: "10.1.2.3:443"},
+		{name: "loopback", addr: "127.0.0.1:443"},
+		{name: "cgnat", addr: "100.64.0.1:443"},
+		{name: "nat64", addr: "[64:ff9b::a9fe:a9fe]:443"},
+		{name: "link-local", addr: "169.254.1.1:443"},
+		{name: "multicast", addr: "224.0.0.1:443"},
+		{name: "metadata service", addr: regressionMetadataIP + ":443"},
+	}
+	for _, tt := range refuse {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if err := sec.CheckDialAddr(tt.addr); !errors.Is(err, ErrNonPublicAddr) {
+				t.Fatalf("CheckDialAddr(%q) = %v, want ErrNonPublicAddr", tt.addr, err)
+			}
+		})
+	}
+
+	t.Run("public address accepted", func(t *testing.T) {
+		t.Parallel()
+		if err := sec.CheckDialAddr("8.8.8.8:443"); err != nil {
+			t.Fatalf("public CheckDialAddr: %v", err)
+		}
+	})
+
+	t.Run("live public HTTPS is accepted", func(t *testing.T) {
+		srv := startPublicTLSServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("ok"))
+		}))
+		c := regressionPublicOnlyClient(5 * time.Second)
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp, err := c.client.Do(req)
+		if err != nil {
+			t.Fatalf("public HTTPS GET: %v", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("status = %d, want 200", resp.StatusCode)
+		}
+	})
+}
+
+func testRegressionUntrustedClientContract(t *testing.T) {
+	t.Parallel()
+
+	t.Run("HTTP is refused", func(t *testing.T) {
+		t.Parallel()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			t.Error("untrusted client must not fetch HTTP")
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer srv.Close()
+
+		c := regressionPublicOnlyClient(5 * time.Second)
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp, err := c.client.Do(req)
+		closeResponse(resp)
+		if !errors.Is(err, ErrNonHTTPS) {
+			t.Fatalf("got %v, want ErrNonHTTPS", err)
+		}
+	})
+
+	t.Run("TLS 1.2 default and configured 1.3", func(t *testing.T) {
+		t.Parallel()
+		def := publicOnlyHTTPTransport(t, regressionPublicOnlyClient(5*time.Second))
+		if def.TLSClientConfig == nil || def.TLSClientConfig.MinVersion != tls.VersionTLS12 {
+			t.Fatalf("default MinVersion = %v, want TLS 1.2", def.TLSClientConfig)
+		}
+		raised := NewPublicOnlyClient(
+			5*time.Second,
+			true,
+			testSec(),
+			0,
+			tls.VersionTLS13,
+		)
+		got := publicOnlyHTTPTransport(t, raised)
+		if got.TLSClientConfig == nil || got.TLSClientConfig.MinVersion != tls.VersionTLS13 {
+			t.Fatalf("configured MinVersion = %v, want TLS 1.3", got.TLSClientConfig)
+		}
+	})
+
+	t.Run("below TLS 1.2 is rejected", func(t *testing.T) {
+		t.Parallel()
+		defer func() {
+			got := recover()
+			if got == nil {
+				t.Fatal("newOCMTransport must reject TLS 1.1")
+			}
+			msg, ok := got.(string)
+			if !ok || !strings.Contains(msg, "below TLS 1.2") {
+				t.Fatalf("panic = %v, want TLS 1.2 floor rejection", got)
+			}
+		}()
+		_ = newOCMTransport(false, tls.VersionTLS11)
+	})
+
+	t.Run("TLS 1.1 handshake is refused", func(t *testing.T) {
+		srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			t.Error("TLS 1.1 handshake must not succeed")
+			w.WriteHeader(http.StatusOK)
+		}))
+		srv.TLS = &tls.Config{
+			MinVersion: tls.VersionTLS11,
+			MaxVersion: tls.VersionTLS11,
+		}
+		srv.StartTLS()
+		defer srv.Close()
+
+		rt := UntrustedHTTPTransport(
+			5*time.Second,
+			true,
+			testSec(),
+			0,
+		)
+		allowUntrustedLoopback(t, rt)
+		resp, err := doUntrustedRequest(t, rt, srv.URL)
+		closeResponse(resp)
+		if err == nil {
+			t.Fatal("expected TLS 1.1 handshake refusal")
+		}
+		assertTLSProtocolVersionError(t, err)
+	})
+
+	t.Run("split timeouts are bounded on metadata client", func(t *testing.T) {
+		const (
+			requestTimeout = 400 * time.Millisecond
+			dialTimeout    = 5 * time.Second
+			peerSleep      = 500 * time.Millisecond
+		)
+		started := make(chan struct{})
+		srv := startPublicTLSServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			close(started)
+			time.Sleep(peerSleep)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("ok"))
+		}))
+
+		sec := testSec()
+		c := &http.Client{
+			Transport: UntrustedHTTPTransport(
+				dialTimeout,
+				true,
+				sec,
+				0,
+			),
+			Timeout:       requestTimeout,
+			CheckRedirect: sec.CheckRedirect,
+		}
+		req, err := http.NewRequestWithContext(
+			context.Background(),
+			http.MethodGet,
+			srv.URL,
+			nil,
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		start := time.Now()
+		resp, err := c.Do(req)
+		elapsed := time.Since(start)
+		closeResponse(resp)
+		if err == nil {
+			t.Fatal("expected the request deadline to fire against a slow peer")
+		}
+		assertHTTPClientTimeout(t, err)
+		if elapsed < requestTimeout/2 {
+			t.Fatalf("failed too quickly to be the request deadline: elapsed %v", elapsed)
+		}
+		if elapsed >= dialTimeout/2 {
+			t.Fatalf("elapsed %v looks like the dial deadline, want request timeout %v", elapsed, requestTimeout)
+		}
+		select {
+		case <-started:
+		default:
+			t.Fatal("expected the slow metadata peer to accept the connection")
+		}
+	})
+}
+
+func testRegressionTrustedTLSIsolation(t *testing.T) {
+	t.Parallel()
+
+	trusted := NewClient(5*time.Second, false, 0)
+	tr, ok := trusted.client.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("trusted transport: got %T, want *http.Transport", trusted.client.Transport)
+	}
+	if tr.TLSClientConfig == nil || tr.TLSClientConfig.MinVersion != tls.VersionTLS12 {
+		t.Fatalf("NewClient MinVersion = %v, want TLS 1.2", tr.TLSClientConfig)
+	}
+
+	untrusted := NewPublicOnlyClient(
+		5*time.Second,
+		false,
+		testSec(),
+		0,
+		tls.VersionTLS13,
+	)
+	got := publicOnlyHTTPTransport(t, untrusted)
+	if got.TLSClientConfig == nil || got.TLSClientConfig.MinVersion != tls.VersionTLS13 {
+		t.Fatalf("NewPublicOnlyClient MinVersion = %v, want TLS 1.3", got.TLSClientConfig)
+	}
+	if tr.TLSClientConfig.MinVersion != tls.VersionTLS12 {
+		t.Fatal("NewClient must not inherit the untrusted TLS knob")
+	}
+
+	t.Run("trusted NewClient completes TLS 1.2 handshake", func(t *testing.T) {
+		srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("ok"))
+		}))
+		srv.TLS = &tls.Config{
+			MinVersion: tls.VersionTLS12,
+			MaxVersion: tls.VersionTLS12,
+		}
+		srv.StartTLS()
+		t.Cleanup(srv.Close)
+
+		trustedLive := NewClient(5*time.Second, true, 0)
+		var negotiated uint16
+		ctx := httptrace.WithClientTrace(context.Background(), &httptrace.ClientTrace{
+			TLSHandshakeDone: func(state tls.ConnectionState, err error) {
+				if err != nil {
+					return
+				}
+				negotiated = state.Version
+			},
+		})
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp, err := trustedLive.client.Do(req)
+		if err != nil {
+			t.Fatalf("trusted NewClient TLS 1.2 handshake: %v", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("status = %d, want 200", resp.StatusCode)
+		}
+		if negotiated != tls.VersionTLS12 {
+			t.Fatalf("negotiated TLS %#x, want TLS 1.2 (trusted floor must not rise to 1.3)", negotiated)
+		}
+	})
+}
+
+func testRegressionStickyIPReuse(t *testing.T) {
+	t.Run("same IP dialed on every redirect hop", func(t *testing.T) {
+		runStickyIPRedirectChain(t, false)
+	})
+	t.Run("Control refuses mid-chain rebind without reuse", func(t *testing.T) {
+		runStickyIPRedirectChain(t, true)
+	})
+
+	t.Run("metadata IP is refused after a public hop", func(t *testing.T) {
+		srv := startPublicTLSServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("ok"))
+		}))
+
+		c := regressionPublicOnlyClient(5 * time.Second)
+		tr := publicOnlyHTTPTransport(t, c)
+		if tr.DialContext == nil {
+			t.Fatal("untrusted transport must set DialContext")
+		}
+
+		req, err := http.NewRequestWithContext(
+			context.Background(),
+			http.MethodGet,
+			srv.URL,
+			nil,
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp, err := c.client.Do(req)
+		if err != nil {
+			t.Fatalf("public warmup GET: %v", err)
+		}
+		resp.Body.Close()
+
+		var established bool
+		ctx := httptrace.WithClientTrace(context.Background(), &httptrace.ClientTrace{
+			GotConn: func(httptrace.GotConnInfo) {
+				established = true
+			},
+		})
+		priv, err := http.NewRequestWithContext(
+			ctx,
+			http.MethodGet,
+			"https://"+regressionMetadataIP+"/",
+			nil,
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		privResp, err := c.client.Do(priv)
+		closeResponse(privResp)
+		if established {
+			t.Fatal("sticky-IP reuse must not connect to 169.254.169.254")
+		}
+		if !errors.Is(err, ErrNonPublicAddr) {
+			t.Fatalf("metadata dial: got %v, want ErrNonPublicAddr", err)
+		}
+	})
+}
+
+// runStickyIPRedirectChain drives a PROPFIND/307 chain through the production
+// UntrustedHTTPTransport DialContext (including Control). Test DNS maps
+// rebind.test onto the public listener first and a reachable loopback peer
+// later. Production Control still sees those resolved IPs.
+func runStickyIPRedirectChain(t *testing.T, disableKeepAlive bool) {
+	t.Helper()
+	const hopRequests = 4
+	var (
+		mu               sync.Mutex
+		hops             int
+		methods          = []string{}
+		privateContacted bool
+	)
+	srv := startPublicTLSServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		hops++
+		n := hops
+		methods = append(methods, r.Method)
+		mu.Unlock()
+		if n < hopRequests {
+			http.Redirect(w, r, "/hop", http.StatusTemporaryRedirect)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	priv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		privateContacted = true
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("rebound"))
+	}))
+	t.Cleanup(priv.Close)
+
+	publicHost, _, err := net.SplitHostPort(srv.Listener.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	privAddr := priv.Listener.Addr().String()
+
+	c := regressionPublicOnlyClient(5 * time.Second)
+	tr := publicOnlyHTTPTransport(t, c)
+	if tr.DialContext == nil {
+		t.Fatal("untrusted transport must set DialContext")
+	}
+	if !disableKeepAlive && tr.DisableKeepAlives {
+		t.Fatal("sticky-IP reuse requires keep-alive; DisableKeepAlives must stay false")
+	}
+	if disableKeepAlive {
+		tr.DisableKeepAlives = true
+	}
+
+	var (
+		dialed  = []string{}
+		lookups int
+		reused  = []bool{}
+	)
+	inner := tr.DialContext
+	tr.DialContext = func(ctx context.Context, network, address string) (net.Conn, error) {
+		host, port, splitErr := net.SplitHostPort(address)
+		if splitErr != nil {
+			return nil, splitErr
+		}
+		resolved := address
+		if host == regressionRebindHost {
+			mu.Lock()
+			lookups++
+			n := lookups
+			mu.Unlock()
+			if n == 1 {
+				resolved = net.JoinHostPort(publicHost, port)
+			} else {
+				resolved = privAddr
+			}
+		}
+		mu.Lock()
+		dialed = append(dialed, resolved)
+		mu.Unlock()
+		// Production Control runs on the resolved IP; this wrap only
+		// observes and supplies test DNS.
+		return inner(ctx, network, resolved)
+	}
+
+	startURL := "https://" + net.JoinHostPort(regressionRebindHost, listenerPort(t, srv)) + "/"
+	ctx := httptrace.WithClientTrace(context.Background(), &httptrace.ClientTrace{
+		GotConn: func(info httptrace.GotConnInfo) {
+			mu.Lock()
+			reused = append(reused, info.Reused)
+			mu.Unlock()
+		},
+	})
+	req, err := http.NewRequestWithContext(
+		ctx,
+		regressionPropfindMethod,
+		startURL,
+		nil,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := c.client.Do(req)
+	closeResponse(resp)
+
+	mu.Lock()
+	defer mu.Unlock()
+	if privateContacted {
+		t.Fatal("mid-chain DNS rebind reached the private peer; production Control must refuse it")
+	}
+	if disableKeepAlive {
+		if err == nil {
+			t.Fatal("expected production Control to refuse the private rebind when reuse is disabled")
+		}
+		if !errors.Is(err, ErrNonPublicAddr) {
+			t.Fatalf("rebind without reuse: got %v, want ErrNonPublicAddr", err)
+		}
+		if lookups < 2 {
+			t.Fatalf("name lookups = %d, want at least 2 when keep-alive is disabled", lookups)
+		}
+		return
+	}
+	if err != nil {
+		t.Fatalf("sticky-IP redirect chain: %v", err)
+	}
+	if hops != hopRequests {
+		t.Fatalf("hop requests = %d, want %d PROPFIND/307 hops", hops, hopRequests)
+	}
+	if len(methods) != hopRequests {
+		t.Fatalf("methods = %d, want %d", len(methods), hopRequests)
+	}
+	for _, m := range methods {
+		if m != regressionPropfindMethod {
+			t.Fatalf("307 must preserve PROPFIND, got %q", m)
+		}
+	}
+	if lookups != 1 {
+		t.Fatalf("name lookups = %d, want 1 (keep-alive must reuse the first resolved IP)", lookups)
+	}
+	if len(dialed) != 1 {
+		t.Fatalf("dials = %d, want 1 reused connection, got %v", len(dialed), dialed)
+	}
+	gotHost, _, splitErr := net.SplitHostPort(dialed[0])
+	if splitErr != nil {
+		t.Fatal(splitErr)
+	}
+	if gotHost != publicHost {
+		t.Fatalf("dialed %q, want sticky public IP %q", dialed[0], publicHost)
+	}
+	if len(reused) != hopRequests {
+		t.Fatalf("GotConn events = %d, want %d", len(reused), hopRequests)
+	}
+	if reused[0] {
+		t.Fatal("first hop must open a new connection")
+	}
+	for i := 1; i < len(reused); i++ {
+		if !reused[i] {
+			t.Fatalf("hop %d must reuse the first connection; a fresh dial could rebind the IP", i+1)
+		}
+	}
+}
+
+func listenerPort(t *testing.T, srv *httptest.Server) string {
+	t.Helper()
+	_, port, err := net.SplitHostPort(srv.Listener.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return port
+}
+
+func regressionTestNet3URL(t *testing.T, srv *httptest.Server, path string) string {
+	t.Helper()
+	if path == "" {
+		path = "/"
+	}
+	return "https://" + net.JoinHostPort(regressionTestNet3IP, listenerPort(t, srv)) + path
+}
+
+// installTestNet3Dial remaps TEST-NET-3 onto the local httptest listener so
+// public-only clients can exercise HTTPS without binding a real public IP.
+func installTestNet3Dial(t *testing.T, tr *http.Transport, listenerAddr string) {
+	t.Helper()
+	tr.DialContext = func(ctx context.Context, network, address string) (net.Conn, error) {
+		host, _, err := net.SplitHostPort(address)
+		if err != nil {
+			return nil, err
+		}
+		if host != regressionTestNet3IP {
+			return nil, errors.New("test dialer expected TEST-NET-3 203.0.113.1")
+		}
+		ip := net.ParseIP(host)
+		if ip == nil || !isPublicIP(ip) {
+			return nil, ErrNonPublicAddr
+		}
+		return (&net.Dialer{Timeout: 5 * time.Second}).DialContext(ctx, network, listenerAddr)
+	}
+}
+
+func testRegressionGowebdavHTTPRedirect(t *testing.T) {
+	httpFetched := false
+	httpSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		httpFetched = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer httpSrv.Close()
+
+	tlsSrv := startPublicTLSServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, httpSrv.URL+r.URL.Path, http.StatusTemporaryRedirect)
+	}))
+
+	dav := gowebdav.NewClient(tlsSrv.URL, "", "")
+	dav.SetTransport(UntrustedHTTPTransport(
+		5*time.Second,
+		true,
+		testSec(),
+		0,
+	))
+	_, err := dav.Stat("")
+	if httpFetched {
+		t.Fatal("gowebdav HTTP redirect must be refused before dialing")
+	}
+	if err == nil {
+		t.Fatal("expected gowebdav HTTP redirect refusal")
+	}
+	if !errors.Is(err, ErrNonHTTPS) {
+		t.Fatalf("got %v, want ErrNonHTTPS", err)
+	}
+}
+
+func testRegressionGowebdavHTTPSRedirectCap(t *testing.T) {
+	const redirectCap = 3
+	// gowebdav.NewClient starts with nullAuth, which inhibits the first
+	// redirect so it can negotiate auth. The following noAuth Stat is the
+	// hop chain the transport walker must cap.
+	const authProbeHops = 1
+
+	newDav := func(t *testing.T, srv *httptest.Server) *gowebdav.Client {
+		t.Helper()
+		sec := UntrustedClientSecurity{MaxRedirects: redirectCap}
+		sec.ApplyDefaults()
+		if err := sec.Compile(); err != nil {
+			t.Fatal(err)
+		}
+		rt := UntrustedHTTPTransport(
+			5*time.Second,
+			true,
+			sec,
+			0,
+		)
+		installTestNet3Dial(t, innerUntrustedTransport(t, rt), srv.Listener.Addr().String())
+		dav := gowebdav.NewClient(regressionTestNet3URL(t, srv, "/"), "", "")
+		dav.SetTransport(rt)
+		return dav
+	}
+
+	t.Run("refuses above configured cap", func(t *testing.T) {
+		hops := 0
+		methods := []string{}
+		srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			methods = append(methods, r.Method)
+			hops++
+			http.Redirect(w, r, "/hop", http.StatusTemporaryRedirect)
+		}))
+		t.Cleanup(srv.Close)
+
+		_, err := newDav(t, srv).Stat("")
+		if !errors.Is(err, ErrTooManyRedirects) {
+			t.Fatalf("got %v, want ErrTooManyRedirects", err)
+		}
+		wantHops := authProbeHops + redirectCap + 1
+		if hops != wantHops {
+			t.Fatalf("hops = %d, want %d (auth probe plus cap+1 HTTPS 307 hops)", hops, wantHops)
+		}
+		if len(methods) == 0 {
+			t.Fatal("expected gowebdav to issue at least one PROPFIND")
+		}
+		for _, m := range methods {
+			if m != regressionPropfindMethod {
+				t.Fatalf("307 must preserve PROPFIND, got %q", m)
+			}
+		}
+	})
+
+	t.Run("allows exactly the configured cap", func(t *testing.T) {
+		hops := 0
+		srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != regressionPropfindMethod {
+				t.Errorf("unexpected method %s", r.Method)
+				w.WriteHeader(http.StatusMethodNotAllowed)
+				return
+			}
+			hops++
+			followed := hops - authProbeHops
+			if hops == authProbeHops || followed <= redirectCap {
+				http.Redirect(w, r, "/hop", http.StatusTemporaryRedirect)
+				return
+			}
+			w.Header().Set("Content-Type", "application/xml")
+			w.WriteHeader(207)
+			_, _ = w.Write([]byte(ingestWebDAVPropfindXML))
+		}))
+		t.Cleanup(srv.Close)
+
+		info, err := newDav(t, srv).Stat("")
+		if err != nil {
+			t.Fatalf("expected gowebdav to allow %d HTTPS 307 redirects: %v", redirectCap, err)
+		}
+		if info == nil {
+			t.Fatal("expected WebDAV stat info after the capped 307 chain")
+		}
+		wantHops := authProbeHops + redirectCap + 1
+		if hops != wantHops {
+			t.Fatalf("hops = %d, want %d (auth probe plus exactly %d HTTPS 307 redirects then 207)", hops, wantHops, redirectCap)
+		}
+	})
+}
+
+func testRegressionPublicHTTPSRedirectCap(t *testing.T) {
+	const redirectCap = 3
+
+	newCapWalker := func(t *testing.T, srv *httptest.Server) *http.Client {
+		t.Helper()
+		sec := UntrustedClientSecurity{MaxRedirects: redirectCap}
+		sec.ApplyDefaults()
+		if err := sec.Compile(); err != nil {
+			t.Fatal(err)
+		}
+		rt := UntrustedHTTPTransport(5*time.Second, true, sec, 0)
+		installTestNet3Dial(t, innerUntrustedTransport(t, rt), srv.Listener.Addr().String())
+		return regressionWalkerClient(rt)
+	}
+
+	t.Run("refuses above configured cap", func(t *testing.T) {
+		hops := 0
+		methods := []string{}
+		srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			methods = append(methods, r.Method)
+			hops++
+			if hops <= redirectCap+1 {
+				http.Redirect(w, r, "/hop", http.StatusTemporaryRedirect)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+		}))
+		t.Cleanup(srv.Close)
+
+		req, err := http.NewRequestWithContext(
+			context.Background(),
+			regressionPropfindMethod,
+			regressionTestNet3URL(t, srv, "/"),
+			nil,
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp, err := newCapWalker(t, srv).Do(req)
+		closeResponse(resp)
+		if !errors.Is(err, ErrTooManyRedirects) {
+			t.Fatalf("got %v, want ErrTooManyRedirects", err)
+		}
+		if hops != redirectCap+1 {
+			t.Fatalf("hops = %d, want %d (cap enforced after %d redirects)", hops, redirectCap+1, redirectCap)
+		}
+		if len(methods) == 0 {
+			t.Fatal("expected the walker to issue at least one PROPFIND")
+		}
+		for _, m := range methods {
+			if m != regressionPropfindMethod {
+				t.Fatalf("307 must preserve PROPFIND, got %q", m)
+			}
+		}
+	})
+
+	t.Run("allows exactly the configured cap", func(t *testing.T) {
+		hops := 0
+		srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != regressionPropfindMethod {
+				t.Errorf("unexpected method %s", r.Method)
+				w.WriteHeader(http.StatusMethodNotAllowed)
+				return
+			}
+			hops++
+			if hops <= redirectCap {
+				http.Redirect(w, r, "/hop", http.StatusTemporaryRedirect)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("ok"))
+		}))
+		t.Cleanup(srv.Close)
+
+		req, err := http.NewRequestWithContext(
+			context.Background(),
+			regressionPropfindMethod,
+			regressionTestNet3URL(t, srv, "/"),
+			nil,
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp, err := newCapWalker(t, srv).Do(req)
+		if err != nil {
+			t.Fatalf("expected transport walker to allow %d redirects: %v", redirectCap, err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("status = %d, want 200", resp.StatusCode)
+		}
+		if hops != redirectCap+1 {
+			t.Fatalf("hops = %d, want %d (exactly %d redirects then 200)", hops, redirectCap+1, redirectCap)
+		}
+	})
+}
+
+func testRegressionHatchPinLinkLocal(t *testing.T) {
+	t.Parallel()
+
+	t.Run("PIN stays exclusive", func(t *testing.T) {
+		t.Parallel()
+		s := UntrustedClientSecurity{
+			AllowedCIDRs:  []string{"10.0.0.0/8"},
+			AllowLoopback: true,
+		}
+		if err := s.Compile(); err != nil {
+			t.Fatal(err)
+		}
+		if err := s.CheckDialAddr("10.1.2.3:443"); err != nil {
+			t.Fatalf("PIN must allow a listed address: %v", err)
+		}
+		if err := s.CheckDialAddr("8.8.8.8:443"); !errors.Is(err, ErrNonPublicAddr) {
+			t.Fatalf("PIN must refuse an unlisted public IP: %v", err)
+		}
+		if err := s.CheckDialAddr("127.0.0.1:443"); !errors.Is(err, ErrNonPublicAddr) {
+			t.Fatalf("PIN must ignore AllowLoopback: %v", err)
+		}
+	})
+
+	t.Run("link-local hard-deny without exact host", func(t *testing.T) {
+		t.Parallel()
+		s := UntrustedClientSecurity{AllowedCIDRs: []string{"169.254.0.0/16"}}
+		if err := s.Compile(); err != nil {
+			t.Fatal(err)
+		}
+		if err := s.CheckDialAddr("169.254.1.1:443"); !errors.Is(err, ErrNonPublicAddr) {
+			t.Fatalf("link-local /16 must stay denied: %v", err)
+		}
+
+		s = UntrustedClientSecurity{AllowedCIDRs: []string{regressionMetadataIP + "/32"}}
+		if err := s.Compile(); err != nil {
+			t.Fatal(err)
+		}
+		if err := s.CheckDialAddr(regressionMetadataIP + ":443"); err != nil {
+			t.Fatalf("exact /32 must allow the metadata host: %v", err)
+		}
+	})
+}
+
+func testRegressionResponseLimitInvite(t *testing.T) {
+	t.Parallel()
+
+	t.Run("zero and negative select the default", func(t *testing.T) {
+		t.Parallel()
+		for _, limit := range []int64{0, -1} {
+			c := NewPublicOnlyClient(
+				time.Second,
+				true,
+				testSec(),
+				limit,
+				0,
+			)
+			if c.responseLimit != maxOCMResponseBytes {
+				t.Fatalf("limit %d: responseLimit = %d, want %d", limit, c.responseLimit, maxOCMResponseBytes)
+			}
+		}
+	})
+
+	t.Run("bounded F2 invite response", func(t *testing.T) {
+		body := oversizedJSON(t, map[string]any{"email": "a@b.c"}, "name")
+		srv := startPublicTLSServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write(body)
+		}))
+
+		c := NewPublicOnlyClient(
+			5*time.Second,
+			true,
+			testSec(),
+			0,
+			0,
+		)
+		u, err := c.InviteAccepted(context.Background(), srv.URL, &InviteAcceptedRequest{
+			UserID: "alice",
+			Token:  "tok",
+		})
+		assertOCMResponseTooLarge(t, err)
+		if u != nil {
+			t.Fatalf("oversized invite-accepted body must not be decoded, got %+v", u)
+		}
+	})
+}
+
+func assertTLSProtocolVersionError(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected a TLS protocol-version error")
+	}
+	msg := strings.ToLower(err.Error())
+	if !strings.Contains(msg, "tls") || !strings.Contains(msg, "protocol version") {
+		t.Fatalf("got %v, want a TLS protocol-version failure (server below the configured floor)", err)
+	}
+}
+
+func assertHTTPClientTimeout(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected request deadline")
+	}
+	if strings.Contains(err.Error(), "Client.Timeout") {
+		return
+	}
+	if errors.Is(err, os.ErrDeadlineExceeded) || errors.Is(err, context.DeadlineExceeded) {
+		return
+	}
+	t.Fatalf("got %v, want request deadline, not a dial failure", err)
+}

--- a/internal/http/services/opencloudmesh/ocmd/untrusted_security.go
+++ b/internal/http/services/opencloudmesh/ocmd/untrusted_security.go
@@ -1,0 +1,315 @@
+// Copyright 2018-2026 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package ocmd
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"syscall"
+
+	"github.com/cs3org/reva/v3/pkg/errtypes"
+)
+
+const (
+	defaultMaxRedirects  = 3
+	maxRedirectsCeiling  = 10
+	cloudMetadataIPv4    = "169.254.169.254"
+	cloudMetadataAWSIPv6 = "fd00:ec2::254"
+)
+
+// UntrustedClientSecurity is the shared hatch and redirect policy for
+// untrusted outbound OCM HTTP clients.
+type UntrustedClientSecurity struct {
+	MaxRedirects int      `mapstructure:"max_redirects"` // 0 => 3, ceiling 10
+	AllowHTTP    bool     `mapstructure:"allow_http"`    // ocmreceived only
+	AllowedCIDRs []string `mapstructure:"allowed_cidrs"` // ocmreceived only
+	allowedNets  []*net.IPNet
+}
+
+// 64:ff9b::/96 embeds an IPv4 address in its low 32 bits (RFC 6052), so on a
+// NAT64 network it can still reach internal hosts.
+var nat64WellKnownPrefix = net.IPNet{IP: net.ParseIP("64:ff9b::"), Mask: net.CIDRMask(96, 128)}
+
+// ErrNonHTTPS is returned when the untrusted client refuses a URL whose
+// scheme is not allowed (https, or http only when AllowHTTP is set).
+var ErrNonHTTPS = errors.New("untrusted OCM client requires https")
+
+// ErrTooManyRedirects is the sentinel for a redirect chain that exceeds
+// the configured cap. Callers should use errors.Is; the wrapped error
+// includes the numeric cap.
+var ErrTooManyRedirects = errors.New("untrusted OCM client: too many redirects")
+
+// ErrNonPublicAddr is returned when dial Control refuses an address that
+// is not allowed by the current policy (public-only, or PIN-when-set).
+var ErrNonPublicAddr = errors.New("refusing to connect to non-public address")
+
+// ErrHatchAllowHTTP is returned when a non-received consumer sets allow_http.
+var ErrHatchAllowHTTP = errors.New("untrusted client security: allow_http is only valid for ocmreceived")
+
+// ErrHatchAllowedCIDRs is returned when a non-received consumer sets allowed_cidrs.
+var ErrHatchAllowedCIDRs = errors.New("untrusted client security: allowed_cidrs is only valid for ocmreceived")
+
+var errInvalidCIDR = errors.New("invalid CIDR")
+
+var errUnrestrictedCIDR = errors.New("unrestricted CIDR is not allowed")
+
+var errNAT64Overlap = errors.New("CIDR overlaps NAT64 64:ff9b::/96")
+
+// ApplyDefaults sets MaxRedirects 0 to 3 and clamps values above 10 to 10.
+func (s *UntrustedClientSecurity) ApplyDefaults() {
+	if s.MaxRedirects == 0 {
+		s.MaxRedirects = defaultMaxRedirects
+	}
+	if s.MaxRedirects > maxRedirectsCeiling {
+		s.MaxRedirects = maxRedirectsCeiling
+	}
+}
+
+// Compile parses AllowedCIDRs into allowedNets. It rejects invalid CIDRs,
+// 0.0.0.0/0, ::/0, and any CIDR that overlaps NAT64 64:ff9b::/96. On failure
+// compiled nets are cleared so a retry cannot keep stale state.
+func (s *UntrustedClientSecurity) Compile() error {
+	s.allowedNets = nil
+
+	nets := make([]*net.IPNet, 0, len(s.AllowedCIDRs))
+	errs := make([]error, 0)
+	for _, cidr := range s.AllowedCIDRs {
+		_, n, err := net.ParseCIDR(cidr)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("invalid CIDR %q: %w", cidr, errors.Join(errInvalidCIDR, err)))
+			continue
+		}
+		if isUnrestrictedCIDR(n) {
+			errs = append(errs, fmt.Errorf("unrestricted CIDR %q is not allowed: %w", cidr, errUnrestrictedCIDR))
+			continue
+		}
+		if cidrOverlapsNAT64(n) {
+			errs = append(errs, fmt.Errorf("CIDR %q overlaps NAT64 64:ff9b::/96: %w", cidr, errNAT64Overlap))
+			continue
+		}
+		nets = append(nets, n)
+	}
+	if len(errs) > 0 {
+		return errors.Join(errs...)
+	}
+	s.allowedNets = nets
+	return nil
+}
+
+// RejectHatch errors if AllowHTTP is true or AllowedCIDRs is non-empty.
+// Non-received consumers call this in their New/start path.
+func (s UntrustedClientSecurity) RejectHatch() error {
+	if s.AllowHTTP {
+		return ErrHatchAllowHTTP
+	}
+	if len(s.AllowedCIDRs) > 0 {
+		return ErrHatchAllowedCIDRs
+	}
+	return nil
+}
+
+func (s UntrustedClientSecurity) maxRedirects() int {
+	n := s.MaxRedirects
+	if n <= 0 {
+		return defaultMaxRedirects
+	}
+	if n > maxRedirectsCeiling {
+		return maxRedirectsCeiling
+	}
+	return n
+}
+
+func (s UntrustedClientSecurity) requireScheme(u *url.URL) error {
+	if u != nil && u.Scheme == "https" {
+		return nil
+	}
+	if s.AllowHTTP && u != nil && u.Scheme == "http" {
+		return nil
+	}
+	scheme := ""
+	if u != nil {
+		scheme = u.Scheme
+	}
+	return fmt.Errorf("untrusted OCM client refuses scheme %q: %w", scheme, ErrNonHTTPS)
+}
+
+func (s UntrustedClientSecurity) tooManyRedirectsError() error {
+	return fmt.Errorf("untrusted OCM client stopped after %d redirects: %w", s.maxRedirects(), ErrTooManyRedirects)
+}
+
+// CheckRedirect refuses more than maxRedirects hops (len(via) > max, not >=)
+// and enforces requireScheme on each target.
+func (s UntrustedClientSecurity) CheckRedirect(req *http.Request, via []*http.Request) error {
+	if len(via) > s.maxRedirects() {
+		return s.tooManyRedirectsError()
+	}
+	if req == nil {
+		return s.requireScheme(nil)
+	}
+	return s.requireScheme(req.URL)
+}
+
+func (s UntrustedClientSecurity) refuseNonPublicAddr(network, addr string) error {
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		return err
+	}
+	ip := net.ParseIP(host)
+	if ip == nil || !s.allowsDial(ip) {
+		return fmt.Errorf("%w: %w", ErrNonPublicAddr, errtypes.BadRequest("refusing to connect to non-public address "+addr))
+	}
+	return nil
+}
+
+func (s UntrustedClientSecurity) dialControl(network, address string, _ syscall.RawConn) error {
+	return s.refuseNonPublicAddr(network, address)
+}
+
+func (s UntrustedClientSecurity) allowsDial(ip net.IP) bool {
+	if ip == nil {
+		return false
+	}
+	unwrapped := unwrapNAT64(ip)
+	if isHardDeniedUnlessExactHost(unwrapped) || isHardDeniedUnlessExactHost(ip) {
+		return hasExactHostAllow(unwrapped, s.allowedNets) || hasExactHostAllow(ip, s.allowedNets)
+	}
+	if len(s.allowedNets) > 0 {
+		return ipInAny(unwrapped, s.allowedNets) || ipInAny(ip, s.allowedNets)
+	}
+	return isPublicIP(unwrapped)
+}
+
+func defaultUntrustedSecurity() UntrustedClientSecurity {
+	var s UntrustedClientSecurity
+	s.ApplyDefaults()
+	return s
+}
+
+func isUnrestrictedCIDR(n *net.IPNet) bool {
+	if n == nil {
+		return false
+	}
+	ones, bits := n.Mask.Size()
+	if ones != 0 {
+		return false
+	}
+	switch bits {
+	case 32:
+		return n.IP.Equal(net.IPv4zero)
+	case 128:
+		return n.IP.Equal(net.IPv6zero)
+	default:
+		return false
+	}
+}
+
+func cidrOverlapsNAT64(n *net.IPNet) bool {
+	if n == nil {
+		return false
+	}
+	_, bits := n.Mask.Size()
+	if bits == 32 {
+		return false
+	}
+	return n.Contains(nat64WellKnownPrefix.IP) || nat64WellKnownPrefix.Contains(n.IP)
+}
+
+func unwrapNAT64(ip net.IP) net.IP {
+	if ip == nil || !nat64WellKnownPrefix.Contains(ip) {
+		return ip
+	}
+	v6 := ip.To16()
+	if v6 == nil {
+		return ip
+	}
+	return net.IPv4(v6[12], v6[13], v6[14], v6[15])
+}
+
+func ipInAny(ip net.IP, nets []*net.IPNet) bool {
+	for _, n := range nets {
+		if n != nil && n.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+func isHardDeniedUnlessExactHost(ip net.IP) bool {
+	if ip == nil {
+		return false
+	}
+	if ip.IsLinkLocalUnicast() {
+		return true
+	}
+	if ip.Equal(net.ParseIP(cloudMetadataIPv4)) {
+		return true
+	}
+	if ip.Equal(net.ParseIP(cloudMetadataAWSIPv6)) {
+		return true
+	}
+	return false
+}
+
+func isExactHostNet(n *net.IPNet) bool {
+	if n == nil {
+		return false
+	}
+	ones, bits := n.Mask.Size()
+	return ones == bits && (bits == 32 || bits == 128)
+}
+
+func hasExactHostAllow(ip net.IP, nets []*net.IPNet) bool {
+	for _, n := range nets {
+		if n != nil && isExactHostNet(n) && n.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+func isPublicIP(ip net.IP) bool {
+	ip = unwrapNAT64(ip)
+	if ip == nil {
+		return false
+	}
+	if ip.IsLoopback() || ip.IsPrivate() || ip.IsUnspecified() ||
+		ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() ||
+		ip.IsMulticast() || ip.IsInterfaceLocalMulticast() {
+		return false
+	}
+	// 100.64.0.0/10 is carrier-grade NAT, which net.IP.IsPrivate does not cover
+	if ip4 := ip.To4(); ip4 != nil && ip4[0] == 100 && ip4[1]&0xc0 == 64 {
+		return false
+	}
+	return true
+}
+
+// refuseNonPublicAddr is the default-hatch Control used by existing tests.
+func refuseNonPublicAddr(network, address string, c syscall.RawConn) error {
+	return defaultUntrustedSecurity().dialControl(network, address, c)
+}
+
+// PublicOnlyCheckRedirect is the default-hatch CheckRedirect (3 hops, https).
+// Owned clients should prefer UntrustedClientSecurity.CheckRedirect.
+func PublicOnlyCheckRedirect(req *http.Request, via []*http.Request) error {
+	return defaultUntrustedSecurity().CheckRedirect(req, via)
+}

--- a/internal/http/services/opencloudmesh/ocmd/untrusted_security.go
+++ b/internal/http/services/opencloudmesh/ocmd/untrusted_security.go
@@ -39,10 +39,11 @@ const (
 // UntrustedClientSecurity is the shared hatch and redirect policy for
 // untrusted outbound OCM HTTP clients.
 type UntrustedClientSecurity struct {
-	MaxRedirects int      `mapstructure:"max_redirects"` // 0 => 3, ceiling 10
-	AllowHTTP    bool     `mapstructure:"allow_http"`    // ocmreceived only
-	AllowedCIDRs []string `mapstructure:"allowed_cidrs"` // ocmreceived only
-	allowedNets  []*net.IPNet
+	MaxRedirects  int      `mapstructure:"max_redirects"`  // 0 => 3, ceiling 10
+	AllowHTTP     bool     `mapstructure:"allow_http"`     // ocmreceived only
+	AllowedCIDRs  []string `mapstructure:"allowed_cidrs"`  // ocmreceived only; exclusive PIN
+	AllowLoopback bool     `mapstructure:"allow_loopback"` // ocmreceived only; additive public+loopback
+	allowedNets   []*net.IPNet
 }
 
 // 64:ff9b::/96 embeds an IPv4 address in its low 32 bits (RFC 6052), so on a
@@ -60,6 +61,9 @@ var ErrTooManyRedirects = errors.New("untrusted OCM client: too many redirects")
 
 // ErrNonPublicAddr is returned when dial Control refuses an address that
 // is not allowed by the current policy (public-only, or PIN-when-set).
+// When AllowLoopback is enabled, loopback addresses are also accepted
+// in addition to public ones; non-loopback private addresses remain
+// refused.
 var ErrNonPublicAddr = errors.New("refusing to connect to non-public address")
 
 // ErrHatchAllowHTTP is returned when a non-received consumer sets allow_http.
@@ -67,6 +71,9 @@ var ErrHatchAllowHTTP = errors.New("untrusted client security: allow_http is onl
 
 // ErrHatchAllowedCIDRs is returned when a non-received consumer sets allowed_cidrs.
 var ErrHatchAllowedCIDRs = errors.New("untrusted client security: allowed_cidrs is only valid for ocmreceived")
+
+// ErrHatchAllowLoopback is returned when a non-received consumer sets allow_loopback.
+var ErrHatchAllowLoopback = errors.New("untrusted client security: allow_loopback is only valid for ocmreceived")
 
 var errInvalidCIDR = errors.New("invalid CIDR")
 
@@ -115,14 +122,17 @@ func (s *UntrustedClientSecurity) Compile() error {
 	return nil
 }
 
-// RejectHatch errors if AllowHTTP is true or AllowedCIDRs is non-empty.
-// Non-received consumers call this in their New/start path.
+// RejectHatch errors if AllowHTTP is true, AllowedCIDRs is non-empty, or
+// AllowLoopback is true. Non-received consumers call this in their New/start path.
 func (s UntrustedClientSecurity) RejectHatch() error {
 	if s.AllowHTTP {
 		return ErrHatchAllowHTTP
 	}
 	if len(s.AllowedCIDRs) > 0 {
 		return ErrHatchAllowedCIDRs
+	}
+	if s.AllowLoopback {
+		return ErrHatchAllowLoopback
 	}
 	return nil
 }
@@ -168,6 +178,13 @@ func (s UntrustedClientSecurity) CheckRedirect(req *http.Request, via []*http.Re
 	return s.requireScheme(req.URL)
 }
 
+// CheckDialAddr applies the same address policy as Dialer.Control without
+// opening a network connection. addr must be host:port as Control receives
+// it after default ports are applied.
+func (s UntrustedClientSecurity) CheckDialAddr(addr string) error {
+	return s.refuseNonPublicAddr("tcp", addr)
+}
+
 func (s UntrustedClientSecurity) refuseNonPublicAddr(network, addr string) error {
 	host, _, err := net.SplitHostPort(addr)
 	if err != nil {
@@ -195,7 +212,10 @@ func (s UntrustedClientSecurity) allowsDial(ip net.IP) bool {
 	if len(s.allowedNets) > 0 {
 		return ipInAny(unwrapped, s.allowedNets) || ipInAny(ip, s.allowedNets)
 	}
-	return isPublicIP(unwrapped)
+	publicOK := isPublicIP(unwrapped)
+	// Check the original address so NAT64-wrapped loopback stays refused.
+	loopbackOK := s.AllowLoopback && isLoopbackHatchIP(ip)
+	return publicOK || loopbackOK
 }
 
 func defaultUntrustedSecurity() UntrustedClientSecurity {
@@ -284,6 +304,10 @@ func hasExactHostAllow(ip net.IP, nets []*net.IPNet) bool {
 		}
 	}
 	return false
+}
+
+func isLoopbackHatchIP(ip net.IP) bool {
+	return ip != nil && ip.IsLoopback()
 }
 
 func isPublicIP(ip net.IP) bool {

--- a/internal/http/services/opencloudmesh/ocmd/untrusted_security.go
+++ b/internal/http/services/opencloudmesh/ocmd/untrusted_security.go
@@ -39,7 +39,7 @@ const (
 // UntrustedClientSecurity is the shared hatch and redirect policy for
 // untrusted outbound OCM HTTP clients.
 type UntrustedClientSecurity struct {
-	MaxRedirects  int      `mapstructure:"max_redirects"`  // 0 => 3, ceiling 10
+	MaxRedirects  int      `mapstructure:"max_redirects"`  // 0 selects the default; values above the ceiling are clamped
 	AllowHTTP     bool     `mapstructure:"allow_http"`     // ocmreceived only
 	AllowedCIDRs  []string `mapstructure:"allowed_cidrs"`  // ocmreceived only; exclusive PIN
 	AllowLoopback bool     `mapstructure:"allow_loopback"` // ocmreceived only; additive public+loopback
@@ -81,7 +81,8 @@ var errUnrestrictedCIDR = errors.New("unrestricted CIDR is not allowed")
 
 var errNAT64Overlap = errors.New("CIDR overlaps NAT64 64:ff9b::/96")
 
-// ApplyDefaults sets MaxRedirects 0 to 3 and clamps values above 10 to 10.
+// ApplyDefaults fills MaxRedirects: 0 selects the default, and values above
+// the ceiling are clamped.
 func (s *UntrustedClientSecurity) ApplyDefaults() {
 	if s.MaxRedirects == 0 {
 		s.MaxRedirects = defaultMaxRedirects
@@ -122,8 +123,8 @@ func (s *UntrustedClientSecurity) Compile() error {
 	return nil
 }
 
-// RejectHatch errors if AllowHTTP is true, AllowedCIDRs is non-empty, or
-// AllowLoopback is true. Non-received consumers call this in their New/start path.
+// RejectHatch errors if a non-received consumer opens the ocmreceived-only
+// hatch (allow_http, allowed_cidrs, or allow_loopback).
 func (s UntrustedClientSecurity) RejectHatch() error {
 	if s.AllowHTTP {
 		return ErrHatchAllowHTTP
@@ -197,6 +198,20 @@ func (s UntrustedClientSecurity) refuseNonPublicAddr(network, addr string) error
 	return nil
 }
 
+// dialControl is the net.Dialer.Control hook: post-resolution, pre-dial. It
+// sees the resolved IP before the kernel connects and refuses addresses not
+// allowed by the current policy. Default is public-only. AllowLoopback is
+// the additive public + loopback exception. PIN mode via AllowedCIDRs is an
+// exclusive allowlist: only listed CIDRs are allowed and everything else is
+// refused. The post-resolution, pre-dial hook defeats SSRF, DNS rebinding,
+// and metadata attacks.
+//
+// The check belongs here rather than only in DialContext or request logic so
+// every actual dial is covered. Control inspects the resolved peer address
+// on direct dials and redirect targets. The public-only transport disables
+// proxying, so there is no proxy CONNECT path to guard. After Control sees
+// the fixed address there is no rebind window on that dial; reused idle
+// connections stay sticky to the already-validated peer.
 func (s UntrustedClientSecurity) dialControl(network, address string, _ syscall.RawConn) error {
 	return s.refuseNonPublicAddr(network, address)
 }
@@ -332,8 +347,8 @@ func refuseNonPublicAddr(network, address string, c syscall.RawConn) error {
 	return defaultUntrustedSecurity().dialControl(network, address, c)
 }
 
-// PublicOnlyCheckRedirect is the default-hatch CheckRedirect (3 hops, https).
-// Owned clients should prefer UntrustedClientSecurity.CheckRedirect.
+// PublicOnlyCheckRedirect is the default-hatch CheckRedirect (https, default
+// hop cap). Owned clients should prefer UntrustedClientSecurity.CheckRedirect.
 func PublicOnlyCheckRedirect(req *http.Request, via []*http.Request) error {
 	return defaultUntrustedSecurity().CheckRedirect(req, via)
 }

--- a/internal/http/services/opencloudmesh/ocmd/untrusted_security_test.go
+++ b/internal/http/services/opencloudmesh/ocmd/untrusted_security_test.go
@@ -1,0 +1,319 @@
+// Copyright 2018-2026 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package ocmd
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"net/url"
+	"testing"
+)
+
+func testSec() UntrustedClientSecurity {
+	return defaultUntrustedSecurity()
+}
+
+func TestUntrustedClientSecurityApplyDefaults(t *testing.T) {
+	t.Parallel()
+
+	t.Run("zero becomes three", func(t *testing.T) {
+		s := UntrustedClientSecurity{}
+		s.ApplyDefaults()
+		if s.MaxRedirects != 3 {
+			t.Fatalf("MaxRedirects = %d, want 3", s.MaxRedirects)
+		}
+	})
+
+	t.Run("values above 10 clamp to 10", func(t *testing.T) {
+		s := UntrustedClientSecurity{MaxRedirects: 11}
+		s.ApplyDefaults()
+		if s.MaxRedirects != 10 {
+			t.Fatalf("MaxRedirects = %d, want 10", s.MaxRedirects)
+		}
+	})
+
+	t.Run("explicit value in range is kept", func(t *testing.T) {
+		s := UntrustedClientSecurity{MaxRedirects: 7}
+		s.ApplyDefaults()
+		if s.MaxRedirects != 7 {
+			t.Fatalf("MaxRedirects = %d, want 7", s.MaxRedirects)
+		}
+	})
+}
+
+func TestUntrustedClientSecurityCompile(t *testing.T) {
+	t.Parallel()
+
+	t.Run("invalid CIDR", func(t *testing.T) {
+		s := UntrustedClientSecurity{AllowedCIDRs: []string{"not-a-cidr"}}
+		if err := s.Compile(); err == nil {
+			t.Fatal("expected invalid CIDR error")
+		}
+	})
+
+	t.Run("rejects 0.0.0.0/0", func(t *testing.T) {
+		s := UntrustedClientSecurity{AllowedCIDRs: []string{"0.0.0.0/0"}}
+		if err := s.Compile(); err == nil {
+			t.Fatal("expected unrestricted IPv4 CIDR error")
+		}
+	})
+
+	t.Run("rejects ::/0", func(t *testing.T) {
+		s := UntrustedClientSecurity{AllowedCIDRs: []string{"::/0"}}
+		if err := s.Compile(); err == nil {
+			t.Fatal("expected unrestricted IPv6 CIDR error")
+		}
+	})
+
+	t.Run("rejects NAT64 overlap", func(t *testing.T) {
+		s := UntrustedClientSecurity{AllowedCIDRs: []string{"64:ff9b::/96"}}
+		if err := s.Compile(); err == nil {
+			t.Fatal("expected NAT64 overlap error")
+		}
+	})
+
+	t.Run("returns an error for every rejection", func(t *testing.T) {
+		s := UntrustedClientSecurity{AllowedCIDRs: []string{"not-a-cidr", "0.0.0.0/0", "::/0"}}
+		err := s.Compile()
+		if err == nil {
+			t.Fatal("expected joined compile errors")
+		}
+		if !errors.Is(err, errInvalidCIDR) {
+			t.Fatalf("joined error missing invalid CIDR: %v", err)
+		}
+		if !errors.Is(err, errUnrestrictedCIDR) {
+			t.Fatalf("joined error missing unrestricted CIDR: %v", err)
+		}
+	})
+
+	t.Run("clears stale compiled nets after failure", func(t *testing.T) {
+		s := UntrustedClientSecurity{AllowedCIDRs: []string{"10.0.0.0/8"}}
+		if err := s.Compile(); err != nil {
+			t.Fatal(err)
+		}
+		if !s.allowsDial(net.ParseIP("10.1.2.3")) {
+			t.Fatal("expected PIN allow before failed recompile")
+		}
+		s.AllowedCIDRs = []string{"0.0.0.0/0"}
+		if err := s.Compile(); err == nil {
+			t.Fatal("expected recompile to fail")
+		}
+		if s.allowsDial(net.ParseIP("10.1.2.3")) {
+			t.Fatal("stale compiled nets must not survive a failed Compile")
+		}
+	})
+}
+
+func TestUntrustedClientSecurityAllowsDialPIN(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty hatch is public-only", func(t *testing.T) {
+		s := testSec()
+		if !s.allowsDial(net.ParseIP("8.8.8.8")) {
+			t.Fatal("empty hatch must allow a public IP")
+		}
+		if s.allowsDial(net.ParseIP("10.1.2.3")) {
+			t.Fatal("empty hatch must refuse a private IP")
+		}
+	})
+
+	t.Run("non-empty PIN allows listed only", func(t *testing.T) {
+		s := UntrustedClientSecurity{AllowedCIDRs: []string{"10.0.0.0/8"}}
+		if err := s.Compile(); err != nil {
+			t.Fatal(err)
+		}
+		if !s.allowsDial(net.ParseIP("10.1.2.3")) {
+			t.Fatal("PIN must allow an address in the listed net")
+		}
+		if s.allowsDial(net.ParseIP("8.8.8.8")) {
+			t.Fatal("PIN must refuse a public IP that is not listed")
+		}
+	})
+
+	t.Run("link-local denied unless exact /32", func(t *testing.T) {
+		s := UntrustedClientSecurity{AllowedCIDRs: []string{"169.254.0.0/16"}}
+		if err := s.Compile(); err != nil {
+			t.Fatal(err)
+		}
+		if s.allowsDial(net.ParseIP("169.254.169.254")) {
+			t.Fatal("listing 169.254.0.0/16 must not allow 169.254.169.254")
+		}
+		if s.allowsDial(net.ParseIP("169.254.1.1")) {
+			t.Fatal("link-local must stay denied without an exact host entry")
+		}
+
+		s = UntrustedClientSecurity{AllowedCIDRs: []string{"169.254.169.254/32"}}
+		if err := s.Compile(); err != nil {
+			t.Fatal(err)
+		}
+		if !s.allowsDial(net.ParseIP("169.254.169.254")) {
+			t.Fatal("exact /32 must allow the metadata host")
+		}
+		if s.allowsDial(net.ParseIP("169.254.1.1")) {
+			t.Fatal("exact /32 must not allow a different link-local host")
+		}
+	})
+
+	t.Run("ipv6 metadata and nat64 denied unless exact host", func(t *testing.T) {
+		meta6 := net.ParseIP(cloudMetadataAWSIPv6)
+		s := UntrustedClientSecurity{AllowedCIDRs: []string{"fd00:ec2::/64"}}
+		if err := s.Compile(); err != nil {
+			t.Fatal(err)
+		}
+		if s.allowsDial(meta6) {
+			t.Fatal("listing fd00:ec2::/64 must not allow fd00:ec2::254")
+		}
+		if !s.allowsDial(net.ParseIP("fd00:ec2::1")) {
+			t.Fatal("PIN fd00:ec2::/64 must still allow a non-metadata address")
+		}
+
+		s = UntrustedClientSecurity{AllowedCIDRs: []string{"fd00:ec2::254/128"}}
+		if err := s.Compile(); err != nil {
+			t.Fatal(err)
+		}
+		if !s.allowsDial(meta6) {
+			t.Fatal("exact /128 must allow the IPv6 metadata host")
+		}
+		if s.allowsDial(net.ParseIP("fd00:ec2::1")) {
+			t.Fatal("exact /128 must not allow a different IPv6 host")
+		}
+
+		nat64Meta := net.ParseIP("64:ff9b::a9fe:a9fe")
+		s = UntrustedClientSecurity{AllowedCIDRs: []string{"169.254.0.0/16"}}
+		if err := s.Compile(); err != nil {
+			t.Fatal(err)
+		}
+		if s.allowsDial(nat64Meta) {
+			t.Fatal("listing 169.254.0.0/16 must not allow NAT64 metadata")
+		}
+
+		s = UntrustedClientSecurity{AllowedCIDRs: []string{"169.254.169.254/32"}}
+		if err := s.Compile(); err != nil {
+			t.Fatal(err)
+		}
+		if !s.allowsDial(nat64Meta) {
+			t.Fatal("exact IPv4 /32 must allow the NAT64-wrapped metadata host")
+		}
+	})
+}
+
+func TestUntrustedClientSecurityCheckRedirect(t *testing.T) {
+	t.Parallel()
+
+	s := testSec()
+	httpsURL, err := url.Parse("https://example.com/next")
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := &http.Request{URL: httpsURL}
+
+	via3 := []*http.Request{{}, {}, {}}
+	if err := s.CheckRedirect(req, via3); err != nil {
+		t.Fatalf("len(via)=3 must be allowed with max 3: %v", err)
+	}
+
+	via4 := []*http.Request{{}, {}, {}, {}}
+	if err := s.CheckRedirect(req, via4); err == nil {
+		t.Fatal("len(via)=4 must be refused with max 3")
+	} else if !errors.Is(err, ErrTooManyRedirects) {
+		t.Fatalf("got %v, want ErrTooManyRedirects", err)
+	}
+}
+
+func TestUntrustedClientSecurityRequireScheme(t *testing.T) {
+	t.Parallel()
+
+	httpsURL, err := url.Parse("https://example.com/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	httpURL, err := url.Parse("http://example.com/")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s := testSec()
+	if err := s.requireScheme(httpsURL); err != nil {
+		t.Fatalf("https must be allowed: %v", err)
+	}
+	if err := s.requireScheme(httpURL); err == nil {
+		t.Fatal("http must be refused when AllowHTTP is false")
+	} else if !errors.Is(err, ErrNonHTTPS) {
+		t.Fatalf("got %v, want ErrNonHTTPS", err)
+	}
+
+	s.AllowHTTP = true
+	if err := s.requireScheme(httpURL); err != nil {
+		t.Fatalf("http must be allowed when AllowHTTP is true: %v", err)
+	}
+}
+
+func TestUntrustedClientSecurityRejectHatch(t *testing.T) {
+	t.Parallel()
+
+	if err := (UntrustedClientSecurity{}).RejectHatch(); err != nil {
+		t.Fatalf("empty hatch must be accepted: %v", err)
+	}
+	if err := (UntrustedClientSecurity{AllowHTTP: true}).RejectHatch(); err == nil {
+		t.Fatal("AllowHTTP must be rejected for non-received consumers")
+	} else if !errors.Is(err, ErrHatchAllowHTTP) {
+		t.Fatalf("got %v, want ErrHatchAllowHTTP", err)
+	}
+	if err := (UntrustedClientSecurity{AllowedCIDRs: []string{"10.0.0.0/8"}}).RejectHatch(); err == nil {
+		t.Fatal("AllowedCIDRs must be rejected for non-received consumers")
+	} else if !errors.Is(err, ErrHatchAllowedCIDRs) {
+		t.Fatalf("got %v, want ErrHatchAllowedCIDRs", err)
+	}
+}
+
+func TestOCMDNewRejectsHatch(t *testing.T) {
+	t.Parallel()
+
+	t.Run("allow_http", func(t *testing.T) {
+		_, err := New(context.Background(), map[string]any{
+			"gatewaysvc": "gateway:9142",
+			"ocm_client_security": map[string]any{
+				"allow_http": true,
+			},
+		})
+		if err == nil {
+			t.Fatal("expected ocmd.New to reject allow_http")
+		}
+		if !errors.Is(err, ErrHatchAllowHTTP) {
+			t.Fatalf("got %v, want ErrHatchAllowHTTP", err)
+		}
+	})
+
+	t.Run("allowed_cidrs", func(t *testing.T) {
+		_, err := New(context.Background(), map[string]any{
+			"gatewaysvc": "gateway:9142",
+			"ocm_client_security": map[string]any{
+				"allowed_cidrs": []string{"10.0.0.0/8"},
+			},
+		})
+		if err == nil {
+			t.Fatal("expected ocmd.New to reject allowed_cidrs")
+		}
+		if !errors.Is(err, ErrHatchAllowedCIDRs) {
+			t.Fatalf("got %v, want ErrHatchAllowedCIDRs", err)
+		}
+	})
+}

--- a/internal/http/services/opencloudmesh/ocmd/untrusted_security_test.go
+++ b/internal/http/services/opencloudmesh/ocmd/untrusted_security_test.go
@@ -133,6 +133,74 @@ func TestUntrustedClientSecurityAllowsDialPIN(t *testing.T) {
 		if s.allowsDial(net.ParseIP("10.1.2.3")) {
 			t.Fatal("empty hatch must refuse a private IP")
 		}
+		if s.allowsDial(net.ParseIP("127.0.0.1")) {
+			t.Fatal("empty hatch must refuse loopback")
+		}
+	})
+
+	t.Run("AllowLoopback is additive public plus loopback", func(t *testing.T) {
+		s := UntrustedClientSecurity{AllowLoopback: true}
+		if err := s.Compile(); err != nil {
+			t.Fatal(err)
+		}
+		if !s.allowsDial(net.ParseIP("8.8.8.8")) {
+			t.Fatal("AllowLoopback must still allow a public IP")
+		}
+		if !s.allowsDial(net.ParseIP("127.0.0.1")) {
+			t.Fatal("AllowLoopback must allow 127.0.0.1")
+		}
+		if !s.allowsDial(net.ParseIP("127.1.2.3")) {
+			t.Fatal("AllowLoopback must allow 127.0.0.0/8")
+		}
+		if !s.allowsDial(net.ParseIP("::1")) {
+			t.Fatal("AllowLoopback must allow ::1")
+		}
+		if s.allowsDial(net.ParseIP("10.1.2.3")) {
+			t.Fatal("AllowLoopback must refuse 10.x")
+		}
+		if s.allowsDial(net.ParseIP("192.168.1.1")) {
+			t.Fatal("AllowLoopback must refuse 192.168.x")
+		}
+		if s.allowsDial(net.ParseIP("172.16.0.1")) {
+			t.Fatal("AllowLoopback must refuse 172.16/12")
+		}
+		if s.allowsDial(net.ParseIP("100.64.0.1")) {
+			t.Fatal("AllowLoopback must refuse CGNAT 100.64/10")
+		}
+		if s.allowsDial(net.ParseIP("169.254.1.1")) {
+			t.Fatal("AllowLoopback must refuse link-local")
+		}
+		if s.allowsDial(net.ParseIP("64:ff9b::7f00:1")) {
+			t.Fatal("AllowLoopback must refuse NAT64-wrapped loopback")
+		}
+		if err := s.CheckDialAddr("8.8.8.8:443"); err != nil {
+			t.Fatalf("CheckDialAddr public: %v", err)
+		}
+		if err := s.CheckDialAddr("127.0.0.1:443"); err != nil {
+			t.Fatalf("CheckDialAddr loopback: %v", err)
+		}
+		if err := s.CheckDialAddr("10.1.2.3:443"); !errors.Is(err, ErrNonPublicAddr) {
+			t.Fatalf("CheckDialAddr private: got %v, want ErrNonPublicAddr", err)
+		}
+	})
+
+	t.Run("PIN stays exclusive when AllowLoopback is also set", func(t *testing.T) {
+		s := UntrustedClientSecurity{
+			AllowedCIDRs:  []string{"10.0.0.0/8"},
+			AllowLoopback: true,
+		}
+		if err := s.Compile(); err != nil {
+			t.Fatal(err)
+		}
+		if !s.allowsDial(net.ParseIP("10.1.2.3")) {
+			t.Fatal("PIN must still allow a listed address")
+		}
+		if s.allowsDial(net.ParseIP("8.8.8.8")) {
+			t.Fatal("PIN must stay exclusive and refuse an unlisted public IP")
+		}
+		if s.allowsDial(net.ParseIP("127.0.0.1")) {
+			t.Fatal("PIN must stay exclusive and ignore AllowLoopback")
+		}
 	})
 
 	t.Run("non-empty PIN allows listed only", func(t *testing.T) {
@@ -282,6 +350,11 @@ func TestUntrustedClientSecurityRejectHatch(t *testing.T) {
 	} else if !errors.Is(err, ErrHatchAllowedCIDRs) {
 		t.Fatalf("got %v, want ErrHatchAllowedCIDRs", err)
 	}
+	if err := (UntrustedClientSecurity{AllowLoopback: true}).RejectHatch(); err == nil {
+		t.Fatal("AllowLoopback must be rejected for non-received consumers")
+	} else if !errors.Is(err, ErrHatchAllowLoopback) {
+		t.Fatalf("got %v, want ErrHatchAllowLoopback", err)
+	}
 }
 
 func TestOCMDNewRejectsHatch(t *testing.T) {
@@ -314,6 +387,21 @@ func TestOCMDNewRejectsHatch(t *testing.T) {
 		}
 		if !errors.Is(err, ErrHatchAllowedCIDRs) {
 			t.Fatalf("got %v, want ErrHatchAllowedCIDRs", err)
+		}
+	})
+
+	t.Run("allow_loopback", func(t *testing.T) {
+		_, err := New(context.Background(), map[string]any{
+			"gatewaysvc": "gateway:9142",
+			"ocm_client_security": map[string]any{
+				"allow_loopback": true,
+			},
+		})
+		if err == nil {
+			t.Fatal("expected ocmd.New to reject allow_loopback")
+		}
+		if !errors.Is(err, ErrHatchAllowLoopback) {
+			t.Fatalf("got %v, want ErrHatchAllowLoopback", err)
 		}
 	})
 }

--- a/internal/http/services/sciencemesh/sciencemesh.go
+++ b/internal/http/services/sciencemesh/sciencemesh.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"net/http"
 
+	"github.com/cs3org/reva/v3/internal/http/services/opencloudmesh/ocmd"
 	"github.com/cs3org/reva/v3/pkg/appctx"
 	"github.com/cs3org/reva/v3/pkg/rhttp/global"
 	"github.com/cs3org/reva/v3/pkg/sharedconf"
@@ -70,8 +71,7 @@ type config struct {
 	BodyTemplatePath     string                      `mapstructure:"body_template_path"`
 	OCMMountPoint        string                      `mapstructure:"ocm_mount_point"`
 	DirectoryServiceURLs string                      `mapstructure:"directory_service_urls"`
-	OCMClientTimeout     int                         `mapstructure:"ocm_client_timeout"`
-	OCMClientInsecure    bool                        `mapstructure:"ocm_client_insecure"`
+	OCMClient            ocmd.ClientSecurityConfig   `mapstructure:"ocm_client"`
 }
 
 func (c *config) ApplyDefaults() {
@@ -81,9 +81,7 @@ func (c *config) ApplyDefaults() {
 	if c.OCMMountPoint == "" {
 		c.OCMMountPoint = "/ocm"
 	}
-	if c.OCMClientTimeout == 0 {
-		c.OCMClientTimeout = 10
-	}
+	c.OCMClient.ApplyDefaults()
 
 	c.GatewaySvc = sharedconf.GetGatewaySVC(c.GatewaySvc)
 }

--- a/internal/http/services/sciencemesh/sciencemesh.go
+++ b/internal/http/services/sciencemesh/sciencemesh.go
@@ -61,17 +61,17 @@ func (s *svc) Close() error {
 }
 
 type config struct {
-	Prefix               string                      `mapstructure:"prefix"`
-	SMTPCredentials      *smtpclient.SMTPCredentials `mapstructure:"smtp_credentials"`
-	GatewaySvc           string                      `mapstructure:"gatewaysvc"         validate:"required"`
-	MeshDirectoryURL     string                      `mapstructure:"mesh_directory_url" validate:"required"`
-	ProviderDomain       string                      `mapstructure:"provider_domain"    validate:"required"`
-	SubjectTemplate      string                      `mapstructure:"subject_template"`
-	BodyTemplatePath     string                      `mapstructure:"body_template_path"`
-	OCMMountPoint        string                      `mapstructure:"ocm_mount_point"`
-	DirectoryServiceURLs string                      `mapstructure:"directory_service_urls"`
-	OCMClientTimeout     int                         `mapstructure:"ocm_client_timeout"`
-	OCMClientInsecure    bool                        `mapstructure:"ocm_client_insecure"`
+	Prefix            string                      `mapstructure:"prefix"`
+	SMTPCredentials   *smtpclient.SMTPCredentials `mapstructure:"smtp_credentials"`
+	GatewaySvc        string                      `mapstructure:"gatewaysvc"         validate:"required"`
+	MeshDirectoryURL  string                      `mapstructure:"mesh_directory_url" validate:"required"`
+	ProviderDomain    string                      `mapstructure:"provider_domain"    validate:"required"`
+	SubjectTemplate   string                      `mapstructure:"subject_template"`
+	BodyTemplatePath  string                      `mapstructure:"body_template_path"`
+	OCMMountPoint     string                      `mapstructure:"ocm_mount_point"`
+	FederationsFile   string                      `mapstructure:"federations_file"`
+	OCMClientTimeout  int                         `mapstructure:"ocm_client_timeout"`
+	OCMClientInsecure bool                        `mapstructure:"ocm_client_insecure"`
 }
 
 func (c *config) ApplyDefaults() {
@@ -80,6 +80,9 @@ func (c *config) ApplyDefaults() {
 	}
 	if c.OCMMountPoint == "" {
 		c.OCMMountPoint = "/ocm"
+	}
+	if c.FederationsFile == "" {
+		c.FederationsFile = "/etc/revad/federations.json"
 	}
 	if c.OCMClientTimeout == 0 {
 		c.OCMClientTimeout = 10

--- a/internal/http/services/sciencemesh/sciencemesh.go
+++ b/internal/http/services/sciencemesh/sciencemesh.go
@@ -61,17 +61,17 @@ func (s *svc) Close() error {
 }
 
 type config struct {
-	Prefix            string                      `mapstructure:"prefix"`
-	SMTPCredentials   *smtpclient.SMTPCredentials `mapstructure:"smtp_credentials"`
-	GatewaySvc        string                      `mapstructure:"gatewaysvc"         validate:"required"`
-	MeshDirectoryURL  string                      `mapstructure:"mesh_directory_url" validate:"required"`
-	ProviderDomain    string                      `mapstructure:"provider_domain"    validate:"required"`
-	SubjectTemplate   string                      `mapstructure:"subject_template"`
-	BodyTemplatePath  string                      `mapstructure:"body_template_path"`
-	OCMMountPoint     string                      `mapstructure:"ocm_mount_point"`
-	FederationsFile   string                      `mapstructure:"federations_file"`
-	OCMClientTimeout  int                         `mapstructure:"ocm_client_timeout"`
-	OCMClientInsecure bool                        `mapstructure:"ocm_client_insecure"`
+	Prefix               string                      `mapstructure:"prefix"`
+	SMTPCredentials      *smtpclient.SMTPCredentials `mapstructure:"smtp_credentials"`
+	GatewaySvc           string                      `mapstructure:"gatewaysvc"         validate:"required"`
+	MeshDirectoryURL     string                      `mapstructure:"mesh_directory_url" validate:"required"`
+	ProviderDomain       string                      `mapstructure:"provider_domain"    validate:"required"`
+	SubjectTemplate      string                      `mapstructure:"subject_template"`
+	BodyTemplatePath     string                      `mapstructure:"body_template_path"`
+	OCMMountPoint        string                      `mapstructure:"ocm_mount_point"`
+	DirectoryServiceURLs string                      `mapstructure:"directory_service_urls"`
+	OCMClientTimeout     int                         `mapstructure:"ocm_client_timeout"`
+	OCMClientInsecure    bool                        `mapstructure:"ocm_client_insecure"`
 }
 
 func (c *config) ApplyDefaults() {
@@ -80,9 +80,6 @@ func (c *config) ApplyDefaults() {
 	}
 	if c.OCMMountPoint == "" {
 		c.OCMMountPoint = "/ocm"
-	}
-	if c.FederationsFile == "" {
-		c.FederationsFile = "/etc/revad/federations.json"
 	}
 	if c.OCMClientTimeout == 0 {
 		c.OCMClientTimeout = 10

--- a/internal/http/services/sciencemesh/sciencemesh.go
+++ b/internal/http/services/sciencemesh/sciencemesh.go
@@ -49,6 +49,11 @@ func New(ctx context.Context, m map[string]any) (global.Service, error) {
 	if err := c.UntrustedClientSecurity.RejectHatch(); err != nil {
 		return nil, err
 	}
+	minVersion, err := ocmd.ParseTLSMinVersion(c.OCMClientTLSMinVersion)
+	if err != nil {
+		return nil, err
+	}
+	c.ocmClientTLSMin = minVersion
 
 	r := chi.NewRouter()
 	s := &svc{
@@ -81,10 +86,14 @@ type config struct {
 	OCMClientTimeout       int                         `mapstructure:"ocm_client_timeout"`
 	OCMClientInsecure      bool                        `mapstructure:"ocm_client_insecure"`
 	OCMClientResponseLimit int                         `mapstructure:"ocm_client_response_limit"`
+	// OCMClientTLSMinVersion is the untrusted-client TLS minimum enum string.
+	// Empty means TLS 1.2. Accepted values are "1.2" and "1.3".
+	OCMClientTLSMinVersion string `mapstructure:"ocm_client_tls_min_version"`
 	// UntrustedClientSecurity configures MaxRedirects for /discover
 	// (TOML block ocm_client_security). The hatch (allow_http / allowed_cidrs)
 	// must stay closed.
 	UntrustedClientSecurity ocmd.UntrustedClientSecurity `mapstructure:"ocm_client_security"`
+	ocmClientTLSMin         uint16
 }
 
 func (c *config) ApplyDefaults() {
@@ -107,6 +116,7 @@ func (c *config) ApplyDefaults() {
 type svc struct {
 	conf   *config
 	router chi.Router
+	wayf   *wayfHandler
 }
 
 func (s *svc) routerInit() error {
@@ -128,6 +138,7 @@ func (s *svc) routerInit() error {
 	if err := wayfHandler.init(s.conf); err != nil {
 		return err
 	}
+	s.wayf = wayfHandler
 	embeddedHandler := new(embeddedHandler)
 	if err := embeddedHandler.init(s.conf); err != nil {
 		return err

--- a/internal/http/services/sciencemesh/sciencemesh.go
+++ b/internal/http/services/sciencemesh/sciencemesh.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"net/http"
 
+	"github.com/cs3org/reva/v3/internal/http/services/opencloudmesh/ocmd"
 	"github.com/cs3org/reva/v3/pkg/appctx"
 	"github.com/cs3org/reva/v3/pkg/rhttp/global"
 	"github.com/cs3org/reva/v3/pkg/sharedconf"
@@ -39,6 +40,13 @@ func init() {
 func New(ctx context.Context, m map[string]any) (global.Service, error) {
 	var c config
 	if err := cfg.Decode(m, &c); err != nil {
+		return nil, err
+	}
+	c.UntrustedClientSecurity.ApplyDefaults()
+	if err := c.UntrustedClientSecurity.Compile(); err != nil {
+		return nil, err
+	}
+	if err := c.UntrustedClientSecurity.RejectHatch(); err != nil {
 		return nil, err
 	}
 
@@ -73,6 +81,10 @@ type config struct {
 	OCMClientTimeout       int                         `mapstructure:"ocm_client_timeout"`
 	OCMClientInsecure      bool                        `mapstructure:"ocm_client_insecure"`
 	OCMClientResponseLimit int                         `mapstructure:"ocm_client_response_limit"`
+	// UntrustedClientSecurity configures MaxRedirects for /discover
+	// (TOML block ocm_client_security). The hatch (allow_http / allowed_cidrs)
+	// must stay closed.
+	UntrustedClientSecurity ocmd.UntrustedClientSecurity `mapstructure:"ocm_client_security"`
 }
 
 func (c *config) ApplyDefaults() {

--- a/internal/http/services/sciencemesh/sciencemesh.go
+++ b/internal/http/services/sciencemesh/sciencemesh.go
@@ -84,6 +84,7 @@ type config struct {
 	OCMMountPoint          string                      `mapstructure:"ocm_mount_point"`
 	DirectoryServiceURLs   string                      `mapstructure:"directory_service_urls"`
 	OCMClientTimeout       int                         `mapstructure:"ocm_client_timeout"`
+	OCMClientDialTimeout   int                         `mapstructure:"ocm_client_dial_timeout"`
 	OCMClientInsecure      bool                        `mapstructure:"ocm_client_insecure"`
 	OCMClientResponseLimit int                         `mapstructure:"ocm_client_response_limit"`
 	// OCMClientTLSMinVersion is the untrusted-client TLS minimum enum string.
@@ -103,8 +104,11 @@ func (c *config) ApplyDefaults() {
 	if c.OCMMountPoint == "" {
 		c.OCMMountPoint = "/ocm"
 	}
-	if c.OCMClientTimeout == 0 {
+	if c.OCMClientTimeout <= 0 {
 		c.OCMClientTimeout = 10
+	}
+	if c.OCMClientDialTimeout <= 0 {
+		c.OCMClientDialTimeout = 10
 	}
 	if c.OCMClientResponseLimit == 0 {
 		c.OCMClientResponseLimit = 1 << 20

--- a/internal/http/services/sciencemesh/sciencemesh.go
+++ b/internal/http/services/sciencemesh/sciencemesh.go
@@ -61,17 +61,18 @@ func (s *svc) Close() error {
 }
 
 type config struct {
-	Prefix               string                      `mapstructure:"prefix"`
-	SMTPCredentials      *smtpclient.SMTPCredentials `mapstructure:"smtp_credentials"`
-	GatewaySvc           string                      `mapstructure:"gatewaysvc"         validate:"required"`
-	MeshDirectoryURL     string                      `mapstructure:"mesh_directory_url" validate:"required"`
-	ProviderDomain       string                      `mapstructure:"provider_domain"    validate:"required"`
-	SubjectTemplate      string                      `mapstructure:"subject_template"`
-	BodyTemplatePath     string                      `mapstructure:"body_template_path"`
-	OCMMountPoint        string                      `mapstructure:"ocm_mount_point"`
-	DirectoryServiceURLs string                      `mapstructure:"directory_service_urls"`
-	OCMClientTimeout     int                         `mapstructure:"ocm_client_timeout"`
-	OCMClientInsecure    bool                        `mapstructure:"ocm_client_insecure"`
+	Prefix                 string                      `mapstructure:"prefix"`
+	SMTPCredentials        *smtpclient.SMTPCredentials `mapstructure:"smtp_credentials"`
+	GatewaySvc             string                      `mapstructure:"gatewaysvc"         validate:"required"`
+	MeshDirectoryURL       string                      `mapstructure:"mesh_directory_url" validate:"required"`
+	ProviderDomain         string                      `mapstructure:"provider_domain"    validate:"required"`
+	SubjectTemplate        string                      `mapstructure:"subject_template"`
+	BodyTemplatePath       string                      `mapstructure:"body_template_path"`
+	OCMMountPoint          string                      `mapstructure:"ocm_mount_point"`
+	DirectoryServiceURLs   string                      `mapstructure:"directory_service_urls"`
+	OCMClientTimeout       int                         `mapstructure:"ocm_client_timeout"`
+	OCMClientInsecure      bool                        `mapstructure:"ocm_client_insecure"`
+	OCMClientResponseLimit int                         `mapstructure:"ocm_client_response_limit"`
 }
 
 func (c *config) ApplyDefaults() {
@@ -83,6 +84,9 @@ func (c *config) ApplyDefaults() {
 	}
 	if c.OCMClientTimeout == 0 {
 		c.OCMClientTimeout = 10
+	}
+	if c.OCMClientResponseLimit == 0 {
+		c.OCMClientResponseLimit = 1 << 20
 	}
 
 	c.GatewaySvc = sharedconf.GetGatewaySVC(c.GatewaySvc)

--- a/internal/http/services/sciencemesh/sciencemesh_test.go
+++ b/internal/http/services/sciencemesh/sciencemesh_test.go
@@ -1,0 +1,78 @@
+// Copyright 2018-2026 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package sciencemesh
+
+import (
+	"testing"
+
+	"github.com/cs3org/reva/v3/pkg/utils/cfg"
+)
+
+func requiredScienceMeshConfig() map[string]any {
+	return map[string]any{
+		"gatewaysvc":         "gateway:9142",
+		"mesh_directory_url": "https://mesh.example",
+		"provider_domain":    "example.org",
+	}
+}
+
+func TestConfigOCMClientLimits(t *testing.T) {
+	tests := []struct {
+		name        string
+		extra       map[string]any
+		wantLimit   int
+		wantTimeout int
+	}{
+		{
+			name: "parses flat keys",
+			extra: map[string]any{
+				"ocm_client_response_limit": 2097152,
+				"ocm_client_timeout":        45,
+			},
+			wantLimit:   2097152,
+			wantTimeout: 45,
+		},
+		{
+			name:        "defaults when unset",
+			extra:       map[string]any{},
+			wantLimit:   1 << 20,
+			wantTimeout: 10,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input := requiredScienceMeshConfig()
+			for k, v := range tt.extra {
+				input[k] = v
+			}
+
+			var c config
+			if err := cfg.Decode(input, &c); err != nil {
+				t.Fatalf("cfg.Decode: %v", err)
+			}
+			if c.OCMClientResponseLimit != tt.wantLimit {
+				t.Errorf("OCMClientResponseLimit = %d, want %d", c.OCMClientResponseLimit, tt.wantLimit)
+			}
+			if c.OCMClientTimeout != tt.wantTimeout {
+				t.Errorf("OCMClientTimeout = %d, want %d", c.OCMClientTimeout, tt.wantTimeout)
+			}
+		})
+	}
+}

--- a/internal/http/services/sciencemesh/sciencemesh_test.go
+++ b/internal/http/services/sciencemesh/sciencemesh_test.go
@@ -142,7 +142,7 @@ func TestNewWiresTLSMinVersionToDiscoverTransport(t *testing.T) {
 	if s.wayf == nil || s.wayf.untrustedClient == nil {
 		t.Fatal("untrusted discover client is nil")
 	}
-	tr := innerUntrustedHTTPTransport(t, s.wayf.untrustedClient.Transport)
+	tr := innerUntrustedHTTPTransport(t, s.wayf.untrustedClient.HTTPTransport())
 	if tr.TLSClientConfig == nil || tr.TLSClientConfig.MinVersion != tls.VersionTLS13 {
 		t.Fatalf("discover transport MinVersion = %v, want TLS 1.3", tr.TLSClientConfig)
 	}

--- a/internal/http/services/sciencemesh/sciencemesh_test.go
+++ b/internal/http/services/sciencemesh/sciencemesh_test.go
@@ -19,8 +19,11 @@
 package sciencemesh
 
 import (
+	"context"
+	"errors"
 	"testing"
 
+	"github.com/cs3org/reva/v3/internal/http/services/opencloudmesh/ocmd"
 	"github.com/cs3org/reva/v3/pkg/utils/cfg"
 )
 
@@ -30,6 +33,34 @@ func requiredScienceMeshConfig() map[string]any {
 		"mesh_directory_url": "https://mesh.example",
 		"provider_domain":    "example.org",
 	}
+}
+
+func TestNewRejectsHatch(t *testing.T) {
+	t.Parallel()
+
+	t.Run("allow_http", func(t *testing.T) {
+		m := requiredScienceMeshConfig()
+		m["ocm_client_security"] = map[string]any{"allow_http": true}
+		_, err := New(context.Background(), m)
+		if err == nil {
+			t.Fatal("expected sciencemesh.New to reject allow_http")
+		}
+		if !errors.Is(err, ocmd.ErrHatchAllowHTTP) {
+			t.Fatalf("got %v, want ocmd.ErrHatchAllowHTTP", err)
+		}
+	})
+
+	t.Run("allowed_cidrs", func(t *testing.T) {
+		m := requiredScienceMeshConfig()
+		m["ocm_client_security"] = map[string]any{"allowed_cidrs": []string{"10.0.0.0/8"}}
+		_, err := New(context.Background(), m)
+		if err == nil {
+			t.Fatal("expected sciencemesh.New to reject allowed_cidrs")
+		}
+		if !errors.Is(err, ocmd.ErrHatchAllowedCIDRs) {
+			t.Fatalf("got %v, want ocmd.ErrHatchAllowedCIDRs", err)
+		}
+	})
 }
 
 func TestConfigOCMClientLimits(t *testing.T) {

--- a/internal/http/services/sciencemesh/sciencemesh_test.go
+++ b/internal/http/services/sciencemesh/sciencemesh_test.go
@@ -20,6 +20,7 @@ package sciencemesh
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"testing"
 
@@ -105,5 +106,59 @@ func TestConfigOCMClientLimits(t *testing.T) {
 				t.Errorf("OCMClientTimeout = %d, want %d", c.OCMClientTimeout, tt.wantTimeout)
 			}
 		})
+	}
+}
+
+func TestNewWiresTLSMinVersionToDiscoverTransport(t *testing.T) {
+	t.Parallel()
+
+	m := requiredScienceMeshConfig()
+	m["ocm_client_tls_min_version"] = "1.3"
+	got, err := New(context.Background(), m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s, ok := got.(*svc)
+	if !ok {
+		t.Fatalf("got %T, want *svc", got)
+	}
+	if s.wayf == nil || s.wayf.untrustedClient == nil {
+		t.Fatal("untrusted discover client is nil")
+	}
+	tr := innerUntrustedHTTPTransport(t, s.wayf.untrustedClient.Transport)
+	if tr.TLSClientConfig == nil || tr.TLSClientConfig.MinVersion != tls.VersionTLS13 {
+		t.Fatalf("discover transport MinVersion = %v, want TLS 1.3", tr.TLSClientConfig)
+	}
+}
+
+func TestNewRejectsInvalidTLSMinVersion(t *testing.T) {
+	t.Parallel()
+
+	m := requiredScienceMeshConfig()
+	m["ocm_client_tls_min_version"] = "1.1"
+	_, err := New(context.Background(), m)
+	if err == nil {
+		t.Fatal("expected sciencemesh.New to reject TLS min version 1.1")
+	}
+	if !errors.Is(err, ocmd.ErrInvalidTLSMinVersion) {
+		t.Fatalf("got %v, want ocmd.ErrInvalidTLSMinVersion", err)
+	}
+}
+
+func TestConfigOCMClientTLSMinVersion(t *testing.T) {
+	t.Parallel()
+
+	input := requiredScienceMeshConfig()
+	input["ocm_client_tls_min_version"] = "1.3"
+	var c config
+	if err := cfg.Decode(input, &c); err != nil {
+		t.Fatalf("cfg.Decode: %v", err)
+	}
+	got, err := ocmd.ParseTLSMinVersion(c.OCMClientTLSMinVersion)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != tls.VersionTLS13 {
+		t.Fatalf("ParseTLSMinVersion(%q) = %#x, want TLS 1.3", c.OCMClientTLSMinVersion, got)
 	}
 }

--- a/internal/http/services/sciencemesh/sciencemesh_test.go
+++ b/internal/http/services/sciencemesh/sciencemesh_test.go
@@ -66,25 +66,39 @@ func TestNewRejectsHatch(t *testing.T) {
 
 func TestConfigOCMClientLimits(t *testing.T) {
 	tests := []struct {
-		name        string
-		extra       map[string]any
-		wantLimit   int
-		wantTimeout int
+		name            string
+		extra           map[string]any
+		wantLimit       int
+		wantTimeout     int
+		wantDialTimeout int
 	}{
 		{
 			name: "parses flat keys",
 			extra: map[string]any{
 				"ocm_client_response_limit": 2097152,
 				"ocm_client_timeout":        45,
+				"ocm_client_dial_timeout":   2,
 			},
-			wantLimit:   2097152,
-			wantTimeout: 45,
+			wantLimit:       2097152,
+			wantTimeout:     45,
+			wantDialTimeout: 2,
 		},
 		{
-			name:        "defaults when unset",
-			extra:       map[string]any{},
-			wantLimit:   1 << 20,
-			wantTimeout: 10,
+			name:            "defaults when unset",
+			extra:           map[string]any{},
+			wantLimit:       1 << 20,
+			wantTimeout:     10,
+			wantDialTimeout: 10,
+		},
+		{
+			name: "negative timeouts use defaults",
+			extra: map[string]any{
+				"ocm_client_timeout":      -1,
+				"ocm_client_dial_timeout": -3,
+			},
+			wantLimit:       1 << 20,
+			wantTimeout:     10,
+			wantDialTimeout: 10,
 		},
 	}
 
@@ -104,6 +118,9 @@ func TestConfigOCMClientLimits(t *testing.T) {
 			}
 			if c.OCMClientTimeout != tt.wantTimeout {
 				t.Errorf("OCMClientTimeout = %d, want %d", c.OCMClientTimeout, tt.wantTimeout)
+			}
+			if c.OCMClientDialTimeout != tt.wantDialTimeout {
+				t.Errorf("OCMClientDialTimeout = %d, want %d", c.OCMClientDialTimeout, tt.wantDialTimeout)
 			}
 		})
 	}

--- a/internal/http/services/sciencemesh/untrusted_client.go
+++ b/internal/http/services/sciencemesh/untrusted_client.go
@@ -20,7 +20,6 @@ package sciencemesh
 
 import (
 	"context"
-	"crypto/tls"
 	"encoding/json"
 	stderrors "errors"
 	"fmt"
@@ -32,14 +31,15 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/cs3org/reva/v3/internal/http/services/opencloudmesh/ocmd"
 	"github.com/cs3org/reva/v3/internal/http/services/wellknown"
 	"github.com/cs3org/reva/v3/pkg/errtypes"
 	"github.com/pkg/errors"
 )
 
 // ocmd.NewPublicOnlyClient is the shared constructor, but OCMClient.client is
-// unexported and Discover hard-codes a 1 MiB cap. /discover rebuilds the same
-// public-only transport here so OCMClientResponseLimit can bound the body.
+// unexported and Discover hard-codes a 1 MiB cap. /discover composes
+// ocmd.UntrustedHTTPTransport so OCMClientResponseLimit can bound the body.
 
 const maxUntrustedRedirects = 3
 
@@ -47,37 +47,22 @@ const defaultDiscoverResponseLimit = 1 << 20
 
 var errUntrustedNonHTTPS = stderrors.New("untrusted discover client requires https")
 
-var errUntrustedTooManyRedirects = fmt.Errorf(
-	"untrusted discover client stopped after %d redirects",
-	maxUntrustedRedirects,
-)
+// errUntrustedTooManyRedirects aliases the shared sentinel so leftover
+// helpers stay on errors.Is(err, ocmd.ErrTooManyRedirects).
+var errUntrustedTooManyRedirects = ocmd.ErrTooManyRedirects
 
 var errDiscoverResponseTooLarge = stderrors.New("discovery response body exceeds size limit")
 
-func newUntrustedDiscoverClient(timeout time.Duration, insecure bool) *http.Client {
-	var tr *http.Transport
-	if dt, ok := http.DefaultTransport.(*http.Transport); ok {
-		tr = dt.Clone()
-	} else {
-		tr = &http.Transport{}
-	}
-	tr.Proxy = nil
-	tr.TLSClientConfig = &tls.Config{
-		InsecureSkipVerify: insecure,
-		MinVersion:         tls.VersionTLS12,
-	}
-	tr.DialContext = (&net.Dialer{
-		Timeout:   timeout,
-		KeepAlive: 30 * time.Second,
-		Control:   refuseNonPublicAddr,
-	}).DialContext
+func newUntrustedDiscoverClient(timeout time.Duration, insecure bool, sec ocmd.UntrustedClientSecurity) *http.Client {
 	return &http.Client{
-		Transport:     &publicOnlyTransport{Transport: tr},
+		Transport:     ocmd.UntrustedHTTPTransport(timeout, insecure, sec),
 		Timeout:       timeout,
-		CheckRedirect: untrustedCheckRedirect,
+		CheckRedirect: sec.CheckRedirect,
 	}
 }
 
+// publicOnlyTransport is a leftover default-hatch RoundTripper. The live
+// /discover client uses ocmd.UntrustedHTTPTransport.
 type publicOnlyTransport struct {
 	*http.Transport
 }
@@ -100,11 +85,15 @@ func requireUntrustedHTTPS(u *url.URL) error {
 	return fmt.Errorf("untrusted discover client refuses non-https scheme %q: %w", scheme, errUntrustedNonHTTPS)
 }
 
+// untrustedCheckRedirect is the leftover default-hatch CheckRedirect.
+// The live /discover client uses sec.CheckRedirect on the configured
+// UntrustedClientSecurity. This helper keeps the net/http CheckRedirect
+// signature, so it cannot see service config; it applies the default cap
+// through UntrustedClientSecurity.maxRedirects().
 func untrustedCheckRedirect(req *http.Request, via []*http.Request) error {
-	if len(via) > maxUntrustedRedirects {
-		return errUntrustedTooManyRedirects
-	}
-	return requireUntrustedHTTPS(req.URL)
+	sec := ocmd.UntrustedClientSecurity{MaxRedirects: maxUntrustedRedirects}
+	sec.ApplyDefaults()
+	return sec.CheckRedirect(req, via)
 }
 
 func refuseNonPublicAddr(_, address string, _ syscall.RawConn) error {

--- a/internal/http/services/sciencemesh/untrusted_client.go
+++ b/internal/http/services/sciencemesh/untrusted_client.go
@@ -38,8 +38,8 @@ import (
 )
 
 // ocmd.NewPublicOnlyClient is the shared constructor, but OCMClient.client is
-// unexported and Discover hard-codes a 1 MiB cap. /discover composes
-// ocmd.UntrustedHTTPTransport so OCMClientResponseLimit can bound the body.
+// unexported. Discover uses c.readOCMBody with the configurable responseLimit.
+// /discover composes ocmd.UntrustedHTTPTransport so OCMClientResponseLimit can bound the body.
 
 const maxUntrustedRedirects = 3
 

--- a/internal/http/services/sciencemesh/untrusted_client.go
+++ b/internal/http/services/sciencemesh/untrusted_client.go
@@ -53,9 +53,19 @@ var errUntrustedTooManyRedirects = ocmd.ErrTooManyRedirects
 
 var errDiscoverResponseTooLarge = stderrors.New("discovery response body exceeds size limit")
 
-func newUntrustedDiscoverClient(timeout time.Duration, insecure bool, sec ocmd.UntrustedClientSecurity) *http.Client {
+func newUntrustedDiscoverClient(
+	timeout time.Duration,
+	insecure bool,
+	sec ocmd.UntrustedClientSecurity,
+	minVersion uint16,
+) *http.Client {
 	return &http.Client{
-		Transport:     ocmd.UntrustedHTTPTransport(timeout, insecure, sec),
+		Transport: ocmd.UntrustedHTTPTransport(
+			timeout,
+			insecure,
+			sec,
+			minVersion,
+		),
 		Timeout:       timeout,
 		CheckRedirect: sec.CheckRedirect,
 	}

--- a/internal/http/services/sciencemesh/untrusted_client.go
+++ b/internal/http/services/sciencemesh/untrusted_client.go
@@ -20,204 +20,53 @@ package sciencemesh
 
 import (
 	"context"
-	"encoding/json"
-	stderrors "errors"
-	"fmt"
-	"io"
 	"net"
 	"net/http"
-	"net/url"
-	"strings"
-	"syscall"
+	"reflect"
 	"time"
 
 	"github.com/cs3org/reva/v3/internal/http/services/opencloudmesh/ocmd"
-	"github.com/cs3org/reva/v3/internal/http/services/wellknown"
-	"github.com/cs3org/reva/v3/pkg/errtypes"
-	"github.com/pkg/errors"
 )
 
-// ocmd.NewPublicOnlyClient is the shared constructor, but OCMClient.client is
-// unexported. Discover uses c.readOCMBody with the configurable responseLimit.
-// /discover composes ocmd.UntrustedHTTPTransport so OCMClientResponseLimit can bound the body.
-
-const maxUntrustedRedirects = 3
-
-const defaultDiscoverResponseLimit = 1 << 20
-
-var errUntrustedNonHTTPS = stderrors.New("untrusted discover client requires https")
-
-// errUntrustedTooManyRedirects aliases the shared sentinel so leftover
-// helpers stay on errors.Is(err, ocmd.ErrTooManyRedirects).
-var errUntrustedTooManyRedirects = ocmd.ErrTooManyRedirects
-
-var errDiscoverResponseTooLarge = stderrors.New("discovery response body exceeds size limit")
-
-func newUntrustedDiscoverClient(
-	dialTimeout time.Duration,
-	requestTimeout time.Duration,
-	insecure bool,
-	sec ocmd.UntrustedClientSecurity,
-	minVersion uint16,
-) *http.Client {
-	return &http.Client{
-		Transport: ocmd.UntrustedHTTPTransport(
-			dialTimeout,
-			insecure,
-			sec,
-			minVersion,
-		),
-		Timeout:       requestTimeout,
-		CheckRedirect: sec.CheckRedirect,
+// overridePublicOnlyDialTimeout keeps sciencemesh's split timeouts after
+// ocmd.NewPublicOnlyClient, which applies one duration to both the request
+// and the dialer. The shared DialContext (public-only Control, scheme, and
+// redirect policy) is left in place; only the dial deadline is tightened or
+// replaced via context.
+func overridePublicOnlyDialTimeout(c *ocmd.OCMClient, dialTimeout time.Duration) {
+	if c == nil || dialTimeout <= 0 {
+		return
+	}
+	tr := untrustedInnerTransport(c.HTTPTransport())
+	if tr == nil || tr.DialContext == nil {
+		return
+	}
+	inner := tr.DialContext
+	tr.DialContext = func(ctx context.Context, network, address string) (net.Conn, error) {
+		ctx, cancel := context.WithTimeout(ctx, dialTimeout)
+		defer cancel()
+		return inner(ctx, network, address)
 	}
 }
 
-// publicOnlyTransport is a leftover default-hatch RoundTripper. The live
-// /discover client uses ocmd.UntrustedHTTPTransport.
-type publicOnlyTransport struct {
-	*http.Transport
-}
-
-func (t *publicOnlyTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	if err := requireUntrustedHTTPS(req.URL); err != nil {
-		return nil, err
+func untrustedInnerTransport(rt http.RoundTripper) *http.Transport {
+	if tr, ok := rt.(*http.Transport); ok {
+		return tr
 	}
-	return t.Transport.RoundTrip(req)
-}
-
-func requireUntrustedHTTPS(u *url.URL) error {
-	if u != nil && u.Scheme == "https" {
+	v := reflect.ValueOf(rt)
+	if v.Kind() == reflect.Pointer {
+		v = v.Elem()
+	}
+	if !v.IsValid() || v.Kind() != reflect.Struct {
 		return nil
 	}
-	scheme := ""
-	if u != nil {
-		scheme = u.Scheme
+	f := v.FieldByName("Transport")
+	if !f.IsValid() || !f.CanInterface() {
+		return nil
 	}
-	return fmt.Errorf("untrusted discover client refuses non-https scheme %q: %w", scheme, errUntrustedNonHTTPS)
-}
-
-// untrustedCheckRedirect is the leftover default-hatch CheckRedirect.
-// The live /discover client uses sec.CheckRedirect on the configured
-// UntrustedClientSecurity. This helper keeps the net/http CheckRedirect
-// signature, so it cannot see service config; it applies the default cap
-// through UntrustedClientSecurity.maxRedirects().
-func untrustedCheckRedirect(req *http.Request, via []*http.Request) error {
-	sec := ocmd.UntrustedClientSecurity{MaxRedirects: maxUntrustedRedirects}
-	sec.ApplyDefaults()
-	return sec.CheckRedirect(req, via)
-}
-
-func refuseNonPublicAddr(_, address string, _ syscall.RawConn) error {
-	host, _, err := net.SplitHostPort(address)
-	if err != nil {
-		return err
+	tr, ok := f.Interface().(*http.Transport)
+	if !ok {
+		return nil
 	}
-	ip := net.ParseIP(host)
-	if ip == nil || !isPublicIP(ip) {
-		return errtypes.BadRequest("refusing to connect to non-public address " + address)
-	}
-	return nil
-}
-
-// 64:ff9b::/96 embeds an IPv4 address in its low 32 bits (RFC 6052), so on a
-// NAT64 network it can still reach internal hosts.
-var nat64WellKnownPrefix = net.IPNet{IP: net.ParseIP("64:ff9b::"), Mask: net.CIDRMask(96, 128)}
-
-func isPublicIP(ip net.IP) bool {
-	if nat64WellKnownPrefix.Contains(ip) {
-		v6 := ip.To16()
-		return isPublicIP(net.IPv4(v6[12], v6[13], v6[14], v6[15]))
-	}
-	if ip.IsLoopback() || ip.IsPrivate() || ip.IsUnspecified() ||
-		ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() ||
-		ip.IsMulticast() || ip.IsInterfaceLocalMulticast() {
-		return false
-	}
-	// 100.64.0.0/10 is carrier-grade NAT, which net.IP.IsPrivate does not cover
-	if ip4 := ip.To4(); ip4 != nil && ip4[0] == 100 && ip4[1]&0xc0 == 64 {
-		return false
-	}
-	return true
-}
-
-func discoverUntrusted(
-	ctx context.Context,
-	client *http.Client,
-	endpoint string,
-	limit int64,
-) (*wellknown.OcmDiscoveryData, error) {
-	if limit <= 0 {
-		limit = defaultDiscoverResponseLimit
-	}
-	if !strings.HasPrefix(endpoint, "http://") && !strings.HasPrefix(endpoint, "https://") {
-		endpoint = "https://" + endpoint
-	}
-
-	remoteURL, err := url.JoinPath(endpoint, "/.well-known/ocm")
-	if err != nil {
-		return nil, err
-	}
-	body, err := discoverGET(
-		ctx,
-		client,
-		remoteURL,
-		limit,
-	)
-	if stderrors.Is(err, errDiscoverResponseTooLarge) {
-		return nil, err
-	}
-	if err != nil || len(body) == 0 {
-		remoteURL, err = url.JoinPath(endpoint, "/ocm-provider")
-		if err != nil {
-			return nil, err
-		}
-		body, err = discoverGET(
-			ctx,
-			client,
-			remoteURL,
-			limit,
-		)
-		if stderrors.Is(err, errDiscoverResponseTooLarge) {
-			return nil, err
-		}
-		if err != nil {
-			return nil, fmt.Errorf("Invalid response on OCM discovery: %w", err)
-		}
-		if len(body) == 0 {
-			return nil, errtypes.InternalError("Invalid response on OCM discovery")
-		}
-	}
-
-	var disco wellknown.OcmDiscoveryData
-	if err := json.Unmarshal(body, &disco); err != nil {
-		return nil, errtypes.InternalError("Invalid payload on OCM discovery")
-	}
-	return &disco, nil
-}
-
-func discoverGET(ctx context.Context, client *http.Client, rawURL string, limit int64) ([]byte, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
-	if err != nil {
-		return nil, errors.Wrap(err, "error creating OCM discovery request")
-	}
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, errors.Wrap(err, "error doing OCM discovery request")
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, errtypes.InternalError("Remote does not offer a valid OCM discovery endpoint")
-	}
-
-	body, err := io.ReadAll(io.LimitReader(resp.Body, limit+1))
-	if err != nil {
-		return nil, errors.Wrap(err, "malformed remote OCM discovery")
-	}
-	if int64(len(body)) > limit {
-		return nil, errDiscoverResponseTooLarge
-	}
-	return body, nil
+	return tr
 }

--- a/internal/http/services/sciencemesh/untrusted_client.go
+++ b/internal/http/services/sciencemesh/untrusted_client.go
@@ -28,11 +28,10 @@ import (
 	"github.com/cs3org/reva/v3/internal/http/services/opencloudmesh/ocmd"
 )
 
-// overridePublicOnlyDialTimeout keeps sciencemesh's split timeouts after
-// ocmd.NewPublicOnlyClient, which applies one duration to both the request
-// and the dialer. The shared DialContext (public-only Control, scheme, and
-// redirect policy) is left in place; only the dial deadline is tightened or
-// replaced via context.
+// overridePublicOnlyDialTimeout keeps sciencemesh's split dial vs request
+// timeouts after ocmd.NewPublicOnlyClient, which applies one duration to
+// both. The shared security wrapper (Control, scheme, redirect) stays in
+// place; only the dial deadline is replaced via context.
 func overridePublicOnlyDialTimeout(c *ocmd.OCMClient, dialTimeout time.Duration) {
 	if c == nil || dialTimeout <= 0 {
 		return
@@ -49,6 +48,10 @@ func overridePublicOnlyDialTimeout(c *ocmd.OCMClient, dialTimeout time.Duration)
 	}
 }
 
+// untrustedInnerTransport reaches the inner *http.Transport through the
+// unexported publicOnlyTransport wrapper. Reflection is an intentional
+// N-1 compatibility adapter, not an exported unwrap API; update this if
+// the private wrapper shape changes.
 func untrustedInnerTransport(rt http.RoundTripper) *http.Transport {
 	if tr, ok := rt.(*http.Transport); ok {
 		return tr

--- a/internal/http/services/sciencemesh/untrusted_client.go
+++ b/internal/http/services/sciencemesh/untrusted_client.go
@@ -54,19 +54,20 @@ var errUntrustedTooManyRedirects = ocmd.ErrTooManyRedirects
 var errDiscoverResponseTooLarge = stderrors.New("discovery response body exceeds size limit")
 
 func newUntrustedDiscoverClient(
-	timeout time.Duration,
+	dialTimeout time.Duration,
+	requestTimeout time.Duration,
 	insecure bool,
 	sec ocmd.UntrustedClientSecurity,
 	minVersion uint16,
 ) *http.Client {
 	return &http.Client{
 		Transport: ocmd.UntrustedHTTPTransport(
-			timeout,
+			dialTimeout,
 			insecure,
 			sec,
 			minVersion,
 		),
-		Timeout:       timeout,
+		Timeout:       requestTimeout,
 		CheckRedirect: sec.CheckRedirect,
 	}
 }

--- a/internal/http/services/sciencemesh/untrusted_client.go
+++ b/internal/http/services/sciencemesh/untrusted_client.go
@@ -1,0 +1,223 @@
+// Copyright 2018-2026 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package sciencemesh
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	stderrors "errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/cs3org/reva/v3/internal/http/services/wellknown"
+	"github.com/cs3org/reva/v3/pkg/errtypes"
+	"github.com/pkg/errors"
+)
+
+// ocmd.NewPublicOnlyClient is the shared constructor, but OCMClient.client is
+// unexported and Discover hard-codes a 1 MiB cap. /discover rebuilds the same
+// public-only transport here so OCMClientResponseLimit can bound the body.
+
+const maxUntrustedRedirects = 3
+
+const defaultDiscoverResponseLimit = 1 << 20
+
+var errUntrustedNonHTTPS = stderrors.New("untrusted discover client requires https")
+
+var errUntrustedTooManyRedirects = fmt.Errorf(
+	"untrusted discover client stopped after %d redirects",
+	maxUntrustedRedirects,
+)
+
+var errDiscoverResponseTooLarge = stderrors.New("discovery response body exceeds size limit")
+
+func newUntrustedDiscoverClient(timeout time.Duration, insecure bool) *http.Client {
+	var tr *http.Transport
+	if dt, ok := http.DefaultTransport.(*http.Transport); ok {
+		tr = dt.Clone()
+	} else {
+		tr = &http.Transport{}
+	}
+	tr.Proxy = nil
+	tr.TLSClientConfig = &tls.Config{
+		InsecureSkipVerify: insecure,
+		MinVersion:         tls.VersionTLS12,
+	}
+	tr.DialContext = (&net.Dialer{
+		Timeout:   timeout,
+		KeepAlive: 30 * time.Second,
+		Control:   refuseNonPublicAddr,
+	}).DialContext
+	return &http.Client{
+		Transport:     &publicOnlyTransport{Transport: tr},
+		Timeout:       timeout,
+		CheckRedirect: untrustedCheckRedirect,
+	}
+}
+
+type publicOnlyTransport struct {
+	*http.Transport
+}
+
+func (t *publicOnlyTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if err := requireUntrustedHTTPS(req.URL); err != nil {
+		return nil, err
+	}
+	return t.Transport.RoundTrip(req)
+}
+
+func requireUntrustedHTTPS(u *url.URL) error {
+	if u != nil && u.Scheme == "https" {
+		return nil
+	}
+	scheme := ""
+	if u != nil {
+		scheme = u.Scheme
+	}
+	return fmt.Errorf("untrusted discover client refuses non-https scheme %q: %w", scheme, errUntrustedNonHTTPS)
+}
+
+func untrustedCheckRedirect(req *http.Request, via []*http.Request) error {
+	if len(via) > maxUntrustedRedirects {
+		return errUntrustedTooManyRedirects
+	}
+	return requireUntrustedHTTPS(req.URL)
+}
+
+func refuseNonPublicAddr(_, address string, _ syscall.RawConn) error {
+	host, _, err := net.SplitHostPort(address)
+	if err != nil {
+		return err
+	}
+	ip := net.ParseIP(host)
+	if ip == nil || !isPublicIP(ip) {
+		return errtypes.BadRequest("refusing to connect to non-public address " + address)
+	}
+	return nil
+}
+
+// 64:ff9b::/96 embeds an IPv4 address in its low 32 bits (RFC 6052), so on a
+// NAT64 network it can still reach internal hosts.
+var nat64WellKnownPrefix = net.IPNet{IP: net.ParseIP("64:ff9b::"), Mask: net.CIDRMask(96, 128)}
+
+func isPublicIP(ip net.IP) bool {
+	if nat64WellKnownPrefix.Contains(ip) {
+		v6 := ip.To16()
+		return isPublicIP(net.IPv4(v6[12], v6[13], v6[14], v6[15]))
+	}
+	if ip.IsLoopback() || ip.IsPrivate() || ip.IsUnspecified() ||
+		ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() ||
+		ip.IsMulticast() || ip.IsInterfaceLocalMulticast() {
+		return false
+	}
+	// 100.64.0.0/10 is carrier-grade NAT, which net.IP.IsPrivate does not cover
+	if ip4 := ip.To4(); ip4 != nil && ip4[0] == 100 && ip4[1]&0xc0 == 64 {
+		return false
+	}
+	return true
+}
+
+func discoverUntrusted(
+	ctx context.Context,
+	client *http.Client,
+	endpoint string,
+	limit int64,
+) (*wellknown.OcmDiscoveryData, error) {
+	if limit <= 0 {
+		limit = defaultDiscoverResponseLimit
+	}
+	if !strings.HasPrefix(endpoint, "http://") && !strings.HasPrefix(endpoint, "https://") {
+		endpoint = "https://" + endpoint
+	}
+
+	remoteURL, err := url.JoinPath(endpoint, "/.well-known/ocm")
+	if err != nil {
+		return nil, err
+	}
+	body, err := discoverGET(
+		ctx,
+		client,
+		remoteURL,
+		limit,
+	)
+	if stderrors.Is(err, errDiscoverResponseTooLarge) {
+		return nil, err
+	}
+	if err != nil || len(body) == 0 {
+		remoteURL, err = url.JoinPath(endpoint, "/ocm-provider")
+		if err != nil {
+			return nil, err
+		}
+		body, err = discoverGET(
+			ctx,
+			client,
+			remoteURL,
+			limit,
+		)
+		if stderrors.Is(err, errDiscoverResponseTooLarge) {
+			return nil, err
+		}
+		if err != nil {
+			return nil, fmt.Errorf("Invalid response on OCM discovery: %w", err)
+		}
+		if len(body) == 0 {
+			return nil, errtypes.InternalError("Invalid response on OCM discovery")
+		}
+	}
+
+	var disco wellknown.OcmDiscoveryData
+	if err := json.Unmarshal(body, &disco); err != nil {
+		return nil, errtypes.InternalError("Invalid payload on OCM discovery")
+	}
+	return &disco, nil
+}
+
+func discoverGET(ctx context.Context, client *http.Client, rawURL string, limit int64) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "error creating OCM discovery request")
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, errors.Wrap(err, "error doing OCM discovery request")
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, errtypes.InternalError("Remote does not offer a valid OCM discovery endpoint")
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, limit+1))
+	if err != nil {
+		return nil, errors.Wrap(err, "malformed remote OCM discovery")
+	}
+	if int64(len(body)) > limit {
+		return nil, errDiscoverResponseTooLarge
+	}
+	return body, nil
+}

--- a/internal/http/services/sciencemesh/untrusted_hardening_regression_test.go
+++ b/internal/http/services/sciencemesh/untrusted_hardening_regression_test.go
@@ -1,0 +1,282 @@
+// Copyright 2018-2026 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package sciencemesh
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/http/httptrace"
+	"sync"
+	"testing"
+
+	"github.com/cs3org/reva/v3/internal/http/services/opencloudmesh/ocmd"
+)
+
+// TestUntrustedHardeningRegression proves sciencemesh.New wires the
+// shared public-only discover client. Per-host matrices stay in
+// wayf_test.go.
+func TestUntrustedHardeningRegression(t *testing.T) {
+	m := requiredScienceMeshConfig()
+	m["ocm_client_insecure"] = true
+	got, err := New(context.Background(), m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s, ok := got.(*svc)
+	if !ok {
+		t.Fatalf("got %T, want *svc", got)
+	}
+	if s.wayf == nil || s.wayf.untrustedClient == nil {
+		t.Fatal("sciencemesh.New must construct the untrusted discover client")
+	}
+	c := s.wayf.untrustedClient
+
+	t.Run("HTTP is refused", func(t *testing.T) {
+		fetched := false
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fetched = true
+			w.WriteHeader(http.StatusOK)
+		}))
+		t.Cleanup(srv.Close)
+
+		resp, err := roundTripConstructor(t, c, srv.URL)
+		if resp != nil && resp.Body != nil {
+			_ = resp.Body.Close()
+		}
+		if fetched {
+			t.Fatal("sciencemesh.New client must not fetch HTTP")
+		}
+		if !errors.Is(err, ocmd.ErrNonHTTPS) {
+			t.Fatalf("got %v, want ocmd.ErrNonHTTPS", err)
+		}
+	})
+
+	t.Run("metadata host is refused", func(t *testing.T) {
+		ctx, tr := contextWithPeerDialTrace(context.Background())
+		resp, err := roundTripConstructorCtx(t, c, ctx, "https://169.254.169.254/")
+		if resp != nil && resp.Body != nil {
+			_ = resp.Body.Close()
+		}
+		assertDialAttemptedHost(t, tr, "169.254.169.254")
+		assertNoEstablishedHost(t, tr, "169.254.169.254")
+		if !errors.Is(err, ocmd.ErrNonPublicAddr) {
+			t.Fatalf("got %v, want ocmd.ErrNonPublicAddr", err)
+		}
+	})
+
+	t.Run("loopback peer is refused before contact", func(t *testing.T) {
+		contacted := false
+		srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			contacted = true
+			w.WriteHeader(http.StatusOK)
+		}))
+		t.Cleanup(srv.Close)
+
+		ctx, tr := contextWithPeerDialTrace(context.Background())
+		resp, err := roundTripConstructorCtx(t, c, ctx, srv.URL)
+		if resp != nil && resp.Body != nil {
+			_ = resp.Body.Close()
+		}
+		if contacted {
+			t.Fatal("sciencemesh.New client contacted a loopback peer; public-only guard must refuse before contact")
+		}
+		host, _, splitErr := net.SplitHostPort(srv.Listener.Addr().String())
+		if splitErr != nil {
+			t.Fatal(splitErr)
+		}
+		assertDialAttemptedHost(t, tr, host)
+		assertNoEstablishedHost(t, tr, host)
+		if !errors.Is(err, ocmd.ErrNonPublicAddr) {
+			t.Fatalf("got %v, want ocmd.ErrNonPublicAddr", err)
+		}
+	})
+
+	t.Run("public HTTPS discovery succeeds", func(t *testing.T) {
+		var srv *httptest.Server
+		srv = startScienceMeshPublicTLSServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/.well-known/ocm" {
+				http.NotFound(w, r)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"enabled":            true,
+				"apiVersion":         "1.1",
+				"inviteAcceptDialog": "/accept",
+			})
+		}))
+
+		disco, err := c.Discover(context.Background(), srv.URL)
+		if err != nil {
+			t.Fatalf("Discover on a public HTTPS host: %v", err)
+		}
+		if disco == nil || disco.InviteAcceptDialog != "/accept" {
+			t.Fatalf("unexpected discovery payload: %+v", disco)
+		}
+	})
+}
+
+func startScienceMeshPublicTLSServer(t *testing.T, h http.Handler) *httptest.Server {
+	t.Helper()
+	ip, ok := firstScienceMeshPublicIPv4()
+	if !ok {
+		t.Skip("no public IPv4 address available for public-only httptest")
+	}
+	ln, err := net.Listen("tcp", net.JoinHostPort(ip, "0"))
+	if err != nil {
+		t.Skipf("cannot listen on public IP %s: %v", ip, err)
+	}
+	srv := httptest.NewUnstartedServer(h)
+	if srv.Listener != nil {
+		_ = srv.Listener.Close()
+	}
+	srv.Listener = ln
+	srv.StartTLS()
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func firstScienceMeshPublicIPv4() (string, bool) {
+	addrs, err := net.InterfaceAddrs()
+	if err != nil {
+		return "", false
+	}
+	for _, a := range addrs {
+		n, ok := a.(*net.IPNet)
+		if !ok || n.IP == nil {
+			continue
+		}
+		ip := n.IP.To4()
+		if ip == nil || ip.IsLoopback() || ip.IsPrivate() || ip.IsUnspecified() ||
+			ip.IsLinkLocalUnicast() || ip.IsMulticast() {
+			continue
+		}
+		if ip[0] == 100 && ip[1]&0xc0 == 64 {
+			continue
+		}
+		return ip.String(), true
+	}
+	return "", false
+}
+
+func roundTripConstructor(t *testing.T, c *ocmd.OCMClient, rawURL string) (*http.Response, error) {
+	t.Helper()
+	return roundTripConstructorCtx(t, c, context.Background(), rawURL)
+}
+
+func roundTripConstructorCtx(
+	t *testing.T,
+	c *ocmd.OCMClient,
+	ctx context.Context,
+	rawURL string,
+) (*http.Response, error) {
+	t.Helper()
+	if c == nil || c.HTTPTransport() == nil {
+		t.Fatal("constructor-wired client has no transport")
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return c.HTTPTransport().RoundTrip(req)
+}
+
+type peerDialTrace struct {
+	mu          sync.Mutex
+	attempted   []string
+	established []string
+}
+
+func contextWithPeerDialTrace(ctx context.Context) (context.Context, *peerDialTrace) {
+	tr := &peerDialTrace{attempted: []string{}, established: []string{}}
+	ctx = httptrace.WithClientTrace(ctx, &httptrace.ClientTrace{
+		ConnectStart: func(_, addr string) {
+			tr.mu.Lock()
+			tr.attempted = append(tr.attempted, addr)
+			tr.mu.Unlock()
+		},
+		ConnectDone: func(_, addr string, err error) {
+			if err != nil {
+				return
+			}
+			tr.mu.Lock()
+			tr.established = append(tr.established, addr)
+			tr.mu.Unlock()
+		},
+		GotConn: func(info httptrace.GotConnInfo) {
+			if info.Conn == nil {
+				return
+			}
+			tr.mu.Lock()
+			tr.established = append(tr.established, info.Conn.RemoteAddr().String())
+			tr.mu.Unlock()
+		},
+	})
+	return ctx, tr
+}
+
+func hostOf(addr string) string {
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		host = addr
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		if ip4 := ip.To4(); ip4 != nil {
+			return ip4.String()
+		}
+		return ip.String()
+	}
+	return host
+}
+
+func (tr *peerDialTrace) sawHost(kind string, host string) bool {
+	tr.mu.Lock()
+	defer tr.mu.Unlock()
+	list := tr.established
+	if kind == "attempted" {
+		list = tr.attempted
+	}
+	for _, addr := range list {
+		if hostOf(addr) == host {
+			return true
+		}
+	}
+	return false
+}
+
+func assertDialAttemptedHost(t *testing.T, tr *peerDialTrace, host string) {
+	t.Helper()
+	if !tr.sawHost("attempted", host) {
+		tr.mu.Lock()
+		attempted := append([]string{}, tr.attempted...)
+		tr.mu.Unlock()
+		t.Fatalf("public-only guard must dial %s before refusing; attempted %v", host, attempted)
+	}
+}
+
+func assertNoEstablishedHost(t *testing.T, tr *peerDialTrace, host string) {
+	t.Helper()
+	if tr.sawHost("established", host) {
+		t.Fatalf("public-only client established a connection to %s", host)
+	}
+}

--- a/internal/http/services/sciencemesh/wayf.go
+++ b/internal/http/services/sciencemesh/wayf.go
@@ -110,7 +110,7 @@ func (h *wayfHandler) init(c *config) error {
 
 		for _, srv := range fed.Servers {
 			if srv.DisplayName == "" || srv.URL == "" {
-				log.Warn().Str("federation", fed.Federation).
+				log.Debug().Str("federation", fed.Federation).
 					Str("displayName", srv.DisplayName).
 					Str("url", srv.URL).
 					Msg("Skipping server with missing displayName or url")

--- a/internal/http/services/sciencemesh/wayf.go
+++ b/internal/http/services/sciencemesh/wayf.go
@@ -65,11 +65,8 @@ func (h *wayfHandler) init(c *config) error {
 	log := appctx.GetLogger(context.Background())
 
 	// Create OCM client for discovery from config
-	h.ocmClient = ocmd.NewClient(time.Duration(c.OCMClientTimeout)*time.Second, c.OCMClientInsecure)
-	log.Debug().
-		Int("timeout_seconds", c.OCMClientTimeout).
-		Bool("insecure", c.OCMClientInsecure).
-		Msg("Created OCM client for discovery")
+	h.ocmClient = ocmd.NewClientWithConfig(&c.OCMClient)
+	log.Debug().Msg("Created OCM client for discovery")
 
 	urls := strings.Fields(c.DirectoryServiceURLs)
 	if len(urls) == 0 {

--- a/internal/http/services/sciencemesh/wayf.go
+++ b/internal/http/services/sciencemesh/wayf.go
@@ -77,7 +77,7 @@ func (h *wayfHandler) init(c *config) error {
 
 		directoryService, err := h.ocmClient.GetDirectoryService(ctx, directoryURL)
 		if err != nil {
-			log.Warn().Err(err).Str("url", directoryURL).Msg("Failed to fetch directory service, skipping")
+			log.Info().Err(err).Str("url", directoryURL).Msg("Failed to fetch directory service, skipping")
 			fetchErrors++
 			continue
 		}
@@ -99,7 +99,7 @@ func (h *wayfHandler) init(c *config) error {
 			// Discover inviteAcceptDialog from OCM endpoint
 			disco, err := h.ocmClient.Discover(ctx, srv.URL)
 			if err != nil {
-				log.Warn().Err(err).
+				log.Debug().Err(err).
 					Str("federation", directoryService.Federation).
 					Str("server", srv.DisplayName).
 					Str("url", srv.URL).
@@ -117,7 +117,7 @@ func (h *wayfHandler) init(c *config) error {
 					inviteDialog = baseURL.Scheme + "://" + baseURL.Host + inviteDialog
 					log.Debug().Str("original", disco.InviteAcceptDialog).Str("converted", inviteDialog).Msg("Converted relative path to absolute")
 				} else {
-					log.Warn().Err(parseErr).
+					log.Debug().Err(parseErr).
 						Str("url", srv.URL).
 						Str("inviteDialog", disco.InviteAcceptDialog).
 						Msg("Failed to parse server URL for relative path conversion")
@@ -146,7 +146,7 @@ func (h *wayfHandler) init(c *config) error {
 			})
 			log.Debug().Str("federation", directoryService.Federation).Int("valid_servers", len(validServers)).Msg("Added directory service with valid servers")
 		} else {
-			log.Warn().Str("federation", directoryService.Federation).
+			log.Info().Str("federation", directoryService.Federation).
 				Msg("Directory service has no valid servers, skipping entirely")
 		}
 	}
@@ -200,7 +200,7 @@ func (h *wayfHandler) DiscoverProvider(w http.ResponseWriter, r *http.Request) {
 	log.Debug().Str("domain", domain).Msg("Attempting OCM discovery")
 	disco, err := h.ocmClient.Discover(ctx, domain)
 	if err != nil {
-		log.Warn().Err(err).Str("domain", domain).Msg("Discovery failed")
+		log.Info().Err(err).Str("domain", domain).Msg("Discovery failed")
 		reqres.WriteError(w, r, reqres.APIErrorNotFound,
 			fmt.Sprintf("Provider at '%s' does not support OCM discovery", req.Domain), err)
 		return

--- a/internal/http/services/sciencemesh/wayf.go
+++ b/internal/http/services/sciencemesh/wayf.go
@@ -36,8 +36,7 @@ type wayfHandler struct {
 	directoryServices []ocmd.DirectoryService
 	ocmClient         *ocmd.OCMClient
 	// for /discover, where the host comes from the request body, not from config
-	untrustedClient *http.Client
-	responseLimit   int
+	untrustedClient *ocmd.OCMClient
 }
 
 type DiscoverRequest struct {
@@ -76,14 +75,16 @@ func (h *wayfHandler) init(c *config) error {
 		dialTimeout = 10 * time.Second
 	}
 	h.ocmClient = ocmd.NewClient(requestTimeout, c.OCMClientInsecure, int64(c.OCMClientResponseLimit))
-	h.untrustedClient = newUntrustedDiscoverClient(
-		dialTimeout,
+	h.untrustedClient = ocmd.NewPublicOnlyClient(
 		requestTimeout,
 		c.OCMClientInsecure,
 		c.UntrustedClientSecurity,
+		int64(c.OCMClientResponseLimit),
 		c.ocmClientTLSMin,
 	)
-	h.responseLimit = c.OCMClientResponseLimit
+	if dialTimeout > 0 && dialTimeout != requestTimeout {
+		overridePublicOnlyDialTimeout(h.untrustedClient, dialTimeout)
+	}
 	log.Debug().
 		Int("timeout_seconds", c.OCMClientTimeout).
 		Int("dial_timeout_seconds", c.OCMClientDialTimeout).
@@ -236,12 +237,7 @@ func (h *wayfHandler) DiscoverProvider(w http.ResponseWriter, r *http.Request) {
 	}
 
 	log.Debug().Str("domain", domain).Msg("Attempting OCM discovery")
-	disco, err := discoverUntrusted(
-		ctx,
-		h.untrustedClient,
-		domain,
-		int64(h.responseLimit),
-	)
+	disco, err := h.untrustedClient.Discover(ctx, domain)
 	if err != nil {
 		log.Info().Err(err).Str("domain", domain).Msg("Discovery failed")
 		reqres.WriteError(w, r, reqres.APIErrorNotFound,

--- a/internal/http/services/sciencemesh/wayf.go
+++ b/internal/http/services/sciencemesh/wayf.go
@@ -36,7 +36,8 @@ type wayfHandler struct {
 	directoryServices []ocmd.DirectoryService
 	ocmClient         *ocmd.OCMClient
 	// for /discover, where the host comes from the request body, not from config
-	untrustedClient *ocmd.OCMClient
+	untrustedClient *http.Client
+	responseLimit   int
 }
 
 type DiscoverRequest struct {
@@ -66,11 +67,13 @@ func makeAbsoluteURL(baseURL, dialogURL string) (string, error) {
 func (h *wayfHandler) init(c *config) error {
 	log := appctx.GetLogger(context.Background())
 
-	// Create OCM client for discovery from config
-	h.ocmClient = ocmd.NewClient(time.Duration(c.OCMClientTimeout)*time.Second, c.OCMClientInsecure)
-	h.untrustedClient = ocmd.NewPublicOnlyClient(time.Duration(c.OCMClientTimeout)*time.Second, c.OCMClientInsecure)
+	timeout := time.Duration(c.OCMClientTimeout) * time.Second
+	h.ocmClient = ocmd.NewClient(timeout, c.OCMClientInsecure)
+	h.untrustedClient = newUntrustedDiscoverClient(timeout, c.OCMClientInsecure)
+	h.responseLimit = c.OCMClientResponseLimit
 	log.Debug().
 		Int("timeout_seconds", c.OCMClientTimeout).
+		Int("response_limit", c.OCMClientResponseLimit).
 		Bool("insecure", c.OCMClientInsecure).
 		Msg("Created OCM client for discovery")
 
@@ -219,7 +222,12 @@ func (h *wayfHandler) DiscoverProvider(w http.ResponseWriter, r *http.Request) {
 	}
 
 	log.Debug().Str("domain", domain).Msg("Attempting OCM discovery")
-	disco, err := h.untrustedClient.Discover(ctx, domain)
+	disco, err := discoverUntrusted(
+		ctx,
+		h.untrustedClient,
+		domain,
+		int64(h.responseLimit),
+	)
 	if err != nil {
 		log.Info().Err(err).Str("domain", domain).Msg("Discovery failed")
 		reqres.WriteError(w, r, reqres.APIErrorNotFound,

--- a/internal/http/services/sciencemesh/wayf.go
+++ b/internal/http/services/sciencemesh/wayf.go
@@ -68,7 +68,7 @@ func (h *wayfHandler) init(c *config) error {
 	log := appctx.GetLogger(context.Background())
 
 	timeout := time.Duration(c.OCMClientTimeout) * time.Second
-	h.ocmClient = ocmd.NewClient(timeout, c.OCMClientInsecure)
+	h.ocmClient = ocmd.NewClient(timeout, c.OCMClientInsecure, int64(c.OCMClientResponseLimit))
 	h.untrustedClient = newUntrustedDiscoverClient(timeout, c.OCMClientInsecure, c.UntrustedClientSecurity)
 	h.responseLimit = c.OCMClientResponseLimit
 	log.Debug().

--- a/internal/http/services/sciencemesh/wayf.go
+++ b/internal/http/services/sciencemesh/wayf.go
@@ -69,7 +69,12 @@ func (h *wayfHandler) init(c *config) error {
 
 	timeout := time.Duration(c.OCMClientTimeout) * time.Second
 	h.ocmClient = ocmd.NewClient(timeout, c.OCMClientInsecure, int64(c.OCMClientResponseLimit))
-	h.untrustedClient = newUntrustedDiscoverClient(timeout, c.OCMClientInsecure, c.UntrustedClientSecurity)
+	h.untrustedClient = newUntrustedDiscoverClient(
+		timeout,
+		c.OCMClientInsecure,
+		c.UntrustedClientSecurity,
+		c.ocmClientTLSMin,
+	)
 	h.responseLimit = c.OCMClientResponseLimit
 	log.Debug().
 		Int("timeout_seconds", c.OCMClientTimeout).

--- a/internal/http/services/sciencemesh/wayf.go
+++ b/internal/http/services/sciencemesh/wayf.go
@@ -67,10 +67,18 @@ func makeAbsoluteURL(baseURL, dialogURL string) (string, error) {
 func (h *wayfHandler) init(c *config) error {
 	log := appctx.GetLogger(context.Background())
 
-	timeout := time.Duration(c.OCMClientTimeout) * time.Second
-	h.ocmClient = ocmd.NewClient(timeout, c.OCMClientInsecure, int64(c.OCMClientResponseLimit))
+	requestTimeout := time.Duration(c.OCMClientTimeout) * time.Second
+	if requestTimeout <= 0 {
+		requestTimeout = 10 * time.Second
+	}
+	dialTimeout := time.Duration(c.OCMClientDialTimeout) * time.Second
+	if dialTimeout <= 0 {
+		dialTimeout = 10 * time.Second
+	}
+	h.ocmClient = ocmd.NewClient(requestTimeout, c.OCMClientInsecure, int64(c.OCMClientResponseLimit))
 	h.untrustedClient = newUntrustedDiscoverClient(
-		timeout,
+		dialTimeout,
+		requestTimeout,
 		c.OCMClientInsecure,
 		c.UntrustedClientSecurity,
 		c.ocmClientTLSMin,
@@ -78,6 +86,7 @@ func (h *wayfHandler) init(c *config) error {
 	h.responseLimit = c.OCMClientResponseLimit
 	log.Debug().
 		Int("timeout_seconds", c.OCMClientTimeout).
+		Int("dial_timeout_seconds", c.OCMClientDialTimeout).
 		Int("response_limit", c.OCMClientResponseLimit).
 		Bool("insecure", c.OCMClientInsecure).
 		Msg("Created OCM client for discovery")

--- a/internal/http/services/sciencemesh/wayf.go
+++ b/internal/http/services/sciencemesh/wayf.go
@@ -69,7 +69,7 @@ func (h *wayfHandler) init(c *config) error {
 
 	timeout := time.Duration(c.OCMClientTimeout) * time.Second
 	h.ocmClient = ocmd.NewClient(timeout, c.OCMClientInsecure)
-	h.untrustedClient = newUntrustedDiscoverClient(timeout, c.OCMClientInsecure)
+	h.untrustedClient = newUntrustedDiscoverClient(timeout, c.OCMClientInsecure, c.UntrustedClientSecurity)
 	h.responseLimit = c.OCMClientResponseLimit
 	log.Debug().
 		Int("timeout_seconds", c.OCMClientTimeout).

--- a/internal/http/services/sciencemesh/wayf.go
+++ b/internal/http/services/sciencemesh/wayf.go
@@ -32,10 +32,12 @@ import (
 	"github.com/cs3org/reva/v3/pkg/appctx"
 )
 
+// wayfHandler: ocmClient is trusted NewClient for operator-configured
+// directory URLs; untrustedClient discovers a host from the /discover body.
 type wayfHandler struct {
 	directoryServices []ocmd.DirectoryService
 	ocmClient         *ocmd.OCMClient
-	// for /discover, where the host comes from the request body, not from config
+	// body-supplied host; not the trusted directory client
 	untrustedClient *ocmd.OCMClient
 }
 
@@ -47,9 +49,7 @@ type DiscoverResponse struct {
 	InviteAcceptDialog string `json:"inviteAcceptDialog"`
 }
 
-// makeAbsoluteURL takes a base URL and a path/URL and returns an absolute URL.
-// If dialogURL is already absolute (has scheme and host), it returns it as-is.
-// Otherwise, it joins the dialogURL with the baseURL to create an absolute URL.
+// makeAbsoluteURL joins dialogURL onto baseURL unless dialogURL is already absolute.
 func makeAbsoluteURL(baseURL, dialogURL string) (string, error) {
 	if dialogURL == "" {
 		return "", nil
@@ -133,7 +133,6 @@ func (h *wayfHandler) init(c *config) error {
 
 			log.Debug().Str("federation", directoryService.Federation).Str("server", srv.DisplayName).Str("url", srv.URL).Msg("Discovering server")
 
-			// Discover inviteAcceptDialog from OCM endpoint
 			disco, err := h.ocmClient.Discover(ctx, srv.URL)
 			if err != nil {
 				log.Debug().Err(err).

--- a/internal/http/services/sciencemesh/wayf_test.go
+++ b/internal/http/services/sciencemesh/wayf_test.go
@@ -369,3 +369,39 @@ func TestUntrustedCheckRedirectUsesSharedSentinel(t *testing.T) {
 		t.Fatalf("got %v, want errUntrustedTooManyRedirects", err)
 	}
 }
+
+func TestUntrustedDiscoverClientSplitsDialAndRequestTimeout(t *testing.T) {
+	h := new(wayfHandler)
+	if err := h.init(&config{
+		OCMClientTimeout:       3,
+		OCMClientDialTimeout:   1,
+		OCMClientInsecure:      true,
+		OCMClientResponseLimit: 1 << 20,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if h.untrustedClient == nil {
+		t.Fatal("untrustedClient is nil")
+	}
+	if h.untrustedClient.Timeout != 3*time.Second {
+		t.Errorf("untrusted request timeout = %v, want 3s", h.untrustedClient.Timeout)
+	}
+	if h.ocmClient == nil || h.ocmClient.RequestTimeout() != 3*time.Second {
+		t.Errorf("trusted directory client timeout = %v, want 3s", h.ocmClient.RequestTimeout())
+	}
+
+	start := time.Now()
+	_, err := discoverUntrusted(
+		context.Background(),
+		h.untrustedClient,
+		"https://240.0.0.1",
+		1<<20,
+	)
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatal("expected discover to a non-responsive public address to fail")
+	}
+	if elapsed > 5*time.Second {
+		t.Fatalf("dial timeout was not applied to the untrusted transport; elapsed %v", elapsed)
+	}
+}

--- a/internal/http/services/sciencemesh/wayf_test.go
+++ b/internal/http/services/sciencemesh/wayf_test.go
@@ -325,6 +325,27 @@ func TestUntrustedDiscoverClientHardening(t *testing.T) {
 	}
 }
 
+func TestWayfUntrustedTLSMinVersion(t *testing.T) {
+	t.Parallel()
+
+	h := new(wayfHandler)
+	if err := h.init(&config{
+		OCMClientTimeout:       5,
+		OCMClientInsecure:      true,
+		OCMClientResponseLimit: 1 << 20,
+		ocmClientTLSMin:        tls.VersionTLS13,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if h.ocmClient == nil {
+		t.Fatal("trusted ocmClient is nil")
+	}
+	tr := innerUntrustedHTTPTransport(t, h.untrustedClient.Transport)
+	if tr.TLSClientConfig == nil || tr.TLSClientConfig.MinVersion != tls.VersionTLS13 {
+		t.Fatalf("untrusted MinVersion = %v, want TLS 1.3", tr.TLSClientConfig)
+	}
+}
+
 func TestUntrustedCheckRedirectUsesSharedSentinel(t *testing.T) {
 	t.Parallel()
 

--- a/internal/http/services/sciencemesh/wayf_test.go
+++ b/internal/http/services/sciencemesh/wayf_test.go
@@ -24,11 +24,12 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"reflect"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -38,23 +39,11 @@ import (
 
 func innerUntrustedHTTPTransport(t *testing.T, rt http.RoundTripper) *http.Transport {
 	t.Helper()
-	if tr, ok := rt.(*http.Transport); ok {
-		return tr
+	tr := untrustedInnerTransport(rt)
+	if tr == nil {
+		t.Fatalf("untrusted transport: got %T, want an *http.Transport wrapper", rt)
 	}
-	v := reflect.ValueOf(rt)
-	if v.Kind() == reflect.Pointer {
-		v = v.Elem()
-	}
-	if v.IsValid() && v.Kind() == reflect.Struct {
-		f := v.FieldByName("Transport")
-		if f.IsValid() && f.CanInterface() {
-			if tr, ok := f.Interface().(*http.Transport); ok && tr != nil {
-				return tr
-			}
-		}
-	}
-	t.Fatalf("untrusted transport: got %T, want an *http.Transport wrapper", rt)
-	return nil
+	return tr
 }
 
 func newDiscoverHandler(t *testing.T, limit int) *wayfHandler {
@@ -88,17 +77,32 @@ func postDiscover(t *testing.T, h *wayfHandler, domain string) *httptest.Respons
 // only drop Control so the TLS fixture is reachable.
 func allowUntrustedLoopback(t *testing.T, h *wayfHandler) {
 	t.Helper()
-	tr := innerUntrustedHTTPTransport(t, h.untrustedClient.Transport)
+	tr := innerUntrustedHTTPTransport(t, h.untrustedClient.HTTPTransport())
 	tr.DialContext = (&net.Dialer{Timeout: 5 * time.Second}).DialContext
+}
+
+// refuseNonPublicTestAddr is the test-only public-address check used when a
+// public URL is redirected onto the httptest listener.
+func refuseNonPublicTestAddr(_, address string) error {
+	host, _, err := net.SplitHostPort(address)
+	if err != nil {
+		return err
+	}
+	ip := net.ParseIP(host)
+	if ip == nil || ip.IsLoopback() || ip.IsPrivate() || ip.IsUnspecified() ||
+		ip.IsLinkLocalUnicast() {
+		return fmt.Errorf("refusing non-public address %s", address)
+	}
+	return nil
 }
 
 // dialPublicHostToListener keeps the public-address dial check, then connects
 // to the httptest listener so a public URL can exercise HTTPS redirects.
 func dialPublicHostToListener(t *testing.T, h *wayfHandler, listenerAddr string) {
 	t.Helper()
-	tr := innerUntrustedHTTPTransport(t, h.untrustedClient.Transport)
+	tr := innerUntrustedHTTPTransport(t, h.untrustedClient.HTTPTransport())
 	tr.DialContext = func(ctx context.Context, network, address string) (net.Conn, error) {
-		if err := refuseNonPublicAddr(network, address, nil); err != nil {
+		if err := refuseNonPublicTestAddr(network, address); err != nil {
 			return nil, err
 		}
 		return (&net.Dialer{Timeout: 5 * time.Second}).DialContext(ctx, network, listenerAddr)
@@ -200,12 +204,16 @@ func TestDiscoverProviderUntrustedClient(t *testing.T) {
 	// guard. The https check runs in RoundTrip before Dial.
 	t.Run("http public host is refused by https guard", func(t *testing.T) {
 		h := newDiscoverHandler(t, 1<<20)
-		_, err := discoverUntrusted(
+		req, err := http.NewRequestWithContext(
 			context.Background(),
-			h.untrustedClient,
-			"http://1.1.1.1",
-			1<<20,
+			http.MethodGet,
+			"http://1.1.1.1/",
+			nil,
 		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, err = h.untrustedClient.HTTPTransport().RoundTrip(req)
 		if err == nil {
 			t.Fatal("expected https refusal for a public http URL")
 		}
@@ -228,16 +236,32 @@ func TestDiscoverProviderUntrustedClient(t *testing.T) {
 			t.Fatal(err)
 		}
 		// TEST-NET-3 is a public documentation address; the dial helper
-		// still runs refuseNonPublicAddr on it, then connects to httptest.
+		// still runs refuseNonPublicTestAddr on it, then connects to httptest.
 		publicURL := "https://203.0.113.1:" + port
-		_, err = discoverUntrusted(
-			context.Background(),
-			h.untrustedClient,
-			publicURL,
-			1<<20,
-		)
+		_, err = h.untrustedClient.Discover(context.Background(), publicURL)
 		if err == nil {
 			t.Fatal("expected redirect-cap refusal")
+		}
+
+		req, err := http.NewRequestWithContext(
+			context.Background(),
+			http.MethodGet,
+			publicURL+"/.well-known/ocm",
+			nil,
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp, err := (&http.Client{
+			Transport:     h.untrustedClient.HTTPTransport(),
+			Timeout:       h.untrustedClient.RequestTimeout(),
+			CheckRedirect: ocmd.PublicOnlyCheckRedirect,
+		}).Do(req)
+		if resp != nil {
+			_ = resp.Body.Close()
+		}
+		if err == nil {
+			t.Fatal("expected redirect-cap refusal from the shared transport")
 		}
 		if !errors.Is(err, ocmd.ErrTooManyRedirects) {
 			t.Fatalf("err = %v, want ocmd.ErrTooManyRedirects", err)
@@ -282,11 +306,20 @@ func TestUntrustedDiscoverClientHardening(t *testing.T) {
 	if h.untrustedClient == nil {
 		t.Fatal("untrustedClient is nil")
 	}
-	if h.untrustedClient.Timeout != 5*time.Second {
-		t.Errorf("untrusted timeout = %v, want 5s", h.untrustedClient.Timeout)
+	if h.untrustedClient.RequestTimeout() != 5*time.Second {
+		t.Errorf("untrusted timeout = %v, want 5s", h.untrustedClient.RequestTimeout())
+	}
+	if _, ok := h.untrustedClient.HTTPTransport().(*http.Transport); ok {
+		t.Fatal("untrusted discover client must use the shared public-only transport")
+	}
+	if h.ocmClient == nil {
+		t.Fatal("trusted ocmClient is nil")
+	}
+	if _, ok := h.ocmClient.HTTPTransport().(*http.Transport); !ok {
+		t.Fatalf("trusted WAYF client transport = %T, want *http.Transport", h.ocmClient.HTTPTransport())
 	}
 
-	tr := innerUntrustedHTTPTransport(t, h.untrustedClient.Transport)
+	tr := innerUntrustedHTTPTransport(t, h.untrustedClient.HTTPTransport())
 	if tr.Proxy != nil {
 		t.Error("untrusted client must not use a proxy")
 	}
@@ -295,9 +328,6 @@ func TestUntrustedDiscoverClientHardening(t *testing.T) {
 	}
 	if tr.TLSClientConfig.MinVersion < tls.VersionTLS12 {
 		t.Errorf("MinVersion = %#x, want at least TLS 1.2", tr.TLSClientConfig.MinVersion)
-	}
-	if h.untrustedClient.CheckRedirect == nil {
-		t.Error("CheckRedirect is nil")
 	}
 
 	// newDiscoverHandler sets OCMClientInsecure so the TLS fixture works.
@@ -313,10 +343,7 @@ func TestUntrustedDiscoverClientHardening(t *testing.T) {
 	if secure.untrustedClient == nil {
 		t.Fatal("secure untrustedClient is nil")
 	}
-	if secure.untrustedClient.CheckRedirect == nil {
-		t.Error("secure CheckRedirect is nil")
-	}
-	secureTr := innerUntrustedHTTPTransport(t, secure.untrustedClient.Transport)
+	secureTr := innerUntrustedHTTPTransport(t, secure.untrustedClient.HTTPTransport())
 	if secureTr.TLSClientConfig == nil {
 		t.Fatal("secure TLSClientConfig is nil")
 	}
@@ -340,33 +367,16 @@ func TestWayfUntrustedTLSMinVersion(t *testing.T) {
 	if h.ocmClient == nil {
 		t.Fatal("trusted ocmClient is nil")
 	}
-	tr := innerUntrustedHTTPTransport(t, h.untrustedClient.Transport)
+	tr := innerUntrustedHTTPTransport(t, h.untrustedClient.HTTPTransport())
 	if tr.TLSClientConfig == nil || tr.TLSClientConfig.MinVersion != tls.VersionTLS13 {
 		t.Fatalf("untrusted MinVersion = %v, want TLS 1.3", tr.TLSClientConfig)
 	}
-}
-
-func TestUntrustedCheckRedirectUsesSharedSentinel(t *testing.T) {
-	t.Parallel()
-
-	httpsURL, err := url.Parse("https://example.com/next")
-	if err != nil {
-		t.Fatal(err)
+	trustedTr, ok := h.ocmClient.HTTPTransport().(*http.Transport)
+	if !ok {
+		t.Fatalf("trusted WAYF client transport = %T, want *http.Transport", h.ocmClient.HTTPTransport())
 	}
-	req := &http.Request{URL: httpsURL}
-	err = untrustedCheckRedirect(req, []*http.Request{{}, {}, {}})
-	if err != nil {
-		t.Fatalf("len(via)=3 must be allowed with default cap 3: %v", err)
-	}
-	err = untrustedCheckRedirect(req, []*http.Request{{}, {}, {}, {}})
-	if err == nil {
-		t.Fatal("expected leftover CheckRedirect to refuse more than 3 hops")
-	}
-	if !errors.Is(err, ocmd.ErrTooManyRedirects) {
-		t.Fatalf("got %v, want ocmd.ErrTooManyRedirects", err)
-	}
-	if !errors.Is(err, errUntrustedTooManyRedirects) {
-		t.Fatalf("got %v, want errUntrustedTooManyRedirects", err)
+	if trustedTr.TLSClientConfig == nil || trustedTr.TLSClientConfig.MinVersion != tls.VersionTLS12 {
+		t.Fatalf("trusted MinVersion = %v, want TLS 1.2", trustedTr.TLSClientConfig)
 	}
 }
 
@@ -383,25 +393,33 @@ func TestUntrustedDiscoverClientSplitsDialAndRequestTimeout(t *testing.T) {
 	if h.untrustedClient == nil {
 		t.Fatal("untrustedClient is nil")
 	}
-	if h.untrustedClient.Timeout != 3*time.Second {
-		t.Errorf("untrusted request timeout = %v, want 3s", h.untrustedClient.Timeout)
+	if h.untrustedClient.RequestTimeout() != 3*time.Second {
+		t.Errorf("untrusted request timeout = %v, want 3s", h.untrustedClient.RequestTimeout())
 	}
 	if h.ocmClient == nil || h.ocmClient.RequestTimeout() != 3*time.Second {
 		t.Errorf("trusted directory client timeout = %v, want 3s", h.ocmClient.RequestTimeout())
 	}
 
+	tr := innerUntrustedHTTPTransport(t, h.untrustedClient.HTTPTransport())
+	if tr.DialContext == nil {
+		t.Fatal("untrusted DialContext is nil; dial-timeout override did not install")
+	}
+	wrapper := runtime.FuncForPC(reflect.ValueOf(tr.DialContext).Pointer()).Name()
+	if !strings.Contains(wrapper, "overridePublicOnlyDialTimeout") {
+		t.Fatalf("DialContext = %s, want overridePublicOnlyDialTimeout wrapper", wrapper)
+	}
+
 	start := time.Now()
-	_, err := discoverUntrusted(
-		context.Background(),
-		h.untrustedClient,
-		"https://240.0.0.1",
-		1<<20,
-	)
+	_, err := h.untrustedClient.Discover(context.Background(), "https://240.0.0.1")
 	elapsed := time.Since(start)
 	if err == nil {
 		t.Fatal("expected discover to a non-responsive public address to fail")
 	}
-	if elapsed > 5*time.Second {
-		t.Fatalf("dial timeout was not applied to the untrusted transport; elapsed %v", elapsed)
+	// Discover falls back to a second path. Each dial is capped at 1s, so a
+	// working override finishes before the 3s request deadline. A silent
+	// no-op keeps the 3s NewPublicOnlyClient dial/request timeout and cannot
+	// pass this bound.
+	if elapsed >= 3*time.Second {
+		t.Fatalf("dial timeout was not applied to the untrusted transport; elapsed %v, want < 3s request deadline", elapsed)
 	}
 }

--- a/internal/http/services/sciencemesh/wayf_test.go
+++ b/internal/http/services/sciencemesh/wayf_test.go
@@ -1,0 +1,319 @@
+// Copyright 2018-2026 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package sciencemesh
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"errors"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func newDiscoverHandler(t *testing.T, limit int) *wayfHandler {
+	t.Helper()
+	h := new(wayfHandler)
+	err := h.init(&config{
+		OCMClientTimeout:       5,
+		OCMClientInsecure:      true,
+		OCMClientResponseLimit: limit,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return h
+}
+
+func postDiscover(t *testing.T, h *wayfHandler, domain string) *httptest.ResponseRecorder {
+	t.Helper()
+	body, err := json.Marshal(DiscoverRequest{Domain: domain})
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/discover", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	h.DiscoverProvider(rec, req)
+	return rec
+}
+
+// httptest servers bind loopback, which the public-only dial guard refuses.
+// Keep https-only, the redirect cap, and Proxy=nil; only drop Control so the
+// TLS fixture is reachable.
+func allowUntrustedLoopback(t *testing.T, h *wayfHandler) {
+	t.Helper()
+	tr, ok := h.untrustedClient.Transport.(*publicOnlyTransport)
+	if !ok {
+		t.Fatalf("untrusted transport: got %T, want *publicOnlyTransport", h.untrustedClient.Transport)
+	}
+	if tr.Transport == nil {
+		t.Fatal("untrusted client is missing an inner *http.Transport")
+	}
+	tr.DialContext = (&net.Dialer{Timeout: 5 * time.Second}).DialContext
+}
+
+// dialPublicHostToListener keeps the public-address dial check, then connects
+// to the httptest listener so a public URL can exercise HTTPS redirects.
+func dialPublicHostToListener(t *testing.T, h *wayfHandler, listenerAddr string) {
+	t.Helper()
+	tr, ok := h.untrustedClient.Transport.(*publicOnlyTransport)
+	if !ok {
+		t.Fatalf("untrusted transport: got %T, want *publicOnlyTransport", h.untrustedClient.Transport)
+	}
+	if tr.Transport == nil {
+		t.Fatal("untrusted client is missing an inner *http.Transport")
+	}
+	tr.DialContext = func(ctx context.Context, network, address string) (net.Conn, error) {
+		if err := refuseNonPublicAddr(network, address, nil); err != nil {
+			return nil, err
+		}
+		return (&net.Dialer{Timeout: 5 * time.Second}).DialContext(ctx, network, listenerAddr)
+	}
+}
+
+func discoveryJSON(t *testing.T, invite string) []byte {
+	t.Helper()
+	body, err := json.Marshal(map[string]any{
+		"enabled":            true,
+		"apiVersion":         "1.1",
+		"inviteAcceptDialog": invite,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return body
+}
+
+func TestDiscoverProviderUntrustedClient(t *testing.T) {
+	t.Run("public https host succeeds with a bounded read", func(t *testing.T) {
+		srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/.well-known/ocm" {
+				http.NotFound(w, r)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write(discoveryJSON(t, "/accept"))
+		}))
+		defer srv.Close()
+
+		h := newDiscoverHandler(t, 4096)
+		allowUntrustedLoopback(t, h)
+
+		rec := postDiscover(t, h, srv.URL)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200; body = %s", rec.Code, rec.Body.String())
+		}
+
+		var got DiscoverResponse
+		if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+			t.Fatalf("decode response: %v", err)
+		}
+		if got.InviteAcceptDialog == "" {
+			t.Fatal("expected inviteAcceptDialog in the discovery response")
+		}
+		if !strings.HasSuffix(got.InviteAcceptDialog, "/accept") {
+			t.Fatalf("inviteAcceptDialog = %q, want a URL ending in /accept", got.InviteAcceptDialog)
+		}
+	})
+
+	t.Run("private metadata host is refused at dial", func(t *testing.T) {
+		fetched := false
+		srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fetched = true
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(discoveryJSON(t, "/accept"))
+		}))
+		defer srv.Close()
+
+		h := newDiscoverHandler(t, 1<<20)
+
+		// Loopback httptest is a private address; the dial guard must refuse
+		// before the handler runs.
+		rec := postDiscover(t, h, srv.URL)
+		if fetched {
+			t.Error("untrusted /discover reached a private httptest host")
+		}
+		if rec.Code == http.StatusOK {
+			t.Fatalf("status = %d, want a refusal for a private host; body = %s", rec.Code, rec.Body.String())
+		}
+
+		rec = postDiscover(t, h, "https://169.254.169.254")
+		if rec.Code == http.StatusOK {
+			t.Fatalf("status = %d, want a refusal for the metadata address", rec.Code)
+		}
+	})
+
+	t.Run("http host is refused", func(t *testing.T) {
+		fetched := false
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fetched = true
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(discoveryJSON(t, "/accept"))
+		}))
+		defer srv.Close()
+
+		h := newDiscoverHandler(t, 1<<20)
+		rec := postDiscover(t, h, srv.URL)
+		if fetched {
+			t.Error("untrusted /discover fetched a non-https URL")
+		}
+		if rec.Code == http.StatusOK {
+			t.Fatalf("status = %d, want a refusal for http; body = %s", rec.Code, rec.Body.String())
+		}
+	})
+
+	// 1.1.1.1 is a public address, so a refusal cannot be the private-dial
+	// guard. The https check runs in RoundTrip before Dial.
+	t.Run("http public host is refused by https guard", func(t *testing.T) {
+		h := newDiscoverHandler(t, 1<<20)
+		_, err := discoverUntrusted(
+			context.Background(),
+			h.untrustedClient,
+			"http://1.1.1.1",
+			1<<20,
+		)
+		if err == nil {
+			t.Fatal("expected https refusal for a public http URL")
+		}
+		if !errors.Is(err, errUntrustedNonHTTPS) {
+			t.Fatalf("err = %v, want errUntrustedNonHTTPS", err)
+		}
+	})
+
+	t.Run("more than 3 https redirects are refused", func(t *testing.T) {
+		srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Redirect(w, r, "/next", http.StatusFound)
+		}))
+		defer srv.Close()
+
+		h := newDiscoverHandler(t, 1<<20)
+		dialPublicHostToListener(t, h, srv.Listener.Addr().String())
+
+		_, port, err := net.SplitHostPort(srv.Listener.Addr().String())
+		if err != nil {
+			t.Fatal(err)
+		}
+		// TEST-NET-3 is a public documentation address; the dial helper
+		// still runs refuseNonPublicAddr on it, then connects to httptest.
+		publicURL := "https://203.0.113.1:" + port
+		_, err = discoverUntrusted(
+			context.Background(),
+			h.untrustedClient,
+			publicURL,
+			1<<20,
+		)
+		if err == nil {
+			t.Fatal("expected redirect-cap refusal")
+		}
+		if !errors.Is(err, errUntrustedTooManyRedirects) {
+			t.Fatalf("err = %v, want errUntrustedTooManyRedirects", err)
+		}
+	})
+
+	t.Run("response over the configured limit is rejected", func(t *testing.T) {
+		const limit = 64
+		srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			payload := map[string]any{
+				"enabled":            true,
+				"apiVersion":         "1.1",
+				"inviteAcceptDialog": "/accept",
+				"provider":           strings.Repeat("a", 2048),
+			}
+			body, err := json.Marshal(payload)
+			if err != nil {
+				t.Error(err)
+				http.Error(w, "marshal", http.StatusInternalServerError)
+				return
+			}
+			if len(body) <= limit {
+				t.Errorf("fixture body is %d bytes, want more than limit %d", len(body), limit)
+			}
+			_, _ = w.Write(body)
+		}))
+		defer srv.Close()
+
+		h := newDiscoverHandler(t, limit)
+		allowUntrustedLoopback(t, h)
+
+		rec := postDiscover(t, h, srv.URL)
+		if rec.Code == http.StatusOK {
+			t.Fatalf("oversized discovery body must be rejected; body = %s", rec.Body.String())
+		}
+	})
+}
+
+func TestUntrustedDiscoverClientHardening(t *testing.T) {
+	h := newDiscoverHandler(t, 1<<20)
+	if h.untrustedClient == nil {
+		t.Fatal("untrustedClient is nil")
+	}
+	if h.untrustedClient.Timeout != 5*time.Second {
+		t.Errorf("untrusted timeout = %v, want 5s", h.untrustedClient.Timeout)
+	}
+
+	tr, ok := h.untrustedClient.Transport.(*publicOnlyTransport)
+	if !ok {
+		t.Fatalf("transport: got %T, want *publicOnlyTransport", h.untrustedClient.Transport)
+	}
+	if tr.Proxy != nil {
+		t.Error("untrusted client must not use a proxy")
+	}
+	if tr.TLSClientConfig == nil {
+		t.Fatal("TLSClientConfig is nil")
+	}
+	if tr.TLSClientConfig.MinVersion < tls.VersionTLS12 {
+		t.Errorf("MinVersion = %#x, want at least TLS 1.2", tr.TLSClientConfig.MinVersion)
+	}
+	if h.untrustedClient.CheckRedirect == nil {
+		t.Error("CheckRedirect is nil")
+	}
+
+	// newDiscoverHandler sets OCMClientInsecure so the TLS fixture works.
+	// Construct the secure path separately to assert verification stays on.
+	secure := new(wayfHandler)
+	if err := secure.init(&config{
+		OCMClientTimeout:       5,
+		OCMClientInsecure:      false,
+		OCMClientResponseLimit: 1 << 20,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if secure.untrustedClient == nil {
+		t.Fatal("secure untrustedClient is nil")
+	}
+	if secure.untrustedClient.CheckRedirect == nil {
+		t.Error("secure CheckRedirect is nil")
+	}
+	secureTr, ok := secure.untrustedClient.Transport.(*publicOnlyTransport)
+	if !ok {
+		t.Fatalf("secure transport: got %T, want *publicOnlyTransport", secure.untrustedClient.Transport)
+	}
+	if secureTr.TLSClientConfig == nil {
+		t.Fatal("secure TLSClientConfig is nil")
+	}
+	if secureTr.TLSClientConfig.InsecureSkipVerify {
+		t.Error("InsecureSkipVerify must be false when OCMClientInsecure is false")
+	}
+}

--- a/internal/http/services/sciencemesh/wayf_test.go
+++ b/internal/http/services/sciencemesh/wayf_test.go
@@ -27,10 +27,35 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/cs3org/reva/v3/internal/http/services/opencloudmesh/ocmd"
 )
+
+func innerUntrustedHTTPTransport(t *testing.T, rt http.RoundTripper) *http.Transport {
+	t.Helper()
+	if tr, ok := rt.(*http.Transport); ok {
+		return tr
+	}
+	v := reflect.ValueOf(rt)
+	if v.Kind() == reflect.Pointer {
+		v = v.Elem()
+	}
+	if v.IsValid() && v.Kind() == reflect.Struct {
+		f := v.FieldByName("Transport")
+		if f.IsValid() && f.CanInterface() {
+			if tr, ok := f.Interface().(*http.Transport); ok && tr != nil {
+				return tr
+			}
+		}
+	}
+	t.Fatalf("untrusted transport: got %T, want an *http.Transport wrapper", rt)
+	return nil
+}
 
 func newDiscoverHandler(t *testing.T, limit int) *wayfHandler {
 	t.Helper()
@@ -58,18 +83,12 @@ func postDiscover(t *testing.T, h *wayfHandler, domain string) *httptest.Respons
 	return rec
 }
 
-// httptest servers bind loopback, which the public-only dial guard refuses.
-// Keep https-only, the redirect cap, and Proxy=nil; only drop Control so the
-// TLS fixture is reachable.
+// httptest servers bind loopback, which the untrusted dial guard refuses
+// when the hatch is empty. Keep the https gate, redirect cap, and Proxy=nil;
+// only drop Control so the TLS fixture is reachable.
 func allowUntrustedLoopback(t *testing.T, h *wayfHandler) {
 	t.Helper()
-	tr, ok := h.untrustedClient.Transport.(*publicOnlyTransport)
-	if !ok {
-		t.Fatalf("untrusted transport: got %T, want *publicOnlyTransport", h.untrustedClient.Transport)
-	}
-	if tr.Transport == nil {
-		t.Fatal("untrusted client is missing an inner *http.Transport")
-	}
+	tr := innerUntrustedHTTPTransport(t, h.untrustedClient.Transport)
 	tr.DialContext = (&net.Dialer{Timeout: 5 * time.Second}).DialContext
 }
 
@@ -77,13 +96,7 @@ func allowUntrustedLoopback(t *testing.T, h *wayfHandler) {
 // to the httptest listener so a public URL can exercise HTTPS redirects.
 func dialPublicHostToListener(t *testing.T, h *wayfHandler, listenerAddr string) {
 	t.Helper()
-	tr, ok := h.untrustedClient.Transport.(*publicOnlyTransport)
-	if !ok {
-		t.Fatalf("untrusted transport: got %T, want *publicOnlyTransport", h.untrustedClient.Transport)
-	}
-	if tr.Transport == nil {
-		t.Fatal("untrusted client is missing an inner *http.Transport")
-	}
+	tr := innerUntrustedHTTPTransport(t, h.untrustedClient.Transport)
 	tr.DialContext = func(ctx context.Context, network, address string) (net.Conn, error) {
 		if err := refuseNonPublicAddr(network, address, nil); err != nil {
 			return nil, err
@@ -196,8 +209,8 @@ func TestDiscoverProviderUntrustedClient(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected https refusal for a public http URL")
 		}
-		if !errors.Is(err, errUntrustedNonHTTPS) {
-			t.Fatalf("err = %v, want errUntrustedNonHTTPS", err)
+		if !errors.Is(err, ocmd.ErrNonHTTPS) {
+			t.Fatalf("err = %v, want ocmd.ErrNonHTTPS", err)
 		}
 	})
 
@@ -226,8 +239,8 @@ func TestDiscoverProviderUntrustedClient(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected redirect-cap refusal")
 		}
-		if !errors.Is(err, errUntrustedTooManyRedirects) {
-			t.Fatalf("err = %v, want errUntrustedTooManyRedirects", err)
+		if !errors.Is(err, ocmd.ErrTooManyRedirects) {
+			t.Fatalf("err = %v, want ocmd.ErrTooManyRedirects", err)
 		}
 	})
 
@@ -273,10 +286,7 @@ func TestUntrustedDiscoverClientHardening(t *testing.T) {
 		t.Errorf("untrusted timeout = %v, want 5s", h.untrustedClient.Timeout)
 	}
 
-	tr, ok := h.untrustedClient.Transport.(*publicOnlyTransport)
-	if !ok {
-		t.Fatalf("transport: got %T, want *publicOnlyTransport", h.untrustedClient.Transport)
-	}
+	tr := innerUntrustedHTTPTransport(t, h.untrustedClient.Transport)
 	if tr.Proxy != nil {
 		t.Error("untrusted client must not use a proxy")
 	}
@@ -306,14 +316,35 @@ func TestUntrustedDiscoverClientHardening(t *testing.T) {
 	if secure.untrustedClient.CheckRedirect == nil {
 		t.Error("secure CheckRedirect is nil")
 	}
-	secureTr, ok := secure.untrustedClient.Transport.(*publicOnlyTransport)
-	if !ok {
-		t.Fatalf("secure transport: got %T, want *publicOnlyTransport", secure.untrustedClient.Transport)
-	}
+	secureTr := innerUntrustedHTTPTransport(t, secure.untrustedClient.Transport)
 	if secureTr.TLSClientConfig == nil {
 		t.Fatal("secure TLSClientConfig is nil")
 	}
 	if secureTr.TLSClientConfig.InsecureSkipVerify {
 		t.Error("InsecureSkipVerify must be false when OCMClientInsecure is false")
+	}
+}
+
+func TestUntrustedCheckRedirectUsesSharedSentinel(t *testing.T) {
+	t.Parallel()
+
+	httpsURL, err := url.Parse("https://example.com/next")
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := &http.Request{URL: httpsURL}
+	err = untrustedCheckRedirect(req, []*http.Request{{}, {}, {}})
+	if err != nil {
+		t.Fatalf("len(via)=3 must be allowed with default cap 3: %v", err)
+	}
+	err = untrustedCheckRedirect(req, []*http.Request{{}, {}, {}, {}})
+	if err == nil {
+		t.Fatal("expected leftover CheckRedirect to refuse more than 3 hops")
+	}
+	if !errors.Is(err, ocmd.ErrTooManyRedirects) {
+		t.Fatalf("got %v, want ocmd.ErrTooManyRedirects", err)
+	}
+	if !errors.Is(err, errUntrustedTooManyRedirects) {
+		t.Fatalf("got %v, want errUntrustedTooManyRedirects", err)
 	}
 }

--- a/internal/http/services/wellknown/ocm.go
+++ b/internal/http/services/wellknown/ocm.go
@@ -129,7 +129,7 @@ func (h *wkocmHandler) init(c *OcmProviderConfig) {
 		Protocols:  rtProtos,         // expose the protocols as per configuration
 	}}
 	// for now, we hardcoded the capabilities, as this is currently only advisory
-	d.Capabilities = []string{"invites", "webdav-uri", "protocol-object"}
+	d.Capabilities = []string{"invites", "webdav-uri", "protocol-object", "invite-wayf"}
 	d.InviteAcceptDialog, _ = url.JoinPath(c.Endpoint, c.InviteAcceptDialog)
 	h.data = d
 }

--- a/internal/http/services/wellknown/ocm.go
+++ b/internal/http/services/wellknown/ocm.go
@@ -30,23 +30,23 @@ import (
 const OCMAPIVersion = "1.2.0"
 
 type OcmProviderConfig struct {
-	OCMPrefix          string `docs:"ocm;The prefix URL where the OCM API is served."                                            mapstructure:"ocm_prefix"`
-	Endpoint           string `docs:"This host's full URL. If it's not configured, it is assumed OCM is not available."          mapstructure:"endpoint"`
-	Provider           string `docs:"reva;A friendly name that defines this service."                                            mapstructure:"provider"`
-	WebdavRoot         string `docs:"/remote.php/dav/ocm;The root URL of the WebDAV endpoint to serve OCM shares."               mapstructure:"webdav_root"`
-	WebappRoot         string `docs:"/external/sciencemesh;The root URL to serve Web apps via OCM."                              mapstructure:"webapp_root"`
+	OCMPrefix          string `docs:"ocm;The prefix URL where the OCM API is served."                                          mapstructure:"ocm_prefix"`
+	Endpoint           string `docs:"This host's full URL. If it's not configured, it is assumed OCM is not available."        mapstructure:"endpoint"`
+	Provider           string `docs:"reva;A friendly name that defines this service."                                          mapstructure:"provider"`
+	WebdavRoot         string `docs:"/remote.php/dav/ocm;The root URL of the WebDAV endpoint to serve OCM shares."             mapstructure:"webdav_root"`
+	WebappRoot         string `docs:"/external/sciencemesh;The root URL to serve Web apps via OCM."                            mapstructure:"webapp_root"`
 	InviteAcceptDialog string `docs:"/open-cloud-mesh/accept-invite;The frontend URL where to land when receiving an invitation" mapstructure:"invite_accept_dialog"`
-	EnableWebapp       bool   `docs:"false;Whether web apps are enabled in OCM shares."                                          mapstructure:"enable_webapp"`
-	EnableDatatx       bool   `docs:"false;Whether data transfers are enabled in OCM shares."                                    mapstructure:"enable_datatx"`
+	EnableWebapp       bool   `docs:"false;Whether web apps are enabled in OCM shares."                                        mapstructure:"enable_webapp"`
+	EnableDatatx       bool   `docs:"false;Whether data transfers are enabled in OCM shares."                                  mapstructure:"enable_datatx"`
 }
 
 type OcmDiscoveryData struct {
-	Enabled            bool            `json:"enabled"            xml:"enabled"`
-	APIVersion         string          `json:"apiVersion"         xml:"apiVersion"`
-	Endpoint           string          `json:"endPoint"           xml:"endPoint"`
-	Provider           string          `json:"provider"           xml:"provider"`
-	ResourceTypes      []resourceTypes `json:"resourceTypes"      xml:"resourceTypes"`
-	Capabilities       []string        `json:"capabilities"       xml:"capabilities"`
+	Enabled            bool            `json:"enabled"       xml:"enabled"`
+	APIVersion         string          `json:"apiVersion"    xml:"apiVersion"`
+	Endpoint           string          `json:"endPoint"      xml:"endPoint"`
+	Provider           string          `json:"provider"      xml:"provider"`
+	ResourceTypes      []resourceTypes `json:"resourceTypes" xml:"resourceTypes"`
+	Capabilities       []string        `json:"capabilities"  xml:"capabilities"`
 	InviteAcceptDialog string          `json:"inviteAcceptDialog" xml:"inviteAcceptDialog"`
 }
 

--- a/internal/http/services/wellknown/ocm.go
+++ b/internal/http/services/wellknown/ocm.go
@@ -134,7 +134,7 @@ func (h *wkocmHandler) init(c *OcmProviderConfig) {
 	h.data = d
 }
 
-// This handler implements the OCM discovery endpoint specified in
+// Ocm handles the OCM discovery endpoint specified in
 // https://cs3org.github.io/OCM-API/docs.html?repo=OCM-API&user=cs3org#/paths/~1ocm-provider/get
 func (h *wkocmHandler) Ocm(w http.ResponseWriter, r *http.Request) {
 	log := appctx.GetLogger(r.Context())

--- a/internal/http/services/wellknown/ocm.go
+++ b/internal/http/services/wellknown/ocm.go
@@ -30,23 +30,23 @@ import (
 const OCMAPIVersion = "1.2.0"
 
 type OcmProviderConfig struct {
-	OCMPrefix          string `docs:"ocm;The prefix URL where the OCM API is served."                                          mapstructure:"ocm_prefix"`
-	Endpoint           string `docs:"This host's full URL. If it's not configured, it is assumed OCM is not available."        mapstructure:"endpoint"`
-	Provider           string `docs:"reva;A friendly name that defines this service."                                          mapstructure:"provider"`
-	WebdavRoot         string `docs:"/remote.php/dav/ocm;The root URL of the WebDAV endpoint to serve OCM shares."             mapstructure:"webdav_root"`
-	WebappRoot         string `docs:"/external/sciencemesh;The root URL to serve Web apps via OCM."                            mapstructure:"webapp_root"`
+	OCMPrefix          string `docs:"ocm;The prefix URL where the OCM API is served."                                            mapstructure:"ocm_prefix"`
+	Endpoint           string `docs:"This host's full URL. If it's not configured, it is assumed OCM is not available."          mapstructure:"endpoint"`
+	Provider           string `docs:"reva;A friendly name that defines this service."                                            mapstructure:"provider"`
+	WebdavRoot         string `docs:"/remote.php/dav/ocm;The root URL of the WebDAV endpoint to serve OCM shares."               mapstructure:"webdav_root"`
+	WebappRoot         string `docs:"/external/sciencemesh;The root URL to serve Web apps via OCM."                              mapstructure:"webapp_root"`
 	InviteAcceptDialog string `docs:"/open-cloud-mesh/accept-invite;The frontend URL where to land when receiving an invitation" mapstructure:"invite_accept_dialog"`
-	EnableWebapp       bool   `docs:"false;Whether web apps are enabled in OCM shares."                                        mapstructure:"enable_webapp"`
-	EnableDatatx       bool   `docs:"false;Whether data transfers are enabled in OCM shares."                                  mapstructure:"enable_datatx"`
+	EnableWebapp       bool   `docs:"false;Whether web apps are enabled in OCM shares."                                          mapstructure:"enable_webapp"`
+	EnableDatatx       bool   `docs:"false;Whether data transfers are enabled in OCM shares."                                    mapstructure:"enable_datatx"`
 }
 
 type OcmDiscoveryData struct {
-	Enabled            bool            `json:"enabled"       xml:"enabled"`
-	APIVersion         string          `json:"apiVersion"    xml:"apiVersion"`
-	Endpoint           string          `json:"endPoint"      xml:"endPoint"`
-	Provider           string          `json:"provider"      xml:"provider"`
-	ResourceTypes      []resourceTypes `json:"resourceTypes" xml:"resourceTypes"`
-	Capabilities       []string        `json:"capabilities"  xml:"capabilities"`
+	Enabled            bool            `json:"enabled"            xml:"enabled"`
+	APIVersion         string          `json:"apiVersion"         xml:"apiVersion"`
+	Endpoint           string          `json:"endPoint"           xml:"endPoint"`
+	Provider           string          `json:"provider"           xml:"provider"`
+	ResourceTypes      []resourceTypes `json:"resourceTypes"      xml:"resourceTypes"`
+	Capabilities       []string        `json:"capabilities"       xml:"capabilities"`
 	InviteAcceptDialog string          `json:"inviteAcceptDialog" xml:"inviteAcceptDialog"`
 }
 
@@ -129,12 +129,12 @@ func (h *wkocmHandler) init(c *OcmProviderConfig) {
 		Protocols:  rtProtos,         // expose the protocols as per configuration
 	}}
 	// for now, we hardcoded the capabilities, as this is currently only advisory
-	d.Capabilities = []string{"invites", "webdav-uri", "protocol-object", "invite-wayf"}
+	d.Capabilities = []string{"invites", "webdav-uri", "protocol-object"}
 	d.InviteAcceptDialog, _ = url.JoinPath(c.Endpoint, c.InviteAcceptDialog)
 	h.data = d
 }
 
-// Ocm handles the OCM discovery endpoint specified in
+// This handler implements the OCM discovery endpoint specified in
 // https://cs3org.github.io/OCM-API/docs.html?repo=OCM-API&user=cs3org#/paths/~1ocm-provider/get
 func (h *wkocmHandler) Ocm(w http.ResponseWriter, r *http.Request) {
 	log := appctx.GetLogger(r.Context())

--- a/pkg/ocm/embedded/embedded.go
+++ b/pkg/ocm/embedded/embedded.go
@@ -33,6 +33,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/cs3org/reva/v3/internal/http/services/opencloudmesh/ocmd"
 	"github.com/cs3org/reva/v3/pkg/appctx"
 	"github.com/cs3org/reva/v3/pkg/utils/cfg"
 	"github.com/pkg/errors"
@@ -146,12 +147,22 @@ func (d *driver) Process(ctx context.Context, payload, destination string, onCom
 	return nil
 }
 
+// newEmbeddedSrcClient builds the HTTP client used to fetch a peer-supplied
+// embedded srcURL. The URL is attacker-influenced, so the client uses the
+// public-only untrusted transport (https-only, public dial, TLS 1.2, redirect cap).
+func newEmbeddedSrcClient(timeout time.Duration, insecure bool) *http.Client {
+	return &http.Client{
+		Transport:     ocmd.UntrustedHTTPTransport(timeout, insecure),
+		CheckRedirect: ocmd.PublicOnlyCheckRedirect,
+	}
+}
+
 // transferEntries streams each entry to the WebDAV destination. A file that keeps
 // failing is skipped so one bad file doesn't abort the whole dataset. It returns
 // an error only when the transfer cannot proceed at all (e.g. the destination is
 // unreachable); per-file failures are best-effort and do not produce an error.
 func (d *driver) transferEntries(log *zerolog.Logger, token, destination string, entries []transferEntry, timeout time.Duration) error {
-	httpClient := &http.Client{}
+	httpClient := newEmbeddedSrcClient(timeout, false)
 	// Preemptive auth, not gowebdav's default auto-auth: auto-auth buffers each
 	// upload body in memory to replay on an auth challenge, blowing up RAM on
 	// multi-GB files. We pass the bearer token via the interceptor below.

--- a/pkg/ocm/embedded/embedded.go
+++ b/pkg/ocm/embedded/embedded.go
@@ -51,6 +51,10 @@ type Config struct {
 	IdleTimeout int `mapstructure:"embedded_transfer_idle_timeout"`
 	// Retries is the number of attempts per file (1 = no retry).
 	Retries int `mapstructure:"embedded_transfer_retries"`
+	// UntrustedClientSecurity configures MaxRedirects for peer-supplied src URLs
+	// (TOML block ocm_client_security). The hatch (allow_http / allowed_cidrs)
+	// must stay closed.
+	UntrustedClientSecurity ocmd.UntrustedClientSecurity `mapstructure:"ocm_client_security"`
 }
 
 // ApplyDefaults fills in sensible defaults for any unset setting.
@@ -96,7 +100,8 @@ func init() {
 // driver is the built-in Transferrer: it downloads each file over HTTP and
 // streams it to the configured WebDAV endpoint.
 type driver struct {
-	c Config
+	c   Config
+	sec ocmd.UntrustedClientSecurity
 }
 
 // New builds the built-in WebDAV embedded-transfer driver.
@@ -105,7 +110,14 @@ func New(ctx context.Context, m map[string]any) (Transferrer, error) {
 	if err := cfg.Decode(m, &c); err != nil {
 		return nil, err
 	}
-	return &driver{c: c}, nil
+	c.UntrustedClientSecurity.ApplyDefaults()
+	if err := c.UntrustedClientSecurity.Compile(); err != nil {
+		return nil, err
+	}
+	if err := c.UntrustedClientSecurity.RejectHatch(); err != nil {
+		return nil, err
+	}
+	return &driver{c: c, sec: c.UntrustedClientSecurity}, nil
 }
 
 // embeddedRetryBaseBackoff is the base per-file retry delay; it grows exponentially.
@@ -149,11 +161,11 @@ func (d *driver) Process(ctx context.Context, payload, destination string, onCom
 
 // newEmbeddedSrcClient builds the HTTP client used to fetch a peer-supplied
 // embedded srcURL. The URL is attacker-influenced, so the client uses the
-// public-only untrusted transport (https-only, public dial, TLS 1.2, redirect cap).
-func newEmbeddedSrcClient(timeout time.Duration, insecure bool) *http.Client {
+// untrusted transport (scheme policy, PIN-when-set dial, TLS 1.2, redirect cap).
+func newEmbeddedSrcClient(timeout time.Duration, insecure bool, sec ocmd.UntrustedClientSecurity) *http.Client {
 	return &http.Client{
-		Transport:     ocmd.UntrustedHTTPTransport(timeout, insecure),
-		CheckRedirect: ocmd.PublicOnlyCheckRedirect,
+		Transport:     ocmd.UntrustedHTTPTransport(timeout, insecure, sec),
+		CheckRedirect: sec.CheckRedirect,
 	}
 }
 
@@ -162,7 +174,7 @@ func newEmbeddedSrcClient(timeout time.Duration, insecure bool) *http.Client {
 // an error only when the transfer cannot proceed at all (e.g. the destination is
 // unreachable); per-file failures are best-effort and do not produce an error.
 func (d *driver) transferEntries(log *zerolog.Logger, token, destination string, entries []transferEntry, timeout time.Duration) error {
-	httpClient := newEmbeddedSrcClient(timeout, false)
+	httpClient := newEmbeddedSrcClient(timeout, false, d.sec)
 	// Preemptive auth, not gowebdav's default auto-auth: auto-auth buffers each
 	// upload body in memory to replay on an auth challenge, blowing up RAM on
 	// multi-GB files. We pass the bearer token via the interceptor below.

--- a/pkg/ocm/embedded/embedded.go
+++ b/pkg/ocm/embedded/embedded.go
@@ -58,6 +58,10 @@ type Config struct {
 	// EmbeddedSrcTLSMinVersion is the untrusted src-client TLS minimum enum
 	// string. Empty means TLS 1.2. Accepted values are "1.2" and "1.3".
 	EmbeddedSrcTLSMinVersion string `mapstructure:"embedded_src_tls_min_version"`
+	// SrcDialTimeout is the source untrusted-transport net.Dialer timeout
+	// in seconds. Zero or negative means 10s. It is not the per-file
+	// transfer ceiling.
+	SrcDialTimeout int `mapstructure:"embedded_src_dial_timeout"`
 }
 
 // ApplyDefaults fills in sensible defaults for any unset setting.
@@ -70,6 +74,9 @@ func (c *Config) ApplyDefaults() {
 	}
 	if c.Retries <= 0 {
 		c.Retries = 3
+	}
+	if c.SrcDialTimeout <= 0 {
+		c.SrcDialTimeout = 10
 	}
 }
 
@@ -175,15 +182,17 @@ func (d *driver) Process(ctx context.Context, payload, destination string, onCom
 // embedded srcURL. The URL is attacker-influenced, so the client uses the
 // untrusted transport: scheme policy, PIN-when-set dial, redirect cap, and a
 // minimum TLS version (default 1.2, configurable via tls_min_version).
+// dialTimeout is the net.Dialer timeout only; this client has no total
+// http.Client.Timeout so long transfers stay uncapped at the request layer.
 func newEmbeddedSrcClient(
-	timeout time.Duration,
+	dialTimeout time.Duration,
 	insecure bool,
 	sec ocmd.UntrustedClientSecurity,
 	minVersion uint16,
 ) *http.Client {
 	return &http.Client{
 		Transport: ocmd.UntrustedHTTPTransport(
-			timeout,
+			dialTimeout,
 			insecure,
 			sec,
 			minVersion,
@@ -192,13 +201,20 @@ func newEmbeddedSrcClient(
 	}
 }
 
+func (d *driver) srcDialTimeout() time.Duration {
+	if d.c.SrcDialTimeout > 0 {
+		return time.Duration(d.c.SrcDialTimeout) * time.Second
+	}
+	return 10 * time.Second
+}
+
 // transferEntries streams each entry to the WebDAV destination. A file that keeps
 // failing is skipped so one bad file doesn't abort the whole dataset. It returns
 // an error only when the transfer cannot proceed at all (e.g. the destination is
 // unreachable); per-file failures are best-effort and do not produce an error.
 func (d *driver) transferEntries(log *zerolog.Logger, token, destination string, entries []transferEntry, timeout time.Duration) error {
 	httpClient := newEmbeddedSrcClient(
-		timeout,
+		d.srcDialTimeout(),
 		false,
 		d.sec,
 		d.tlsMinVersion,

--- a/pkg/ocm/embedded/embedded.go
+++ b/pkg/ocm/embedded/embedded.go
@@ -55,6 +55,9 @@ type Config struct {
 	// (TOML block ocm_client_security). The hatch (allow_http / allowed_cidrs)
 	// must stay closed.
 	UntrustedClientSecurity ocmd.UntrustedClientSecurity `mapstructure:"ocm_client_security"`
+	// EmbeddedSrcTLSMinVersion is the untrusted src-client TLS minimum enum
+	// string. Empty means TLS 1.2. Accepted values are "1.2" and "1.3".
+	EmbeddedSrcTLSMinVersion string `mapstructure:"embedded_src_tls_min_version"`
 }
 
 // ApplyDefaults fills in sensible defaults for any unset setting.
@@ -100,8 +103,9 @@ func init() {
 // driver is the built-in Transferrer: it downloads each file over HTTP and
 // streams it to the configured WebDAV endpoint.
 type driver struct {
-	c   Config
-	sec ocmd.UntrustedClientSecurity
+	c             Config
+	sec           ocmd.UntrustedClientSecurity
+	tlsMinVersion uint16
 }
 
 // New builds the built-in WebDAV embedded-transfer driver.
@@ -117,7 +121,15 @@ func New(ctx context.Context, m map[string]any) (Transferrer, error) {
 	if err := c.UntrustedClientSecurity.RejectHatch(); err != nil {
 		return nil, err
 	}
-	return &driver{c: c, sec: c.UntrustedClientSecurity}, nil
+	minVersion, err := ocmd.ParseTLSMinVersion(c.EmbeddedSrcTLSMinVersion)
+	if err != nil {
+		return nil, err
+	}
+	return &driver{
+		c:             c,
+		sec:           c.UntrustedClientSecurity,
+		tlsMinVersion: minVersion,
+	}, nil
 }
 
 // embeddedRetryBaseBackoff is the base per-file retry delay; it grows exponentially.
@@ -161,10 +173,21 @@ func (d *driver) Process(ctx context.Context, payload, destination string, onCom
 
 // newEmbeddedSrcClient builds the HTTP client used to fetch a peer-supplied
 // embedded srcURL. The URL is attacker-influenced, so the client uses the
-// untrusted transport (scheme policy, PIN-when-set dial, TLS 1.2, redirect cap).
-func newEmbeddedSrcClient(timeout time.Duration, insecure bool, sec ocmd.UntrustedClientSecurity) *http.Client {
+// untrusted transport: scheme policy, PIN-when-set dial, redirect cap, and a
+// minimum TLS version (default 1.2, configurable via tls_min_version).
+func newEmbeddedSrcClient(
+	timeout time.Duration,
+	insecure bool,
+	sec ocmd.UntrustedClientSecurity,
+	minVersion uint16,
+) *http.Client {
 	return &http.Client{
-		Transport:     ocmd.UntrustedHTTPTransport(timeout, insecure, sec),
+		Transport: ocmd.UntrustedHTTPTransport(
+			timeout,
+			insecure,
+			sec,
+			minVersion,
+		),
 		CheckRedirect: sec.CheckRedirect,
 	}
 }
@@ -174,7 +197,12 @@ func newEmbeddedSrcClient(timeout time.Duration, insecure bool, sec ocmd.Untrust
 // an error only when the transfer cannot proceed at all (e.g. the destination is
 // unreachable); per-file failures are best-effort and do not produce an error.
 func (d *driver) transferEntries(log *zerolog.Logger, token, destination string, entries []transferEntry, timeout time.Duration) error {
-	httpClient := newEmbeddedSrcClient(timeout, false, d.sec)
+	httpClient := newEmbeddedSrcClient(
+		timeout,
+		false,
+		d.sec,
+		d.tlsMinVersion,
+	)
 	// Preemptive auth, not gowebdav's default auto-auth: auto-auth buffers each
 	// upload body in memory to replay on an auth challenge, blowing up RAM on
 	// multi-GB files. We pass the bearer token via the interceptor below.

--- a/pkg/ocm/embedded/embedded.go
+++ b/pkg/ocm/embedded/embedded.go
@@ -51,16 +51,16 @@ type Config struct {
 	IdleTimeout int `mapstructure:"embedded_transfer_idle_timeout"`
 	// Retries is the number of attempts per file (1 = no retry).
 	Retries int `mapstructure:"embedded_transfer_retries"`
-	// UntrustedClientSecurity configures MaxRedirects for peer-supplied src URLs
-	// (TOML block ocm_client_security). The hatch (allow_http / allowed_cidrs)
-	// must stay closed.
+	// UntrustedClientSecurity configures redirect policy for peer-supplied src
+	// URLs (TOML block ocm_client_security). The hatch (allow_http,
+	// allowed_cidrs, allow_loopback) must stay closed.
 	UntrustedClientSecurity ocmd.UntrustedClientSecurity `mapstructure:"ocm_client_security"`
-	// EmbeddedSrcTLSMinVersion is the untrusted src-client TLS minimum enum
-	// string. Empty means TLS 1.2. Accepted values are "1.2" and "1.3".
+	// EmbeddedSrcTLSMinVersion is the untrusted src-client TLS-minimum knob.
+	// Empty selects ParseTLSMinVersion's default.
 	EmbeddedSrcTLSMinVersion string `mapstructure:"embedded_src_tls_min_version"`
 	// SrcDialTimeout is the source untrusted-transport net.Dialer timeout
-	// in seconds. Zero or negative means 10s. It is not the per-file
-	// transfer ceiling.
+	// in seconds. Zero or negative selects the dial-timeout default. It is
+	// not the per-file transfer ceiling.
 	SrcDialTimeout int `mapstructure:"embedded_src_dial_timeout"`
 }
 
@@ -178,12 +178,13 @@ func (d *driver) Process(ctx context.Context, payload, destination string, onCom
 	return nil
 }
 
-// newEmbeddedSrcClient builds the HTTP client used to fetch a peer-supplied
-// embedded srcURL. The URL is attacker-influenced, so the client uses the
-// untrusted transport: scheme policy, PIN-when-set dial, redirect cap, and a
-// minimum TLS version (default 1.2, configurable via tls_min_version).
-// dialTimeout is the net.Dialer timeout only; this client has no total
-// http.Client.Timeout so long transfers stay uncapped at the request layer.
+// newEmbeddedSrcClient builds the HTTP client for a peer-supplied src URL.
+// This is not trusted NewClient: the URL is attacker-influenced, so the
+// client must enforce untrusted scheme, dial, and redirect policy.
+// There is no http.Client.Timeout. Destination SetTimeout and the
+// per-file context both derive from the same transfer timeout
+// (default 3600s). SetTimeout bounds each individual WebDAV request;
+// the per-file context bounds the total copy.
 func newEmbeddedSrcClient(
 	dialTimeout time.Duration,
 	insecure bool,
@@ -384,8 +385,10 @@ func (pr *progressReader) Read(p []byte) (int, error) {
 	return n, err
 }
 
-// monitorTransfer periodically logs transfer progress and aborts the transfer
-// (via cancel) if no data has flowed for idleTimeout. It exits when stop closes.
+// monitorTransfer aborts a file attempt when no bytes flow for idleTimeout.
+// It is a liveness guard against a peer that stops sending: it bounds
+// idle/stalled transfers with no progress within the idle window. It does
+// not guarantee protection against arbitrary slow-drip throughput.
 func monitorTransfer(log *zerolog.Logger, pr *progressReader, remotePath string, idleTimeout time.Duration, cancel context.CancelFunc, stop <-chan struct{}) {
 	const interval = 15 * time.Second
 	ticker := time.NewTicker(interval)

--- a/pkg/ocm/embedded/embedded_test.go
+++ b/pkg/ocm/embedded/embedded_test.go
@@ -20,6 +20,7 @@ package embedded
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"io"
@@ -129,6 +130,70 @@ func TestNewRejectsHatch(t *testing.T) {
 		}
 		if !errors.Is(err, ocmd.ErrHatchAllowedCIDRs) {
 			t.Fatalf("got %v, want ocmd.ErrHatchAllowedCIDRs", err)
+		}
+	})
+}
+
+func innerUntrustedTransport(t *testing.T, rt http.RoundTripper) *http.Transport {
+	t.Helper()
+	if tr, ok := rt.(*http.Transport); ok {
+		return tr
+	}
+	v := reflect.ValueOf(rt)
+	if v.Kind() == reflect.Pointer {
+		v = v.Elem()
+	}
+	if v.IsValid() && v.Kind() == reflect.Struct {
+		f := v.FieldByName("Transport")
+		if f.IsValid() && f.CanInterface() {
+			if tr, ok := f.Interface().(*http.Transport); ok && tr != nil {
+				return tr
+			}
+		}
+	}
+	t.Fatalf("untrusted transport: got %T, want an *http.Transport wrapper", rt)
+	return nil
+}
+
+func TestNewTLSMinVersion(t *testing.T) {
+	t.Parallel()
+
+	t.Run("configured 1.3 reaches the transport", func(t *testing.T) {
+		t.Parallel()
+		tr, err := New(context.Background(), map[string]any{
+			"webdav_url":                   "https://dav.example.org/",
+			"embedded_src_tls_min_version": "1.3",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		d := tr.(*driver)
+		if d.tlsMinVersion != tls.VersionTLS13 {
+			t.Fatalf("tlsMinVersion = %#x, want TLS 1.3", d.tlsMinVersion)
+		}
+		client := newEmbeddedSrcClient(
+			5*time.Second,
+			false,
+			d.sec,
+			d.tlsMinVersion,
+		)
+		got := innerUntrustedTransport(t, client.Transport)
+		if got.TLSClientConfig == nil || got.TLSClientConfig.MinVersion != tls.VersionTLS13 {
+			t.Fatalf("src client MinVersion = %v, want TLS 1.3", got.TLSClientConfig)
+		}
+	})
+
+	t.Run("invalid value fails service start", func(t *testing.T) {
+		t.Parallel()
+		_, err := New(context.Background(), map[string]any{
+			"webdav_url":                   "https://dav.example.org/",
+			"embedded_src_tls_min_version": "1.0",
+		})
+		if err == nil {
+			t.Fatal("expected embedded.New to reject TLS min version 1.0")
+		}
+		if !errors.Is(err, ocmd.ErrInvalidTLSMinVersion) {
+			t.Fatalf("got %v, want ocmd.ErrInvalidTLSMinVersion", err)
 		}
 	})
 }
@@ -556,7 +621,7 @@ func TestEmbeddedSrcURLFetchPublicHTTPSHostSucceeds(t *testing.T) {
 	err := uploadURLToWebDAV(
 		ctx,
 		testLogger(),
-		newEmbeddedSrcClient(5*time.Second, true, testEmbeddedSec()),
+		newEmbeddedSrcClient(5*time.Second, true, testEmbeddedSec(), 0),
 		dav,
 		src.URL+"/file.txt",
 		"/dest/file.txt",
@@ -580,7 +645,7 @@ func TestEmbeddedSrcURLFetchRefusesPrivateHost(t *testing.T) {
 		err := uploadURLToWebDAV(
 			ctx,
 			testLogger(),
-			newEmbeddedSrcClient(5*time.Second, true, testEmbeddedSec()),
+			newEmbeddedSrcClient(5*time.Second, true, testEmbeddedSec(), 0),
 			dummyDAV(),
 			"https://169.254.169.254/file.txt",
 			"/dest/file.txt",
@@ -614,7 +679,7 @@ func TestEmbeddedSrcURLFetchRefusesPrivateHost(t *testing.T) {
 		err := uploadURLToWebDAV(
 			ctx,
 			testLogger(),
-			newEmbeddedSrcClient(5*time.Second, true, testEmbeddedSec()),
+			newEmbeddedSrcClient(5*time.Second, true, testEmbeddedSec(), 0),
 			dummyDAV(),
 			src.URL+"/file.txt",
 			"/dest/file.txt",

--- a/pkg/ocm/embedded/embedded_test.go
+++ b/pkg/ocm/embedded/embedded_test.go
@@ -21,13 +21,19 @@ package embedded
 import (
 	"context"
 	"encoding/json"
+	"io"
+	"net"
 	"net/http"
+	"net/http/httptest"
+	"net/http/httptrace"
 	"reflect"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/rs/zerolog"
+	"github.com/studio-b12/gowebdav"
 )
 
 func testLogger() *zerolog.Logger {
@@ -357,5 +363,259 @@ func TestProcessNoTransferableEntries(t *testing.T) {
 	}
 	if gotErr != nil {
 		t.Errorf("Process with no transferable entries: onComplete error = %v, want nil", gotErr)
+	}
+}
+
+func firstPublicIPv4() (string, bool) {
+	addrs, err := net.InterfaceAddrs()
+	if err != nil {
+		return "", false
+	}
+	for _, a := range addrs {
+		n, ok := a.(*net.IPNet)
+		if !ok || n.IP == nil {
+			continue
+		}
+		ip := n.IP.To4()
+		if ip == nil || ip.IsLoopback() || ip.IsPrivate() || ip.IsUnspecified() ||
+			ip.IsLinkLocalUnicast() || ip.IsMulticast() {
+			continue
+		}
+		if ip[0] == 100 && ip[1]&0xc0 == 64 {
+			continue
+		}
+		return ip.String(), true
+	}
+	return "", false
+}
+
+func startPublicTLSServer(t *testing.T, h http.Handler) *httptest.Server {
+	t.Helper()
+	ip, ok := firstPublicIPv4()
+	if !ok {
+		t.Skip("no public IPv4 address available for public-only httptest")
+	}
+	ln, err := net.Listen("tcp", net.JoinHostPort(ip, "0"))
+	if err != nil {
+		t.Skipf("cannot listen on public IP %s: %v", ip, err)
+	}
+	srv := httptest.NewUnstartedServer(h)
+	if srv.Listener != nil {
+		_ = srv.Listener.Close()
+	}
+	srv.Listener = ln
+	srv.StartTLS()
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func startDestWebDAV(t *testing.T) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPut, "MKCOL":
+			if r.Body != nil {
+				_, _ = io.Copy(io.Discard, r.Body)
+			}
+			w.WriteHeader(http.StatusCreated)
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func dummyDAV() *gowebdav.Client {
+	return gowebdav.NewClient("https://127.0.0.1:1", "", "")
+}
+
+type hostDialTrace struct {
+	mu          sync.Mutex
+	established []string
+}
+
+func contextWithHostDialTrace(ctx context.Context) (context.Context, *hostDialTrace) {
+	tr := &hostDialTrace{established: []string{}}
+	ctx = httptrace.WithClientTrace(ctx, &httptrace.ClientTrace{
+		ConnectDone: func(_, addr string, err error) {
+			if err != nil {
+				return
+			}
+			tr.mu.Lock()
+			tr.established = append(tr.established, addr)
+			tr.mu.Unlock()
+		},
+		GotConn: func(info httptrace.GotConnInfo) {
+			if info.Conn == nil {
+				return
+			}
+			tr.mu.Lock()
+			tr.established = append(tr.established, info.Conn.RemoteAddr().String())
+			tr.mu.Unlock()
+		},
+	})
+	return ctx, tr
+}
+
+func hostOf(addr string) string {
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		host = addr
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		if ip4 := ip.To4(); ip4 != nil {
+			return ip4.String()
+		}
+		return ip.String()
+	}
+	return host
+}
+
+func (tr *hostDialTrace) establishedHost(host string) bool {
+	tr.mu.Lock()
+	defer tr.mu.Unlock()
+	for _, addr := range tr.established {
+		if hostOf(addr) == host {
+			return true
+		}
+	}
+	return false
+}
+
+func assertNoEstablishedHost(t *testing.T, tr *hostDialTrace, host string) {
+	t.Helper()
+	if tr.establishedHost(host) {
+		t.Fatalf("embedded srcURL fetch established a connection to %s", host)
+	}
+}
+
+func TestEmbeddedSrcURLFetchPublicHTTPSHostSucceeds(t *testing.T) {
+	const body = "embedded-src"
+	contacted := false
+	src := startPublicTLSServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		contacted = true
+		if r.Method != http.MethodGet {
+			t.Errorf("unexpected method %s", r.Method)
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(body))
+	}))
+	dest := startDestWebDAV(t)
+	dav := gowebdav.NewClient(dest.URL, "", "")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	err := uploadURLToWebDAV(
+		ctx,
+		testLogger(),
+		newEmbeddedSrcClient(5*time.Second, true),
+		dav,
+		src.URL+"/file.txt",
+		"/dest/file.txt",
+		int64(len(body)),
+		5*time.Second,
+	)
+	if err != nil {
+		t.Fatalf("embedded srcURL fetch to a public HTTPS host: %v", err)
+	}
+	if !contacted {
+		t.Fatal("expected embedded srcURL fetch to reach the public HTTPS host")
+	}
+}
+
+func TestEmbeddedSrcURLFetchRefusesPrivateHost(t *testing.T) {
+	t.Run("metadata host is refused at dial", func(t *testing.T) {
+		ctx, tr := contextWithHostDialTrace(context.Background())
+		ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+
+		err := uploadURLToWebDAV(
+			ctx,
+			testLogger(),
+			newEmbeddedSrcClient(5*time.Second, true),
+			dummyDAV(),
+			"https://169.254.169.254/file.txt",
+			"/dest/file.txt",
+			-1,
+			5*time.Second,
+		)
+		assertNoEstablishedHost(t, tr, "169.254.169.254")
+		if err == nil {
+			t.Fatal("expected embedded srcURL fetch to refuse the metadata host at dial")
+		}
+		if !strings.Contains(err.Error(), "non-public") {
+			t.Fatalf("got %v, want the existing non-public dial error", err)
+		}
+	})
+
+	t.Run("reachable private host is not contacted", func(t *testing.T) {
+		contacted := false
+		src := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			contacted = true
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("secret"))
+		}))
+		defer src.Close()
+
+		// insecure=true so TLS cannot short-circuit before the public-only dial
+		// guard. The old default client would then reach this loopback server.
+		ctx, tr := contextWithHostDialTrace(context.Background())
+		ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+
+		err := uploadURLToWebDAV(
+			ctx,
+			testLogger(),
+			newEmbeddedSrcClient(5*time.Second, true),
+			dummyDAV(),
+			src.URL+"/file.txt",
+			"/dest/file.txt",
+			-1,
+			5*time.Second,
+		)
+		if contacted {
+			t.Fatal("embedded srcURL fetch contacted a private host; the untrusted transport must refuse it at dial")
+		}
+		assertNoEstablishedHost(t, tr, hostOf(src.Listener.Addr().String()))
+		if err == nil {
+			t.Fatal("expected embedded srcURL fetch to refuse the private host at dial")
+		}
+		if !strings.Contains(err.Error(), "non-public") {
+			t.Fatalf("got %v, want the existing non-public dial error", err)
+		}
+	})
+}
+
+func TestEmbeddedSrcURLFetchRefusesHTTP(t *testing.T) {
+	contacted := false
+	src := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		contacted = true
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("secret"))
+	}))
+	defer src.Close()
+
+	dest := startDestWebDAV(t)
+	d := &driver{c: Config{
+		WebDAVURL:   dest.URL,
+		Timeout:     5,
+		IdleTimeout: 2,
+		Retries:     1,
+	}}
+	err := d.transferEntries(
+		testLogger(),
+		"tok",
+		"/dest",
+		[]transferEntry{{srcURL: src.URL + "/file.txt", name: "file.txt", sizeHint: -1}},
+		5*time.Second,
+	)
+	if contacted {
+		t.Fatal("embedded srcURL fetch contacted an http host; the untrusted transport must refuse it")
+	}
+	if err != nil {
+		t.Fatalf("transferEntries returned %v, want nil (per-file failures are skipped)", err)
 	}
 }

--- a/pkg/ocm/embedded/embedded_test.go
+++ b/pkg/ocm/embedded/embedded_test.go
@@ -75,12 +75,23 @@ func TestConfigApplyDefaults(t *testing.T) {
 		if c.Retries != 3 {
 			t.Errorf("Retries = %d, want 3", c.Retries)
 		}
+		if c.SrcDialTimeout != 10 {
+			t.Errorf("SrcDialTimeout = %d, want 10", c.SrcDialTimeout)
+		}
+	})
+
+	t.Run("negative src dial timeout uses default", func(t *testing.T) {
+		c := Config{SrcDialTimeout: -1}
+		c.ApplyDefaults()
+		if c.SrcDialTimeout != 10 {
+			t.Errorf("SrcDialTimeout = %d, want 10", c.SrcDialTimeout)
+		}
 	})
 
 	t.Run("explicit values preserved", func(t *testing.T) {
-		c := Config{WebDAVURL: "https://dav.example.org/", Timeout: 10, IdleTimeout: 5, Retries: 1}
+		c := Config{WebDAVURL: "https://dav.example.org/", Timeout: 10, IdleTimeout: 5, Retries: 1, SrcDialTimeout: 2}
 		c.ApplyDefaults()
-		if c.Timeout != 10 || c.IdleTimeout != 5 || c.Retries != 1 {
+		if c.Timeout != 10 || c.IdleTimeout != 5 || c.Retries != 1 || c.SrcDialTimeout != 2 {
 			t.Errorf("explicit values were overwritten: %+v", c)
 		}
 		if c.WebDAVURL != "https://dav.example.org/" {
@@ -95,8 +106,65 @@ func TestNewAppliesDefaults(t *testing.T) {
 		t.Fatalf("New: unexpected error %v", err)
 	}
 	d := tr.(*driver)
-	if d.c.Timeout != 3600 || d.c.IdleTimeout != 120 || d.c.Retries != 3 {
+	if d.c.Timeout != 3600 || d.c.IdleTimeout != 120 || d.c.Retries != 3 || d.c.SrcDialTimeout != 10 {
 		t.Errorf("New did not apply defaults: %+v", d.c)
+	}
+}
+
+func TestConfigSrcDialTimeoutIndependentOfTransferTimeout(t *testing.T) {
+	tr, err := New(context.Background(), map[string]any{
+		"webdav_url":                "https://dav.example.org/",
+		"embedded_transfer_timeout": 1800,
+		"embedded_src_dial_timeout": 2,
+	})
+	if err != nil {
+		t.Fatalf("New: unexpected error %v", err)
+	}
+	d := tr.(*driver)
+	if d.c.Timeout != 1800 {
+		t.Errorf("Timeout = %d, want 1800 transfer ceiling", d.c.Timeout)
+	}
+	if d.c.SrcDialTimeout != 2 {
+		t.Errorf("SrcDialTimeout = %d, want 2", d.c.SrcDialTimeout)
+	}
+	if d.srcDialTimeout() != 2*time.Second {
+		t.Errorf("srcDialTimeout() = %v, want 2s", d.srcDialTimeout())
+	}
+}
+
+func TestEmbeddedSrcClientHasNoRequestTimeout(t *testing.T) {
+	client := newEmbeddedSrcClient(2*time.Second, false, testEmbeddedSec(), 0)
+	if client.Timeout != 0 {
+		t.Fatalf("source http.Client.Timeout = %v, want 0", client.Timeout)
+	}
+}
+
+func TestEmbeddedSrcDialTimeoutBoundsNonResponsiveDial(t *testing.T) {
+	dest := startDestWebDAV(t)
+	d := &driver{
+		c: Config{
+			WebDAVURL:      dest.URL,
+			Timeout:        3600,
+			IdleTimeout:    2,
+			Retries:        1,
+			SrcDialTimeout: 1,
+		},
+		sec: testEmbeddedSec(),
+	}
+	start := time.Now()
+	err := d.transferEntries(
+		testLogger(),
+		"tok",
+		"/dest",
+		[]transferEntry{{srcURL: "https://240.0.0.1/file.txt", name: "file.txt", sizeHint: -1}},
+		3600*time.Second,
+	)
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("transferEntries returned %v, want nil (per-file failures are skipped)", err)
+	}
+	if elapsed > 5*time.Second {
+		t.Fatalf("source dial used the transfer ceiling; elapsed %v", elapsed)
 	}
 }
 

--- a/pkg/ocm/embedded/embedded_test.go
+++ b/pkg/ocm/embedded/embedded_test.go
@@ -21,6 +21,7 @@ package embedded
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net"
 	"net/http"
@@ -32,9 +33,19 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cs3org/reva/v3/internal/http/services/opencloudmesh/ocmd"
 	"github.com/rs/zerolog"
 	"github.com/studio-b12/gowebdav"
 )
+
+func testEmbeddedSec() ocmd.UntrustedClientSecurity {
+	var s ocmd.UntrustedClientSecurity
+	s.ApplyDefaults()
+	if err := s.Compile(); err != nil {
+		panic(err)
+	}
+	return s
+}
 
 func testLogger() *zerolog.Logger {
 	l := zerolog.Nop()
@@ -86,6 +97,40 @@ func TestNewAppliesDefaults(t *testing.T) {
 	if d.c.Timeout != 3600 || d.c.IdleTimeout != 120 || d.c.Retries != 3 {
 		t.Errorf("New did not apply defaults: %+v", d.c)
 	}
+}
+
+func TestNewRejectsHatch(t *testing.T) {
+	t.Parallel()
+
+	t.Run("allow_http", func(t *testing.T) {
+		_, err := New(context.Background(), map[string]any{
+			"webdav_url": "https://dav.example.org/",
+			"ocm_client_security": map[string]any{
+				"allow_http": true,
+			},
+		})
+		if err == nil {
+			t.Fatal("expected embedded.New to reject allow_http")
+		}
+		if !errors.Is(err, ocmd.ErrHatchAllowHTTP) {
+			t.Fatalf("got %v, want ocmd.ErrHatchAllowHTTP", err)
+		}
+	})
+
+	t.Run("allowed_cidrs", func(t *testing.T) {
+		_, err := New(context.Background(), map[string]any{
+			"webdav_url": "https://dav.example.org/",
+			"ocm_client_security": map[string]any{
+				"allowed_cidrs": []string{"10.0.0.0/8"},
+			},
+		})
+		if err == nil {
+			t.Fatal("expected embedded.New to reject allowed_cidrs")
+		}
+		if !errors.Is(err, ocmd.ErrHatchAllowedCIDRs) {
+			t.Fatalf("got %v, want ocmd.ErrHatchAllowedCIDRs", err)
+		}
+	})
 }
 
 func TestParseRetryAfter(t *testing.T) {
@@ -511,7 +556,7 @@ func TestEmbeddedSrcURLFetchPublicHTTPSHostSucceeds(t *testing.T) {
 	err := uploadURLToWebDAV(
 		ctx,
 		testLogger(),
-		newEmbeddedSrcClient(5*time.Second, true),
+		newEmbeddedSrcClient(5*time.Second, true, testEmbeddedSec()),
 		dav,
 		src.URL+"/file.txt",
 		"/dest/file.txt",
@@ -535,7 +580,7 @@ func TestEmbeddedSrcURLFetchRefusesPrivateHost(t *testing.T) {
 		err := uploadURLToWebDAV(
 			ctx,
 			testLogger(),
-			newEmbeddedSrcClient(5*time.Second, true),
+			newEmbeddedSrcClient(5*time.Second, true, testEmbeddedSec()),
 			dummyDAV(),
 			"https://169.254.169.254/file.txt",
 			"/dest/file.txt",
@@ -546,8 +591,8 @@ func TestEmbeddedSrcURLFetchRefusesPrivateHost(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected embedded srcURL fetch to refuse the metadata host at dial")
 		}
-		if !strings.Contains(err.Error(), "non-public") {
-			t.Fatalf("got %v, want the existing non-public dial error", err)
+		if !errors.Is(err, ocmd.ErrNonPublicAddr) {
+			t.Fatalf("got %v, want ocmd.ErrNonPublicAddr", err)
 		}
 	})
 
@@ -560,7 +605,7 @@ func TestEmbeddedSrcURLFetchRefusesPrivateHost(t *testing.T) {
 		}))
 		defer src.Close()
 
-		// insecure=true so TLS cannot short-circuit before the public-only dial
+		// insecure=true so TLS cannot short-circuit before the untrusted dial
 		// guard. The old default client would then reach this loopback server.
 		ctx, tr := contextWithHostDialTrace(context.Background())
 		ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
@@ -569,7 +614,7 @@ func TestEmbeddedSrcURLFetchRefusesPrivateHost(t *testing.T) {
 		err := uploadURLToWebDAV(
 			ctx,
 			testLogger(),
-			newEmbeddedSrcClient(5*time.Second, true),
+			newEmbeddedSrcClient(5*time.Second, true, testEmbeddedSec()),
 			dummyDAV(),
 			src.URL+"/file.txt",
 			"/dest/file.txt",
@@ -583,8 +628,8 @@ func TestEmbeddedSrcURLFetchRefusesPrivateHost(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected embedded srcURL fetch to refuse the private host at dial")
 		}
-		if !strings.Contains(err.Error(), "non-public") {
-			t.Fatalf("got %v, want the existing non-public dial error", err)
+		if !errors.Is(err, ocmd.ErrNonPublicAddr) {
+			t.Fatalf("got %v, want ocmd.ErrNonPublicAddr", err)
 		}
 	})
 }

--- a/pkg/ocm/embedded/untrusted_hardening_regression_test.go
+++ b/pkg/ocm/embedded/untrusted_hardening_regression_test.go
@@ -1,0 +1,167 @@
+// Copyright 2018-2026 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package embedded
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/cs3org/reva/v3/internal/http/services/opencloudmesh/ocmd"
+)
+
+// TestUntrustedHardeningRegression proves embedded.New wires the untrusted
+// src client used by transferEntries/uploadURLToWebDAV. Per-host matrices
+// stay in embedded_test.go.
+func TestUntrustedHardeningRegression(t *testing.T) {
+	dest := startDestWebDAV(t)
+	got, err := New(context.Background(), map[string]any{
+		"webdav_url":                     dest.URL,
+		"embedded_transfer_retries":      1,
+		"embedded_transfer_timeout":      5,
+		"embedded_transfer_idle_timeout": 2,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	d, ok := got.(*driver)
+	if !ok {
+		t.Fatalf("got %T, want *driver", got)
+	}
+
+	t.Run("HTTP is refused", func(t *testing.T) {
+		fetched := false
+		src := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fetched = true
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("secret"))
+		}))
+		t.Cleanup(src.Close)
+
+		err := d.transferEntries(
+			testLogger(),
+			"tok",
+			"/dest",
+			[]transferEntry{{
+				srcURL:   src.URL + "/file.txt",
+				name:     "file.txt",
+				sizeHint: -1,
+			}},
+			5*time.Second,
+		)
+		if fetched {
+			t.Fatal("embedded.New transferEntries must not fetch HTTP")
+		}
+		if err != nil {
+			t.Fatalf("transferEntries returned %v, want nil (per-file failures are skipped)", err)
+		}
+	})
+
+	t.Run("metadata host is refused", func(t *testing.T) {
+		err := d.transferEntries(
+			testLogger(),
+			"tok",
+			"/dest",
+			[]transferEntry{{
+				srcURL:   "https://169.254.169.254/file.txt",
+				name:     "file.txt",
+				sizeHint: -1,
+			}},
+			5*time.Second,
+		)
+		if err != nil {
+			t.Fatalf("transferEntries returned %v, want nil (per-file failures are skipped)", err)
+		}
+
+		// transferEntries swallows the src error. uploadURLToWebDAV is the
+		// GET it uses, so the sentinel is visible here.
+		ctx, tr := contextWithHostDialTrace(context.Background())
+		ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+		err = uploadURLToWebDAV(
+			ctx,
+			testLogger(),
+			d.productionSrcClient(),
+			dummyDAV(),
+			"https://169.254.169.254/file.txt",
+			"/dest/file.txt",
+			-1,
+			2*time.Second,
+		)
+		assertNoEstablishedHost(t, tr, "169.254.169.254")
+		if !errors.Is(err, ocmd.ErrNonPublicAddr) {
+			t.Fatalf("got %v, want ocmd.ErrNonPublicAddr", err)
+		}
+	})
+
+	t.Run("public HTTPS is not blocked as non-public", func(t *testing.T) {
+		contacted := false
+		src := startPublicTLSServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			contacted = true
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("embedded-src"))
+		}))
+
+		err := d.transferEntries(
+			testLogger(),
+			"tok",
+			"/dest",
+			[]transferEntry{{
+				srcURL:   src.URL + "/file.txt",
+				name:     "file.txt",
+				sizeHint: -1,
+			}},
+			5*time.Second,
+		)
+		if err != nil {
+			t.Fatalf("transferEntries returned %v, want nil (per-file failures are skipped)", err)
+		}
+		if contacted {
+			t.Fatal("production src client verifies TLS; httptest cert must fail after the public dial")
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		err = uploadURLToWebDAV(
+			ctx,
+			testLogger(),
+			d.productionSrcClient(),
+			dummyDAV(),
+			src.URL+"/file.txt",
+			"/dest/file.txt",
+			-1,
+			2*time.Second,
+		)
+		if errors.Is(err, ocmd.ErrNonPublicAddr) {
+			t.Fatal("public HTTPS must not be refused as non-public")
+		}
+		if err == nil || contacted {
+			t.Fatal("production src client verifies TLS; httptest cert must fail after the public dial")
+		}
+	})
+}
+
+// productionSrcClient is the untrusted client transferEntries builds after New:
+// insecure is false, and timeout/security/TLS come from the constructor.
+func (d *driver) productionSrcClient() *http.Client {
+	return newEmbeddedSrcClient(d.srcDialTimeout(), false, d.sec, d.tlsMinVersion)
+}

--- a/pkg/ocm/provider/authorizer/open/open.go
+++ b/pkg/ocm/provider/authorizer/open/open.go
@@ -37,7 +37,9 @@ func init() {
 	registry.Register("open", New)
 }
 
-// New returns a new authorizer object.
+// New returns an open authorizer that discovers unknown providers with the
+// untrusted public-only client. Discovery hosts are caller-supplied, so
+// scheme, dial, and redirect policy must stay enforced.
 func New(ctx context.Context, m map[string]any) (provider.Authorizer, error) {
 	var c config
 	if err := cfg.Decode(m, &c); err != nil {
@@ -68,23 +70,22 @@ func New(ctx context.Context, m map[string]any) (provider.Authorizer, error) {
 }
 
 type config struct {
-	// Users holds a path to a file containing json conforming the Users struct
 	Providers string `mapstructure:"providers"`
 	// Insecure skips TLS verification when discovering an unknown provider. Off by
 	// default; turning it on exposes discovery to MITM.
 	Insecure bool `mapstructure:"insecure"`
-	// OCMResponseLimit caps outbound OCM JSON response bodies in bytes.
-	// Zero means 1 MiB.
+	// OCMResponseLimit caps outbound OCM JSON response bodies. Zero selects
+	// the package default.
 	OCMResponseLimit int64 `mapstructure:"ocm_response_limit"`
-	// OCMTLSMinVersion is the untrusted-client TLS minimum enum string.
-	// Empty means TLS 1.2. Accepted values are "1.2" and "1.3".
+	// OCMTLSMinVersion is the untrusted-client TLS-minimum knob. Empty
+	// selects ParseTLSMinVersion's default.
 	OCMTLSMinVersion string `mapstructure:"ocm_tls_min_version"`
-	// UntrustedClientSecurity configures MaxRedirects for discovery of unknown
-	// providers (TOML block ocm_client_security). The hatch (allow_http /
-	// allowed_cidrs) must stay closed.
+	// UntrustedClientSecurity configures redirect policy for discovery of
+	// unknown providers (TOML block ocm_client_security). The hatch
+	// (allow_http, allowed_cidrs, allow_loopback) must stay closed.
 	UntrustedClientSecurity client.UntrustedClientSecurity `mapstructure:"ocm_client_security"`
 	// Timeout is the outbound OCM discovery request timeout in seconds.
-	// Zero or negative means 10s.
+	// Zero or negative selects the request-timeout default.
 	Timeout int `mapstructure:"timeout"`
 }
 
@@ -132,7 +133,6 @@ func (a *authorizer) GetInfoByDomain(ctx context.Context, domain string) (*ocmpr
 	}
 	host, _ := url.Parse(ocmCaps.Endpoint)
 
-	// return a provider info record for this domain, including the OCM service
 	return &ocmprovider.ProviderInfo{
 		Name:         "ocm_" + domain,
 		FullName:     ocmCaps.Provider,

--- a/pkg/ocm/provider/authorizer/open/open.go
+++ b/pkg/ocm/provider/authorizer/open/open.go
@@ -57,7 +57,7 @@ func New(ctx context.Context, m map[string]any) (provider.Authorizer, error) {
 
 	a := &authorizer{
 		publicOCMClient: client.NewPublicOnlyClient(
-			10*time.Second,
+			time.Duration(c.Timeout)*time.Second,
 			c.Insecure,
 			c.UntrustedClientSecurity,
 			c.OCMResponseLimit,
@@ -83,11 +83,17 @@ type config struct {
 	// providers (TOML block ocm_client_security). The hatch (allow_http /
 	// allowed_cidrs) must stay closed.
 	UntrustedClientSecurity client.UntrustedClientSecurity `mapstructure:"ocm_client_security"`
+	// Timeout is the outbound OCM discovery request timeout in seconds.
+	// Zero or negative means 10s.
+	Timeout int `mapstructure:"timeout"`
 }
 
 func (c *config) ApplyDefaults() {
 	if c.OCMResponseLimit == 0 {
 		c.OCMResponseLimit = 1 << 20
+	}
+	if c.Timeout <= 0 {
+		c.Timeout = 10
 	}
 }
 

--- a/pkg/ocm/provider/authorizer/open/open.go
+++ b/pkg/ocm/provider/authorizer/open/open.go
@@ -52,7 +52,12 @@ func New(ctx context.Context, m map[string]any) (provider.Authorizer, error) {
 	}
 
 	a := &authorizer{
-		publicOCMClient: client.NewPublicOnlyClient(10*time.Second, c.Insecure, c.UntrustedClientSecurity),
+		publicOCMClient: client.NewPublicOnlyClient(
+			10*time.Second,
+			c.Insecure,
+			c.UntrustedClientSecurity,
+			c.OCMResponseLimit,
+		),
 	}
 	return a, nil
 }
@@ -63,6 +68,9 @@ type config struct {
 	// Insecure skips TLS verification when discovering an unknown provider. Off by
 	// default; turning it on exposes discovery to MITM.
 	Insecure bool `mapstructure:"insecure"`
+	// OCMResponseLimit caps outbound OCM JSON response bodies in bytes.
+	// Zero means 1 MiB.
+	OCMResponseLimit int64 `mapstructure:"ocm_response_limit"`
 	// UntrustedClientSecurity configures MaxRedirects for discovery of unknown
 	// providers (TOML block ocm_client_security). The hatch (allow_http /
 	// allowed_cidrs) must stay closed.
@@ -70,6 +78,9 @@ type config struct {
 }
 
 func (c *config) ApplyDefaults() {
+	if c.OCMResponseLimit == 0 {
+		c.OCMResponseLimit = 1 << 20
+	}
 }
 
 type authorizer struct {

--- a/pkg/ocm/provider/authorizer/open/open.go
+++ b/pkg/ocm/provider/authorizer/open/open.go
@@ -50,6 +50,10 @@ func New(ctx context.Context, m map[string]any) (provider.Authorizer, error) {
 	if err := c.UntrustedClientSecurity.RejectHatch(); err != nil {
 		return nil, err
 	}
+	minVersion, err := client.ParseTLSMinVersion(c.OCMTLSMinVersion)
+	if err != nil {
+		return nil, err
+	}
 
 	a := &authorizer{
 		publicOCMClient: client.NewPublicOnlyClient(
@@ -57,6 +61,7 @@ func New(ctx context.Context, m map[string]any) (provider.Authorizer, error) {
 			c.Insecure,
 			c.UntrustedClientSecurity,
 			c.OCMResponseLimit,
+			minVersion,
 		),
 	}
 	return a, nil
@@ -71,6 +76,9 @@ type config struct {
 	// OCMResponseLimit caps outbound OCM JSON response bodies in bytes.
 	// Zero means 1 MiB.
 	OCMResponseLimit int64 `mapstructure:"ocm_response_limit"`
+	// OCMTLSMinVersion is the untrusted-client TLS minimum enum string.
+	// Empty means TLS 1.2. Accepted values are "1.2" and "1.3".
+	OCMTLSMinVersion string `mapstructure:"ocm_tls_min_version"`
 	// UntrustedClientSecurity configures MaxRedirects for discovery of unknown
 	// providers (TOML block ocm_client_security). The hatch (allow_http /
 	// allowed_cidrs) must stay closed.

--- a/pkg/ocm/provider/authorizer/open/open.go
+++ b/pkg/ocm/provider/authorizer/open/open.go
@@ -43,9 +43,16 @@ func New(ctx context.Context, m map[string]any) (provider.Authorizer, error) {
 	if err := cfg.Decode(m, &c); err != nil {
 		return nil, err
 	}
+	c.UntrustedClientSecurity.ApplyDefaults()
+	if err := c.UntrustedClientSecurity.Compile(); err != nil {
+		return nil, err
+	}
+	if err := c.UntrustedClientSecurity.RejectHatch(); err != nil {
+		return nil, err
+	}
 
 	a := &authorizer{
-		publicOCMClient: client.NewPublicOnlyClient(10*time.Second, c.Insecure),
+		publicOCMClient: client.NewPublicOnlyClient(10*time.Second, c.Insecure, c.UntrustedClientSecurity),
 	}
 	return a, nil
 }
@@ -56,6 +63,10 @@ type config struct {
 	// Insecure skips TLS verification when discovering an unknown provider. Off by
 	// default; turning it on exposes discovery to MITM.
 	Insecure bool `mapstructure:"insecure"`
+	// UntrustedClientSecurity configures MaxRedirects for discovery of unknown
+	// providers (TOML block ocm_client_security). The hatch (allow_http /
+	// allowed_cidrs) must stay closed.
+	UntrustedClientSecurity client.UntrustedClientSecurity `mapstructure:"ocm_client_security"`
 }
 
 func (c *config) ApplyDefaults() {

--- a/pkg/ocm/provider/authorizer/open/open.go
+++ b/pkg/ocm/provider/authorizer/open/open.go
@@ -44,7 +44,9 @@ func New(ctx context.Context, m map[string]any) (provider.Authorizer, error) {
 		return nil, err
 	}
 
-	a := &authorizer{insecure: c.Insecure}
+	a := &authorizer{
+		publicOCMClient: client.NewPublicOnlyClient(10*time.Second, c.Insecure),
+	}
 	return a, nil
 }
 
@@ -60,8 +62,8 @@ func (c *config) ApplyDefaults() {
 }
 
 type authorizer struct {
-	providers []*ocmprovider.ProviderInfo
-	insecure  bool
+	providers       []*ocmprovider.ProviderInfo
+	publicOCMClient *client.OCMClient
 }
 
 func (a *authorizer) GetInfoByDomain(ctx context.Context, domain string) (*ocmprovider.ProviderInfo, error) {
@@ -79,8 +81,7 @@ func (a *authorizer) GetInfoByDomain(ctx context.Context, domain string) (*ocmpr
 	}
 
 	// not yet known: try to discover the remote OCM endpoint
-	ocmClient := client.NewClient(time.Duration(10)*time.Second, a.insecure)
-	ocmCaps, err := ocmClient.Discover(ctx, endpoint)
+	ocmCaps, err := a.publicOCMClient.Discover(ctx, endpoint)
 	if err != nil {
 		return nil, errors.Wrap(err, "error probing OCM services at remote server")
 	}

--- a/pkg/ocm/provider/authorizer/open/open_test.go
+++ b/pkg/ocm/provider/authorizer/open/open_test.go
@@ -20,12 +20,14 @@ package open
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httptrace"
+	"reflect"
 	"sync"
 	"testing"
 
@@ -103,6 +105,72 @@ func TestConfigOCMResponseLimit(t *testing.T) {
 			}
 		})
 	}
+}
+
+func innerUntrustedTransport(t *testing.T, rt http.RoundTripper) *http.Transport {
+	t.Helper()
+	if tr, ok := rt.(*http.Transport); ok {
+		return tr
+	}
+	v := reflect.ValueOf(rt)
+	if v.Kind() == reflect.Pointer {
+		v = v.Elem()
+	}
+	if v.IsValid() && v.Kind() == reflect.Struct {
+		f := v.FieldByName("Transport")
+		if f.IsValid() && f.CanInterface() {
+			if tr, ok := f.Interface().(*http.Transport); ok && tr != nil {
+				return tr
+			}
+		}
+	}
+	t.Fatalf("untrusted transport: got %T, want an *http.Transport wrapper", rt)
+	return nil
+}
+
+func TestNewTLSMinVersion(t *testing.T) {
+	t.Parallel()
+
+	t.Run("configured 1.3 reaches the transport", func(t *testing.T) {
+		t.Parallel()
+		got, err := New(context.Background(), map[string]any{
+			"insecure":            true,
+			"ocm_tls_min_version": "1.3",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		a, ok := got.(*authorizer)
+		if !ok {
+			t.Fatalf("got %T, want *authorizer", got)
+		}
+		rt := clientUntrustedTransport(t, a)
+		if rt.TLSClientConfig == nil || rt.TLSClientConfig.MinVersion != tls.VersionTLS13 {
+			t.Fatalf("constructed transport MinVersion = %v, want TLS 1.3", rt.TLSClientConfig)
+		}
+	})
+
+	t.Run("invalid value fails service start", func(t *testing.T) {
+		t.Parallel()
+		_, err := New(context.Background(), map[string]any{
+			"insecure":            true,
+			"ocm_tls_min_version": "bogus",
+		})
+		if err == nil {
+			t.Fatal("expected open.New to reject invalid TLS min version")
+		}
+		if !errors.Is(err, ocmd.ErrInvalidTLSMinVersion) {
+			t.Fatalf("got %v, want ocmd.ErrInvalidTLSMinVersion", err)
+		}
+	})
+}
+
+func clientUntrustedTransport(t *testing.T, a *authorizer) *http.Transport {
+	t.Helper()
+	if a == nil || a.publicOCMClient == nil {
+		t.Fatal("public OCM client is nil")
+	}
+	return innerUntrustedTransport(t, a.publicOCMClient.HTTPTransport())
 }
 
 func newOpenAuthorizer(t *testing.T) *authorizer {

--- a/pkg/ocm/provider/authorizer/open/open_test.go
+++ b/pkg/ocm/provider/authorizer/open/open_test.go
@@ -30,6 +30,7 @@ import (
 	"reflect"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/cs3org/reva/v3/internal/http/services/opencloudmesh/ocmd"
 	"github.com/cs3org/reva/v3/pkg/utils/cfg"
@@ -403,5 +404,120 @@ func TestGetInfoByDomainPublicHTTPSHostSucceeds(t *testing.T) {
 	}
 	if info == nil || info.FullName != "public-host" {
 		t.Fatalf("unexpected provider info: %+v", info)
+	}
+}
+
+func TestConfigTimeout(t *testing.T) {
+	tests := []struct {
+		name        string
+		extra       map[string]any
+		wantTimeout int
+	}{
+		{name: "defaults when unset", extra: map[string]any{}, wantTimeout: 10},
+		{
+			name:        "parses configured timeout",
+			extra:       map[string]any{"timeout": 3},
+			wantTimeout: 3,
+		},
+		{
+			name:        "negative uses default",
+			extra:       map[string]any{"timeout": -1},
+			wantTimeout: 10,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input := map[string]any{"insecure": true}
+			for k, v := range tt.extra {
+				input[k] = v
+			}
+
+			var c config
+			if err := cfg.Decode(input, &c); err != nil {
+				t.Fatalf("cfg.Decode: %v", err)
+			}
+			if c.Timeout != tt.wantTimeout {
+				t.Errorf("Timeout = %d, want %d", c.Timeout, tt.wantTimeout)
+			}
+		})
+	}
+}
+
+func TestNewWiresTimeoutToAuthorizerClient(t *testing.T) {
+	t.Parallel()
+
+	got, err := New(context.Background(), map[string]any{
+		"insecure": true,
+		"timeout":  3,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	a, ok := got.(*authorizer)
+	if !ok {
+		t.Fatalf("got %T, want *authorizer", got)
+	}
+	if a.publicOCMClient.RequestTimeout() != 3*time.Second {
+		t.Fatalf("RequestTimeout = %v, want 3s", a.publicOCMClient.RequestTimeout())
+	}
+}
+
+func TestNewNormalizesNegativeTimeout(t *testing.T) {
+	t.Parallel()
+
+	got, err := New(context.Background(), map[string]any{
+		"insecure": true,
+		"timeout":  -1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	a, ok := got.(*authorizer)
+	if !ok {
+		t.Fatalf("got %T, want *authorizer", got)
+	}
+	if a.publicOCMClient.RequestTimeout() != 10*time.Second {
+		t.Fatalf("RequestTimeout = %v, want 10s", a.publicOCMClient.RequestTimeout())
+	}
+}
+
+func TestGetInfoByDomainHonorsConfiguredTimeout(t *testing.T) {
+	var startOnce sync.Once
+	started := make(chan struct{})
+	srv := startPublicTLSServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		startOnce.Do(func() { close(started) })
+		time.Sleep(2 * time.Second)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"enabled":    true,
+			"apiVersion": "1.2.0",
+			"endPoint":   "https://example.invalid/ocm",
+			"provider":   "slow-host",
+		})
+	}))
+
+	got, err := New(context.Background(), map[string]any{
+		"insecure": true,
+		"timeout":  1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	a := got.(*authorizer)
+
+	start := time.Now()
+	_, err = a.GetInfoByDomain(context.Background(), srv.URL)
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatal("expected configured timeout to bound a slow discovery peer")
+	}
+	if elapsed > 3*time.Second {
+		t.Fatalf("authorizer timeout was not applied; elapsed %v", elapsed)
+	}
+	select {
+	case <-started:
+	default:
+		t.Fatal("expected the slow discovery peer to accept the connection")
 	}
 }

--- a/pkg/ocm/provider/authorizer/open/open_test.go
+++ b/pkg/ocm/provider/authorizer/open/open_test.go
@@ -30,6 +30,7 @@ import (
 	"testing"
 
 	"github.com/cs3org/reva/v3/internal/http/services/opencloudmesh/ocmd"
+	"github.com/cs3org/reva/v3/pkg/utils/cfg"
 )
 
 func TestNewRejectsHatch(t *testing.T) {
@@ -64,6 +65,44 @@ func TestNewRejectsHatch(t *testing.T) {
 			t.Fatalf("got %v, want ocmd.ErrHatchAllowedCIDRs", err)
 		}
 	})
+}
+
+func TestConfigOCMResponseLimit(t *testing.T) {
+	tests := []struct {
+		name      string
+		extra     map[string]any
+		wantLimit int64
+	}{
+		{
+			name:      "defaults when unset",
+			extra:     map[string]any{},
+			wantLimit: 1 << 20,
+		},
+		{
+			name: "parses configured limit",
+			extra: map[string]any{
+				"ocm_response_limit": 2097152,
+			},
+			wantLimit: 2097152,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input := map[string]any{"insecure": true}
+			for k, v := range tt.extra {
+				input[k] = v
+			}
+
+			var c config
+			if err := cfg.Decode(input, &c); err != nil {
+				t.Fatalf("cfg.Decode: %v", err)
+			}
+			if c.OCMResponseLimit != tt.wantLimit {
+				t.Errorf("OCMResponseLimit = %d, want %d", c.OCMResponseLimit, tt.wantLimit)
+			}
+		})
+	}
 }
 
 func newOpenAuthorizer(t *testing.T) *authorizer {

--- a/pkg/ocm/provider/authorizer/open/open_test.go
+++ b/pkg/ocm/provider/authorizer/open/open_test.go
@@ -21,13 +21,50 @@ package open
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httptrace"
 	"sync"
 	"testing"
+
+	"github.com/cs3org/reva/v3/internal/http/services/opencloudmesh/ocmd"
 )
+
+func TestNewRejectsHatch(t *testing.T) {
+	t.Parallel()
+
+	t.Run("allow_http", func(t *testing.T) {
+		_, err := New(context.Background(), map[string]any{
+			"insecure": true,
+			"ocm_client_security": map[string]any{
+				"allow_http": true,
+			},
+		})
+		if err == nil {
+			t.Fatal("expected open.New to reject allow_http")
+		}
+		if !errors.Is(err, ocmd.ErrHatchAllowHTTP) {
+			t.Fatalf("got %v, want ocmd.ErrHatchAllowHTTP", err)
+		}
+	})
+
+	t.Run("allowed_cidrs", func(t *testing.T) {
+		_, err := New(context.Background(), map[string]any{
+			"insecure": true,
+			"ocm_client_security": map[string]any{
+				"allowed_cidrs": []string{"10.0.0.0/8"},
+			},
+		})
+		if err == nil {
+			t.Fatal("expected open.New to reject allowed_cidrs")
+		}
+		if !errors.Is(err, ocmd.ErrHatchAllowedCIDRs) {
+			t.Fatalf("got %v, want ocmd.ErrHatchAllowedCIDRs", err)
+		}
+	})
+}
 
 func newOpenAuthorizer(t *testing.T) *authorizer {
 	t.Helper()

--- a/pkg/ocm/provider/authorizer/open/open_test.go
+++ b/pkg/ocm/provider/authorizer/open/open_test.go
@@ -1,0 +1,263 @@
+// Copyright 2018-2026 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package open
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/http/httptrace"
+	"sync"
+	"testing"
+)
+
+func newOpenAuthorizer(t *testing.T) *authorizer {
+	t.Helper()
+	got, err := New(context.Background(), map[string]any{"insecure": true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	a, ok := got.(*authorizer)
+	if !ok {
+		t.Fatalf("got %T, want *authorizer", got)
+	}
+	return a
+}
+
+func firstPublicIPv4() (string, bool) {
+	addrs, err := net.InterfaceAddrs()
+	if err != nil {
+		return "", false
+	}
+	for _, a := range addrs {
+		n, ok := a.(*net.IPNet)
+		if !ok || n.IP == nil {
+			continue
+		}
+		ip := n.IP.To4()
+		if ip == nil || ip.IsLoopback() || ip.IsPrivate() || ip.IsUnspecified() ||
+			ip.IsLinkLocalUnicast() || ip.IsMulticast() {
+			continue
+		}
+		if ip[0] == 100 && ip[1]&0xc0 == 64 {
+			continue
+		}
+		return ip.String(), true
+	}
+	return "", false
+}
+
+func startPublicTLSServer(t *testing.T, h http.Handler) *httptest.Server {
+	t.Helper()
+	ip, ok := firstPublicIPv4()
+	if !ok {
+		t.Skip("no public IPv4 address available for public-only httptest")
+	}
+	ln, err := net.Listen("tcp", net.JoinHostPort(ip, "0"))
+	if err != nil {
+		t.Skipf("cannot listen on public IP %s: %v", ip, err)
+	}
+	srv := httptest.NewUnstartedServer(h)
+	if srv.Listener != nil {
+		_ = srv.Listener.Close()
+	}
+	srv.Listener = ln
+	srv.StartTLS()
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// hostDialTrace records hosts the HTTP client actually connected to.
+type hostDialTrace struct {
+	mu          sync.Mutex
+	established []string
+}
+
+func contextWithHostDialTrace(ctx context.Context) (context.Context, *hostDialTrace) {
+	tr := &hostDialTrace{established: []string{}}
+	ctx = httptrace.WithClientTrace(ctx, &httptrace.ClientTrace{
+		ConnectDone: func(_, addr string, err error) {
+			if err != nil {
+				return
+			}
+			tr.mu.Lock()
+			tr.established = append(tr.established, addr)
+			tr.mu.Unlock()
+		},
+		GotConn: func(info httptrace.GotConnInfo) {
+			if info.Conn == nil {
+				return
+			}
+			tr.mu.Lock()
+			tr.established = append(tr.established, info.Conn.RemoteAddr().String())
+			tr.mu.Unlock()
+		},
+	})
+	return ctx, tr
+}
+
+func hostOf(addr string) string {
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		host = addr
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		if ip4 := ip.To4(); ip4 != nil {
+			return ip4.String()
+		}
+		return ip.String()
+	}
+	return host
+}
+
+func (tr *hostDialTrace) establishedHost(host string) bool {
+	tr.mu.Lock()
+	defer tr.mu.Unlock()
+	for _, addr := range tr.established {
+		if hostOf(addr) == host {
+			return true
+		}
+	}
+	return false
+}
+
+func assertNoEstablishedHost(t *testing.T, tr *hostDialTrace, host string) {
+	t.Helper()
+	if tr.establishedHost(host) {
+		t.Fatalf("public-only client established a connection to %s", host)
+	}
+}
+
+func TestGetInfoByDomainUsesPublicOnlyClient(t *testing.T) {
+	var srv *httptest.Server
+	fetched := false
+	srv = httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fetched = true
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"enabled":    true,
+			"apiVersion": "1.2.0",
+			"endPoint":   srv.URL + "/ocm",
+			"provider":   "loopback",
+			"resourceTypes": []any{
+				map[string]any{
+					"name":      "file",
+					"protocols": map[string]any{"webdav": "/remote.php/dav/ocm"},
+				},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	a := newOpenAuthorizer(t)
+	_, err := a.GetInfoByDomain(context.Background(), srv.URL)
+	if fetched {
+		t.Fatal("GetInfoByDomain fetched a loopback discovery host; the public-only client must refuse it at dial")
+	}
+	if err == nil {
+		t.Fatal("GetInfoByDomain must refuse body-supplied discovery to a private loopback host")
+	}
+}
+
+func TestGetInfoByDomainRefusesPrivateAndMetadataHosts(t *testing.T) {
+	a := newOpenAuthorizer(t)
+
+	tests := []struct {
+		name   string
+		domain string
+		host   string
+	}{
+		{name: "cloud metadata service", domain: "169.254.169.254", host: "169.254.169.254"},
+		{name: "loopback", domain: "127.0.0.1", host: "127.0.0.1"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, tr := contextWithHostDialTrace(context.Background())
+			_, err := a.GetInfoByDomain(ctx, tt.domain)
+			assertNoEstablishedHost(t, tr, tt.host)
+			if err == nil {
+				t.Fatal("expected body-supplied discovery to a private or metadata host to fail")
+			}
+		})
+	}
+
+	t.Run("reachable private host is not contacted", func(t *testing.T) {
+		fetched := false
+		srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fetched = true
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"enabled":    true,
+				"apiVersion": "1.2.0",
+				"endPoint":   "https://127.0.0.1/ocm",
+				"provider":   "loopback",
+			})
+		}))
+		defer srv.Close()
+
+		loopHost, _, err := net.SplitHostPort(srv.Listener.Addr().String())
+		if err != nil {
+			t.Fatal(err)
+		}
+		ctx, tr := contextWithHostDialTrace(context.Background())
+		_, err = a.GetInfoByDomain(ctx, srv.URL)
+		if fetched {
+			t.Fatal("GetInfoByDomain fetched a private discovery host; the public-only client must refuse it at dial")
+		}
+		assertNoEstablishedHost(t, tr, loopHost)
+		if err == nil {
+			t.Fatal("expected body-supplied discovery to a private host to fail")
+		}
+	})
+}
+
+func TestGetInfoByDomainPublicHTTPSHostSucceeds(t *testing.T) {
+	var srv *httptest.Server
+	srv = startPublicTLSServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/.well-known/ocm" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"enabled":    true,
+			"apiVersion": "1.2.0",
+			"endPoint":   srv.URL + "/ocm",
+			"provider":   "public-host",
+			"resourceTypes": []any{
+				map[string]any{
+					"name":      "file",
+					"protocols": map[string]any{"webdav": "/remote.php/dav/ocm"},
+				},
+			},
+		})
+	}))
+
+	a := newOpenAuthorizer(t)
+	info, err := a.GetInfoByDomain(context.Background(), srv.URL)
+	if err != nil {
+		t.Fatalf("GetInfoByDomain() on a public HTTPS host: %v", err)
+	}
+	if info == nil || info.FullName != "public-host" {
+		t.Fatalf("unexpected provider info: %+v", info)
+	}
+}

--- a/pkg/ocm/provider/authorizer/open/untrusted_hardening_regression_test.go
+++ b/pkg/ocm/provider/authorizer/open/untrusted_hardening_regression_test.go
@@ -1,0 +1,125 @@
+// Copyright 2018-2026 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package open
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/cs3org/reva/v3/internal/http/services/opencloudmesh/ocmd"
+)
+
+// TestUntrustedHardeningRegression proves open.New wires the shared
+// public-only client. Per-host matrices stay in open_test.go.
+func TestUntrustedHardeningRegression(t *testing.T) {
+	got, err := New(context.Background(), map[string]any{"insecure": true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	a, ok := got.(*authorizer)
+	if !ok {
+		t.Fatalf("got %T, want *authorizer", got)
+	}
+	if a.publicOCMClient == nil {
+		t.Fatal("open.New must construct a public-only OCM client")
+	}
+
+	t.Run("HTTP is refused", func(t *testing.T) {
+		fetched := false
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fetched = true
+			w.WriteHeader(http.StatusOK)
+		}))
+		t.Cleanup(srv.Close)
+
+		resp, err := roundTripConstructor(t, a.publicOCMClient, srv.URL)
+		if resp != nil && resp.Body != nil {
+			_ = resp.Body.Close()
+		}
+		if fetched {
+			t.Fatal("open.New client must not fetch HTTP")
+		}
+		if !errors.Is(err, ocmd.ErrNonHTTPS) {
+			t.Fatalf("got %v, want ocmd.ErrNonHTTPS", err)
+		}
+	})
+
+	t.Run("metadata host is refused", func(t *testing.T) {
+		ctx, tr := contextWithHostDialTrace(context.Background())
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://169.254.169.254/", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp, err := a.publicOCMClient.HTTPTransport().RoundTrip(req)
+		if resp != nil && resp.Body != nil {
+			_ = resp.Body.Close()
+		}
+		assertNoEstablishedHost(t, tr, "169.254.169.254")
+		if !errors.Is(err, ocmd.ErrNonPublicAddr) {
+			t.Fatalf("got %v, want ocmd.ErrNonPublicAddr", err)
+		}
+	})
+
+	t.Run("public HTTPS discovery succeeds", func(t *testing.T) {
+		var srv *httptest.Server
+		srv = startPublicTLSServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/.well-known/ocm" {
+				http.NotFound(w, r)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"enabled":    true,
+				"apiVersion": "1.2.0",
+				"endPoint":   srv.URL + "/ocm",
+				"provider":   "public-host",
+				"resourceTypes": []any{
+					map[string]any{
+						"name":      "file",
+						"protocols": map[string]any{"webdav": "/remote.php/dav/ocm"},
+					},
+				},
+			})
+		}))
+
+		info, err := a.GetInfoByDomain(context.Background(), srv.URL)
+		if err != nil {
+			t.Fatalf("GetInfoByDomain on a public HTTPS host: %v", err)
+		}
+		if info == nil || info.FullName != "public-host" {
+			t.Fatalf("unexpected provider info: %+v", info)
+		}
+	})
+}
+
+func roundTripConstructor(t *testing.T, c *ocmd.OCMClient, rawURL string) (*http.Response, error) {
+	t.Helper()
+	if c == nil || c.HTTPTransport() == nil {
+		t.Fatal("constructor-wired client has no transport")
+	}
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, rawURL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return c.HTTPTransport().RoundTrip(req)
+}

--- a/pkg/ocm/storage/received/ocm.go
+++ b/pkg/ocm/storage/received/ocm.go
@@ -77,12 +77,18 @@ type config struct {
 	GatewaySVC        string `mapstructure:"gatewaysvc"`
 	OCMClientTimeout  int    `mapstructure:"ocm_timeout"`
 	OCMClientInsecure bool   `mapstructure:"ocm_insecure"`
+	// OCMResponseLimit caps outbound OCM JSON response bodies in bytes.
+	// Zero means 1 MiB. WebDAV file streams are not capped.
+	OCMResponseLimit int64 `mapstructure:"ocm_response_limit"`
 }
 
 func (c *config) ApplyDefaults() {
 	c.GatewaySVC = sharedconf.GetGatewaySVC(c.GatewaySVC)
 	if c.OCMClientTimeout == 0 {
 		c.OCMClientTimeout = 10
+	}
+	if c.OCMResponseLimit == 0 {
+		c.OCMResponseLimit = 1 << 20
 	}
 }
 
@@ -118,6 +124,7 @@ func New(ctx context.Context, m map[string]any) (storage.FS, error) {
 			time.Duration(c.OCMClientTimeout)*time.Second,
 			c.OCMClientInsecure,
 			sec,
+			c.OCMResponseLimit,
 		),
 		sec: sec,
 	}

--- a/pkg/ocm/storage/received/ocm.go
+++ b/pkg/ocm/storage/received/ocm.go
@@ -71,6 +71,7 @@ type driver struct {
 	discoveryCache *ttlcache.Cache
 	ocmClient      *ocmd.OCMClient
 	sec            ocmd.UntrustedClientSecurity
+	tlsMinVersion  uint16
 }
 
 type config struct {
@@ -80,6 +81,9 @@ type config struct {
 	// OCMResponseLimit caps outbound OCM JSON response bodies in bytes.
 	// Zero means 1 MiB. WebDAV file streams are not capped.
 	OCMResponseLimit int64 `mapstructure:"ocm_response_limit"`
+	// OCMTLSMinVersion is the untrusted-client TLS minimum enum string.
+	// Empty means TLS 1.2. Accepted values are "1.2" and "1.3".
+	OCMTLSMinVersion string `mapstructure:"ocm_tls_min_version"`
 }
 
 func (c *config) ApplyDefaults() {
@@ -97,6 +101,10 @@ func (c *config) ApplyDefaults() {
 func New(ctx context.Context, m map[string]any) (storage.FS, error) {
 	var c config
 	if err := cfg.Decode(m, &c); err != nil {
+		return nil, err
+	}
+	minVersion, err := ocmd.ParseTLSMinVersion(c.OCMTLSMinVersion)
+	if err != nil {
 		return nil, err
 	}
 
@@ -125,8 +133,10 @@ func New(ctx context.Context, m map[string]any) (storage.FS, error) {
 			c.OCMClientInsecure,
 			sec,
 			c.OCMResponseLimit,
+			minVersion,
 		),
-		sec: sec,
+		sec:           sec,
+		tlsMinVersion: minVersion,
 	}
 	return d, nil
 }
@@ -303,7 +313,12 @@ func (d *driver) newReceivedWebDAVClient(endpoint string) *gowebdav.Client {
 		insecure = d.c.OCMClientInsecure
 	}
 	c := gowebdav.NewClient(endpoint, "", "")
-	c.SetTransport(ocmd.UntrustedHTTPTransport(timeout, insecure, d.sec))
+	c.SetTransport(ocmd.UntrustedHTTPTransport(
+		timeout,
+		insecure,
+		d.sec,
+		d.tlsMinVersion,
+	))
 	return c
 }
 

--- a/pkg/ocm/storage/received/ocm.go
+++ b/pkg/ocm/storage/received/ocm.go
@@ -59,7 +59,8 @@ func init() {
 }
 
 type cachedClient struct {
-	client     *gowebdav.Client
+	metadata   *gowebdav.Client
+	stream     *gowebdav.Client
 	share      *ocmpb.ReceivedShare
 	authHeader string
 }
@@ -84,15 +85,32 @@ type config struct {
 	// OCMTLSMinVersion is the untrusted-client TLS minimum enum string.
 	// Empty means TLS 1.2. Accepted values are "1.2" and "1.3".
 	OCMTLSMinVersion string `mapstructure:"ocm_tls_min_version"`
+	// WebDAVDialTimeout is the untrusted-transport net.Dialer timeout
+	// in seconds for peer-supplied WebDAV URLs. Zero or negative means 10s.
+	WebDAVDialTimeout int `mapstructure:"webdav_dial_timeout"`
+	// WebDAVTimeout is the gowebdav SetTimeout for metadata requests
+	// (Stat, ReadDir, unary ops) in seconds. Zero or negative means 30s.
+	WebDAVTimeout int `mapstructure:"webdav_timeout"`
+	// WebDAVTransferTimeout is accepted for operators but reserved for the
+	// idle-stall monitor follow-up. Zero (the default) means no stream cap
+	// and emits no warning. A nonzero value is ignored so stream clients
+	// stay uncapped; it is not applied as Client.Timeout or SetTimeout.
+	WebDAVTransferTimeout int `mapstructure:"webdav_transfer_timeout"`
 }
 
 func (c *config) ApplyDefaults() {
 	c.GatewaySVC = sharedconf.GetGatewaySVC(c.GatewaySVC)
-	if c.OCMClientTimeout == 0 {
+	if c.OCMClientTimeout <= 0 {
 		c.OCMClientTimeout = 10
 	}
 	if c.OCMResponseLimit == 0 {
 		c.OCMResponseLimit = 1 << 20
+	}
+	if c.WebDAVDialTimeout <= 0 {
+		c.WebDAVDialTimeout = 10
+	}
+	if c.WebDAVTimeout <= 0 {
+		c.WebDAVTimeout = 30
 	}
 }
 
@@ -102,6 +120,12 @@ func New(ctx context.Context, m map[string]any) (storage.FS, error) {
 	var c config
 	if err := cfg.Decode(m, &c); err != nil {
 		return nil, err
+	}
+	if c.WebDAVTransferTimeout != 0 {
+		appctx.GetLogger(ctx).Warn().
+			Int("webdav_transfer_timeout", c.WebDAVTransferTimeout).
+			Msg("webdav_transfer_timeout is reserved for the idle-stall monitor (follow-up); " +
+				"streams remain uncapped for now")
 	}
 	minVersion, err := ocmd.ParseTLSMinVersion(c.OCMTLSMinVersion)
 	if err != nil {
@@ -300,64 +324,105 @@ func (e invalidCredsCause) Error() string {
 
 func (e invalidCredsCause) Unwrap() error { return e.cause }
 
-// newReceivedWebDAVClient builds a gowebdav client for a peer-supplied
-// received-share WebDAV URL. The URL is attacker-influenced, so the client
-// uses UntrustedHTTPTransport.
-func (d *driver) newReceivedWebDAVClient(endpoint string) *gowebdav.Client {
-	timeout := 10 * time.Second
-	insecure := false
+func (d *driver) ocmInsecure() bool {
 	if d.c != nil {
-		if d.c.OCMClientTimeout > 0 {
-			timeout = time.Duration(d.c.OCMClientTimeout) * time.Second
-		}
-		insecure = d.c.OCMClientInsecure
+		return d.c.OCMClientInsecure
 	}
+	return false
+}
+
+func (d *driver) webdavDialTimeout() time.Duration {
+	if d.c != nil && d.c.WebDAVDialTimeout > 0 {
+		return time.Duration(d.c.WebDAVDialTimeout) * time.Second
+	}
+	return 10 * time.Second
+}
+
+func (d *driver) webdavRequestTimeout() time.Duration {
+	if d.c != nil && d.c.WebDAVTimeout > 0 {
+		return time.Duration(d.c.WebDAVTimeout) * time.Second
+	}
+	return 30 * time.Second
+}
+
+func (d *driver) applyReceivedAuth(c *gowebdav.Client, authHdr string) {
+	c.SetHeader("Authorization", authHdr)
+}
+
+func (d *driver) pairReceivedWebDAVClients(endpoint, authHdr string) (*gowebdav.Client, *gowebdav.Client) {
+	meta := d.newReceivedWebDAVClient(endpoint)
+	d.applyReceivedAuth(meta, authHdr)
+	stream := d.newReceivedWebDAVStreamClient(endpoint)
+	d.applyReceivedAuth(stream, authHdr)
+	return meta, stream
+}
+
+// newReceivedWebDAVClient builds a metadata gowebdav client for a
+// peer-supplied received-share WebDAV URL. The URL is attacker-influenced,
+// so the client uses UntrustedHTTPTransport plus SetTimeout.
+func (d *driver) newReceivedWebDAVClient(endpoint string) *gowebdav.Client {
 	c := gowebdav.NewClient(endpoint, "", "")
 	c.SetTransport(ocmd.UntrustedHTTPTransport(
-		timeout,
-		insecure,
+		d.webdavDialTimeout(),
+		d.ocmInsecure(),
+		d.sec,
+		d.tlsMinVersion,
+	))
+	c.SetTimeout(d.webdavRequestTimeout())
+	return c
+}
+
+// newReceivedWebDAVStreamClient builds a stream gowebdav client for
+// ReadStream/WriteStream. It uses the untrusted transport for dial/scheme
+// policy and does not call SetTimeout or set http.Client.Timeout.
+// webdav_transfer_timeout is accepted but reserved for the idle-stall
+// monitor follow-up; a nonzero value is ignored here so streams stay
+// uncapped. received has no idle-stall monitor unlike embedded, so a
+// slow-drip peer can still hang mid-body until that follow-up lands.
+func (d *driver) newReceivedWebDAVStreamClient(endpoint string) *gowebdav.Client {
+	c := gowebdav.NewClient(endpoint, "", "")
+	c.SetTransport(ocmd.UntrustedHTTPTransport(
+		d.webdavDialTimeout(),
+		d.ocmInsecure(),
 		d.sec,
 		d.tlsMinVersion,
 	))
 	return c
 }
 
-func (d *driver) webdavClient(ctx context.Context, ref *provider.Reference) (*gowebdav.Client, *ocmpb.ReceivedShare, string, error) {
+func (d *driver) resolveReceivedWebDAV(ctx context.Context, ref *provider.Reference) (*cachedClient, string, error) {
 	log := appctx.GetLogger(ctx)
 	id, rel := shareInfoFromReference(ref)
 
 	share, endpoint, secret, err := d.getWebDAVFromShare(ctx, id)
 	if err != nil {
-		return nil, nil, "", err
+		return nil, "", err
 	}
 	endpoint, err = url.PathUnescape(endpoint)
 	if err != nil {
-		return nil, nil, "", err
+		return nil, "", err
 	}
 
 	if !requiresExchange(share.Protocols) {
-		// legacy path: check cache first
 		if entry, err := d.ccache.Get(id.OpaqueId); err == nil {
 			cc := entry.(*cachedClient)
 			log.Info().Str("shareId", cc.share.GetId().GetOpaqueId()).Str("rel", rel).Msg("accessing OCM share via cached client")
-			return cc.client, cc.share, rel, nil
+			return cc, rel, nil
 		}
 
-		// build legacy client: try bearer (OCM v1.1+), then basic (OCM v1.0)
-		var c *gowebdav.Client
-		var authHdr string
 		bearerHdr := "Bearer " + secret
-		c = d.newReceivedWebDAVClient(endpoint)
-		c.SetHeader("Authorization", bearerHdr)
-		_, err = c.Stat("")
+		meta := d.newReceivedWebDAVClient(endpoint)
+		d.applyReceivedAuth(meta, bearerHdr)
+		_, err = meta.Stat("")
+		var authHdr string
 		if err != nil {
 			basicHdr := "Basic " + base64.StdEncoding.EncodeToString([]byte(secret+":"))
-			c = d.newReceivedWebDAVClient(endpoint)
-			c.SetHeader("Authorization", basicHdr)
-			_, err2 := c.Stat("")
+			meta = d.newReceivedWebDAVClient(endpoint)
+			d.applyReceivedAuth(meta, basicHdr)
+			_, err2 := meta.Stat("")
 			if err2 != nil {
 				log.Info().Any("former_error", err).Err(err2).Str("endpoint", endpoint).Str("shareId", share.GetId().GetOpaqueId()).Msg("failed accessing OCM share")
-				return nil, nil, "", invalidCredsCause{
+				return nil, "", invalidCredsCause{
 					InvalidCredentials: "error accessing OCM share",
 					cause:              err2,
 				}
@@ -369,22 +434,50 @@ func (d *driver) webdavClient(ctx context.Context, ref *provider.Reference) (*go
 			log.Info().Str("endpoint", endpoint).Str("shareId", share.GetId().GetOpaqueId()).Str("mode", "bearer").Msg("access to remote OCM share succeeded")
 		}
 
-		d.ccache.SetWithTTL(id.OpaqueId, &cachedClient{client: c, share: share, authHeader: authHdr}, time.Hour)
-		return c, share, rel, nil
+		stream := d.newReceivedWebDAVStreamClient(endpoint)
+		d.applyReceivedAuth(stream, authHdr)
+		cc := &cachedClient{
+			metadata:   meta,
+			stream:     stream,
+			share:      share,
+			authHeader: authHdr,
+		}
+		d.ccache.SetWithTTL(id.OpaqueId, cc, time.Hour)
+		return cc, rel, nil
 	}
 
-	// code-flow path: exchange token every time, no cache
 	tokenEndpoint, err := d.getTokenEndpoint(ctx, share)
 	if err != nil {
-		return nil, nil, "", errors.Wrap(err, "could not discover token endpoint for code-flow share")
+		return nil, "", errors.Wrap(err, "could not discover token endpoint for code-flow share")
 	}
 	accessToken, err := d.exchangeAccessToken(ctx, share, tokenEndpoint, secret)
 	if err != nil {
-		return nil, nil, "", errors.Wrap(err, "token exchange failed")
+		return nil, "", errors.Wrap(err, "token exchange failed")
 	}
-	c := d.newReceivedWebDAVClient(endpoint)
-	c.SetHeader("Authorization", "Bearer "+accessToken)
-	return c, share, rel, nil
+	authHdr := "Bearer " + accessToken
+	meta, stream := d.pairReceivedWebDAVClients(endpoint, authHdr)
+	return &cachedClient{
+		metadata:   meta,
+		stream:     stream,
+		share:      share,
+		authHeader: authHdr,
+	}, rel, nil
+}
+
+func (d *driver) webdavClient(ctx context.Context, ref *provider.Reference) (*gowebdav.Client, *ocmpb.ReceivedShare, string, error) {
+	cc, rel, err := d.resolveReceivedWebDAV(ctx, ref)
+	if err != nil {
+		return nil, nil, "", err
+	}
+	return cc.metadata, cc.share, rel, nil
+}
+
+func (d *driver) webdavStreamClient(ctx context.Context, ref *provider.Reference) (*gowebdav.Client, *ocmpb.ReceivedShare, string, error) {
+	cc, rel, err := d.resolveReceivedWebDAV(ctx, ref)
+	if err != nil {
+		return nil, nil, "", err
+	}
+	return cc.stream, cc.share, rel, nil
 }
 
 // withExchangeRetry wraps a unary DAV operation (CreateDir, Delete, TouchFile).
@@ -617,7 +710,7 @@ func (d *driver) InitiateUpload(ctx context.Context, ref *provider.Reference, _ 
 // uploadOnFreshClient creates a one-off DAV client for the upload so that
 // Upload-Length: -1 does not leak onto a cached client used by later operations.
 func (d *driver) uploadOnFreshClient(endpoint, authHeader, rel string, body io.Reader) error {
-	c := d.newReceivedWebDAVClient(endpoint)
+	c := d.newReceivedWebDAVStreamClient(endpoint)
 	c.SetHeader("Authorization", authHeader)
 	c.SetHeader(ocdav.HeaderUploadLength, "-1")
 	return c.WriteStream(rel, body, 0)
@@ -703,7 +796,7 @@ func (d *driver) uploadAuth(ctx context.Context, share *ocmpb.ReceivedShare, end
 // withExchangeDownloadOpenRetry wraps ReadStream open with a single 401 retry.
 // Once a stream is returned, no mid-stream recovery is attempted.
 func (d *driver) withExchangeDownloadOpenRetry(ctx context.Context, ref *provider.Reference, fn func(*gowebdav.Client, string) (io.ReadCloser, error)) (io.ReadCloser, error) {
-	client, _, rel, err := d.webdavClient(ctx, ref)
+	client, _, rel, err := d.webdavStreamClient(ctx, ref)
 	if err != nil {
 		return nil, err
 	}
@@ -716,7 +809,7 @@ func (d *driver) withExchangeDownloadOpenRetry(ctx context.Context, ref *provide
 	}
 	id, _ := shareInfoFromReference(ref)
 	d.ccache.Remove(id.OpaqueId)
-	client, _, rel, err = d.webdavClient(ctx, ref)
+	client, _, rel, err = d.webdavStreamClient(ctx, ref)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ocm/storage/received/ocm.go
+++ b/pkg/ocm/storage/received/ocm.go
@@ -254,6 +254,23 @@ func (d *driver) exchangeAccessToken(ctx context.Context, share *ocmpb.ReceivedS
 	return accessToken, nil
 }
 
+// newReceivedWebDAVClient builds a gowebdav client for a peer-supplied
+// received-share WebDAV URL. The URL is attacker-influenced, so the client
+// uses UntrustedHTTPTransport.
+func (d *driver) newReceivedWebDAVClient(endpoint string) *gowebdav.Client {
+	timeout := 10 * time.Second
+	insecure := false
+	if d != nil && d.c != nil {
+		if d.c.OCMClientTimeout > 0 {
+			timeout = time.Duration(d.c.OCMClientTimeout) * time.Second
+		}
+		insecure = d.c.OCMClientInsecure
+	}
+	c := gowebdav.NewClient(endpoint, "", "")
+	c.SetTransport(ocmd.UntrustedHTTPTransport(timeout, insecure))
+	return c
+}
+
 func (d *driver) webdavClient(ctx context.Context, ref *provider.Reference) (*gowebdav.Client, *ocmpb.ReceivedShare, string, error) {
 	log := appctx.GetLogger(ctx)
 	id, rel := shareInfoFromReference(ref)
@@ -279,12 +296,12 @@ func (d *driver) webdavClient(ctx context.Context, ref *provider.Reference) (*go
 		var c *gowebdav.Client
 		var authHdr string
 		bearerHdr := "Bearer " + secret
-		c = gowebdav.NewClient(endpoint, "", "")
+		c = d.newReceivedWebDAVClient(endpoint)
 		c.SetHeader("Authorization", bearerHdr)
 		_, err = c.Stat("")
 		if err != nil {
 			basicHdr := "Basic " + base64.StdEncoding.EncodeToString([]byte(secret+":"))
-			c = gowebdav.NewClient(endpoint, "", "")
+			c = d.newReceivedWebDAVClient(endpoint)
 			c.SetHeader("Authorization", basicHdr)
 			_, err2 := c.Stat("")
 			if err2 != nil {
@@ -311,7 +328,7 @@ func (d *driver) webdavClient(ctx context.Context, ref *provider.Reference) (*go
 	if err != nil {
 		return nil, nil, "", errors.Wrap(err, "token exchange failed")
 	}
-	c := gowebdav.NewClient(endpoint, "", "")
+	c := d.newReceivedWebDAVClient(endpoint)
 	c.SetHeader("Authorization", "Bearer "+accessToken)
 	return c, share, rel, nil
 }
@@ -545,8 +562,8 @@ func (d *driver) InitiateUpload(ctx context.Context, ref *provider.Reference, _ 
 
 // uploadOnFreshClient creates a one-off DAV client for the upload so that
 // Upload-Length: -1 does not leak onto a cached client used by later operations.
-func uploadOnFreshClient(endpoint, authHeader, rel string, body io.Reader) error {
-	c := gowebdav.NewClient(endpoint, "", "")
+func (d *driver) uploadOnFreshClient(endpoint, authHeader, rel string, body io.Reader) error {
+	c := d.newReceivedWebDAVClient(endpoint)
 	c.SetHeader("Authorization", authHeader)
 	c.SetHeader(ocdav.HeaderUploadLength, "-1")
 	return c.WriteStream(rel, body, 0)
@@ -575,7 +592,7 @@ func (d *driver) Upload(ctx context.Context, ref *provider.Reference, r io.ReadC
 		return err
 	}
 
-	err = uploadOnFreshClient(endpoint, authHeader, rel, bytes.NewReader(buf))
+	err = d.uploadOnFreshClient(endpoint, authHeader, rel, bytes.NewReader(buf))
 	if err == nil {
 		return nil
 	}
@@ -597,7 +614,7 @@ func (d *driver) Upload(ctx context.Context, ref *provider.Reference, r io.ReadC
 	if err != nil {
 		return err
 	}
-	if err = uploadOnFreshClient(endpoint, authHeader, rel, bytes.NewReader(buf)); err != nil {
+	if err = d.uploadOnFreshClient(endpoint, authHeader, rel, bytes.NewReader(buf)); err != nil {
 		if isWebDAV401(err) {
 			return errtypes.InvalidCredentials("remote OCM upload denied after token re-exchange")
 		}

--- a/pkg/ocm/storage/received/ocm.go
+++ b/pkg/ocm/storage/received/ocm.go
@@ -106,7 +106,7 @@ func New(ctx context.Context, m map[string]any) (storage.FS, error) {
 		gateway:        gateway,
 		ccache:         ttlcache.NewCache(),
 		discoveryCache: disco,
-		ocmClient:      ocmd.NewClient(time.Duration(c.OCMClientTimeout)*time.Second, c.OCMClientInsecure),
+		ocmClient:      ocmd.NewPublicOnlyClient(time.Duration(c.OCMClientTimeout)*time.Second, c.OCMClientInsecure),
 	}
 	return d, nil
 }

--- a/pkg/ocm/storage/received/ocm.go
+++ b/pkg/ocm/storage/received/ocm.go
@@ -80,17 +80,19 @@ type config struct {
 	GatewaySVC        string `mapstructure:"gatewaysvc"`
 	OCMClientTimeout  int    `mapstructure:"ocm_timeout"`
 	OCMClientInsecure bool   `mapstructure:"ocm_insecure"`
-	// OCMResponseLimit caps outbound OCM JSON response bodies in bytes.
-	// Zero means 1 MiB. WebDAV file streams are not capped.
+	// OCMResponseLimit caps outbound OCM JSON response bodies. Zero selects
+	// the package default. WebDAV file streams are not capped.
 	OCMResponseLimit int64 `mapstructure:"ocm_response_limit"`
-	// OCMTLSMinVersion is the untrusted-client TLS minimum enum string.
-	// Empty means TLS 1.2. Accepted values are "1.2" and "1.3".
+	// OCMTLSMinVersion is the untrusted-client TLS-minimum knob. Empty
+	// selects ParseTLSMinVersion's default.
 	OCMTLSMinVersion string `mapstructure:"ocm_tls_min_version"`
 	// WebDAVDialTimeout is the untrusted-transport net.Dialer timeout
-	// in seconds for peer-supplied WebDAV URLs. Zero or negative means 10s.
+	// in seconds for peer-supplied WebDAV URLs. Zero or negative selects
+	// the dial-timeout default.
 	WebDAVDialTimeout int `mapstructure:"webdav_dial_timeout"`
 	// WebDAVTimeout is the gowebdav SetTimeout for metadata requests
-	// (Stat, ReadDir, unary ops) in seconds. Zero or negative means 30s.
+	// (Stat, ReadDir, unary ops) in seconds. Zero or negative selects
+	// the metadata-request default. Stream clients do not use this knob.
 	WebDAVTimeout int `mapstructure:"webdav_timeout"`
 	// WebDAVTransferTimeout is accepted for operators but reserved for the
 	// idle-stall monitor follow-up. Zero (the default) means no stream cap
@@ -99,11 +101,11 @@ type config struct {
 	WebDAVTransferTimeout int `mapstructure:"webdav_transfer_timeout"`
 	// OCMAllowLoopbackFederation, when true, opts received WebDAV into
 	// an additive dial hatch: public federation peers remain allowed, and
-	// loopback (127.0.0.0/8 and ::1) is also accepted. Discovery and
-	// token exchange stay public-only. Non-loopback private and reserved
-	// ranges stay refused. It is off by default. Enabling it weakens
-	// SSRF protection for received WebDAV only; it does not allow HTTP,
-	// private ranges, or disable other untrusted-client guards.
+	// loopback is also accepted. Discovery and token exchange stay
+	// public-only. Non-loopback private and reserved ranges stay refused.
+	// Enabling it weakens SSRF protection for received WebDAV only; it
+	// does not allow HTTP, private ranges, or disable other untrusted-client
+	// guards.
 	OCMAllowLoopbackFederation bool `mapstructure:"ocm_allow_loopback_federation"`
 }
 
@@ -149,14 +151,8 @@ func New(ctx context.Context, m map[string]any) (storage.FS, error) {
 	disco := ttlcache.NewCache()
 	_ = disco.SetTTL(5 * time.Minute)
 
-	// ocm_allow_loopback_federation is ADDITIVE and WebDAV-only:
-	// public peers stay allowed (public + loopback) on received
-	// WebDAV metadata and stream clients. Discovery and token
-	// exchange stay public-only. Only non-loopback private peers
-	// are refused. It is for local development and specific
-	// federation scenarios, off by default, and weakens SSRF
-	// protection for received WebDAV only. HTTPS and the other
-	// untrusted-client guards stay in force on both clients.
+	// Additive WebDAV-only hatch: public peers stay allowed; loopback is
+	// also accepted. Discovery and token exchange stay public-only.
 	var webdavSec ocmd.UntrustedClientSecurity
 	if c.OCMAllowLoopbackFederation {
 		appctx.GetLogger(ctx).Warn().
@@ -393,7 +389,8 @@ func (d *driver) pairReceivedWebDAVClients(endpoint, authHdr string) (*gowebdav.
 
 // newReceivedWebDAVClient builds a metadata gowebdav client for a
 // peer-supplied received-share WebDAV URL. The URL is attacker-influenced,
-// so the client uses UntrustedHTTPTransport plus SetTimeout.
+// so the client uses UntrustedHTTPTransport. SetTimeout applies the
+// metadata-request knob so Stat/ReadDir cannot hang the worker.
 func (d *driver) newReceivedWebDAVClient(endpoint string) *gowebdav.Client {
 	c := gowebdav.NewClient(endpoint, "", "")
 	c.SetTransport(ocmd.UntrustedHTTPTransport(
@@ -408,11 +405,11 @@ func (d *driver) newReceivedWebDAVClient(endpoint string) *gowebdav.Client {
 
 // newReceivedWebDAVStreamClient builds a stream gowebdav client for
 // ReadStream/WriteStream. It uses the untrusted transport for dial/scheme
-// policy and does not call SetTimeout or set http.Client.Timeout.
-// webdav_transfer_timeout is accepted but reserved for the idle-stall
-// monitor follow-up; a nonzero value is ignored here so streams stay
-// uncapped. received has no idle-stall monitor unlike embedded, so a
-// slow-drip peer can still hang mid-body until that follow-up lands.
+// policy and does not set Client.Timeout or call SetTimeout, so a large
+// transfer is not truncated. webdav_transfer_timeout is reserved for the
+// idle-stall monitor follow-up and is ignored here. Unlike embedded,
+// received streams have no idle-stall monitor, so a slow-drip peer can
+// hang mid-body until that follow-up lands.
 func (d *driver) newReceivedWebDAVStreamClient(endpoint string) *gowebdav.Client {
 	c := gowebdav.NewClient(endpoint, "", "")
 	c.SetTransport(ocmd.UntrustedHTTPTransport(

--- a/pkg/ocm/storage/received/ocm.go
+++ b/pkg/ocm/storage/received/ocm.go
@@ -72,6 +72,7 @@ type driver struct {
 	discoveryCache *ttlcache.Cache
 	ocmClient      *ocmd.OCMClient
 	sec            ocmd.UntrustedClientSecurity
+	discoverySec   ocmd.UntrustedClientSecurity
 	tlsMinVersion  uint16
 }
 
@@ -96,6 +97,14 @@ type config struct {
 	// and emits no warning. A nonzero value is ignored so stream clients
 	// stay uncapped; it is not applied as Client.Timeout or SetTimeout.
 	WebDAVTransferTimeout int `mapstructure:"webdav_transfer_timeout"`
+	// OCMAllowLoopbackFederation, when true, opts received WebDAV into
+	// an additive dial hatch: public federation peers remain allowed, and
+	// loopback (127.0.0.0/8 and ::1) is also accepted. Discovery and
+	// token exchange stay public-only. Non-loopback private and reserved
+	// ranges stay refused. It is off by default. Enabling it weakens
+	// SSRF protection for received WebDAV only; it does not allow HTTP,
+	// private ranges, or disable other untrusted-client guards.
+	OCMAllowLoopbackFederation bool `mapstructure:"ocm_allow_loopback_federation"`
 }
 
 func (c *config) ApplyDefaults() {
@@ -140,10 +149,34 @@ func New(ctx context.Context, m map[string]any) (storage.FS, error) {
 	disco := ttlcache.NewCache()
 	_ = disco.SetTTL(5 * time.Minute)
 
-	// Empty hatch for T1. Received hatch config lands in a later task.
-	var sec ocmd.UntrustedClientSecurity
-	sec.ApplyDefaults()
-	if err := sec.Compile(); err != nil {
+	// ocm_allow_loopback_federation is ADDITIVE and WebDAV-only:
+	// public peers stay allowed (public + loopback) on received
+	// WebDAV metadata and stream clients. Discovery and token
+	// exchange stay public-only. Only non-loopback private peers
+	// are refused. It is for local development and specific
+	// federation scenarios, off by default, and weakens SSRF
+	// protection for received WebDAV only. HTTPS and the other
+	// untrusted-client guards stay in force on both clients.
+	var webdavSec ocmd.UntrustedClientSecurity
+	if c.OCMAllowLoopbackFederation {
+		appctx.GetLogger(ctx).Warn().
+			Bool("ocm_allow_loopback_federation", true).
+			Msg("ocm_allow_loopback_federation is enabled; " +
+				"additive public+loopback hatch (public peers stay allowed; " +
+				"only non-loopback private is refused); " +
+				"WebDAV-only weakening; discovery and token exchange stay public-only; " +
+				"for local development / specific federation; off by default; " +
+				"SSRF protection is weakened for this received surface only")
+		webdavSec.AllowLoopback = true
+	}
+	webdavSec.ApplyDefaults()
+	if err := webdavSec.Compile(); err != nil {
+		return nil, err
+	}
+
+	var discoverySec ocmd.UntrustedClientSecurity
+	discoverySec.ApplyDefaults()
+	if err := discoverySec.Compile(); err != nil {
 		return nil, err
 	}
 
@@ -155,11 +188,12 @@ func New(ctx context.Context, m map[string]any) (storage.FS, error) {
 		ocmClient: ocmd.NewPublicOnlyClient(
 			time.Duration(c.OCMClientTimeout)*time.Second,
 			c.OCMClientInsecure,
-			sec,
+			discoverySec,
 			c.OCMResponseLimit,
 			minVersion,
 		),
-		sec:           sec,
+		sec:           webdavSec,
+		discoverySec:  discoverySec,
 		tlsMinVersion: minVersion,
 	}
 	return d, nil

--- a/pkg/ocm/storage/received/ocm.go
+++ b/pkg/ocm/storage/received/ocm.go
@@ -70,6 +70,7 @@ type driver struct {
 	ccache         *ttlcache.Cache
 	discoveryCache *ttlcache.Cache
 	ocmClient      *ocmd.OCMClient
+	sec            ocmd.UntrustedClientSecurity
 }
 
 type config struct {
@@ -101,12 +102,24 @@ func New(ctx context.Context, m map[string]any) (storage.FS, error) {
 	disco := ttlcache.NewCache()
 	_ = disco.SetTTL(5 * time.Minute)
 
+	// Empty hatch for T1. Received hatch config lands in a later task.
+	var sec ocmd.UntrustedClientSecurity
+	sec.ApplyDefaults()
+	if err := sec.Compile(); err != nil {
+		return nil, err
+	}
+
 	d := &driver{
 		c:              &c,
 		gateway:        gateway,
 		ccache:         ttlcache.NewCache(),
 		discoveryCache: disco,
-		ocmClient:      ocmd.NewPublicOnlyClient(time.Duration(c.OCMClientTimeout)*time.Second, c.OCMClientInsecure),
+		ocmClient: ocmd.NewPublicOnlyClient(
+			time.Duration(c.OCMClientTimeout)*time.Second,
+			c.OCMClientInsecure,
+			sec,
+		),
+		sec: sec,
 	}
 	return d, nil
 }
@@ -254,20 +267,36 @@ func (d *driver) exchangeAccessToken(ctx context.Context, share *ocmpb.ReceivedS
 	return accessToken, nil
 }
 
+// invalidCredsCause keeps the InvalidCredentials type-switch used by
+// gRPC status mapping while still unwrapping to the dial/scheme sentinel.
+type invalidCredsCause struct {
+	errtypes.InvalidCredentials
+	cause error
+}
+
+func (e invalidCredsCause) Error() string {
+	if e.cause == nil {
+		return e.InvalidCredentials.Error()
+	}
+	return e.InvalidCredentials.Error() + ": " + e.cause.Error()
+}
+
+func (e invalidCredsCause) Unwrap() error { return e.cause }
+
 // newReceivedWebDAVClient builds a gowebdav client for a peer-supplied
 // received-share WebDAV URL. The URL is attacker-influenced, so the client
 // uses UntrustedHTTPTransport.
 func (d *driver) newReceivedWebDAVClient(endpoint string) *gowebdav.Client {
 	timeout := 10 * time.Second
 	insecure := false
-	if d != nil && d.c != nil {
+	if d.c != nil {
 		if d.c.OCMClientTimeout > 0 {
 			timeout = time.Duration(d.c.OCMClientTimeout) * time.Second
 		}
 		insecure = d.c.OCMClientInsecure
 	}
 	c := gowebdav.NewClient(endpoint, "", "")
-	c.SetTransport(ocmd.UntrustedHTTPTransport(timeout, insecure))
+	c.SetTransport(ocmd.UntrustedHTTPTransport(timeout, insecure, d.sec))
 	return c
 }
 
@@ -306,7 +335,10 @@ func (d *driver) webdavClient(ctx context.Context, ref *provider.Reference) (*go
 			_, err2 := c.Stat("")
 			if err2 != nil {
 				log.Info().Any("former_error", err).Err(err2).Str("endpoint", endpoint).Str("shareId", share.GetId().GetOpaqueId()).Msg("failed accessing OCM share")
-				return nil, nil, "", errtypes.InvalidCredentials("error accessing OCM share: " + err2.Error())
+				return nil, nil, "", invalidCredsCause{
+					InvalidCredentials: "error accessing OCM share",
+					cause:              err2,
+				}
 			}
 			authHdr = basicHdr
 			log.Info().Str("endpoint", endpoint).Str("shareId", share.GetId().GetOpaqueId()).Str("mode", "legacy").Msg("access to remote OCM share succeeded")

--- a/pkg/ocm/storage/received/ocm_test.go
+++ b/pkg/ocm/storage/received/ocm_test.go
@@ -1,6 +1,7 @@
 package ocm
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
 	"encoding/json"
@@ -29,6 +30,7 @@ import (
 	"github.com/cs3org/reva/v3/internal/http/services/wellknown"
 	"github.com/cs3org/reva/v3/pkg/appctx"
 	"github.com/cs3org/reva/v3/pkg/errtypes"
+	"github.com/rs/zerolog"
 	"github.com/studio-b12/gowebdav"
 	"google.golang.org/grpc"
 )
@@ -312,6 +314,8 @@ func newTestReceivedDriver() *driver {
 		c: &config{
 			OCMClientTimeout:  10,
 			OCMClientInsecure: true,
+			WebDAVDialTimeout: 10,
+			WebDAVTimeout:     30,
 		},
 		ccache:         ttlcache.NewCache(),
 		discoveryCache: disco,
@@ -1308,5 +1312,313 @@ func TestReceivedShareWebDAVUploadRefusesPrivateHost(t *testing.T) {
 	}
 	if !errors.Is(err, ocmd.ErrNonPublicAddr) {
 		t.Fatalf("got %v, want ocmd.ErrNonPublicAddr", err)
+	}
+}
+
+func TestConfigWebDAVTimeouts(t *testing.T) {
+	tests := []struct {
+		name         string
+		extra        map[string]any
+		wantOCM      int
+		wantDial     int
+		wantMeta     int
+		wantTransfer int
+	}{
+		{
+			name:         "defaults when unset",
+			extra:        map[string]any{},
+			wantOCM:      10,
+			wantDial:     10,
+			wantMeta:     30,
+			wantTransfer: 0,
+		},
+		{
+			name: "parses configured timeouts",
+			extra: map[string]any{
+				"ocm_timeout":             15,
+				"webdav_dial_timeout":     2,
+				"webdav_timeout":          4,
+				"webdav_transfer_timeout": 90,
+			},
+			wantOCM:      15,
+			wantDial:     2,
+			wantMeta:     4,
+			wantTransfer: 90,
+		},
+		{
+			name: "negative timeouts use defaults",
+			extra: map[string]any{
+				"ocm_timeout":         -1,
+				"webdav_dial_timeout": -5,
+				"webdav_timeout":      -2,
+			},
+			wantOCM:      10,
+			wantDial:     10,
+			wantMeta:     30,
+			wantTransfer: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := map[string]any{
+				"gatewaysvc":   "public-only-received-test.invalid:1",
+				"ocm_insecure": true,
+			}
+			for k, v := range tt.extra {
+				m[k] = v
+			}
+			fs, err := New(context.Background(), m)
+			if err != nil {
+				t.Fatal(err)
+			}
+			d, ok := fs.(*driver)
+			if !ok {
+				t.Fatalf("got %T, want *driver", fs)
+			}
+			if d.c.OCMClientTimeout != tt.wantOCM {
+				t.Errorf("OCMClientTimeout = %d, want %d", d.c.OCMClientTimeout, tt.wantOCM)
+			}
+			if d.c.WebDAVDialTimeout != tt.wantDial {
+				t.Errorf("WebDAVDialTimeout = %d, want %d", d.c.WebDAVDialTimeout, tt.wantDial)
+			}
+			if d.c.WebDAVTimeout != tt.wantMeta {
+				t.Errorf("WebDAVTimeout = %d, want %d", d.c.WebDAVTimeout, tt.wantMeta)
+			}
+			if d.c.WebDAVTransferTimeout != tt.wantTransfer {
+				t.Errorf("WebDAVTransferTimeout = %d, want %d", d.c.WebDAVTransferTimeout, tt.wantTransfer)
+			}
+			if d.ocmClient.RequestTimeout() != time.Duration(tt.wantOCM)*time.Second {
+				t.Errorf("OCM RequestTimeout = %v, want %ds", d.ocmClient.RequestTimeout(), tt.wantOCM)
+			}
+		})
+	}
+}
+
+func TestConfigWebDAVTransferTimeoutWarnsWhenNonzero(t *testing.T) {
+	var buf bytes.Buffer
+	log := zerolog.New(&buf)
+	ctx := appctx.WithLogger(context.Background(), &log)
+
+	fs, err := New(ctx, map[string]any{
+		"gatewaysvc":              "public-only-received-test.invalid:1",
+		"ocm_insecure":            true,
+		"webdav_transfer_timeout": 90,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := buf.String()
+	if !strings.Contains(got, "webdav_transfer_timeout") || !strings.Contains(got, "idle-stall") {
+		t.Fatalf("expected reserved-timeout warning, got %q", got)
+	}
+	d, ok := fs.(*driver)
+	if !ok {
+		t.Fatalf("got %T, want *driver", fs)
+	}
+	if d.c.WebDAVTransferTimeout != 90 {
+		t.Fatalf("WebDAVTransferTimeout = %d, want parsed 90", d.c.WebDAVTransferTimeout)
+	}
+
+	buf.Reset()
+	_, err = New(ctx, map[string]any{
+		"gatewaysvc":   "public-only-received-test.invalid:1",
+		"ocm_insecure": true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(buf.String(), "webdav_transfer_timeout") {
+		t.Fatalf("default 0 must not warn; got %q", buf.String())
+	}
+}
+
+func receivedShareDAVHandler(t *testing.T, onPropfind, onGet http.HandlerFunc) http.Handler {
+	t.Helper()
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case "PROPFIND":
+			if onPropfind != nil {
+				onPropfind(w, r)
+				return
+			}
+			w.Header().Set("Content-Type", "application/xml")
+			w.WriteHeader(207)
+			_, _ = w.Write([]byte(receivedWebDAVPropfindXML))
+		case http.MethodGet:
+			if onGet != nil {
+				onGet(w, r)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("ok"))
+		case http.MethodPut:
+			if r.Body != nil {
+				_, _ = io.Copy(io.Discard, r.Body)
+			}
+			w.WriteHeader(http.StatusCreated)
+		default:
+			t.Errorf("unexpected method %s", r.Method)
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	})
+}
+
+func newReceivedDriverWithTimeouts(t *testing.T, dialSec, metaSec, transferSec int) *driver {
+	t.Helper()
+	fs, err := New(context.Background(), map[string]any{
+		"gatewaysvc":              "public-only-received-test.invalid:1",
+		"ocm_timeout":             5,
+		"ocm_insecure":            true,
+		"webdav_dial_timeout":     dialSec,
+		"webdav_timeout":          metaSec,
+		"webdav_transfer_timeout": transferSec,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	d, ok := fs.(*driver)
+	if !ok {
+		t.Fatalf("got %T, want *driver", fs)
+	}
+	return d
+}
+
+func TestReceivedMetadataTimeoutBoundsSlowStat(t *testing.T) {
+	var startOnce sync.Once
+	started := make(chan struct{})
+	srv := startPublicTLSServer(t, receivedShareDAVHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		startOnce.Do(func() { close(started) })
+		time.Sleep(2 * time.Second)
+		w.Header().Set("Content-Type", "application/xml")
+		w.WriteHeader(207)
+		_, _ = w.Write([]byte(receivedWebDAVPropfindXML))
+	}, nil))
+
+	d := newReceivedDriverWithTimeouts(t, 5, 1, 0)
+	share := receivedShareWithWebDAVURI(
+		srv.Listener.Addr().String(),
+		"share-abc",
+		srv.URL+"/remote.php/dav/ocm/share-abc",
+	)
+	d.gateway = &mockReceivedGateway{shares: []*ocmpb.ReceivedShare{share}}
+
+	start := time.Now()
+	_, err := d.GetMD(context.Background(), &provider.Reference{Path: "/share-abc"}, nil)
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatal("expected slow Stat to be bounded by webdav_timeout")
+	}
+	// Legacy resolve probes Bearer then Basic. Each Stat is bounded by
+	// webdav_timeout (1s), so two attempts can approach 2s plus slack.
+	if elapsed > 3*time.Second {
+		t.Fatalf("metadata SetTimeout was not honored; elapsed %v", elapsed)
+	}
+	select {
+	case <-started:
+	default:
+		t.Fatal("expected the slow metadata peer to accept the connection")
+	}
+}
+
+func TestReceivedStreamClientHasNoTotalTimeout(t *testing.T) {
+	const dripCount = 8
+	const dripGap = 250 * time.Millisecond
+	body := bytes.Repeat([]byte("x"), 256*1024)
+
+	t.Run("large ReadStream completes", func(t *testing.T) {
+		srv := startPublicTLSServer(t, receivedShareDAVHandler(t, nil, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(body)
+		}))
+
+		d := newReceivedDriverWithTimeouts(t, 5, 1, 0)
+		share := receivedShareWithWebDAVURI(
+			srv.Listener.Addr().String(),
+			"share-abc",
+			srv.URL+"/remote.php/dav/ocm/share-abc",
+		)
+		d.gateway = &mockReceivedGateway{shares: []*ocmpb.ReceivedShare{share}}
+
+		rc, err := d.Download(context.Background(), &provider.Reference{Path: "/share-abc"}, nil)
+		if err != nil {
+			t.Fatalf("Download: %v", err)
+		}
+		defer rc.Close()
+		got, err := io.ReadAll(rc)
+		if err != nil {
+			t.Fatalf("ReadAll: %v", err)
+		}
+		if !bytes.Equal(got, body) {
+			t.Fatalf("ReadStream truncated: got %d bytes, want %d", len(got), len(body))
+		}
+	})
+
+	t.Run("slow-drip stream is not truncated", func(t *testing.T) {
+		srv := startPublicTLSServer(t, receivedShareDAVHandler(t, nil, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			flusher, _ := w.(http.Flusher)
+			for i := 0; i < dripCount; i++ {
+				_, _ = w.Write([]byte("x"))
+				if flusher != nil {
+					flusher.Flush()
+				}
+				time.Sleep(dripGap)
+			}
+		}))
+
+		d := newReceivedDriverWithTimeouts(t, 5, 1, 0)
+		share := receivedShareWithWebDAVURI(
+			srv.Listener.Addr().String(),
+			"share-slow",
+			srv.URL+"/remote.php/dav/ocm/share-slow",
+		)
+		d.gateway = &mockReceivedGateway{shares: []*ocmpb.ReceivedShare{share}}
+
+		start := time.Now()
+		rc, err := d.Download(context.Background(), &provider.Reference{Path: "/share-slow"}, nil)
+		if err != nil {
+			t.Fatalf("Download: %v", err)
+		}
+		defer rc.Close()
+		got, err := io.ReadAll(rc)
+		elapsed := time.Since(start)
+		if err != nil {
+			t.Fatalf("ReadAll: %v", err)
+		}
+		if string(got) != strings.Repeat("x", dripCount) {
+			t.Fatalf("slow-drip stream truncated: got %q", got)
+		}
+		if elapsed < time.Duration(dripCount-1)*dripGap {
+			t.Fatalf("expected the drip to take more than webdav_timeout; elapsed %v", elapsed)
+		}
+	})
+}
+
+func TestReceivedMetadataAndStreamClientsAreDistinct(t *testing.T) {
+	d := newReceivedDriverWithTimeouts(t, 5, 1, 0)
+	meta := d.newReceivedWebDAVClient("https://192.0.2.1/dav")
+	stream := d.newReceivedWebDAVStreamClient("https://192.0.2.1/dav")
+	if meta == stream {
+		t.Fatal("metadata and stream builders returned the same instance")
+	}
+
+	srv := startPublicTLSServer(t, receivedShareDAVHandler(t, nil, nil))
+	share := receivedShareWithWebDAVURI(
+		srv.Listener.Addr().String(),
+		"share-abc",
+		srv.URL+"/remote.php/dav/ocm/share-abc",
+	)
+	d.gateway = &mockReceivedGateway{shares: []*ocmpb.ReceivedShare{share}}
+
+	cc, _, err := d.resolveReceivedWebDAV(context.Background(), &provider.Reference{Path: "/share-abc"})
+	if err != nil {
+		t.Fatalf("resolveReceivedWebDAV: %v", err)
+	}
+	if cc.metadata == nil || cc.stream == nil {
+		t.Fatal("expected both cached clients to be set")
+	}
+	if cc.metadata == cc.stream {
+		t.Fatal("cached metadata and stream clients must be distinct instances")
 	}
 }

--- a/pkg/ocm/storage/received/ocm_test.go
+++ b/pkg/ocm/storage/received/ocm_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/fs"
 	"net"
 	"net/http"
@@ -305,6 +306,10 @@ func newTestReceivedDriver() *driver {
 	disco := ttlcache.NewCache()
 	_ = disco.SetTTL(5 * time.Minute)
 	return &driver{
+		c: &config{
+			OCMClientTimeout:  10,
+			OCMClientInsecure: true,
+		},
 		ccache:         ttlcache.NewCache(),
 		discoveryCache: disco,
 		ocmClient:      ocmd.NewClient(10*time.Second, true),
@@ -1020,5 +1025,171 @@ func TestGetTokenEndpointRefusesRedirectToLinkLocal(t *testing.T) {
 	assertNoEstablishedHost(t, tr, "169.254.169.254")
 	if err == nil {
 		t.Fatal("expected received Discover to refuse a redirect to a link-local metadata address")
+	}
+}
+
+const receivedWebDAVPropfindXML = `<?xml version="1.0" encoding="utf-8"?>
+<d:multistatus xmlns:d="DAV:">
+  <d:response>
+    <d:href>/</d:href>
+    <d:propstat>
+      <d:prop>
+        <d:displayname>shared-doc.txt</d:displayname>
+        <d:getcontentlength>4</d:getcontentlength>
+        <d:getcontenttype>text/plain</d:getcontenttype>
+        <d:getetag>"abc"</d:getetag>
+        <d:getlastmodified>Mon, 02 Jan 2006 15:04:05 GMT</d:getlastmodified>
+      </d:prop>
+      <d:status>HTTP/1.1 200 OK</d:status>
+    </d:propstat>
+  </d:response>
+</d:multistatus>`
+
+func receivedWebDAVHandler(t *testing.T, contacted *bool) http.Handler {
+	t.Helper()
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		*contacted = true
+		if r.Method != "PROPFIND" && r.Method != http.MethodPut {
+			t.Errorf("unexpected method %s", r.Method)
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		if r.Method == http.MethodPut {
+			w.WriteHeader(http.StatusCreated)
+			return
+		}
+		w.Header().Set("Content-Type", "application/xml")
+		w.WriteHeader(207)
+		_, _ = w.Write([]byte(receivedWebDAVPropfindXML))
+	})
+}
+
+func receivedShareWithWebDAVURI(senderAddr, id, uri string) *ocmpb.ReceivedShare {
+	share := testReceivedShare(senderAddr, id, true)
+	share.Protocols[0].GetWebdavOptions().Uri = uri
+	return share
+}
+
+func TestReceivedShareWebDAVAccessPublicHTTPSHostSucceeds(t *testing.T) {
+	contacted := false
+	srv := startPublicTLSServer(t, receivedWebDAVHandler(t, &contacted))
+
+	d := newProductionReceivedDriver(t)
+	share := receivedShareWithWebDAVURI(
+		srv.Listener.Addr().String(),
+		"share-abc",
+		srv.URL+"/remote.php/dav/ocm/share-abc",
+	)
+	d.gateway = &mockReceivedGateway{shares: []*ocmpb.ReceivedShare{share}}
+
+	info, err := d.GetMD(context.Background(), &provider.Reference{Path: "/share-abc"}, nil)
+	if err != nil {
+		t.Fatalf("received-share WebDAV access to a public HTTPS host: %v", err)
+	}
+	if info == nil {
+		t.Fatal("expected resource info for a public HTTPS WebDAV host")
+	}
+	if !contacted {
+		t.Fatal("expected received-share WebDAV access to reach the public HTTPS host")
+	}
+}
+
+func TestReceivedShareWebDAVAccessRefusesPrivateHost(t *testing.T) {
+	t.Run("metadata host is refused at dial", func(t *testing.T) {
+		d := newProductionReceivedDriver(t)
+		share := receivedShareWithWebDAVURI(
+			"169.254.169.254",
+			"share-abc",
+			"https://169.254.169.254/remote.php/dav/ocm/share-abc",
+		)
+		d.gateway = &mockReceivedGateway{shares: []*ocmpb.ReceivedShare{share}}
+
+		_, err := d.GetMD(context.Background(), &provider.Reference{Path: "/share-abc"}, nil)
+		if err == nil {
+			t.Fatal("expected received-share WebDAV access to refuse the metadata host at dial")
+		}
+		if !strings.Contains(err.Error(), "non-public") {
+			t.Fatalf("got %v, want the existing non-public dial error", err)
+		}
+	})
+
+	t.Run("reachable private host is not contacted", func(t *testing.T) {
+		contacted := false
+		srv := httptest.NewTLSServer(receivedWebDAVHandler(t, &contacted))
+		defer srv.Close()
+
+		d := newProductionReceivedDriver(t)
+		share := receivedShareWithWebDAVURI(
+			srv.Listener.Addr().String(),
+			"share-abc",
+			srv.URL+"/remote.php/dav/ocm/share-abc",
+		)
+		d.gateway = &mockReceivedGateway{shares: []*ocmpb.ReceivedShare{share}}
+
+		_, err := d.GetMD(context.Background(), &provider.Reference{Path: "/share-abc"}, nil)
+		if contacted {
+			t.Fatal("received-share WebDAV access contacted a private host; the untrusted transport must refuse it at dial")
+		}
+		if err == nil {
+			t.Fatal("expected received-share WebDAV access to a private host to fail")
+		}
+		if !strings.Contains(err.Error(), "non-public") {
+			t.Fatalf("got %v, want the existing non-public dial error", err)
+		}
+	})
+}
+
+func TestReceivedShareWebDAVAccessRefusesHTTP(t *testing.T) {
+	contacted := false
+	srv := httptest.NewServer(receivedWebDAVHandler(t, &contacted))
+	defer srv.Close()
+
+	d := newProductionReceivedDriver(t)
+	share := receivedShareWithWebDAVURI(
+		srv.Listener.Addr().String(),
+		"share-abc",
+		srv.URL+"/remote.php/dav/ocm/share-abc",
+	)
+	d.gateway = &mockReceivedGateway{shares: []*ocmpb.ReceivedShare{share}}
+
+	_, err := d.GetMD(context.Background(), &provider.Reference{Path: "/share-abc"}, nil)
+	if contacted {
+		t.Fatal("received-share WebDAV access contacted an http host; the untrusted transport must refuse it")
+	}
+	if err == nil {
+		t.Fatal("expected received-share WebDAV access to refuse a non-https URL")
+	}
+	if !strings.Contains(err.Error(), "non-https") {
+		t.Fatalf("got %v, want a non-https refusal", err)
+	}
+}
+
+func TestReceivedShareWebDAVUploadRefusesPrivateHost(t *testing.T) {
+	contacted := false
+	srv := httptest.NewTLSServer(receivedWebDAVHandler(t, &contacted))
+	defer srv.Close()
+
+	d := newProductionReceivedDriver(t)
+	share := receivedShareWithWebDAVURI(
+		srv.Listener.Addr().String(),
+		"share-abc",
+		srv.URL+"/remote.php/dav/ocm/share-abc",
+	)
+	d.gateway = &mockReceivedGateway{shares: []*ocmpb.ReceivedShare{share}}
+
+	err := d.Upload(
+		context.Background(),
+		&provider.Reference{Path: "/share-abc/file.txt"},
+		io.NopCloser(strings.NewReader("hi")),
+		nil,
+	)
+	if contacted {
+		t.Fatal("received-share WebDAV upload contacted a private host; the untrusted transport must refuse it at dial")
+	}
+	if err == nil {
+		t.Fatal("expected received-share WebDAV upload to a private host to fail")
+	}
+	if !strings.Contains(err.Error(), "non-public") {
+		t.Fatalf("got %v, want the existing non-public dial error", err)
 	}
 }

--- a/pkg/ocm/storage/received/ocm_test.go
+++ b/pkg/ocm/storage/received/ocm_test.go
@@ -2,6 +2,7 @@ package ocm
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -12,6 +13,7 @@ import (
 	"net/http/httptest"
 	"net/http/httptrace"
 	"os"
+	"reflect"
 	"strings"
 	"sync"
 	"testing"
@@ -821,6 +823,75 @@ func TestConfigOCMResponseLimit(t *testing.T) {
 			}
 		})
 	}
+}
+
+func innerUntrustedTransport(t *testing.T, rt http.RoundTripper) *http.Transport {
+	t.Helper()
+	if tr, ok := rt.(*http.Transport); ok {
+		return tr
+	}
+	v := reflect.ValueOf(rt)
+	if v.Kind() == reflect.Pointer {
+		v = v.Elem()
+	}
+	if v.IsValid() && v.Kind() == reflect.Struct {
+		f := v.FieldByName("Transport")
+		if f.IsValid() && f.CanInterface() {
+			if tr, ok := f.Interface().(*http.Transport); ok && tr != nil {
+				return tr
+			}
+		}
+	}
+	t.Fatalf("untrusted transport: got %T, want an *http.Transport wrapper", rt)
+	return nil
+}
+
+func TestNewTLSMinVersion(t *testing.T) {
+	t.Parallel()
+
+	t.Run("configured 1.3 reaches the transport", func(t *testing.T) {
+		t.Parallel()
+		fs, err := New(context.Background(), map[string]any{
+			"gatewaysvc":          "public-only-received-test.invalid:1",
+			"ocm_timeout":         5,
+			"ocm_insecure":        true,
+			"ocm_tls_min_version": "1.3",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		d, ok := fs.(*driver)
+		if !ok {
+			t.Fatalf("got %T, want *driver", fs)
+		}
+		if d.tlsMinVersion != tls.VersionTLS13 {
+			t.Fatalf("tlsMinVersion = %#x, want TLS 1.3", d.tlsMinVersion)
+		}
+		rt := ocmd.UntrustedHTTPTransport(
+			5*time.Second,
+			true,
+			d.sec,
+			d.tlsMinVersion,
+		)
+		inner := innerUntrustedTransport(t, rt)
+		if inner.TLSClientConfig == nil || inner.TLSClientConfig.MinVersion != tls.VersionTLS13 {
+			t.Fatalf("constructed transport MinVersion = %v, want TLS 1.3", inner.TLSClientConfig)
+		}
+	})
+
+	t.Run("invalid value fails service start", func(t *testing.T) {
+		t.Parallel()
+		_, err := New(context.Background(), map[string]any{
+			"gatewaysvc":          "public-only-received-test.invalid:1",
+			"ocm_tls_min_version": "1.1",
+		})
+		if err == nil {
+			t.Fatal("expected received.New to reject TLS min version 1.1")
+		}
+		if !errors.Is(err, ocmd.ErrInvalidTLSMinVersion) {
+			t.Fatalf("got %v, want ocmd.ErrInvalidTLSMinVersion", err)
+		}
+	})
 }
 
 func newProductionReceivedDriver(t *testing.T) *driver {

--- a/pkg/ocm/storage/received/ocm_test.go
+++ b/pkg/ocm/storage/received/ocm_test.go
@@ -3,6 +3,7 @@ package ocm
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -772,8 +773,8 @@ func assertRefusedNonPublic(t *testing.T, err error) {
 	if err == nil {
 		t.Fatal("expected body-supplied discovery to refuse a non-public address")
 	}
-	if !strings.Contains(err.Error(), "non-public") {
-		t.Fatalf("got %v, want a non-public dial refusal", err)
+	if !errors.Is(err, ocmd.ErrNonPublicAddr) {
+		t.Fatalf("got %v, want ocmd.ErrNonPublicAddr", err)
 	}
 }
 
@@ -1108,8 +1109,8 @@ func TestReceivedShareWebDAVAccessRefusesPrivateHost(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected received-share WebDAV access to refuse the metadata host at dial")
 		}
-		if !strings.Contains(err.Error(), "non-public") {
-			t.Fatalf("got %v, want the existing non-public dial error", err)
+		if !errors.Is(err, ocmd.ErrNonPublicAddr) {
+			t.Fatalf("got %v, want ocmd.ErrNonPublicAddr", err)
 		}
 	})
 
@@ -1133,8 +1134,8 @@ func TestReceivedShareWebDAVAccessRefusesPrivateHost(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected received-share WebDAV access to a private host to fail")
 		}
-		if !strings.Contains(err.Error(), "non-public") {
-			t.Fatalf("got %v, want the existing non-public dial error", err)
+		if !errors.Is(err, ocmd.ErrNonPublicAddr) {
+			t.Fatalf("got %v, want ocmd.ErrNonPublicAddr", err)
 		}
 	})
 }
@@ -1159,8 +1160,8 @@ func TestReceivedShareWebDAVAccessRefusesHTTP(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected received-share WebDAV access to refuse a non-https URL")
 	}
-	if !strings.Contains(err.Error(), "non-https") {
-		t.Fatalf("got %v, want a non-https refusal", err)
+	if !errors.Is(err, ocmd.ErrNonHTTPS) {
+		t.Fatalf("got %v, want ocmd.ErrNonHTTPS", err)
 	}
 }
 
@@ -1189,7 +1190,7 @@ func TestReceivedShareWebDAVUploadRefusesPrivateHost(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected received-share WebDAV upload to a private host to fail")
 	}
-	if !strings.Contains(err.Error(), "non-public") {
-		t.Fatalf("got %v, want the existing non-public dial error", err)
+	if !errors.Is(err, ocmd.ErrNonPublicAddr) {
+		t.Fatalf("got %v, want ocmd.ErrNonPublicAddr", err)
 	}
 }

--- a/pkg/ocm/storage/received/ocm_test.go
+++ b/pkg/ocm/storage/received/ocm_test.go
@@ -5,9 +5,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/fs"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/http/httptrace"
 	"os"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -755,5 +759,266 @@ func TestIsWebDAV401_OsPathError(t *testing.T) {
 	err := &os.PathError{Op: "GET", Path: "/test", Err: fmt.Errorf("not a StatusError")}
 	if isWebDAV401(err) {
 		t.Error("expected isWebDAV401=false for PathError with non-StatusError inner")
+	}
+}
+
+func assertRefusedNonPublic(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected body-supplied discovery to refuse a non-public address")
+	}
+	if !strings.Contains(err.Error(), "non-public") {
+		t.Fatalf("got %v, want a non-public dial refusal", err)
+	}
+}
+
+func newProductionReceivedDriver(t *testing.T) *driver {
+	t.Helper()
+	fs, err := New(context.Background(), map[string]any{
+		"gatewaysvc":   "public-only-received-test.invalid:1",
+		"ocm_timeout":  5,
+		"ocm_insecure": true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	d, ok := fs.(*driver)
+	if !ok {
+		t.Fatalf("got %T, want *driver", fs)
+	}
+	return d
+}
+
+func firstPublicIPv4() (string, bool) {
+	addrs, err := net.InterfaceAddrs()
+	if err != nil {
+		return "", false
+	}
+	for _, a := range addrs {
+		n, ok := a.(*net.IPNet)
+		if !ok || n.IP == nil {
+			continue
+		}
+		ip := n.IP.To4()
+		if ip == nil || ip.IsLoopback() || ip.IsPrivate() || ip.IsUnspecified() ||
+			ip.IsLinkLocalUnicast() || ip.IsMulticast() {
+			continue
+		}
+		if ip[0] == 100 && ip[1]&0xc0 == 64 {
+			continue
+		}
+		return ip.String(), true
+	}
+	return "", false
+}
+
+func startPublicTLSServer(t *testing.T, h http.Handler) *httptest.Server {
+	t.Helper()
+	ip, ok := firstPublicIPv4()
+	if !ok {
+		t.Skip("no public IPv4 address available for public-only httptest")
+	}
+	ln, err := net.Listen("tcp", net.JoinHostPort(ip, "0"))
+	if err != nil {
+		t.Skipf("cannot listen on public IP %s: %v", ip, err)
+	}
+	srv := httptest.NewUnstartedServer(h)
+	if srv.Listener != nil {
+		_ = srv.Listener.Close()
+	}
+	srv.Listener = ln
+	srv.StartTLS()
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// hostDialTrace records hosts the HTTP client actually connected to.
+type hostDialTrace struct {
+	mu          sync.Mutex
+	established []string
+}
+
+func contextWithHostDialTrace(ctx context.Context) (context.Context, *hostDialTrace) {
+	tr := &hostDialTrace{established: []string{}}
+	ctx = httptrace.WithClientTrace(ctx, &httptrace.ClientTrace{
+		ConnectDone: func(_, addr string, err error) {
+			if err != nil {
+				return
+			}
+			tr.mu.Lock()
+			tr.established = append(tr.established, addr)
+			tr.mu.Unlock()
+		},
+		GotConn: func(info httptrace.GotConnInfo) {
+			if info.Conn == nil {
+				return
+			}
+			tr.mu.Lock()
+			tr.established = append(tr.established, info.Conn.RemoteAddr().String())
+			tr.mu.Unlock()
+		},
+	})
+	return ctx, tr
+}
+
+func hostOf(addr string) string {
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		host = addr
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		if ip4 := ip.To4(); ip4 != nil {
+			return ip4.String()
+		}
+		return ip.String()
+	}
+	return host
+}
+
+func (tr *hostDialTrace) establishedHost(host string) bool {
+	tr.mu.Lock()
+	defer tr.mu.Unlock()
+	for _, addr := range tr.established {
+		if hostOf(addr) == host {
+			return true
+		}
+	}
+	return false
+}
+
+func assertNoEstablishedHost(t *testing.T, tr *hostDialTrace, host string) {
+	t.Helper()
+	if tr.establishedHost(host) {
+		t.Fatalf("public-only client established a connection to %s", host)
+	}
+}
+
+func TestGetTokenEndpointUsesPublicOnlyClient(t *testing.T) {
+	var srv *httptest.Server
+	fetched := false
+	srv = httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fetched = true
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"enabled":       true,
+			"apiVersion":    "1.2.0",
+			"endPoint":      srv.URL + "/ocm",
+			"provider":      "reva",
+			"resourceTypes": []any{},
+			"tokenEndPoint": srv.URL + "/ocm/token",
+		})
+	}))
+	defer srv.Close()
+
+	d := newProductionReceivedDriver(t)
+	share := testCodeFlowReceivedShare(srv.Listener.Addr().String(), srv.URL)
+
+	_, err := d.getTokenEndpoint(context.Background(), share)
+	if fetched {
+		t.Fatal("getTokenEndpoint fetched a loopback discovery host; the public-only client must refuse it at dial")
+	}
+	if err == nil {
+		t.Fatal("getTokenEndpoint must refuse body-supplied discovery to a private loopback host")
+	}
+}
+
+func TestGetTokenEndpointRefusesPrivateDiscoveryHost(t *testing.T) {
+	d := newProductionReceivedDriver(t)
+
+	t.Run("metadata host", func(t *testing.T) {
+		share := testCodeFlowReceivedShare("169.254.169.254", "https://169.254.169.254")
+		ctx, tr := contextWithHostDialTrace(context.Background())
+		_, err := d.getTokenEndpoint(ctx, share)
+		assertNoEstablishedHost(t, tr, "169.254.169.254")
+		if err == nil {
+			t.Fatal("expected body-supplied discovery to a metadata host to fail")
+		}
+	})
+
+	t.Run("reachable private host is not contacted", func(t *testing.T) {
+		fetched := false
+		srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fetched = true
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer srv.Close()
+
+		loopHost, _, err := net.SplitHostPort(srv.Listener.Addr().String())
+		if err != nil {
+			t.Fatal(err)
+		}
+		share := testCodeFlowReceivedShare(srv.Listener.Addr().String(), srv.URL)
+		ctx, tr := contextWithHostDialTrace(context.Background())
+		_, err = d.getTokenEndpoint(ctx, share)
+		if fetched {
+			t.Fatal("getTokenEndpoint fetched a private discovery host; the public-only client must refuse it at dial")
+		}
+		assertNoEstablishedHost(t, tr, loopHost)
+		if err == nil {
+			t.Fatal("expected body-supplied discovery to a private host to fail")
+		}
+	})
+}
+
+func TestExchangeAccessTokenRefusesPrivateTokenEndpoint(t *testing.T) {
+	d := newProductionReceivedDriver(t)
+	share := testCodeFlowReceivedShare("169.254.169.254", "https://169.254.169.254")
+
+	_, err := d.exchangeAccessToken(context.Background(), share, "https://169.254.169.254/ocm/token", "secret")
+	assertRefusedNonPublic(t, err)
+}
+
+func TestGetTokenEndpointPublicHTTPSHostSucceeds(t *testing.T) {
+	var srv *httptest.Server
+	srv = startPublicTLSServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/.well-known/ocm" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"enabled":       true,
+			"apiVersion":    "1.2.0",
+			"endPoint":      srv.URL + "/ocm",
+			"provider":      "reva",
+			"resourceTypes": []any{},
+			"tokenEndPoint": srv.URL + "/ocm/token",
+		})
+	}))
+
+	d := newProductionReceivedDriver(t)
+	share := testCodeFlowReceivedShare(srv.Listener.Addr().String(), srv.URL)
+
+	got, err := d.getTokenEndpoint(context.Background(), share)
+	if err != nil {
+		t.Fatalf("getTokenEndpoint() on a public HTTPS host: %v", err)
+	}
+	want := srv.URL + "/ocm/token"
+	if got != want {
+		t.Fatalf("getTokenEndpoint() = %q, want %q", got, want)
+	}
+}
+
+func TestGetTokenEndpointRefusesRedirectToLinkLocal(t *testing.T) {
+	srv := startPublicTLSServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "https://169.254.169.254"+r.URL.Path, http.StatusFound)
+	}))
+
+	publicHost, _, err := net.SplitHostPort(srv.Listener.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	d := newProductionReceivedDriver(t)
+	share := testCodeFlowReceivedShare(srv.Listener.Addr().String(), srv.URL)
+
+	ctx, tr := contextWithHostDialTrace(context.Background())
+	_, err = d.getTokenEndpoint(ctx, share)
+	if !tr.establishedHost(publicHost) {
+		t.Fatalf("expected Discover to reach the public first hop %s", publicHost)
+	}
+	assertNoEstablishedHost(t, tr, "169.254.169.254")
+	if err == nil {
+		t.Fatal("expected received Discover to refuse a redirect to a link-local metadata address")
 	}
 }

--- a/pkg/ocm/storage/received/ocm_test.go
+++ b/pkg/ocm/storage/received/ocm_test.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/http/httptrace"
+	"net/url"
 	"os"
 	"reflect"
 	"strings"
@@ -1621,4 +1622,645 @@ func TestReceivedMetadataAndStreamClientsAreDistinct(t *testing.T) {
 	if cc.metadata == cc.stream {
 		t.Fatal("cached metadata and stream clients must be distinct instances")
 	}
+}
+
+func newLoopbackHatchReceivedDriver(t *testing.T) *driver {
+	t.Helper()
+	fs, err := New(context.Background(), map[string]any{
+		"gatewaysvc":                    "public-only-received-test.invalid:1",
+		"ocm_timeout":                   5,
+		"ocm_insecure":                  true,
+		"ocm_allow_loopback_federation": true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	d, ok := fs.(*driver)
+	if !ok {
+		t.Fatalf("got %T, want *driver", fs)
+	}
+	return d
+}
+
+func roundTripReceivedOCM(t *testing.T, d *driver, rawURL string) error {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodGet, rawURL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rt := d.ocmClient.HTTPTransport()
+	if rt == nil {
+		t.Fatal("received ocm client has no transport")
+	}
+	resp, err := rt.RoundTrip(req)
+	if resp != nil && resp.Body != nil {
+		_ = resp.Body.Close()
+	}
+	return err
+}
+
+func roundTripReceivedWebDAV(t *testing.T, d *driver, rawURL string) error {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodGet, rawURL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rt := ocmd.UntrustedHTTPTransport(
+		d.webdavDialTimeout(),
+		d.ocmInsecure(),
+		d.sec,
+		d.tlsMinVersion,
+	)
+	resp, err := rt.RoundTrip(req)
+	if resp != nil && resp.Body != nil {
+		_ = resp.Body.Close()
+	}
+	return err
+}
+
+func dialAddrFromReceivedURL(t *testing.T, rawURL string) string {
+	t.Helper()
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if u.Host == "" {
+		t.Fatalf("url %q has no host", rawURL)
+	}
+	if _, _, err := net.SplitHostPort(u.Host); err == nil {
+		return u.Host
+	}
+	port := "443"
+	if u.Scheme == "http" {
+		port = "80"
+	}
+	return net.JoinHostPort(u.Hostname(), port)
+}
+
+func receivedPeerDialPolicy(t *testing.T, d *driver, rawURL string) error {
+	t.Helper()
+	if d.ocmClient == nil || d.ocmClient.HTTPTransport() == nil {
+		t.Fatal("received ocm client has no transport")
+	}
+	if ocmd.UntrustedHTTPTransport(
+		d.webdavDialTimeout(),
+		d.ocmInsecure(),
+		d.sec,
+		d.tlsMinVersion,
+	) == nil {
+		t.Fatal("received webdav transport is nil")
+	}
+	return d.sec.CheckDialAddr(dialAddrFromReceivedURL(t, rawURL))
+}
+
+func receivedDiscoveryDialPolicy(t *testing.T, d *driver, rawURL string) error {
+	t.Helper()
+	if d.ocmClient == nil || d.ocmClient.HTTPTransport() == nil {
+		t.Fatal("received ocm client has no transport")
+	}
+	// Exercise the live discovery client, not d.discoverySec. A wiring
+	// bug that gives ocmClient the WebDAV hatch would pass a mirror-field
+	// check and still allow loopback discovery.
+	return roundTripReceivedOCM(t, d, rawURL)
+}
+
+func assertReceivedDialAllowed(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		return
+	}
+	if errors.Is(err, ocmd.ErrNonPublicAddr) {
+		t.Fatalf("public or loopback peer must stay allowed (additive, not exclusive), got %v", err)
+	}
+	t.Fatalf("dial policy must allow this address, got %v", err)
+}
+
+func TestConfigOCMAllowLoopbackFederation(t *testing.T) {
+	tests := []struct {
+		name      string
+		extra     map[string]any
+		wantHatch bool
+	}{
+		{
+			name:      "defaults off when unset",
+			extra:     map[string]any{},
+			wantHatch: false,
+		},
+		{
+			name: "explicit false stays off",
+			extra: map[string]any{
+				"ocm_allow_loopback_federation": false,
+			},
+			wantHatch: false,
+		},
+		{
+			name: "explicit true enables loopback hatch",
+			extra: map[string]any{
+				"ocm_allow_loopback_federation": true,
+			},
+			wantHatch: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := map[string]any{
+				"gatewaysvc":   "public-only-received-test.invalid:1",
+				"ocm_timeout":  5,
+				"ocm_insecure": true,
+			}
+			for k, v := range tt.extra {
+				m[k] = v
+			}
+			fs, err := New(context.Background(), m)
+			if err != nil {
+				t.Fatal(err)
+			}
+			d, ok := fs.(*driver)
+			if !ok {
+				t.Fatalf("got %T, want *driver", fs)
+			}
+			if d.c.OCMAllowLoopbackFederation != tt.wantHatch {
+				t.Errorf("OCMAllowLoopbackFederation = %v, want %v", d.c.OCMAllowLoopbackFederation, tt.wantHatch)
+			}
+			if d.sec.AllowLoopback != tt.wantHatch {
+				t.Errorf("sec.AllowLoopback = %v, want %v", d.sec.AllowLoopback, tt.wantHatch)
+			}
+			if d.discoverySec.AllowLoopback {
+				t.Fatal("discoverySec.AllowLoopback must stay false")
+			}
+			if d.sec.AllowHTTP || d.discoverySec.AllowHTTP {
+				t.Fatal("loopback hatch must not set AllowHTTP")
+			}
+			if len(d.sec.AllowedCIDRs) != 0 || len(d.discoverySec.AllowedCIDRs) != 0 {
+				t.Errorf("AllowedCIDRs webdav=%#v discovery=%#v, want empty (PIN must stay unused)",
+					d.sec.AllowedCIDRs, d.discoverySec.AllowedCIDRs)
+			}
+		})
+	}
+}
+
+func TestConfigOCMAllowLoopbackFederationWarnsWhenEnabled(t *testing.T) {
+	var buf bytes.Buffer
+	log := zerolog.New(&buf)
+	ctx := appctx.WithLogger(context.Background(), &log)
+
+	fs, err := New(ctx, map[string]any{
+		"gatewaysvc":                    "public-only-received-test.invalid:1",
+		"ocm_insecure":                  true,
+		"ocm_allow_loopback_federation": true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := buf.String()
+	if !strings.Contains(got, "ocm_allow_loopback_federation") ||
+		!strings.Contains(got, "SSRF") ||
+		!strings.Contains(got, "additive") ||
+		!strings.Contains(got, "public") ||
+		!strings.Contains(got, "only non-loopback private") ||
+		!strings.Contains(got, "local development") ||
+		!strings.Contains(got, "specific federation") ||
+		!strings.Contains(got, "off by default") ||
+		!strings.Contains(got, "received surface") ||
+		!strings.Contains(got, "WebDAV-only") ||
+		!strings.Contains(got, "public-only") {
+		t.Fatalf("expected additive WebDAV-only loopback-hatch warning, got %q", got)
+	}
+	on, ok := fs.(*driver)
+	if !ok {
+		t.Fatalf("got %T, want *driver", fs)
+	}
+	if !on.sec.AllowLoopback {
+		t.Fatal("enabled hatch must set WebDAV AllowLoopback")
+	}
+	if on.discoverySec.AllowLoopback {
+		t.Fatal("enabled hatch must not set discovery AllowLoopback")
+	}
+	assertReceivedDialAllowed(t, receivedPeerDialPolicy(t, on, "https://8.8.8.8:1/"))
+	assertReceivedDialAllowed(t, receivedPeerDialPolicy(t, on, "https://192.0.2.1:1/"))
+	assertReceivedDialAllowed(t, receivedPeerDialPolicy(t, on, "https://127.0.0.1:1/"))
+	assertReceivedDialRefused(t, receivedPeerDialPolicy(t, on, "https://10.1.2.3:443/"))
+	t.Run("discovery allows public", func(t *testing.T) {
+		srv := startPublicTLSServer(t, http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+		assertReceivedDialAllowed(t, receivedDiscoveryDialPolicy(t, on, srv.URL+"/"))
+	})
+	assertReceivedDialRefused(t, receivedDiscoveryDialPolicy(t, on, "https://127.0.0.1:1/"))
+	assertReceivedDialRefused(t, receivedDiscoveryDialPolicy(t, on, "https://10.1.2.3:443/"))
+
+	buf.Reset()
+	fs, err = New(ctx, map[string]any{
+		"gatewaysvc":   "public-only-received-test.invalid:1",
+		"ocm_insecure": true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(buf.String(), "ocm_allow_loopback_federation") {
+		t.Fatalf("default off must not warn; got %q", buf.String())
+	}
+	off, ok := fs.(*driver)
+	if !ok {
+		t.Fatalf("got %T, want *driver", fs)
+	}
+	if off.c.OCMAllowLoopbackFederation || off.sec.AllowLoopback || off.discoverySec.AllowLoopback {
+		t.Fatal("hatch must default off")
+	}
+	assertReceivedDialAllowed(t, receivedPeerDialPolicy(t, off, "https://8.8.8.8:1/"))
+	assertReceivedDialRefused(t, receivedPeerDialPolicy(t, off, "https://127.0.0.1:1/"))
+	assertReceivedDialRefused(t, receivedDiscoveryDialPolicy(t, off, "https://127.0.0.1:1/"))
+}
+
+func assertReceivedDialRefused(t *testing.T, err error) {
+	t.Helper()
+	if !errors.Is(err, ocmd.ErrNonPublicAddr) {
+		t.Fatalf("got %v, want ocmd.ErrNonPublicAddr", err)
+	}
+}
+
+func TestReceivedLoopbackHatchOffDialPolicy(t *testing.T) {
+	d := newProductionReceivedDriver(t)
+	if d.c.OCMAllowLoopbackFederation || d.sec.AllowLoopback || d.discoverySec.AllowLoopback {
+		t.Fatal("missing knob must default to false")
+	}
+
+	t.Run("refuses loopback", func(t *testing.T) {
+		for _, rawURL := range []string{
+			"https://127.0.0.1/",
+			"https://[::1]/",
+		} {
+			t.Run(rawURL, func(t *testing.T) {
+				assertReceivedDialRefused(t, receivedPeerDialPolicy(t, d, rawURL))
+				assertReceivedDialRefused(t, receivedDiscoveryDialPolicy(t, d, rawURL))
+			})
+		}
+	})
+
+	t.Run("allows public", func(t *testing.T) {
+		for _, rawURL := range []string{
+			"https://8.8.8.8:1/",
+			"https://192.0.2.1:1/",
+		} {
+			t.Run(rawURL, func(t *testing.T) {
+				assertReceivedDialAllowed(t, receivedPeerDialPolicy(t, d, rawURL))
+			})
+		}
+	})
+
+	t.Run("refuses non-loopback private", func(t *testing.T) {
+		for _, rawURL := range []string{
+			"https://10.1.2.3/",
+			"https://192.168.1.1/",
+			"https://172.16.0.1/",
+			"https://172.31.255.1/",
+			"https://100.64.0.1/",
+		} {
+			t.Run(rawURL, func(t *testing.T) {
+				assertReceivedDialRefused(t, receivedPeerDialPolicy(t, d, rawURL))
+			})
+		}
+	})
+}
+
+func TestReceivedLoopbackHatchOnDialPolicy(t *testing.T) {
+	d := newLoopbackHatchReceivedDriver(t)
+	if !d.sec.AllowLoopback {
+		t.Fatal("WebDAV hatch must set AllowLoopback")
+	}
+	if d.discoverySec.AllowLoopback {
+		t.Fatal("discovery must stay public-only with hatch on")
+	}
+
+	t.Run("webdav allows loopback", func(t *testing.T) {
+		for _, rawURL := range []string{
+			"https://127.0.0.1:1/",
+			"https://127.1.2.3:1/",
+			"https://[::1]:1/",
+		} {
+			t.Run(rawURL, func(t *testing.T) {
+				assertReceivedDialAllowed(t, receivedPeerDialPolicy(t, d, rawURL))
+			})
+		}
+	})
+
+	t.Run("discovery refuses loopback", func(t *testing.T) {
+		for _, rawURL := range []string{
+			"https://127.0.0.1:1/",
+			"https://127.1.2.3:1/",
+			"https://[::1]:1/",
+		} {
+			t.Run(rawURL, func(t *testing.T) {
+				assertReceivedDialRefused(t, receivedDiscoveryDialPolicy(t, d, rawURL))
+			})
+		}
+	})
+
+	t.Run("allows public peer", func(t *testing.T) {
+		for _, rawURL := range []string{
+			"https://8.8.8.8:1/",
+			"https://192.0.2.1:1/",
+		} {
+			t.Run(rawURL, func(t *testing.T) {
+				assertReceivedDialAllowed(t, receivedPeerDialPolicy(t, d, rawURL))
+			})
+		}
+		t.Run("discovery", func(t *testing.T) {
+			srv := startPublicTLSServer(t, http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+			assertReceivedDialAllowed(t, receivedDiscoveryDialPolicy(t, d, srv.URL+"/"))
+		})
+	})
+
+	t.Run("refuses non-loopback private", func(t *testing.T) {
+		for _, rawURL := range []string{
+			"https://10.1.2.3/",
+			"https://192.168.1.1/",
+			"https://172.16.0.1/",
+			"https://172.31.255.1/",
+			"https://100.64.0.1/",
+		} {
+			t.Run(rawURL, func(t *testing.T) {
+				assertReceivedDialRefused(t, receivedPeerDialPolicy(t, d, rawURL))
+				assertReceivedDialRefused(t, receivedDiscoveryDialPolicy(t, d, rawURL))
+			})
+		}
+	})
+}
+
+func TestReceivedLoopbackHatchOnStillRefusesHTTP(t *testing.T) {
+	d := newLoopbackHatchReceivedDriver(t)
+
+	for _, rawURL := range []string{
+		"http://127.0.0.1/",
+		"http://[::1]/",
+	} {
+		t.Run(rawURL, func(t *testing.T) {
+			ocmErr := roundTripReceivedOCM(t, d, rawURL)
+			if !errors.Is(ocmErr, ocmd.ErrNonHTTPS) {
+				t.Fatalf("ocm transport: got %v, want ocmd.ErrNonHTTPS", ocmErr)
+			}
+			davErr := roundTripReceivedWebDAV(t, d, rawURL)
+			if !errors.Is(davErr, ocmd.ErrNonHTTPS) {
+				t.Fatalf("webdav transport: got %v, want ocmd.ErrNonHTTPS", davErr)
+			}
+		})
+	}
+
+	contacted := false
+	srv := httptest.NewServer(receivedWebDAVHandler(t, &contacted))
+	defer srv.Close()
+
+	share := receivedShareWithWebDAVURI(
+		srv.Listener.Addr().String(),
+		"share-abc",
+		srv.URL+"/remote.php/dav/ocm/share-abc",
+	)
+	d.gateway = &mockReceivedGateway{shares: []*ocmpb.ReceivedShare{share}}
+
+	_, err := d.GetMD(context.Background(), &provider.Reference{Path: "/share-abc"}, nil)
+	if contacted {
+		t.Fatal("hatch on must still refuse http before contacting the peer")
+	}
+	if !errors.Is(err, ocmd.ErrNonHTTPS) {
+		t.Fatalf("GetMD: got %v, want ocmd.ErrNonHTTPS", err)
+	}
+}
+
+func TestReceivedLoopbackHatchOnKeepsOtherGuards(t *testing.T) {
+	fs, err := New(context.Background(), map[string]any{
+		"gatewaysvc":                    "public-only-received-test.invalid:1",
+		"ocm_timeout":                   5,
+		"ocm_insecure":                  true,
+		"ocm_allow_loopback_federation": true,
+		"ocm_tls_min_version":           "1.3",
+		"ocm_response_limit":            4096,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	d, ok := fs.(*driver)
+	if !ok {
+		t.Fatalf("got %T, want *driver", fs)
+	}
+	if !d.sec.AllowLoopback {
+		t.Fatal("expected WebDAV AllowLoopback")
+	}
+	if d.discoverySec.AllowLoopback {
+		t.Fatal("discovery must stay public-only with hatch on")
+	}
+	if d.c.OCMResponseLimit != 4096 {
+		t.Fatalf("OCMResponseLimit = %d, want 4096 with hatch on", d.c.OCMResponseLimit)
+	}
+	if d.tlsMinVersion != tls.VersionTLS13 {
+		t.Fatalf("tlsMinVersion = %#x, want TLS 1.3 with hatch on", d.tlsMinVersion)
+	}
+
+	webdavRT := ocmd.UntrustedHTTPTransport(
+		5*time.Second,
+		true,
+		d.sec,
+		d.tlsMinVersion,
+	)
+	webdavInner := innerUntrustedTransport(t, webdavRT)
+	if webdavInner.TLSClientConfig == nil || webdavInner.TLSClientConfig.MinVersion != tls.VersionTLS13 {
+		t.Fatalf("hatch-on WebDAV transport MinVersion = %v, want TLS 1.3", webdavInner.TLSClientConfig)
+	}
+	discoInner := innerUntrustedTransport(t, d.ocmClient.HTTPTransport())
+	if discoInner.TLSClientConfig == nil || discoInner.TLSClientConfig.MinVersion != tls.VersionTLS13 {
+		t.Fatalf("hatch-on discovery transport MinVersion = %v, want TLS 1.3", discoInner.TLSClientConfig)
+	}
+
+	httpsURL, err := http.NewRequest(http.MethodGet, "https://127.0.0.1/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, sec := range []ocmd.UntrustedClientSecurity{d.sec, d.discoverySec} {
+		if err := sec.CheckRedirect(httpsURL, []*http.Request{{}, {}, {}}); err != nil {
+			t.Fatalf("len(via)=3 must still be allowed with hatch on: %v", err)
+		}
+		if err := sec.CheckRedirect(httpsURL, []*http.Request{{}, {}, {}, {}}); err == nil {
+			t.Fatal("hatch on must still refuse a fourth redirect")
+		} else if !errors.Is(err, ocmd.ErrTooManyRedirects) {
+			t.Fatalf("got %v, want ocmd.ErrTooManyRedirects", err)
+		}
+	}
+}
+
+func TestReceivedLoopbackHatchOnRejectsOversizedDiscovery(t *testing.T) {
+	fs, err := New(context.Background(), map[string]any{
+		"gatewaysvc":                    "public-only-received-test.invalid:1",
+		"ocm_timeout":                   5,
+		"ocm_insecure":                  true,
+		"ocm_allow_loopback_federation": true,
+		"ocm_response_limit":            64,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	d, ok := fs.(*driver)
+	if !ok {
+		t.Fatalf("got %T, want *driver", fs)
+	}
+
+	payload := map[string]any{
+		"enabled":       true,
+		"apiVersion":    "1.2.0",
+		"provider":      strings.Repeat("a", 80),
+		"resourceTypes": []any{},
+		"tokenEndPoint": "https://example.invalid/ocm/token",
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(body) <= 64 {
+		t.Fatalf("fixture body is %d bytes, want more than 64", len(body))
+	}
+
+	contacted := false
+	srv := startPublicTLSServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		contacted = true
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(body)
+	}))
+
+	got, err := d.getTokenEndpoint(
+		context.Background(),
+		testCodeFlowReceivedShare(srv.Listener.Addr().String(), srv.URL),
+	)
+	if !contacted {
+		t.Fatal("hatch on must still reach the public peer before applying the response limit")
+	}
+	if err == nil {
+		t.Fatal("expected oversized discovery body to be rejected with hatch on")
+	}
+	if !strings.Contains(err.Error(), "ocm response body exceeds size limit") {
+		t.Fatalf("got %v, want ocm response size-limit error", err)
+	}
+	if got != "" {
+		t.Fatalf("oversized discovery must not return a token endpoint, got %q", got)
+	}
+}
+
+func TestReceivedLoopbackHatchOnAllowsPublicHTTPS(t *testing.T) {
+	d := newLoopbackHatchReceivedDriver(t)
+
+	var discoSrv *httptest.Server
+	discoSrv = startPublicTLSServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/.well-known/ocm" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"enabled":       true,
+			"apiVersion":    "1.2.0",
+			"endPoint":      discoSrv.URL + "/ocm",
+			"provider":      "reva",
+			"resourceTypes": []any{},
+			"tokenEndPoint": discoSrv.URL + "/ocm/token",
+		})
+	}))
+
+	got, err := d.getTokenEndpoint(context.Background(), testCodeFlowReceivedShare(discoSrv.Listener.Addr().String(), discoSrv.URL))
+	if err != nil {
+		t.Fatalf("getTokenEndpoint on public HTTPS with hatch on: %v", err)
+	}
+	want := discoSrv.URL + "/ocm/token"
+	if got != want {
+		t.Fatalf("getTokenEndpoint() = %q, want %q", got, want)
+	}
+
+	contacted := false
+	davSrv := startPublicTLSServer(t, receivedWebDAVHandler(t, &contacted))
+	share := receivedShareWithWebDAVURI(
+		davSrv.Listener.Addr().String(),
+		"share-abc",
+		davSrv.URL+"/remote.php/dav/ocm/share-abc",
+	)
+	d.gateway = &mockReceivedGateway{shares: []*ocmpb.ReceivedShare{share}}
+
+	info, err := d.GetMD(context.Background(), &provider.Reference{Path: "/share-abc"}, nil)
+	if err != nil {
+		t.Fatalf("GetMD on public HTTPS with hatch on: %v", err)
+	}
+	if info == nil {
+		t.Fatal("expected resource info for public HTTPS WebDAV with hatch on")
+	}
+	if !contacted {
+		t.Fatal("expected received-share WebDAV access to reach the public HTTPS host with hatch on")
+	}
+}
+
+func TestReceivedLoopbackHatchOnAllowsLoopbackHTTPS(t *testing.T) {
+	d := newLoopbackHatchReceivedDriver(t)
+
+	contacted := false
+	davSrv := httptest.NewTLSServer(receivedWebDAVHandler(t, &contacted))
+	defer davSrv.Close()
+
+	davShare := receivedShareWithWebDAVURI(
+		davSrv.Listener.Addr().String(),
+		"share-abc",
+		davSrv.URL+"/remote.php/dav/ocm/share-abc",
+	)
+	d.gateway = &mockReceivedGateway{shares: []*ocmpb.ReceivedShare{davShare}}
+
+	info, err := d.GetMD(context.Background(), &provider.Reference{Path: "/share-abc"}, nil)
+	if err != nil {
+		t.Fatalf("GetMD on loopback HTTPS with hatch on: %v", err)
+	}
+	if info == nil {
+		t.Fatal("expected resource info for loopback HTTPS WebDAV with hatch on")
+	}
+	if !contacted {
+		t.Fatal("expected received-share WebDAV access to reach the loopback HTTPS host")
+	}
+}
+
+func TestReceivedLoopbackHatchOnRejectsLoopbackDiscovery(t *testing.T) {
+	d := newLoopbackHatchReceivedDriver(t)
+
+	fetched := false
+	var discoSrv *httptest.Server
+	discoSrv = httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fetched = true
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"enabled":       true,
+			"apiVersion":    "1.2.0",
+			"endPoint":      discoSrv.URL + "/ocm",
+			"provider":      "reva",
+			"resourceTypes": []any{},
+			"tokenEndPoint": discoSrv.URL + "/ocm/token",
+		})
+	}))
+	defer discoSrv.Close()
+
+	loopHost, _, err := net.SplitHostPort(discoSrv.Listener.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	share := testCodeFlowReceivedShare(discoSrv.Listener.Addr().String(), discoSrv.URL)
+	ctx, tr := contextWithHostDialTrace(context.Background())
+	got, err := d.getTokenEndpoint(ctx, share)
+	if fetched {
+		t.Fatal("hatch on must still refuse loopback discovery before contacting the peer")
+	}
+	assertNoEstablishedHost(t, tr, loopHost)
+	if err == nil {
+		t.Fatal("expected loopback discovery to be rejected with ocm_allow_loopback_federation=true")
+	}
+	if got != "" {
+		t.Fatalf("loopback discovery must not return a token endpoint, got %q", got)
+	}
+	discoErr := roundTripReceivedOCM(t, d, discoSrv.URL+"/.well-known/ocm")
+	if !errors.Is(discoErr, ocmd.ErrNonPublicAddr) {
+		t.Fatalf("discovery transport: got %v, want ocmd.ErrNonPublicAddr", discoErr)
+	}
+
+	_, exchErr := d.exchangeAccessToken(context.Background(), share, discoSrv.URL+"/ocm/token", "secret")
+	if fetched {
+		t.Fatal("hatch on must still refuse loopback token exchange before contacting the peer")
+	}
+	assertRefusedNonPublic(t, exchErr)
 }

--- a/pkg/ocm/storage/received/ocm_test.go
+++ b/pkg/ocm/storage/received/ocm_test.go
@@ -313,7 +313,7 @@ func newTestReceivedDriver() *driver {
 		},
 		ccache:         ttlcache.NewCache(),
 		discoveryCache: disco,
-		ocmClient:      ocmd.NewClient(10*time.Second, true),
+		ocmClient:      ocmd.NewClient(10*time.Second, true, 0),
 	}
 }
 
@@ -775,6 +775,51 @@ func assertRefusedNonPublic(t *testing.T, err error) {
 	}
 	if !errors.Is(err, ocmd.ErrNonPublicAddr) {
 		t.Fatalf("got %v, want ocmd.ErrNonPublicAddr", err)
+	}
+}
+
+func TestConfigOCMResponseLimit(t *testing.T) {
+	tests := []struct {
+		name      string
+		extra     map[string]any
+		wantLimit int64
+	}{
+		{
+			name:      "defaults when unset",
+			extra:     map[string]any{},
+			wantLimit: 1 << 20,
+		},
+		{
+			name: "parses configured limit",
+			extra: map[string]any{
+				"ocm_response_limit": 2097152,
+			},
+			wantLimit: 2097152,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := map[string]any{
+				"gatewaysvc":   "public-only-received-test.invalid:1",
+				"ocm_timeout":  5,
+				"ocm_insecure": true,
+			}
+			for k, v := range tt.extra {
+				m[k] = v
+			}
+			fs, err := New(context.Background(), m)
+			if err != nil {
+				t.Fatal(err)
+			}
+			d, ok := fs.(*driver)
+			if !ok {
+				t.Fatalf("got %T, want *driver", fs)
+			}
+			if d.c.OCMResponseLimit != tt.wantLimit {
+				t.Errorf("OCMResponseLimit = %d, want %d", d.c.OCMResponseLimit, tt.wantLimit)
+			}
+		})
 	}
 }
 

--- a/pkg/ocm/storage/received/untrusted_hardening_regression_test.go
+++ b/pkg/ocm/storage/received/untrusted_hardening_regression_test.go
@@ -1,0 +1,230 @@
+// Copyright 2018-2026 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package ocm
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	ocmpb "github.com/cs3org/go-cs3apis/cs3/sharing/ocm/v1beta1"
+	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+	"github.com/cs3org/reva/v3/internal/http/services/opencloudmesh/ocmd"
+)
+
+// TestUntrustedHardeningRegression is the received-surface T8 sweep. It
+// goes through received.New and the constructor-wired WebDAV builders;
+// the broad T4/T6 matrices stay in ocm_test.go.
+func TestUntrustedHardeningRegression(t *testing.T) {
+	t.Run("loopback hatch via received.New", testRegressionReceivedLoopbackHatch)
+	t.Run("metadata timeout vs uncapped stream", testRegressionReceivedSplitClients)
+}
+
+func testRegressionReceivedLoopbackHatch(t *testing.T) {
+	t.Run("off by default", func(t *testing.T) {
+		d := newProductionReceivedDriver(t)
+		if d.c.OCMAllowLoopbackFederation || d.sec.AllowLoopback || d.discoverySec.AllowLoopback {
+			t.Fatal("ocm_allow_loopback_federation must default off")
+		}
+		assertReceivedDialRefused(t, receivedPeerDialPolicy(t, d, "https://127.0.0.1:443/"))
+		assertReceivedDialRefused(t, receivedDiscoveryDialPolicy(t, d, "https://127.0.0.1:1/"))
+	})
+
+	d := newLoopbackHatchReceivedDriver(t)
+	if !d.c.OCMAllowLoopbackFederation || !d.sec.AllowLoopback {
+		t.Fatal("received.New must enable the WebDAV loopback hatch")
+	}
+	if d.discoverySec.AllowLoopback {
+		t.Fatal("discovery must stay public-only with the hatch on")
+	}
+
+	t.Run("webdav hatch allows loopback", func(t *testing.T) {
+		assertReceivedDialAllowed(t, receivedPeerDialPolicy(t, d, "https://127.0.0.1:443/"))
+		assertReceivedDialAllowed(t, receivedPeerDialPolicy(t, d, "https://[::1]:443/"))
+
+		contacted := false
+		davSrv := httptest.NewTLSServer(receivedWebDAVHandler(t, &contacted))
+		t.Cleanup(davSrv.Close)
+		share := receivedShareWithWebDAVURI(
+			davSrv.Listener.Addr().String(),
+			"share-abc",
+			davSrv.URL+"/remote.php/dav/ocm/share-abc",
+		)
+		d.gateway = &mockReceivedGateway{shares: []*ocmpb.ReceivedShare{share}}
+		info, err := d.GetMD(context.Background(), &provider.Reference{Path: "/share-abc"}, nil)
+		if err != nil {
+			t.Fatalf("GetMD on loopback HTTPS with hatch on: %v", err)
+		}
+		if info == nil || !contacted {
+			t.Fatal("loopback WebDAV must be reachable through received.New")
+		}
+	})
+
+	t.Run("discovery stays public-only", func(t *testing.T) {
+		assertReceivedDialRefused(t, receivedDiscoveryDialPolicy(t, d, "https://127.0.0.1:1/"))
+
+		fetched := false
+		disco := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fetched = true
+			w.WriteHeader(http.StatusOK)
+		}))
+		t.Cleanup(disco.Close)
+		if err := roundTripReceivedOCM(t, d, disco.URL+"/.well-known/ocm"); !errors.Is(err, ocmd.ErrNonPublicAddr) {
+			t.Fatalf("discovery Do: got %v, want ocmd.ErrNonPublicAddr", err)
+		}
+		if fetched {
+			t.Fatal("loopback discovery must be refused before contact")
+		}
+	})
+
+	t.Run("non-loopback private is refused", func(t *testing.T) {
+		assertReceivedDialRefused(t, receivedPeerDialPolicy(t, d, "https://10.1.2.3:443/"))
+		assertReceivedDialRefused(t, receivedDiscoveryDialPolicy(t, d, "https://10.1.2.3:443/"))
+	})
+}
+
+func testRegressionReceivedSplitClients(t *testing.T) {
+	d := newReceivedDriverWithTimeouts(t, 5, 1, 0)
+	if d.c.WebDAVTransferTimeout != 0 {
+		t.Fatalf("WebDAVTransferTimeout = %d, want 0", d.c.WebDAVTransferTimeout)
+	}
+
+	t.Run("large ReadStream completes with no total cap", func(t *testing.T) {
+		const (
+			requestTimeout = time.Second
+			dripCount      = 8
+			dripGap        = 250 * time.Millisecond
+		)
+		body := bytes.Repeat([]byte("x"), 256*1024)
+
+		t.Run("large ReadStream completes", func(t *testing.T) {
+			srv := startPublicTLSServer(t, receivedShareDAVHandler(t, nil, func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write(body)
+			}))
+
+			stream := d.newReceivedWebDAVStreamClient(srv.URL + "/remote.php/dav/ocm/share-abc")
+			rc, err := stream.ReadStream("")
+			if err != nil {
+				t.Fatalf("ReadStream: %v", err)
+			}
+			defer rc.Close()
+			got, err := io.ReadAll(rc)
+			if err != nil {
+				t.Fatalf("ReadAll: %v", err)
+			}
+			if !bytes.Equal(got, body) {
+				t.Fatalf("ReadStream truncated: got %d bytes, want %d", len(got), len(body))
+			}
+		})
+
+		t.Run("slow-drip stream is not truncated", func(t *testing.T) {
+			srv := startPublicTLSServer(t, receivedShareDAVHandler(t, nil, func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				flusher, _ := w.(http.Flusher)
+				for i := 0; i < dripCount; i++ {
+					_, _ = w.Write([]byte("x"))
+					if flusher != nil {
+						flusher.Flush()
+					}
+					time.Sleep(dripGap)
+				}
+			}))
+
+			stream := d.newReceivedWebDAVStreamClient(srv.URL + "/remote.php/dav/ocm/share-slow")
+			start := time.Now()
+			rc, err := stream.ReadStream("")
+			if err != nil {
+				t.Fatalf("ReadStream: %v", err)
+			}
+			defer rc.Close()
+			got, err := io.ReadAll(rc)
+			elapsed := time.Since(start)
+			if err != nil {
+				t.Fatalf("ReadAll: %v", err)
+			}
+			if string(got) != strings.Repeat("x", dripCount) {
+				t.Fatalf("slow-drip stream truncated: got %q", got)
+			}
+			if elapsed < requestTimeout {
+				t.Fatalf("elapsed %v did not exceed metadata timeout %v", elapsed, requestTimeout)
+			}
+			if elapsed < time.Duration(dripCount-1)*dripGap {
+				t.Fatalf("expected the drip to take more than webdav_timeout; elapsed %v", elapsed)
+			}
+		})
+	})
+
+	t.Run("metadata client remains bounded", func(t *testing.T) {
+		const (
+			requestTimeout = time.Second
+			dialTimeout    = 5 * time.Second
+			peerSleep      = 1200 * time.Millisecond
+		)
+		started := make(chan struct{})
+		srv := startPublicTLSServer(t, receivedShareDAVHandler(t, func(w http.ResponseWriter, r *http.Request) {
+			close(started)
+			time.Sleep(peerSleep)
+			w.Header().Set("Content-Type", "application/xml")
+			w.WriteHeader(207)
+			_, _ = w.Write([]byte(receivedWebDAVPropfindXML))
+		}, nil))
+
+		meta := d.newReceivedWebDAVClient(srv.URL + "/remote.php/dav/ocm/share-abc")
+		start := time.Now()
+		_, err := meta.Stat("")
+		elapsed := time.Since(start)
+		if err == nil {
+			t.Fatal("expected slow Stat to be bounded by webdav_timeout")
+		}
+		assertReceivedHTTPClientTimeout(t, err)
+		if elapsed < requestTimeout/2 {
+			t.Fatalf("failed too quickly to be the request deadline: elapsed %v", elapsed)
+		}
+		if elapsed >= dialTimeout/2 {
+			t.Fatalf("elapsed %v looks like the dial deadline, want request timeout %v", elapsed, requestTimeout)
+		}
+		select {
+		case <-started:
+		default:
+			t.Fatal("expected the slow metadata peer to accept the connection")
+		}
+	})
+}
+
+func assertReceivedHTTPClientTimeout(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected request deadline")
+	}
+	if strings.Contains(err.Error(), "Client.Timeout") {
+		return
+	}
+	if errors.Is(err, os.ErrDeadlineExceeded) || errors.Is(err, context.DeadlineExceeded) {
+		return
+	}
+	t.Fatalf("got %v, want request deadline, not a dial failure", err)
+}


### PR DESCRIPTION
This PR is a part of https://github.com/cs3org/OCM-STA/issues/1
This PR depends on the https://github.com/cs3org/reva/pull/5385 to be merged first.

## Description
This PR introduces security measures to the OCM client to prevent common attack vectors such as SSRF, DNS rebinding, and resource exhaustion attacks. The implementation provides configurable security controls while maintaining backward compatibility with existing code.