### PR TITLE
Fixed permissions for upload-only links

### DIFF
--- a/changelog/unreleased/fix-upload-links.md
+++ b/changelog/unreleased/fix-upload-links.md
@@ -1,0 +1,7 @@
+Bugfix: Fixed permissions for upload-only links
+
+Pending a proper refactoring of the permissions model,
+this PR fixes the bug unveiled after merging #5364.
+Cf. also Jira CERNBOX-4127.
+
+https://github.com/cs3org/reva/pull/5392

--- a/internal/http/services/owncloud/ocs/conversions/role.go
+++ b/internal/http/services/owncloud/ocs/conversions/role.go
@@ -296,11 +296,7 @@ func RoleFromResourcePermissions(rp *provider.ResourcePermissions) *Role {
 		rp.InitiateFileDownload {
 		r.ocsPermissions |= PermissionRead
 	}
-	if rp.InitiateFileUpload {
-		r.ocsPermissions |= PermissionWrite
-	}
-	if rp.ListContainer &&
-		rp.Stat &&
+	if rp.Stat &&
 		rp.InitiateFileUpload {
 		r.ocsPermissions |= PermissionCreate
 	}
@@ -317,8 +313,9 @@ func RoleFromResourcePermissions(rp *provider.ResourcePermissions) *Role {
 	}
 
 	if r.ocsPermissions.Contain(PermissionRead) {
-		if r.ocsPermissions.Contain(PermissionWrite) {
+		if r.ocsPermissions.Contain(PermissionCreate) {
 			r.Name = RoleFileEditor
+			r.ocsPermissions |= PermissionWrite
 			if r.ocsPermissions.Contain(PermissionCreate) && r.ocsPermissions.Contain(PermissionDelete) {
 				r.Name = RoleEditor
 				if r.ocsPermissions.Contain(PermissionShare) {


### PR DESCRIPTION
Pending a proper refactoring of the permissions model, this fixes the bug unveiled by #5364