### PR TITLE
Acess-Control-Expose-Headers for Range requests

### DIFF
--- a/changelog/unreleased/cors-headers-defaults.md
+++ b/changelog/unreleased/cors-headers-defaults.md
@@ -1,0 +1,5 @@
+Enhancement: add Acess-Control-Expose-Headers for Range requests
+
+We add the necessary headers for multipart range requests to Acess-Control-Expose-Headers to expose these, so that clients can read them
+
+https://github.com/cs3org/reva/pull/5403

--- a/internal/http/interceptors/cors/cors.go
+++ b/internal/http/interceptors/cors/cors.go
@@ -104,12 +104,16 @@ func New(m map[string]interface{}) (global.Middleware, int, error) {
 			"Upload-Checksum",
 			"Upload-Offset",
 			"X-HTTP-Method-Override",
+			"Range",
 		}
 	}
 
 	if len(conf.ExposedHeaders) == 0 {
 		conf.ExposedHeaders = []string{
 			"Location",
+			"Content-Range",
+			"Content-Length",
+			"Accept-Ranges",
 		}
 	}
 

--- a/internal/http/services/owncloud/ocdav/ocdav.go
+++ b/internal/http/services/owncloud/ocdav/ocdav.go
@@ -335,7 +335,7 @@ func applyLayout(ctx context.Context, ns string, useLoggedInUserNS bool, request
 func addAccessHeaders(w http.ResponseWriter, r *http.Request) {
 	headers := w.Header()
 	// the webdav api is accessible from anywhere
-	headers.Set("Access-Control-Allow-Origin", "*")
+	headers.Set(HeaderAccessControlAllowOrigin, "*")
 	// all resources served via the DAV endpoint should have the strictest possible as default
 	headers.Set("Content-Security-Policy", "default-src 'none';")
 	// disable sniffing the content type for IE

--- a/internal/http/services/owncloud/ocdav/webdav.go
+++ b/internal/http/services/owncloud/ocdav/webdav.go
@@ -42,6 +42,7 @@ const (
 	HeaderAcceptRanges               = "Accept-Ranges"
 	HeaderAccessControlAllowHeaders  = "Access-Control-Allow-Headers"
 	HeaderAccessControlExposeHeaders = "Access-Control-Expose-Headers"
+	HeaderAccessControlAllowOrigin   = "Access-Control-Allow-Origin"
 	HeaderContentDisposistion        = "Content-Disposition"
 	HeaderContentLength              = "Content-Length"
 	HeaderContentRange               = "Content-Range"


### PR DESCRIPTION
We add the necessary headers for multipart range requests to  Acess-Control-Expose-Headers to expose these, so that clients can read them