### PR TITLE
add(build): musl-based fully static build target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ GIT_COMMIT	?= `git rev-parse --short HEAD`
 VERSION		?= `git describe --always`
 GO_VERSION	?= `go version | awk '{print $$3}'`
 BUILD_DATE	= `date +%FT%T%z`
-BUILD_FLAGS     = -X github.com/cs3org/reva/cmd/revad.gitCommit=$(GIT_COMMIT) -X github.com/cs3org/reva/cmd/revad.version=$(VERSION) -X github.com/cs3org/reva/cmd/revad.goVersion=$(GO_VERSION) -X github.com/cs3org/reva/cmd/revad.buildDate=$(BUILD_DATE)
+BUILD_FLAGS     = -X github.com/cs3org/reva/v3/cmd/revad.gitCommit=$(GIT_COMMIT) -X github.com/cs3org/reva/v3/cmd/revad.version=$(VERSION) -X github.com/cs3org/reva/v3/cmd/revad.goVersion=$(GO_VERSION) -X github.com/cs3org/reva/v3/cmd/revad.buildDate=$(BUILD_DATE)
 
 .PHONY: revad
 revad:
@@ -37,7 +37,12 @@ revad:
 
 .PHONY: revad-static
 revad-static:
-	go build -ldflags "-extldflags=-static $(BUILD_FLAGS)" -o ./cmd/revad/revad ./cmd/revad/main
+	go build -tags "sqlite_omit_load_extension" -ldflags "-extldflags=-static $(BUILD_FLAGS)" -o ./cmd/revad/revad ./cmd/revad/main
+
+.PHONY: revad-static-musl
+revad-static-musl:
+	@command -v musl-gcc >/dev/null 2>&1 || { echo "Error: musl-gcc not found. Install with: sudo apt install musl-tools"; exit 1; }
+	CGO_ENABLED=1 CC=musl-gcc go build -tags "sqlite_omit_load_extension" -ldflags "-extldflags '-static' $(BUILD_FLAGS)" -o ./cmd/revad/revad ./cmd/revad/main
 
 .PHONY: gaia
 gaia:

--- a/changelog/unreleased/musl-static-build.md
+++ b/changelog/unreleased/musl-static-build.md
@@ -1,0 +1,13 @@
+Enhancement: Add musl-based fully static build target
+
+Added a new `revad-static-musl` Makefile target that produces a fully statically
+linked binary using musl libc instead of glibc. This eliminates the linker
+warnings that appeared with the standard static build and creates a truly portable
+binary that runs on any Linux distribution without requiring matching glibc
+versions.
+
+Also fixed the build info injection by correcting the package path in BUILD_FLAGS
+to include the `/v3` module version, ensuring version, commit, and build date
+information are properly displayed in the binary.
+
+https://github.com/cs3org/reva/pull/5407


### PR DESCRIPTION
Reva version is fixed,
Then:
```
root in reva at homelab on  mahdi/fix/version [$!] …
➜ make revad-static-musl     
CGO_ENABLED=1 CC=musl-gcc go build -tags "sqlite_omit_load_extension" -ldflags "-extldflags '-static' -X github.com/cs3org/reva/cmd/revad.gitCommit=$(git rev-parse --short HEAD) -X github.com/cs3org/reva/cmd/revad.version=$(git describe --always) -X github.com/cs3org/reva/cmd/revad.goVersion=$(go version | awk '{print $3}') -X github.com/cs3org/reva/cmd/revad.buildDate=$(date +%FT%T%z)" -o ./cmd/revad/revad ./cmd/revad/main

root in reva at homelab took 2.2s …
➜ ./cmd/revad/revad --version
version= commit= go_version= build_date=
```

Now:
```
root in reva at homelab on  mahdi/fix/version [$!] took 2.5s …
➜ make revad-static-musl
CGO_ENABLED=1 CC=musl-gcc go build -tags "sqlite_omit_load_extension" -ldflags "-extldflags '-static' -X github.com/cs3org/reva/v3/cmd/revad.gitCommit=`git rev-parse --short HEAD` -X github.com/cs3org/reva/v3/cmd/revad.version=`git describe --always` -X github.com/cs3org/reva/v3/cmd/revad.goVersion=`go version | awk '{print $3}'` -X github.com/cs3org/reva/v3/cmd/revad.buildDate=`date +%FT%T%z`" -o ./cmd/revad/revad ./cmd/revad/main

root in reva at homelab on  mahdi/fix/version [$!] took 2.4s …
➜ ./cmd/revad/revad --version                                                                              
version=728aca32b commit=728aca32b go_version=go1.25.1 build_date=2025-11-21T11:12:43+0000
```