### PR TITLE
Do not give `delete` permission to root of public links

### DIFF
--- a/changelog/unreleased/fix-pl-self-delete.md
+++ b/changelog/unreleased/fix-pl-self-delete.md
@@ -1,0 +1,5 @@
+Bugfix: do not give delete permission to root of public links
+
+Otherwise, a folder shared through a public link could itself be deleted
+
+https://github.com/cs3org/reva/pull/5422

--- a/internal/grpc/services/publicstorageprovider/publicstorageprovider.go
+++ b/internal/grpc/services/publicstorageprovider/publicstorageprovider.go
@@ -503,6 +503,13 @@ func (s *service) Stat(ctx context.Context, req *provider.StatRequest) (*provide
 	}
 
 	if shareInfo.Type == provider.ResourceType_RESOURCE_TYPE_FILE || (relativePath == "" && nodeID == "") || shareInfo.Id.OpaqueId == nodeID {
+		// We do not want public links to be able to "delete" themselves
+		// so on the root, we remove the delete permission
+		if shareInfo.Type == provider.ResourceType_RESOURCE_TYPE_CONTAINER && (relativePath == "" || relativePath == "/") {
+			shareInfo.PermissionSet.Delete = false
+
+		}
+
 		res := &provider.StatResponse{
 			Status: status.NewOK(ctx),
 			Info:   shareInfo,


### PR DESCRIPTION
Otherwise, a folder shared through a public link could itself be deleted