### PR TITLE
Make `href` proper in `REPORT`

### DIFF
--- a/changelog/unreleased/report-href.md
+++ b/changelog/unreleased/report-href.md
@@ -1,0 +1,5 @@
+Bugfix: make href proper in REPORT
+
+github.com/cs3org/reva/pull/5409 broke REPORT calls, which are used for favorites. This is now fixed
+
+https://github.com/cs3org/reva/pull/5423

--- a/internal/http/services/owncloud/ocdav/propfind.go
+++ b/internal/http/services/owncloud/ocdav/propfind.go
@@ -529,6 +529,18 @@ func (s *svc) mdToPropResponse(ctx context.Context, pf *propfindXML, md *provide
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to join relative path with ref: %v", md.Path)
 		}
+	} else {
+		// If no parent specified, we just take space id + path relative to space
+		spaceID := md.Id.SpaceId
+		spacePath, _ := spaces.DecodeSpaceID(spaceID)
+		relativePath, err := filepath.Rel(spacePath, md.Path)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to calculate path relative to space: %v. %v", spacePath, md.Path)
+		}
+		href, err = url.JoinPath(ref, spaceID, relativePath)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to join relative path with ref: %v", md.Path)
+		}
 	}
 
 	if md.Type == provider.ResourceType_RESOURCE_TYPE_CONTAINER {

--- a/internal/http/services/owncloud/ocdav/report.go
+++ b/internal/http/services/owncloud/ocdav/report.go
@@ -22,7 +22,6 @@ import (
 	"encoding/xml"
 	"io"
 	"net/http"
-	"net/url"
 	"strings"
 
 	rpcv1beta1 "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
@@ -140,13 +139,7 @@ func (s *svc) doFilterFiles(w http.ResponseWriter, r *http.Request, ff *reportFi
 		}
 	}
 
-	baseURI := ctx.Value(ctxKeyBaseURI).(string)
-	href, err := url.JoinPath(baseURI, r.URL.Path)
-	if err != nil {
-		log.Error().Err(err).Msg("error formatting propfind")
-		w.WriteHeader(http.StatusInternalServerError)
-		return
-	}
+	href := ctx.Value(ctxKeyBaseURI).(string)
 	responsesXML, err := s.multistatusResponse(ctx, &propfindXML{Prop: ff.Prop}, resourceInfos, nil, namespace, href, nil, nil)
 	if err != nil {
 		log.Error().Err(err).Msg("error formatting propfind")


### PR DESCRIPTION
[github.com/cs3org/reva/pull/5409 ](https://github.com/cs3org/reva/pull/5409) broke `REPORT` calls, which are used for favorites. This is now fixed