### PR TITLE
Fix: allow lightweight users to use external apps

### DIFF
--- a/changelog/unreleased/fix-edit-lwaccount.md
+++ b/changelog/unreleased/fix-edit-lwaccount.md
@@ -1,0 +1,6 @@
+Bugfix: allow lightweight accounts to use external apps
+
+For that, we need to explicitly allow all relevant
+storage provider requests when checking the lw scope.
+
+https://github.com/cs3org/reva/pull/5444


### PR DESCRIPTION
This requires allowing lock operations in the lightweight accounts scope