### PR TITLE
OCM: removed datatx protocol, now deprecated, and added accessTypes

### DIFF
--- a/changelog/unreleased/ocm-remove-datatx.md
+++ b/changelog/unreleased/ocm-remove-datatx.md
@@ -1,0 +1,6 @@
+Enhancement: OCM: support access_types and drop datatx protocol
+
+This PR adapts the OCM implementation to v1.3.
+No new capabilities have been added yet.
+
+https://github.com/cs3org/reva/pull/5476

--- a/cmd/reva/ocm-share-create.go
+++ b/cmd/reva/ocm-share-create.go
@@ -33,8 +33,8 @@ import (
 	ocm "github.com/cs3org/go-cs3apis/cs3/sharing/ocm/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	types "github.com/cs3org/go-cs3apis/cs3/types/v1beta1"
-	"github.com/cs3org/reva/v3/pkg/permissions"
 	ocmshare "github.com/cs3org/reva/v3/pkg/ocm/share"
+	"github.com/cs3org/reva/v3/pkg/permissions"
 	"github.com/cs3org/reva/v3/pkg/utils"
 	"github.com/jedib0t/go-pretty/table"
 	"github.com/pkg/errors"
@@ -197,7 +197,7 @@ func getAccessMethods(webdav, webapp, datatx bool, rol string) ([]*ocm.AccessMet
 		if err != nil {
 			return nil, err
 		}
-		m = append(m, ocmshare.NewWebDavAccessMethod(perm, []string{}))
+		m = append(m, ocmshare.NewWebDavAccessMethod(perm, []ocm.AccessType{}, []string{}))
 	}
 	if webapp {
 		v, err := getOCMViewMode(rol)
@@ -205,9 +205,6 @@ func getAccessMethods(webdav, webapp, datatx bool, rol string) ([]*ocm.AccessMet
 			return nil, err
 		}
 		m = append(m, ocmshare.NewWebappAccessMethod(v))
-	}
-	if datatx {
-		m = append(m, ocmshare.NewTransferAccessMethod())
 	}
 	return m, nil
 }
@@ -219,7 +216,7 @@ func getOCMSharePerm(p string) (*provider.ResourcePermissions, error) {
 	case editorPermission:
 		return permissions.NewEditorRole().CS3ResourcePermissions(), nil
 	}
-	return nil, errors.New("invalid rol: " + p)
+	return nil, errors.New("invalid role: " + p)
 }
 
 func getOCMViewMode(p string) (appprovider.ViewMode, error) {
@@ -229,5 +226,5 @@ func getOCMViewMode(p string) (appprovider.ViewMode, error) {
 	case editorPermission:
 		return appprovider.ViewMode_VIEW_MODE_READ_WRITE, nil
 	}
-	return 0, errors.New("invalid rol: " + p)
+	return 0, errors.New("invalid role: " + p)
 }

--- a/cmd/reva/ocm-share-update-received.go
+++ b/cmd/reva/ocm-share-update-received.go
@@ -24,7 +24,6 @@ import (
 
 	rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
 	ocm "github.com/cs3org/go-cs3apis/cs3/sharing/ocm/v1beta1"
-	typesv1beta1 "github.com/cs3org/go-cs3apis/cs3/types/v1beta1"
 	"github.com/pkg/errors"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 )
@@ -78,25 +77,9 @@ func ocmShareUpdateReceivedCommand() *command {
 		}
 		shareRes.Share.State = shareState
 
-		// check if we are dealing with a transfer in case the destination path needs to be set
-		_, ok := getTransferProtocol(shareRes.Share)
-		var opaque *typesv1beta1.Opaque
-		if ok {
-			// transfer_destination_path is not part of TransferProtocol and is specified as an opaque field
-			opaque = &typesv1beta1.Opaque{
-				Map: map[string]*typesv1beta1.OpaqueEntry{
-					"transfer_destination_path": {
-						Decoder: "plain",
-						Value:   []byte(*path),
-					},
-				},
-			}
-		}
-
 		shareRequest := &ocm.UpdateReceivedOCMShareRequest{
 			Share:      shareRes.Share,
 			UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"state"}},
-			Opaque:     opaque,
 		}
 
 		updateRes, err := shareClient.UpdateReceivedOCMShare(ctx, shareRequest)
@@ -112,15 +95,6 @@ func ocmShareUpdateReceivedCommand() *command {
 		return nil
 	}
 	return cmd
-}
-
-func getTransferProtocol(share *ocm.ReceivedShare) (*ocm.TransferProtocol, bool) {
-	for _, p := range share.Protocols {
-		if d, ok := p.Term.(*ocm.Protocol_TransferOptions); ok {
-			return d.TransferOptions, true
-		}
-	}
-	return nil, false
 }
 
 func getOCMShareState(state string) ocm.ShareState {

--- a/docs/content/en/docs/autogenerated/http/services/wellknown/_index.md
+++ b/docs/content/en/docs/autogenerated/http/services/wellknown/_index.md
@@ -64,11 +64,3 @@ enable_webapp = false
 {{< /highlight >}}
 {{% /dir %}}
 
-{{% dir name="enable_datatx" type="bool" default=false %}}
-Whether data transfers are enabled in OCM shares. [[Ref]](https://github.com/cs3org/reva/tree/master/internal/http/services/wellknown/ocm.go#L40)
-{{< highlight toml >}}
-[http.services.wellknown]
-enable_datatx = false
-{{< /highlight >}}
-{{% /dir %}}
-

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/coreos/go-oidc/v3 v3.17.0
 	github.com/creasty/defaults v1.8.0
 	github.com/cs3org/cato v0.0.0-20200828125504-e418fc54dd5e
-	github.com/cs3org/go-cs3apis v0.0.0-20251211091140-ea69016c2473
+        github.com/cs3org/go-cs3apis v0.0.0-20260130145416-2dc593dc27e7
 	github.com/dgraph-io/ristretto v0.2.0
 	github.com/dolthub/go-mysql-server v0.14.0
 	github.com/glpatcern/go-mime v0.0.0-20221026162842-2a8d71ad17a9

--- a/go.sum
+++ b/go.sum
@@ -897,8 +897,8 @@ github.com/creasty/defaults v1.8.0 h1:z27FJxCAa0JKt3utc0sCImAEb+spPucmKoOdLHvHYK
 github.com/creasty/defaults v1.8.0/go.mod h1:iGzKe6pbEHnpMPtfDXZEr0NVxWnPTjb1bbDy08fPzYM=
 github.com/cs3org/cato v0.0.0-20200828125504-e418fc54dd5e h1:tqSPWQeueWTKnJVMJffz4pz0o1WuQxJ28+5x5JgaHD8=
 github.com/cs3org/cato v0.0.0-20200828125504-e418fc54dd5e/go.mod h1:XJEZ3/EQuI3BXTp/6DUzFr850vlxq11I6satRtz0YQ4=
-github.com/cs3org/go-cs3apis v0.0.0-20251211091140-ea69016c2473 h1:VJcXFu3RPqJMiHVKA4N4bFfAB3xxbc3spbZzRl71QF8=
-github.com/cs3org/go-cs3apis v0.0.0-20251211091140-ea69016c2473/go.mod h1:DedpcqXl193qF/08Y04IO0PpxyyMu8+GrkD6kWK2MEQ=
+github.com/cs3org/go-cs3apis v0.0.0-20260130145416-2dc593dc27e7 h1:ez+InorrZ2HXkPmPeeDstPSTkjNmySUZXaT7xEJNOkk=
+github.com/cs3org/go-cs3apis v0.0.0-20260130145416-2dc593dc27e7/go.mod h1:DedpcqXl193qF/08Y04IO0PpxyyMu8+GrkD6kWK2MEQ=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/internal/grpc/services/gateway/ocmshareprovider.go
+++ b/internal/grpc/services/gateway/ocmshareprovider.go
@@ -24,6 +24,7 @@ import (
 	"net/url"
 	"path"
 	"strings"
+	"slices"
 
 	"github.com/alitto/pond/v2"
 	gateway "github.com/cs3org/go-cs3apis/cs3/gateway/v1beta1"
@@ -349,7 +350,7 @@ func (s *svc) handleTransfer(ctx context.Context, share *ocm.ReceivedShare, tran
 	if !ok {
 		return errors.New("gateway: unable to retrieve transfer protocol")
 	}
-	sourceURI := protocol.SourceUri
+	sourceURI := protocol.Uri
 
 	// get the webdav endpoint of the grantee's idp
 	var granteeIdp string
@@ -451,10 +452,12 @@ func (s *svc) GetReceivedOCMShare(ctx context.Context, req *ocm.GetReceivedOCMSh
 	return res, nil
 }
 
-func (s *svc) getTransferProtocol(share *ocm.ReceivedShare) (*ocm.TransferProtocol, bool) {
+func (s *svc) getTransferProtocol(share *ocm.ReceivedShare) (*ocm.WebDAVProtocol, bool) {
 	for _, p := range share.Protocols {
-		if d, ok := p.Term.(*ocm.Protocol_TransferOptions); ok {
-			return d.TransferOptions, true
+		if d, ok := p.Term.(*ocm.Protocol_WebdavOptions); ok {
+			if slices.Contains(d.WebdavOptions.AccessTypes, ocm.AccessType_ACCESS_TYPE_DATATX) {
+				return d.WebdavOptions, true
+			}
 		}
 	}
 	return nil, false

--- a/internal/http/services/opencloudmesh/ocmd/shares.go
+++ b/internal/http/services/opencloudmesh/ocmd/shares.go
@@ -65,7 +65,7 @@ func (h *sharesHandler) init(c *config) error {
 	return nil
 }
 
-// CreateShare implements the OCM /shares call.
+// CreateShare implements the OCM /shares call and stores an incoming share
 func (h *sharesHandler) CreateShare(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	log := appctx.GetLogger(ctx)
@@ -221,8 +221,8 @@ func getResourceTypeFromOCMRequest(t string) ocm.SharedResourceType {
 	}
 }
 
-func getOCMShareType(t string) ocm.RecipientType {
-	switch t {
+func getOCMShareType(st string) ocm.RecipientType {
+	switch st {
 	case "user":
 		return ocm.RecipientType_RECIPIENT_TYPE_USER
 	case "group":

--- a/internal/http/services/owncloud/ocgraph/shares.go
+++ b/internal/http/services/owncloud/ocgraph/shares.go
@@ -43,9 +43,9 @@ import (
 	link "github.com/cs3org/go-cs3apis/cs3/sharing/link/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	"github.com/cs3org/reva/v3/internal/http/services/opencloudmesh/ocmd"
-	"github.com/cs3org/reva/v3/pkg/permissions"
 	"github.com/cs3org/reva/v3/pkg/appctx"
 	"github.com/cs3org/reva/v3/pkg/ocm/share"
+	"github.com/cs3org/reva/v3/pkg/permissions"
 	"github.com/cs3org/reva/v3/pkg/spaces"
 	"github.com/cs3org/reva/v3/pkg/utils"
 	libregraph "github.com/owncloud/libre-graph-api-go"
@@ -198,7 +198,7 @@ func (s *svc) createOCMShare(ctx context.Context, gw gateway.GatewayAPIClient, r
 		},
 		RecipientMeshProvider: recipientProviderInfo.ProviderInfo,
 		AccessMethods: []*ocm.AccessMethod{
-			share.NewWebDavAccessMethod(perm, []string{}),
+			share.NewWebDavAccessMethod(perm, []ocm.AccessType{ocm.AccessType_ACCESS_TYPE_REMOTE}, []string{}),
 			share.NewWebappAccessMethod(viewMode),
 		},
 	})

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/remote.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/remote.go
@@ -34,10 +34,10 @@ import (
 	types "github.com/cs3org/go-cs3apis/cs3/types/v1beta1"
 	ocmd "github.com/cs3org/reva/v3/internal/http/services/opencloudmesh/ocmd"
 	"github.com/cs3org/reva/v3/internal/http/services/owncloud/ocs/conversions"
-	"github.com/cs3org/reva/v3/pkg/permissions"
 	"github.com/cs3org/reva/v3/internal/http/services/owncloud/ocs/response"
 	"github.com/cs3org/reva/v3/pkg/appctx"
 	"github.com/cs3org/reva/v3/pkg/ocm/share"
+	"github.com/cs3org/reva/v3/pkg/permissions"
 	"github.com/cs3org/reva/v3/pkg/rgrpc/todo/pool"
 	"github.com/cs3org/reva/v3/pkg/utils"
 	"github.com/go-chi/chi/v5"
@@ -112,7 +112,7 @@ func (h *Handler) createFederatedCloudShare(w http.ResponseWriter, r *http.Reque
 		},
 		RecipientMeshProvider: providerInfoResp.ProviderInfo,
 		AccessMethods: []*ocm.AccessMethod{
-			share.NewWebDavAccessMethod(role.CS3ResourcePermissions(), []string{}),
+			share.NewWebDavAccessMethod(role.CS3ResourcePermissions(), []ocm.AccessType{ocm.AccessType_ACCESS_TYPE_REMOTE}, []string{}),
 			share.NewWebappAccessMethod(getViewModeFromRole(role)),
 		},
 	})

--- a/pkg/ocm/share/repository/nextcloud/nextcloud.go
+++ b/pkg/ocm/share/repository/nextcloud/nextcloud.go
@@ -33,11 +33,11 @@ import (
 	ocm "github.com/cs3org/go-cs3apis/cs3/sharing/ocm/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	typespb "github.com/cs3org/go-cs3apis/cs3/types/v1beta1"
-	"github.com/cs3org/reva/v3/pkg/permissions"
 	"github.com/cs3org/reva/v3/pkg/appctx"
 	"github.com/cs3org/reva/v3/pkg/errtypes"
 	"github.com/cs3org/reva/v3/pkg/ocm/share"
 	"github.com/cs3org/reva/v3/pkg/ocm/share/repository/registry"
+	"github.com/cs3org/reva/v3/pkg/permissions"
 	"github.com/cs3org/reva/v3/pkg/utils"
 	"github.com/cs3org/reva/v3/pkg/utils/cfg"
 	"github.com/pkg/errors"
@@ -181,12 +181,10 @@ func (sm *Manager) efssShareToOcm(resp *EfssShare) *ocm.Share {
 	// first generate the map of access methods, assuming WebDAV is always present
 	var am = make([]*ocm.AccessMethod, 0, 3)
 	am = append(am, share.NewWebDavAccessMethod(permissions.RoleFromOCSPermissions(
-		permissions.OcsPermissions(resp.Protocols.WebDAV.Permissions)).CS3ResourcePermissions(), []string{}))
+		permissions.OcsPermissions(resp.Protocols.WebDAV.Permissions)).CS3ResourcePermissions(),
+		[]ocm.AccessType{ocm.AccessType_ACCESS_TYPE_REMOTE}, []string{}))
 	if resp.Protocols.WebApp.ViewMode != "" {
 		am = append(am, share.NewWebappAccessMethod(utils.GetAppViewMode(resp.Protocols.WebApp.ViewMode)))
-	}
-	if resp.Protocols.DataTx.SourceURI != "" {
-		am = append(am, share.NewTransferAccessMethod())
 	}
 
 	// return the OCM Share payload
@@ -326,12 +324,9 @@ func efssReceivedShareToOcm(resp *ReceivedEfssShare) *ocm.ReceivedShare {
 	var proto = make([]*ocm.Protocol, 0, 3)
 	proto = append(proto, share.NewWebDAVProtocol(resp.Share.Protocols.WebDAV.URI, resp.Share.Token, &ocm.SharePermissions{
 		Permissions: permissions.RoleFromOCSPermissions(permissions.OcsPermissions(resp.Share.Protocols.WebDAV.Permissions)).CS3ResourcePermissions(),
-	}, []string{}))
+	}, []ocm.AccessType{ocm.AccessType_ACCESS_TYPE_DATATX}, []string{}))
 	if resp.Share.Protocols.WebApp.ViewMode != "" {
 		proto = append(proto, share.NewWebappProtocol(resp.Share.Protocols.WebApp.URI, utils.GetAppViewMode(resp.Share.Protocols.WebApp.ViewMode)))
-	}
-	if resp.Share.Protocols.DataTx.SourceURI != "" {
-		proto = append(proto, share.NewTransferProtocol(resp.Share.Protocols.DataTx.SourceURI, resp.Share.Token, uint64(resp.Share.Protocols.DataTx.Size)))
 	}
 
 	// return the OCM Received Share payload

--- a/pkg/ocm/share/repository/nextcloud/nextcloud_server_mock.go
+++ b/pkg/ocm/share/repository/nextcloud/nextcloud_server_mock.go
@@ -39,7 +39,7 @@ type Response struct {
 const serverStateError = "ERROR"
 const serverStateEmpty = "EMPTY"
 const serverStateHome = "HOME"
-const testShare = `{"id":{},"resource_id":{"opaque_id":"fileid-/some/path"},"token":"some-token","name":"test share","protocols":{"webdav":{"uri":"webdav-uri","permissions":15},"webapp":{"uri_template":"app-uri-template","view_mode":"write"},"transfer":{"source_uri":"source-uri","size":1}},"grantee":{"id":{"idp":"0.0.0.0:19000","opaque_id":"f7fbf8c8-139b-4376-b307-cf0a8c2d0d9c","type":1}},"owner":{"id":{"idp":"0.0.0.0:19000","opaque_id":"f7fbf8c8-139b-4376-b307-cf0a8c2d0d9c","type":1}},"creator":{"id":{"idp":"0.0.0.0:19000","opaque_id":"f7fbf8c8-139b-4376-b307-cf0a8c2d0d9c","type":1}},"ctime":{"seconds":1234567890},"mtime":{"seconds":1234567890}}`
+const testShare = `{"id":{},"resource_id":{"opaque_id":"fileid-/some/path"},"token":"some-token","name":"test share","protocols":{"webdav":{"uri":"webdav-uri","permissions":15},"webapp":{"uri_template":"app-uri-template","view_mode":"write"}},"grantee":{"id":{"idp":"0.0.0.0:19000","opaque_id":"f7fbf8c8-139b-4376-b307-cf0a8c2d0d9c","type":1}},"owner":{"id":{"idp":"0.0.0.0:19000","opaque_id":"f7fbf8c8-139b-4376-b307-cf0a8c2d0d9c","type":1}},"creator":{"id":{"idp":"0.0.0.0:19000","opaque_id":"f7fbf8c8-139b-4376-b307-cf0a8c2d0d9c","type":1}},"ctime":{"seconds":1234567890},"mtime":{"seconds":1234567890}}`
 
 var serverState = serverStateEmpty
 

--- a/pkg/ocm/share/repository/nextcloud/nextcloud_test.go.disabled
+++ b/pkg/ocm/share/repository/nextcloud/nextcloud_test.go.disabled
@@ -283,9 +283,8 @@ var _ = Describe("Nextcloud", func() {
 					OpaqueId: "f7fbf8c8-139b-4376-b307-cf0a8c2d0d9c",
 				},
 				AccessMethods: []*ocm.AccessMethod{
-					ocmshare.NewWebDavAccessMethod(permissions.NewEditorRole().CS3ResourcePermissions(), []string{}),
+					ocmshare.NewWebDavAccessMethod(permissions.NewEditorRole().CS3ResourcePermissions(), []ocm.AccessType{}, []string{}),
 					ocmshare.NewWebappAccessMethod(appprovider.ViewMode_VIEW_MODE_READ_WRITE),
-					ocmshare.NewTransferAccessMethod(),
 				},
 				Ctime: &types.Timestamp{
 					Seconds: 1234567890,
@@ -422,9 +421,8 @@ var _ = Describe("Nextcloud", func() {
 				},
 				ShareType: ocm.ShareType_SHARE_TYPE_USER,
 				AccessMethods: []*ocm.AccessMethod{
-					ocmshare.NewWebDavAccessMethod(permissions.NewEditorRole().CS3ResourcePermissions(), []string{}),
+					ocmshare.NewWebDavAccessMethod(permissions.NewEditorRole().CS3ResourcePermissions(), []ocm.AccessType{}, []string{}),
 					ocmshare.NewWebappAccessMethod(appprovider.ViewMode_VIEW_MODE_READ_WRITE),
-					ocmshare.NewTransferAccessMethod(),
 				},
 				Token: "some-token",
 			}))
@@ -475,9 +473,8 @@ var _ = Describe("Nextcloud", func() {
 				Protocols: []*ocm.Protocol{
 					ocmshare.NewWebDAVProtocol("webdav-uri", "some-token", &ocm.SharePermissions{
 						Permissions: permissions.NewEditorRole().CS3ResourcePermissions(),
-					}, []string{}),
+					}, []ocm.AccessType{}, []string{}),
 					ocmshare.NewWebappProtocol("app-uri-template", appprovider.ViewMode_VIEW_MODE_READ_WRITE),
-					ocmshare.NewTransferProtocol("source-uri", "some-token", 1),
 				},
 				State: ocm.ShareState_SHARE_STATE_ACCEPTED,
 			}))
@@ -533,9 +530,8 @@ var _ = Describe("Nextcloud", func() {
 				Protocols: []*ocm.Protocol{
 					ocmshare.NewWebDAVProtocol("webdav-uri", "some-token", &ocm.SharePermissions{
 						Permissions: permissions.NewEditorRole().CS3ResourcePermissions(),
-					}, []string{}),
+					}, []ocm.AccessType{}, []string{}),
 					ocmshare.NewWebappProtocol("app-uri-template", appprovider.ViewMode_VIEW_MODE_READ_WRITE),
-					ocmshare.NewTransferProtocol("source-uri", "some-token", 1),
 				},
 				State: ocm.ShareState_SHARE_STATE_ACCEPTED,
 			}))
@@ -622,9 +618,8 @@ var _ = Describe("Nextcloud", func() {
 				Protocols: []*ocm.Protocol{
 					ocmshare.NewWebDAVProtocol("webdav-uri", "some-token", &ocm.SharePermissions{
 						Permissions: permissions.NewEditorRole().CS3ResourcePermissions(),
-					}, []string{}),
+					}, []ocm.AccessType{}, []string{}),
 					ocmshare.NewWebappProtocol("app-uri-template", appprovider.ViewMode_VIEW_MODE_READ_WRITE),
-					ocmshare.NewTransferProtocol("source-uri", "some-token", 1),
 				},
 				State: ocm.ShareState_SHARE_STATE_ACCEPTED,
 			}))

--- a/pkg/ocm/share/utils.go
+++ b/pkg/ocm/share/utils.go
@@ -25,13 +25,14 @@ import (
 )
 
 // NewWebDAVProtocol is an abstraction for creating a WebDAV protocol.
-func NewWebDAVProtocol(uri, sharedSecret string, perms *ocm.SharePermissions, reqs []string) *ocm.Protocol {
+func NewWebDAVProtocol(uri, sharedSecret string, perms *ocm.SharePermissions, accTypes []ocm.AccessType, reqs []string) *ocm.Protocol {
 	return &ocm.Protocol{
 		Term: &ocm.Protocol_WebdavOptions{
 			WebdavOptions: &ocm.WebDAVProtocol{
 				Uri:          uri,
 				SharedSecret: sharedSecret,
 				Permissions:  perms,
+				AccessTypes:  accTypes,
 				Requirements: reqs,
 			},
 		},
@@ -50,19 +51,6 @@ func NewWebappProtocol(uri string, viewMode appprovider.ViewMode) *ocm.Protocol 
 	}
 }
 
-// NewTransferProtocol is an abstraction for creating a Transfer protocol.
-func NewTransferProtocol(sourceURI, sharedSecret string, size uint64) *ocm.Protocol {
-	return &ocm.Protocol{
-		Term: &ocm.Protocol_TransferOptions{
-			TransferOptions: &ocm.TransferProtocol{
-				SourceUri:    sourceURI,
-				SharedSecret: sharedSecret,
-				Size:         size,
-			},
-		},
-	}
-}
-
 // NewEmbeddedProtocol is an abstraction for creating an OCM embedded protocol.
 func NewEmbeddedProtocol(payload string) *ocm.Protocol {
 	return &ocm.Protocol{
@@ -74,34 +62,28 @@ func NewEmbeddedProtocol(payload string) *ocm.Protocol {
 	}
 }
 
-// NewWebDavAccessMethod is an abstraction for creating a WebDAV access method.
-func NewWebDavAccessMethod(perms *provider.ResourcePermissions, reqs []string) *ocm.AccessMethod {
+// NewWebDavAccessMethod is an abstraction for creating a WebDAV access method,
+// which is the protocol used by remote users to access an OCM share.
+func NewWebDavAccessMethod(perms *provider.ResourcePermissions, accTypes []ocm.AccessType, reqs []string) *ocm.AccessMethod {
 	return &ocm.AccessMethod{
 		Term: &ocm.AccessMethod_WebdavOptions{
 			WebdavOptions: &ocm.WebDAVAccessMethod{
 				Permissions:  perms,
+				AccessTypes:  accTypes,
 				Requirements: reqs,
 			},
 		},
 	}
 }
 
-// NewWebappAccessMethod is an abstraction for creating a Webapp access method.
+// NewWebappAccessMethod is an abstraction for creating a Webapp access method,
+// which is the protocol used by remote users to access an OCM share.
 func NewWebappAccessMethod(mode appprovider.ViewMode) *ocm.AccessMethod {
 	return &ocm.AccessMethod{
 		Term: &ocm.AccessMethod_WebappOptions{
 			WebappOptions: &ocm.WebappAccessMethod{
 				ViewMode: mode,
 			},
-		},
-	}
-}
-
-// NewTransferAccessMethod is an abstraction for creating a Transfer access method.
-func NewTransferAccessMethod() *ocm.AccessMethod {
-	return &ocm.AccessMethod{
-		Term: &ocm.AccessMethod_TransferOptions{
-			TransferOptions: &ocm.TransferAccessMethod{},
 		},
 	}
 }

--- a/pkg/share/manager/sql/model/model.go
+++ b/pkg/share/manager/sql/model/model.go
@@ -82,10 +82,24 @@ const (
 	WebDAVProtocol OcmProtocol = iota
 	// WebappProtocol is the OCM `webapp` protocol.
 	WebappProtocol
-	// TransferProtocol is the OCM `datatx` protocol.
-	TransferProtocol
 	// EmbeddedProtocol is the OCM `embedded` protocol.
 	EmbeddedProtocol
+	// SshProtocol is the OCM `ssh` protocol (not currently supported).
+	SshProtocol
+)
+
+// OcmAccessType represents the access type to be used in OCM shares:
+// currently supported values are `remote` and `datatx`, possibly
+// combined as a bitmask.
+type OcmAccessType int32
+
+const (
+	// AccessTypeRemote is the OCM `remote` access type.
+	AccessTypeRemote OcmAccessType = 1
+	// AccessTypeDataTx is the OCM `datatx` access type.
+	AccessTypeDataTx OcmAccessType = 2
+	// AccessTypeBoth is the OCM `remote+datatx` access type.
+	AccessTypeBoth OcmAccessType = 3
 )
 
 // ShareID only contains IDs of shares and public links. This is because the Web UI requires
@@ -183,12 +197,13 @@ type OcmShare struct {
 	Protocols     []OcmShareProtocol `gorm:"constraint:OnDelete:CASCADE;"`
 }
 
-// OcmShareProtocol represents the protocol used to access an OCM share, named AccessMethod in the OCM CS3 APIs.
+// OcmShareProtocol represents the protocol used to serve an OCM share, named AccessMethod in the OCM CS3 APIs.
 type OcmShareProtocol struct {
 	gorm.Model
-	OcmShareID  uint        `gorm:"not null;uniqueIndex:u_ocm_share_protocol"`
-	Type        OcmProtocol `gorm:"not null;uniqueIndex:u_ocm_share_protocol"`
-	Permissions int         `gorm:"default:null"`
+	OcmShareID  uint          `gorm:"not null;uniqueIndex:u_ocm_share_protocol"`
+	Type        OcmProtocol   `gorm:"not null;uniqueIndex:u_ocm_share_protocol"`
+	Permissions int           `gorm:"default:null"`
+	AccessTypes OcmAccessType `gorm:"default:null"`
 }
 
 // OcmReceivedShare represents an OCM share received from a remote user.
@@ -218,9 +233,8 @@ type OcmReceivedShareProtocol struct {
 	Uri                string           `gorm:"size:255"`
 	SharedSecret       string           `gorm:"type:text;not null"`
 	// WebDAV and WebApp Protocol fields
-	Permissions int `gorm:"default:null"`
-	// Transfer Protocol fields
-	Size uint64 `gorm:"default:null"`
+	Permissions int           `gorm:"default:null"`
+	AccessTypes OcmAccessType `gorm:"default:null"`
 	// JSON field for the embedded protocol payload
 	Payload datatypes.JSON `gorm:"type:json;default:null"`
 }

--- a/pkg/share/manager/sql/ocm_shares.go
+++ b/pkg/share/manager/sql/ocm_shares.go
@@ -121,10 +121,6 @@ func (m *mgr) StoreShare(ctx context.Context, s *ocm.Share) (*ocm.Share, error) 
 				if err := storeWebappAccessMethod(tx, id, r); err != nil {
 					return err
 				}
-			case *ocm.AccessMethod_TransferOptions:
-				if err := storeTransferAccessMethod(tx, id, r); err != nil {
-					return err
-				}
 			}
 		}
 		return nil
@@ -160,19 +156,6 @@ func storeWebappAccessMethod(tx *gorm.DB, shareID uint, o *ocm.AccessMethod_Weba
 	err := tx.Create(accessMethod).Error
 	if err != nil {
 		return errors.Wrap(err, "failed to store webapp access method")
-	}
-	return nil
-}
-
-func storeTransferAccessMethod(tx *gorm.DB, shareID uint, o *ocm.AccessMethod_TransferOptions) error {
-	accessMethod := &model.OcmShareProtocol{
-		OcmShareID: uint(shareID),
-		Type:       model.TransferProtocol,
-	}
-
-	err := tx.Create(accessMethod).Error
-	if err != nil {
-		return errors.Wrap(err, "failed to store transfer access method")
 	}
 	return nil
 }
@@ -302,10 +285,6 @@ func (m *mgr) StoreReceivedShare(ctx context.Context, s *ocm.ReceivedShare) (*oc
 				if err := storeWebappProtocol(tx, int64(receivedShare.ID), r); err != nil {
 					return err
 				}
-			case *ocm.Protocol_TransferOptions:
-				if err := storeTransferProtocol(tx, int64(receivedShare.ID), r); err != nil {
-					return err
-				}
 			case *ocm.Protocol_EmbeddedOptions:
 				if err := storeEmbeddedProtocol(tx, int64(receivedShare.ID), r); err != nil {
 					return err
@@ -355,20 +334,6 @@ func storeEmbeddedProtocol(tx *gorm.DB, shareID int64, o *ocm.Protocol_EmbeddedO
 		OcmReceivedShareID: uint(shareID),
 		Type:               model.EmbeddedProtocol,
 		Payload:            datatypes.JSON([]byte(o.EmbeddedOptions.Payload)),
-	}
-	if err := tx.Create(protocol).Error; err != nil {
-		return err
-	}
-	return nil
-}
-
-func storeTransferProtocol(tx *gorm.DB, shareID int64, o *ocm.Protocol_TransferOptions) error {
-	protocol := &model.OcmReceivedShareProtocol{
-		OcmReceivedShareID: uint(shareID),
-		Type:               model.TransferProtocol,
-		Uri:                o.TransferOptions.SourceUri,
-		SharedSecret:       o.TransferOptions.SharedSecret,
-		Size:               o.TransferOptions.Size,
 	}
 	if err := tx.Create(protocol).Error; err != nil {
 		return err

--- a/pkg/share/manager/sql/ocm_shares_test.go
+++ b/pkg/share/manager/sql/ocm_shares_test.go
@@ -12,6 +12,7 @@ import (
 	ocm "github.com/cs3org/go-cs3apis/cs3/sharing/ocm/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	typesv1beta1 "github.com/cs3org/go-cs3apis/cs3/types/v1beta1"
+
 	//permissions "github.com/cs3org/reva/v3/pkg/cbox/utils"
 	"github.com/cs3org/reva/v3/pkg/permissions"
 
@@ -70,9 +71,9 @@ func getOcmShare(accessMethods []*ocm.AccessMethod, grantee *provider.Grantee, c
 func getWebDavProtocol(uri string, sharedsecret string, perms *ocm.SharePermissions, role string) *ocm.Protocol {
 	switch role {
 	case "viewer":
-		return share.NewWebDAVProtocol(uri, sharedsecret, perms, []string{})
+		return share.NewWebDAVProtocol(uri, sharedsecret, perms, []ocm.AccessType{}, []string{})
 	case "editor":
-		return share.NewWebDAVProtocol(uri, sharedsecret, perms, []string{})
+		return share.NewWebDAVProtocol(uri, sharedsecret, perms, []ocm.AccessType{}, []string{})
 	}
 	return nil
 }
@@ -141,12 +142,12 @@ func getOcmAccessMethods(role string) []*ocm.AccessMethod {
 	switch role {
 	case "viewer":
 		return []*ocm.AccessMethod{
-			share.NewWebDavAccessMethod(permissions.NewViewerRole().CS3ResourcePermissions(), []string{}),
+			share.NewWebDavAccessMethod(permissions.NewViewerRole().CS3ResourcePermissions(), []ocm.AccessType{}, []string{}),
 			share.NewWebappAccessMethod(appprovider.ViewMode_VIEW_MODE_READ_ONLY),
 		}
 	case "editor":
 		return []*ocm.AccessMethod{
-			share.NewWebDavAccessMethod(permissions.NewEditorRole().CS3ResourcePermissions(), []string{}),
+			share.NewWebDavAccessMethod(permissions.NewEditorRole().CS3ResourcePermissions(), []ocm.AccessType{}, []string{}),
 			share.NewWebappAccessMethod(appprovider.ViewMode_VIEW_MODE_READ_WRITE),
 		}
 	}

--- a/tests/integration/grpc/fixtures/ocm-server-cernbox-http.toml
+++ b/tests/integration/grpc/fixtures/ocm-server-cernbox-http.toml
@@ -28,4 +28,3 @@ ocm_prefix = "ocm"
 provider = "Reva for CERNBox"
 endpoint = "http://{{cernboxhttp_address}}"
 enable_webapp = true
-enable_datatx = true

--- a/tests/integration/grpc/fixtures/ocm-server-cesnet-http.toml
+++ b/tests/integration/grpc/fixtures/ocm-server-cesnet-http.toml
@@ -28,4 +28,3 @@ ocm_prefix = "ocm"
 provider = "Reva for CESNET"
 endpoint = "http://{{cesnethttp_address}}"
 enable_webapp = true
-enable_datatx = true

--- a/tests/integration/grpc/fixtures/ocm-share/ocm-server-cernbox-http.toml
+++ b/tests/integration/grpc/fixtures/ocm-share/ocm-server-cernbox-http.toml
@@ -42,4 +42,3 @@ ocm_prefix = "ocm"
 provider = "Reva for CERNBox"
 endpoint = "http://{{cernboxhttp_address}}"
 enable_webapp = true
-enable_datatx = true

--- a/tests/integration/grpc/fixtures/ocm-share/ocm-server-cesnet-http.toml
+++ b/tests/integration/grpc/fixtures/ocm-share/ocm-server-cesnet-http.toml
@@ -34,4 +34,3 @@ ocm_prefix = "ocm"
 provider = "Reva for CESNET"
 endpoint = "http://{{cesnethttp_address}}"
 enable_webapp = true
-enable_datatx = true

--- a/tests/integration/grpc/ocm_share_test.go
+++ b/tests/integration/grpc/ocm_share_test.go
@@ -37,9 +37,9 @@ import (
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	"github.com/cs3org/reva/v3/internal/http/services/datagateway"
 	"github.com/cs3org/reva/v3/internal/http/services/owncloud/ocdav"
-	"github.com/cs3org/reva/v3/pkg/permissions"
 	"github.com/cs3org/reva/v3/pkg/httpclient"
 	"github.com/cs3org/reva/v3/pkg/ocm/share"
+	"github.com/cs3org/reva/v3/pkg/permissions"
 	"github.com/cs3org/reva/v3/pkg/rgrpc/todo/pool"
 	jwt "github.com/cs3org/reva/v3/pkg/token/manager/jwt"
 	"github.com/cs3org/reva/v3/tests/helpers"
@@ -200,7 +200,7 @@ var _ = Describe("ocm share", func() {
 						},
 					},
 					AccessMethods: []*ocmv1beta1.AccessMethod{
-						share.NewWebDavAccessMethod(permissions.NewViewerRole().CS3ResourcePermissions(), []string{}),
+						share.NewWebDavAccessMethod(permissions.NewViewerRole().CS3ResourcePermissions(), []ocmv1beta1.AccessType{}, []string{}),
 					},
 					RecipientMeshProvider: cesnet.ProviderInfo,
 				})
@@ -241,7 +241,7 @@ var _ = Describe("ocm share", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(d2).To(Equal([]byte("test")))
 
-				By("marie can access the share using the ocm mount")
+				By("marie can access the share using the OCM mount")
 				ref := &provider.Reference{Path: ocmPath(share.Id, "")}
 				statRes, err := cesnetgw.Stat(ctxMarie, &provider.StatRequest{Ref: ref})
 				Expect(err).ToNot(HaveOccurred())
@@ -262,7 +262,7 @@ var _ = Describe("ocm share", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(data).To(Equal([]byte("test")))
 
-				By("marie cannot upload to the ocm mount")
+				By("marie cannot upload to the OCM mount")
 				Expect(helpers.UploadGateway(ctxMarie, cesnetgw, ref, []byte("will-never-be-written"))).ToNot(Succeed())
 			})
 		})
@@ -293,7 +293,7 @@ var _ = Describe("ocm share", func() {
 						},
 					},
 					AccessMethods: []*ocmv1beta1.AccessMethod{
-						share.NewWebDavAccessMethod(permissions.NewEditorRole().CS3ResourcePermissions(), []string{}),
+						share.NewWebDavAccessMethod(permissions.NewEditorRole().CS3ResourcePermissions(), []ocmv1beta1.AccessType{}, []string{}),
 					},
 					RecipientMeshProvider: cesnet.ProviderInfo,
 				})
@@ -389,7 +389,7 @@ var _ = Describe("ocm share", func() {
 						},
 					},
 					AccessMethods: []*ocmv1beta1.AccessMethod{
-						share.NewWebDavAccessMethod(permissions.NewViewerRole().CS3ResourcePermissions(), []string{}),
+						share.NewWebDavAccessMethod(permissions.NewViewerRole().CS3ResourcePermissions(), []ocmv1beta1.AccessType{}, []string{}),
 					},
 					RecipientMeshProvider: cesnet.ProviderInfo,
 				})
@@ -492,7 +492,7 @@ var _ = Describe("ocm share", func() {
 						},
 					},
 					AccessMethods: []*ocmv1beta1.AccessMethod{
-						share.NewWebDavAccessMethod(permissions.NewEditorRole().CS3ResourcePermissions(), []string{}),
+						share.NewWebDavAccessMethod(permissions.NewEditorRole().CS3ResourcePermissions(), []ocmv1beta1.AccessType{}, []string{}),
 					},
 					RecipientMeshProvider: cesnet.ProviderInfo,
 				})
@@ -641,7 +641,7 @@ var _ = Describe("ocm share", func() {
 						},
 					},
 					AccessMethods: []*ocmv1beta1.AccessMethod{
-						share.NewWebDavAccessMethod(permissions.NewEditorRole().CS3ResourcePermissions(), []string{}),
+						share.NewWebDavAccessMethod(permissions.NewEditorRole().CS3ResourcePermissions(), []ocmv1beta1.AccessType{}, []string{}),
 					},
 					RecipientMeshProvider: cesnet.ProviderInfo,
 				})
@@ -658,7 +658,7 @@ var _ = Describe("ocm share", func() {
 						},
 					},
 					AccessMethods: []*ocmv1beta1.AccessMethod{
-						share.NewWebDavAccessMethod(permissions.NewEditorRole().CS3ResourcePermissions(), []string{}),
+						share.NewWebDavAccessMethod(permissions.NewEditorRole().CS3ResourcePermissions(), []ocmv1beta1.AccessType{}, []string{}),
 					},
 					RecipientMeshProvider: cesnet.ProviderInfo,
 				})
@@ -683,7 +683,7 @@ var _ = Describe("ocm share", func() {
 						},
 					},
 					AccessMethods: []*ocmv1beta1.AccessMethod{
-						share.NewWebDavAccessMethod(permissions.NewEditorRole().CS3ResourcePermissions(), []string{}),
+						share.NewWebDavAccessMethod(permissions.NewEditorRole().CS3ResourcePermissions(), []ocmv1beta1.AccessType{}, []string{}),
 					},
 					RecipientMeshProvider: cesnet.ProviderInfo,
 				})
@@ -718,7 +718,7 @@ var _ = Describe("ocm share", func() {
 						},
 					},
 					AccessMethods: []*ocmv1beta1.AccessMethod{
-						share.NewWebDavAccessMethod(permissions.NewEditorRole().CS3ResourcePermissions(), []string{"unsupported-requirement"}),
+						share.NewWebDavAccessMethod(permissions.NewEditorRole().CS3ResourcePermissions(), []ocmv1beta1.AccessType{}, []string{"unsupported-requirement"}),
 					},
 					RecipientMeshProvider: cesnet.ProviderInfo,
 				})


### PR DESCRIPTION
Depends on https://github.com/cs3org/cs3apis/pull/259

In this PR the Nextcloud storage driver tests have been disabled as we're not actively supporting Nextcloud as a storage provider.