### PR TITLE
Feat/share consistency

### DIFF
--- a/changelog/3.6.2_2026-03-29/refactor-eosfs-auth.md
+++ b/changelog/3.6.2_2026-03-29/refactor-eosfs-auth.md
@@ -1,0 +1,8 @@
+Enhancement: refactor EOSFS auth logic
+
+- Use a dedicated service account for accesses made by external accounts,
+  instead of impersonating the owner or using a token
+- Renamed the different types of auth to be more clear (e.g. cboxAuth became systemAuth)
+- Added a `InvalidAuthorization` to be returned instead of an empty auth; because empty auth maps to the system user (which is a sudo'er)
+
+https://github.com/cs3org/reva/pull/5514

--- a/changelog/3.6.2_2026-03-29/refactor-eosfs-auth.md
+++ b/changelog/3.6.2_2026-03-29/refactor-eosfs-auth.md
@@ -1,8 +1,0 @@
-Enhancement: refactor EOSFS auth logic
-
-- Use a dedicated service account for accesses made by external accounts,
-  instead of impersonating the owner or using a token
-- Renamed the different types of auth to be more clear (e.g. cboxAuth became systemAuth)
-- Added a `InvalidAuthorization` to be returned instead of an empty auth; because empty auth maps to the system user (which is a sudo'er)
-
-https://github.com/cs3org/reva/pull/5514

--- a/changelog/unreleased/share-hierarchy.md
+++ b/changelog/unreleased/share-hierarchy.md
@@ -1,0 +1,16 @@
+Enhancement: share hierarchy checks
+
+This PR adds a hierarchical checking algorithm for shares to the gateway,
+as defined in ADR general/0005-sharing. Concrectely, the new algorithm does
+the following: 
+
+* Before applying any ACL, the gateway checks for parent and child shares in 
+  the database.
+* Based on their relationships and permission levels, the gateway decides whether
+  to apply, reapply, or reject the operation.
+* ACL updates will be applied orderd by path-length (where the shortest comes
+  first) to maintain  consistent inheritance semantics (otherwise, you would 
+  overwrite child shares).
+* The algorithm applies equally to create, update, and delete operations.
+
+https://github.com/cs3org/reva/pull/5562

--- a/internal/grpc/services/gateway/storageprovider.go
+++ b/internal/grpc/services/gateway/storageprovider.go
@@ -726,7 +726,6 @@ func (s *svc) splitPath(_ context.Context, p string) []string {
 	return strings.SplitN(p, "/", 4) // ["home", "MyShares", "photos", "Ibiza/beach.png"]
 }
 
-
 func (s *svc) CreateSymlink(ctx context.Context, req *provider.CreateSymlinkRequest) (*provider.CreateSymlinkResponse, error) {
 	return &provider.CreateSymlinkResponse{
 		Status: status.NewUnimplemented(ctx, errtypes.NotSupported("CreateSymlink not implemented"), "CreateSymlink not implemented"),

--- a/internal/grpc/services/gateway/usershareprovider.go
+++ b/internal/grpc/services/gateway/usershareprovider.go
@@ -117,6 +117,8 @@ func (s *svc) CreateShare(ctx context.Context, req *collaboration.CreateShareReq
 	}
 
 	// If we commit to the storage, first we apply to the new resource, then we clean up
+	toDelete := sharehierarchy.Shares(result.ToDelete)
+	toReapply := sharehierarchy.Shares(result.ToReapply)
 	if s.c.CommitShareToStorageGrant {
 		if grantStatus, err := s.applyGrant(ctx, req.ResourceInfo.Id, req.Grant.Grantee, req.Grant.Permissions.Permissions); err != nil || grantStatus.Code != rpc.Code_CODE_OK {
 			if err != nil {
@@ -125,7 +127,7 @@ func (s *svc) CreateShare(ctx context.Context, req *collaboration.CreateShareReq
 			return &collaboration.CreateShareResponse{Status: grantStatus}, nil
 		}
 		// Remove grants for child shares made redundant by the new share.
-		if st, err := s.removeChildGrants(ctx, result.ToDelete); err != nil || st.Code != rpc.Code_CODE_OK {
+		if st, err := s.removeChildGrants(ctx, toDelete); err != nil || st.Code != rpc.Code_CODE_OK {
 			if err != nil {
 				return nil, err
 			}
@@ -133,7 +135,7 @@ func (s *svc) CreateShare(ctx context.Context, req *collaboration.CreateShareReq
 		}
 		// Re-apply grants for children that retain higher permissions (N=R, C=RW).
 		// ToReapply is already sorted shallowest-first by CheckGrantConsistency.
-		s.reapplyChildGrants(ctx, result.ToReapply)
+		s.reapplyChildGrants(ctx, toReapply)
 	}
 
 	// Finally, we write to the db
@@ -147,7 +149,7 @@ func (s *svc) CreateShare(ctx context.Context, req *collaboration.CreateShareReq
 	}
 
 	// And we remove from the db the deleted shares made redundant by the new share.
-	s.removeChildShareRecords(ctx, shareClient, result.ToDelete)
+	s.removeChildShareRecords(ctx, shareClient, toDelete)
 
 	return res, nil
 
@@ -406,8 +408,8 @@ func (s *svc) UpdateShare(ctx context.Context, req *collaboration.UpdateShareReq
 				Status: status.NewConflict(ctx, conflictErr, conflictErr.MarshalToJSON()),
 			}, nil
 		}
-		toDelete = result.ToDelete
-		toReapply = result.ToReapply
+		toDelete = sharehierarchy.Shares(result.ToDelete)
+		toReapply = sharehierarchy.Shares(result.ToReapply)
 	}
 
 	if isPermUpdate && s.c.CommitShareToStorageGrant {

--- a/internal/grpc/services/gateway/usershareprovider.go
+++ b/internal/grpc/services/gateway/usershareprovider.go
@@ -31,6 +31,8 @@ import (
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	typesv1beta1 "github.com/cs3org/go-cs3apis/cs3/types/v1beta1"
 	"github.com/cs3org/reva/v3/pkg/appctx"
+	revashare "github.com/cs3org/reva/v3/pkg/share"
+	"github.com/cs3org/reva/v3/pkg/sharehierarchy"
 	"github.com/cs3org/reva/v3/pkg/utils/resourceid"
 
 	"github.com/cs3org/reva/v3/pkg/errtypes"
@@ -73,40 +75,63 @@ func (s *svc) CreateShare(ctx context.Context, req *collaboration.CreateShareReq
 		return nil, errtypes.InternalError("ShareManager is not online")
 	}
 
-	// Then we set ACLs on the storage layer
-	// -------------------------------------
+	// Hierarchy check (ADR-GENERAL-005)
+	// (https://gitlab.cern.ch/cernbox/adr/-/blob/master/decisions/general/0005-sharing.md)
+	// ---------------------------------
+	spaceId := req.ResourceInfo.Id.SpaceId
+	// Force means we delete child shares, instead of returning a conflict error
+	force := parseForce(req.Opaque)
 
-	// TODO(labkode): if both commits are enabled they could be done concurrently.
+	existingShares, err := s.listSharesForGranteeInSpace(ctx, shareClient, spaceId, req.Grant.Grantee)
+	if err != nil {
+		return &collaboration.CreateShareResponse{
+			Status: status.NewInternal(ctx, err, "error listing shares for hierarchy check"),
+		}, nil
+	}
+
+	checker := &sharehierarchy.Checker{GetPath: s.getPathForResourceId}
+	result, err := checker.CheckGrantConsistency(ctx, req.ResourceInfo.Path, req.Grant.Permissions.Permissions, existingShares)
+	if err != nil {
+		return &collaboration.CreateShareResponse{
+			Status: status.NewStatusFromErrType(ctx, "hierarchy check", err),
+		}, nil
+	}
+	// If we don't force, we show a warning to the user that shares will be deleted
+	if !force && len(result.ToDelete) > 0 {
+		conflictErr := errtypes.ShareChildConflict(sharehierarchy.ChildConflictMessage(result.ToDelete))
+		return &collaboration.CreateShareResponse{
+			Status: status.NewStatusFromErrType(ctx, "hierarchy check", conflictErr),
+		}, nil
+	}
+
+	// If we commit to the storage, first we apply to the new resource, then we clean up
 	if s.c.CommitShareToStorageGrant {
-		// If the share is a denial we call  denyGrant instead.
-		if grants.PermissionsEqual(req.Grant.Permissions.Permissions, &provider.ResourcePermissions{}) {
-			denyGrantStatus, err := s.denyGrant(ctx, req.ResourceInfo.Id, req.Grant.Grantee)
+		if grantStatus, err := s.applyGrant(ctx, req.ResourceInfo.Id, req.Grant.Grantee, req.Grant.Permissions.Permissions); err != nil || grantStatus.Code != rpc.Code_CODE_OK {
 			if err != nil {
-				return nil, errors.Wrap(err, "gateway: error denying grant in storage")
+				return nil, errors.Wrap(err, "gateway: error applying grant to storage")
 			}
-			if denyGrantStatus.Code != rpc.Code_CODE_OK {
-				return &collaboration.CreateShareResponse{
-					Status: denyGrantStatus,
-				}, nil
+			return &collaboration.CreateShareResponse{Status: grantStatus}, nil
+		}
+		// Remove grants for child shares made redundant by the new share.
+		for _, child := range result.ToDelete {
+			if st, err := s.removeGrant(ctx, child.ResourceId, child.Grantee, child.Permissions.Permissions); err != nil || st.Code != rpc.Code_CODE_OK {
+				if err != nil {
+					return nil, errors.Wrap(err, "gateway: error removing child grant")
+				}
+				return &collaboration.CreateShareResponse{Status: st}, nil
 			}
-		} else {
-			addGrantStatus, err := s.addGrant(ctx, req.ResourceInfo.Id, req.Grant.Grantee, req.Grant.Permissions.Permissions)
-			if err != nil {
-				log.Error().Err(err).Str("ResourceInfo", req.ResourceInfo.String()).Str("Grantee", req.Grant.Grantee.String()).Str("Message", addGrantStatus.Message).Msg("Failed to Create Share: error during addGrant")
-				return nil, errors.Wrap(err, "gateway: error adding grant to storage")
-			}
-			if addGrantStatus.Code != rpc.Code_CODE_OK {
-				return &collaboration.CreateShareResponse{
-					Status: addGrantStatus,
-				}, nil
+		}
+		// Re-apply grants for children that retain higher permissions (N=R, C=RW).
+		// ToReapply is already sorted shallowest-first by CheckGrantConsistency.
+		for _, child := range result.ToReapply {
+			if _, err := s.addGrant(ctx, child.ResourceId, child.Grantee, child.Permissions.Permissions); err != nil {
+				log.Error().Err(err).Str("shareId", child.Id.OpaqueId).Msg("error re-applying child grant after CreateShare")
 			}
 		}
 	}
 
-	// Then we commit to the db
-	// ------------------------
+	// Finally, we write to the db
 	res, err := shareClient.CreateShare(ctx, req)
-
 	if err != nil {
 		log.Error().Str("ResourceInfo", req.ResourceInfo.String()).Str("Grantee", req.Grant.Grantee.String()).Msg("Failed to Create Share but ACLs are already set")
 		return nil, errors.Wrap(err, "gateway: error calling CreateShare")
@@ -115,10 +140,23 @@ func (s *svc) CreateShare(ctx context.Context, req *collaboration.CreateShareReq
 		return nil, errors.New("ShareClient returned error: " + res.Status.Code.String() + ": " + res.Status.Message)
 	}
 
+	// And we remove from the db the deleted shares
+	// Remove child share records made redundant by the new share.
+	for _, child := range result.ToDelete {
+		if _, err := shareClient.RemoveShare(ctx, &collaboration.RemoveShareRequest{
+			Ref: &collaboration.ShareReference{Spec: &collaboration.ShareReference_Id{Id: child.Id}},
+		}); err != nil {
+			log.Error().Err(err).Str("shareId", child.Id.OpaqueId).Msg("error removing child share from DB after CreateShare")
+		}
+	}
+
 	return res, nil
+
 }
 
 func (s *svc) RemoveShare(ctx context.Context, req *collaboration.RemoveShareRequest) (*collaboration.RemoveShareResponse, error) {
+	log := appctx.GetLogger(ctx)
+
 	c, err := pool.GetUserShareProviderClient(pool.Endpoint(s.c.UserShareProviderEndpoint))
 	if err != nil {
 		return &collaboration.RemoveShareResponse{
@@ -126,38 +164,62 @@ func (s *svc) RemoveShare(ctx context.Context, req *collaboration.RemoveShareReq
 		}, nil
 	}
 
-	getShareReq := &collaboration.GetShareRequest{
-		Ref: req.Ref,
-	}
-	getShareRes, err := c.GetShare(ctx, getShareReq)
+	getShareRes, err := c.GetShare(ctx, &collaboration.GetShareRequest{Ref: req.Ref})
 	if err != nil {
 		return nil, errors.Wrap(err, "gateway: error calling GetShare")
 	}
-
 	if getShareRes.Status.Code != rpc.Code_CODE_OK {
-		res := &collaboration.RemoveShareResponse{
+		return &collaboration.RemoveShareResponse{
 			Status: status.NewInternal(ctx, status.NewErrorFromCode(getShareRes.Status.Code, "gateway"),
 				"error getting share to be removed"),
-		}
-		return res, nil
+		}, nil
 	}
 	share := getShareRes.Share
 
-	// Now we first try to remove from EOS
+	// Resolve parent / child shares so we can reapply the hierarchy (ADR-GENERAL-005).
+	var ancestors, descendants []*collaboration.Share
+	var paths map[string]string
+	checker := &sharehierarchy.Checker{GetPath: s.getPathForResourceId}
+
+	existingShares, listErr := s.listSharesForGranteeInSpace(ctx, c, share.ResourceId.SpaceId, share.Grantee)
+	if listErr != nil {
+		return &collaboration.RemoveShareResponse{
+			Status: status.NewInternal(ctx, listErr, "error listing shares for hierarchy reapply"),
+		}, nil
+	}
+	existingShares = filterOutShare(existingShares, share.Id.OpaqueId)
+	paths = checker.ResolvePaths(ctx, existingShares)
+	sharePath, pathErr := s.getPathForResourceId(ctx, share.ResourceId)
+	if pathErr == nil {
+		ancestors = sharehierarchy.FilterAncestors(existingShares, paths, sharePath)
+		descendants = sharehierarchy.FilterDescendants(existingShares, paths, sharePath)
+	}
+
 	if s.c.CommitShareToStorageGrant {
 		removeGrantStatus, err := s.removeGrant(ctx, share.ResourceId, share.Grantee, share.Permissions.Permissions)
 		if err != nil {
 			return nil, errors.Wrap(err, "gateway: error removing grant from storage")
 		}
-		// If this fails, we abort, so that the user does not think the share is removed while the permissions remain
 		if removeGrantStatus.Code != rpc.Code_CODE_OK {
-			return &collaboration.RemoveShareResponse{
-				Status: removeGrantStatus,
-			}, err
+			return &collaboration.RemoveShareResponse{Status: removeGrantStatus}, nil
+		}
+
+		// Re-apply the closest parent's permissions to the now-unshared node.
+		if parent := sharehierarchy.ClosestAncestor(ancestors, paths); parent != nil {
+			if _, err := s.addGrant(ctx, share.ResourceId, share.Grantee, parent.Permissions.Permissions); err != nil {
+				log.Error().Err(err).Str("shareId", share.Id.OpaqueId).Msg("error reapplying parent grant after RemoveShare")
+			}
+		}
+
+		// Re-apply descendant grants shallowest-first so child permissions are not overridden.
+		sharehierarchy.SortByPathDepthAsc(descendants, paths)
+		for _, child := range descendants {
+			if _, err := s.addGrant(ctx, child.ResourceId, child.Grantee, child.Permissions.Permissions); err != nil {
+				log.Error().Err(err).Str("childShareId", child.Id.OpaqueId).Msg("error reapplying child grant after RemoveShare")
+			}
 		}
 	}
 
-	// Finally, we remove from the db
 	res, err := c.RemoveShare(ctx, req)
 	if err != nil {
 		return nil, errors.Wrap(err, "gateway: error calling RemoveShare")
@@ -289,32 +351,99 @@ func (s *svc) UpdateShare(ctx context.Context, req *collaboration.UpdateShareReq
 		}, nil
 	}
 
+	// Fetch the current share before updating so we have its path and space.
+	getRes, err := c.GetShare(ctx, &collaboration.GetShareRequest{Ref: req.Ref})
+	if err != nil {
+		return nil, errors.Wrap(err, "gateway: error calling GetShare for UpdateShare")
+	}
+	if getRes.Status.Code != rpc.Code_CODE_OK {
+		return &collaboration.UpdateShareResponse{
+			Status: status.NewInternal(ctx, status.NewErrorFromCode(getRes.Status.Code, "gateway"), "error getting share for update"),
+		}, nil
+	}
+	currentShare := getRes.Share
+
+	_, isPermUpdate := req.Field.GetField().(*collaboration.UpdateShareRequest_UpdateField_Permissions)
+	newPerms := req.Field.GetPermissions().GetPermissions()
+
+	// Hierarchy check (ADR-GENERAL-005) — only for permission updates when SpaceId is available.
+	// Returns early on conflict; on success, populates toDelete/toReapply for use below.
+	checker := &sharehierarchy.Checker{GetPath: s.getPathForResourceId}
+	var toDelete, toReapply []*collaboration.Share
+	if isPermUpdate && currentShare.ResourceId.SpaceId != "" {
+		force := parseForce(req.Opaque)
+
+		existingShares, listErr := s.listSharesForGranteeInSpace(ctx, c, currentShare.ResourceId.SpaceId, currentShare.Grantee)
+		if listErr != nil {
+			return &collaboration.UpdateShareResponse{
+				Status: status.NewInternal(ctx, listErr, "error listing shares for hierarchy check"),
+			}, nil
+		}
+		existingShares = filterOutShare(existingShares, currentShare.Id.OpaqueId)
+
+		currentPath, pathErr := s.getPathForResourceId(ctx, currentShare.ResourceId)
+		if pathErr != nil {
+			return &collaboration.UpdateShareResponse{
+				Status: status.NewInternal(ctx, pathErr, "error resolving share path for hierarchy check"),
+			}, nil
+		}
+
+		result, checkErr := checker.CheckGrantConsistency(ctx, currentPath, newPerms, existingShares)
+		if checkErr != nil {
+			return &collaboration.UpdateShareResponse{
+				Status: status.NewStatusFromErrType(ctx, "hierarchy check", checkErr),
+			}, nil
+		}
+		if !force && len(result.ToDelete) > 0 {
+			conflictErr := errtypes.ShareChildConflict(sharehierarchy.ChildConflictMessage(result.ToDelete))
+			return &collaboration.UpdateShareResponse{
+				Status: status.NewStatusFromErrType(ctx, "hierarchy check", conflictErr),
+			}, nil
+		}
+		toDelete = result.ToDelete
+		toReapply = result.ToReapply
+	}
+
+	if isPermUpdate && s.c.CommitShareToStorageGrant {
+		if grantStatus, err := s.updateGrant(ctx, currentShare.ResourceId, currentShare.Grantee, newPerms); err != nil || grantStatus.Code != rpc.Code_CODE_OK {
+			if err != nil {
+				return nil, errors.Wrap(err, "gateway: error calling updateGrant")
+			}
+			return &collaboration.UpdateShareResponse{Status: grantStatus}, nil
+		}
+
+		// Remove grants for child shares made redundant by the updated permissions.
+		for _, child := range toDelete {
+			if st, err := s.removeGrant(ctx, child.ResourceId, child.Grantee, child.Permissions.Permissions); err != nil || st.Code != rpc.Code_CODE_OK {
+				if err != nil {
+					return nil, errors.Wrap(err, "gateway: error removing child grant")
+				}
+				return &collaboration.UpdateShareResponse{Status: st}, nil
+			}
+		}
+
+		// Re-apply grants for children that retain higher permissions.
+		// toReapply is already sorted shallowest-first by CheckGrantConsistency.
+		for _, child := range toReapply {
+			if _, err := s.addGrant(ctx, child.ResourceId, child.Grantee, child.Permissions.Permissions); err != nil {
+				appctx.GetLogger(ctx).Error().Err(err).Str("shareId", child.Id.OpaqueId).Msg("error re-applying child grant after UpdateShare")
+			}
+		}
+	}
+
 	res, err := c.UpdateShare(ctx, req)
 	if err != nil {
 		return nil, errors.Wrap(err, "gateway: error calling UpdateShare")
 	}
-
-	// if we don't need to commit we return earlier
-	if !s.c.CommitShareToStorageGrant {
+	if res.Status.Code != rpc.Code_CODE_OK {
 		return res, nil
 	}
-
-	// TODO(labkode): if both commits are enabled they could be done concurrently.
-
-	if s.c.CommitShareToStorageGrant {
-		updateGrantStatus, err := s.updateGrant(ctx, res.GetShare().GetResourceId(),
-			res.GetShare().GetGrantee(),
-			res.GetShare().GetPermissions().GetPermissions())
-
-		if err != nil {
-			return nil, errors.Wrap(err, "gateway: error calling updateGrant")
-		}
-
-		if updateGrantStatus.Code != rpc.Code_CODE_OK {
-			return &collaboration.UpdateShareResponse{
-				Status: updateGrantStatus,
-				Share:  res.Share,
-			}, nil
+	// Remove child share records made redundant by the updated permissions.
+	for _, child := range toDelete {
+		if _, err := c.RemoveShare(ctx, &collaboration.RemoveShareRequest{
+			Ref: &collaboration.ShareReference{Spec: &collaboration.ShareReference_Id{Id: child.Id}},
+		}); err != nil {
+			appctx.GetLogger(ctx).Error().Err(err).Str("shareId", child.Id.OpaqueId).Msg("error removing child share from DB after UpdateShare")
 		}
 	}
 
@@ -482,6 +611,74 @@ func (s *svc) UpdateReceivedShare(ctx context.Context, req *collaboration.Update
 
 	return res, nil
 }
+
+// ---------------------------------------------------------------------------
+// Hierarchy helpers (ADR-0005-P01)
+// ---------------------------------------------------------------------------
+
+// parseForce reads the "force" flag from the request opaque map.
+func parseForce(opaque *typesv1beta1.Opaque) bool {
+	if opaque == nil {
+		return false
+	}
+	v, ok := opaque.Map["force"]
+	return ok && string(v.Value) == "true"
+}
+
+// getPathForResourceId resolves a ResourceId to its current filesystem path.
+func (s *svc) getPathForResourceId(ctx context.Context, id *provider.ResourceId) (string, error) {
+	res, err := s.GetPath(ctx, &provider.GetPathRequest{ResourceId: id})
+	if err != nil {
+		return "", errors.Wrap(err, "gateway: error calling GetPath")
+	}
+	if res.Status.Code != rpc.Code_CODE_OK {
+		return "", errors.New("gateway: GetPath failed: " + res.Status.Message)
+	}
+	return res.Path, nil
+}
+
+// listSharesForGranteeInSpace returns all active shares for the given grantee in the given space.
+func (s *svc) listSharesForGranteeInSpace(ctx context.Context, c collaboration.CollaborationAPIClient, spaceId string, grantee *provider.Grantee) ([]*collaboration.Share, error) {
+	if spaceId == "" {
+		return nil, nil
+	}
+
+	res, err := c.ListShares(ctx, &collaboration.ListSharesRequest{
+		Filters: []*collaboration.Filter{
+			revashare.SpaceIDFilter(spaceId),
+			revashare.GranteeFilter(grantee),
+		},
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "gateway: error listing shares for grantee in space")
+	}
+	if res.Status.Code != rpc.Code_CODE_OK {
+		return nil, errors.New("gateway: ListShares for space returned: " + res.Status.Message)
+	}
+	return res.Shares, nil
+}
+
+// applyGrant sets an ACL on EOS for the given resource, calling denyGrant for empty permissions
+// or addGrant for normal permissions.
+func (s *svc) applyGrant(ctx context.Context, id *provider.ResourceId, grantee *provider.Grantee, perms *provider.ResourcePermissions) (*rpc.Status, error) {
+	if grants.PermissionsEqual(perms, &provider.ResourcePermissions{}) {
+		return s.denyGrant(ctx, id, grantee)
+	}
+	return s.addGrant(ctx, id, grantee, perms)
+}
+
+// filterOutShare returns shares with the given opaqueId excluded.
+func filterOutShare(shares []*collaboration.Share, opaqueId string) []*collaboration.Share {
+	result := make([]*collaboration.Share, 0, len(shares))
+	for _, s := range shares {
+		if s.Id.OpaqueId != opaqueId {
+			result = append(result, s)
+		}
+	}
+	return result
+}
+
+// ---------------------------------------------------------------------------
 
 func (s *svc) removeReference(ctx context.Context, resourceID *provider.ResourceId) *rpc.Status {
 	log := appctx.GetLogger(ctx)

--- a/internal/grpc/services/gateway/usershareprovider.go
+++ b/internal/grpc/services/gateway/usershareprovider.go
@@ -85,7 +85,8 @@ func (s *svc) CreateShare(ctx context.Context, req *collaboration.CreateShareReq
 			req.ResourceInfo.Id.SpaceId = spaceId
 			log.Debug().Str("keyword", "sharehierarchy").Str("spaceId", spaceId).Msg("sharehierarchy: populated missing spaceId via stat")
 		} else {
-			log.Warn().Str("keyword", "sharehierarchy").Msg("sharehierarchy: spaceId missing and stat could not resolve it")
+			log.Error().Str("keyword", "sharehierarchy").Msg("sharehierarchy: spaceId missing and stat could not resolve it")
+			return nil, errors.New("SpaceID missing when creating share")
 		}
 	}
 

--- a/internal/grpc/services/gateway/usershareprovider.go
+++ b/internal/grpc/services/gateway/usershareprovider.go
@@ -102,15 +102,16 @@ func (s *svc) CreateShare(ctx context.Context, req *collaboration.CreateShareReq
 	checker := &sharehierarchy.Checker{GetPath: s.getPathForResourceId}
 	result, err := checker.CheckGrantConsistency(ctx, req.ResourceInfo.Path, req.Grant.Permissions.Permissions, existingShares)
 	if err != nil {
+		conflictErr := err.(*sharehierarchy.HierarchyConflictError)
 		return &collaboration.CreateShareResponse{
-			Status: status.NewStatusFromErrType(ctx, "hierarchy check", err),
+			Status: status.NewConflict(ctx, conflictErr, conflictErr.MarshalToJSON()),
 		}, nil
 	}
 	// If we don't force, we show a warning to the user that shares will be deleted
 	if !force && len(result.ToDelete) > 0 {
-		conflictErr := errtypes.ShareChildConflict(sharehierarchy.ChildConflictMessage(result.ToDelete))
+		conflictErr := sharehierarchy.NewChildConflictError(sharehierarchy.ChildConflictMessage(result.ToDelete), result.ToDelete)
 		return &collaboration.CreateShareResponse{
-			Status: status.NewStatusFromErrType(ctx, "hierarchy check", conflictErr),
+			Status: status.NewConflict(ctx, conflictErr, conflictErr.MarshalToJSON()),
 		}, nil
 	}
 
@@ -392,14 +393,15 @@ func (s *svc) UpdateShare(ctx context.Context, req *collaboration.UpdateShareReq
 
 		result, checkErr := checker.CheckGrantConsistency(ctx, currentPath, newPerms, existingShares)
 		if checkErr != nil {
+			conflictErr := checkErr.(*sharehierarchy.HierarchyConflictError)
 			return &collaboration.UpdateShareResponse{
-				Status: status.NewStatusFromErrType(ctx, "hierarchy check", checkErr),
+				Status: status.NewConflict(ctx, conflictErr, conflictErr.MarshalToJSON()),
 			}, nil
 		}
 		if !force && len(result.ToDelete) > 0 {
-			conflictErr := errtypes.ShareChildConflict(sharehierarchy.ChildConflictMessage(result.ToDelete))
+			conflictErr := sharehierarchy.NewChildConflictError(sharehierarchy.ChildConflictMessage(result.ToDelete), result.ToDelete)
 			return &collaboration.UpdateShareResponse{
-				Status: status.NewStatusFromErrType(ctx, "hierarchy check", conflictErr),
+				Status: status.NewConflict(ctx, conflictErr, conflictErr.MarshalToJSON()),
 			}, nil
 		}
 		toDelete = result.ToDelete

--- a/internal/grpc/services/gateway/usershareprovider.go
+++ b/internal/grpc/services/gateway/usershareprovider.go
@@ -83,9 +83,9 @@ func (s *svc) CreateShare(ctx context.Context, req *collaboration.CreateShareReq
 		if stat, statErr := s.Stat(ctx, &provider.StatRequest{Ref: &provider.Reference{ResourceId: req.ResourceInfo.Id}}); statErr == nil && stat.Status.Code == rpc.Code_CODE_OK && stat.Info.Id.SpaceId != "" {
 			spaceId = stat.Info.Id.SpaceId
 			req.ResourceInfo.Id.SpaceId = spaceId
-			log.Debug().Str("keyword", "sharehierarchy").Str("spaceId", spaceId).Msg("sharehierarchy: populated missing spaceId via stat")
+			log.Debug().Str("spaceId", spaceId).Msg("sharehierarchy: populated missing spaceId via stat")
 		} else {
-			log.Error().Str("keyword", "sharehierarchy").Msg("sharehierarchy: spaceId missing and stat could not resolve it")
+			log.Error().Msg("sharehierarchy: spaceId missing and stat could not resolve it")
 			return nil, errors.New("SpaceID missing when creating share")
 		}
 	}
@@ -182,9 +182,9 @@ func (s *svc) RemoveShare(ctx context.Context, req *collaboration.RemoveShareReq
 	if share.ResourceId.SpaceId == "" {
 		if stat, statErr := s.Stat(ctx, &provider.StatRequest{Ref: &provider.Reference{ResourceId: share.ResourceId}}); statErr == nil && stat.Status.Code == rpc.Code_CODE_OK && stat.Info.Id.SpaceId != "" {
 			share.ResourceId.SpaceId = stat.Info.Id.SpaceId
-			log.Debug().Str("keyword", "sharehierarchy").Str("spaceId", share.ResourceId.SpaceId).Msg("sharehierarchy: populated missing spaceId for DeleteShare via stat")
+			log.Debug().Str("spaceId", share.ResourceId.SpaceId).Msg("sharehierarchy: populated missing spaceId for DeleteShare via stat")
 		} else {
-			log.Warn().Str("keyword", "sharehierarchy").Msg("sharehierarchy: spaceId missing on DeleteShare and stat could not resolve it")
+			log.Warn().Msg("sharehierarchy: spaceId missing on DeleteShare and stat could not resolve it")
 		}
 	}
 
@@ -367,9 +367,9 @@ func (s *svc) UpdateShare(ctx context.Context, req *collaboration.UpdateShareReq
 	if isPermUpdate && currentShare.ResourceId.SpaceId == "" {
 		if stat, statErr := s.Stat(ctx, &provider.StatRequest{Ref: &provider.Reference{ResourceId: currentShare.ResourceId}}); statErr == nil && stat.Status.Code == rpc.Code_CODE_OK && stat.Info.Id.SpaceId != "" {
 			currentShare.ResourceId.SpaceId = stat.Info.Id.SpaceId
-			appctx.GetLogger(ctx).Debug().Str("keyword", "sharehierarchy").Str("spaceId", currentShare.ResourceId.SpaceId).Msg("sharehierarchy: populated missing spaceId for UpdateShare via stat")
+			appctx.GetLogger(ctx).Debug().Str("spaceId", currentShare.ResourceId.SpaceId).Msg("sharehierarchy: populated missing spaceId for UpdateShare via stat")
 		} else {
-			appctx.GetLogger(ctx).Warn().Str("keyword", "sharehierarchy").Msg("sharehierarchy: spaceId missing on UpdateShare and stat could not resolve it")
+			appctx.GetLogger(ctx).Warn().Msg("sharehierarchy: spaceId missing on UpdateShare and stat could not resolve it")
 		}
 	}
 
@@ -636,7 +636,7 @@ func (s *svc) getPathForResourceId(ctx context.Context, id *provider.ResourceId)
 // listSharesForGranteeInSpace returns all active shares for the given grantee in the given space.
 func (s *svc) listSharesForGranteeInSpace(ctx context.Context, c collaboration.CollaborationAPIClient, spaceId string, grantee *provider.Grantee) ([]*collaboration.Share, error) {
 	if spaceId == "" {
-		appctx.GetLogger(ctx).Warn().Str("keyword", "sharehierarchy").Msg("sharehierarchy: spaceId is empty, skipping hierarchy check")
+		appctx.GetLogger(ctx).Warn().Msg("sharehierarchy: spaceId is empty, skipping hierarchy check")
 		return nil, nil
 	}
 

--- a/internal/grpc/services/gateway/usershareprovider.go
+++ b/internal/grpc/services/gateway/usershareprovider.go
@@ -189,6 +189,15 @@ func (s *svc) RemoveShare(ctx context.Context, req *collaboration.RemoveShareReq
 
 	checker := &sharehierarchy.Checker{GetPath: s.getPathForResourceId}
 
+	if share.ResourceId.SpaceId == "" {
+		if stat, statErr := s.Stat(ctx, &provider.StatRequest{Ref: &provider.Reference{ResourceId: share.ResourceId}}); statErr == nil && stat.Status.Code == rpc.Code_CODE_OK && stat.Info.Id.SpaceId != "" {
+			share.ResourceId.SpaceId = stat.Info.Id.SpaceId
+			log.Debug().Str("keyword", "sharehierarchy").Str("spaceId", share.ResourceId.SpaceId).Msg("sharehierarchy: populated missing spaceId for DeleteShare via stat")
+		} else {
+			log.Warn().Str("keyword", "sharehierarchy").Msg("sharehierarchy: spaceId missing on DeleteShare and stat could not resolve it")
+		}
+	}
+
 	// Resolve parent / child shares so we can reapply the hierarchy (ADR-GENERAL-005).
 	existingShares, listErr := s.listSharesForGranteeInSpace(ctx, c, share.ResourceId.SpaceId, share.Grantee)
 	if listErr != nil {
@@ -368,6 +377,15 @@ func (s *svc) UpdateShare(ctx context.Context, req *collaboration.UpdateShareReq
 
 	_, isPermUpdate := req.Field.GetField().(*collaboration.UpdateShareRequest_UpdateField_Permissions)
 	newPerms := req.Field.GetPermissions().GetPermissions()
+
+	if isPermUpdate && currentShare.ResourceId.SpaceId == "" {
+		if stat, statErr := s.Stat(ctx, &provider.StatRequest{Ref: &provider.Reference{ResourceId: currentShare.ResourceId}}); statErr == nil && stat.Status.Code == rpc.Code_CODE_OK && stat.Info.Id.SpaceId != "" {
+			currentShare.ResourceId.SpaceId = stat.Info.Id.SpaceId
+			appctx.GetLogger(ctx).Debug().Str("keyword", "sharehierarchy").Str("spaceId", currentShare.ResourceId.SpaceId).Msg("sharehierarchy: populated missing spaceId for UpdateShare via stat")
+		} else {
+			appctx.GetLogger(ctx).Warn().Str("keyword", "sharehierarchy").Msg("sharehierarchy: spaceId missing on UpdateShare and stat could not resolve it")
+		}
+	}
 
 	// Hierarchy check (ADR-GENERAL-005) — only for permission updates when SpaceId is available.
 	// Returns early on conflict; on success, populates toDelete/toReapply for use below.

--- a/internal/grpc/services/gateway/usershareprovider.go
+++ b/internal/grpc/services/gateway/usershareprovider.go
@@ -125,21 +125,15 @@ func (s *svc) CreateShare(ctx context.Context, req *collaboration.CreateShareReq
 			return &collaboration.CreateShareResponse{Status: grantStatus}, nil
 		}
 		// Remove grants for child shares made redundant by the new share.
-		for _, child := range result.ToDelete {
-			if st, err := s.removeGrant(ctx, child.ResourceId, child.Grantee, child.Permissions.Permissions); err != nil || st.Code != rpc.Code_CODE_OK {
-				if err != nil {
-					return nil, errors.Wrap(err, "gateway: error removing child grant")
-				}
-				return &collaboration.CreateShareResponse{Status: st}, nil
+		if st, err := s.removeChildGrants(ctx, result.ToDelete); err != nil || st.Code != rpc.Code_CODE_OK {
+			if err != nil {
+				return nil, err
 			}
+			return &collaboration.CreateShareResponse{Status: st}, nil
 		}
 		// Re-apply grants for children that retain higher permissions (N=R, C=RW).
 		// ToReapply is already sorted shallowest-first by CheckGrantConsistency.
-		for _, child := range result.ToReapply {
-			if _, err := s.addGrant(ctx, child.ResourceId, child.Grantee, child.Permissions.Permissions); err != nil {
-				log.Error().Err(err).Str("shareId", child.Id.OpaqueId).Msg("error re-applying child grant after CreateShare")
-			}
-		}
+		s.reapplyChildGrants(ctx, result.ToReapply)
 	}
 
 	// Finally, we write to the db
@@ -152,15 +146,8 @@ func (s *svc) CreateShare(ctx context.Context, req *collaboration.CreateShareReq
 		return nil, errors.New("ShareClient returned error: " + res.Status.Code.String() + ": " + res.Status.Message)
 	}
 
-	// And we remove from the db the deleted shares
-	// Remove child share records made redundant by the new share.
-	for _, child := range result.ToDelete {
-		if _, err := shareClient.RemoveShare(ctx, &collaboration.RemoveShareRequest{
-			Ref: &collaboration.ShareReference{Spec: &collaboration.ShareReference_Id{Id: child.Id}},
-		}); err != nil {
-			log.Error().Err(err).Str("shareId", child.Id.OpaqueId).Msg("error removing child share from DB after CreateShare")
-		}
-	}
+	// And we remove from the db the deleted shares made redundant by the new share.
+	s.removeChildShareRecords(ctx, shareClient, result.ToDelete)
 
 	return res, nil
 
@@ -226,11 +213,7 @@ func (s *svc) RemoveShare(ctx context.Context, req *collaboration.RemoveShareReq
 
 		// Re-apply descendant grants shallowest-first so child permissions are not overridden.
 		// (and the results are already pre-sorted to be shallowest-first)
-		for _, child := range reapply.ChildGrants {
-			if _, err := s.addGrant(ctx, child.ResourceId, child.Grantee, child.Permissions.Permissions); err != nil {
-				log.Error().Err(err).Str("childShareId", child.Id.OpaqueId).Msg("error reapplying child grant after RemoveShare")
-			}
-		}
+		s.reapplyChildGrants(ctx, reapply.ChildGrants)
 	}
 
 	res, err := c.RemoveShare(ctx, req)
@@ -436,22 +419,16 @@ func (s *svc) UpdateShare(ctx context.Context, req *collaboration.UpdateShareReq
 		}
 
 		// Remove grants for child shares made redundant by the updated permissions.
-		for _, child := range toDelete {
-			if st, err := s.removeGrant(ctx, child.ResourceId, child.Grantee, child.Permissions.Permissions); err != nil || st.Code != rpc.Code_CODE_OK {
-				if err != nil {
-					return nil, errors.Wrap(err, "gateway: error removing child grant")
-				}
-				return &collaboration.UpdateShareResponse{Status: st}, nil
+		if st, err := s.removeChildGrants(ctx, toDelete); err != nil || st.Code != rpc.Code_CODE_OK {
+			if err != nil {
+				return nil, err
 			}
+			return &collaboration.UpdateShareResponse{Status: st}, nil
 		}
 
 		// Re-apply grants for children that retain higher permissions.
 		// toReapply is already sorted shallowest-first by CheckGrantConsistency.
-		for _, child := range toReapply {
-			if _, err := s.addGrant(ctx, child.ResourceId, child.Grantee, child.Permissions.Permissions); err != nil {
-				appctx.GetLogger(ctx).Error().Err(err).Str("shareId", child.Id.OpaqueId).Msg("error re-applying child grant after UpdateShare")
-			}
-		}
+		s.reapplyChildGrants(ctx, toReapply)
 	}
 
 	res, err := c.UpdateShare(ctx, req)
@@ -462,13 +439,7 @@ func (s *svc) UpdateShare(ctx context.Context, req *collaboration.UpdateShareReq
 		return res, nil
 	}
 	// Remove child share records made redundant by the updated permissions.
-	for _, child := range toDelete {
-		if _, err := c.RemoveShare(ctx, &collaboration.RemoveShareRequest{
-			Ref: &collaboration.ShareReference{Spec: &collaboration.ShareReference_Id{Id: child.Id}},
-		}); err != nil {
-			appctx.GetLogger(ctx).Error().Err(err).Str("shareId", child.Id.OpaqueId).Msg("error removing child share from DB after UpdateShare")
-		}
-	}
+	s.removeChildShareRecords(ctx, c, toDelete)
 
 	return res, nil
 }
@@ -689,6 +660,48 @@ func (s *svc) applyGrant(ctx context.Context, id *provider.ResourceId, grantee *
 		return s.denyGrant(ctx, id, grantee)
 	}
 	return s.addGrant(ctx, id, grantee, perms)
+}
+
+// removeChildGrants removes the storage grants for the given child shares.
+// It aborts on the first failure, returning a non-OK status (when the storage
+// rejected the call) or an error (when the call itself failed), mirroring the
+// caller's expectation that a redundant child must be cleaned up before we proceed.
+func (s *svc) removeChildGrants(ctx context.Context, children []*collaboration.Share) (*rpc.Status, error) {
+	for _, child := range children {
+		st, err := s.removeGrant(ctx, child.ResourceId, child.Grantee, child.Permissions.Permissions)
+		if err != nil {
+			return nil, errors.Wrap(err, "gateway: error removing child grant")
+		}
+		if st.Code != rpc.Code_CODE_OK {
+			return st, nil
+		}
+	}
+	return status.NewOK(ctx), nil
+}
+
+// reapplyChildGrants re-applies the storage grants for the given child shares on a
+// best-effort basis. Children must be pre-sorted shallowest-first so that deeper,
+// more specific grants are not overridden. Failures are logged but do not abort the caller.
+func (s *svc) reapplyChildGrants(ctx context.Context, children []*collaboration.Share) {
+	log := appctx.GetLogger(ctx)
+	for _, child := range children {
+		if _, err := s.addGrant(ctx, child.ResourceId, child.Grantee, child.Permissions.Permissions); err != nil {
+			log.Error().Err(err).Str("shareId", child.Id.OpaqueId).Msg("error re-applying child grant")
+		}
+	}
+}
+
+// removeChildShareRecords deletes the share DB records for the given child shares
+// on a best-effort basis. Failures are logged but do not abort the caller.
+func (s *svc) removeChildShareRecords(ctx context.Context, c collaboration.CollaborationAPIClient, children []*collaboration.Share) {
+	log := appctx.GetLogger(ctx)
+	for _, child := range children {
+		if _, err := c.RemoveShare(ctx, &collaboration.RemoveShareRequest{
+			Ref: &collaboration.ShareReference{Spec: &collaboration.ShareReference_Id{Id: child.Id}},
+		}); err != nil {
+			log.Error().Err(err).Str("shareId", child.Id.OpaqueId).Msg("error removing child share from DB")
+		}
+	}
 }
 
 // filterOutShare returns shares with the given opaqueId excluded.

--- a/internal/grpc/services/gateway/usershareprovider.go
+++ b/internal/grpc/services/gateway/usershareprovider.go
@@ -79,6 +79,16 @@ func (s *svc) CreateShare(ctx context.Context, req *collaboration.CreateShareReq
 	// (https://gitlab.cern.ch/cernbox/adr/-/blob/master/decisions/general/0005-sharing.md)
 	// ---------------------------------
 	spaceId := req.ResourceInfo.Id.SpaceId
+	if spaceId == "" {
+		if stat, statErr := s.Stat(ctx, &provider.StatRequest{Ref: &provider.Reference{ResourceId: req.ResourceInfo.Id}}); statErr == nil && stat.Status.Code == rpc.Code_CODE_OK && stat.Info.Id.SpaceId != "" {
+			spaceId = stat.Info.Id.SpaceId
+			req.ResourceInfo.Id.SpaceId = spaceId
+			log.Debug().Str("keyword", "sharehierarchy").Str("spaceId", spaceId).Msg("sharehierarchy: populated missing spaceId via stat")
+		} else {
+			log.Warn().Str("keyword", "sharehierarchy").Msg("sharehierarchy: spaceId missing and stat could not resolve it")
+		}
+	}
+
 	// Force means we delete child shares, instead of returning a conflict error
 	force := parseForce(req.Opaque)
 
@@ -632,6 +642,7 @@ func (s *svc) getPathForResourceId(ctx context.Context, id *provider.ResourceId)
 // listSharesForGranteeInSpace returns all active shares for the given grantee in the given space.
 func (s *svc) listSharesForGranteeInSpace(ctx context.Context, c collaboration.CollaborationAPIClient, spaceId string, grantee *provider.Grantee) ([]*collaboration.Share, error) {
 	if spaceId == "" {
+		appctx.GetLogger(ctx).Warn().Str("keyword", "sharehierarchy").Msg("sharehierarchy: spaceId is empty, skipping hierarchy check")
 		return nil, nil
 	}
 

--- a/internal/grpc/services/gateway/usershareprovider.go
+++ b/internal/grpc/services/gateway/usershareprovider.go
@@ -176,24 +176,16 @@ func (s *svc) RemoveShare(ctx context.Context, req *collaboration.RemoveShareReq
 	}
 	share := getShareRes.Share
 
-	// Resolve parent / child shares so we can reapply the hierarchy (ADR-GENERAL-005).
-	var ancestors, descendants []*collaboration.Share
-	var paths map[string]string
 	checker := &sharehierarchy.Checker{GetPath: s.getPathForResourceId}
 
+	// Resolve parent / child shares so we can reapply the hierarchy (ADR-GENERAL-005).
 	existingShares, listErr := s.listSharesForGranteeInSpace(ctx, c, share.ResourceId.SpaceId, share.Grantee)
 	if listErr != nil {
 		return &collaboration.RemoveShareResponse{
 			Status: status.NewInternal(ctx, listErr, "error listing shares for hierarchy reapply"),
 		}, nil
 	}
-	existingShares = filterOutShare(existingShares, share.Id.OpaqueId)
-	paths = checker.ResolvePaths(ctx, existingShares)
-	sharePath, pathErr := s.getPathForResourceId(ctx, share.ResourceId)
-	if pathErr == nil {
-		ancestors = sharehierarchy.FilterAncestors(existingShares, paths, sharePath)
-		descendants = sharehierarchy.FilterDescendants(existingShares, paths, sharePath)
-	}
+	reapply := checker.GrantsToReapplyAfterRemove(ctx, share.Id.OpaqueId, share.ResourceId, existingShares)
 
 	if s.c.CommitShareToStorageGrant {
 		removeGrantStatus, err := s.removeGrant(ctx, share.ResourceId, share.Grantee, share.Permissions.Permissions)
@@ -204,16 +196,16 @@ func (s *svc) RemoveShare(ctx context.Context, req *collaboration.RemoveShareReq
 			return &collaboration.RemoveShareResponse{Status: removeGrantStatus}, nil
 		}
 
-		// Re-apply the closest parent's permissions to the now-unshared node.
-		if parent := sharehierarchy.ClosestAncestor(ancestors, paths); parent != nil {
-			if _, err := s.addGrant(ctx, share.ResourceId, share.Grantee, parent.Permissions.Permissions); err != nil {
+		// Re-apply the closest parent's permissions to the now-unshared node (if any).
+		if reapply.ParentGrant != nil {
+			if _, err := s.addGrant(ctx, share.ResourceId, share.Grantee, reapply.ParentGrant.Permissions.Permissions); err != nil {
 				log.Error().Err(err).Str("shareId", share.Id.OpaqueId).Msg("error reapplying parent grant after RemoveShare")
 			}
 		}
 
 		// Re-apply descendant grants shallowest-first so child permissions are not overridden.
-		sharehierarchy.SortByPathDepthAsc(descendants, paths)
-		for _, child := range descendants {
+		// (and the results are already pre-sorted to be shallowest-first)
+		for _, child := range reapply.ChildGrants {
 			if _, err := s.addGrant(ctx, child.ResourceId, child.Grantee, child.Permissions.Permissions); err != nil {
 				log.Error().Err(err).Str("childShareId", child.Id.OpaqueId).Msg("error reapplying child grant after RemoveShare")
 			}

--- a/internal/grpc/services/publicstorageprovider/publicstorageprovider.go
+++ b/internal/grpc/services/publicstorageprovider/publicstorageprovider.go
@@ -742,7 +742,6 @@ func (s *service) GetQuota(ctx context.Context, req *provider.GetQuotaRequest) (
 	return nil, gstatus.Errorf(codes.Unimplemented, "method not implemented")
 }
 
-
 func (s *service) trimMountPrefix(fn string) (string, error) {
 	if after, ok := strings.CutPrefix(fn, s.mountPath); ok {
 		return path.Join("/", after), nil

--- a/internal/http/services/owncloud/ocgraph/drive_permissions.go
+++ b/internal/http/services/owncloud/ocgraph/drive_permissions.go
@@ -16,10 +16,12 @@ import (
 	linkv1beta1 "github.com/cs3org/go-cs3apis/cs3/sharing/link/v1beta1"
 	ocm "github.com/cs3org/go-cs3apis/cs3/sharing/ocm/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+	types "github.com/cs3org/go-cs3apis/cs3/types/v1beta1"
 
 	"github.com/cs3org/reva/v3/pkg/appctx"
 	"github.com/cs3org/reva/v3/pkg/errtypes"
 	"github.com/cs3org/reva/v3/pkg/permissions"
+	"github.com/cs3org/reva/v3/pkg/sharehierarchy"
 	"github.com/cs3org/reva/v3/pkg/spaces"
 	"github.com/go-chi/chi/v5"
 	libregraph "github.com/owncloud/libre-graph-api-go"
@@ -185,7 +187,7 @@ func (s *svc) updateDrivePermissions(w http.ResponseWriter, r *http.Request) {
 
 	switch genericShare.shareType {
 	case ShareTypeShare, ShareTypeOCMShare:
-		s.updateSharePermissions(ctx, w, *genericShare, permission, resourceID)
+		s.updateSharePermissions(ctx, w, *genericShare, permission, resourceID, r.Header.Get("Force") == "true")
 	default:
 		s.updateLinkPermissions(ctx, w, genericShare.link, permission, resourceID)
 	}
@@ -303,7 +305,7 @@ func (s *svc) updateLinkPermissions(ctx context.Context, w http.ResponseWriter, 
 	_ = json.NewEncoder(w).Encode(lgPerm)
 }
 
-func (s *svc) updateSharePermissions(ctx context.Context, w http.ResponseWriter, genericShare GenericShare, lgPerm *libregraph.Permission, resourceId *provider.ResourceId) {
+func (s *svc) updateSharePermissions(ctx context.Context, w http.ResponseWriter, genericShare GenericShare, lgPerm *libregraph.Permission, resourceId *provider.ResourceId, force bool) {
 	log := appctx.GetLogger(ctx)
 
 	gw, err := s.getClient()
@@ -368,7 +370,17 @@ func (s *svc) updateSharePermissions(ctx context.Context, w http.ResponseWriter,
 			return
 		}
 
+		var updateOpaque *types.Opaque
+		if force {
+			updateOpaque = &types.Opaque{
+				Map: map[string]*types.OpaqueEntry{
+					"force": {Decoder: "plain", Value: []byte("true")},
+				},
+			}
+		}
+
 		res, err := gw.UpdateShare(ctx, &collaborationv1beta1.UpdateShareRequest{
+			Opaque: updateOpaque,
 			Ref: &collaborationv1beta1.ShareReference{
 				Spec: &collaborationv1beta1.ShareReference_Id{
 					Id: genericShare.share.Id,
@@ -383,6 +395,14 @@ func (s *svc) updateSharePermissions(ctx context.Context, w http.ResponseWriter,
 		}
 
 		if res.Status.Code != rpcv1beta1.Code_CODE_OK {
+			if res.Status.Code == rpcv1beta1.Code_CODE_ABORTED {
+				if conflictErr := sharehierarchy.UnmarshalHierarchyConflictError(res.Status.Message); conflictErr != nil {
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(http.StatusConflict)
+					json.NewEncoder(w).Encode(conflictErr)
+					return
+				}
+			}
 			log.Error().Interface("response", res).Msg("error updating public share")
 			w.WriteHeader(http.StatusInternalServerError)
 			return

--- a/internal/http/services/owncloud/ocgraph/shares.go
+++ b/internal/http/services/owncloud/ocgraph/shares.go
@@ -84,7 +84,7 @@ func (s *svc) getSharedWithMe(w http.ResponseWriter, r *http.Request) {
 	shares := make([]*libregraph.DriveItem, 0)
 	for _, share := range recvSharesResp.ShareInfos {
 		role := CS3ResourcePermissionsToUnifiedRole(ctx, share.ResourceInfo.PermissionSet)
-		if role != nil && *role.Id == UnifiedRoleDenyAccessID {
+		if role != nil && *role.Id == permissions.UnifiedRoleDenyAccessID {
 			continue
 		}
 		drive, err := s.cs3ReceivedShareToDriveItem(ctx, share)

--- a/internal/http/services/owncloud/ocgraph/shares.go
+++ b/internal/http/services/owncloud/ocgraph/shares.go
@@ -143,7 +143,7 @@ func (s *svc) getSharedWithMe(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func (s *svc) createLocalShare(ctx context.Context, gw gateway.GatewayAPIClient, ri *provider.ResourceId, path string, owner *userpb.UserId, resourceType provider.ResourceType, recipientType string, recipientID string, exp *types.Timestamp, requestedPerms *provider.ResourcePermissions) (*collaboration.CreateShareResponse, error) {
+func (s *svc) createLocalShare(ctx context.Context, gw gateway.GatewayAPIClient, ri *provider.ResourceId, path string, owner *userpb.UserId, resourceType provider.ResourceType, recipientType string, recipientID string, exp *types.Timestamp, requestedPerms *provider.ResourcePermissions, force bool) (*collaboration.CreateShareResponse, error) {
 	grantee, err := s.toGrantee(ctx, recipientType, recipientID)
 	if err != nil {
 		return nil, err
@@ -318,11 +318,7 @@ func (s *svc) share(w http.ResponseWriter, r *http.Request) {
 		// If the recipient is a user or a group, we create a local share
 		switch *recipient.LibreGraphRecipientType {
 		case "user", "group":
-<<<<<<< HEAD
-			resp, err := s.createLocalShare(ctx, gw, statRes.Info.Id, path, owner, statRes.Info.Type, *recipient.LibreGraphRecipientType, *recipient.ObjectId, exp, requestedPerms)
-=======
-			resp, err := s.createLocalShare(ctx, gw, storageID, itemID, path, owner, statRes.Info.Type, *recipient.LibreGraphRecipientType, *recipient.ObjectId, exp, requestedPerms, force)
->>>>>>> e44dc51c4 (make `force` param work)
+			resp, err := s.createLocalShare(ctx, gw, statRes.Info.Id, path, owner, statRes.Info.Type, *recipient.LibreGraphRecipientType, *recipient.ObjectId, exp, requestedPerms, force)
 			if err != nil {
 				if conflictErr, ok := err.(*sharehierarchy.HierarchyConflictError); ok {
 					w.Header().Set("Content-Type", "application/json")

--- a/internal/http/services/owncloud/ocgraph/shares.go
+++ b/internal/http/services/owncloud/ocgraph/shares.go
@@ -46,6 +46,7 @@ import (
 	"github.com/cs3org/reva/v3/pkg/appctx"
 	"github.com/cs3org/reva/v3/pkg/ocm/share"
 	"github.com/cs3org/reva/v3/pkg/permissions"
+	"github.com/cs3org/reva/v3/pkg/sharehierarchy"
 	"github.com/cs3org/reva/v3/pkg/spaces"
 	"github.com/cs3org/reva/v3/pkg/utils"
 	libregraph "github.com/owncloud/libre-graph-api-go"
@@ -169,6 +170,11 @@ func (s *svc) createLocalShare(ctx context.Context, gw gateway.GatewayAPIClient,
 		return nil, err
 	}
 	if resp.Status.Code != rpc.Code_CODE_OK {
+		if resp.Status.Code == rpc.Code_CODE_ABORTED {
+			if conflictErr := sharehierarchy.UnmarshalHierarchyConflictError(resp.Status.Message); conflictErr != nil {
+				return nil, conflictErr
+			}
+		}
 		return nil, errors.New("failed to create share: " + resp.Status.Message)
 	}
 
@@ -302,6 +308,12 @@ func (s *svc) share(w http.ResponseWriter, r *http.Request) {
 		case "user", "group":
 			resp, err := s.createLocalShare(ctx, gw, statRes.Info.Id, path, owner, statRes.Info.Type, *recipient.LibreGraphRecipientType, *recipient.ObjectId, exp, requestedPerms)
 			if err != nil {
+				if conflictErr, ok := err.(*sharehierarchy.HierarchyConflictError); ok {
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(http.StatusConflict)
+					json.NewEncoder(w).Encode(conflictErr)
+					return
+				}
 				log.Error().Err(err).Msg("")
 				handleError(ctx, err, w)
 				return

--- a/internal/http/services/owncloud/ocgraph/shares.go
+++ b/internal/http/services/owncloud/ocgraph/shares.go
@@ -149,7 +149,17 @@ func (s *svc) createLocalShare(ctx context.Context, gw gateway.GatewayAPIClient,
 		return nil, err
 	}
 
+	var opaque *types.Opaque
+	if force {
+		opaque = &types.Opaque{
+			Map: map[string]*types.OpaqueEntry{
+				"force": {Decoder: "plain", Value: []byte("true")},
+			},
+		}
+	}
+
 	createShareRequest := &collaboration.CreateShareRequest{
+		Opaque: opaque,
 		ResourceInfo: &provider.ResourceInfo{
 			Id:    ri,
 			Path:  path,
@@ -294,6 +304,8 @@ func (s *svc) share(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	force := r.Header.Get("Force") == "true"
+
 	// And we keep a list of share responses
 	response := make([]*libregraph.Permission, 0, len(invite.Recipients))
 
@@ -306,7 +318,11 @@ func (s *svc) share(w http.ResponseWriter, r *http.Request) {
 		// If the recipient is a user or a group, we create a local share
 		switch *recipient.LibreGraphRecipientType {
 		case "user", "group":
+<<<<<<< HEAD
 			resp, err := s.createLocalShare(ctx, gw, statRes.Info.Id, path, owner, statRes.Info.Type, *recipient.LibreGraphRecipientType, *recipient.ObjectId, exp, requestedPerms)
+=======
+			resp, err := s.createLocalShare(ctx, gw, storageID, itemID, path, owner, statRes.Info.Type, *recipient.LibreGraphRecipientType, *recipient.ObjectId, exp, requestedPerms, force)
+>>>>>>> e44dc51c4 (make `force` param work)
 			if err != nil {
 				if conflictErr, ok := err.(*sharehierarchy.HierarchyConflictError); ok {
 					w.Header().Set("Content-Type", "application/json")

--- a/internal/http/services/owncloud/ocgraph/unifiedrole.go
+++ b/internal/http/services/owncloud/ocgraph/unifiedrole.go
@@ -34,27 +34,6 @@ import (
 )
 
 const (
-	// UnifiedRoleViewerID Unified role viewer id.
-	UnifiedRoleViewerID = "b1e2218d-eef8-4d4c-b82d-0f1a1b48f3b5"
-	// UnifiedRoleSpaceViewerID Unified role space viewer id.
-	UnifiedRoleSpaceViewerID = "a8d5fe5e-96e3-418d-825b-534dbdf22b99"
-	// UnifiedRoleEditorID Unified role editor id.
-	UnifiedRoleEditorID = "fb6c3e19-e378-47e5-b277-9732f9de6e21"
-	// UnifiedRoleSpaceEditorID Unified role space editor id.
-	UnifiedRoleSpaceEditorID = "58c63c02-1d89-4572-916a-870abc5a1b7d"
-	// UnifiedRoleFileEditorID Unified role file editor id.
-	UnifiedRoleFileEditorID = "2d00ce52-1fc2-4dbc-8b95-a73b73395f5a"
-	// UnifiedRoleEditorLiteID Unified role editor-lite id.
-	UnifiedRoleEditorLiteID = "1c996275-f1c9-4e71-abdf-a42f6495e960"
-	// UnifiedRoleManagerID Unified role manager id.
-	UnifiedRoleManagerID = "312c0871-5ef7-4b3a-85b6-0e4074c64049"
-	// UnifiedRoleSecureViewerID Unified role secure viewer id.
-	UnifiedRoleSecureViewerID = "aa97fe03-7980-45ac-9e50-b325749fd7e6"
-	// UnifiedRoleUploaderID Unified role uploader id.
-	UnifiedRoleUploaderID = "bf483fbf-5998-4afd-b593-e0f5ab823695"
-	// UnifiedRoleDenyAccessID Unified role deny access id.
-	UnifiedRoleDenyAccessID = "5d3754fa-a6a6-4985-b0af-dd1359e5d616"
-
 	// UnifiedRoleConditionDrive defines constraint that matches a Driveroot/Spaceroot
 	UnifiedRoleConditionDrive = "exists @Resource.Root"
 	// UnifiedRoleConditionFolder defines constraints that matches a DriveItem representing a Folder
@@ -84,22 +63,22 @@ const (
 )
 
 var legacyNames map[string]string = map[string]string{
-	UnifiedRoleViewerID: permissions.RoleViewer,
+	permissions.UnifiedRoleViewerID: permissions.RoleViewer,
 	// in the V1 api the "spaceviewer" role was call "viewer" and the "spaceeditor" was "editor",
 	// we need to stay compatible with that
-	UnifiedRoleSpaceViewerID: "viewer",
-	UnifiedRoleSpaceEditorID: "editor",
-	UnifiedRoleEditorID:      permissions.RoleEditor,
-	UnifiedRoleFileEditorID:  permissions.RoleFileEditor,
-	// UnifiedRoleEditorLiteID:   permissions.RoleEditorLite,
-	UnifiedRoleManagerID: permissions.RoleManager,
+	permissions.UnifiedRoleSpaceViewerID: "viewer",
+	permissions.UnifiedRoleSpaceEditorID: "editor",
+	permissions.UnifiedRoleEditorID:      permissions.RoleEditor,
+	permissions.UnifiedRoleFileEditorID:  permissions.RoleFileEditor,
+	// permissions.UnifiedRoleEditorLiteID:   permissions.RoleEditorLite,
+	permissions.UnifiedRoleManagerID: permissions.RoleManager,
 }
 
 // NewViewerUnifiedRole creates a viewer role.
 func NewViewerUnifiedRole() *libregraph.UnifiedRoleDefinition {
 	r := permissions.NewViewerRole()
 	return &libregraph.UnifiedRoleDefinition{
-		Id:          proto.String(UnifiedRoleViewerID),
+		Id:          proto.String(permissions.UnifiedRoleViewerID),
 		Description: proto.String("View and download."),
 		DisplayName: displayName(r),
 		RolePermissions: []libregraph.UnifiedRolePermission{
@@ -120,7 +99,7 @@ func NewViewerUnifiedRole() *libregraph.UnifiedRoleDefinition {
 func NewSpaceViewerUnifiedRole() *libregraph.UnifiedRoleDefinition {
 	r := permissions.NewViewerRole()
 	return &libregraph.UnifiedRoleDefinition{
-		Id:          proto.String(UnifiedRoleSpaceViewerID),
+		Id:          proto.String(permissions.UnifiedRoleSpaceViewerID),
 		Description: proto.String("View and download."),
 		DisplayName: displayName(r),
 		RolePermissions: []libregraph.UnifiedRolePermission{
@@ -137,7 +116,7 @@ func NewSpaceViewerUnifiedRole() *libregraph.UnifiedRoleDefinition {
 func NewEditorUnifiedRole() *libregraph.UnifiedRoleDefinition {
 	r := permissions.NewEditorRole()
 	return &libregraph.UnifiedRoleDefinition{
-		Id:          proto.String(UnifiedRoleEditorID),
+		Id:          proto.String(permissions.UnifiedRoleEditorID),
 		Description: proto.String("View, download, upload, edit, add and delete."),
 		DisplayName: displayName(r),
 		RolePermissions: []libregraph.UnifiedRolePermission{
@@ -154,7 +133,7 @@ func NewEditorUnifiedRole() *libregraph.UnifiedRoleDefinition {
 func NewSpaceEditorUnifiedRole() *libregraph.UnifiedRoleDefinition {
 	r := permissions.NewEditorRole()
 	return &libregraph.UnifiedRoleDefinition{
-		Id:          proto.String(UnifiedRoleSpaceEditorID),
+		Id:          proto.String(permissions.UnifiedRoleSpaceEditorID),
 		Description: proto.String("View, download, upload, edit, add and delete."),
 		DisplayName: displayName(r),
 		RolePermissions: []libregraph.UnifiedRolePermission{
@@ -171,7 +150,7 @@ func NewSpaceEditorUnifiedRole() *libregraph.UnifiedRoleDefinition {
 func NewFileEditorUnifiedRole() *libregraph.UnifiedRoleDefinition {
 	r := permissions.NewFileEditorRole()
 	return &libregraph.UnifiedRoleDefinition{
-		Id:          proto.String(UnifiedRoleFileEditorID),
+		Id:          proto.String(permissions.UnifiedRoleFileEditorID),
 		Description: proto.String("View, download and edit."),
 		DisplayName: displayName(r),
 		RolePermissions: []libregraph.UnifiedRolePermission{
@@ -188,7 +167,7 @@ func NewFileEditorUnifiedRole() *libregraph.UnifiedRoleDefinition {
 func NewManagerUnifiedRole() *libregraph.UnifiedRoleDefinition {
 	r := permissions.NewManagerRole()
 	return &libregraph.UnifiedRoleDefinition{
-		Id:          proto.String(UnifiedRoleManagerID),
+		Id:          proto.String(permissions.UnifiedRoleManagerID),
 		Description: proto.String("View, download, upload, edit, add, delete and manage members."),
 		DisplayName: displayName(r),
 		RolePermissions: []libregraph.UnifiedRolePermission{
@@ -205,7 +184,7 @@ func NewManagerUnifiedRole() *libregraph.UnifiedRoleDefinition {
 func NewUploaderUnifiedRole() *libregraph.UnifiedRoleDefinition {
 	r := permissions.NewUploaderRole()
 	return &libregraph.UnifiedRoleDefinition{
-		Id:          proto.String(UnifiedRoleUploaderID),
+		Id:          proto.String(permissions.UnifiedRoleUploaderID),
 		Description: proto.String("Upload only."),
 		DisplayName: displayName(r),
 		RolePermissions: []libregraph.UnifiedRolePermission{
@@ -221,7 +200,7 @@ func NewUploaderUnifiedRole() *libregraph.UnifiedRoleDefinition {
 func NewAccessDeniedUnifiedRole() *libregraph.UnifiedRoleDefinition {
 	r := permissions.NewDeniedRole()
 	return &libregraph.UnifiedRoleDefinition{
-		Id:          proto.String(UnifiedRoleDenyAccessID),
+		Id:          proto.String(permissions.UnifiedRoleDenyAccessID),
 		Description: proto.String("Remove all permissions."),
 		DisplayName: displayName(r),
 		RolePermissions: []libregraph.UnifiedRolePermission{
@@ -508,23 +487,23 @@ var ocsRoleUnifiedRole = map[string]*libregraph.UnifiedRoleDefinition{
 
 func UnifiedRoleIDToDefinition(unifiedRoleID string) (*libregraph.UnifiedRoleDefinition, bool) {
 	switch unifiedRoleID {
-	case UnifiedRoleViewerID:
+	case permissions.UnifiedRoleViewerID:
 		return NewViewerUnifiedRole(), true
-	case UnifiedRoleSpaceViewerID:
+	case permissions.UnifiedRoleSpaceViewerID:
 		return NewViewerUnifiedRole(), true
-	case UnifiedRoleEditorID:
+	case permissions.UnifiedRoleEditorID:
 		return NewEditorUnifiedRole(), true
-	case UnifiedRoleSpaceEditorID:
+	case permissions.UnifiedRoleSpaceEditorID:
 		return NewEditorUnifiedRole(), true
-	case UnifiedRoleFileEditorID:
+	case permissions.UnifiedRoleFileEditorID:
 		return NewEditorUnifiedRole(), true
-	case UnifiedRoleEditorLiteID:
+	case permissions.UnifiedRoleEditorLiteID:
 		return NewEditorUnifiedRole(), true
-	case UnifiedRoleManagerID:
+	case permissions.UnifiedRoleManagerID:
 		return NewManagerUnifiedRole(), true
-	case UnifiedRoleSecureViewerID:
+	case permissions.UnifiedRoleSecureViewerID:
 		return NewViewerUnifiedRole(), true
-	case UnifiedRoleDenyAccessID:
+	case permissions.UnifiedRoleDenyAccessID:
 		return NewAccessDeniedUnifiedRole(), true
 	default:
 		return nil, false

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/group.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/group.go
@@ -31,9 +31,9 @@ import (
 	"github.com/cs3org/reva/v3/internal/http/services/owncloud/ocs/conversions"
 	"github.com/cs3org/reva/v3/pkg/permissions"
 	"github.com/cs3org/reva/v3/internal/http/services/owncloud/ocs/response"
-
 	"github.com/cs3org/reva/v3/pkg/appctx"
 	"github.com/cs3org/reva/v3/pkg/rgrpc/todo/pool"
+	"github.com/cs3org/reva/v3/pkg/sharehierarchy"
 )
 
 func (h *Handler) createGroupShare(w http.ResponseWriter, r *http.Request, statInfo *provider.ResourceInfo, role *permissions.Role, roleVal []byte) {
@@ -102,6 +102,10 @@ func (h *Handler) createGroupShare(w http.ResponseWriter, r *http.Request, statI
 				}
 			}
 		} else {
+			if conflictErr, ok := err.(*sharehierarchy.HierarchyConflictError); ok {
+				response.WriteOCSData(w, r, response.Meta{Status: "error", StatusCode: http.StatusConflict, Message: conflictErr.Message}, conflictErr, nil)
+				return
+			}
 			response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "An error occurred when creating the share", err)
 		}
 	}

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/shares.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/shares.go
@@ -59,6 +59,7 @@ import (
 	"github.com/cs3org/reva/v3/pkg/share/cache"
 	cachereg "github.com/cs3org/reva/v3/pkg/share/cache/registry"
 	warmupreg "github.com/cs3org/reva/v3/pkg/share/cache/warmup/registry"
+	"github.com/cs3org/reva/v3/pkg/sharehierarchy"
 	"github.com/cs3org/reva/v3/pkg/utils"
 	"github.com/cs3org/reva/v3/pkg/utils/resourceid"
 	"github.com/go-chi/chi/v5"
@@ -1436,7 +1437,12 @@ func (h *Handler) createCs3Share(ctx context.Context, r *http.Request, client ga
 		if createShareResponse.Status.Code == rpc.Code_CODE_NOT_FOUND {
 			return nil, nil
 		}
-		return nil, err
+		if createShareResponse.Status.Code == rpc.Code_CODE_ABORTED {
+			if conflictErr := sharehierarchy.UnmarshalHierarchyConflictError(createShareResponse.Status.Message); conflictErr != nil {
+				return nil, conflictErr
+			}
+		}
+		return nil, errors.New(createShareResponse.Status.Message)
 	}
 	s, err := conversions.CS3Share2ShareData(ctx, createShareResponse.Share)
 	if err != nil {

--- a/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/user.go
+++ b/internal/http/services/owncloud/ocs/handlers/apps/sharing/shares/user.go
@@ -36,7 +36,7 @@ import (
 	"github.com/cs3org/reva/v3/internal/http/services/owncloud/ocs/response"
 	"github.com/cs3org/reva/v3/pkg/appctx"
 	"github.com/cs3org/reva/v3/pkg/permissions"
-
+	"github.com/cs3org/reva/v3/pkg/sharehierarchy"
 	"github.com/cs3org/reva/v3/pkg/rgrpc/todo/pool"
 )
 
@@ -107,6 +107,10 @@ func (h *Handler) createUserShare(w http.ResponseWriter, r *http.Request, statIn
 				}
 			}
 		} else {
+			if conflictErr, ok := err.(*sharehierarchy.HierarchyConflictError); ok {
+				response.WriteOCSData(w, r, response.Meta{Status: "error", StatusCode: http.StatusConflict, Message: conflictErr.Message}, conflictErr, nil)
+				return
+			}
 			response.WriteOCSError(w, r, response.MetaServerError.StatusCode, "An error occurred when creating the share", err)
 		}
 	}

--- a/pkg/errtypes/errtypes.go
+++ b/pkg/errtypes/errtypes.go
@@ -195,3 +195,31 @@ type IsChecksumMismatch interface {
 type IsInsufficientStorage interface {
 	IsInsufficientStorage()
 }
+
+// ShareParentConflict is returned when creating a share is redundant or inconsistent
+// because a parent resource is already shared with the same grantee.
+type ShareParentConflict string
+
+func (e ShareParentConflict) Error() string { return "error: share parent conflict: " + string(e) }
+
+// IsShareParentConflict marks the error as a share parent conflict.
+func (e ShareParentConflict) IsShareParentConflict() {}
+
+// ShareChildConflict is returned when creating or updating a share would cause existing
+// child shares to be deleted or have their effective permissions altered.
+type ShareChildConflict string
+
+func (e ShareChildConflict) Error() string { return "error: share child conflict: " + string(e) }
+
+// IsShareChildConflict marks the error as a share child conflict.
+func (e ShareChildConflict) IsShareChildConflict() {}
+
+// IsShareParentConflict is the interface to implement to signal a share parent conflict.
+type IsShareParentConflict interface {
+	IsShareParentConflict()
+}
+
+// IsShareChildConflict is the interface to implement to signal a share child conflict.
+type IsShareChildConflict interface {
+	IsShareChildConflict()
+}

--- a/pkg/permissions/unifiedrole.go
+++ b/pkg/permissions/unifiedrole.go
@@ -1,0 +1,42 @@
+// Copyright 2018-2026 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package permissions
+
+const (
+	// UnifiedRoleViewerID Unified role viewer id.
+	UnifiedRoleViewerID = "b1e2218d-eef8-4d4c-b82d-0f1a1b48f3b5"
+	// UnifiedRoleSpaceViewerID Unified role space viewer id.
+	UnifiedRoleSpaceViewerID = "a8d5fe5e-96e3-418d-825b-534dbdf22b99"
+	// UnifiedRoleEditorID Unified role editor id.
+	UnifiedRoleEditorID = "fb6c3e19-e378-47e5-b277-9732f9de6e21"
+	// UnifiedRoleSpaceEditorID Unified role space editor id.
+	UnifiedRoleSpaceEditorID = "58c63c02-1d89-4572-916a-870abc5a1b7d"
+	// UnifiedRoleFileEditorID Unified role file editor id.
+	UnifiedRoleFileEditorID = "2d00ce52-1fc2-4dbc-8b95-a73b73395f5a"
+	// UnifiedRoleEditorLiteID Unified role editor-lite id.
+	UnifiedRoleEditorLiteID = "1c996275-f1c9-4e71-abdf-a42f6495e960"
+	// UnifiedRoleManagerID Unified role manager id.
+	UnifiedRoleManagerID = "312c0871-5ef7-4b3a-85b6-0e4074c64049"
+	// UnifiedRoleSecureViewerID Unified role secure viewer id.
+	UnifiedRoleSecureViewerID = "aa97fe03-7980-45ac-9e50-b325749fd7e6"
+	// UnifiedRoleUploaderID Unified role uploader id.
+	UnifiedRoleUploaderID = "bf483fbf-5998-4afd-b593-e0f5ab823695"
+	// UnifiedRoleDenyAccessID Unified role deny access id.
+	UnifiedRoleDenyAccessID = "5d3754fa-a6a6-4985-b0af-dd1359e5d616"
+)

--- a/pkg/rgrpc/status/status.go
+++ b/pkg/rgrpc/status/status.go
@@ -183,10 +183,6 @@ func NewStatusFromErrType(ctx context.Context, msg string, err error) *rpc.Statu
 		return NewInvalidArg(ctx, "gateway: "+msg+":"+err.Error())
 	case errtypes.AlreadyExists:
 		return NewAlreadyExists(ctx, err, "gateway: "+msg+":"+err.Error())
-	case errtypes.IsShareParentConflict:
-		return NewConflict(ctx, err, "gateway: "+msg+": "+err.Error())
-	case errtypes.IsShareChildConflict:
-		return NewConflict(ctx, err, "gateway: "+msg+": "+err.Error())
 	}
 
 	// map GRPC status codes coming from the auth middleware

--- a/pkg/rgrpc/status/status.go
+++ b/pkg/rgrpc/status/status.go
@@ -183,6 +183,10 @@ func NewStatusFromErrType(ctx context.Context, msg string, err error) *rpc.Statu
 		return NewInvalidArg(ctx, "gateway: "+msg+":"+err.Error())
 	case errtypes.AlreadyExists:
 		return NewAlreadyExists(ctx, err, "gateway: "+msg+":"+err.Error())
+	case errtypes.IsShareParentConflict:
+		return NewConflict(ctx, err, "gateway: "+msg+": "+err.Error())
+	case errtypes.IsShareChildConflict:
+		return NewConflict(ctx, err, "gateway: "+msg+": "+err.Error())
 	}
 
 	// map GRPC status codes coming from the auth middleware

--- a/pkg/share/manager/sql/model/model.go
+++ b/pkg/share/manager/sql/model/model.go
@@ -149,7 +149,6 @@ type Share struct {
 	DeletedAt         gorm.DeletedAt `gorm:"uniqueIndex:u_share"`
 	Inode             string         `gorm:"size:32;uniqueIndex:u_share;index"`
 	Instance          string         `gorm:"size:32;uniqueIndex:u_share;index"`
-	SpaceId           string         `gorm:"size:64;index:idx_space_sharewith"`
 	ShareWith         string         `gorm:"size:255;uniqueIndex:u_share;index:idx_space_sharewith"` // 255 because this can be an external account, which has a long representation
 	SharedWithIsGroup bool
 	Description       string `gorm:"size:1024"`

--- a/pkg/share/manager/sql/model/model.go
+++ b/pkg/share/manager/sql/model/model.go
@@ -149,7 +149,8 @@ type Share struct {
 	DeletedAt         gorm.DeletedAt `gorm:"uniqueIndex:u_share"`
 	Inode             string         `gorm:"size:32;uniqueIndex:u_share;index"`
 	Instance          string         `gorm:"size:32;uniqueIndex:u_share;index"`
-	ShareWith         string         `gorm:"size:255;uniqueIndex:u_share;index"` // 255 because this can be an external account, which has a long representation
+	SpaceId           string         `gorm:"size:64;index:idx_space_sharewith"`
+	ShareWith         string         `gorm:"size:255;uniqueIndex:u_share;index:idx_space_sharewith"` // 255 because this can be an external account, which has a long representation
 	SharedWithIsGroup bool
 	Description       string `gorm:"size:1024"`
 }

--- a/pkg/share/manager/sql/share.go
+++ b/pkg/share/manager/sql/share.go
@@ -133,6 +133,7 @@ func (m *ShareMgr) Share(ctx context.Context, md *provider.ResourceInfo, g *coll
 	share.ItemType = model.ItemType(conversions.ResourceTypeToItem(md.Type))
 	share.Inode = md.Id.OpaqueId
 	share.Instance = md.Id.StorageId
+	share.SpaceId = md.Id.SpaceId
 	share.Permissions = uint8(permissions.OCSFromCS3Permission(g.Permissions.Permissions))
 	share.Orphan = false
 	share.SpaceID = md.Id.SpaceId
@@ -720,6 +721,27 @@ func (m *ShareMgr) appendShareFiltersToQuery(query *gorm.DB, filters []*collabor
 					innerQuery = innerQuery.Where("uid_initiator = ?", filter.GetCreator().OpaqueId)
 				} else {
 					innerQuery = innerQuery.Or("uid_initiator = ?", filter.GetCreator().OpaqueId)
+				}
+			}
+			query = query.Where(innerQuery)
+		case collaboration.Filter_TYPE_SPACE_ID:
+			innerQuery := m.db
+			for i, filter := range filters {
+				if i == 0 {
+					innerQuery = innerQuery.Where("space_id = ?", filter.GetSpaceId())
+				} else {
+					innerQuery = innerQuery.Or("space_id = ?", filter.GetSpaceId())
+				}
+			}
+			query = query.Where(innerQuery)
+		case collaboration.Filter_TYPE_GRANTEE:
+			innerQuery := m.db
+			for i, filter := range filters {
+				_, shareWith := conversions.FormatGrantee(filter.GetGrantee())
+				if i == 0 {
+					innerQuery = innerQuery.Where("share_with = ?", shareWith)
+				} else {
+					innerQuery = innerQuery.Or("share_with = ?", shareWith)
 				}
 			}
 			query = query.Where(innerQuery)

--- a/pkg/share/manager/sql/share.go
+++ b/pkg/share/manager/sql/share.go
@@ -133,7 +133,6 @@ func (m *ShareMgr) Share(ctx context.Context, md *provider.ResourceInfo, g *coll
 	share.ItemType = model.ItemType(conversions.ResourceTypeToItem(md.Type))
 	share.Inode = md.Id.OpaqueId
 	share.Instance = md.Id.StorageId
-	share.SpaceId = md.Id.SpaceId
 	share.Permissions = uint8(permissions.OCSFromCS3Permission(g.Permissions.Permissions))
 	share.Orphan = false
 	share.SpaceID = md.Id.SpaceId

--- a/pkg/share/share.go
+++ b/pkg/share/share.go
@@ -89,6 +89,27 @@ func ResourceIDFilter(id *provider.ResourceId) *collaboration.Filter {
 	}
 }
 
+// SpaceIDFilter is an abstraction for creating a filter by space ID.
+func SpaceIDFilter(spaceID string) *collaboration.Filter {
+	return &collaboration.Filter{
+		Type: collaboration.Filter_TYPE_SPACE_ID,
+		Term: &collaboration.Filter_SpaceId{
+			SpaceId: spaceID,
+		},
+	}
+}
+
+// GranteeFilter is an abstraction for creating a filter by grantee (ADR-0005-P01).
+// Requires Filter_TYPE_GRANTEE support in go-cs3apis (cs3org/cs3apis#262).
+func GranteeFilter(grantee *provider.Grantee) *collaboration.Filter {
+	return &collaboration.Filter{
+		Type: collaboration.Filter_TYPE_GRANTEE,
+		Term: &collaboration.Filter_Grantee{
+			Grantee: grantee,
+		},
+	}
+}
+
 // IsCreatedByUser checks if the user is the owner or creator of the share.
 func IsCreatedByUser(share *collaboration.Share, user *userv1beta1.User) bool {
 	return utils.UserEqual(user.Id, share.Owner) || utils.UserEqual(user.Id, share.Creator)

--- a/pkg/sharehierarchy/errors.go
+++ b/pkg/sharehierarchy/errors.go
@@ -37,11 +37,11 @@ type ConflictingShare struct {
 // Status.Message field so the HTTP layer can decode it and return a 409 with detail.
 type HierarchyConflictError struct {
 	// ErrorType is either "parent_conflict" or "child_conflict".
-	ErrorType string             `json:"error_type"`
-	Message   string             `json:"message"`
-	// CausedBy is the existing share that blocks the operation (parent_conflict only).
-	CausedBy  *ConflictingShare  `json:"caused_by,omitempty"`
-	Shares    []ConflictingShare `json:"conflicting_shares,omitempty"`
+	ErrorType         string             `json:"error_type"`
+	Message           string             `json:"message"`
+	// CanForce indicates whether the caller may retry with force=true to override the conflict.
+	CanForce          bool               `json:"can_force"`
+	ConflictingShares []ConflictingShare `json:"conflicting_shares,omitempty"`
 }
 
 func (e *HierarchyConflictError) Error() string { return e.Message }
@@ -55,7 +55,7 @@ func NewChildConflictError(msg string, shares []*collaboration.Share) *Hierarchy
 			ResourceID: s.ResourceId.StorageId + "!" + s.ResourceId.OpaqueId,
 		})
 	}
-	return &HierarchyConflictError{ErrorType: "child_conflict", Message: msg, Shares: cs}
+	return &HierarchyConflictError{ErrorType: "child_conflict", CanForce: true, Message: msg, ConflictingShares: cs}
 }
 
 // MarshalToJSON serialises the error to a JSON string suitable for embedding in a gRPC Status message.

--- a/pkg/sharehierarchy/errors.go
+++ b/pkg/sharehierarchy/errors.go
@@ -59,7 +59,7 @@ func NewChildConflictError(msg string, shares []ResolvedShare) *HierarchyConflic
 			ID:             s.Id.OpaqueId,
 			ResourceID:     s.ResourceId.StorageId + "!" + s.ResourceId.OpaqueId,
 			Sharee:         sharee,
-			PermissionType: PermLevelFromCS3(s.Permissions.GetPermissions()).String(),
+			PermissionType: PermLevelFromCS3(s.Permissions.GetPermissions()).RoleID(),
 			Path:           resolved.Path,
 		})
 	}

--- a/pkg/sharehierarchy/errors.go
+++ b/pkg/sharehierarchy/errors.go
@@ -20,8 +20,6 @@ package sharehierarchy
 
 import (
 	"encoding/json"
-
-	collaboration "github.com/cs3org/go-cs3apis/cs3/sharing/collaboration/v1beta1"
 )
 
 // ConflictingShare identifies a share involved in a hierarchy conflict.
@@ -30,6 +28,7 @@ type ConflictingShare struct {
 	ResourceID     string `json:"resource_id,omitempty"`
 	Path           string `json:"path,omitempty"`
 	PermissionType string `json:"permission_type,omitempty"`
+	Sharee         string `json:"sharee,omitempty"`
 }
 
 // HierarchyConflictError is the structured payload returned when a share operation is
@@ -37,8 +36,8 @@ type ConflictingShare struct {
 // Status.Message field so the HTTP layer can decode it and return a 409 with detail.
 type HierarchyConflictError struct {
 	// ErrorType is either "parent_conflict" or "child_conflict".
-	ErrorType         string             `json:"error_type"`
-	Message           string             `json:"message"`
+	ErrorType string `json:"error_type"`
+	Message   string `json:"message"`
 	// CanForce indicates whether the caller may retry with force=true to override the conflict.
 	CanForce          bool               `json:"can_force"`
 	ConflictingShares []ConflictingShare `json:"conflicting_shares,omitempty"`
@@ -47,12 +46,21 @@ type HierarchyConflictError struct {
 func (e *HierarchyConflictError) Error() string { return e.Message }
 
 // NewChildConflictError builds a HierarchyConflictError for a would-delete-children situation.
-func NewChildConflictError(msg string, shares []*collaboration.Share) *HierarchyConflictError {
+func NewChildConflictError(msg string, shares []ResolvedShare) *HierarchyConflictError {
 	cs := make([]ConflictingShare, 0, len(shares))
-	for _, s := range shares {
+	for _, resolved := range shares {
+		s := resolved.Share
+		var sharee string
+		if s.Grantee != nil && s.Grantee.GetUserId() != nil {
+			sharee = s.Grantee.GetUserId().OpaqueId
+		}
+
 		cs = append(cs, ConflictingShare{
-			ID:         s.Id.OpaqueId,
-			ResourceID: s.ResourceId.StorageId + "!" + s.ResourceId.OpaqueId,
+			ID:             s.Id.OpaqueId,
+			ResourceID:     s.ResourceId.StorageId + "!" + s.ResourceId.OpaqueId,
+			Sharee:         sharee,
+			PermissionType: PermLevelFromCS3(s.Permissions.GetPermissions()).String(),
+			Path:           resolved.Path,
 		})
 	}
 	return &HierarchyConflictError{ErrorType: "child_conflict", CanForce: true, Message: msg, ConflictingShares: cs}

--- a/pkg/sharehierarchy/errors.go
+++ b/pkg/sharehierarchy/errors.go
@@ -1,0 +1,75 @@
+// Copyright 2018-2026 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package sharehierarchy
+
+import (
+	"encoding/json"
+
+	collaboration "github.com/cs3org/go-cs3apis/cs3/sharing/collaboration/v1beta1"
+)
+
+// ConflictingShare identifies a share involved in a hierarchy conflict.
+type ConflictingShare struct {
+	ID             string `json:"id,omitempty"`
+	ResourceID     string `json:"resource_id,omitempty"`
+	Path           string `json:"path,omitempty"`
+	PermissionType string `json:"permission_type,omitempty"`
+}
+
+// HierarchyConflictError is the structured payload returned when a share operation is
+// rejected due to hierarchy inconsistency. It is JSON-encoded into the gRPC
+// Status.Message field so the HTTP layer can decode it and return a 409 with detail.
+type HierarchyConflictError struct {
+	// ErrorType is either "parent_conflict" or "child_conflict".
+	ErrorType string             `json:"error_type"`
+	Message   string             `json:"message"`
+	// CausedBy is the existing share that blocks the operation (parent_conflict only).
+	CausedBy  *ConflictingShare  `json:"caused_by,omitempty"`
+	Shares    []ConflictingShare `json:"conflicting_shares,omitempty"`
+}
+
+func (e *HierarchyConflictError) Error() string { return e.Message }
+
+// NewChildConflictError builds a HierarchyConflictError for a would-delete-children situation.
+func NewChildConflictError(msg string, shares []*collaboration.Share) *HierarchyConflictError {
+	cs := make([]ConflictingShare, 0, len(shares))
+	for _, s := range shares {
+		cs = append(cs, ConflictingShare{
+			ID:         s.Id.OpaqueId,
+			ResourceID: s.ResourceId.StorageId + "!" + s.ResourceId.OpaqueId,
+		})
+	}
+	return &HierarchyConflictError{ErrorType: "child_conflict", Message: msg, Shares: cs}
+}
+
+// MarshalToJSON serialises the error to a JSON string suitable for embedding in a gRPC Status message.
+func (e *HierarchyConflictError) MarshalToJSON() string {
+	b, _ := json.Marshal(e)
+	return string(b)
+}
+
+// UnmarshalHierarchyConflictError tries to decode a gRPC Status message as a HierarchyConflictError.
+// Returns nil if the message is not a valid HierarchyConflictError.
+func UnmarshalHierarchyConflictError(msg string) *HierarchyConflictError {
+	var e HierarchyConflictError
+	if json.Unmarshal([]byte(msg), &e) == nil && e.ErrorType != "" {
+		return &e
+	}
+	return nil
+}

--- a/pkg/sharehierarchy/errors.go
+++ b/pkg/sharehierarchy/errors.go
@@ -20,6 +20,13 @@ package sharehierarchy
 
 import (
 	"encoding/json"
+
+	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+)
+
+const (
+	ShareeTypeUser  = "user"
+	ShareeTypeGroup = "group"
 )
 
 // ConflictingShare identifies a share involved in a hierarchy conflict.
@@ -29,6 +36,7 @@ type ConflictingShare struct {
 	Path           string `json:"path,omitempty"`
 	PermissionType string `json:"permission_type,omitempty"`
 	Sharee         string `json:"sharee,omitempty"`
+	ShareeType     string `json:"sharee_type,omitempty"`
 }
 
 // HierarchyConflictError is the structured payload returned when a share operation is
@@ -50,20 +58,31 @@ func NewChildConflictError(msg string, shares []ResolvedShare) *HierarchyConflic
 	cs := make([]ConflictingShare, 0, len(shares))
 	for _, resolved := range shares {
 		s := resolved.Share
-		var sharee string
-		if s.Grantee != nil && s.Grantee.GetUserId() != nil {
-			sharee = s.Grantee.GetUserId().OpaqueId
-		}
+		sharee, shareeType := shareeInfo(s.Grantee)
 
 		cs = append(cs, ConflictingShare{
 			ID:             s.Id.OpaqueId,
 			ResourceID:     s.ResourceId.StorageId + "!" + s.ResourceId.OpaqueId,
 			Sharee:         sharee,
+			ShareeType:     shareeType,
 			PermissionType: PermLevelFromCS3(s.Permissions.GetPermissions()).RoleID(),
 			Path:           resolved.Path,
 		})
 	}
 	return &HierarchyConflictError{ErrorType: "child_conflict", CanForce: true, Message: msg, ConflictingShares: cs}
+}
+
+func shareeInfo(grantee *provider.Grantee) (string, string) {
+	if grantee == nil {
+		return "", ""
+	}
+	if userID := grantee.GetUserId(); userID != nil {
+		return userID.OpaqueId, ShareeTypeUser
+	}
+	if groupID := grantee.GetGroupId(); groupID != nil {
+		return groupID.OpaqueId, ShareeTypeGroup
+	}
+	return "", ""
 }
 
 // MarshalToJSON serialises the error to a JSON string suitable for embedding in a gRPC Status message.

--- a/pkg/sharehierarchy/hierarchy.go
+++ b/pkg/sharehierarchy/hierarchy.go
@@ -32,6 +32,7 @@ import (
 
 	collaboration "github.com/cs3org/go-cs3apis/cs3/sharing/collaboration/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+	"github.com/cs3org/reva/v3/pkg/appctx"
 	"github.com/cs3org/reva/v3/pkg/errtypes"
 )
 
@@ -74,14 +75,18 @@ type HierarchyCheckResult struct {
 //     may be non-empty and must be acted on by the caller.
 //   - (nil, ShareParentConflict): hard failure, operation must be aborted.
 func (c *Checker) CheckGrantConsistency(ctx context.Context, nodePath string, nodePerms *provider.ResourcePermissions, existingShares []*collaboration.Share) (*HierarchyCheckResult, error) {
+	log := appctx.GetLogger(ctx)
 	result := &HierarchyCheckResult{}
 	nodePermLevel := PermLevelFromCS3(nodePerms)
 	reapplyPaths := make(map[string]string)
+
+	log.Debug().Str("keyword", "sharehierarchy").Str("nodePath", nodePath).Str("nodePerms", nodePermLevel.String()).Int("existingShares", len(existingShares)).Msg("sharehierarchy: CheckGrantConsistency start")
 
 	for _, s := range existingShares {
 		path, err := c.GetPath(ctx, s.ResourceId)
 		if err != nil {
 			// Share may be orphaned or its resource temporarily unavailable; skip it.
+			log.Debug().Str("keyword", "sharehierarchy").Str("shareId", s.Id.OpaqueId).Err(err).Msg("sharehierarchy: skipping share with unresolvable path")
 			continue
 		}
 
@@ -93,8 +98,10 @@ func (c *Checker) CheckGrantConsistency(ctx context.Context, nodePath string, no
 			// Allowed only when N strictly escalates beyond P in the permission ordering.
 			// Any other combination means N is redundant or conflicts with P.
 			if nodePermLevel > sharePerms {
+				log.Debug().Str("keyword", "sharehierarchy").Str("shareId", s.Id.OpaqueId).Str("parentPath", path).Str("parentPerms", sharePerms.String()).Msg("sharehierarchy: parent share allows escalation, continuing")
 				continue
 			}
+			log.Debug().Str("keyword", "sharehierarchy").Str("shareId", s.Id.OpaqueId).Str("parentPath", path).Str("parentPerms", sharePerms.String()).Str("nodePath", nodePath).Str("nodePerms", nodePermLevel.String()).Msg("sharehierarchy: parent conflict detected")
 			return nil, errtypes.ShareParentConflict(fmt.Sprintf(
 				"resource at %q is already accessible via a %s share on parent %q",
 				nodePath, sharePerms, path,
@@ -106,9 +113,11 @@ func (c *Checker) CheckGrantConsistency(ctx context.Context, nodePath string, no
 			// must be re-applied after adding N so it is not shadowed.
 			// Otherwise the child is redundant or would be implicitly elevated and must be deleted.
 			if sharePerms > nodePermLevel {
+				log.Debug().Str("keyword", "sharehierarchy").Str("shareId", s.Id.OpaqueId).Str("childPath", path).Str("childPerms", sharePerms.String()).Msg("sharehierarchy: child share has higher perms, will reapply")
 				result.ToReapply = append(result.ToReapply, s)
 				reapplyPaths[s.Id.OpaqueId] = path
 			} else {
+				log.Debug().Str("keyword", "sharehierarchy").Str("shareId", s.Id.OpaqueId).Str("childPath", path).Str("childPerms", sharePerms.String()).Msg("sharehierarchy: child share is redundant, will delete")
 				result.ToDelete = append(result.ToDelete, s)
 			}
 		}
@@ -116,6 +125,7 @@ func (c *Checker) CheckGrantConsistency(ctx context.Context, nodePath string, no
 
 	// Sort ToReapply shallowest-first so the caller can apply ACLs in the correct order.
 	sortByPathDepthAsc(result.ToReapply, reapplyPaths)
+	log.Debug().Str("keyword", "sharehierarchy").Str("nodePath", nodePath).Int("toDelete", len(result.ToDelete)).Int("toReapply", len(result.ToReapply)).Msg("sharehierarchy: CheckGrantConsistency done")
 	return result, nil
 }
 
@@ -137,6 +147,9 @@ type RemoveReapplyResult struct {
 //
 // If the path of the removed resource cannot be resolved, both fields are nil/empty.
 func (c *Checker) GrantsToReapplyAfterRemove(ctx context.Context, removedID string, removedResourceID *provider.ResourceId, allShares []*collaboration.Share) *RemoveReapplyResult {
+	log := appctx.GetLogger(ctx)
+	log.Debug().Str("keyword", "sharehierarchy").Str("removedShareId", removedID).Int("totalShares", len(allShares)).Msg("sharehierarchy: GrantsToReapplyAfterRemove start")
+
 	// Resolve paths for all shares except the one being removed.
 	// Shares absent from the map are naturally excluded by filterAncestors/filterDescendants.
 	paths := make(map[string]string, len(allShares))
@@ -145,21 +158,31 @@ func (c *Checker) GrantsToReapplyAfterRemove(ctx context.Context, removedID stri
 		path, err := c.GetPath(ctx, s.ResourceId)
 		if s.Id.OpaqueId == removedID {
 			if err != nil {
+				log.Warn().Str("keyword", "sharehierarchy").Str("removedShareId", removedID).Err(err).Msg("sharehierarchy: cannot resolve path of removed share, skipping reapply")
 				return &RemoveReapplyResult{}
 			}
 			removedPath = path
 		} else if err == nil {
 			paths[s.Id.OpaqueId] = path
+		} else {
+			log.Debug().Str("keyword", "sharehierarchy").Str("shareId", s.Id.OpaqueId).Err(err).Msg("sharehierarchy: skipping share with unresolvable path during remove")
 		}
 	}
 
 	ancestors := filterAncestors(allShares, paths, removedPath)
 	descendants := filterDescendants(allShares, paths, removedPath)
 	sortByPathDepthAsc(descendants, paths)
-	return &RemoveReapplyResult{
+	result := &RemoveReapplyResult{
 		ParentGrant: closestAncestor(ancestors, paths),
 		ChildGrants: descendants,
 	}
+
+	if result.ParentGrant != nil {
+		log.Debug().Str("keyword", "sharehierarchy").Str("removedShareId", removedID).Str("removedPath", removedPath).Str("parentShareId", result.ParentGrant.Id.OpaqueId).Int("childGrants", len(result.ChildGrants)).Msg("sharehierarchy: GrantsToReapplyAfterRemove done")
+	} else {
+		log.Debug().Str("keyword", "sharehierarchy").Str("removedShareId", removedID).Str("removedPath", removedPath).Int("childGrants", len(result.ChildGrants)).Msg("sharehierarchy: GrantsToReapplyAfterRemove done, no parent grant")
+	}
+	return result
 }
 
 // filterAncestors returns the subset of shares whose resolved path is a strict

--- a/pkg/sharehierarchy/hierarchy.go
+++ b/pkg/sharehierarchy/hierarchy.go
@@ -33,7 +33,6 @@ import (
 	collaboration "github.com/cs3org/go-cs3apis/cs3/sharing/collaboration/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	"github.com/cs3org/reva/v3/pkg/appctx"
-	"github.com/cs3org/reva/v3/pkg/errtypes"
 )
 
 // Checker runs the hierarchical share consistency algorithm.
@@ -102,10 +101,18 @@ func (c *Checker) CheckGrantConsistency(ctx context.Context, nodePath string, no
 				continue
 			}
 			log.Debug().Str("keyword", "sharehierarchy").Str("shareId", s.Id.OpaqueId).Str("parentPath", path).Str("parentPerms", sharePerms.String()).Str("nodePath", nodePath).Str("nodePerms", nodePermLevel.String()).Msg("sharehierarchy: parent conflict detected")
-			return nil, errtypes.ShareParentConflict(fmt.Sprintf(
-				"resource at %q is already accessible via a %s share on parent %q",
-				nodePath, sharePerms, path,
-			))
+			return nil, &HierarchyConflictError{
+				ErrorType: "parent_conflict",
+				Message: fmt.Sprintf(
+					"resource at %q is already accessible via a %s share on parent %q",
+					nodePath, sharePerms, path,
+				),
+				CausedBy: &ConflictingShare{
+					ID:             s.Id.OpaqueId,
+					Path:           path,
+					PermissionType: sharePerms.String(),
+				},
+			}
 
 		case isStrictAncestor(nodePath, path):
 			// Step 2: existing share S is a child of the new node N.

--- a/pkg/sharehierarchy/hierarchy.go
+++ b/pkg/sharehierarchy/hierarchy.go
@@ -49,12 +49,18 @@ type HierarchyCheckResult struct {
 	// When force=true these are populated and the caller must remove them.
 	// When force=false and this slice would be non-empty, CheckForAdd returns
 	// ShareChildConflict instead of populating this field.
-	ToDelete []*collaboration.Share
+	ToDelete []ResolvedShare
 
 	// ToReapply contains child shares whose ACLs must be explicitly re-applied after
 	// adding the new ACL. This covers the (N=R, C=RW) case where the child has higher
 	// permissions than the new parent share and must retain its explicit ACL.
-	ToReapply []*collaboration.Share
+	ToReapply []ResolvedShare
+}
+
+// ResolvedShare wraps a share with the path resolved during hierarchy checking.
+type ResolvedShare struct {
+	Share *collaboration.Share
+	Path  string
 }
 
 // CheckGrantConsistency runs the two-step hierarchy check for creating or updating a share.
@@ -77,7 +83,6 @@ func (c *Checker) CheckGrantConsistency(ctx context.Context, nodePath string, no
 	log := appctx.GetLogger(ctx)
 	result := &HierarchyCheckResult{}
 	nodePermLevel := PermLevelFromCS3(nodePerms)
-	reapplyPaths := make(map[string]string)
 
 	log.Debug().Str("keyword", "sharehierarchy").Str("nodePath", nodePath).Str("nodePerms", nodePermLevel.String()).Int("existingShares", len(existingShares)).Msg("sharehierarchy: CheckGrantConsistency start")
 
@@ -101,6 +106,10 @@ func (c *Checker) CheckGrantConsistency(ctx context.Context, nodePath string, no
 				continue
 			}
 			log.Debug().Str("keyword", "sharehierarchy").Str("shareId", s.Id.OpaqueId).Str("parentPath", path).Str("parentPerms", sharePerms.String()).Str("nodePath", nodePath).Str("nodePerms", nodePermLevel.String()).Msg("sharehierarchy: parent conflict detected")
+			var sharee string
+			if s.Grantee != nil && s.Grantee.GetUserId() != nil {
+				sharee = s.Grantee.GetUserId().OpaqueId
+			}
 			return nil, &HierarchyConflictError{
 				ErrorType: "parent_conflict",
 				CanForce:  false,
@@ -113,6 +122,7 @@ func (c *Checker) CheckGrantConsistency(ctx context.Context, nodePath string, no
 						ID:             s.Id.OpaqueId,
 						Path:           path,
 						PermissionType: sharePerms.String(),
+						Sharee:         sharee,
 					},
 				},
 			}
@@ -124,17 +134,16 @@ func (c *Checker) CheckGrantConsistency(ctx context.Context, nodePath string, no
 			// Otherwise the child is redundant or would be implicitly elevated and must be deleted.
 			if sharePerms > nodePermLevel {
 				log.Debug().Str("keyword", "sharehierarchy").Str("shareId", s.Id.OpaqueId).Str("childPath", path).Str("childPerms", sharePerms.String()).Msg("sharehierarchy: child share has higher perms, will reapply")
-				result.ToReapply = append(result.ToReapply, s)
-				reapplyPaths[s.Id.OpaqueId] = path
+				result.ToReapply = append(result.ToReapply, ResolvedShare{Share: s, Path: path})
 			} else {
 				log.Debug().Str("keyword", "sharehierarchy").Str("shareId", s.Id.OpaqueId).Str("childPath", path).Str("childPerms", sharePerms.String()).Msg("sharehierarchy: child share is redundant, will delete")
-				result.ToDelete = append(result.ToDelete, s)
+				result.ToDelete = append(result.ToDelete, ResolvedShare{Share: s, Path: path})
 			}
 		}
 	}
 
 	// Sort ToReapply shallowest-first so the caller can apply ACLs in the correct order.
-	sortByPathDepthAsc(result.ToReapply, reapplyPaths)
+	sortResolvedSharesByPathDepthAsc(result.ToReapply)
 	log.Debug().Str("keyword", "sharehierarchy").Str("nodePath", nodePath).Int("toDelete", len(result.ToDelete)).Int("toReapply", len(result.ToReapply)).Msg("sharehierarchy: CheckGrantConsistency done")
 	return result, nil
 }
@@ -245,6 +254,22 @@ func sortByPathDepthAsc(shares []*collaboration.Share, paths map[string]string) 
 	})
 }
 
+// sortResolvedSharesByPathDepthAsc sorts resolved shares by ascending path depth.
+func sortResolvedSharesByPathDepthAsc(shares []ResolvedShare) {
+	sort.Slice(shares, func(i, j int) bool {
+		return strings.Count(shares[i].Path, string(os.PathSeparator)) < strings.Count(shares[j].Path, string(os.PathSeparator))
+	})
+}
+
+// Shares unwraps resolved shares for callers that only need the original share object.
+func Shares(resolved []ResolvedShare) []*collaboration.Share {
+	shares := make([]*collaboration.Share, 0, len(resolved))
+	for _, r := range resolved {
+		shares = append(shares, r.Share)
+	}
+	return shares
+}
+
 // isStrictAncestor returns true if ancestorPath is a proper prefix of childPath,
 // i.e. every component of ancestorPath is a parent of childPath.
 // "/a" is a strict ancestor of "/a/b" but not of "/a" itself or "/ab/c".
@@ -258,14 +283,12 @@ func isStrictAncestor(ancestorPath, childPath string) bool {
 
 // ChildConflictMessage builds a human-readable description of a child conflict
 // for use in error responses. Called by the gateway when force=false and ToDelete is non-empty.
-func ChildConflictMessage(shares []*collaboration.Share) string {
+func ChildConflictMessage(shares []ResolvedShare) string {
 	descs := make([]string, 0, len(shares))
-	for _, s := range shares {
+	for _, resolved := range shares {
+		s := resolved.Share
 		descs = append(descs, fmt.Sprintf("share %s (resource %s/%s)",
 			s.Id.OpaqueId, s.ResourceId.StorageId, s.ResourceId.OpaqueId))
 	}
-	return fmt.Sprintf(
-		"creating this share will delete %d child share(s): %s",
-		len(shares), strings.Join(descs, ", "),
-	)
+	return fmt.Sprintf("creating this share requires the deletion of %d child share(s)", len(shares))
 }

--- a/pkg/sharehierarchy/hierarchy.go
+++ b/pkg/sharehierarchy/hierarchy.go
@@ -84,13 +84,13 @@ func (c *Checker) CheckGrantConsistency(ctx context.Context, nodePath string, no
 	result := &HierarchyCheckResult{}
 	nodePermLevel := PermLevelFromCS3(nodePerms)
 
-	log.Debug().Str("keyword", "sharehierarchy").Str("nodePath", nodePath).Str("nodePerms", nodePermLevel.String()).Int("existingShares", len(existingShares)).Msg("sharehierarchy: CheckGrantConsistency start")
+	log.Debug().Str("nodePath", nodePath).Str("nodePerms", nodePermLevel.String()).Int("existingShares", len(existingShares)).Msg("sharehierarchy: CheckGrantConsistency start")
 
 	for _, s := range existingShares {
 		path, err := c.GetPath(ctx, s.ResourceId)
 		if err != nil {
 			// Share may be orphaned or its resource temporarily unavailable; skip it.
-			log.Debug().Str("keyword", "sharehierarchy").Str("shareId", s.Id.OpaqueId).Err(err).Msg("sharehierarchy: skipping share with unresolvable path")
+			log.Debug().Str("shareId", s.Id.OpaqueId).Err(err).Msg("sharehierarchy: skipping share with unresolvable path")
 			continue
 		}
 
@@ -102,10 +102,10 @@ func (c *Checker) CheckGrantConsistency(ctx context.Context, nodePath string, no
 			// Allowed only when N strictly escalates beyond P in the permission ordering.
 			// Any other combination means N is redundant or conflicts with P.
 			if nodePermLevel > sharePerms {
-				log.Debug().Str("keyword", "sharehierarchy").Str("shareId", s.Id.OpaqueId).Str("parentPath", path).Str("parentPerms", sharePerms.String()).Msg("sharehierarchy: parent share allows escalation, continuing")
+				log.Debug().Str("shareId", s.Id.OpaqueId).Str("parentPath", path).Str("parentPerms", sharePerms.String()).Msg("sharehierarchy: parent share allows escalation, continuing")
 				continue
 			}
-			log.Debug().Str("keyword", "sharehierarchy").Str("shareId", s.Id.OpaqueId).Str("parentPath", path).Str("parentPerms", sharePerms.String()).Str("nodePath", nodePath).Str("nodePerms", nodePermLevel.String()).Msg("sharehierarchy: parent conflict detected")
+			log.Debug().Str("shareId", s.Id.OpaqueId).Str("parentPath", path).Str("parentPerms", sharePerms.String()).Str("nodePath", nodePath).Str("nodePerms", nodePermLevel.String()).Msg("sharehierarchy: parent conflict detected")
 			var sharee string
 			if s.Grantee != nil && s.Grantee.GetUserId() != nil {
 				sharee = s.Grantee.GetUserId().OpaqueId
@@ -133,10 +133,10 @@ func (c *Checker) CheckGrantConsistency(ctx context.Context, nodePath string, no
 			// must be re-applied after adding N so it is not shadowed.
 			// Otherwise the child is redundant or would be implicitly elevated and must be deleted.
 			if sharePerms > nodePermLevel {
-				log.Debug().Str("keyword", "sharehierarchy").Str("shareId", s.Id.OpaqueId).Str("childPath", path).Str("childPerms", sharePerms.String()).Msg("sharehierarchy: child share has higher perms, will reapply")
+				log.Debug().Str("shareId", s.Id.OpaqueId).Str("childPath", path).Str("childPerms", sharePerms.String()).Msg("sharehierarchy: child share has higher perms, will reapply")
 				result.ToReapply = append(result.ToReapply, ResolvedShare{Share: s, Path: path})
 			} else {
-				log.Debug().Str("keyword", "sharehierarchy").Str("shareId", s.Id.OpaqueId).Str("childPath", path).Str("childPerms", sharePerms.String()).Msg("sharehierarchy: child share is redundant, will delete")
+				log.Debug().Str("shareId", s.Id.OpaqueId).Str("childPath", path).Str("childPerms", sharePerms.String()).Msg("sharehierarchy: child share is redundant, will delete")
 				result.ToDelete = append(result.ToDelete, ResolvedShare{Share: s, Path: path})
 			}
 		}
@@ -144,7 +144,7 @@ func (c *Checker) CheckGrantConsistency(ctx context.Context, nodePath string, no
 
 	// Sort ToReapply shallowest-first so the caller can apply ACLs in the correct order.
 	sortResolvedSharesByPathDepthAsc(result.ToReapply)
-	log.Debug().Str("keyword", "sharehierarchy").Str("nodePath", nodePath).Int("toDelete", len(result.ToDelete)).Int("toReapply", len(result.ToReapply)).Msg("sharehierarchy: CheckGrantConsistency done")
+	log.Debug().Str("nodePath", nodePath).Int("toDelete", len(result.ToDelete)).Int("toReapply", len(result.ToReapply)).Msg("sharehierarchy: CheckGrantConsistency done")
 	return result, nil
 }
 
@@ -167,7 +167,7 @@ type RemoveReapplyResult struct {
 // If the path of the removed resource cannot be resolved, both fields are nil/empty.
 func (c *Checker) GrantsToReapplyAfterRemove(ctx context.Context, removedID string, removedResourceID *provider.ResourceId, allShares []*collaboration.Share) *RemoveReapplyResult {
 	log := appctx.GetLogger(ctx)
-	log.Debug().Str("keyword", "sharehierarchy").Str("removedShareId", removedID).Int("totalShares", len(allShares)).Msg("sharehierarchy: GrantsToReapplyAfterRemove start")
+	log.Debug().Str("removedShareId", removedID).Int("totalShares", len(allShares)).Msg("sharehierarchy: GrantsToReapplyAfterRemove start")
 
 	// Resolve paths for all shares except the one being removed.
 	// Shares absent from the map are naturally excluded by filterAncestors/filterDescendants.
@@ -177,14 +177,14 @@ func (c *Checker) GrantsToReapplyAfterRemove(ctx context.Context, removedID stri
 		path, err := c.GetPath(ctx, s.ResourceId)
 		if s.Id.OpaqueId == removedID {
 			if err != nil {
-				log.Warn().Str("keyword", "sharehierarchy").Str("removedShareId", removedID).Err(err).Msg("sharehierarchy: cannot resolve path of removed share, skipping reapply")
+				log.Warn().Str("removedShareId", removedID).Err(err).Msg("sharehierarchy: cannot resolve path of removed share, skipping reapply")
 				return &RemoveReapplyResult{}
 			}
 			removedPath = path
 		} else if err == nil {
 			paths[s.Id.OpaqueId] = path
 		} else {
-			log.Debug().Str("keyword", "sharehierarchy").Str("shareId", s.Id.OpaqueId).Err(err).Msg("sharehierarchy: skipping share with unresolvable path during remove")
+			log.Debug().Str("shareId", s.Id.OpaqueId).Err(err).Msg("sharehierarchy: skipping share with unresolvable path during remove")
 		}
 	}
 
@@ -197,9 +197,9 @@ func (c *Checker) GrantsToReapplyAfterRemove(ctx context.Context, removedID stri
 	}
 
 	if result.ParentGrant != nil {
-		log.Debug().Str("keyword", "sharehierarchy").Str("removedShareId", removedID).Str("removedPath", removedPath).Str("parentShareId", result.ParentGrant.Id.OpaqueId).Int("childGrants", len(result.ChildGrants)).Msg("sharehierarchy: GrantsToReapplyAfterRemove done")
+		log.Debug().Str("removedShareId", removedID).Str("removedPath", removedPath).Str("parentShareId", result.ParentGrant.Id.OpaqueId).Int("childGrants", len(result.ChildGrants)).Msg("sharehierarchy: GrantsToReapplyAfterRemove done")
 	} else {
-		log.Debug().Str("keyword", "sharehierarchy").Str("removedShareId", removedID).Str("removedPath", removedPath).Int("childGrants", len(result.ChildGrants)).Msg("sharehierarchy: GrantsToReapplyAfterRemove done, no parent grant")
+		log.Debug().Str("removedShareId", removedID).Str("removedPath", removedPath).Int("childGrants", len(result.ChildGrants)).Msg("sharehierarchy: GrantsToReapplyAfterRemove done, no parent grant")
 	}
 	return result
 }

--- a/pkg/sharehierarchy/hierarchy.go
+++ b/pkg/sharehierarchy/hierarchy.go
@@ -103,14 +103,17 @@ func (c *Checker) CheckGrantConsistency(ctx context.Context, nodePath string, no
 			log.Debug().Str("keyword", "sharehierarchy").Str("shareId", s.Id.OpaqueId).Str("parentPath", path).Str("parentPerms", sharePerms.String()).Str("nodePath", nodePath).Str("nodePerms", nodePermLevel.String()).Msg("sharehierarchy: parent conflict detected")
 			return nil, &HierarchyConflictError{
 				ErrorType: "parent_conflict",
+				CanForce:  false,
 				Message: fmt.Sprintf(
 					"resource at %q is already accessible via a %s share on parent %q",
 					nodePath, sharePerms, path,
 				),
-				CausedBy: &ConflictingShare{
-					ID:             s.Id.OpaqueId,
-					Path:           path,
-					PermissionType: sharePerms.String(),
+				ConflictingShares: []ConflictingShare{
+					{
+						ID:             s.Id.OpaqueId,
+						Path:           path,
+						PermissionType: sharePerms.String(),
+					},
 				},
 			}
 

--- a/pkg/sharehierarchy/hierarchy.go
+++ b/pkg/sharehierarchy/hierarchy.go
@@ -113,28 +113,56 @@ func (c *Checker) CheckGrantConsistency(ctx context.Context, nodePath string, no
 	}
 
 	// Sort ToReapply shallowest-first so the caller can apply ACLs in the correct order.
-	SortByPathDepthAsc(result.ToReapply, reapplyPaths)
+	sortByPathDepthAsc(result.ToReapply, reapplyPaths)
 	return result, nil
 }
 
-// ResolvePaths resolves the current filesystem path for each share.
-// Returns a map from share OpaqueId to path. Shares whose paths cannot be
-// resolved (e.g. orphaned resources) are silently omitted.
-func (c *Checker) ResolvePaths(ctx context.Context, shares []*collaboration.Share) map[string]string {
-	paths := make(map[string]string, len(shares))
-	for _, s := range shares {
-		path, err := c.GetPath(ctx, s.ResourceId)
-		if err != nil {
-			continue
-		}
-		paths[s.Id.OpaqueId] = path
-	}
-	return paths
+// RemoveReapplyResult holds the grants that must be re-applied after a share is removed.
+type RemoveReapplyResult struct {
+	// ParentGrant is the closest ancestor share, or nil if none exists.
+	// Its permissions must be re-applied to the removed share's resource.
+	ParentGrant *collaboration.Share
+	// ChildGrants is the list of descendant shares sorted shallowest-first.
+	// Each must be re-applied to its own resource.
+	ChildGrants []*collaboration.Share
 }
 
-// FilterAncestors returns the subset of shares whose resolved path is a strict
+// GrantsToReapplyAfterRemove computes the grants that must be re-applied once the
+// share identified by removedID on removedResourceID is deleted.
+//
+// allShares must contain all active shares for the same (spaceId, grantee), including
+// the share being removed — this method excludes it internally.
+//
+// If the path of the removed resource cannot be resolved, both fields are nil/empty.
+func (c *Checker) GrantsToReapplyAfterRemove(ctx context.Context, removedID string, removedResourceID *provider.ResourceId, allShares []*collaboration.Share) *RemoveReapplyResult {
+	// Resolve paths for all shares except the one being removed.
+	// Shares absent from the map are naturally excluded by filterAncestors/filterDescendants.
+	paths := make(map[string]string, len(allShares))
+	var removedPath string
+	for _, s := range allShares {
+		path, err := c.GetPath(ctx, s.ResourceId)
+		if s.Id.OpaqueId == removedID {
+			if err != nil {
+				return &RemoveReapplyResult{}
+			}
+			removedPath = path
+		} else if err == nil {
+			paths[s.Id.OpaqueId] = path
+		}
+	}
+
+	ancestors := filterAncestors(allShares, paths, removedPath)
+	descendants := filterDescendants(allShares, paths, removedPath)
+	sortByPathDepthAsc(descendants, paths)
+	return &RemoveReapplyResult{
+		ParentGrant: closestAncestor(ancestors, paths),
+		ChildGrants: descendants,
+	}
+}
+
+// filterAncestors returns the subset of shares whose resolved path is a strict
 // ancestor of targetPath.
-func FilterAncestors(shares []*collaboration.Share, paths map[string]string, targetPath string) []*collaboration.Share {
+func filterAncestors(shares []*collaboration.Share, paths map[string]string, targetPath string) []*collaboration.Share {
 	var result []*collaboration.Share
 	for _, s := range shares {
 		if p, ok := paths[s.Id.OpaqueId]; ok && isStrictAncestor(p, targetPath) {
@@ -144,9 +172,9 @@ func FilterAncestors(shares []*collaboration.Share, paths map[string]string, tar
 	return result
 }
 
-// FilterDescendants returns the subset of shares whose resolved path is a strict
+// filterDescendants returns the subset of shares whose resolved path is a strict
 // descendant of targetPath.
-func FilterDescendants(shares []*collaboration.Share, paths map[string]string, targetPath string) []*collaboration.Share {
+func filterDescendants(shares []*collaboration.Share, paths map[string]string, targetPath string) []*collaboration.Share {
 	var result []*collaboration.Share
 	for _, s := range shares {
 		if p, ok := paths[s.Id.OpaqueId]; ok && isStrictAncestor(targetPath, p) {
@@ -156,9 +184,9 @@ func FilterDescendants(shares []*collaboration.Share, paths map[string]string, t
 	return result
 }
 
-// ClosestAncestor returns the ancestor share with the longest (most specific) path,
+// closestAncestor returns the ancestor share with the longest (most specific) path,
 // i.e. the nearest parent. Returns nil if ancestors is empty.
-func ClosestAncestor(ancestors []*collaboration.Share, paths map[string]string) *collaboration.Share {
+func closestAncestor(ancestors []*collaboration.Share, paths map[string]string) *collaboration.Share {
 	var closest *collaboration.Share
 	var closestPath string
 	for _, s := range ancestors {
@@ -171,10 +199,10 @@ func ClosestAncestor(ancestors []*collaboration.Share, paths map[string]string) 
 	return closest
 }
 
-// SortByPathDepthAsc sorts shares in place by ascending path depth (shallowest first).
+// sortByPathDepthAsc sorts shares in place by ascending path depth (shallowest first).
 // Applying ACLs in this order ensures parent permissions are set before child permissions,
 // maintaining correct inheritance semantics.
-func SortByPathDepthAsc(shares []*collaboration.Share, paths map[string]string) {
+func sortByPathDepthAsc(shares []*collaboration.Share, paths map[string]string) {
 	sort.Slice(shares, func(i, j int) bool {
 		pi := paths[shares[i].Id.OpaqueId]
 		pj := paths[shares[j].Id.OpaqueId]

--- a/pkg/sharehierarchy/hierarchy.go
+++ b/pkg/sharehierarchy/hierarchy.go
@@ -106,10 +106,7 @@ func (c *Checker) CheckGrantConsistency(ctx context.Context, nodePath string, no
 				continue
 			}
 			log.Debug().Str("shareId", s.Id.OpaqueId).Str("parentPath", path).Str("parentPerms", sharePerms.String()).Str("nodePath", nodePath).Str("nodePerms", nodePermLevel.String()).Msg("sharehierarchy: parent conflict detected")
-			var sharee string
-			if s.Grantee != nil && s.Grantee.GetUserId() != nil {
-				sharee = s.Grantee.GetUserId().OpaqueId
-			}
+			sharee, shareeType := shareeInfo(s.Grantee)
 			return nil, &HierarchyConflictError{
 				ErrorType: "parent_conflict",
 				CanForce:  false,
@@ -123,6 +120,7 @@ func (c *Checker) CheckGrantConsistency(ctx context.Context, nodePath string, no
 						Path:           path,
 						PermissionType: sharePerms.RoleID(),
 						Sharee:         sharee,
+						ShareeType:     shareeType,
 					},
 				},
 			}

--- a/pkg/sharehierarchy/hierarchy.go
+++ b/pkg/sharehierarchy/hierarchy.go
@@ -25,6 +25,8 @@ package sharehierarchy
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 
@@ -206,7 +208,7 @@ func sortByPathDepthAsc(shares []*collaboration.Share, paths map[string]string) 
 	sort.Slice(shares, func(i, j int) bool {
 		pi := paths[shares[i].Id.OpaqueId]
 		pj := paths[shares[j].Id.OpaqueId]
-		return strings.Count(pi, "/") < strings.Count(pj, "/")
+		return strings.Count(pi, string(os.PathSeparator)) < strings.Count(pj, string(os.PathSeparator))
 	})
 }
 
@@ -214,13 +216,11 @@ func sortByPathDepthAsc(shares []*collaboration.Share, paths map[string]string) 
 // i.e. every component of ancestorPath is a parent of childPath.
 // "/a" is a strict ancestor of "/a/b" but not of "/a" itself or "/ab/c".
 func isStrictAncestor(ancestorPath, childPath string) bool {
-	if ancestorPath == childPath {
+	rel, err := filepath.Rel(ancestorPath, childPath)
+	if err != nil {
 		return false
 	}
-	// Normalise: ensure the ancestor ends with exactly one slash for prefix matching,
-	// so that "/a" does not accidentally match "/ab/c".
-	ancestor := strings.TrimRight(ancestorPath, "/") + "/"
-	return strings.HasPrefix(childPath, ancestor)
+	return rel != "." && !strings.HasPrefix(rel, "..")
 }
 
 // ChildConflictMessage builds a human-readable description of a child conflict

--- a/pkg/sharehierarchy/hierarchy.go
+++ b/pkg/sharehierarchy/hierarchy.go
@@ -121,7 +121,7 @@ func (c *Checker) CheckGrantConsistency(ctx context.Context, nodePath string, no
 					{
 						ID:             s.Id.OpaqueId,
 						Path:           path,
-						PermissionType: sharePerms.String(),
+						PermissionType: sharePerms.RoleID(),
 						Sharee:         sharee,
 					},
 				},

--- a/pkg/sharehierarchy/hierarchy.go
+++ b/pkg/sharehierarchy/hierarchy.go
@@ -1,0 +1,210 @@
+// Copyright 2018-2026 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+// Package sharehierarchy implements the hierarchical share consistency algorithm
+// described in ADR-0005-P01. It ensures that when a share is created, updated, or
+// deleted, the resulting set of EOS ACLs remains consistent with all outstanding
+// shares for the same grantee in the same storage space.
+package sharehierarchy
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	collaboration "github.com/cs3org/go-cs3apis/cs3/sharing/collaboration/v1beta1"
+	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+	"github.com/cs3org/reva/v3/pkg/errtypes"
+)
+
+// Checker runs the hierarchical share consistency algorithm.
+// GetPath must be populated before any method is called.
+type Checker struct {
+	// GetPath resolves a ResourceId to its current filesystem path.
+	GetPath func(ctx context.Context, id *provider.ResourceId) (string, error)
+}
+
+// HierarchyCheckResult is the outcome of CheckForAdd.
+// It contains lists of which shares should be re-applied and which ones should be deleted.
+type HierarchyCheckResult struct {
+	// ToDelete contains child shares that would become redundant or inconsistent.
+	// When force=true these are populated and the caller must remove them.
+	// When force=false and this slice would be non-empty, CheckForAdd returns
+	// ShareChildConflict instead of populating this field.
+	ToDelete []*collaboration.Share
+
+	// ToReapply contains child shares whose ACLs must be explicitly re-applied after
+	// adding the new ACL. This covers the (N=R, C=RW) case where the child has higher
+	// permissions than the new parent share and must retain its explicit ACL.
+	ToReapply []*collaboration.Share
+}
+
+// CheckGrantConsistency runs the two-step hierarchy check for creating or updating a share.
+//
+// It verifies that granting nodePerms on nodePath is consistent
+// with all existing shares for the same grantee in the same space. It returns a
+// HierarchyCheckResult describing which child shares must be deleted or re-applied,
+// or a ShareParentConflict error if a parent share makes the grant invalid.
+//
+// nodePath is the current filesystem path of the resource being shared.
+// nodePerms is the permission level being granted.
+// existingShares contains all active shares for the same (spaceId, grantee), with
+// the share being updated (if any) already excluded by the caller.
+//
+// Possible return values:
+//   - (result, nil): operation can proceed. result.ToDelete and result.ToReapply
+//     may be non-empty and must be acted on by the caller.
+//   - (nil, ShareParentConflict): hard failure, operation must be aborted.
+func (c *Checker) CheckGrantConsistency(ctx context.Context, nodePath string, nodePerms *provider.ResourcePermissions, existingShares []*collaboration.Share) (*HierarchyCheckResult, error) {
+	result := &HierarchyCheckResult{}
+	nodePermLevel := PermLevelFromCS3(nodePerms)
+	reapplyPaths := make(map[string]string)
+
+	for _, s := range existingShares {
+		path, err := c.GetPath(ctx, s.ResourceId)
+		if err != nil {
+			// Share may be orphaned or its resource temporarily unavailable; skip it.
+			continue
+		}
+
+		sharePerms := PermLevelFromCS3(s.Permissions.GetPermissions())
+
+		switch {
+		case isStrictAncestor(path, nodePath):
+			// Step 1: existing share S is a parent of the new node N.
+			// Allowed only when N strictly escalates beyond P in the permission ordering.
+			// Any other combination means N is redundant or conflicts with P.
+			if nodePermLevel > sharePerms {
+				continue
+			}
+			return nil, errtypes.ShareParentConflict(fmt.Sprintf(
+				"resource at %q is already accessible via a %s share on parent %q",
+				nodePath, sharePerms, path,
+			))
+
+		case isStrictAncestor(nodePath, path):
+			// Step 2: existing share S is a child of the new node N.
+			// When the child has strictly higher permissions than N, its explicit ACL
+			// must be re-applied after adding N so it is not shadowed.
+			// Otherwise the child is redundant or would be implicitly elevated and must be deleted.
+			if sharePerms > nodePermLevel {
+				result.ToReapply = append(result.ToReapply, s)
+				reapplyPaths[s.Id.OpaqueId] = path
+			} else {
+				result.ToDelete = append(result.ToDelete, s)
+			}
+		}
+	}
+
+	// Sort ToReapply shallowest-first so the caller can apply ACLs in the correct order.
+	SortByPathDepthAsc(result.ToReapply, reapplyPaths)
+	return result, nil
+}
+
+// ResolvePaths resolves the current filesystem path for each share.
+// Returns a map from share OpaqueId to path. Shares whose paths cannot be
+// resolved (e.g. orphaned resources) are silently omitted.
+func (c *Checker) ResolvePaths(ctx context.Context, shares []*collaboration.Share) map[string]string {
+	paths := make(map[string]string, len(shares))
+	for _, s := range shares {
+		path, err := c.GetPath(ctx, s.ResourceId)
+		if err != nil {
+			continue
+		}
+		paths[s.Id.OpaqueId] = path
+	}
+	return paths
+}
+
+// FilterAncestors returns the subset of shares whose resolved path is a strict
+// ancestor of targetPath.
+func FilterAncestors(shares []*collaboration.Share, paths map[string]string, targetPath string) []*collaboration.Share {
+	var result []*collaboration.Share
+	for _, s := range shares {
+		if p, ok := paths[s.Id.OpaqueId]; ok && isStrictAncestor(p, targetPath) {
+			result = append(result, s)
+		}
+	}
+	return result
+}
+
+// FilterDescendants returns the subset of shares whose resolved path is a strict
+// descendant of targetPath.
+func FilterDescendants(shares []*collaboration.Share, paths map[string]string, targetPath string) []*collaboration.Share {
+	var result []*collaboration.Share
+	for _, s := range shares {
+		if p, ok := paths[s.Id.OpaqueId]; ok && isStrictAncestor(targetPath, p) {
+			result = append(result, s)
+		}
+	}
+	return result
+}
+
+// ClosestAncestor returns the ancestor share with the longest (most specific) path,
+// i.e. the nearest parent. Returns nil if ancestors is empty.
+func ClosestAncestor(ancestors []*collaboration.Share, paths map[string]string) *collaboration.Share {
+	var closest *collaboration.Share
+	var closestPath string
+	for _, s := range ancestors {
+		p := paths[s.Id.OpaqueId]
+		if closest == nil || len(p) > len(closestPath) {
+			closest = s
+			closestPath = p
+		}
+	}
+	return closest
+}
+
+// SortByPathDepthAsc sorts shares in place by ascending path depth (shallowest first).
+// Applying ACLs in this order ensures parent permissions are set before child permissions,
+// maintaining correct inheritance semantics.
+func SortByPathDepthAsc(shares []*collaboration.Share, paths map[string]string) {
+	sort.Slice(shares, func(i, j int) bool {
+		pi := paths[shares[i].Id.OpaqueId]
+		pj := paths[shares[j].Id.OpaqueId]
+		return strings.Count(pi, "/") < strings.Count(pj, "/")
+	})
+}
+
+// isStrictAncestor returns true if ancestorPath is a proper prefix of childPath,
+// i.e. every component of ancestorPath is a parent of childPath.
+// "/a" is a strict ancestor of "/a/b" but not of "/a" itself or "/ab/c".
+func isStrictAncestor(ancestorPath, childPath string) bool {
+	if ancestorPath == childPath {
+		return false
+	}
+	// Normalise: ensure the ancestor ends with exactly one slash for prefix matching,
+	// so that "/a" does not accidentally match "/ab/c".
+	ancestor := strings.TrimRight(ancestorPath, "/") + "/"
+	return strings.HasPrefix(childPath, ancestor)
+}
+
+// ChildConflictMessage builds a human-readable description of a child conflict
+// for use in error responses. Called by the gateway when force=false and ToDelete is non-empty.
+func ChildConflictMessage(shares []*collaboration.Share) string {
+	descs := make([]string, 0, len(shares))
+	for _, s := range shares {
+		descs = append(descs, fmt.Sprintf("share %s (resource %s/%s)",
+			s.Id.OpaqueId, s.ResourceId.StorageId, s.ResourceId.OpaqueId))
+	}
+	return fmt.Sprintf(
+		"creating this share will delete %d child share(s): %s",
+		len(shares), strings.Join(descs, ", "),
+	)
+}

--- a/pkg/sharehierarchy/hierarchy_test.go
+++ b/pkg/sharehierarchy/hierarchy_test.go
@@ -86,8 +86,8 @@ func TestCheckForAdd_ParentR_NodeR_Conflict(t *testing.T) {
 
 	_, err := checker.CheckGrantConsistency(context.Background(), "/a/b", readPerms, []*collaboration.Share{parent})
 	require.Error(t, err)
-	_, ok := err.(errtypes.IsShareParentConflict)
-	assert.True(t, ok, "expected ShareParentConflict, got %T: %v", err, err)
+	conflictErr, ok := err.(*sharehierarchy.HierarchyConflictError); _ = conflictErr
+	assert.True(t, ok, "expected HierarchyConflictError, got %T: %v", err, err)
 }
 
 func TestCheckForAdd_ParentRW_NodeR_Conflict(t *testing.T) {
@@ -97,7 +97,7 @@ func TestCheckForAdd_ParentRW_NodeR_Conflict(t *testing.T) {
 
 	_, err := checker.CheckGrantConsistency(context.Background(), "/a/b", readPerms, []*collaboration.Share{parent})
 	require.Error(t, err)
-	_, ok := err.(errtypes.IsShareParentConflict)
+	conflictErr, ok := err.(*sharehierarchy.HierarchyConflictError); _ = conflictErr
 	assert.True(t, ok)
 }
 
@@ -108,7 +108,7 @@ func TestCheckForAdd_ParentRW_NodeRW_Conflict(t *testing.T) {
 
 	_, err := checker.CheckGrantConsistency(context.Background(), "/a/b", rwPerms, []*collaboration.Share{parent})
 	require.Error(t, err)
-	_, ok := err.(errtypes.IsShareParentConflict)
+	conflictErr, ok := err.(*sharehierarchy.HierarchyConflictError); _ = conflictErr
 	assert.True(t, ok)
 }
 
@@ -212,7 +212,7 @@ func TestCheckForAdd_DenyParent_Conflict(t *testing.T) {
 
 	_, err := checker.CheckGrantConsistency(context.Background(), "/a/b", readPerms, []*collaboration.Share{parent})
 	require.Error(t, err)
-	_, ok := err.(errtypes.IsShareParentConflict)
+	conflictErr, ok := err.(*sharehierarchy.HierarchyConflictError); _ = conflictErr
 	assert.True(t, ok)
 }
 
@@ -245,7 +245,7 @@ func TestCheckForAdd_ParentDeny_NodeDeny_Conflict(t *testing.T) {
 
 	_, err := checker.CheckGrantConsistency(context.Background(), "/a/b", denyPerms, []*collaboration.Share{parent})
 	require.Error(t, err)
-	_, ok := err.(errtypes.IsShareParentConflict)
+	conflictErr, ok := err.(*sharehierarchy.HierarchyConflictError); _ = conflictErr
 	assert.True(t, ok)
 }
 
@@ -256,7 +256,7 @@ func TestCheckForAdd_ParentDeny_NodeRW_Conflict(t *testing.T) {
 
 	_, err := checker.CheckGrantConsistency(context.Background(), "/a/b", rwPerms, []*collaboration.Share{parent})
 	require.Error(t, err)
-	_, ok := err.(errtypes.IsShareParentConflict)
+	conflictErr, ok := err.(*sharehierarchy.HierarchyConflictError); _ = conflictErr
 	assert.True(t, ok)
 }
 

--- a/pkg/sharehierarchy/hierarchy_test.go
+++ b/pkg/sharehierarchy/hierarchy_test.go
@@ -87,8 +87,9 @@ func TestCheckForAdd_ParentR_NodeR_Conflict(t *testing.T) {
 	_, err := checker.CheckGrantConsistency(context.Background(), "/a/b", readPerms, []*collaboration.Share{parent})
 	require.Error(t, err)
 	conflictErr, ok := err.(*sharehierarchy.HierarchyConflictError)
-	_ = conflictErr
-	assert.True(t, ok, "expected HierarchyConflictError, got %T: %v", err, err)
+	require.True(t, ok, "expected HierarchyConflictError, got %T: %v", err, err)
+	require.Len(t, conflictErr.ConflictingShares, 1)
+	assert.Equal(t, sharehierarchy.PermRead.RoleID(), conflictErr.ConflictingShares[0].PermissionType)
 }
 
 func TestCheckForAdd_ParentRW_NodeR_Conflict(t *testing.T) {
@@ -99,8 +100,9 @@ func TestCheckForAdd_ParentRW_NodeR_Conflict(t *testing.T) {
 	_, err := checker.CheckGrantConsistency(context.Background(), "/a/b", readPerms, []*collaboration.Share{parent})
 	require.Error(t, err)
 	conflictErr, ok := err.(*sharehierarchy.HierarchyConflictError)
-	_ = conflictErr
-	assert.True(t, ok)
+	require.True(t, ok)
+	require.Len(t, conflictErr.ConflictingShares, 1)
+	assert.Equal(t, sharehierarchy.PermRW.RoleID(), conflictErr.ConflictingShares[0].PermissionType)
 }
 
 func TestCheckForAdd_ParentRW_NodeRW_Conflict(t *testing.T) {
@@ -150,6 +152,7 @@ func TestNewChildConflictError_IncludesResolvedChildPath(t *testing.T) {
 	conflictErr := sharehierarchy.NewChildConflictError(sharehierarchy.ChildConflictMessage(result.ToDelete), result.ToDelete)
 	require.Len(t, conflictErr.ConflictingShares, 1)
 	assert.Equal(t, "/a/b", conflictErr.ConflictingShares[0].Path)
+	assert.Equal(t, sharehierarchy.PermRead.RoleID(), conflictErr.ConflictingShares[0].PermissionType)
 }
 
 func TestCheckForAdd_ChildRW_NodeRW_ToDelete(t *testing.T) {
@@ -229,8 +232,9 @@ func TestCheckForAdd_DenyParent_Conflict(t *testing.T) {
 	_, err := checker.CheckGrantConsistency(context.Background(), "/a/b", readPerms, []*collaboration.Share{parent})
 	require.Error(t, err)
 	conflictErr, ok := err.(*sharehierarchy.HierarchyConflictError)
-	_ = conflictErr
-	assert.True(t, ok)
+	require.True(t, ok)
+	require.Len(t, conflictErr.ConflictingShares, 1)
+	assert.Equal(t, sharehierarchy.PermDeny.RoleID(), conflictErr.ConflictingShares[0].PermissionType)
 }
 
 func TestCheckForAdd_ParentRW_NodeDeny_OK(t *testing.T) {

--- a/pkg/sharehierarchy/hierarchy_test.go
+++ b/pkg/sharehierarchy/hierarchy_test.go
@@ -1,0 +1,351 @@
+// Copyright 2018-2026 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package sharehierarchy_test
+
+import (
+	"context"
+	"strconv"
+	"testing"
+
+	collaboration "github.com/cs3org/go-cs3apis/cs3/sharing/collaboration/v1beta1"
+	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+	"github.com/cs3org/reva/v3/pkg/errtypes"
+	"github.com/cs3org/reva/v3/pkg/sharehierarchy"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// pathMap builds a static path resolver from a map of opaqueId → path.
+func pathMap(m map[string]string) func(context.Context, *provider.ResourceId) (string, error) {
+	return func(_ context.Context, id *provider.ResourceId) (string, error) {
+		if p, ok := m[id.OpaqueId]; ok {
+			return p, nil
+		}
+		return "", errtypes.NotFound(id.OpaqueId)
+	}
+}
+
+// makeShare creates a minimal collaboration.Share for testing.
+func makeShare(id int, opaqueId string, perms *provider.ResourcePermissions) *collaboration.Share {
+	return &collaboration.Share{
+		Id: &collaboration.ShareId{OpaqueId: strconv.Itoa(id)},
+		ResourceId: &provider.ResourceId{
+			StorageId: "instance1",
+			SpaceId:   "space1",
+			OpaqueId:  opaqueId,
+		},
+		Permissions: &collaboration.SharePermissions{Permissions: perms},
+	}
+}
+
+var (
+	readPerms = &provider.ResourcePermissions{Stat: true, ListContainer: true, InitiateFileDownload: true}
+	rwPerms   = &provider.ResourcePermissions{Stat: true, ListContainer: true, InitiateFileDownload: true, InitiateFileUpload: true, CreateContainer: true}
+	denyPerms = &provider.ResourcePermissions{} // all false = active denial
+)
+
+func TestCheckForAdd_NoExistingShares(t *testing.T) {
+	checker := &sharehierarchy.Checker{GetPath: pathMap(map[string]string{})}
+	result, err := checker.CheckGrantConsistency(context.Background(), "/a/b", readPerms, nil)
+	require.NoError(t, err)
+	assert.Empty(t, result.ToDelete)
+	assert.Empty(t, result.ToReapply)
+}
+
+func TestCheckForAdd_ParentR_NodeRW_OK(t *testing.T) {
+	// P=R, N=RW → OK (new share escalates within parent's subtree)
+	parent := makeShare(1, "inode-a", readPerms)
+	checker := &sharehierarchy.Checker{GetPath: pathMap(map[string]string{"inode-a": "/a"})}
+
+	result, err := checker.CheckGrantConsistency(context.Background(), "/a/b", rwPerms, []*collaboration.Share{parent})
+	require.NoError(t, err)
+	assert.Empty(t, result.ToDelete)
+	assert.Empty(t, result.ToReapply)
+}
+
+func TestCheckForAdd_ParentR_NodeR_Conflict(t *testing.T) {
+	// P=R, N=R → ShareParentConflict (already covered by parent)
+	parent := makeShare(1, "inode-a", readPerms)
+	checker := &sharehierarchy.Checker{GetPath: pathMap(map[string]string{"inode-a": "/a"})}
+
+	_, err := checker.CheckGrantConsistency(context.Background(), "/a/b", readPerms, []*collaboration.Share{parent})
+	require.Error(t, err)
+	_, ok := err.(errtypes.IsShareParentConflict)
+	assert.True(t, ok, "expected ShareParentConflict, got %T: %v", err, err)
+}
+
+func TestCheckForAdd_ParentRW_NodeR_Conflict(t *testing.T) {
+	// P=RW, N=R → ShareParentConflict (parent already grants more)
+	parent := makeShare(1, "inode-a", rwPerms)
+	checker := &sharehierarchy.Checker{GetPath: pathMap(map[string]string{"inode-a": "/a"})}
+
+	_, err := checker.CheckGrantConsistency(context.Background(), "/a/b", readPerms, []*collaboration.Share{parent})
+	require.Error(t, err)
+	_, ok := err.(errtypes.IsShareParentConflict)
+	assert.True(t, ok)
+}
+
+func TestCheckForAdd_ParentRW_NodeRW_Conflict(t *testing.T) {
+	// P=RW, N=RW → ShareParentConflict (redundant)
+	parent := makeShare(1, "inode-a", rwPerms)
+	checker := &sharehierarchy.Checker{GetPath: pathMap(map[string]string{"inode-a": "/a"})}
+
+	_, err := checker.CheckGrantConsistency(context.Background(), "/a/b", rwPerms, []*collaboration.Share{parent})
+	require.Error(t, err)
+	_, ok := err.(errtypes.IsShareParentConflict)
+	assert.True(t, ok)
+}
+
+func TestCheckForAdd_ChildRW_NodeR_ReApply(t *testing.T) {
+	// N=R, C=RW → child goes to ToReapply (child keeps its higher explicit ACL)
+	child := makeShare(2, "inode-ab", rwPerms)
+	checker := &sharehierarchy.Checker{GetPath: pathMap(map[string]string{"inode-ab": "/a/b"})}
+
+	result, err := checker.CheckGrantConsistency(context.Background(), "/a", readPerms, []*collaboration.Share{child})
+	require.NoError(t, err)
+	assert.Empty(t, result.ToDelete)
+	require.Len(t, result.ToReapply, 1)
+	assert.Equal(t, "2", result.ToReapply[0].Id.OpaqueId)
+}
+
+func TestCheckForAdd_ChildR_NodeR_ToDelete(t *testing.T) {
+	// N=R, C=R → child is redundant; goes to ToDelete
+	child := makeShare(2, "inode-ab", readPerms)
+	checker := &sharehierarchy.Checker{GetPath: pathMap(map[string]string{"inode-ab": "/a/b"})}
+
+	result, err := checker.CheckGrantConsistency(context.Background(), "/a", readPerms, []*collaboration.Share{child})
+	require.NoError(t, err)
+	require.Len(t, result.ToDelete, 1)
+	assert.Equal(t, "2", result.ToDelete[0].Id.OpaqueId)
+	assert.Empty(t, result.ToReapply)
+}
+
+func TestCheckForAdd_ChildRW_NodeRW_ToDelete(t *testing.T) {
+	// N=RW, C=RW → child is redundant; goes to ToDelete
+	child := makeShare(2, "inode-ab", rwPerms)
+	checker := &sharehierarchy.Checker{GetPath: pathMap(map[string]string{"inode-ab": "/a/b"})}
+
+	result, err := checker.CheckGrantConsistency(context.Background(), "/a", rwPerms, []*collaboration.Share{child})
+	require.NoError(t, err)
+	require.Len(t, result.ToDelete, 1)
+}
+
+func TestCheckForAdd_ChildR_NodeRW_ToDelete(t *testing.T) {
+	// N=RW, C=R → child would be effectively elevated; goes to ToDelete
+	child := makeShare(2, "inode-ab", readPerms)
+	checker := &sharehierarchy.Checker{GetPath: pathMap(map[string]string{"inode-ab": "/a/b"})}
+
+	result, err := checker.CheckGrantConsistency(context.Background(), "/a", rwPerms, []*collaboration.Share{child})
+	require.NoError(t, err)
+	require.Len(t, result.ToDelete, 1)
+}
+
+func TestCheckForAdd_UnrelatedShare_Ignored(t *testing.T) {
+	// Share on /b has no relationship to /a
+	other := makeShare(3, "inode-b", readPerms)
+	checker := &sharehierarchy.Checker{GetPath: pathMap(map[string]string{"inode-b": "/b"})}
+
+	result, err := checker.CheckGrantConsistency(context.Background(), "/a", readPerms, []*collaboration.Share{other})
+	require.NoError(t, err)
+	assert.Empty(t, result.ToDelete)
+	assert.Empty(t, result.ToReapply)
+}
+
+func TestCheckForAdd_DeepChild_ToDelete(t *testing.T) {
+	// Deep child /a/b/c/d should still be detected
+	child := makeShare(2, "inode-deep", readPerms)
+	checker := &sharehierarchy.Checker{GetPath: pathMap(map[string]string{"inode-deep": "/a/b/c/d"})}
+
+	result, err := checker.CheckGrantConsistency(context.Background(), "/a", readPerms, []*collaboration.Share{child})
+	require.NoError(t, err)
+	require.Len(t, result.ToDelete, 1)
+}
+
+func TestCheckForAdd_MultipleChildren_MixedResult(t *testing.T) {
+	// /a/b (RW) → ToReapply; /a/c (R) → ToDelete
+	childRW := makeShare(1, "inode-ab", rwPerms)
+	childR := makeShare(2, "inode-ac", readPerms)
+	checker := &sharehierarchy.Checker{GetPath: pathMap(map[string]string{
+		"inode-ab": "/a/b",
+		"inode-ac": "/a/c",
+	})}
+
+	result, err := checker.CheckGrantConsistency(context.Background(), "/a", readPerms, []*collaboration.Share{childRW, childR})
+	require.NoError(t, err)
+	require.Len(t, result.ToReapply, 1)
+	assert.Equal(t, "1", result.ToReapply[0].Id.OpaqueId)
+	require.Len(t, result.ToDelete, 1)
+	assert.Equal(t, "2", result.ToDelete[0].Id.OpaqueId)
+}
+
+func TestCheckForAdd_SiblingPrefix_NotAncestor(t *testing.T) {
+	// /ab/c must NOT be treated as a child of /a (prefix but not path ancestor)
+	other := makeShare(3, "inode-abc", readPerms)
+	checker := &sharehierarchy.Checker{GetPath: pathMap(map[string]string{"inode-abc": "/ab/c"})}
+
+	result, err := checker.CheckGrantConsistency(context.Background(), "/a", readPerms, []*collaboration.Share{other})
+	require.NoError(t, err)
+	assert.Empty(t, result.ToDelete)
+	assert.Empty(t, result.ToReapply)
+}
+
+func TestCheckForAdd_DenyParent_Conflict(t *testing.T) {
+	// P=Deny, N=R → conflict (Deny is max; nothing escalates beyond it)
+	parent := makeShare(1, "inode-a", denyPerms)
+	checker := &sharehierarchy.Checker{GetPath: pathMap(map[string]string{"inode-a": "/a"})}
+
+	_, err := checker.CheckGrantConsistency(context.Background(), "/a/b", readPerms, []*collaboration.Share{parent})
+	require.Error(t, err)
+	_, ok := err.(errtypes.IsShareParentConflict)
+	assert.True(t, ok)
+}
+
+func TestCheckForAdd_ParentRW_NodeDeny_OK(t *testing.T) {
+	// P=RW, N=Deny → OK (Deny > RW in the ordering; new share escalates)
+	parent := makeShare(1, "inode-a", rwPerms)
+	checker := &sharehierarchy.Checker{GetPath: pathMap(map[string]string{"inode-a": "/a"})}
+
+	result, err := checker.CheckGrantConsistency(context.Background(), "/a/b", denyPerms, []*collaboration.Share{parent})
+	require.NoError(t, err)
+	assert.Empty(t, result.ToDelete)
+	assert.Empty(t, result.ToReapply)
+}
+
+func TestCheckForAdd_ParentR_NodeDeny_OK(t *testing.T) {
+	// P=R, N=Deny → OK (Deny > R)
+	parent := makeShare(1, "inode-a", readPerms)
+	checker := &sharehierarchy.Checker{GetPath: pathMap(map[string]string{"inode-a": "/a"})}
+
+	result, err := checker.CheckGrantConsistency(context.Background(), "/a/b", denyPerms, []*collaboration.Share{parent})
+	require.NoError(t, err)
+	assert.Empty(t, result.ToDelete)
+	assert.Empty(t, result.ToReapply)
+}
+
+func TestCheckForAdd_ParentDeny_NodeDeny_Conflict(t *testing.T) {
+	// P=Deny, N=Deny → conflict (equal, not an escalation)
+	parent := makeShare(1, "inode-a", denyPerms)
+	checker := &sharehierarchy.Checker{GetPath: pathMap(map[string]string{"inode-a": "/a"})}
+
+	_, err := checker.CheckGrantConsistency(context.Background(), "/a/b", denyPerms, []*collaboration.Share{parent})
+	require.Error(t, err)
+	_, ok := err.(errtypes.IsShareParentConflict)
+	assert.True(t, ok)
+}
+
+func TestCheckForAdd_ParentDeny_NodeRW_Conflict(t *testing.T) {
+	// P=Deny, N=RW → conflict (RW < Deny; cannot de-escalate via a child share)
+	parent := makeShare(1, "inode-a", denyPerms)
+	checker := &sharehierarchy.Checker{GetPath: pathMap(map[string]string{"inode-a": "/a"})}
+
+	_, err := checker.CheckGrantConsistency(context.Background(), "/a/b", rwPerms, []*collaboration.Share{parent})
+	require.Error(t, err)
+	_, ok := err.(errtypes.IsShareParentConflict)
+	assert.True(t, ok)
+}
+
+func TestCheckForAdd_ChildDeny_NodeR_ToReapply(t *testing.T) {
+	// N=R, C=Deny → child has higher perms (Deny > R); must be re-applied
+	child := makeShare(2, "inode-ab", denyPerms)
+	checker := &sharehierarchy.Checker{GetPath: pathMap(map[string]string{"inode-ab": "/a/b"})}
+
+	result, err := checker.CheckGrantConsistency(context.Background(), "/a", readPerms, []*collaboration.Share{child})
+	require.NoError(t, err)
+	assert.Empty(t, result.ToDelete)
+	require.Len(t, result.ToReapply, 1)
+	assert.Equal(t, "2", result.ToReapply[0].Id.OpaqueId)
+}
+
+func TestCheckForAdd_ChildDeny_NodeRW_ToReapply(t *testing.T) {
+	// N=RW, C=Deny → child has higher perms (Deny > RW); must be re-applied
+	child := makeShare(2, "inode-ab", denyPerms)
+	checker := &sharehierarchy.Checker{GetPath: pathMap(map[string]string{"inode-ab": "/a/b"})}
+
+	result, err := checker.CheckGrantConsistency(context.Background(), "/a", rwPerms, []*collaboration.Share{child})
+	require.NoError(t, err)
+	assert.Empty(t, result.ToDelete)
+	require.Len(t, result.ToReapply, 1)
+}
+
+func TestCheckForAdd_ChildR_NodeDeny_ToDelete(t *testing.T) {
+	// N=Deny, C=R → child has lower perms (R < Deny); delete it
+	child := makeShare(2, "inode-ab", readPerms)
+	checker := &sharehierarchy.Checker{GetPath: pathMap(map[string]string{"inode-ab": "/a/b"})}
+
+	result, err := checker.CheckGrantConsistency(context.Background(), "/a", denyPerms, []*collaboration.Share{child})
+	require.NoError(t, err)
+	require.Len(t, result.ToDelete, 1)
+	assert.Empty(t, result.ToReapply)
+}
+
+func TestCheckForAdd_ChildRW_NodeDeny_ToDelete(t *testing.T) {
+	// N=Deny, C=RW → child has lower perms (RW < Deny); delete it
+	child := makeShare(2, "inode-ab", rwPerms)
+	checker := &sharehierarchy.Checker{GetPath: pathMap(map[string]string{"inode-ab": "/a/b"})}
+
+	result, err := checker.CheckGrantConsistency(context.Background(), "/a", denyPerms, []*collaboration.Share{child})
+	require.NoError(t, err)
+	require.Len(t, result.ToDelete, 1)
+	assert.Empty(t, result.ToReapply)
+}
+
+func TestIsStrictAncestor(t *testing.T) {
+	tests := []struct {
+		ancestor string
+		child    string
+		want     bool
+	}{
+		{"/a", "/a/b", true},
+		{"/a", "/a/b/c", true},
+		{"/a/b", "/a/b/c", true},
+		{"/a", "/a", false},    // same path
+		{"/a/b", "/a", false},  // child is actually parent
+		{"/a", "/ab/c", false}, // prefix but not path ancestor
+		{"/a", "/b", false},    // unrelated
+		{"/", "/a", true},      // root
+	}
+	for _, tt := range tests {
+		t.Run(tt.ancestor+"→"+tt.child, func(t *testing.T) {
+			// Access via exported helpers since isStrictAncestor is unexported.
+			// We test it indirectly through FilterAncestors.
+			share := makeShare(1, "id", readPerms)
+			paths := map[string]string{"1": tt.ancestor}
+			result := sharehierarchy.FilterAncestors([]*collaboration.Share{share}, paths, tt.child)
+			got := len(result) == 1
+			assert.Equal(t, tt.want, got, "ancestor=%q child=%q", tt.ancestor, tt.child)
+		})
+	}
+}
+
+func TestSortByPathDepthAsc(t *testing.T) {
+	shares := []*collaboration.Share{
+		makeShare(1, "deep", readPerms),
+		makeShare(2, "root", readPerms),
+		makeShare(3, "mid", readPerms),
+	}
+	paths := map[string]string{
+		"1": "/a/b/c/d",
+		"2": "/a",
+		"3": "/a/b",
+	}
+	sharehierarchy.SortByPathDepthAsc(shares, paths)
+	assert.Equal(t, "2", shares[0].Id.OpaqueId) // /a
+	assert.Equal(t, "3", shares[1].Id.OpaqueId) // /a/b
+	assert.Equal(t, "1", shares[2].Id.OpaqueId) // /a/b/c/d
+}

--- a/pkg/sharehierarchy/hierarchy_test.go
+++ b/pkg/sharehierarchy/hierarchy_test.go
@@ -86,7 +86,8 @@ func TestCheckForAdd_ParentR_NodeR_Conflict(t *testing.T) {
 
 	_, err := checker.CheckGrantConsistency(context.Background(), "/a/b", readPerms, []*collaboration.Share{parent})
 	require.Error(t, err)
-	conflictErr, ok := err.(*sharehierarchy.HierarchyConflictError); _ = conflictErr
+	conflictErr, ok := err.(*sharehierarchy.HierarchyConflictError)
+	_ = conflictErr
 	assert.True(t, ok, "expected HierarchyConflictError, got %T: %v", err, err)
 }
 
@@ -97,7 +98,8 @@ func TestCheckForAdd_ParentRW_NodeR_Conflict(t *testing.T) {
 
 	_, err := checker.CheckGrantConsistency(context.Background(), "/a/b", readPerms, []*collaboration.Share{parent})
 	require.Error(t, err)
-	conflictErr, ok := err.(*sharehierarchy.HierarchyConflictError); _ = conflictErr
+	conflictErr, ok := err.(*sharehierarchy.HierarchyConflictError)
+	_ = conflictErr
 	assert.True(t, ok)
 }
 
@@ -108,7 +110,8 @@ func TestCheckForAdd_ParentRW_NodeRW_Conflict(t *testing.T) {
 
 	_, err := checker.CheckGrantConsistency(context.Background(), "/a/b", rwPerms, []*collaboration.Share{parent})
 	require.Error(t, err)
-	conflictErr, ok := err.(*sharehierarchy.HierarchyConflictError); _ = conflictErr
+	conflictErr, ok := err.(*sharehierarchy.HierarchyConflictError)
+	_ = conflictErr
 	assert.True(t, ok)
 }
 
@@ -121,7 +124,7 @@ func TestCheckForAdd_ChildRW_NodeR_ReApply(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, result.ToDelete)
 	require.Len(t, result.ToReapply, 1)
-	assert.Equal(t, "2", result.ToReapply[0].Id.OpaqueId)
+	assert.Equal(t, "2", result.ToReapply[0].Share.Id.OpaqueId)
 }
 
 func TestCheckForAdd_ChildR_NodeR_ToDelete(t *testing.T) {
@@ -132,8 +135,21 @@ func TestCheckForAdd_ChildR_NodeR_ToDelete(t *testing.T) {
 	result, err := checker.CheckGrantConsistency(context.Background(), "/a", readPerms, []*collaboration.Share{child})
 	require.NoError(t, err)
 	require.Len(t, result.ToDelete, 1)
-	assert.Equal(t, "2", result.ToDelete[0].Id.OpaqueId)
+	assert.Equal(t, "2", result.ToDelete[0].Share.Id.OpaqueId)
 	assert.Empty(t, result.ToReapply)
+}
+
+func TestNewChildConflictError_IncludesResolvedChildPath(t *testing.T) {
+	child := makeShare(2, "inode-ab", readPerms)
+	checker := &sharehierarchy.Checker{GetPath: pathMap(map[string]string{"inode-ab": "/a/b"})}
+
+	result, err := checker.CheckGrantConsistency(context.Background(), "/a", readPerms, []*collaboration.Share{child})
+	require.NoError(t, err)
+	require.Len(t, result.ToDelete, 1)
+
+	conflictErr := sharehierarchy.NewChildConflictError(sharehierarchy.ChildConflictMessage(result.ToDelete), result.ToDelete)
+	require.Len(t, conflictErr.ConflictingShares, 1)
+	assert.Equal(t, "/a/b", conflictErr.ConflictingShares[0].Path)
 }
 
 func TestCheckForAdd_ChildRW_NodeRW_ToDelete(t *testing.T) {
@@ -189,9 +205,9 @@ func TestCheckForAdd_MultipleChildren_MixedResult(t *testing.T) {
 	result, err := checker.CheckGrantConsistency(context.Background(), "/a", readPerms, []*collaboration.Share{childRW, childR})
 	require.NoError(t, err)
 	require.Len(t, result.ToReapply, 1)
-	assert.Equal(t, "1", result.ToReapply[0].Id.OpaqueId)
+	assert.Equal(t, "1", result.ToReapply[0].Share.Id.OpaqueId)
 	require.Len(t, result.ToDelete, 1)
-	assert.Equal(t, "2", result.ToDelete[0].Id.OpaqueId)
+	assert.Equal(t, "2", result.ToDelete[0].Share.Id.OpaqueId)
 }
 
 func TestCheckForAdd_SiblingPrefix_NotAncestor(t *testing.T) {
@@ -212,7 +228,8 @@ func TestCheckForAdd_DenyParent_Conflict(t *testing.T) {
 
 	_, err := checker.CheckGrantConsistency(context.Background(), "/a/b", readPerms, []*collaboration.Share{parent})
 	require.Error(t, err)
-	conflictErr, ok := err.(*sharehierarchy.HierarchyConflictError); _ = conflictErr
+	conflictErr, ok := err.(*sharehierarchy.HierarchyConflictError)
+	_ = conflictErr
 	assert.True(t, ok)
 }
 
@@ -245,7 +262,8 @@ func TestCheckForAdd_ParentDeny_NodeDeny_Conflict(t *testing.T) {
 
 	_, err := checker.CheckGrantConsistency(context.Background(), "/a/b", denyPerms, []*collaboration.Share{parent})
 	require.Error(t, err)
-	conflictErr, ok := err.(*sharehierarchy.HierarchyConflictError); _ = conflictErr
+	conflictErr, ok := err.(*sharehierarchy.HierarchyConflictError)
+	_ = conflictErr
 	assert.True(t, ok)
 }
 
@@ -256,7 +274,8 @@ func TestCheckForAdd_ParentDeny_NodeRW_Conflict(t *testing.T) {
 
 	_, err := checker.CheckGrantConsistency(context.Background(), "/a/b", rwPerms, []*collaboration.Share{parent})
 	require.Error(t, err)
-	conflictErr, ok := err.(*sharehierarchy.HierarchyConflictError); _ = conflictErr
+	conflictErr, ok := err.(*sharehierarchy.HierarchyConflictError)
+	_ = conflictErr
 	assert.True(t, ok)
 }
 
@@ -269,7 +288,7 @@ func TestCheckForAdd_ChildDeny_NodeR_ToReapply(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, result.ToDelete)
 	require.Len(t, result.ToReapply, 1)
-	assert.Equal(t, "2", result.ToReapply[0].Id.OpaqueId)
+	assert.Equal(t, "2", result.ToReapply[0].Share.Id.OpaqueId)
 }
 
 func TestCheckForAdd_ChildDeny_NodeRW_ToReapply(t *testing.T) {
@@ -362,7 +381,7 @@ func TestToReapplySortedShallowestFirst(t *testing.T) {
 	result, err := checker.CheckGrantConsistency(context.Background(), "/a", readPerms, []*collaboration.Share{deep, root, mid})
 	require.NoError(t, err)
 	require.Len(t, result.ToReapply, 3)
-	assert.Equal(t, "2", result.ToReapply[0].Id.OpaqueId) // /a/b
-	assert.Equal(t, "3", result.ToReapply[1].Id.OpaqueId) // /a/b/c
-	assert.Equal(t, "1", result.ToReapply[2].Id.OpaqueId) // /a/b/c/d
+	assert.Equal(t, "2", result.ToReapply[0].Share.Id.OpaqueId) // /a/b
+	assert.Equal(t, "3", result.ToReapply[1].Share.Id.OpaqueId) // /a/b/c
+	assert.Equal(t, "1", result.ToReapply[2].Share.Id.OpaqueId) // /a/b/c/d
 }

--- a/pkg/sharehierarchy/hierarchy_test.go
+++ b/pkg/sharehierarchy/hierarchy_test.go
@@ -23,9 +23,12 @@ import (
 	"strconv"
 	"testing"
 
+	grouppb "github.com/cs3org/go-cs3apis/cs3/identity/group/v1beta1"
+	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	collaboration "github.com/cs3org/go-cs3apis/cs3/sharing/collaboration/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	"github.com/cs3org/reva/v3/pkg/errtypes"
+	"github.com/cs3org/reva/v3/pkg/permissions"
 	"github.com/cs3org/reva/v3/pkg/sharehierarchy"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -52,6 +55,28 @@ func makeShare(id int, opaqueId string, perms *provider.ResourcePermissions) *co
 		},
 		Permissions: &collaboration.SharePermissions{Permissions: perms},
 	}
+}
+
+func makeUserShare(id int, opaqueId string, perms *provider.ResourcePermissions, userID string) *collaboration.Share {
+	share := makeShare(id, opaqueId, perms)
+	share.Grantee = &provider.Grantee{
+		Type: provider.GranteeType_GRANTEE_TYPE_USER,
+		Id: &provider.Grantee_UserId{
+			UserId: &userpb.UserId{OpaqueId: userID},
+		},
+	}
+	return share
+}
+
+func makeGroupShare(id int, opaqueId string, perms *provider.ResourcePermissions, groupID string) *collaboration.Share {
+	share := makeShare(id, opaqueId, perms)
+	share.Grantee = &provider.Grantee{
+		Type: provider.GranteeType_GRANTEE_TYPE_GROUP,
+		Id: &provider.Grantee_GroupId{
+			GroupId: &grouppb.GroupId{OpaqueId: groupID},
+		},
+	}
+	return share
 }
 
 var (
@@ -81,7 +106,7 @@ func TestCheckForAdd_ParentR_NodeRW_OK(t *testing.T) {
 
 func TestCheckForAdd_ParentR_NodeR_Conflict(t *testing.T) {
 	// P=R, N=R → ShareParentConflict (already covered by parent)
-	parent := makeShare(1, "inode-a", readPerms)
+	parent := makeUserShare(1, "inode-a", readPerms, "user1")
 	checker := &sharehierarchy.Checker{GetPath: pathMap(map[string]string{"inode-a": "/a"})}
 
 	_, err := checker.CheckGrantConsistency(context.Background(), "/a/b", readPerms, []*collaboration.Share{parent})
@@ -89,7 +114,9 @@ func TestCheckForAdd_ParentR_NodeR_Conflict(t *testing.T) {
 	conflictErr, ok := err.(*sharehierarchy.HierarchyConflictError)
 	require.True(t, ok, "expected HierarchyConflictError, got %T: %v", err, err)
 	require.Len(t, conflictErr.ConflictingShares, 1)
-	assert.Equal(t, sharehierarchy.PermRead.RoleID(), conflictErr.ConflictingShares[0].PermissionType)
+	assert.Equal(t, permissions.UnifiedRoleViewerID, conflictErr.ConflictingShares[0].PermissionType)
+	assert.Equal(t, "user1", conflictErr.ConflictingShares[0].Sharee)
+	assert.Equal(t, sharehierarchy.ShareeTypeUser, conflictErr.ConflictingShares[0].ShareeType)
 }
 
 func TestCheckForAdd_ParentRW_NodeR_Conflict(t *testing.T) {
@@ -102,7 +129,22 @@ func TestCheckForAdd_ParentRW_NodeR_Conflict(t *testing.T) {
 	conflictErr, ok := err.(*sharehierarchy.HierarchyConflictError)
 	require.True(t, ok)
 	require.Len(t, conflictErr.ConflictingShares, 1)
-	assert.Equal(t, sharehierarchy.PermRW.RoleID(), conflictErr.ConflictingShares[0].PermissionType)
+	assert.Equal(t, permissions.UnifiedRoleEditorID, conflictErr.ConflictingShares[0].PermissionType)
+}
+
+func TestCheckForAdd_GroupParentConflictIncludesShareeType(t *testing.T) {
+	parent := makeGroupShare(1, "inode-a", readPerms, "group1")
+	checker := &sharehierarchy.Checker{GetPath: pathMap(map[string]string{"inode-a": "/a"})}
+
+	_, err := checker.CheckGrantConsistency(context.Background(), "/a/b", readPerms, []*collaboration.Share{parent})
+	require.Error(t, err)
+	conflictErr, ok := err.(*sharehierarchy.HierarchyConflictError)
+	require.True(t, ok)
+	require.Len(t, conflictErr.ConflictingShares, 1)
+	assert.Equal(t, "group1", conflictErr.ConflictingShares[0].Sharee)
+	assert.Equal(t, sharehierarchy.ShareeTypeGroup, conflictErr.ConflictingShares[0].ShareeType)
+	assert.Contains(t, conflictErr.MarshalToJSON(), `"sharee":"group1"`)
+	assert.Contains(t, conflictErr.MarshalToJSON(), `"sharee_type":"group"`)
 }
 
 func TestCheckForAdd_ParentRW_NodeRW_Conflict(t *testing.T) {
@@ -152,7 +194,25 @@ func TestNewChildConflictError_IncludesResolvedChildPath(t *testing.T) {
 	conflictErr := sharehierarchy.NewChildConflictError(sharehierarchy.ChildConflictMessage(result.ToDelete), result.ToDelete)
 	require.Len(t, conflictErr.ConflictingShares, 1)
 	assert.Equal(t, "/a/b", conflictErr.ConflictingShares[0].Path)
-	assert.Equal(t, sharehierarchy.PermRead.RoleID(), conflictErr.ConflictingShares[0].PermissionType)
+	assert.Equal(t, permissions.UnifiedRoleViewerID, conflictErr.ConflictingShares[0].PermissionType)
+	assert.Contains(t, conflictErr.MarshalToJSON(), `"permission_type":"`+permissions.UnifiedRoleViewerID+`"`)
+	assert.NotContains(t, conflictErr.MarshalToJSON(), `"permission_type":"R"`)
+}
+
+func TestNewChildConflictError_GroupShareIncludesShareeType(t *testing.T) {
+	child := makeGroupShare(2, "inode-ab", readPerms, "group1")
+	checker := &sharehierarchy.Checker{GetPath: pathMap(map[string]string{"inode-ab": "/a/b"})}
+
+	result, err := checker.CheckGrantConsistency(context.Background(), "/a", readPerms, []*collaboration.Share{child})
+	require.NoError(t, err)
+	require.Len(t, result.ToDelete, 1)
+
+	conflictErr := sharehierarchy.NewChildConflictError(sharehierarchy.ChildConflictMessage(result.ToDelete), result.ToDelete)
+	require.Len(t, conflictErr.ConflictingShares, 1)
+	assert.Equal(t, "group1", conflictErr.ConflictingShares[0].Sharee)
+	assert.Equal(t, sharehierarchy.ShareeTypeGroup, conflictErr.ConflictingShares[0].ShareeType)
+	assert.Contains(t, conflictErr.MarshalToJSON(), `"sharee":"group1"`)
+	assert.Contains(t, conflictErr.MarshalToJSON(), `"sharee_type":"group"`)
 }
 
 func TestCheckForAdd_ChildRW_NodeRW_ToDelete(t *testing.T) {
@@ -234,7 +294,7 @@ func TestCheckForAdd_DenyParent_Conflict(t *testing.T) {
 	conflictErr, ok := err.(*sharehierarchy.HierarchyConflictError)
 	require.True(t, ok)
 	require.Len(t, conflictErr.ConflictingShares, 1)
-	assert.Equal(t, sharehierarchy.PermDeny.RoleID(), conflictErr.ConflictingShares[0].PermissionType)
+	assert.Equal(t, permissions.UnifiedRoleDenyAccessID, conflictErr.ConflictingShares[0].PermissionType)
 }
 
 func TestCheckForAdd_ParentRW_NodeDeny_OK(t *testing.T) {

--- a/pkg/sharehierarchy/hierarchy_test.go
+++ b/pkg/sharehierarchy/hierarchy_test.go
@@ -322,30 +322,47 @@ func TestIsStrictAncestor(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.ancestor+"→"+tt.child, func(t *testing.T) {
-			// Access via exported helpers since isStrictAncestor is unexported.
-			// We test it indirectly through FilterAncestors.
+			// Test isStrictAncestor indirectly via CheckGrantConsistency:
+			// a share at tt.ancestor is a parent of the new node at tt.child
+			// only when isStrictAncestor(tt.ancestor, tt.child) is true.
 			share := makeShare(1, "id", readPerms)
-			paths := map[string]string{"1": tt.ancestor}
-			result := sharehierarchy.FilterAncestors([]*collaboration.Share{share}, paths, tt.child)
-			got := len(result) == 1
+			checker := &sharehierarchy.Checker{GetPath: pathMap(map[string]string{"id": tt.ancestor})}
+			_, err := checker.CheckGrantConsistency(context.Background(), tt.child, rwPerms, []*collaboration.Share{share})
+			// rwPerms escalates beyond readPerms, so a true ancestor produces no error.
+			// A non-ancestor produces no error either, but also no ToDelete/ToReapply.
+			// We detect ancestry by whether the share appears in the result at all.
+			result, _ := checker.CheckGrantConsistency(context.Background(), tt.child, readPerms, []*collaboration.Share{share})
+			var detected bool
+			if err != nil {
+				detected = true // ShareParentConflict means ancestor was found
+			} else if result != nil && len(result.ToDelete)+len(result.ToReapply) > 0 {
+				detected = true // child relationship found — not what we're testing here
+			}
+			// For the ancestor direction: use readPerms on node so same-or-lower triggers conflict.
+			_, ancestorErr := checker.CheckGrantConsistency(context.Background(), tt.child, readPerms, []*collaboration.Share{share})
+			got := ancestorErr != nil
 			assert.Equal(t, tt.want, got, "ancestor=%q child=%q", tt.ancestor, tt.child)
+			_ = detected
 		})
 	}
 }
 
-func TestSortByPathDepthAsc(t *testing.T) {
-	shares := []*collaboration.Share{
-		makeShare(1, "deep", readPerms),
-		makeShare(2, "root", readPerms),
-		makeShare(3, "mid", readPerms),
-	}
-	paths := map[string]string{
-		"1": "/a/b/c/d",
-		"2": "/a",
-		"3": "/a/b",
-	}
-	sharehierarchy.SortByPathDepthAsc(shares, paths)
-	assert.Equal(t, "2", shares[0].Id.OpaqueId) // /a
-	assert.Equal(t, "3", shares[1].Id.OpaqueId) // /a/b
-	assert.Equal(t, "1", shares[2].Id.OpaqueId) // /a/b/c/d
+func TestToReapplySortedShallowestFirst(t *testing.T) {
+	// Three children at different depths; all have higher perms (RW) than the new node (R).
+	// ToReapply must come out sorted shallowest-first without any manual sorting by the caller.
+	deep := makeShare(1, "deep", rwPerms)
+	root := makeShare(2, "root-child", rwPerms)
+	mid := makeShare(3, "mid", rwPerms)
+	checker := &sharehierarchy.Checker{GetPath: pathMap(map[string]string{
+		"deep":       "/a/b/c/d",
+		"root-child": "/a/b",
+		"mid":        "/a/b/c",
+	})}
+
+	result, err := checker.CheckGrantConsistency(context.Background(), "/a", readPerms, []*collaboration.Share{deep, root, mid})
+	require.NoError(t, err)
+	require.Len(t, result.ToReapply, 3)
+	assert.Equal(t, "2", result.ToReapply[0].Id.OpaqueId) // /a/b
+	assert.Equal(t, "3", result.ToReapply[1].Id.OpaqueId) // /a/b/c
+	assert.Equal(t, "1", result.ToReapply[2].Id.OpaqueId) // /a/b/c/d
 }

--- a/pkg/sharehierarchy/permissions.go
+++ b/pkg/sharehierarchy/permissions.go
@@ -20,6 +20,7 @@ package sharehierarchy
 
 import (
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+	"github.com/cs3org/reva/v3/pkg/permissions"
 )
 
 // PermLevel represents a permission level in the hierarchy ordering.
@@ -50,6 +51,19 @@ func (p PermLevel) String() string {
 		return "D"
 	default:
 		return "unknown"
+	}
+}
+
+func (p PermLevel) RoleID() string {
+	switch p {
+	case PermRead:
+		return permissions.UnifiedRoleViewerID
+	case PermRW:
+		return permissions.UnifiedRoleEditorID
+	case PermDeny:
+		return permissions.UnifiedRoleDenyAccessID
+	default:
+		return ""
 	}
 }
 

--- a/pkg/sharehierarchy/permissions.go
+++ b/pkg/sharehierarchy/permissions.go
@@ -1,0 +1,88 @@
+// Copyright 2018-2026 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package sharehierarchy
+
+import (
+	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+)
+
+// PermLevel represents a permission level in the hierarchy ordering.
+// It exists because raw OCS uint8 values cannot be compared directly for ordering:
+// OCS uses 0 for denial, which is numerically smallest but semantically most powerful.
+// PermLevel provides a correctly-ordered integer so that p1 > p2 means "p1 is more powerful".
+type PermLevel int
+
+const (
+	// PermRead represents read-only access (stat, list, download).
+	PermRead PermLevel = 1
+	// PermRW represents read-write access (read + upload, create, delete, move).
+	PermRW PermLevel = 2
+	// PermDeny represents an active denial — an explicit ACL entry that blocks access.
+	// This is the most powerful level in the ordering (D > RW > R).
+	// It is distinct from the absence of a share: PermDeny corresponds to a DB record
+	// with permissions=0, whereas no share simply means no entry exists.
+	PermDeny PermLevel = 3
+)
+
+func (p PermLevel) String() string {
+	switch p {
+	case PermRead:
+		return "R"
+	case PermRW:
+		return "RW"
+	case PermDeny:
+		return "D"
+	default:
+		return "unknown"
+	}
+}
+
+// PermLevelFromCS3 converts CS3 ResourcePermissions to the PermLevel ordering.
+// An empty ResourcePermissions (all false) maps to PermDeny — an active denial.
+func PermLevelFromCS3(p *provider.ResourcePermissions) PermLevel {
+	if p == nil || isEmptyPermissions(p) {
+		return PermDeny
+	}
+	if p.InitiateFileUpload || p.CreateContainer {
+		return PermRW
+	}
+	return PermRead
+}
+
+func isEmptyPermissions(p *provider.ResourcePermissions) bool {
+	return !p.AddGrant &&
+		!p.CreateContainer &&
+		!p.Delete &&
+		!p.GetPath &&
+		!p.GetQuota &&
+		!p.InitiateFileDownload &&
+		!p.InitiateFileUpload &&
+		!p.ListContainer &&
+		!p.ListFileVersions &&
+		!p.ListGrants &&
+		!p.ListRecycle &&
+		!p.Move &&
+		!p.PurgeRecycle &&
+		!p.RemoveGrant &&
+		!p.RestoreFileVersion &&
+		!p.RestoreRecycleItem &&
+		!p.Stat &&
+		!p.UpdateGrant &&
+		!p.DenyGrant
+}

--- a/pkg/storage/fs/eos/grant.go
+++ b/pkg/storage/fs/eos/grant.go
@@ -49,6 +49,7 @@ func (fs *Eosfs) AddGrant(ctx context.Context, ref *provider.Reference, g *provi
 
 	eosACL, err := fs.getEosACL(ctx, g)
 	if err != nil {
+
 		return err
 	}
 


### PR DESCRIPTION
This PR adds a hierarchical checking algorithm for shares to the gateway, as defined in ADR general/0005-sharing. Concrectely, the new algorithm does the following: 

* Before applying any ACL, the gateway checks for parent and child shares in the database.
* Based on their relationships and permission levels, the gateway decides whether to apply, reapply, or reject the operation.
* ACL updates will be applied orderd by path-length (where the shortest comes first) to maintain  consistent inheritance semantics (otherwise, you would overwrite child shares).
* The algorithm applies equally to create, update, and delete operations.