### PR TITLE
bugfix: ocm shared folders are displayed correctly

### DIFF
--- a/changelog/unreleased/fix-ocm-folders.md
+++ b/changelog/unreleased/fix-ocm-folders.md
@@ -1,0 +1,3 @@
+Bugfix: Display ResourceType correctly for OCM Shares
+
+https://github.com/cs3org/reva/pull/5610

--- a/pkg/share/manager/sql/conversions.go
+++ b/pkg/share/manager/sql/conversions.go
@@ -142,10 +142,10 @@ func convertToCS3OCMReceivedShare(s *model.OcmReceivedShare, p []*ocm.Protocol) 
 		Mtime: &types.Timestamp{
 			Seconds: uint64(s.Mtime),
 		},
-		ResourceType: convertToCS3ResourceType(s.ItemType),
-		ShareType:    convertToCS3OCMShareType(s.RecipientType),
-		State:        convertToCS3OCMShareState(s.State),
-		Protocols:    p,
+		SharedResourceType: convertToCS3SharedResourceType(s.ItemType),
+		ShareType:          convertToCS3OCMShareType(s.RecipientType),
+		State:              convertToCS3OCMShareState(s.State),
+		Protocols:          p,
 	}
 	if s.Expiration.Valid {
 		share.Expiration = &types.Timestamp{
@@ -216,14 +216,16 @@ func convertToCS3Protocol(p *model.OcmReceivedShareProtocol) *ocm.Protocol {
 	return nil
 }
 
-func convertToCS3ResourceType(t model.ItemType) provider.ResourceType {
+func convertToCS3SharedResourceType(t model.ItemType) ocm.SharedResourceType {
 	switch t {
 	case model.ItemTypeFile:
-		return provider.ResourceType_RESOURCE_TYPE_FILE
+		return ocm.SharedResourceType_SHARE_RESOURCE_TYPE_FILE
 	case model.ItemTypeFolder:
-		return provider.ResourceType_RESOURCE_TYPE_CONTAINER
+		return ocm.SharedResourceType_SHARE_RESOURCE_TYPE_CONTAINER
+	case model.ItemTypeEmbedded:
+		return ocm.SharedResourceType_SHARE_RESOURCE_TYPE_EMBEDDED
 	}
-	return provider.ResourceType_RESOURCE_TYPE_INVALID
+	return ocm.SharedResourceType_SHARE_RESOURCE_TYPE_INVALID
 }
 
 func convertFromCS3ResourceType(t ocm.SharedResourceType) model.ItemType {


### PR DESCRIPTION
Fixes an issue where the received ocm share wasn't displayed properly due to the ocm sql driver still using an outdated field. 