### PR TITLE
Fix PROPFIND inconsistencies

### DIFF
--- a/changelog/unreleased/propfind-inconsistencies.md
+++ b/changelog/unreleased/propfind-inconsistencies.md
@@ -1,0 +1,7 @@
+Bugfix: fix PROPFIND inconsistencies
+
+Stop emitting a duplicate `oc:public-link-expiration` entry in the not-found
+list, drop an erroneous fallthrough from `oc:privatelink` and skip re-adding `oc:name` 
+when explicitly requested (since it's already added unconditionally) 
+
+https://github.com/cs3org/reva/pull/5620

--- a/internal/http/services/owncloud/ocdav/propfind.go
+++ b/internal/http/services/owncloud/ocdav/propfind.go
@@ -701,6 +701,8 @@ func (s *svc) mdToPropResponse(ctx context.Context, pf *propfindXML, md *provide
 				switch pf.Prop[i].Local {
 				// TODO(jfd): maybe phoenix and the other clients can just use this id as an opaque string?
 				// I tested the desktop client and phoenix to annotate which properties are requestted, see below cases
+				case "name":
+					// oc:name is already added unconditionally to propstatOK above
 				case "fileid": // phoenix only
 					if md.Id == nil {
 						propstatNotFound.Prop = append(propstatNotFound.Prop, s.newProp("oc:fileid", ""))
@@ -778,7 +780,6 @@ func (s *svc) mdToPropResponse(ctx context.Context, pf *propfindXML, md *provide
 					} else {
 						propstatNotFound.Prop = append(propstatNotFound.Prop, s.newProp("oc:public-link-expiration", ""))
 					}
-					propstatNotFound.Prop = append(propstatNotFound.Prop, s.newProp("oc:public-link-expiration", ""))
 				case "size": // phoenix only
 					// TODO we cannot find out if md.Size is set or not because ints in go default to 0
 					// TODO what is the difference to d:quota-used-bytes (which only exists for collections)?
@@ -939,7 +940,6 @@ func (s *svc) mdToPropResponse(ctx context.Context, pf *propfindXML, md *provide
 					} else {
 						propstatNotFound.Prop = append(propstatNotFound.Prop, s.newProp("oc:privatelink", ""))
 					}
-					fallthrough
 				case "dDC": // desktop
 					fallthrough
 				case "data-fingerprint": // desktop


### PR DESCRIPTION
Stop emitting a duplicate `oc:public-link-expiration` entry in the not-found
list, drop an erroneous fallthrough from `oc:privatelink` and skip re-adding `oc:name` 
when explicitly requested (since it's already added unconditionally) 