### PR TITLE
Use destination field in received ocm share

### DIFF
--- a/changelog/unreleased/destination-string.md
+++ b/changelog/unreleased/destination-string.md
@@ -1,0 +1,6 @@
+Enhancement: Use destination field in received ocm share
+
+Instead of hijacking the opaque we use the new destination field
+when processing a share
+
+https://github.com/cs3org/reva/pull/5627

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/coreos/go-oidc/v3 v3.18.0
 	github.com/creasty/defaults v1.8.0
 	github.com/cs3org/cato v0.0.0-20200828125504-e418fc54dd5e
-	github.com/cs3org/go-cs3apis v0.0.0-20260505152900-5c56a16e60fb
+	github.com/cs3org/go-cs3apis v0.0.0-20260521131813-a83b8d2afa3f
 	github.com/dgraph-io/ristretto v0.2.0
 	github.com/dolthub/go-mysql-server v0.14.0
 	github.com/glpatcern/go-mime v0.0.0-20221026162842-2a8d71ad17a9

--- a/go.sum
+++ b/go.sum
@@ -900,6 +900,8 @@ github.com/cs3org/go-cs3apis v0.0.0-20260424072047-8d9ef7076ae9 h1:8WtMb7TKKx1AJ
 github.com/cs3org/go-cs3apis v0.0.0-20260424072047-8d9ef7076ae9/go.mod h1:DedpcqXl193qF/08Y04IO0PpxyyMu8+GrkD6kWK2MEQ=
 github.com/cs3org/go-cs3apis v0.0.0-20260505152900-5c56a16e60fb h1:LIgYp+xYlT5Y1DhGhLxREtXkWEJKDsMkdvoRfXhlcPg=
 github.com/cs3org/go-cs3apis v0.0.0-20260505152900-5c56a16e60fb/go.mod h1:DedpcqXl193qF/08Y04IO0PpxyyMu8+GrkD6kWK2MEQ=
+github.com/cs3org/go-cs3apis v0.0.0-20260521131813-a83b8d2afa3f h1:liK7Z1H0nNgK8sEodWsCRWJ4JKiqU474nBbbA9jnfS4=
+github.com/cs3org/go-cs3apis v0.0.0-20260521131813-a83b8d2afa3f/go.mod h1:DedpcqXl193qF/08Y04IO0PpxyyMu8+GrkD6kWK2MEQ=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/internal/grpc/services/ocmshareprovider/ocmshareprovider.go
+++ b/internal/grpc/services/ocmshareprovider/ocmshareprovider.go
@@ -475,21 +475,18 @@ func (s *service) ListReceivedOCMShares(ctx context.Context, req *ocm.ListReceiv
 
 func (s *service) UpdateReceivedOCMShare(ctx context.Context, req *ocm.UpdateReceivedOCMShareRequest) (*ocm.UpdateReceivedOCMShareResponse, error) {
 	user := appctx.ContextMustGetUser(ctx)
-	// If the share is set to pending it means we are "unprocessing"  the share,
-	// meaning it has already been processed and we don't want to do it again
-	if req.Opaque != nil && req.Share.State != ocm.ShareState_SHARE_STATE_PENDING {
-		if dest, ok := req.Opaque.Map["destination"]; ok {
-			destPath := string(dest.Value)
-			if _, err := s.repo.ProcessEmbeddedShare(ctx, user, req.Share, destPath); err != nil {
-				if errors.Is(err, share.ErrShareNotFound) {
-					return &ocm.UpdateReceivedOCMShareResponse{
-						Status: status.NewNotFound(ctx, "share does not exist"),
-					}, nil
-				}
+	// This is the state we are setting when processing a share
+	// meaning it should be ACCEPTED in order to trigger the processing.
+	if req.Share.State == ocm.ShareState_SHARE_STATE_ACCEPTED {
+		if _, err := s.repo.ProcessEmbeddedShare(ctx, user, req.Share); err != nil {
+			if errors.Is(err, share.ErrShareNotFound) {
 				return &ocm.UpdateReceivedOCMShareResponse{
-					Status: status.NewInternal(ctx, err, "error processing embedded share"),
+					Status: status.NewNotFound(ctx, "share does not exist"),
 				}, nil
 			}
+			return &ocm.UpdateReceivedOCMShareResponse{
+				Status: status.NewInternal(ctx, err, "error processing embedded share"),
+			}, nil
 		}
 	}
 	_, err := s.repo.UpdateReceivedShare(ctx, user, req.Share, req.UpdateMask)

--- a/internal/http/services/sciencemesh/embedded.go
+++ b/internal/http/services/sciencemesh/embedded.go
@@ -26,7 +26,6 @@ import (
 	gateway "github.com/cs3org/go-cs3apis/cs3/gateway/v1beta1"
 	ocm "github.com/cs3org/go-cs3apis/cs3/sharing/ocm/v1beta1"
 	storageprovider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
-	types "github.com/cs3org/go-cs3apis/cs3/types/v1beta1"
 	"github.com/cs3org/reva/v3/internal/http/services/owncloud/ocgraph"
 	"github.com/cs3org/reva/v3/internal/http/services/reqres"
 	"github.com/cs3org/reva/v3/pkg/appctx"
@@ -75,22 +74,13 @@ func (h *embeddedHandler) ProcessEmbeddedShare(w http.ResponseWriter, r *http.Re
 		},
 		UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"state"}},
 	}
-
-	// TODO(rawe0): Create a real "ProcessEmbeddedShareRequest" in the CS3APIs and
-	// use that instead of hijacking the UpdateReceivedOCMShareRequest via the opaque.
-	req.Opaque = &types.Opaque{
-		Map: map[string]*types.OpaqueEntry{
-			"destination": {
-				Decoder: "plain",
-				Value:   []byte(dest_path),
-			},
-		},
-	}
 	// Accept the embedded share or set it back to pending
 	// depending on the "process" query parameter
 	switch process {
 	case "true":
 		req.Share.State = ocm.ShareState_SHARE_STATE_ACCEPTED
+		// Update the destination path if we are processing the share.
+		req.Share.Destination = dest_path
 	case "false":
 		req.Share.State = ocm.ShareState_SHARE_STATE_PENDING
 	}

--- a/pkg/ocm/share/repository/json/json.go
+++ b/pkg/ocm/share/repository/json/json.go
@@ -624,6 +624,6 @@ func (m *mgr) UpdateReceivedShare(ctx context.Context, user *userpb.User, share 
 	return rs, nil
 }
 
-func (m *mgr) ProcessEmbeddedShare(ctx context.Context, user *userpb.User, share *ocm.ReceivedShare, destination string) (*ocm.ReceivedShare, error) {
+func (m *mgr) ProcessEmbeddedShare(ctx context.Context, user *userpb.User, share *ocm.ReceivedShare) (*ocm.ReceivedShare, error) {
 	return nil, errtypes.NotSupported("processing embedded shares is not supported")
 }

--- a/pkg/ocm/share/repository/nextcloud/nextcloud.go
+++ b/pkg/ocm/share/repository/nextcloud/nextcloud.go
@@ -483,6 +483,6 @@ func (sm *Manager) do(ctx context.Context, a Action, username string) (int, []by
 	return resp.StatusCode, body, nil
 }
 
-func (sm *Manager) ProcessEmbeddedShare(ctx context.Context, user *userpb.User, share *ocm.ReceivedShare, destination string) (*ocm.ReceivedShare, error) {
+func (sm *Manager) ProcessEmbeddedShare(ctx context.Context, user *userpb.User, share *ocm.ReceivedShare) (*ocm.ReceivedShare, error) {
 	return nil, errtypes.NotSupported("processing embedded shares is not supported")
 }

--- a/pkg/ocm/share/share.go
+++ b/pkg/ocm/share/share.go
@@ -59,7 +59,7 @@ type Repository interface {
 	UpdateReceivedShare(ctx context.Context, user *userpb.User, share *ocm.ReceivedShare, fieldMask *field_mask.FieldMask) (*ocm.ReceivedShare, error)
 
 	// Process the embedded share with the given state.
-	ProcessEmbeddedShare(ctx context.Context, user *userpb.User, share *ocm.ReceivedShare, destination string) (*ocm.ReceivedShare, error)
+	ProcessEmbeddedShare(ctx context.Context, user *userpb.User, share *ocm.ReceivedShare) (*ocm.ReceivedShare, error)
 }
 
 // ResourceIDFilter is an abstraction for creating filter by resource id.

--- a/pkg/share/manager/sql/ocm_shares.go
+++ b/pkg/share/manager/sql/ocm_shares.go
@@ -345,11 +345,11 @@ func uploadURLToWebDAV(ctx context.Context, httpClient *http.Client, dav *gowebd
 	return dav.WriteStream(remotePath, resp.Body, 0644)
 }
 
-func (m *mgr) ProcessEmbeddedShare(ctx context.Context, user *userpb.User, share *ocm.ReceivedShare, destination string) (*ocm.ReceivedShare, error) {
+func (m *mgr) ProcessEmbeddedShare(ctx context.Context, user *userpb.User, share *ocm.ReceivedShare) (*ocm.ReceivedShare, error) {
 	log := appctx.GetLogger(ctx)
 	log.Debug().
 		Interface("share", share).
-		Str("destination", destination).
+		Str("destination", share.Destination).
 		Msg("Processing received share")
 
 	protocols, err := m.getProtocolsByIds(ctx, []any{share.Id.OpaqueId})
@@ -379,7 +379,7 @@ func (m *mgr) ProcessEmbeddedShare(ctx context.Context, user *userpb.User, share
 		return nil, err
 	}
 
-	if err := dav.MkdirAll(destination, 0755); err != nil {
+	if err := dav.MkdirAll(share.Destination, 0755); err != nil {
 		return nil, err
 	}
 
@@ -395,7 +395,7 @@ func (m *mgr) ProcessEmbeddedShare(ctx context.Context, user *userpb.User, share
 		}
 
 		log.Debug().
-			Str("dest_path", destination).
+			Str("dest_path", share.Destination).
 			Int("entities", len(c.Graph)).
 			Msg("Processing embedded share payload")
 
@@ -421,7 +421,7 @@ func (m *mgr) ProcessEmbeddedShare(ctx context.Context, user *userpb.User, share
 				continue
 			}
 
-			remotePath := path.Join(destination, name)
+			remotePath := path.Join(share.Destination, name)
 
 			size := int64(-1)
 			if e.ContentSize != "" {


### PR DESCRIPTION
PR for using the destination string instead of hijacking the opaque field in the UpdateOCMShareRequest