### PR TITLE
feat: add ACL support for container-specific permissions

### DIFF
--- a/pkg/storage/utils/grants/grants.go
+++ b/pkg/storage/utils/grants/grants.go
@@ -59,6 +59,18 @@ func GetACLPerm(set *provider.ResourcePermissions) (string, error) {
 		b.WriteString("!d")
 	}
 
+	if set.DeleteContainer {
+		b.WriteString("+dc")
+	} else {
+		b.WriteString("!dc")
+	}
+
+	if set.MoveContainer {
+		b.WriteString("+mc")
+	} else {
+		b.WriteString("!mc")
+	}
+
 	return b.String(), nil
 }
 
@@ -96,6 +108,16 @@ func GetGrantPermissionSet(perm string) *provider.ResourcePermissions {
 		rp.Delete = false
 		rp.PurgeRecycle = false
 	}
+
+	if strings.Contains(perm, "+dc") {
+		rp.DeleteContainer = true
+	}
+	// !dc is the default (false), no action needed
+
+	if strings.Contains(perm, "+mc") {
+		rp.MoveContainer = true
+	}
+	// !mc is the default (false), no action needed
 
 	if strings.Contains(perm, "m") && !strings.Contains(perm, "!m") {
 		rp.AddGrant = true


### PR DESCRIPTION
## Summary

Extend the grants ACL encoding/decoding to support the new `delete_container` and `move_container` permission fields proposed in cs3org/cs3apis#272.

### Changes

- `pkg/storage/utils/grants/grants.go`: Add ACL flags `+dc`/`!dc` (delete_container) and `+mc`/`!mc` (move_container) to the ACL string representation
- Parsing: Decode `+dc` and `+mc` back to the corresponding `ResourcePermissions` fields

## Motivation

This enables storage backends to distinguish between file and container (directory) delete/move operations, supporting DMS use cases like file plan (Aktenplan) structure protection.

With these ACL flags, a role can be configured that allows:
- Deleting files: yes
- Deleting directories: no
- Renaming files: yes  
- Renaming directories: no

## Depends on

- cs3org/cs3apis#272 (container-specific permissions and immutable flag)

## Test plan

- [ ] Verify `GetACLPerm` encodes `+dc`/`!dc` and `+mc`/`!mc` correctly
- [ ] Verify `GetGrantPermissionSet` decodes `+dc` and `+mc` correctly
- [ ] Verify backward compatibility: existing ACL strings without `dc`/`mc` default to `false`