### PR TITLE
Parse zenodo crate

### DIFF
--- a/changelog/unreleased/zenodo-support.md
+++ b/changelog/unreleased/zenodo-support.md
@@ -1,0 +1,5 @@
+Enhancement: support for zenodo json-ld wrapped ro-crates
+
+Adds support for OCM embedded shares whose payload is an RO-Crate wrapping the Zenodo JSON-LD format (the plain RO-Crate is also supported)
+
+https://github.com/cs3org/reva/pull/5629

--- a/internal/grpc/services/ocmshareprovider/ocmshareprovider.go
+++ b/internal/grpc/services/ocmshareprovider/ocmshareprovider.go
@@ -41,6 +41,7 @@ import (
 
 	"github.com/cs3org/reva/v3/pkg/appctx"
 	"github.com/cs3org/reva/v3/pkg/errtypes"
+	"github.com/cs3org/reva/v3/pkg/ocm/embedded"
 	"github.com/cs3org/reva/v3/pkg/ocm/share"
 	"github.com/cs3org/reva/v3/pkg/ocm/share/repository/registry"
 	"github.com/cs3org/reva/v3/pkg/plugin"
@@ -62,31 +63,42 @@ func init() {
 		utils.Cast(newFunc, &f)
 		registry.Register(name, f)
 	})
+	plugin.RegisterNamespace("grpc.services.ocmshareprovider.embedded_drivers", func(name string, newFunc any) {
+		var f embedded.NewFunc
+		utils.Cast(newFunc, &f)
+		embedded.Register(name, f)
+	})
 }
 
 type config struct {
-	Driver         string                    `mapstructure:"driver"`
-	Drivers        map[string]map[string]any `mapstructure:"drivers"`
-	ClientTimeout  int                       `mapstructure:"client_timeout"`
-	ClientInsecure bool                      `mapstructure:"client_insecure"`
-	GatewaySVC     string                    `mapstructure:"gatewaysvc"                                    validate:"required"`
-	ProviderDomain string                    `docs:"The same domain registered in the provider authorizer" mapstructure:"provider_domain" validate:"required"`
-	WebDAVEndpoint string                    `mapstructure:"webdav_endpoint"                               validate:"required"`
-	WebappTemplate string                    `mapstructure:"webapp_template"                               validate:"required"`
+	Driver          string                    `mapstructure:"driver"`
+	Drivers         map[string]map[string]any `mapstructure:"drivers"`
+	EmbeddedDriver  string                    `mapstructure:"embedded_driver"`
+	EmbeddedDrivers map[string]map[string]any `mapstructure:"embedded_drivers"`
+	ClientTimeout   int                       `mapstructure:"client_timeout"`
+	ClientInsecure  bool                      `mapstructure:"client_insecure"`
+	GatewaySVC      string                    `mapstructure:"gatewaysvc"                                    validate:"required"`
+	ProviderDomain  string                    `docs:"The same domain registered in the provider authorizer" mapstructure:"provider_domain" validate:"required"`
+	WebDAVEndpoint  string                    `mapstructure:"webdav_endpoint"                               validate:"required"`
+	WebappTemplate  string                    `mapstructure:"webapp_template"                               validate:"required"`
 }
 
 type service struct {
-	conf       *config
-	repo       share.Repository
-	client     *ocmd.OCMClient
-	gateway    gateway.GatewayAPIClient
-	webappTmpl *template.Template
-	walker     walker.Walker
+	conf        *config
+	repo        share.Repository
+	client      *ocmd.OCMClient
+	gateway     gateway.GatewayAPIClient
+	webappTmpl  *template.Template
+	walker      walker.Walker
+	transferrer embedded.Transferrer
 }
 
 func (c *config) ApplyDefaults() {
 	if c.Driver == "" {
 		c.Driver = "json"
+	}
+	if c.EmbeddedDriver == "" {
+		c.EmbeddedDriver = "webdav"
 	}
 	if c.ClientTimeout == 0 {
 		c.ClientTimeout = 10
@@ -106,6 +118,13 @@ func getShareRepository(ctx context.Context, c *config) (share.Repository, error
 	return nil, errtypes.NotFound("driver not found: " + c.Driver)
 }
 
+func getEmbeddedTransferrer(ctx context.Context, c *config) (embedded.Transferrer, error) {
+	if f, ok := embedded.NewFuncs[c.EmbeddedDriver]; ok {
+		return f(ctx, c.EmbeddedDrivers[c.EmbeddedDriver])
+	}
+	return nil, errtypes.NotFound("embedded driver not found: " + c.EmbeddedDriver)
+}
+
 // New creates a new ocm share provider svc.
 func New(ctx context.Context, m map[string]any) (rgrpc.Service, error) {
 	var c config
@@ -114,6 +133,11 @@ func New(ctx context.Context, m map[string]any) (rgrpc.Service, error) {
 	}
 
 	repo, err := getShareRepository(ctx, &c)
+	if err != nil {
+		return nil, err
+	}
+
+	transferrer, err := getEmbeddedTransferrer(ctx, &c)
 	if err != nil {
 		return nil, err
 	}
@@ -131,12 +155,13 @@ func New(ctx context.Context, m map[string]any) (rgrpc.Service, error) {
 
 	ocmcl := ocmd.NewClient(time.Duration(c.ClientTimeout)*time.Second, c.ClientInsecure)
 	service := &service{
-		conf:       &c,
-		repo:       repo,
-		client:     ocmcl,
-		gateway:    gateway,
-		webappTmpl: tpl,
-		walker:     walker,
+		conf:        &c,
+		repo:        repo,
+		client:      ocmcl,
+		gateway:     gateway,
+		webappTmpl:  tpl,
+		walker:      walker,
+		transferrer: transferrer,
 	}
 
 	return service, nil
@@ -478,15 +503,23 @@ func (s *service) UpdateReceivedOCMShare(ctx context.Context, req *ocm.UpdateRec
 	// This is the state we are setting when processing a share
 	// meaning it should be ACCEPTED in order to trigger the processing.
 	if req.Share.State == ocm.ShareState_SHARE_STATE_ACCEPTED {
-		if _, err := s.repo.ProcessEmbeddedShare(ctx, user, req.Share); err != nil {
+		payload, err := s.repo.GetEmbeddedPayload(ctx, user, req.Share)
+		if err != nil {
 			if errors.Is(err, share.ErrShareNotFound) {
 				return &ocm.UpdateReceivedOCMShareResponse{
 					Status: status.NewNotFound(ctx, "share does not exist"),
 				}, nil
 			}
 			return &ocm.UpdateReceivedOCMShareResponse{
-				Status: status.NewInternal(ctx, err, "error processing embedded share"),
+				Status: status.NewInternal(ctx, err, "error retrieving embedded share payload"),
 			}, nil
+		}
+		if payload != "" {
+			if err := s.transferrer.Process(ctx, payload, req.Share.Destination); err != nil {
+				return &ocm.UpdateReceivedOCMShareResponse{
+					Status: status.NewInternal(ctx, err, "error processing embedded share"),
+				}, nil
+			}
 		}
 	}
 	_, err := s.repo.UpdateReceivedShare(ctx, user, req.Share, req.UpdateMask)

--- a/internal/http/services/sciencemesh/embedded.go
+++ b/internal/http/services/sciencemesh/embedded.go
@@ -1,4 +1,4 @@
-// Copyright 2018-2025 CERN
+// Copyright 2018-2026 CERN
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/ocm/embedded/crate.go
+++ b/pkg/ocm/embedded/crate.go
@@ -1,0 +1,191 @@
+// Copyright 2018-2026 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package embedded
+
+import (
+	"encoding/json"
+	"net/url"
+	"path"
+	"strconv"
+	"strings"
+
+	"github.com/rs/zerolog"
+)
+
+type crate struct {
+	Graph []crateEntity `json:"@graph"`
+}
+
+type crateEntity struct {
+	ID             string               `json:"@id"`
+	Type           json.RawMessage      `json:"@type"`
+	URL            json.RawMessage      `json:"url"`
+	Name           string               `json:"name"`
+	ContentSize    string               `json:"contentSize"`
+	EncodingFormat string               `json:"encodingFormat"`
+	Description    string               `json:"description"`
+	Distribution   []zenodoDistribution `json:"distribution"`
+}
+
+type zenodoDistribution struct {
+	Type           string `json:"@type"`
+	ContentURL     string `json:"contentUrl"`
+	EncodingFormat string `json:"encodingFormat"`
+}
+
+type transferEntry struct {
+	srcURL         string
+	name           string
+	sizeHint       int64
+	encodingFormat string
+}
+
+type idRef struct {
+	ID string `json:"@id"`
+}
+
+func (e crateEntity) URLString() string {
+	if len(e.URL) == 0 {
+		return ""
+	}
+
+	var s string
+	if err := json.Unmarshal(e.URL, &s); err == nil {
+		return s
+	}
+
+	var ref idRef
+	if err := json.Unmarshal(e.URL, &ref); err == nil {
+		return ref.ID
+	}
+
+	return ""
+}
+
+func (e crateEntity) HasType(want string) bool {
+	if len(e.Type) == 0 {
+		return false
+	}
+
+	var single string
+	if err := json.Unmarshal(e.Type, &single); err == nil {
+		return single == want
+	}
+
+	var many []string
+	if err := json.Unmarshal(e.Type, &many); err == nil {
+		for _, t := range many {
+			if t == want {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func (e crateEntity) IsTransferable() bool {
+	if e.URLString() == "" {
+		return false
+	}
+
+	return e.HasType("File") || e.HasType("ComputationalWorkflow") || e.HasType("SoftwareSourceCode")
+}
+
+// crateEntries collects every transferable file from the RO-Crate @graph: both
+// plain entities (a File with a direct url) and Zenodo Datasets (whose
+// distribution[] holds DataDownload entries with a contentUrl).
+func crateEntries(log *zerolog.Logger, graph []crateEntity) []transferEntry {
+	var entries []transferEntry
+	for _, e := range graph {
+		if e.IsTransferable() {
+			if entry, ok := plainEntry(log, e); ok {
+				entries = append(entries, entry)
+			}
+		}
+		for _, d := range e.Distribution {
+			if entry, ok := zenodoEntry(log, d); ok {
+				entries = append(entries, entry)
+			}
+		}
+	}
+	return entries
+}
+
+func plainEntry(log *zerolog.Logger, e crateEntity) (transferEntry, bool) {
+	srcURL := e.URLString()
+	if srcURL == "" {
+		return transferEntry{}, false
+	}
+
+	name := strings.TrimSpace(e.Name)
+	if name == "" {
+		name = path.Base(srcURL)
+	}
+	if name == "" || name == "." || name == "/" {
+		log.Warn().
+			Str("entity_id", e.ID).
+			Str("src", srcURL).
+			Msg("Skipping entity with unusable destination name")
+		return transferEntry{}, false
+	}
+
+	size := int64(-1)
+	if e.ContentSize != "" {
+		if parsed, err := strconv.ParseInt(e.ContentSize, 10, 64); err == nil {
+			size = parsed
+		}
+	}
+
+	return transferEntry{
+		srcURL:         srcURL,
+		name:           name,
+		sizeHint:       size,
+		encodingFormat: e.EncodingFormat,
+	}, true
+}
+
+func zenodoEntry(log *zerolog.Logger, d zenodoDistribution) (transferEntry, bool) {
+	if d.Type != "DataDownload" || d.ContentURL == "" {
+		return transferEntry{}, false
+	}
+
+	name := zenodoFilename(d.ContentURL)
+	if name == "" || name == "." || name == "/" {
+		log.Warn().
+			Str("src", d.ContentURL).
+			Msg("Skipping Zenodo distribution with unusable destination name")
+		return transferEntry{}, false
+	}
+
+	return transferEntry{
+		srcURL:         d.ContentURL,
+		name:           name,
+		sizeHint:       -1,
+		encodingFormat: d.EncodingFormat,
+	}, true
+}
+
+func zenodoFilename(rawURL string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil || u.Path == "" {
+		return path.Base(rawURL)
+	}
+	return path.Base(strings.TrimSuffix(u.Path, "/content"))
+}

--- a/pkg/ocm/embedded/embedded.go
+++ b/pkg/ocm/embedded/embedded.go
@@ -1,0 +1,361 @@
+// Copyright 2018-2026 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+// Package embedded transfers the contents of an OCM embedded share (an RO-Crate
+// JSON payload listing plain or Zenodo files) to a WebDAV destination,
+// streaming each referenced file in the background.
+package embedded
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"path"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/cs3org/reva/v3/pkg/appctx"
+	"github.com/cs3org/reva/v3/pkg/utils/cfg"
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog"
+	"github.com/studio-b12/gowebdav"
+)
+
+// Config holds the settings for transferring embedded share payloads.
+type Config struct {
+	// WebDAVURL is the destination WebDAV endpoint files are uploaded to.
+	WebDAVURL string `mapstructure:"webdav_url"`
+	// Timeout is the per-file ceiling, in seconds.
+	Timeout int `mapstructure:"embedded_transfer_timeout"`
+	// IdleTimeout, in seconds, aborts a file attempt if no bytes flow for that long.
+	IdleTimeout int `mapstructure:"embedded_transfer_idle_timeout"`
+	// Retries is the number of attempts per file (1 = no retry).
+	Retries int `mapstructure:"embedded_transfer_retries"`
+}
+
+// ApplyDefaults fills in sensible defaults for any unset setting.
+func (c *Config) ApplyDefaults() {
+	if c.Timeout <= 0 {
+		c.Timeout = 3600
+	}
+	if c.IdleTimeout <= 0 {
+		c.IdleTimeout = 120
+	}
+	if c.Retries <= 0 {
+		c.Retries = 3
+	}
+}
+
+// Transferrer processes an embedded share payload, transferring its referenced
+// files to a destination. Drivers register an implementation via Register.
+type Transferrer interface {
+	Process(ctx context.Context, payload, destination string) error
+}
+
+// NewFunc builds a Transferrer from its driver configuration.
+type NewFunc func(ctx context.Context, m map[string]any) (Transferrer, error)
+
+// NewFuncs holds the registered embedded-transfer drivers.
+var NewFuncs = map[string]NewFunc{}
+
+// Register adds an embedded-transfer driver. Safe for use from package init.
+func Register(name string, f NewFunc) {
+	NewFuncs[name] = f
+}
+
+func init() {
+	Register("webdav", New)
+}
+
+// driver is the built-in Transferrer: it downloads each file over HTTP and
+// streams it to the configured WebDAV endpoint.
+type driver struct {
+	c Config
+}
+
+// New builds the built-in WebDAV embedded-transfer driver.
+func New(ctx context.Context, m map[string]any) (Transferrer, error) {
+	var c Config
+	if err := cfg.Decode(m, &c); err != nil {
+		return nil, err
+	}
+	return &driver{c: c}, nil
+}
+
+// embeddedRetryBaseBackoff is the base per-file retry delay; it grows exponentially.
+const embeddedRetryBaseBackoff = 2 * time.Second
+
+// Process parses the RO-Crate payload and streams its files to destination in the
+// background, using the bearer token from ctx for WebDAV auth. It errors only on a
+// malformed payload.
+func (d *driver) Process(ctx context.Context, payload, destination string) error {
+	log := appctx.GetLogger(ctx)
+
+	var c crate
+	if err := json.Unmarshal([]byte(payload), &c); err != nil {
+		return fmt.Errorf("unmarshal embedded payload: %w", err)
+	}
+
+	entries := crateEntries(log, c.Graph)
+	if len(entries) == 0 {
+		log.Debug().Str("destination", destination).Msg("embedded transfer: no transferable entries in payload")
+		return nil
+	}
+
+	// Run detached so a large transfer doesn't block the accept request. The
+	// captured token may expire mid-transfer, failing later files (best-effort).
+	token := appctx.ContextMustGetToken(ctx)
+	timeout := time.Duration(d.c.Timeout) * time.Second
+	go d.transferEntries(log, token, destination, entries, timeout)
+
+	return nil
+}
+
+// transferEntries streams each entry to the WebDAV destination. A file that keeps
+// failing is skipped so one bad file doesn't abort the whole dataset.
+func (d *driver) transferEntries(log *zerolog.Logger, token, destination string, entries []transferEntry, timeout time.Duration) {
+	httpClient := &http.Client{}
+	// Preemptive auth, not gowebdav's default auto-auth: auto-auth buffers each
+	// upload body in memory to replay on an auth challenge, blowing up RAM on
+	// multi-GB files. We pass the bearer token via the interceptor below.
+	dav := gowebdav.NewAuthClient(d.c.WebDAVURL, gowebdav.NewPreemptiveAuth(&gowebdav.BasicAuth{}))
+	dav.SetTimeout(timeout)
+	dav.SetInterceptor(func(method string, rq *http.Request) {
+		rq.Header.Set("Authorization", "Bearer "+token)
+		if method == http.MethodPut {
+			rq.Header.Set("Content-Type", "application/octet-stream")
+		}
+	})
+
+	if err := dav.Connect(); err != nil {
+		log.Error().Err(err).Msg("embedded transfer: failed to connect to WebDAV")
+		return
+	}
+
+	if err := dav.MkdirAll(destination, 0755); err != nil {
+		log.Error().Err(err).Str("destination", destination).Msg("embedded transfer: failed to create destination directory")
+		return
+	}
+
+	idleTimeout := time.Duration(d.c.IdleTimeout) * time.Second
+
+	log.Debug().
+		Str("dest_path", destination).
+		Int("entries", len(entries)).
+		Msg("Starting embedded share transfer")
+
+	var transferred, failed int
+	for _, e := range entries {
+		remotePath := path.Join(destination, e.name)
+
+		log.Debug().
+			Str("src", e.srcURL).
+			Str("remote", remotePath).
+			Int64("size_hint", e.sizeHint).
+			Str("encoding_format", e.encodingFormat).
+			Msg("Streaming embedded file to WebDAV")
+
+		if err := d.uploadEntryWithRetry(log, httpClient, dav, e, remotePath, timeout, idleTimeout); err != nil {
+			failed++
+			log.Error().Err(err).
+				Str("src", e.srcURL).
+				Str("remote", remotePath).
+				Msg("embedded transfer: skipping file after exhausting retries")
+			continue
+		}
+		transferred++
+	}
+
+	log.Info().
+		Str("destination", destination).
+		Int("transferred", transferred).
+		Int("failed", failed).
+		Int("total", len(entries)).
+		Msg("Finished embedded share transfer")
+}
+
+// uploadEntryWithRetry transfers one entry, retrying up to Retries times with
+// exponential backoff. It returns the last error if all attempts fail.
+func (d *driver) uploadEntryWithRetry(log *zerolog.Logger, httpClient *http.Client, dav *gowebdav.Client, e transferEntry, remotePath string, timeout, idleTimeout time.Duration) error {
+	var err error
+	for attempt := 1; attempt <= d.c.Retries; attempt++ {
+		fileCtx, cancel := context.WithTimeout(context.Background(), timeout)
+		err = uploadURLToWebDAV(fileCtx, log, httpClient, dav, e.srcURL, remotePath, e.sizeHint, idleTimeout)
+		cancel()
+		if err == nil {
+			return nil
+		}
+
+		if attempt < d.c.Retries {
+			backoff := embeddedRetryBaseBackoff << (attempt - 1)
+			// Honor a server-requested delay (e.g. HTTP 429 Retry-After).
+			var re *retryableError
+			if errors.As(err, &re) && re.retryAfter > backoff {
+				backoff = re.retryAfter
+			}
+			log.Warn().Err(err).
+				Str("src", e.srcURL).
+				Str("remote", remotePath).
+				Int("attempt", attempt).
+				Dur("backoff", backoff).
+				Msg("embedded transfer: file failed, retrying")
+			time.Sleep(backoff)
+		}
+	}
+	return err
+}
+
+func uploadURLToWebDAV(ctx context.Context, log *zerolog.Logger, httpClient *http.Client, dav *gowebdav.Client, srcURL, remotePath string, sizeHint int64, idleTimeout time.Duration) error {
+	reqCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, srcURL, nil)
+	if err != nil {
+		return err
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	// Never write a non-2xx body to the destination (e.g. Zenodo's JSON error
+	// for 401/403/404/429) as if it were file data.
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		err := fmt.Errorf("GET %s failed: %s: %s", srcURL, resp.Status, string(body))
+		if resp.StatusCode == http.StatusTooManyRequests {
+			return &retryableError{err: err, retryAfter: parseRetryAfter(resp.Header.Get("Retry-After"))}
+		}
+		return err
+	}
+
+	log.Debug().
+		Str("remote", remotePath).
+		Str("content_type", resp.Header.Get("Content-Type")).
+		Str("content_disposition", resp.Header.Get("Content-Disposition")).
+		Int64("content_length", resp.ContentLength).
+		Msg("Embedded transfer: download response")
+
+	pr := newProgressReader(resp.Body)
+	stop := make(chan struct{})
+	defer close(stop)
+	go monitorTransfer(log, pr, remotePath, idleTimeout, cancel, stop)
+
+	// A known length lets net/http enforce it and surface a truncated download
+	// as an error (retried) instead of storing a short file.
+	length := sizeHint
+	if length < 0 {
+		length = resp.ContentLength
+	}
+	if length >= 0 {
+		return dav.WriteStreamWithLength(remotePath, pr, length, 0644)
+	}
+	return dav.WriteStream(remotePath, pr, 0644)
+}
+
+// progressReader counts bytes read and timestamps the last non-empty read, so the
+// watchdog can log throughput and detect a stall. Safe for concurrent use.
+type progressReader struct {
+	r        io.Reader
+	total    atomic.Int64
+	lastData atomic.Int64 // unix nanos of the last read that returned data
+}
+
+func newProgressReader(r io.Reader) *progressReader {
+	pr := &progressReader{r: r}
+	pr.lastData.Store(time.Now().UnixNano())
+	return pr
+}
+
+func (pr *progressReader) Read(p []byte) (int, error) {
+	n, err := pr.r.Read(p)
+	if n > 0 {
+		pr.total.Add(int64(n))
+		pr.lastData.Store(time.Now().UnixNano())
+	}
+	return n, err
+}
+
+// monitorTransfer periodically logs transfer progress and aborts the transfer
+// (via cancel) if no data has flowed for idleTimeout. It exits when stop closes.
+func monitorTransfer(log *zerolog.Logger, pr *progressReader, remotePath string, idleTimeout time.Duration, cancel context.CancelFunc, stop <-chan struct{}) {
+	const interval = 15 * time.Second
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	var lastTotal int64
+	for {
+		select {
+		case <-stop:
+			return
+		case <-ticker.C:
+			total := pr.total.Load()
+			rate := float64(total-lastTotal) / interval.Seconds() / (1024 * 1024)
+			lastTotal = total
+			idle := time.Since(time.Unix(0, pr.lastData.Load()))
+
+			log.Debug().
+				Str("remote", remotePath).
+				Int64("bytes", total).
+				Float64("mb_per_s", rate).
+				Msg("Embedded transfer progress")
+
+			if idle > idleTimeout {
+				log.Warn().
+					Str("remote", remotePath).
+					Dur("idle", idle).
+					Msg("embedded transfer: no data received, aborting attempt (will retry)")
+				cancel()
+				return
+			}
+		}
+	}
+}
+
+// retryableError wraps an error whose operation should be retried, optionally
+// after a server-suggested delay (e.g. from an HTTP 429 Retry-After header).
+type retryableError struct {
+	err        error
+	retryAfter time.Duration
+}
+
+func (e *retryableError) Error() string { return e.err.Error() }
+func (e *retryableError) Unwrap() error { return e.err }
+
+// parseRetryAfter interprets an HTTP Retry-After header, which may be either a
+// number of seconds or an HTTP date. Returns 0 if absent or unparseable.
+func parseRetryAfter(h string) time.Duration {
+	if h == "" {
+		return 0
+	}
+	if secs, err := strconv.Atoi(strings.TrimSpace(h)); err == nil && secs > 0 {
+		return time.Duration(secs) * time.Second
+	}
+	if t, err := http.ParseTime(h); err == nil {
+		if d := time.Until(t); d > 0 {
+			return d
+		}
+	}
+	return 0
+}

--- a/pkg/ocm/embedded/embedded_test.go
+++ b/pkg/ocm/embedded/embedded_test.go
@@ -1,0 +1,345 @@
+// Copyright 2018-2026 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package embedded
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+func testLogger() *zerolog.Logger {
+	l := zerolog.Nop()
+	return &l
+}
+
+func parseGraph(t *testing.T, payload string) []crateEntity {
+	t.Helper()
+	var c crate
+	if err := json.Unmarshal([]byte(payload), &c); err != nil {
+		t.Fatalf("failed to unmarshal payload: %v", err)
+	}
+	return c.Graph
+}
+
+func TestConfigApplyDefaults(t *testing.T) {
+	t.Run("empty config gets defaults", func(t *testing.T) {
+		c := Config{}
+		c.ApplyDefaults()
+		if c.Timeout != 3600 {
+			t.Errorf("Timeout = %d, want 3600", c.Timeout)
+		}
+		if c.IdleTimeout != 120 {
+			t.Errorf("IdleTimeout = %d, want 120", c.IdleTimeout)
+		}
+		if c.Retries != 3 {
+			t.Errorf("Retries = %d, want 3", c.Retries)
+		}
+	})
+
+	t.Run("explicit values preserved", func(t *testing.T) {
+		c := Config{WebDAVURL: "https://dav.example.org/", Timeout: 10, IdleTimeout: 5, Retries: 1}
+		c.ApplyDefaults()
+		if c.Timeout != 10 || c.IdleTimeout != 5 || c.Retries != 1 {
+			t.Errorf("explicit values were overwritten: %+v", c)
+		}
+		if c.WebDAVURL != "https://dav.example.org/" {
+			t.Errorf("WebDAVURL = %q, want preserved", c.WebDAVURL)
+		}
+	})
+}
+
+func TestNewAppliesDefaults(t *testing.T) {
+	tr, err := New(context.Background(), map[string]any{"webdav_url": "https://dav.example.org/"})
+	if err != nil {
+		t.Fatalf("New: unexpected error %v", err)
+	}
+	d := tr.(*driver)
+	if d.c.Timeout != 3600 || d.c.IdleTimeout != 120 || d.c.Retries != 3 {
+		t.Errorf("New did not apply defaults: %+v", d.c)
+	}
+}
+
+func TestParseRetryAfter(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want time.Duration
+	}{
+		{"empty", "", 0},
+		{"seconds", "120", 120 * time.Second},
+		{"zero seconds", "0", 0},
+		{"negative seconds", "-5", 0},
+		{"garbage", "abc", 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := parseRetryAfter(tt.in); got != tt.want {
+				t.Errorf("parseRetryAfter(%q) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+
+	t.Run("future http date", func(t *testing.T) {
+		h := time.Now().Add(time.Hour).UTC().Format(http.TimeFormat)
+		got := parseRetryAfter(h)
+		if got <= 0 || got > time.Hour {
+			t.Errorf("parseRetryAfter(%q) = %v, want in (0, 1h]", h, got)
+		}
+	})
+
+	t.Run("past http date", func(t *testing.T) {
+		h := time.Now().Add(-time.Hour).UTC().Format(http.TimeFormat)
+		if got := parseRetryAfter(h); got != 0 {
+			t.Errorf("parseRetryAfter(past) = %v, want 0", got)
+		}
+	})
+}
+
+func TestZenodoFilename(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"https://zenodo.org/records/1/files/data.csv/content", "data.csv"},
+		{"https://example.org/path/file.bin", "file.bin"},
+		{"https://example.org/file.txt/content", "file.txt"},
+		{"plainname", "plainname"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			if got := zenodoFilename(tt.in); got != tt.want {
+				t.Errorf("zenodoFilename(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCrateEntityURLString(t *testing.T) {
+	tests := []struct {
+		name string
+		obj  string
+		want string
+	}{
+		{"string url", `{"url":"https://x/y.txt"}`, "https://x/y.txt"},
+		{"id object url", `{"url":{"@id":"https://x/z.bin"}}`, "https://x/z.bin"},
+		{"absent url", `{"name":"foo"}`, ""},
+		{"numeric url", `{"url":123}`, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var e crateEntity
+			if err := json.Unmarshal([]byte(tt.obj), &e); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if got := e.URLString(); got != tt.want {
+				t.Errorf("URLString() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCrateEntityHasType(t *testing.T) {
+	tests := []struct {
+		name    string
+		obj     string
+		want    string
+		hasType bool
+	}{
+		{"single match", `{"@type":"File"}`, "File", true},
+		{"single no match", `{"@type":"Dataset"}`, "File", false},
+		{"array match", `{"@type":["Dataset","File"]}`, "File", true},
+		{"array no match", `{"@type":["Dataset","Image"]}`, "File", false},
+		{"absent", `{"name":"x"}`, "File", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var e crateEntity
+			if err := json.Unmarshal([]byte(tt.obj), &e); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if got := e.HasType(tt.want); got != tt.hasType {
+				t.Errorf("HasType(%q) = %v, want %v", tt.want, got, tt.hasType)
+			}
+		})
+	}
+}
+
+func TestCrateEntityIsTransferable(t *testing.T) {
+	tests := []struct {
+		name string
+		obj  string
+		want bool
+	}{
+		{"file with url", `{"@type":"File","url":"https://x/y"}`, true},
+		{"workflow with url", `{"@type":"ComputationalWorkflow","url":"https://x/y"}`, true},
+		{"file without url", `{"@type":"File"}`, false},
+		{"dataset with url", `{"@type":"Dataset","url":"https://x/y"}`, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var e crateEntity
+			if err := json.Unmarshal([]byte(tt.obj), &e); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if got := e.IsTransferable(); got != tt.want {
+				t.Errorf("IsTransferable() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCrateEntries(t *testing.T) {
+	log := testLogger()
+
+	tests := []struct {
+		name    string
+		payload string
+		want    []transferEntry
+	}{
+		{
+			name: "plain file with explicit name and size",
+			payload: `{"@graph":[
+				{"@id":"f1","@type":"File","url":"https://src.example.org/f1.txt","name":"f1.txt","contentSize":"1234","encodingFormat":"text/plain"}
+			]}`,
+			want: []transferEntry{
+				{srcURL: "https://src.example.org/f1.txt", name: "f1.txt", sizeHint: 1234, encodingFormat: "text/plain"},
+			},
+		},
+		{
+			name: "plain id-object url, name derived from path, unknown size",
+			payload: `{"@graph":[
+				{"@id":"f2","@type":["File","Thing"],"url":{"@id":"https://src.example.org/path/f2.bin"}}
+			]}`,
+			want: []transferEntry{
+				{srcURL: "https://src.example.org/path/f2.bin", name: "f2.bin", sizeHint: -1, encodingFormat: ""},
+			},
+		},
+		{
+			name: "zenodo dataset distributions",
+			payload: `{"@graph":[
+				{"@id":"ds","@type":"Dataset","distribution":[
+					{"@type":"DataDownload","contentUrl":"https://zenodo.org/records/1/files/data.csv/content","encodingFormat":"text/csv"},
+					{"@type":"DataDownload","contentUrl":"https://zenodo.org/records/1/files/img.png/content"}
+				]}
+			]}`,
+			want: []transferEntry{
+				{srcURL: "https://zenodo.org/records/1/files/data.csv/content", name: "data.csv", sizeHint: -1, encodingFormat: "text/csv"},
+				{srcURL: "https://zenodo.org/records/1/files/img.png/content", name: "img.png", sizeHint: -1, encodingFormat: ""},
+			},
+		},
+		{
+			name: "skips non-DataDownload and empty contentUrl distributions",
+			payload: `{"@graph":[
+				{"@id":"ds","@type":"Dataset","distribution":[
+					{"@type":"DataDownload","contentUrl":""},
+					{"@type":"WebPage","contentUrl":"https://zenodo.org/records/1"}
+				]}
+			]}`,
+			want: nil,
+		},
+		{
+			name: "skips non-transferable entity without url",
+			payload: `{"@graph":[
+				{"@id":"d","@type":"Dataset","name":"no url here"}
+			]}`,
+			want: nil,
+		},
+		{
+			name: "mixed plain and zenodo, order preserved",
+			payload: `{"@graph":[
+				{"@id":"f1","@type":"File","url":"https://src.example.org/a.txt"},
+				{"@id":"ds","@type":"Dataset","distribution":[
+					{"@type":"DataDownload","contentUrl":"https://zenodo.org/records/1/files/b.csv/content"}
+				]}
+			]}`,
+			want: []transferEntry{
+				{srcURL: "https://src.example.org/a.txt", name: "a.txt", sizeHint: -1, encodingFormat: ""},
+				{srcURL: "https://zenodo.org/records/1/files/b.csv/content", name: "b.csv", sizeHint: -1, encodingFormat: ""},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := crateEntries(log, parseGraph(t, tt.payload))
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("crateEntries() =\n  %+v\nwant\n  %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestProgressReader(t *testing.T) {
+	const data = "hello world"
+	before := time.Now().UnixNano()
+	pr := newProgressReader(strings.NewReader(data))
+
+	buf := make([]byte, 4)
+	var total int64
+	for {
+		n, err := pr.Read(buf)
+		total += int64(n)
+		if err != nil {
+			break
+		}
+	}
+
+	if total != int64(len(data)) {
+		t.Fatalf("read %d bytes, want %d", total, len(data))
+	}
+	if got := pr.total.Load(); got != int64(len(data)) {
+		t.Errorf("pr.total = %d, want %d", got, len(data))
+	}
+	if pr.lastData.Load() < before {
+		t.Errorf("lastData was not updated")
+	}
+}
+
+func newTestTransferrer(t *testing.T) Transferrer {
+	t.Helper()
+	tr, err := New(context.Background(), map[string]any{"webdav_url": "https://dav.example.org/"})
+	if err != nil {
+		t.Fatalf("New: unexpected error %v", err)
+	}
+	return tr
+}
+
+func TestProcessMalformedPayload(t *testing.T) {
+	tr := newTestTransferrer(t)
+	if err := tr.Process(context.Background(), "{not valid json", "/dest"); err == nil {
+		t.Error("Process with malformed payload: expected error, got nil")
+	}
+}
+
+func TestProcessNoTransferableEntries(t *testing.T) {
+	tr := newTestTransferrer(t)
+	// A valid payload with nothing transferable must be a no-op: it returns nil
+	// and does not require a token (no background transfer is started).
+	payload := `{"@graph":[{"@id":"d","@type":"Dataset","name":"nothing to transfer"}]}`
+	if err := tr.Process(context.Background(), payload, "/dest"); err != nil {
+		t.Errorf("Process with no transferable entries: unexpected error %v", err)
+	}
+}

--- a/pkg/ocm/share/repository/json/json.go
+++ b/pkg/ocm/share/repository/json/json.go
@@ -624,6 +624,6 @@ func (m *mgr) UpdateReceivedShare(ctx context.Context, user *userpb.User, share 
 	return rs, nil
 }
 
-func (m *mgr) ProcessEmbeddedShare(ctx context.Context, user *userpb.User, share *ocm.ReceivedShare) (*ocm.ReceivedShare, error) {
-	return nil, errtypes.NotSupported("processing embedded shares is not supported")
+func (m *mgr) GetEmbeddedPayload(ctx context.Context, user *userpb.User, share *ocm.ReceivedShare) (string, error) {
+	return "", errtypes.NotSupported("operation not supported")
 }

--- a/pkg/ocm/share/repository/nextcloud/nextcloud.go
+++ b/pkg/ocm/share/repository/nextcloud/nextcloud.go
@@ -483,6 +483,6 @@ func (sm *Manager) do(ctx context.Context, a Action, username string) (int, []by
 	return resp.StatusCode, body, nil
 }
 
-func (sm *Manager) ProcessEmbeddedShare(ctx context.Context, user *userpb.User, share *ocm.ReceivedShare) (*ocm.ReceivedShare, error) {
-	return nil, errtypes.NotSupported("processing embedded shares is not supported")
+func (sm *Manager) GetEmbeddedPayload(ctx context.Context, user *userpb.User, share *ocm.ReceivedShare) (string, error) {
+	return "", errtypes.NotSupported("operation not supported")
 }

--- a/pkg/ocm/share/share.go
+++ b/pkg/ocm/share/share.go
@@ -58,8 +58,11 @@ type Repository interface {
 	// UpdateReceivedShare updates the received share with share state.
 	UpdateReceivedShare(ctx context.Context, user *userpb.User, share *ocm.ReceivedShare, fieldMask *field_mask.FieldMask) (*ocm.ReceivedShare, error)
 
-	// Process the embedded share with the given state.
-	ProcessEmbeddedShare(ctx context.Context, user *userpb.User, share *ocm.ReceivedShare) (*ocm.ReceivedShare, error)
+	// GetEmbeddedPayload returns the RO-Crate JSON payload carried by the embedded
+	// protocol of a received share, or an empty string if the share carries no
+	// embedded protocol. It is used to drive the background transfer of embedded
+	// share contents.
+	GetEmbeddedPayload(ctx context.Context, user *userpb.User, share *ocm.ReceivedShare) (string, error)
 }
 
 // ResourceIDFilter is an abstraction for creating filter by resource id.

--- a/pkg/share/manager/sql/common.go
+++ b/pkg/share/manager/sql/common.go
@@ -21,13 +21,9 @@ const (
 )
 
 type Config struct {
-	config.Database         `mapstructure:",squash"`
-	GatewaySvc              string `mapstructure:"gatewaysvc"`
-	LinkPasswordHashCost    int    `mapstructure:"password_hash_cost"`
-	WebDAVURL                   string `mapstructure:"webdav_url"`
-	EmbeddedTransferTimeout     int    `mapstructure:"embedded_transfer_timeout"`
-	EmbeddedTransferIdleTimeout int    `mapstructure:"embedded_transfer_idle_timeout"`
-	EmbeddedTransferRetries     int    `mapstructure:"embedded_transfer_retries"`
+	config.Database      `mapstructure:",squash"`
+	GatewaySvc           string `mapstructure:"gatewaysvc"`
+	LinkPasswordHashCost int    `mapstructure:"password_hash_cost"`
 }
 
 func init() {
@@ -43,26 +39,6 @@ func (c *Config) ApplyDefaults() {
 	// which should be at least 11
 	if c.LinkPasswordHashCost < 11 {
 		c.LinkPasswordHashCost = 11
-	}
-
-	// Absolute per-file ceiling (in seconds) for background transfers of
-	// embedded share payloads. A generous upper bound; the idle timeout below
-	// is what catches stalls quickly.
-	if c.EmbeddedTransferTimeout <= 0 {
-		c.EmbeddedTransferTimeout = 3600
-	}
-
-	// Stall timeout (in seconds): if no bytes flow for this long during a
-	// file transfer, the attempt is aborted (and then retried). Catches a
-	// stalled connection in minutes instead of waiting for the ceiling above.
-	if c.EmbeddedTransferIdleTimeout <= 0 {
-		c.EmbeddedTransferIdleTimeout = 120
-	}
-
-	// Number of attempts per file (1 = no retry) when transferring embedded
-	// share payloads, to ride out transient download/upload failures.
-	if c.EmbeddedTransferRetries <= 0 {
-		c.EmbeddedTransferRetries = 3
 	}
 }
 

--- a/pkg/share/manager/sql/common.go
+++ b/pkg/share/manager/sql/common.go
@@ -21,10 +21,13 @@ const (
 )
 
 type Config struct {
-	config.Database      `mapstructure:",squash"`
-	GatewaySvc           string `mapstructure:"gatewaysvc"`
-	LinkPasswordHashCost int    `mapstructure:"password_hash_cost"`
-	WebDAVURL            string `mapstructure:"webdav_url"`
+	config.Database         `mapstructure:",squash"`
+	GatewaySvc              string `mapstructure:"gatewaysvc"`
+	LinkPasswordHashCost    int    `mapstructure:"password_hash_cost"`
+	WebDAVURL                   string `mapstructure:"webdav_url"`
+	EmbeddedTransferTimeout     int    `mapstructure:"embedded_transfer_timeout"`
+	EmbeddedTransferIdleTimeout int    `mapstructure:"embedded_transfer_idle_timeout"`
+	EmbeddedTransferRetries     int    `mapstructure:"embedded_transfer_retries"`
 }
 
 func init() {
@@ -42,6 +45,25 @@ func (c *Config) ApplyDefaults() {
 		c.LinkPasswordHashCost = 11
 	}
 
+	// Absolute per-file ceiling (in seconds) for background transfers of
+	// embedded share payloads. A generous upper bound; the idle timeout below
+	// is what catches stalls quickly.
+	if c.EmbeddedTransferTimeout <= 0 {
+		c.EmbeddedTransferTimeout = 3600
+	}
+
+	// Stall timeout (in seconds): if no bytes flow for this long during a
+	// file transfer, the attempt is aborted (and then retried). Catches a
+	// stalled connection in minutes instead of waiting for the ceiling above.
+	if c.EmbeddedTransferIdleTimeout <= 0 {
+		c.EmbeddedTransferIdleTimeout = 120
+	}
+
+	// Number of attempts per file (1 = no retry) when transferring embedded
+	// share payloads, to ride out transient download/upload failures.
+	if c.EmbeddedTransferRetries <= 0 {
+		c.EmbeddedTransferRetries = 3
+	}
 }
 
 func getDb(c Config) (*gorm.DB, error) {

--- a/pkg/share/manager/sql/conversions.go
+++ b/pkg/share/manager/sql/conversions.go
@@ -1,4 +1,4 @@
-// Copyright 2018-2025 CERN
+// Copyright 2018-2026 CERN
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/share/manager/sql/model/model.go
+++ b/pkg/share/manager/sql/model/model.go
@@ -1,4 +1,4 @@
-// Copyright 2018-2025 CERN
+// Copyright 2018-2026 CERN
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -198,9 +198,9 @@ type OcmShare struct {
 // OcmShareProtocol represents the protocol used to serve an OCM share, named AccessMethod in the OCM CS3 APIs.
 type OcmShareProtocol struct {
 	gorm.Model
-	OcmShareID  uint          `gorm:"not null;uniqueIndex:u_ocm_share_protocol"`
-	Type        OcmProtocol   `gorm:"not null;uniqueIndex:u_ocm_share_protocol"`
-	Permissions int           `gorm:"default:null"`
+	OcmShareID   uint           `gorm:"not null;uniqueIndex:u_ocm_share_protocol"`
+	Type         OcmProtocol    `gorm:"not null;uniqueIndex:u_ocm_share_protocol"`
+	Permissions  int            `gorm:"default:null"`
 	AccessTypes  OcmAccessType  `gorm:"default:null"`
 	Requirements datatypes.JSON `gorm:"type:json;default:null"`
 }
@@ -329,7 +329,6 @@ func (p *PublicLink) AsCS3PublicShare() *link.PublicShare {
 		NotifyUploadsExtraRecipients: p.NotifyUploadsExtraRecipients,
 	}
 }
-
 
 func defaultLinkDisplayName(displayName string, quickLink bool) string {
 	if displayName != "" {

--- a/pkg/share/manager/sql/ocm_shares.go
+++ b/pkg/share/manager/sql/ocm_shares.go
@@ -1,4 +1,4 @@
-// Copyright 2018-2025 CERN
+// Copyright 2018-2026 CERN
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,13 +22,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
-	"net/http"
-	"net/url"
-	"path"
 	"strconv"
 	"strings"
-	"sync/atomic"
 	"time"
 
 	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
@@ -41,8 +36,6 @@ import (
 	model "github.com/cs3org/reva/v3/pkg/share/manager/sql/model"
 	"github.com/cs3org/reva/v3/pkg/utils/cfg"
 	"github.com/pkg/errors"
-	"github.com/rs/zerolog"
-	"github.com/studio-b12/gowebdav"
 	"google.golang.org/genproto/protobuf/field_mask"
 	"google.golang.org/protobuf/proto"
 	"gorm.io/datatypes"
@@ -54,38 +47,6 @@ import (
 type mgr struct {
 	c  *Config
 	db *gorm.DB
-}
-
-type crate struct {
-	Graph []crateEntity `json:"@graph"`
-}
-
-type crateEntity struct {
-	ID             string               `json:"@id"`
-	Type           json.RawMessage      `json:"@type"`
-	URL            json.RawMessage      `json:"url"`
-	Name           string               `json:"name"`
-	ContentSize    string               `json:"contentSize"`
-	EncodingFormat string               `json:"encodingFormat"`
-	Description    string               `json:"description"`
-	Distribution   []zenodoDistribution `json:"distribution"`
-}
-
-type zenodoDistribution struct {
-	Type           string `json:"@type"`
-	ContentURL     string `json:"contentUrl"`
-	EncodingFormat string `json:"encodingFormat"`
-}
-
-type transferEntry struct {
-	srcURL         string
-	name           string
-	sizeHint       int64
-	encodingFormat string
-}
-
-type idRef struct {
-	ID string `json:"@id"`
 }
 
 func NewOCMShareManager(ctx context.Context, m map[string]any) (share.Repository, error) {
@@ -286,432 +247,26 @@ func (m *mgr) ListShares(ctx context.Context, user *userpb.User, filters []*ocm.
 	return shares, nil
 }
 
-func (e crateEntity) URLString() string {
-	if len(e.URL) == 0 {
-		return ""
-	}
-
-	var s string
-	if err := json.Unmarshal(e.URL, &s); err == nil {
-		return s
-	}
-
-	var ref idRef
-	if err := json.Unmarshal(e.URL, &ref); err == nil {
-		return ref.ID
-	}
-
-	return ""
-}
-
-func (e crateEntity) HasType(want string) bool {
-	if len(e.Type) == 0 {
-		return false
-	}
-
-	var single string
-	if err := json.Unmarshal(e.Type, &single); err == nil {
-		return single == want
-	}
-
-	var many []string
-	if err := json.Unmarshal(e.Type, &many); err == nil {
-		for _, t := range many {
-			if t == want {
-				return true
-			}
-		}
-	}
-
-	return false
-}
-
-func (e crateEntity) IsTransferable() bool {
-	if e.URLString() == "" {
-		return false
-	}
-
-	return e.HasType("File") || e.HasType("ComputationalWorkflow") || e.HasType("SoftwareSourceCode")
-}
-
-// progressReader wraps a reader to track how many bytes have been read and when
-// the last non-empty read happened, so a watchdog can log throughput and detect
-// a stalled transfer. It is safe for concurrent use: the wrapped reader is read
-// by net/http's body goroutine while the watchdog reads the counters.
-type progressReader struct {
-	r        io.Reader
-	total    atomic.Int64
-	lastData atomic.Int64 // unix nanos of the last read that returned data
-}
-
-func newProgressReader(r io.Reader) *progressReader {
-	pr := &progressReader{r: r}
-	pr.lastData.Store(time.Now().UnixNano())
-	return pr
-}
-
-func (pr *progressReader) Read(p []byte) (int, error) {
-	n, err := pr.r.Read(p)
-	if n > 0 {
-		pr.total.Add(int64(n))
-		pr.lastData.Store(time.Now().UnixNano())
-	}
-	return n, err
-}
-
-// monitorTransfer periodically logs transfer progress and aborts the transfer
-// (via cancel) if no data has flowed for idleTimeout. It exits when stop closes.
-func monitorTransfer(log *zerolog.Logger, pr *progressReader, remotePath string, idleTimeout time.Duration, cancel context.CancelFunc, stop <-chan struct{}) {
-	const interval = 15 * time.Second
-	ticker := time.NewTicker(interval)
-	defer ticker.Stop()
-
-	var lastTotal int64
-	for {
-		select {
-		case <-stop:
-			return
-		case <-ticker.C:
-			total := pr.total.Load()
-			rate := float64(total-lastTotal) / interval.Seconds() / (1024 * 1024)
-			lastTotal = total
-			idle := time.Since(time.Unix(0, pr.lastData.Load()))
-
-			log.Debug().
-				Str("remote", remotePath).
-				Int64("bytes", total).
-				Float64("mb_per_s", rate).
-				Msg("Embedded transfer progress")
-
-			if idle > idleTimeout {
-				log.Warn().
-					Str("remote", remotePath).
-					Dur("idle", idle).
-					Msg("embedded transfer: no data received, aborting attempt (will retry)")
-				cancel()
-				return
-			}
-		}
-	}
-}
-
-func uploadURLToWebDAV(ctx context.Context, log *zerolog.Logger, httpClient *http.Client, dav *gowebdav.Client, srcURL, remotePath string, sizeHint int64, idleTimeout time.Duration) error {
-	reqCtx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
-	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, srcURL, nil)
-	if err != nil {
-		return err
-	}
-
-	resp, err := httpClient.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	// Only a 2xx with a body is the actual file. Non-success responses (e.g.
-	// Zenodo's structured JSON for 401/403/404/429) must never be written to
-	// the destination as if they were data.
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-		err := fmt.Errorf("GET %s failed: %s: %s", srcURL, resp.Status, string(body))
-		if resp.StatusCode == http.StatusTooManyRequests {
-			return &retryableError{err: err, retryAfter: parseRetryAfter(resp.Header.Get("Retry-After"))}
-		}
-		return err
-	}
-
-	log.Debug().
-		Str("remote", remotePath).
-		Str("content_type", resp.Header.Get("Content-Type")).
-		Str("content_disposition", resp.Header.Get("Content-Disposition")).
-		Int64("content_length", resp.ContentLength).
-		Msg("Embedded transfer: download response")
-
-	pr := newProgressReader(resp.Body)
-	stop := make(chan struct{})
-	defer close(stop)
-	go monitorTransfer(log, pr, remotePath, idleTimeout, cancel, stop)
-
-	// With a known length gowebdav sets the request ContentLength, so net/http
-	// streams exactly that many bytes and errors if the download is truncated —
-	// a short read surfaces as an error here and is retried, never stored as a
-	// complete file.
-	length := sizeHint
-	if length < 0 {
-		length = resp.ContentLength
-	}
-	if length >= 0 {
-		return dav.WriteStreamWithLength(remotePath, pr, length, 0644)
-	}
-	return dav.WriteStream(remotePath, pr, 0644)
-}
-
-// retryableError wraps an error whose operation should be retried, optionally
-// after a server-suggested delay (e.g. from an HTTP 429 Retry-After header).
-type retryableError struct {
-	err        error
-	retryAfter time.Duration
-}
-
-func (e *retryableError) Error() string { return e.err.Error() }
-func (e *retryableError) Unwrap() error { return e.err }
-
-// parseRetryAfter interprets an HTTP Retry-After header, which may be either a
-// number of seconds or an HTTP date. Returns 0 if absent or unparseable.
-func parseRetryAfter(h string) time.Duration {
-	if h == "" {
-		return 0
-	}
-	if secs, err := strconv.Atoi(strings.TrimSpace(h)); err == nil && secs > 0 {
-		return time.Duration(secs) * time.Second
-	}
-	if t, err := http.ParseTime(h); err == nil {
-		if d := time.Until(t); d > 0 {
-			return d
-		}
-	}
-	return 0
-}
-
-func (m *mgr) ProcessEmbeddedShare(ctx context.Context, user *userpb.User, share *ocm.ReceivedShare) (*ocm.ReceivedShare, error) {
-	log := appctx.GetLogger(ctx)
-	log.Debug().
-		Interface("share", share).
-		Str("destination", share.Destination).
-		Msg("Processing received share")
-
+// GetEmbeddedPayload returns the RO-Crate JSON payload carried by the embedded
+// protocol of the received share, or an empty string if the share has no
+// embedded protocol.
+func (m *mgr) GetEmbeddedPayload(ctx context.Context, user *userpb.User, share *ocm.ReceivedShare) (string, error) {
 	protocols, err := m.getProtocolsByIds(ctx, []any{share.Id.OpaqueId})
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 
 	pList, ok := protocols[share.Id.OpaqueId]
 	if !ok {
-		return nil, errtypes.NotFound("share not found")
+		return "", errtypes.NotFound("share not found")
 	}
 
-	var entries []transferEntry
-	found := false
 	for _, protocol := range pList {
-		embedded, ok := protocol.Term.(*ocm.Protocol_EmbeddedOptions)
-		if !ok {
-			continue
-		}
-		found = true
-
-		var c crate
-		if err := json.Unmarshal([]byte(embedded.EmbeddedOptions.Payload), &c); err != nil {
-			return nil, fmt.Errorf("unmarshal embedded payload: %w", err)
-		}
-		entries = crateEntries(log, c.Graph)
-		break
-	}
-	if !found {
-		return nil, errtypes.NotFound("protocol not found")
-	}
-
-	// The payload can reference many GB across dozens of files. Transferring it
-	// inline would block (and could be cancelled by) the share-accept request,
-	// so run it in the background and return immediately. The request token is
-	// captured for WebDAV auth; a very long transfer may outlive it, in which
-	// case the remaining files fail auth and are skipped (best-effort).
-	token := appctx.ContextMustGetToken(ctx)
-	timeout := time.Duration(m.c.EmbeddedTransferTimeout) * time.Second
-	go m.transferEmbeddedEntries(log, token, share.Destination, entries, timeout)
-
-	return share, nil
-}
-
-// embeddedRetryBaseBackoff is the base delay between per-file retry attempts;
-// it grows exponentially with each subsequent attempt.
-const embeddedRetryBaseBackoff = 2 * time.Second
-
-// transferEmbeddedEntries streams each entry from its source URL to the WebDAV
-// destination. It runs detached from the request context. Each file is retried
-// a few times with backoff and, if it still fails, is logged and skipped so one
-// bad file does not abort the whole dataset; each attempt is bounded by timeout
-// so a stalled connection cannot hang forever.
-func (m *mgr) transferEmbeddedEntries(log *zerolog.Logger, token, destination string, entries []transferEntry, timeout time.Duration) {
-	httpClient := &http.Client{}
-	// e.g. "https://cbox-ocisdev-rasmus.cern.ch/webdav/"
-	// We authenticate via the bearer token set in the interceptor below, so we
-	// use a preemptive authorizer rather than gowebdav's default auto-auth. The
-	// auto-auth authorizer tees every non-seekable upload body into an in-memory
-	// buffer (to be able to replay it on an auth challenge), which would copy
-	// each multi-GB file fully into RAM and peg CPU on GC. The preemptive
-	// authorizer leaves the body untouched, so uploads truly stream.
-	dav := gowebdav.NewAuthClient(m.c.WebDAVURL, gowebdav.NewPreemptiveAuth(&gowebdav.BasicAuth{}))
-	dav.SetTimeout(timeout)
-	dav.SetInterceptor(func(method string, rq *http.Request) {
-		rq.Header.Set("Authorization", "Bearer "+token)
-		if method == http.MethodPut {
-			rq.Header.Set("Content-Type", "application/octet-stream")
-		}
-	})
-
-	if err := dav.Connect(); err != nil {
-		log.Error().Err(err).Msg("embedded transfer: failed to connect to WebDAV")
-		return
-	}
-
-	if err := dav.MkdirAll(destination, 0755); err != nil {
-		log.Error().Err(err).Str("destination", destination).Msg("embedded transfer: failed to create destination directory")
-		return
-	}
-
-	idleTimeout := time.Duration(m.c.EmbeddedTransferIdleTimeout) * time.Second
-
-	log.Debug().
-		Str("dest_path", destination).
-		Int("entries", len(entries)).
-		Msg("Starting embedded share transfer")
-
-	var transferred, failed int
-	for _, e := range entries {
-		remotePath := path.Join(destination, e.name)
-
-		log.Debug().
-			Str("src", e.srcURL).
-			Str("remote", remotePath).
-			Int64("size_hint", e.sizeHint).
-			Str("encoding_format", e.encodingFormat).
-			Msg("Streaming embedded file to WebDAV")
-
-		if err := m.uploadEntryWithRetry(log, httpClient, dav, e, remotePath, timeout, idleTimeout); err != nil {
-			failed++
-			log.Error().Err(err).
-				Str("src", e.srcURL).
-				Str("remote", remotePath).
-				Msg("embedded transfer: skipping file after exhausting retries")
-			continue
-		}
-		transferred++
-	}
-
-	log.Info().
-		Str("destination", destination).
-		Int("transferred", transferred).
-		Int("failed", failed).
-		Int("total", len(entries)).
-		Msg("Finished embedded share transfer")
-}
-
-// uploadEntryWithRetry transfers a single entry, retrying on failure up to
-// EmbeddedTransferRetries attempts with exponential backoff. Each attempt gets a
-// fresh timeout-bounded context. It returns the last error if all attempts fail.
-func (m *mgr) uploadEntryWithRetry(log *zerolog.Logger, httpClient *http.Client, dav *gowebdav.Client, e transferEntry, remotePath string, timeout, idleTimeout time.Duration) error {
-	var err error
-	for attempt := 1; attempt <= m.c.EmbeddedTransferRetries; attempt++ {
-		fileCtx, cancel := context.WithTimeout(context.Background(), timeout)
-		err = uploadURLToWebDAV(fileCtx, log, httpClient, dav, e.srcURL, remotePath, e.sizeHint, idleTimeout)
-		cancel()
-		if err == nil {
-			return nil
-		}
-
-		if attempt < m.c.EmbeddedTransferRetries {
-			backoff := embeddedRetryBaseBackoff << (attempt - 1)
-			// Honor a server-requested delay (e.g. HTTP 429 Retry-After).
-			var re *retryableError
-			if errors.As(err, &re) && re.retryAfter > backoff {
-				backoff = re.retryAfter
-			}
-			log.Warn().Err(err).
-				Str("src", e.srcURL).
-				Str("remote", remotePath).
-				Int("attempt", attempt).
-				Dur("backoff", backoff).
-				Msg("embedded transfer: file failed, retrying")
-			time.Sleep(backoff)
+		if embedded, ok := protocol.Term.(*ocm.Protocol_EmbeddedOptions); ok {
+			return embedded.EmbeddedOptions.Payload, nil
 		}
 	}
-	return err
-}
-
-// crateEntries walks the RO-Crate @graph and collects every transferable file.
-// It handles two flavors that share the same graph envelope:
-//   - ScienceMesh: a graph entity that is itself a File with a direct url.
-//   - Zenodo: a graph entity (a schema.org Dataset) carrying a distribution[]
-//     of DataDownload entries, each with a contentUrl.
-func crateEntries(log *zerolog.Logger, graph []crateEntity) []transferEntry {
-	var entries []transferEntry
-	for _, e := range graph {
-		if e.IsTransferable() {
-			if entry, ok := scienceMeshEntry(log, e); ok {
-				entries = append(entries, entry)
-			}
-		}
-		for _, d := range e.Distribution {
-			if entry, ok := zenodoEntry(log, d); ok {
-				entries = append(entries, entry)
-			}
-		}
-	}
-	return entries
-}
-
-func scienceMeshEntry(log *zerolog.Logger, e crateEntity) (transferEntry, bool) {
-	srcURL := e.URLString()
-	if srcURL == "" {
-		return transferEntry{}, false
-	}
-
-	name := strings.TrimSpace(e.Name)
-	if name == "" {
-		name = path.Base(srcURL)
-	}
-	if name == "" || name == "." || name == "/" {
-		log.Warn().
-			Str("entity_id", e.ID).
-			Str("src", srcURL).
-			Msg("Skipping entity with unusable destination name")
-		return transferEntry{}, false
-	}
-
-	size := int64(-1)
-	if e.ContentSize != "" {
-		if parsed, err := strconv.ParseInt(e.ContentSize, 10, 64); err == nil {
-			size = parsed
-		}
-	}
-
-	return transferEntry{
-		srcURL:         srcURL,
-		name:           name,
-		sizeHint:       size,
-		encodingFormat: e.EncodingFormat,
-	}, true
-}
-
-func zenodoEntry(log *zerolog.Logger, d zenodoDistribution) (transferEntry, bool) {
-	if d.Type != "DataDownload" || d.ContentURL == "" {
-		return transferEntry{}, false
-	}
-
-	name := zenodoFilename(d.ContentURL)
-	if name == "" || name == "." || name == "/" {
-		log.Warn().
-			Str("src", d.ContentURL).
-			Msg("Skipping Zenodo distribution with unusable destination name")
-		return transferEntry{}, false
-	}
-
-	return transferEntry{
-		srcURL:         d.ContentURL,
-		name:           name,
-		sizeHint:       -1,
-		encodingFormat: d.EncodingFormat,
-	}, true
-}
-
-func zenodoFilename(rawURL string) string {
-	u, err := url.Parse(rawURL)
-	if err != nil || u.Path == "" {
-		return path.Base(rawURL)
-	}
-	return path.Base(strings.TrimSuffix(u.Path, "/content"))
+	return "", nil
 }
 
 func (m *mgr) StoreReceivedShare(ctx context.Context, s *ocm.ReceivedShare) (*ocm.ReceivedShare, error) {

--- a/pkg/share/manager/sql/ocm_shares.go
+++ b/pkg/share/manager/sql/ocm_shares.go
@@ -24,9 +24,11 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"path"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
@@ -39,6 +41,7 @@ import (
 	model "github.com/cs3org/reva/v3/pkg/share/manager/sql/model"
 	"github.com/cs3org/reva/v3/pkg/utils/cfg"
 	"github.com/pkg/errors"
+	"github.com/rs/zerolog"
 	"github.com/studio-b12/gowebdav"
 	"google.golang.org/genproto/protobuf/field_mask"
 	"google.golang.org/protobuf/proto"
@@ -58,13 +61,27 @@ type crate struct {
 }
 
 type crateEntity struct {
-	ID             string          `json:"@id"`
-	Type           json.RawMessage `json:"@type"`
-	URL            json.RawMessage `json:"url"`
-	Name           string          `json:"name"`
-	ContentSize    string          `json:"contentSize"`
-	EncodingFormat string          `json:"encodingFormat"`
-	Description    string          `json:"description"`
+	ID             string               `json:"@id"`
+	Type           json.RawMessage      `json:"@type"`
+	URL            json.RawMessage      `json:"url"`
+	Name           string               `json:"name"`
+	ContentSize    string               `json:"contentSize"`
+	EncodingFormat string               `json:"encodingFormat"`
+	Description    string               `json:"description"`
+	Distribution   []zenodoDistribution `json:"distribution"`
+}
+
+type zenodoDistribution struct {
+	Type           string `json:"@type"`
+	ContentURL     string `json:"contentUrl"`
+	EncodingFormat string `json:"encodingFormat"`
+}
+
+type transferEntry struct {
+	srcURL         string
+	name           string
+	sizeHint       int64
+	encodingFormat string
 }
 
 type idRef struct {
@@ -317,8 +334,72 @@ func (e crateEntity) IsTransferable() bool {
 	return e.HasType("File") || e.HasType("ComputationalWorkflow") || e.HasType("SoftwareSourceCode")
 }
 
-func uploadURLToWebDAV(ctx context.Context, httpClient *http.Client, dav *gowebdav.Client, srcURL, remotePath string, sizeHint int64) error {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, srcURL, nil)
+// progressReader wraps a reader to track how many bytes have been read and when
+// the last non-empty read happened, so a watchdog can log throughput and detect
+// a stalled transfer. It is safe for concurrent use: the wrapped reader is read
+// by net/http's body goroutine while the watchdog reads the counters.
+type progressReader struct {
+	r        io.Reader
+	total    atomic.Int64
+	lastData atomic.Int64 // unix nanos of the last read that returned data
+}
+
+func newProgressReader(r io.Reader) *progressReader {
+	pr := &progressReader{r: r}
+	pr.lastData.Store(time.Now().UnixNano())
+	return pr
+}
+
+func (pr *progressReader) Read(p []byte) (int, error) {
+	n, err := pr.r.Read(p)
+	if n > 0 {
+		pr.total.Add(int64(n))
+		pr.lastData.Store(time.Now().UnixNano())
+	}
+	return n, err
+}
+
+// monitorTransfer periodically logs transfer progress and aborts the transfer
+// (via cancel) if no data has flowed for idleTimeout. It exits when stop closes.
+func monitorTransfer(log *zerolog.Logger, pr *progressReader, remotePath string, idleTimeout time.Duration, cancel context.CancelFunc, stop <-chan struct{}) {
+	const interval = 15 * time.Second
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	var lastTotal int64
+	for {
+		select {
+		case <-stop:
+			return
+		case <-ticker.C:
+			total := pr.total.Load()
+			rate := float64(total-lastTotal) / interval.Seconds() / (1024 * 1024)
+			lastTotal = total
+			idle := time.Since(time.Unix(0, pr.lastData.Load()))
+
+			log.Debug().
+				Str("remote", remotePath).
+				Int64("bytes", total).
+				Float64("mb_per_s", rate).
+				Msg("Embedded transfer progress")
+
+			if idle > idleTimeout {
+				log.Warn().
+					Str("remote", remotePath).
+					Dur("idle", idle).
+					Msg("embedded transfer: no data received, aborting attempt (will retry)")
+				cancel()
+				return
+			}
+		}
+	}
+}
+
+func uploadURLToWebDAV(ctx context.Context, log *zerolog.Logger, httpClient *http.Client, dav *gowebdav.Client, srcURL, remotePath string, sizeHint int64, idleTimeout time.Duration) error {
+	reqCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, srcURL, nil)
 	if err != nil {
 		return err
 	}
@@ -329,20 +410,69 @@ func uploadURLToWebDAV(ctx context.Context, httpClient *http.Client, dav *gowebd
 	}
 	defer resp.Body.Close()
 
+	// Only a 2xx with a body is the actual file. Non-success responses (e.g.
+	// Zenodo's structured JSON for 401/403/404/429) must never be written to
+	// the destination as if they were data.
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-		return fmt.Errorf("GET %s failed: %s: %s", srcURL, resp.Status, string(body))
+		err := fmt.Errorf("GET %s failed: %s: %s", srcURL, resp.Status, string(body))
+		if resp.StatusCode == http.StatusTooManyRequests {
+			return &retryableError{err: err, retryAfter: parseRetryAfter(resp.Header.Get("Retry-After"))}
+		}
+		return err
 	}
 
-	if sizeHint >= 0 {
-		return dav.WriteStreamWithLength(remotePath, resp.Body, sizeHint, 0644)
-	}
+	log.Debug().
+		Str("remote", remotePath).
+		Str("content_type", resp.Header.Get("Content-Type")).
+		Str("content_disposition", resp.Header.Get("Content-Disposition")).
+		Int64("content_length", resp.ContentLength).
+		Msg("Embedded transfer: download response")
 
-	if resp.ContentLength >= 0 {
-		return dav.WriteStreamWithLength(remotePath, resp.Body, resp.ContentLength, 0644)
-	}
+	pr := newProgressReader(resp.Body)
+	stop := make(chan struct{})
+	defer close(stop)
+	go monitorTransfer(log, pr, remotePath, idleTimeout, cancel, stop)
 
-	return dav.WriteStream(remotePath, resp.Body, 0644)
+	// With a known length gowebdav sets the request ContentLength, so net/http
+	// streams exactly that many bytes and errors if the download is truncated —
+	// a short read surfaces as an error here and is retried, never stored as a
+	// complete file.
+	length := sizeHint
+	if length < 0 {
+		length = resp.ContentLength
+	}
+	if length >= 0 {
+		return dav.WriteStreamWithLength(remotePath, pr, length, 0644)
+	}
+	return dav.WriteStream(remotePath, pr, 0644)
+}
+
+// retryableError wraps an error whose operation should be retried, optionally
+// after a server-suggested delay (e.g. from an HTTP 429 Retry-After header).
+type retryableError struct {
+	err        error
+	retryAfter time.Duration
+}
+
+func (e *retryableError) Error() string { return e.err.Error() }
+func (e *retryableError) Unwrap() error { return e.err }
+
+// parseRetryAfter interprets an HTTP Retry-After header, which may be either a
+// number of seconds or an HTTP date. Returns 0 if absent or unparseable.
+func parseRetryAfter(h string) time.Duration {
+	if h == "" {
+		return 0
+	}
+	if secs, err := strconv.Atoi(strings.TrimSpace(h)); err == nil && secs > 0 {
+		return time.Duration(secs) * time.Second
+	}
+	if t, err := http.ParseTime(h); err == nil {
+		if d := time.Until(t); d > 0 {
+			return d
+		}
+	}
+	return 0
 }
 
 func (m *mgr) ProcessEmbeddedShare(ctx context.Context, user *userpb.User, share *ocm.ReceivedShare) (*ocm.ReceivedShare, error) {
@@ -362,12 +492,58 @@ func (m *mgr) ProcessEmbeddedShare(ctx context.Context, user *userpb.User, share
 		return nil, errtypes.NotFound("share not found")
 	}
 
-	token := appctx.ContextMustGetToken(ctx)
+	var entries []transferEntry
+	found := false
+	for _, protocol := range pList {
+		embedded, ok := protocol.Term.(*ocm.Protocol_EmbeddedOptions)
+		if !ok {
+			continue
+		}
+		found = true
 
+		var c crate
+		if err := json.Unmarshal([]byte(embedded.EmbeddedOptions.Payload), &c); err != nil {
+			return nil, fmt.Errorf("unmarshal embedded payload: %w", err)
+		}
+		entries = crateEntries(log, c.Graph)
+		break
+	}
+	if !found {
+		return nil, errtypes.NotFound("protocol not found")
+	}
+
+	// The payload can reference many GB across dozens of files. Transferring it
+	// inline would block (and could be cancelled by) the share-accept request,
+	// so run it in the background and return immediately. The request token is
+	// captured for WebDAV auth; a very long transfer may outlive it, in which
+	// case the remaining files fail auth and are skipped (best-effort).
+	token := appctx.ContextMustGetToken(ctx)
+	timeout := time.Duration(m.c.EmbeddedTransferTimeout) * time.Second
+	go m.transferEmbeddedEntries(log, token, share.Destination, entries, timeout)
+
+	return share, nil
+}
+
+// embeddedRetryBaseBackoff is the base delay between per-file retry attempts;
+// it grows exponentially with each subsequent attempt.
+const embeddedRetryBaseBackoff = 2 * time.Second
+
+// transferEmbeddedEntries streams each entry from its source URL to the WebDAV
+// destination. It runs detached from the request context. Each file is retried
+// a few times with backoff and, if it still fails, is logged and skipped so one
+// bad file does not abort the whole dataset; each attempt is bounded by timeout
+// so a stalled connection cannot hang forever.
+func (m *mgr) transferEmbeddedEntries(log *zerolog.Logger, token, destination string, entries []transferEntry, timeout time.Duration) {
 	httpClient := &http.Client{}
 	// e.g. "https://cbox-ocisdev-rasmus.cern.ch/webdav/"
-	// We use the bearer token so leave password and username empty.
-	dav := gowebdav.NewClient(m.c.WebDAVURL, "", "")
+	// We authenticate via the bearer token set in the interceptor below, so we
+	// use a preemptive authorizer rather than gowebdav's default auto-auth. The
+	// auto-auth authorizer tees every non-seekable upload body into an in-memory
+	// buffer (to be able to replay it on an auth challenge), which would copy
+	// each multi-GB file fully into RAM and peg CPU on GC. The preemptive
+	// authorizer leaves the body untouched, so uploads truly stream.
+	dav := gowebdav.NewAuthClient(m.c.WebDAVURL, gowebdav.NewPreemptiveAuth(&gowebdav.BasicAuth{}))
+	dav.SetTimeout(timeout)
 	dav.SetInterceptor(func(method string, rq *http.Request) {
 		rq.Header.Set("Authorization", "Bearer "+token)
 		if method == http.MethodPut {
@@ -376,77 +552,166 @@ func (m *mgr) ProcessEmbeddedShare(ctx context.Context, user *userpb.User, share
 	})
 
 	if err := dav.Connect(); err != nil {
-		return nil, err
+		log.Error().Err(err).Msg("embedded transfer: failed to connect to WebDAV")
+		return
 	}
 
-	if err := dav.MkdirAll(share.Destination, 0755); err != nil {
-		return nil, err
+	if err := dav.MkdirAll(destination, 0755); err != nil {
+		log.Error().Err(err).Str("destination", destination).Msg("embedded transfer: failed to create destination directory")
+		return
 	}
 
-	for _, protocol := range pList {
-		embedded, ok := protocol.Term.(*ocm.Protocol_EmbeddedOptions)
-		if !ok {
-			continue
-		}
+	idleTimeout := time.Duration(m.c.EmbeddedTransferIdleTimeout) * time.Second
 
-		var c crate
-		if err := json.Unmarshal([]byte(embedded.EmbeddedOptions.Payload), &c); err != nil {
-			return nil, fmt.Errorf("unmarshal embedded payload: %w", err)
-		}
+	log.Debug().
+		Str("dest_path", destination).
+		Int("entries", len(entries)).
+		Msg("Starting embedded share transfer")
+
+	var transferred, failed int
+	for _, e := range entries {
+		remotePath := path.Join(destination, e.name)
 
 		log.Debug().
-			Str("dest_path", share.Destination).
-			Int("entities", len(c.Graph)).
-			Msg("Processing embedded share payload")
+			Str("src", e.srcURL).
+			Str("remote", remotePath).
+			Int64("size_hint", e.sizeHint).
+			Str("encoding_format", e.encodingFormat).
+			Msg("Streaming embedded file to WebDAV")
 
-		for _, e := range c.Graph {
-			if !e.IsTransferable() {
-				continue
-			}
-
-			srcURL := e.URLString()
-			if srcURL == "" {
-				continue
-			}
-
-			name := strings.TrimSpace(e.Name)
-			if name == "" {
-				name = path.Base(srcURL)
-			}
-			if name == "" || name == "." || name == "/" {
-				log.Warn().
-					Str("entity_id", e.ID).
-					Str("src", srcURL).
-					Msg("Skipping entity with unusable destination name")
-				continue
-			}
-
-			remotePath := path.Join(share.Destination, name)
-
-			size := int64(-1)
-			if e.ContentSize != "" {
-				if parsed, err := strconv.ParseInt(e.ContentSize, 10, 64); err == nil {
-					size = parsed
-				}
-			}
-
-			log.Debug().
-				Str("entity_id", e.ID).
-				Str("src", srcURL).
+		if err := m.uploadEntryWithRetry(log, httpClient, dav, e, remotePath, timeout, idleTimeout); err != nil {
+			failed++
+			log.Error().Err(err).
+				Str("src", e.srcURL).
 				Str("remote", remotePath).
-				Int64("size_hint", size).
-				Str("encoding_format", e.EncodingFormat).
-				Msg("Streaming embedded file to WebDAV")
-
-			if err := uploadURLToWebDAV(ctx, httpClient, dav, srcURL, remotePath, size); err != nil {
-				return nil, fmt.Errorf("upload %s to %s: %w", srcURL, remotePath, err)
-			}
+				Msg("embedded transfer: skipping file after exhausting retries")
+			continue
 		}
-
-		return share, nil
+		transferred++
 	}
 
-	return nil, errtypes.NotFound("protocol not found")
+	log.Info().
+		Str("destination", destination).
+		Int("transferred", transferred).
+		Int("failed", failed).
+		Int("total", len(entries)).
+		Msg("Finished embedded share transfer")
+}
+
+// uploadEntryWithRetry transfers a single entry, retrying on failure up to
+// EmbeddedTransferRetries attempts with exponential backoff. Each attempt gets a
+// fresh timeout-bounded context. It returns the last error if all attempts fail.
+func (m *mgr) uploadEntryWithRetry(log *zerolog.Logger, httpClient *http.Client, dav *gowebdav.Client, e transferEntry, remotePath string, timeout, idleTimeout time.Duration) error {
+	var err error
+	for attempt := 1; attempt <= m.c.EmbeddedTransferRetries; attempt++ {
+		fileCtx, cancel := context.WithTimeout(context.Background(), timeout)
+		err = uploadURLToWebDAV(fileCtx, log, httpClient, dav, e.srcURL, remotePath, e.sizeHint, idleTimeout)
+		cancel()
+		if err == nil {
+			return nil
+		}
+
+		if attempt < m.c.EmbeddedTransferRetries {
+			backoff := embeddedRetryBaseBackoff << (attempt - 1)
+			// Honor a server-requested delay (e.g. HTTP 429 Retry-After).
+			var re *retryableError
+			if errors.As(err, &re) && re.retryAfter > backoff {
+				backoff = re.retryAfter
+			}
+			log.Warn().Err(err).
+				Str("src", e.srcURL).
+				Str("remote", remotePath).
+				Int("attempt", attempt).
+				Dur("backoff", backoff).
+				Msg("embedded transfer: file failed, retrying")
+			time.Sleep(backoff)
+		}
+	}
+	return err
+}
+
+// crateEntries walks the RO-Crate @graph and collects every transferable file.
+// It handles two flavors that share the same graph envelope:
+//   - ScienceMesh: a graph entity that is itself a File with a direct url.
+//   - Zenodo: a graph entity (a schema.org Dataset) carrying a distribution[]
+//     of DataDownload entries, each with a contentUrl.
+func crateEntries(log *zerolog.Logger, graph []crateEntity) []transferEntry {
+	var entries []transferEntry
+	for _, e := range graph {
+		if e.IsTransferable() {
+			if entry, ok := scienceMeshEntry(log, e); ok {
+				entries = append(entries, entry)
+			}
+		}
+		for _, d := range e.Distribution {
+			if entry, ok := zenodoEntry(log, d); ok {
+				entries = append(entries, entry)
+			}
+		}
+	}
+	return entries
+}
+
+func scienceMeshEntry(log *zerolog.Logger, e crateEntity) (transferEntry, bool) {
+	srcURL := e.URLString()
+	if srcURL == "" {
+		return transferEntry{}, false
+	}
+
+	name := strings.TrimSpace(e.Name)
+	if name == "" {
+		name = path.Base(srcURL)
+	}
+	if name == "" || name == "." || name == "/" {
+		log.Warn().
+			Str("entity_id", e.ID).
+			Str("src", srcURL).
+			Msg("Skipping entity with unusable destination name")
+		return transferEntry{}, false
+	}
+
+	size := int64(-1)
+	if e.ContentSize != "" {
+		if parsed, err := strconv.ParseInt(e.ContentSize, 10, 64); err == nil {
+			size = parsed
+		}
+	}
+
+	return transferEntry{
+		srcURL:         srcURL,
+		name:           name,
+		sizeHint:       size,
+		encodingFormat: e.EncodingFormat,
+	}, true
+}
+
+func zenodoEntry(log *zerolog.Logger, d zenodoDistribution) (transferEntry, bool) {
+	if d.Type != "DataDownload" || d.ContentURL == "" {
+		return transferEntry{}, false
+	}
+
+	name := zenodoFilename(d.ContentURL)
+	if name == "" || name == "." || name == "/" {
+		log.Warn().
+			Str("src", d.ContentURL).
+			Msg("Skipping Zenodo distribution with unusable destination name")
+		return transferEntry{}, false
+	}
+
+	return transferEntry{
+		srcURL:         d.ContentURL,
+		name:           name,
+		sizeHint:       -1,
+		encodingFormat: d.EncodingFormat,
+	}, true
+}
+
+func zenodoFilename(rawURL string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil || u.Path == "" {
+		return path.Base(rawURL)
+	}
+	return path.Base(strings.TrimSuffix(u.Path, "/content"))
 }
 
 func (m *mgr) StoreReceivedShare(ctx context.Context, s *ocm.ReceivedShare) (*ocm.ReceivedShare, error) {


### PR DESCRIPTION
Adds support for OCM embedded shares whose payload is an RO-Crate wrapping the Zenodo JSON-LD format (the ScienceMesh-style RO-Crate is also supported).

The RO-Crate is stored by the `ocmshareprovider` (the SQL DB, in our case). At the provider level a new pluggable driver, the `embedded_driver`, parses the RO-Crate (Zenodo- or ScienceMesh-style) to extract the links to the publicly available data on Zenodo or GitHub, then transfers it. There is no authentication for the source downloads for now, so only publicly accessible data is supported.

### Configuration

The `ocmshareprovider` requires some additional configuration:

```
[grpc.services.ocmshareprovider]
driver = "sql"
embedded_driver = "webdav"   # optional, this is the default
...

[grpc.services.ocmshareprovider.embedded_drivers.webdav]
webdav_url = "https://cbox-ocisdev-rasmus.cern.ch/webdav"
# embedded_transfer_timeout = 3600       (default, seconds)
# embedded_transfer_idle_timeout = 120   (default, seconds)
# embedded_transfer_retries = 3          (default)
```
### Flow

1. The user calls the process-embedded-share endpoint to accept the share.
2. The `ocmshareprovider` retrieves the JSON payload from the DB.
3. The embedded driver parses the payload and extracts the links to the publicly available data.
4. For each link the driver does a GET and streams the response, via a PUT, to the configured WebDAV endpoint (usually the machine itself).

The transfer runs in the background: the endpoint returns immediately and the files are fetched asynchronously.


### Behaviour

- A transfer is aborted if no data flows for the idle timeout (e.g. due to rate limiting). Both the number of retries and the timeouts are configurable. If a file still fails after exhausting retries it is skipped (best-effort) and the remaining files continue.
- Each file also has an absolute timeout ceiling.
- Zenodo may return 429 Too Many Requests when there are too many attempts, along with a time at which requests can resume; this Retry-After is respected.
- Transfers are monitored by logging throughput every 15s (the first log is after 15s, so quick transfers are not logged).
- When all transfers finish, the number of successful and skipped transfers is logged.

### Tests
Tests have been implemented for the embedded driver where it is possible (non network related functionality). 

#### Further development

In a separate PR a share transfer state will be implemented:
- Current: `pending` -> `accepted` -> (transfer started)
- Future: `pending` -> `transfer` (transfer started) -> `accepted` (transfer finished) 

This will also be reflected in the WebUI and a seperate web PR for this will be made. 