### PR TITLE
Add SpaceID field to shares

### DIFF
--- a/changelog/unreleased/space-id-in-shares.md
+++ b/changelog/unreleased/space-id-in-shares.md
@@ -1,0 +1,5 @@
+Enhancement: add SpaceID field in shares table
+
+On top of that, we set the owner of a share to be initiator
+
+https://github.com/cs3org/reva/pull/5638

--- a/pkg/share/manager/sql/model/model.go
+++ b/pkg/share/manager/sql/model/model.go
@@ -131,6 +131,7 @@ type ProtoShare struct {
 	Permissions  uint8
 	Orphan       bool               `gorm:"index"`
 	Expiration   datatypes.NullTime `gorm:"index"`
+	SpaceID      string             `gorm:"index"`
 }
 
 // Share is a regular share between users or groups. The unique index ensures that there

--- a/pkg/share/manager/sql/public_link.go
+++ b/pkg/share/manager/sql/public_link.go
@@ -120,6 +120,7 @@ func (m *PublicShareMgr) CreatePublicShare(ctx context.Context, u *user.User, md
 	publiclink.Instance = md.Id.StorageId
 	publiclink.Permissions = uint8(permissions.OCSFromCS3Permission(g.Permissions.Permissions))
 	publiclink.Orphan = false
+	publiclink.SpaceID = md.Id.SpaceId
 
 	if g.Password != "" {
 		hashedPassword, err := hashPassword(g.Password, m.c.LinkPasswordHashCost)

--- a/pkg/share/manager/sql/public_link.go
+++ b/pkg/share/manager/sql/public_link.go
@@ -112,7 +112,7 @@ func (m *PublicShareMgr) CreatePublicShare(ctx context.Context, u *user.User, md
 
 	publiclink.Id = id
 	publiclink.ShareId = model.ShareID{ID: id}
-	publiclink.UIDOwner = conversions.FormatUserID(md.Owner)
+	publiclink.UIDOwner = conversions.FormatUserID(user.Id)
 	publiclink.UIDInitiator = conversions.FormatUserID(user.Id)
 	publiclink.InitialPath = md.Path
 	publiclink.ItemType = model.ItemType(conversions.ResourceTypeToItem(md.Type))

--- a/pkg/share/manager/sql/share.go
+++ b/pkg/share/manager/sql/share.go
@@ -127,7 +127,7 @@ func (m *ShareMgr) Share(ctx context.Context, md *provider.ResourceInfo, g *coll
 
 	share.Id = id
 	share.ShareId = model.ShareID{ID: id}
-	share.UIDOwner = conversions.FormatUserID(md.Owner)
+	share.UIDOwner = conversions.FormatUserID(user.Id)
 	share.UIDInitiator = conversions.FormatUserID(user.Id)
 	share.InitialPath = md.Path
 	share.ItemType = model.ItemType(conversions.ResourceTypeToItem(md.Type))

--- a/pkg/share/manager/sql/share.go
+++ b/pkg/share/manager/sql/share.go
@@ -135,6 +135,7 @@ func (m *ShareMgr) Share(ctx context.Context, md *provider.ResourceInfo, g *coll
 	share.Instance = md.Id.StorageId
 	share.Permissions = uint8(permissions.OCSFromCS3Permission(g.Permissions.Permissions))
 	share.Orphan = false
+	share.SpaceID = md.Id.SpaceId
 
 	if g.Expiration != nil {
 		share.Expiration.Scan(time.Unix(int64(g.Expiration.Seconds), 0))


### PR DESCRIPTION
In addition, we will put as the owner of a share the person who initiated it and not the owner of a file. Otherwise, you cannot share a folder owned by someone, to that person. 