### PR TITLE
fix: bound Prometheus HTTP handler label cardinality (#4509)

### DIFF
--- a/changelog/unreleased/fix-prom-http-url-label-cardinality.md
+++ b/changelog/unreleased/fix-prom-http-url-label-cardinality.md
@@ -7,4 +7,4 @@ caused excessive metrics storage. The label is now derived from the leading
 static path segment, keeping cardinality bounded to the number of route
 prefixes.
 
-https://github.com/cs3org/reva/issues/4509
+https://github.com/cs3org/reva/pull/5639```

--- a/changelog/unreleased/fix-prom-http-url-label-cardinality.md
+++ b/changelog/unreleased/fix-prom-http-url-label-cardinality.md
@@ -1,0 +1,10 @@
+Bugfix: Bound the Prometheus HTTP handler label cardinality
+
+The HTTP metrics interceptor used the full request URL path as the value of the
+`handler` label on the `http_request_duration_seconds` histogram. Because Reva
+HTTP endpoints are user-bound, this produced unbounded label cardinality and
+caused excessive metrics storage. The label is now derived from the leading
+static path segment, keeping cardinality bounded to the number of route
+prefixes.
+
+https://github.com/cs3org/reva/issues/4509

--- a/go.mod
+++ b/go.mod
@@ -85,6 +85,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.44.0 // indirect
 	go.opentelemetry.io/otel/metric v1.44.0 // indirect
@@ -145,7 +146,7 @@ require (
 	github.com/oliveagle/jsonpath v0.0.0-20180606110733-2e52cf6e6852 // indirect
 	github.com/pkg/term v1.2.0-beta.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/prometheus/client_model v0.6.2 // indirect
+	github.com/prometheus/client_model v0.6.2
 	github.com/prometheus/common v0.66.1 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect

--- a/internal/http/interceptors/metrics/metrics.go
+++ b/internal/http/interceptors/metrics/metrics.go
@@ -24,6 +24,7 @@ package metrics
 import (
 	"context"
 	"net/http"
+	"strings"
 
 	"github.com/cs3org/reva/v3/pkg/prom/registry"
 	"github.com/prometheus/client_golang/prometheus"
@@ -43,8 +44,9 @@ var counter = prometheus.NewCounterVec(
 	[]string{"code", "method"},
 )
 
-// duration is partitioned by the HTTP method and handler. It uses custom
-// buckets based on the expected request duration.
+// duration is partitioned by the HTTP method and handler. The handler label
+// must remain bounded to avoid Prometheus cardinality blow-up; see issue 4509.
+// It uses custom buckets based on the expected request duration.
 var duration = prometheus.NewHistogramVec(
 	prometheus.HistogramOpts{
 		Name:    "http_request_duration_seconds",
@@ -90,7 +92,7 @@ func NewPromCollectors(_ context.Context, m map[string]any) ([]prometheus.Collec
 func New() func(h http.Handler) http.Handler {
 	chain := func(h http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			h = promhttp.InstrumentHandlerDuration(duration.MustCurryWith(prometheus.Labels{"handler": r.URL.Path}),
+			h = promhttp.InstrumentHandlerDuration(duration.MustCurryWith(prometheus.Labels{"handler": handlerLabel(r.URL.Path)}),
 				promhttp.InstrumentHandlerCounter(counter,
 					promhttp.InstrumentHandlerResponseSize(responseSize,
 						promhttp.InstrumentHandlerRequestSize(requestSize,
@@ -103,4 +105,21 @@ func New() func(h http.Handler) http.Handler {
 		})
 	}
 	return chain
+}
+
+// handlerLabel returns a bounded label for Prometheus metrics. It keeps only the
+// first path segment so user-bound URLs such as /remote.php/dav/files/<userid>
+// do not create one handler label per request path; see issue 4509.
+func handlerLabel(path string) string {
+	path = strings.SplitN(path, "?", 2)[0]
+	path = strings.TrimLeft(path, "/")
+	if path == "" {
+		return "/"
+	}
+
+	if i := strings.IndexByte(path, '/'); i >= 0 {
+		path = path[:i]
+	}
+
+	return "/" + path
 }

--- a/internal/http/interceptors/metrics/metrics_test.go
+++ b/internal/http/interceptors/metrics/metrics_test.go
@@ -1,0 +1,110 @@
+// Copyright 2018-2024 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package metrics
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	dto "github.com/prometheus/client_model/go"
+)
+
+func TestHandlerLabel(t *testing.T) {
+	tests := []struct {
+		path string
+		want string
+	}{
+		{path: "", want: "/"},
+		{path: "/", want: "/"},
+		{path: "/remote.php/dav/files/einstein/foo", want: "/remote.php"},
+		{path: "/remote.php/dav/files/marie/b/c?download=1", want: "/remote.php"},
+		{path: "/ocs/v2.php/apps/files_sharing/api/v1/shares", want: "/ocs"},
+		{path: "status.php", want: "/status.php"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			if got := handlerLabel(tt.path); got != tt.want {
+				t.Fatalf("handlerLabel(%q) = %q, want %q", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNewUsesBoundedHandlerLabel(t *testing.T) {
+	duration.Reset()
+	t.Cleanup(duration.Reset)
+
+	middleware := New()
+	handler := middleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	paths := []string{
+		"/remote.php/dav/files/einstein/a",
+		"/remote.php/dav/files/marie/b/c",
+		"/remote.php/dav/files/richard/deep/path/file.txt",
+	}
+	for _, path := range paths {
+		req := httptest.NewRequest(http.MethodGet, "https://example.org"+path, nil)
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+	}
+
+	if got := testutil.CollectAndCount(duration); got != 1 {
+		t.Fatalf("duration collected %d metrics, want 1", got)
+	}
+
+	handlers := collectDurationHandlers(t)
+	if got, want := len(handlers), 1; got != want {
+		t.Fatalf("duration handler labels = %v, want one label", handlers)
+	}
+	if _, ok := handlers["/remote.php"]; !ok {
+		t.Fatalf("duration handler labels = %v, want /remote.php", handlers)
+	}
+}
+
+func collectDurationHandlers(t *testing.T) map[string]struct{} {
+	t.Helper()
+
+	metrics := make(chan prometheus.Metric)
+	go func() {
+		duration.Collect(metrics)
+		close(metrics)
+	}()
+
+	handlers := map[string]struct{}{}
+	for metric := range metrics {
+		var dtoMetric dto.Metric
+		if err := metric.Write(&dtoMetric); err != nil {
+			t.Fatalf("failed to write metric: %v", err)
+		}
+
+		for _, label := range dtoMetric.GetLabel() {
+			if label.GetName() == "handler" {
+				handlers[label.GetValue()] = struct{}{}
+			}
+		}
+	}
+
+	return handlers
+}


### PR DESCRIPTION
## Summary

The HTTP metrics interceptor in `internal/http/interceptors/metrics/metrics.go` used the full per-request URL path (`r.URL.Path`) as the value of the `handler` label on the `http_request_duration_seconds` histogram. This change derives the label from the leading static path segment instead (e.g. `/remote.php/dav/files/einstein/foo` becomes `/remote.php`), so the `handler` label cardinality is bounded by the number of route prefixes rather than the number of distinct user URLs.

A doc comment now records that the `handler` label must stay bounded, referencing #4509, so the regression is not silently reintroduced. A unit test verifies that multiple distinct user-bound URLs sharing a prefix collapse to a single `handler` label value.

## Why this matters

Reva's HTTP endpoints are user-bound (e.g. `/remote.php/dav/files/<userid>/<deep/path>`), so every distinct request path produced a new `handler` label value. Per #4509 this made the label cardinality effectively unbounded and caused Reva to store more than 50GB of metrics behind the `/metrics` endpoint. Bounding the label to the route prefix keeps the metrics series count proportional to the number of services.

## Testing

- `gofmt -l internal/http/interceptors/metrics/` is clean
- `go vet ./internal/http/interceptors/metrics/` passes
- `go build ./internal/http/...` succeeds
- `go test ./internal/http/interceptors/metrics/...` passes (8 tests), including the new cardinality regression test

## Note

This is the minimal first-segment normalization described in the issue. It does not yet coalesce unmatched/non-existent first segments (a request to `/foo123` is still recorded as `/foo123` before routing returns 404). Mapping unmatched prefixes to a single bucket would need the interceptor to know the registered service prefixes, which are config-driven; happy to follow up with that hardening if you prefer it in this PR.

Fixes #4509

AI was used for assistance.
