### PR TITLE
Add transfer state

### DIFF
--- a/changelog/unreleased/ocm-transferring-state.md
+++ b/changelog/unreleased/ocm-transferring-state.md
@@ -1,0 +1,6 @@
+Enhancement: Utilize the new transferring state in the cs3api
+
+- Puts the ocm share in a transferring state when doing the processing of an embedded share is ongoing
+- A callback is implemented that puts the share in the accepted state when the transfer is finished
+
+https://github.com/cs3org/reva/pull/5643

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/coreos/go-oidc/v3 v3.18.0
 	github.com/creasty/defaults v1.8.0
 	github.com/cs3org/cato v0.0.0-20200828125504-e418fc54dd5e
-	github.com/cs3org/go-cs3apis v0.0.0-20260521131813-a83b8d2afa3f
+	github.com/cs3org/go-cs3apis v0.0.0-20260528130041-5761380e5fc1
 	github.com/dgraph-io/ristretto v0.2.0
 	github.com/dolthub/go-mysql-server v0.14.0
 	github.com/glpatcern/go-mime v0.0.0-20221026162842-2a8d71ad17a9

--- a/go.sum
+++ b/go.sum
@@ -898,6 +898,10 @@ github.com/cs3org/cato v0.0.0-20200828125504-e418fc54dd5e h1:tqSPWQeueWTKnJVMJff
 github.com/cs3org/cato v0.0.0-20200828125504-e418fc54dd5e/go.mod h1:XJEZ3/EQuI3BXTp/6DUzFr850vlxq11I6satRtz0YQ4=
 github.com/cs3org/go-cs3apis v0.0.0-20260521131813-a83b8d2afa3f h1:liK7Z1H0nNgK8sEodWsCRWJ4JKiqU474nBbbA9jnfS4=
 github.com/cs3org/go-cs3apis v0.0.0-20260521131813-a83b8d2afa3f/go.mod h1:DedpcqXl193qF/08Y04IO0PpxyyMu8+GrkD6kWK2MEQ=
+github.com/cs3org/go-cs3apis v0.0.0-20260528130041-5761380e5fc1 h1:2oCzdfYZURODq1f7Z/0RgDB92xCfwckqIZmxOIQTwag=
+github.com/cs3org/go-cs3apis v0.0.0-20260528130041-5761380e5fc1/go.mod h1:DedpcqXl193qF/08Y04IO0PpxyyMu8+GrkD6kWK2MEQ=
+github.com/cs3org/go-cs3apis v0.0.0-20260604164754-c3fdb0aa5e9e h1:daOgm7xFqJi6LkKUBAENiHOy4IBVSlpculXLd1cPZWk=
+github.com/cs3org/go-cs3apis v0.0.0-20260604164754-c3fdb0aa5e9e/go.mod h1:DedpcqXl193qF/08Y04IO0PpxyyMu8+GrkD6kWK2MEQ=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/internal/grpc/services/ocmshareprovider/ocmshareprovider.go
+++ b/internal/grpc/services/ocmshareprovider/ocmshareprovider.go
@@ -500,9 +500,12 @@ func (s *service) ListReceivedOCMShares(ctx context.Context, req *ocm.ListReceiv
 
 func (s *service) UpdateReceivedOCMShare(ctx context.Context, req *ocm.UpdateReceivedOCMShareRequest) (*ocm.UpdateReceivedOCMShareResponse, error) {
 	user := appctx.ContextMustGetUser(ctx)
-	// This is the state we are setting when processing a share
-	// meaning it should be ACCEPTED in order to trigger the processing.
-	if req.Share.State == ocm.ShareState_SHARE_STATE_ACCEPTED {
+	// Accepting a share that carries embedded content triggers a background
+	// transfer of that content. Rather than jumping straight to ACCEPTED, the
+	// share is held in the TRANSFERRING state while the copy runs and only
+	// flipped to ACCEPTED once it completes, so the state progresses
+	// pending -> transferring -> accepted.
+	if req.Share.State == ocm.ShareState_SHARE_STATE_ACCEPTED && req.Share.Destination != "" {
 		payload, err := s.repo.GetEmbeddedPayload(ctx, user, req.Share)
 		if err != nil {
 			if errors.Is(err, share.ErrShareNotFound) {
@@ -515,11 +518,7 @@ func (s *service) UpdateReceivedOCMShare(ctx context.Context, req *ocm.UpdateRec
 			}, nil
 		}
 		if payload != "" {
-			if err := s.transferrer.Process(ctx, payload, req.Share.Destination); err != nil {
-				return &ocm.UpdateReceivedOCMShareResponse{
-					Status: status.NewInternal(ctx, err, "error processing embedded share"),
-				}, nil
-			}
+			return s.processEmbeddedShare(ctx, user, req, payload)
 		}
 	}
 	_, err := s.repo.UpdateReceivedShare(ctx, user, req.Share, req.UpdateMask)
@@ -538,6 +537,74 @@ func (s *service) UpdateReceivedOCMShare(ctx context.Context, req *ocm.UpdateRec
 		Status: status.NewOK(ctx),
 	}
 	return res, nil
+}
+
+// processEmbeddedShare marks the received share as TRANSFERRING, kicks off the
+// background transfer of the embedded content and arranges for the share to be
+// flipped to ACCEPTED once the transfer completes.
+func (s *service) processEmbeddedShare(ctx context.Context, user *userpb.User, req *ocm.UpdateReceivedOCMShareRequest, payload string) (*ocm.UpdateReceivedOCMShareResponse, error) {
+	recvShare := req.Share
+	mask := req.UpdateMask
+
+	// Refuse to start a second transfer if one is already in progress for this
+	// share, otherwise concurrent copies would race on the same destination.
+	current, err := s.repo.GetReceivedShare(ctx, user, &ocm.ShareReference{
+		Spec: &ocm.ShareReference_Id{Id: recvShare.Id},
+	})
+	if err != nil {
+		if errors.Is(err, share.ErrShareNotFound) {
+			return &ocm.UpdateReceivedOCMShareResponse{
+				Status: status.NewNotFound(ctx, "share does not exist"),
+			}, nil
+		}
+		return &ocm.UpdateReceivedOCMShareResponse{
+			Status: status.NewInternal(ctx, err, "error getting received share"),
+		}, nil
+	}
+	if current.State == ocm.ShareState_SHARE_STATE_TRANSFERRING {
+		return &ocm.UpdateReceivedOCMShareResponse{
+			Status: status.NewFailedPrecondition(ctx, errors.New("transfer already in progress"), "transfer already in progress"),
+		}, nil
+	}
+
+	// Persist TRANSFERRING before the copy starts so the recipient can observe
+	// the in-progress state.
+	recvShare.State = ocm.ShareState_SHARE_STATE_TRANSFERRING
+	if _, err := s.repo.UpdateReceivedShare(ctx, user, recvShare, mask); err != nil {
+		if errors.Is(err, share.ErrShareNotFound) {
+			return &ocm.UpdateReceivedOCMShareResponse{
+				Status: status.NewNotFound(ctx, "share does not exist"),
+			}, nil
+		}
+		return &ocm.UpdateReceivedOCMShareResponse{
+			Status: status.NewInternal(ctx, err, "error updating received share"),
+		}, nil
+	}
+
+	// The transfer outlives this request, so detach the context from its
+	// cancellation while keeping its values (user, auth token, logger).
+	detached := context.WithoutCancel(ctx)
+	onComplete := func(transferErr error) {
+		log := appctx.GetLogger(detached)
+		if transferErr != nil {
+			log.Error().Err(transferErr).Msg("embedded transfer failed, leaving share in transferring state")
+			return
+		}
+		recvShare.State = ocm.ShareState_SHARE_STATE_ACCEPTED
+		if _, err := s.repo.UpdateReceivedShare(detached, user, recvShare, mask); err != nil {
+			log.Error().Err(err).Msg("error marking received share as accepted after embedded transfer")
+		}
+	}
+
+	if err := s.transferrer.Process(ctx, payload, recvShare.Destination, onComplete); err != nil {
+		return &ocm.UpdateReceivedOCMShareResponse{
+			Status: status.NewInternal(ctx, err, "error processing embedded share"),
+		}, nil
+	}
+
+	return &ocm.UpdateReceivedOCMShareResponse{
+		Status: status.NewOK(ctx),
+	}, nil
 }
 
 func (s *service) GetReceivedOCMShare(ctx context.Context, req *ocm.GetReceivedOCMShareRequest) (*ocm.GetReceivedOCMShareResponse, error) {

--- a/internal/http/services/sciencemesh/embedded.go
+++ b/internal/http/services/sciencemesh/embedded.go
@@ -59,6 +59,8 @@ func (h *embeddedHandler) ProcessEmbeddedShare(w http.ResponseWriter, r *http.Re
 	log := appctx.GetLogger(ctx)
 	queryParams := r.URL.Query()
 
+	log.Debug().Msg("processing embedded share")
+
 	dest_path := queryParams.Get("destination")
 	share_id := queryParams.Get("share_id")
 	process := queryParams.Get("process")
@@ -172,10 +174,11 @@ func CreateStateMapping(ctx context.Context, receivedOCMShare []*ocm.ReceivedSha
 
 func convertShareState(state ocm.ShareState) string {
 	stateMapping := map[ocm.ShareState]string{
-		ocm.ShareState_SHARE_STATE_INVALID:  "invalid",
-		ocm.ShareState_SHARE_STATE_PENDING:  "pending",
-		ocm.ShareState_SHARE_STATE_ACCEPTED: "accepted",
-		ocm.ShareState_SHARE_STATE_REJECTED: "rejected",
+		ocm.ShareState_SHARE_STATE_INVALID:      "invalid",
+		ocm.ShareState_SHARE_STATE_PENDING:      "pending",
+		ocm.ShareState_SHARE_STATE_ACCEPTED:     "accepted",
+		ocm.ShareState_SHARE_STATE_REJECTED:     "rejected",
+		ocm.ShareState_SHARE_STATE_TRANSFERRING: "transferring",
 	}
 	if val, ok := stateMapping[state]; ok {
 		return val

--- a/pkg/ocm/embedded/embedded.go
+++ b/pkg/ocm/embedded/embedded.go
@@ -67,8 +67,14 @@ func (c *Config) ApplyDefaults() {
 
 // Transferrer processes an embedded share payload, transferring its referenced
 // files to a destination. Drivers register an implementation via Register.
+//
+// Process returns synchronously once the transfer has been scheduled; the actual
+// copy runs in the background. The optional onComplete callback is invoked once
+// the transfer has finished, with a nil error on success, allowing the caller to
+// observe completion (e.g. to advance the share state). A malformed payload is
+// reported as a synchronous error from Process and onComplete is not called.
 type Transferrer interface {
-	Process(ctx context.Context, payload, destination string) error
+	Process(ctx context.Context, payload, destination string, onComplete func(error)) error
 }
 
 // NewFunc builds a Transferrer from its driver configuration.
@@ -106,8 +112,10 @@ const embeddedRetryBaseBackoff = 2 * time.Second
 
 // Process parses the RO-Crate payload and streams its files to destination in the
 // background, using the bearer token from ctx for WebDAV auth. It errors only on a
-// malformed payload.
-func (d *driver) Process(ctx context.Context, payload, destination string) error {
+// malformed payload. When set, onComplete is invoked once the transfer finishes
+// (immediately when there is nothing to transfer, otherwise from the background
+// goroutine), with a nil error on success.
+func (d *driver) Process(ctx context.Context, payload, destination string, onComplete func(error)) error {
 	log := appctx.GetLogger(ctx)
 
 	var c crate
@@ -118,6 +126,9 @@ func (d *driver) Process(ctx context.Context, payload, destination string) error
 	entries := crateEntries(log, c.Graph)
 	if len(entries) == 0 {
 		log.Debug().Str("destination", destination).Msg("embedded transfer: no transferable entries in payload")
+		if onComplete != nil {
+			onComplete(nil)
+		}
 		return nil
 	}
 
@@ -125,14 +136,21 @@ func (d *driver) Process(ctx context.Context, payload, destination string) error
 	// captured token may expire mid-transfer, failing later files (best-effort).
 	token := appctx.ContextMustGetToken(ctx)
 	timeout := time.Duration(d.c.Timeout) * time.Second
-	go d.transferEntries(log, token, destination, entries, timeout)
+	go func() {
+		err := d.transferEntries(log, token, destination, entries, timeout)
+		if onComplete != nil {
+			onComplete(err)
+		}
+	}()
 
 	return nil
 }
 
 // transferEntries streams each entry to the WebDAV destination. A file that keeps
-// failing is skipped so one bad file doesn't abort the whole dataset.
-func (d *driver) transferEntries(log *zerolog.Logger, token, destination string, entries []transferEntry, timeout time.Duration) {
+// failing is skipped so one bad file doesn't abort the whole dataset. It returns
+// an error only when the transfer cannot proceed at all (e.g. the destination is
+// unreachable); per-file failures are best-effort and do not produce an error.
+func (d *driver) transferEntries(log *zerolog.Logger, token, destination string, entries []transferEntry, timeout time.Duration) error {
 	httpClient := &http.Client{}
 	// Preemptive auth, not gowebdav's default auto-auth: auto-auth buffers each
 	// upload body in memory to replay on an auth challenge, blowing up RAM on
@@ -148,12 +166,12 @@ func (d *driver) transferEntries(log *zerolog.Logger, token, destination string,
 
 	if err := dav.Connect(); err != nil {
 		log.Error().Err(err).Msg("embedded transfer: failed to connect to WebDAV")
-		return
+		return err
 	}
 
 	if err := dav.MkdirAll(destination, 0755); err != nil {
 		log.Error().Err(err).Str("destination", destination).Msg("embedded transfer: failed to create destination directory")
-		return
+		return err
 	}
 
 	idleTimeout := time.Duration(d.c.IdleTimeout) * time.Second
@@ -191,6 +209,8 @@ func (d *driver) transferEntries(log *zerolog.Logger, token, destination string,
 		Int("failed", failed).
 		Int("total", len(entries)).
 		Msg("Finished embedded share transfer")
+
+	return nil
 }
 
 // uploadEntryWithRetry transfers one entry, retrying up to Retries times with

--- a/pkg/ocm/embedded/embedded_test.go
+++ b/pkg/ocm/embedded/embedded_test.go
@@ -329,17 +329,33 @@ func newTestTransferrer(t *testing.T) Transferrer {
 
 func TestProcessMalformedPayload(t *testing.T) {
 	tr := newTestTransferrer(t)
-	if err := tr.Process(context.Background(), "{not valid json", "/dest"); err == nil {
+	called := false
+	if err := tr.Process(context.Background(), "{not valid json", "/dest", func(error) { called = true }); err == nil {
 		t.Error("Process with malformed payload: expected error, got nil")
+	}
+	if called {
+		t.Error("Process with malformed payload: onComplete must not be called")
 	}
 }
 
 func TestProcessNoTransferableEntries(t *testing.T) {
 	tr := newTestTransferrer(t)
 	// A valid payload with nothing transferable must be a no-op: it returns nil
-	// and does not require a token (no background transfer is started).
+	// and does not require a token (no background transfer is started). The
+	// onComplete callback is still invoked synchronously with a nil error.
 	payload := `{"@graph":[{"@id":"d","@type":"Dataset","name":"nothing to transfer"}]}`
-	if err := tr.Process(context.Background(), payload, "/dest"); err != nil {
+	var gotErr error
+	called := false
+	if err := tr.Process(context.Background(), payload, "/dest", func(err error) {
+		called = true
+		gotErr = err
+	}); err != nil {
 		t.Errorf("Process with no transferable entries: unexpected error %v", err)
+	}
+	if !called {
+		t.Error("Process with no transferable entries: onComplete was not called")
+	}
+	if gotErr != nil {
+		t.Errorf("Process with no transferable entries: onComplete error = %v, want nil", gotErr)
 	}
 }

--- a/pkg/share/manager/sql/conversions.go
+++ b/pkg/share/manager/sql/conversions.go
@@ -62,6 +62,8 @@ func convertFromCS3OCMShareState(shareState ocm.ShareState) model.OcmShareState 
 		return model.OcmShareStatePending
 	case ocm.ShareState_SHARE_STATE_REJECTED:
 		return model.OcmShareStateRejected
+	case ocm.ShareState_SHARE_STATE_TRANSFERRING:
+		return model.OcmShareStateTransferring
 	}
 	return -1
 }
@@ -74,6 +76,8 @@ func convertToCS3OCMShareState(state model.OcmShareState) ocm.ShareState {
 		return ocm.ShareState_SHARE_STATE_PENDING
 	case model.OcmShareStateRejected:
 		return ocm.ShareState_SHARE_STATE_REJECTED
+	case model.OcmShareStateTransferring:
+		return ocm.ShareState_SHARE_STATE_TRANSFERRING
 	}
 	return ocm.ShareState_SHARE_STATE_INVALID
 }

--- a/pkg/share/manager/sql/model/model.go
+++ b/pkg/share/manager/sql/model/model.go
@@ -69,6 +69,9 @@ const (
 	OcmShareStateAccepted
 	// OcmShareStateRejected is the share for a rejected share.
 	OcmShareStateRejected
+	// OcmShareStateTransferring is the state for a share whose embedded
+	// content is currently being transferred to its destination.
+	OcmShareStateTransferring
 )
 
 // OcmProtocol is the protocol used by the recipient of an OCM share


### PR DESCRIPTION
Utilizes the new `transferring` state in the cs3api for received ocm shares.

- Puts the ocm share in a `transferring` state when doing the processing of an embedded share is ongoing.
- A callback is implemented that puts the share in the `accepted` state when the transfer is finished. 