### PR TITLE
Honor the pidfile passed with the -p option

### DIFF
--- a/changelog/unreleased/fix-pidfile.md
+++ b/changelog/unreleased/fix-pidfile.md
@@ -1,0 +1,8 @@
+Bugfix: honor pidfile passed with the -p option
+
+The pidfile was always generated at a random path in the OS temp dir on
+startup, ignoring the location passed with -p. As a result -s reload (and
+the other -s signals) could not find the running master to signal it. The
+-p path is now honored when starting revad.
+
+https://github.com/cs3org/reva/pull/5653

--- a/cmd/revad/main.go
+++ b/cmd/revad/main.go
@@ -338,6 +338,10 @@ func runMultiple(confs []*config.Config) {
 }
 
 func getPidfile() string {
+	if *pidFlag != "" {
+		return *pidFlag
+	}
+
 	uuid := uuid.New().String()
 	name := fmt.Sprintf("revad-%s.pid", uuid)
 


### PR DESCRIPTION
The pidfile was always generated at a random path in the OS temp dir on startup, ignoring the location passed with -p. As a result -s reload (and the other -s signals) could not find the running master to signal it. The -p path is now honored when starting revad.