### PR TITLE
Check for nil pointers

### DIFF
--- a/changelog/unreleased/fix-nilpointer.md
+++ b/changelog/unreleased/fix-nilpointer.md
@@ -1,0 +1,3 @@
+Bugfix: check for nil pointers
+
+https://github.com/cs3org/reva/pull/5662

--- a/pkg/cbox/utils/conversions.go
+++ b/pkg/cbox/utils/conversions.go
@@ -137,12 +137,18 @@ func IntToShareState(g int) collaboration.ShareState {
 
 // FormatUserID formats a CS3API user ID as a string.
 func FormatUserID(u *userpb.UserId) string {
+	if u == nil {
+		return ""
+	}
 	return u.OpaqueId
 }
 
 // FormatGroupID formats a CS3API group ID to a string.
-func FormatGroupID(u *grouppb.GroupId) string {
-	return u.OpaqueId
+func FormatGroupID(g *grouppb.GroupId) string {
+	if g == nil {
+		return ""
+	}
+	return g.OpaqueId
 }
 
 // MakeUserID generates a CS3API user ID from a username, ASSUMING user type is primary.

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -419,6 +419,9 @@ func HasOCMShareRole(u *userpb.User) (string, bool) {
 // HasPermissions returns true if all permissions defined in the struct toCheck
 // are set in the target.
 func HasPermissions(target, toCheck *provider.ResourcePermissions) bool {
+	if target == nil || toCheck == nil {
+		return false
+	}
 	targetStruct := reflect.ValueOf(target).Elem()
 	toCheckStruct := reflect.ValueOf(toCheck).Elem()
 


### PR DESCRIPTION
These stems from runtime errors due to failed preconditions, and the check is only to avoid them. There may be one or more underlying bugs to be unveiled once the thread does not bail out.