### PR TITLE
Associate on-demand jobs with a user

### DIFF
--- a/changelog/unreleased/add-job-ownership.md
+++ b/changelog/unreleased/add-job-ownership.md
@@ -1,0 +1,9 @@
+Enhancement: associate on-demand jobs with a user
+
+On-demand background jobs can now be attached to a user through a WithOwner
+enqueue option, so the jobs a user created can be listed back (e.g. for a UI)
+with ListByOwner; jobs enqueued without it stay internal. An opt-in Unique
+option was also added to keep at most one active run per owner and key, so a
+user cannot, for instance, start the same export twice.
+
+https://github.com/cs3org/reva/pull/5672

--- a/internal/serverless/services/jobs/README.md
+++ b/internal/serverless/services/jobs/README.md
@@ -176,7 +176,8 @@ means "the last attempt failed, another is coming".
 `ListByOwner` returns the runs created for a user with `WithOwner`, most
 recently enqueued first — the read side a UI uses to show "my jobs". The filter
 narrows the result by state, job or page; internal runs (those with no owner)
-never show up in it.
+never show up in it. To list those instead, a system/admin listing can pass
+`ListFilter{Internal: true}`.
 
 ```go
 runs, err := rjobs.Default().ListByOwner(ctx, username, rjobs.ListFilter{

--- a/internal/serverless/services/jobs/README.md
+++ b/internal/serverless/services/jobs/README.md
@@ -128,16 +128,38 @@ if runner == nil {
 }
 
 runID, err := runner.Enqueue(ctx, "mycomponent.export", rjobs.Params{
-    "user_id": uid,
-}, rjobs.WithIdempotencyKey("export:"+uid)) // collapse duplicate requests
+    "space_id": spaceID,
+})
 ```
+
+By default a run is **internal**: it belongs to reva, not to a user. Two
+optional, independent options change that — nothing happens unless you ask for
+it:
+
+```go
+runID, err := runner.Enqueue(ctx, "mycomponent.export", params,
+    rjobs.WithOwner(user.Username),     // attribute the run to a user
+    rjobs.Unique("export:"+spaceID),    // at most one active run for this key
+)
+```
+
+- `WithOwner(username)` records the run against a user, so it shows up in that
+  user's listing (see below). Without it the run has no owner and stays
+  internal.
+- `Unique(key)` makes the run the only active one for its `(owner, key)`: while
+  a run with that key is queued, running or retrying, a second `Enqueue` with
+  the same key does not start another — it returns the id of the one already in
+  flight. The reservation is released once the run **succeeds**, so the key is
+  free again afterwards; fold any finer scope (one per space, one per day, ...)
+  into the key. Pass `rjobs.Reject` as a second argument to fail with an
+  `errtypes.AlreadyExists` error instead of collapsing onto the in-flight run.
 
 `Enqueue` is the seam a future RPC service would wrap; today it is in-process
 only.
 
 ### Checking a run's status
 
-Use the `RunID` to read status back:
+Use the `RunID` to read a single run back:
 
 ```go
 st, err := rjobs.Default().Status(ctx, runID)
@@ -148,6 +170,20 @@ st, err := rjobs.Default().Status(ctx, runID)
 
 Note that `failed` is **not terminal**: a failed run is retried, so `failed`
 means "the last attempt failed, another is coming".
+
+### Listing a user's runs
+
+`ListByOwner` returns the runs created for a user with `WithOwner`, most
+recently enqueued first — the read side a UI uses to show "my jobs". The filter
+narrows the result by state, job or page; internal runs (those with no owner)
+never show up in it.
+
+```go
+runs, err := rjobs.Default().ListByOwner(ctx, username, rjobs.ListFilter{
+    States: []rjobs.State{rjobs.StateQueued, rjobs.StateRunning},
+    Limit:  50,
+})
+```
 
 ## Configuration
 

--- a/pkg/rjobs/enqueue.go
+++ b/pkg/rjobs/enqueue.go
@@ -32,6 +32,15 @@ func WithIdempotencyKey(key string) EnqueueOption {
 	}
 }
 
+// WithOwner attributes the run to a user by username, so it appears in that
+// user's run listing (see Runner.ListByOwner). Without this option a run has no
+// owner and counts as internal.
+func WithOwner(username string) EnqueueOption {
+	return func(r *Run) {
+		r.Owner = username
+	}
+}
+
 // defaultRunner is the process-wide runner, set by the jobs service once at
 // startup. It lets any in-process reva component reach Enqueue without
 // threading the runner through every call site.

--- a/pkg/rjobs/enqueue.go
+++ b/pkg/rjobs/enqueue.go
@@ -23,12 +23,30 @@ import "sync"
 // EnqueueOption customises an on-demand enqueue.
 type EnqueueOption func(*Run)
 
-// WithIdempotencyKey collapses duplicate enqueues carrying the same key into a
-// single run. Use it to make a user action (e.g. clicking "export" twice)
-// enqueue at most one run.
-func WithIdempotencyKey(key string) EnqueueOption {
+// ConflictPolicy decides what Enqueue does when a Unique key is already held by
+// an active run.
+type ConflictPolicy int
+
+const (
+	// Collapse returns the existing run's id, so a duplicate request rides on
+	// the run already in flight. It is the default.
+	Collapse ConflictPolicy = iota
+	// Reject makes Enqueue fail with an errtypes.AlreadyExists error instead of
+	// reusing the in-flight run.
+	Reject
+)
+
+// Unique makes the run the only active one for its (owner, key): while a run
+// with this key is queued, running or retrying, a second Enqueue with the same
+// key does not start another. The reservation is released once the run
+// succeeds, so the key is free again afterwards; fold any finer scope (one per
+// day, one per space, ...) into the key. With no policy a conflict collapses
+// onto the existing run and Enqueue returns its id; pass Reject to fail
+// instead. Pair it with WithOwner to make uniqueness per user.
+func Unique(key string, policy ...ConflictPolicy) EnqueueOption {
 	return func(r *Run) {
-		r.IdempotencyKey = key
+		r.DedupKey = key
+		r.dedupReject = len(policy) > 0 && policy[0] == Reject
 	}
 }
 

--- a/pkg/rjobs/runner.go
+++ b/pkg/rjobs/runner.go
@@ -280,12 +280,14 @@ func (r *Runner) Status(ctx context.Context, id RunID) (Status, error) {
 // ListByOwner returns the runs created for the given user, most recently
 // enqueued first. It is the read side of WithOwner: a UI lists a user's jobs
 // with it. The filter narrows the result further (by state, job or page); its
-// Owner field is ignored, the owner argument wins.
+// Owner and Internal fields are ignored — the owner argument wins and internal
+// runs are never included.
 func (r *Runner) ListByOwner(ctx context.Context, owner string, f ListFilter) ([]Status, error) {
 	if r.status == nil {
 		return nil, errors.New("rjobs: no status store configured")
 	}
 	f.Owner = owner
+	f.Internal = false
 	return r.status.List(ctx, f)
 }
 

--- a/pkg/rjobs/runner.go
+++ b/pkg/rjobs/runner.go
@@ -220,6 +220,18 @@ func (r *Runner) Status(ctx context.Context, id RunID) (Status, error) {
 	return r.status.Get(ctx, id)
 }
 
+// ListByOwner returns the runs created for the given user, most recently
+// enqueued first. It is the read side of WithOwner: a UI lists a user's jobs
+// with it. The filter narrows the result further (by state, job or page); its
+// Owner field is ignored, the owner argument wins.
+func (r *Runner) ListByOwner(ctx context.Context, owner string, f ListFilter) ([]Status, error) {
+	if r.status == nil {
+		return nil, errors.New("rjobs: no status store configured")
+	}
+	f.Owner = owner
+	return r.status.List(ctx, f)
+}
+
 // runLocalTicker drives an all-nodes periodic job on this replica. It never
 // touches the store.
 func (r *Runner) runLocalTicker(ctx context.Context, p Periodic) {

--- a/pkg/rjobs/runner.go
+++ b/pkg/rjobs/runner.go
@@ -202,6 +202,7 @@ func (r *Runner) Enqueue(ctx context.Context, name string, p Params, opts ...Enq
 		State:      StateQueued,
 		Attempt:    1,
 		EnqueuedAt: time.Now(),
+		Owner:      run.Owner,
 	}); err != nil {
 		// the run is already durably queued; a failed status write must not
 		// fail the enqueue, only lose observability for this run.
@@ -392,6 +393,7 @@ func (r *Runner) recordStatus(ctx context.Context, run Run, state State, result 
 		Attempt:    run.Attempt,
 		EnqueuedAt: run.EnqueuedAt,
 		Result:     result,
+		Owner:      run.Owner,
 	}
 	switch state {
 	case StateRunning:

--- a/pkg/rjobs/runner.go
+++ b/pkg/rjobs/runner.go
@@ -20,11 +20,14 @@ package rjobs
 
 import (
 	"context"
+	"fmt"
 	"math/rand"
 	"sync"
 	"time"
 
 	"github.com/cs3org/reva/v3/pkg/appctx"
+	"github.com/cs3org/reva/v3/pkg/errtypes"
+	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 )
@@ -191,6 +194,10 @@ func (r *Runner) Enqueue(ctx context.Context, name string, p Params, opts ...Enq
 		o(&run)
 	}
 
+	if run.DedupKey != "" {
+		return r.enqueueUnique(ctx, run)
+	}
+
 	id, err := r.store.Enqueue(ctx, run)
 	if err != nil {
 		return "", err
@@ -209,6 +216,56 @@ func (r *Runner) Enqueue(ctx context.Context, name string, p Params, opts ...Enq
 		r.log.Error().Err(err).Str("run", string(id)).Msg("rjobs: recording queued status failed")
 	}
 	return id, nil
+}
+
+// enqueueUnique enqueues a run that carries a Unique key. It reserves the key in
+// the status store before publishing, so two concurrent enqueues for the same
+// (owner, key) cannot both start a run: the reservation, backed by a unique
+// index, is the gate. On conflict it collapses onto the in-flight run (default)
+// or rejects, per the run's policy.
+func (r *Runner) enqueueUnique(ctx context.Context, run Run) (RunID, error) {
+	run.ID = RunID(uuid.New().String())
+	run.Attempt = 1
+	run.EnqueuedAt = time.Now()
+
+	queued := Status{
+		RunID:      run.ID,
+		Job:        run.Job,
+		State:      StateQueued,
+		Attempt:    1,
+		EnqueuedAt: run.EnqueuedAt,
+		Owner:      run.Owner,
+	}
+
+	existing, reserved, err := r.status.Reserve(ctx, queued, run.DedupKey)
+	if err != nil {
+		return "", err
+	}
+	if !reserved {
+		if run.dedupReject {
+			return "", errtypes.AlreadyExists(fmt.Sprintf("run %s already active for key %q", existing.RunID, run.DedupKey))
+		}
+		return existing.RunID, nil
+	}
+
+	if _, err := r.store.Enqueue(ctx, run); err != nil {
+		// the key is reserved but nothing reached the queue. Release it and mark
+		// the orphaned run failed, so the key is not stuck and no phantom queued
+		// run lingers.
+		if rerr := r.status.Release(ctx, run.ID); rerr != nil {
+			r.log.Error().Err(rerr).Str("run", string(run.ID)).Msg("rjobs: releasing reservation after failed enqueue errored")
+		}
+		now := time.Now()
+		failed := queued
+		failed.State = StateFailed
+		failed.FinishedAt = &now
+		failed.LastError = err.Error()
+		if perr := r.status.Put(ctx, failed); perr != nil {
+			r.log.Error().Err(perr).Str("run", string(run.ID)).Msg("rjobs: recording failed status after failed enqueue errored")
+		}
+		return "", err
+	}
+	return run.ID, nil
 }
 
 // Status returns the current status of a previously enqueued run. It returns
@@ -350,6 +407,12 @@ func (r *Runner) execRun(ctx context.Context, run Run) {
 	}
 
 	r.recordStatus(ctx, run, StateSucceeded, result, nil, log)
+	if run.DedupKey != "" && r.status != nil {
+		// the run is done; free its Unique key so a new run can take it.
+		if err := r.status.Release(ctx, run.ID); err != nil {
+			log.Error().Err(err).Msg("rjobs: releasing dedup reservation errored")
+		}
+	}
 	if cerr := r.store.Complete(ctx, run.ID); cerr != nil {
 		log.Error().Err(cerr).Msg("rjobs: completing run errored")
 	}

--- a/pkg/rjobs/status.go
+++ b/pkg/rjobs/status.go
@@ -71,6 +71,10 @@ func (s Status) Internal() bool { return s.Owner == "" }
 type ListFilter struct {
 	// Owner, when set, restricts the listing to runs created for that username.
 	Owner string
+	// Internal, when true, restricts the listing to internal runs — those with
+	// no owner (periodic jobs, and on-demand jobs enqueued without WithOwner).
+	// It is mutually exclusive with Owner.
+	Internal bool
 	// States, when non-empty, restricts the listing to runs in any of these
 	// states.
 	States []State

--- a/pkg/rjobs/status.go
+++ b/pkg/rjobs/status.go
@@ -66,6 +66,22 @@ type Status struct {
 // behalf of a user, i.e. it carries no owner.
 func (s Status) Internal() bool { return s.Owner == "" }
 
+// ListFilter narrows a run listing. The zero value matches every run; the
+// common use is to set Owner so a user sees only their own runs.
+type ListFilter struct {
+	// Owner, when set, restricts the listing to runs created for that username.
+	Owner string
+	// States, when non-empty, restricts the listing to runs in any of these
+	// states.
+	States []State
+	// Job, when set, restricts the listing to runs of that job.
+	Job string
+	// Limit caps the number of returned runs; 0 returns all of them.
+	Limit int
+	// Offset skips that many runs from the start, for pagination.
+	Offset int
+}
+
 // StatusStore persists and serves the per-run status. It is a separate
 // concern from the work-queue Store: the queue handles delivery, the status
 // store handles observability, and a deployment may in principle back them
@@ -76,6 +92,8 @@ type StatusStore interface {
 	// Get returns the status of a run. It returns an errtypes.NotFound error
 	// if the run is unknown.
 	Get(ctx context.Context, id RunID) (Status, error)
+	// List returns the runs matching the filter, most recently enqueued first.
+	List(ctx context.Context, f ListFilter) ([]Status, error)
 	// Close releases the status store's resources.
 	Close(ctx context.Context) error
 }

--- a/pkg/rjobs/status.go
+++ b/pkg/rjobs/status.go
@@ -94,6 +94,15 @@ type StatusStore interface {
 	Get(ctx context.Context, id RunID) (Status, error)
 	// List returns the runs matching the filter, most recently enqueued first.
 	List(ctx context.Context, f ListFilter) ([]Status, error)
+	// Reserve persists s as a queued run while enforcing at most one active run
+	// per (Owner, key). If the key is already held by an active run it stores
+	// nothing and returns that run with reserved=false; otherwise it stores s
+	// and returns reserved=true.
+	Reserve(ctx context.Context, s Status, key string) (existing Status, reserved bool, err error)
+	// Release drops a run's uniqueness reservation once it no longer needs it
+	// (it succeeded, or it never reached the queue), freeing the key for a new
+	// run. It is a no-op for a run that holds no reservation.
+	Release(ctx context.Context, id RunID) error
 	// Close releases the status store's resources.
 	Close(ctx context.Context) error
 }

--- a/pkg/rjobs/status.go
+++ b/pkg/rjobs/status.go
@@ -58,7 +58,13 @@ type Status struct {
 	LastError string
 	// Result is the payload returned by the job on success.
 	Result Params
+	// Owner is the username the run was created for, or empty for an internal run.
+	Owner string
 }
+
+// Internal reports whether the run was created by reva itself rather than on
+// behalf of a user, i.e. it carries no owner.
+func (s Status) Internal() bool { return s.Owner == "" }
 
 // StatusStore persists and serves the per-run status. It is a separate
 // concern from the work-queue Store: the queue handles delivery, the status

--- a/pkg/rjobs/store.go
+++ b/pkg/rjobs/store.go
@@ -40,9 +40,15 @@ type Run struct {
 	// run (periodic jobs, and on-demand jobs enqueued without WithOwner). It
 	// travels with the run so the worker can record it in the run's status.
 	Owner string
-	// IdempotencyKey, when set, collapses duplicate enqueues into a single
-	// run. Two enqueues with the same key yield the same run.
-	IdempotencyKey string
+	// DedupKey, set through Unique, makes the run the only active one for its
+	// (Owner, DedupKey): while it is queued, running or retrying, another
+	// enqueue with the same key does not start a second run. It travels with the
+	// run so the reservation can be released once the run succeeds.
+	DedupKey string
+	// dedupReject selects Reject over the default Collapse when DedupKey is
+	// already held. It is read at enqueue time only and never leaves the
+	// process, so it is deliberately unexported and not serialised.
+	dedupReject bool
 	// Attempt is the 1-based delivery attempt for this run.
 	Attempt int
 	// EnqueuedAt is when the run was first persisted.
@@ -67,9 +73,7 @@ type ScheduledRun struct {
 // calling Complete or Fail, the lease expires and the run becomes claimable
 // again, giving at-least-once delivery.
 type Store interface {
-	// Enqueue persists a ready-to-run job instance and returns its id. If the
-	// run carries an IdempotencyKey that already has a live run, the existing
-	// run's id is returned and no new run is created.
+	// Enqueue persists a ready-to-run job instance and returns its id.
 	Enqueue(ctx context.Context, run Run) (RunID, error)
 	// Claim atomically leases the next ready run to the caller. It blocks
 	// until a run is available or ctx is cancelled.

--- a/pkg/rjobs/store.go
+++ b/pkg/rjobs/store.go
@@ -36,6 +36,10 @@ type Run struct {
 	Job string
 	// Params is the on-demand payload. Empty for periodic runs.
 	Params Params
+	// Owner is the username the run was created for, or empty for an internal
+	// run (periodic jobs, and on-demand jobs enqueued without WithOwner). It
+	// travels with the run so the worker can record it in the run's status.
+	Owner string
 	// IdempotencyKey, when set, collapses duplicate enqueues into a single
 	// run. Two enqueues with the same key yield the same run.
 	IdempotencyKey string

--- a/pkg/rjobs/store/nats/nats.go
+++ b/pkg/rjobs/store/nats/nats.go
@@ -238,14 +238,7 @@ func (s *store) Enqueue(ctx context.Context, run rjobs.Run) (rjobs.RunID, error)
 		return "", errors.Wrap(err, "rjobs: marshalling run failed")
 	}
 
-	pubOpts := []nats.PubOpt{nats.Context(ctx)}
-	if run.IdempotencyKey != "" {
-		// JetStream dedups messages carrying the same Nats-Msg-Id within the
-		// stream's duplicate window, collapsing repeated enqueues.
-		pubOpts = append(pubOpts, nats.MsgId(run.IdempotencyKey))
-	}
-
-	if _, err := s.js.Publish(s.subjectFor(run.Job), payload, pubOpts...); err != nil {
+	if _, err := s.js.Publish(s.subjectFor(run.Job), payload, nats.Context(ctx)); err != nil {
 		return "", errors.Wrap(err, "rjobs: publishing run failed")
 	}
 	return run.ID, nil

--- a/pkg/rjobs/store/sql/model/model.go
+++ b/pkg/rjobs/store/sql/model/model.go
@@ -36,6 +36,10 @@ type Run struct {
 	FinishedAt *time.Time
 	LastError  string         `gorm:"type:text"`
 	Result     datatypes.JSON `gorm:"type:json"`
+
+	// Owner is the username the run was created for, empty for an internal run.
+	// It is indexed so a user's runs can be listed.
+	Owner string `gorm:"size:255;index:idx_owner"`
 }
 
 // TableName sets the table name explicitly so it does not collide with other

--- a/pkg/rjobs/store/sql/model/model.go
+++ b/pkg/rjobs/store/sql/model/model.go
@@ -38,8 +38,16 @@ type Run struct {
 	Result     datatypes.JSON `gorm:"type:json"`
 
 	// Owner is the username the run was created for, empty for an internal run.
-	// It is indexed so a user's runs can be listed.
-	Owner string `gorm:"size:255;index:idx_owner"`
+	// It is indexed so a user's runs can be listed, and it is the first column
+	// of the active-dedup unique index below.
+	Owner string `gorm:"size:255;index:idx_owner;uniqueIndex:idx_active_dedup,priority:1"`
+
+	// ActiveDedupKey carries a run's Unique key while it is active (queued,
+	// running or retrying) and is NULL otherwise. The unique index over
+	// (owner, active_dedup_key) therefore allows at most one active run per
+	// (owner, key), while ordinary runs — whose key is NULL — stay entirely
+	// unconstrained.
+	ActiveDedupKey *string `gorm:"size:255;uniqueIndex:idx_active_dedup,priority:2"`
 }
 
 // TableName sets the table name explicitly so it does not collide with other

--- a/pkg/rjobs/store/sql/sql.go
+++ b/pkg/rjobs/store/sql/sql.go
@@ -54,7 +54,9 @@ func New(ctx context.Context, c config.Database) (rjobs.StatusStore, error) {
 }
 
 func openDB(c config.Database) (*gorm.DB, error) {
-	gormCfg := &gorm.Config{}
+	// TranslateError makes a unique-constraint violation surface as
+	// gorm.ErrDuplicatedKey across engines, which Reserve relies on.
+	gormCfg := &gorm.Config{TranslateError: true}
 	switch c.Engine {
 	case "sqlite":
 		return gorm.Open(sqlite.Open(c.DBName), gormCfg)
@@ -70,8 +72,9 @@ func (s *store) Put(ctx context.Context, st rjobs.Status) error {
 		return err
 	}
 	// upsert on the run id: the row is created on enqueue and updated on every
-	// later transition.
-	res := s.db.WithContext(ctx).Save(row)
+	// later transition. The reservation column is owned by Reserve/Release, so
+	// omit it here or a status update would wipe a live reservation.
+	res := s.db.WithContext(ctx).Omit("ActiveDedupKey").Save(row)
 	if res.Error != nil {
 		return errors.Wrap(res.Error, "rjobs sql: storing status failed")
 	}
@@ -126,6 +129,61 @@ func (s *store) List(ctx context.Context, f rjobs.ListFilter) ([]rjobs.Status, e
 		out = append(out, st)
 	}
 	return out, nil
+}
+
+func (s *store) Reserve(ctx context.Context, st rjobs.Status, key string) (rjobs.Status, bool, error) {
+	// Retry to cover the narrow window where the current holder releases the key
+	// between our failed insert and the lookup of that holder.
+	for attempt := 0; attempt < 5; attempt++ {
+		row, err := toModel(st)
+		if err != nil {
+			return rjobs.Status{}, false, err
+		}
+		row.ActiveDedupKey = &key
+
+		if err := s.db.WithContext(ctx).Create(row).Error; err == nil {
+			return rjobs.Status{}, true, nil
+		} else if !errors.Is(err, gorm.ErrDuplicatedKey) {
+			return rjobs.Status{}, false, errors.Wrap(err, "rjobs sql: reserving run failed")
+		}
+
+		holder, found, err := s.activeHolder(ctx, st.Owner, key)
+		if err != nil {
+			return rjobs.Status{}, false, err
+		}
+		if found {
+			return holder, false, nil
+		}
+		// the holder released the key just now; loop and try to take it.
+	}
+	return rjobs.Status{}, false, errors.New("rjobs sql: could not reserve run, key is contended")
+}
+
+func (s *store) Release(ctx context.Context, id rjobs.RunID) error {
+	res := s.db.WithContext(ctx).Model(&model.Run{}).
+		Where("run_id = ?", string(id)).
+		Update("active_dedup_key", nil)
+	if res.Error != nil {
+		return errors.Wrap(res.Error, "rjobs sql: releasing reservation failed")
+	}
+	return nil
+}
+
+// activeHolder loads the run currently holding key for owner, if any.
+func (s *store) activeHolder(ctx context.Context, owner, key string) (rjobs.Status, bool, error) {
+	q := s.db.WithContext(ctx).Where("owner = ? AND active_dedup_key = ?", owner, key)
+	var row model.Run
+	if err := q.First(&row).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return rjobs.Status{}, false, nil
+		}
+		return rjobs.Status{}, false, errors.Wrap(err, "rjobs sql: loading reservation holder failed")
+	}
+	st, err := fromModel(row)
+	if err != nil {
+		return rjobs.Status{}, false, err
+	}
+	return st, true, nil
 }
 
 func (s *store) Close(ctx context.Context) error {

--- a/pkg/rjobs/store/sql/sql.go
+++ b/pkg/rjobs/store/sql/sql.go
@@ -35,6 +35,7 @@ import (
 	"gorm.io/driver/mysql"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 type store struct {
@@ -54,9 +55,7 @@ func New(ctx context.Context, c config.Database) (rjobs.StatusStore, error) {
 }
 
 func openDB(c config.Database) (*gorm.DB, error) {
-	// TranslateError makes a unique-constraint violation surface as
-	// gorm.ErrDuplicatedKey across engines, which Reserve relies on.
-	gormCfg := &gorm.Config{TranslateError: true}
+	gormCfg := &gorm.Config{}
 	switch c.Engine {
 	case "sqlite":
 		return gorm.Open(sqlite.Open(c.DBName), gormCfg)
@@ -133,7 +132,7 @@ func (s *store) List(ctx context.Context, f rjobs.ListFilter) ([]rjobs.Status, e
 
 func (s *store) Reserve(ctx context.Context, st rjobs.Status, key string) (rjobs.Status, bool, error) {
 	// Retry to cover the narrow window where the current holder releases the key
-	// between our failed insert and the lookup of that holder.
+	// between our insert seeing it taken and the lookup of that holder.
 	for attempt := 0; attempt < 5; attempt++ {
 		row, err := toModel(st)
 		if err != nil {
@@ -141,10 +140,15 @@ func (s *store) Reserve(ctx context.Context, st rjobs.Status, key string) (rjobs
 		}
 		row.ActiveDedupKey = &key
 
-		if err := s.db.WithContext(ctx).Create(row).Error; err == nil {
+		// Insert unless (owner, key) is already taken: a unique-index conflict is
+		// the expected "key already held" case, so the database skips it instead
+		// of erroring. RowsAffected == 1 means our row went in — we won the key.
+		res := s.db.WithContext(ctx).Clauses(clause.OnConflict{DoNothing: true}).Create(row)
+		if res.Error != nil {
+			return rjobs.Status{}, false, errors.Wrap(res.Error, "rjobs sql: reserving run failed")
+		}
+		if res.RowsAffected == 1 {
 			return rjobs.Status{}, true, nil
-		} else if !errors.Is(err, gorm.ErrDuplicatedKey) {
-			return rjobs.Status{}, false, errors.Wrap(err, "rjobs sql: reserving run failed")
 		}
 
 		holder, found, err := s.activeHolder(ctx, st.Owner, key)

--- a/pkg/rjobs/store/sql/sql.go
+++ b/pkg/rjobs/store/sql/sql.go
@@ -107,7 +107,7 @@ func toModel(st rjobs.Status) (*model.Run, error) {
 		}
 		result = b
 	}
-	return &model.Run{
+	m := &model.Run{
 		RunID:      string(st.RunID),
 		Job:        st.Job,
 		State:      string(st.State),
@@ -117,7 +117,9 @@ func toModel(st rjobs.Status) (*model.Run, error) {
 		FinishedAt: st.FinishedAt,
 		LastError:  st.LastError,
 		Result:     result,
-	}, nil
+	}
+	m.Owner = st.Owner
+	return m, nil
 }
 
 func fromModel(row model.Run) (rjobs.Status, error) {
@@ -131,6 +133,7 @@ func fromModel(row model.Run) (rjobs.Status, error) {
 		FinishedAt: row.FinishedAt,
 		LastError:  row.LastError,
 	}
+	st.Owner = row.Owner
 	if len(row.Result) > 0 {
 		var p rjobs.Params
 		if err := json.Unmarshal(row.Result, &p); err != nil {

--- a/pkg/rjobs/store/sql/sql.go
+++ b/pkg/rjobs/store/sql/sql.go
@@ -94,7 +94,10 @@ func (s *store) Get(ctx context.Context, id rjobs.RunID) (rjobs.Status, error) {
 
 func (s *store) List(ctx context.Context, f rjobs.ListFilter) ([]rjobs.Status, error) {
 	q := s.db.WithContext(ctx).Model(&model.Run{})
-	if f.Owner != "" {
+	switch {
+	case f.Internal:
+		q = q.Where("owner = ?", "")
+	case f.Owner != "":
 		q = q.Where("owner = ?", f.Owner)
 	}
 	if len(f.States) > 0 {

--- a/pkg/rjobs/store/sql/sql.go
+++ b/pkg/rjobs/store/sql/sql.go
@@ -90,6 +90,44 @@ func (s *store) Get(ctx context.Context, id rjobs.RunID) (rjobs.Status, error) {
 	return fromModel(row)
 }
 
+func (s *store) List(ctx context.Context, f rjobs.ListFilter) ([]rjobs.Status, error) {
+	q := s.db.WithContext(ctx).Model(&model.Run{})
+	if f.Owner != "" {
+		q = q.Where("owner = ?", f.Owner)
+	}
+	if len(f.States) > 0 {
+		states := make([]string, len(f.States))
+		for i, st := range f.States {
+			states[i] = string(st)
+		}
+		q = q.Where("state IN ?", states)
+	}
+	if f.Job != "" {
+		q = q.Where("job = ?", f.Job)
+	}
+	q = q.Order("enqueued_at DESC")
+	if f.Limit > 0 {
+		q = q.Limit(f.Limit)
+	}
+	if f.Offset > 0 {
+		q = q.Offset(f.Offset)
+	}
+
+	var rows []model.Run
+	if err := q.Find(&rows).Error; err != nil {
+		return nil, errors.Wrap(err, "rjobs sql: listing runs failed")
+	}
+	out := make([]rjobs.Status, 0, len(rows))
+	for _, row := range rows {
+		st, err := fromModel(row)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, st)
+	}
+	return out, nil
+}
+
 func (s *store) Close(ctx context.Context) error {
 	db, err := s.db.DB()
 	if err != nil {

--- a/pkg/rjobs/store/sql/sql_test.go
+++ b/pkg/rjobs/store/sql/sql_test.go
@@ -154,3 +154,45 @@ func TestListByOwner(t *testing.T) {
 		t.Fatalf("bob runs = %v, want [b1]", got)
 	}
 }
+
+func TestReserve(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Second)
+
+	alice := "alice"
+	bob := "bob"
+	queued := func(id, owner string) rjobs.Status {
+		return rjobs.Status{RunID: rjobs.RunID(id), Job: "export", State: rjobs.StateQueued, Attempt: 1, EnqueuedAt: now, Owner: owner}
+	}
+
+	// the first reservation of a key wins.
+	if _, reserved, err := s.Reserve(ctx, queued("r1", alice), "export:1"); err != nil || !reserved {
+		t.Fatalf("first reservation should win: reserved=%v err=%v", reserved, err)
+	}
+
+	// a second one for the same (owner, key) collapses onto the holder.
+	existing, reserved, err := s.Reserve(ctx, queued("r2", alice), "export:1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reserved {
+		t.Fatal("second reservation must not win while the key is held")
+	}
+	if existing.RunID != "r1" {
+		t.Errorf("holder = %q, want r1", existing.RunID)
+	}
+
+	// a different user holding the same key is independent.
+	if _, reserved, err := s.Reserve(ctx, queued("r3", bob), "export:1"); err != nil || !reserved {
+		t.Fatalf("a different owner should reserve the same key: reserved=%v err=%v", reserved, err)
+	}
+
+	// once released, the key is free for a new run.
+	if err := s.Release(ctx, "r1"); err != nil {
+		t.Fatal(err)
+	}
+	if _, reserved, err := s.Reserve(ctx, queued("r4", alice), "export:1"); err != nil || !reserved {
+		t.Fatalf("a released key should be reservable again: reserved=%v err=%v", reserved, err)
+	}
+}

--- a/pkg/rjobs/store/sql/sql_test.go
+++ b/pkg/rjobs/store/sql/sql_test.go
@@ -153,6 +153,15 @@ func TestListByOwner(t *testing.T) {
 	if len(got) != 1 || got[0].RunID != "b1" {
 		t.Fatalf("bob runs = %v, want [b1]", got)
 	}
+
+	// the internal-only filter returns just the no-owner runs.
+	got, err = s.List(ctx, rjobs.ListFilter{Internal: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].RunID != "internal" {
+		t.Fatalf("internal runs = %v, want [internal]", got)
+	}
 }
 
 func TestReserve(t *testing.T) {

--- a/pkg/rjobs/store/sql/sql_test.go
+++ b/pkg/rjobs/store/sql/sql_test.go
@@ -93,3 +93,64 @@ func TestGetNotFound(t *testing.T) {
 		t.Errorf("expected NotFound, got %T: %v", err, err)
 	}
 }
+
+func TestListByOwner(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Second)
+
+	alice := "alice"
+	bob := "bob"
+
+	put := func(id, owner, job string, state rjobs.State, enqueued time.Time) {
+		t.Helper()
+		if err := s.Put(ctx, rjobs.Status{
+			RunID:      rjobs.RunID(id),
+			Job:        job,
+			State:      state,
+			Attempt:    1,
+			EnqueuedAt: enqueued,
+			Owner:      owner,
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	put("a1", alice, "export", rjobs.StateQueued, now)
+	put("a2", alice, "report", rjobs.StateSucceeded, now.Add(time.Second))
+	put("b1", bob, "export", rjobs.StateQueued, now)
+	put("internal", "", "cleanup", rjobs.StateRunning, now)
+
+	// all of alice's runs, most recently enqueued first.
+	got, err := s.List(ctx, rjobs.ListFilter{Owner: alice})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("alice runs = %d, want 2", len(got))
+	}
+	if got[0].RunID != "a2" || got[1].RunID != "a1" {
+		t.Errorf("order = %q,%q, want a2,a1", got[0].RunID, got[1].RunID)
+	}
+	if got[0].Owner != "alice" {
+		t.Errorf("owner not round-tripped: %q", got[0].Owner)
+	}
+
+	// narrowing by state keeps only the matching run.
+	got, err = s.List(ctx, rjobs.ListFilter{Owner: alice, States: []rjobs.State{rjobs.StateQueued}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].RunID != "a1" {
+		t.Fatalf("queued alice runs = %v, want [a1]", got)
+	}
+
+	// another user's listing is scoped to their own runs only.
+	got, err = s.List(ctx, rjobs.ListFilter{Owner: bob})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].RunID != "b1" {
+		t.Fatalf("bob runs = %v, want [b1]", got)
+	}
+}


### PR DESCRIPTION
## Why

The background-jobs framework (#5651) creates on-demand jobs without recording
*who* asked for them, so there's no way to, for example, show a user the list of
jobs they started. This PR adds that missing link, plus a couple of related
conveniences.

## What this adds

- **`WithOwner(username)`**: optionally attach an on-demand job to a user.
  It's opt-in; without it a job stays *internal* (created by reva itself), exactly
  as today. Only the username is stored.
- **`ListByOwner(username, …)`**: list the jobs a user created, newest first,
  with optional state/job filters and paging. Internal jobs never show up here.
- **`Unique(key)`**: optionally keep at most one *active* run per `(owner, key)`,
  so a user can't start the same job twice while one is still queued or running.
  A duplicate returns the run already in flight (or fails, with `Reject`). You
  compose the key yourself, e.g. `"export:" + spaceID`.

It also retires the `WithIdempotencyKey`, which only deduplicated within a
~2-minute NATS window and could leave dangling status rows, in favour of
`Unique`, which is durable and scoped per user.