### PR TITLE
Cancel background jobs

### DIFF
--- a/changelog/unreleased/add-job-cancellation.md
+++ b/changelog/unreleased/add-job-cancellation.md
@@ -1,0 +1,10 @@
+Enhancement: Cancel background jobs and trigger scheduled jobs on demand
+
+Added the ability to cancel a background job run, both on-demand and
+leader-scoped periodic, and to trigger a scheduled job to run immediately.
+Cancellation is cooperative through the job's context, durable so it reaches a
+run that is still queued or running on another process, and terminal so a
+cancelled run is not retried. Triggering enqueues an extra run without
+disturbing the schedule's regular cadence.
+
+https://github.com/cs3org/reva/pull/5677

--- a/internal/serverless/services/jobs/README.md
+++ b/internal/serverless/services/jobs/README.md
@@ -163,7 +163,7 @@ Use the `RunID` to read a single run back:
 
 ```go
 st, err := rjobs.Default().Status(ctx, runID)
-// st.State is queued | running | succeeded | failed
+// st.State is queued | running | succeeded | failed | cancelling | cancelled
 // st.Result holds the payload the job returned on success
 // st.LastError holds the error of the last failed attempt
 ```
@@ -185,6 +185,52 @@ runs, err := rjobs.Default().ListByOwner(ctx, username, rjobs.ListFilter{
     Limit:  50,
 })
 ```
+
+### Cancelling a run
+
+Cancel a run by its `RunID`. It works whether the run is still queued or already
+running, and on whichever process is running it:
+
+```go
+st, err := rjobs.Default().Cancel(ctx, runID)
+// st.State is cancelling until the run actually stops, then cancelled.
+```
+
+Cancellation is **cooperative and asynchronous**: the framework cancels the
+`context.Context` passed to the job, and the job has to observe it and return —
+which a job that already respects its context for shutdown does for free.
+
+```go
+func (j *exportJob) Run(ctx context.Context, p rjobs.Params) (rjobs.Params, error) {
+    rows, err := j.db.QueryContext(ctx, "...") // returns promptly on cancel
+    // ...or, in a long CPU-bound loop, check between chunks:
+    if err := ctx.Err(); err != nil {
+        return nil, err
+    }
+}
+```
+
+A job that ignores its context runs to completion and is only then marked
+cancelled. Unlike `failed`, `cancelled` is **terminal**: the run is acked and
+never retried. Cancelling a finished run is a no-op.
+
+### Cancelling or triggering a scheduled job
+
+A `ScopeLeader` periodic job is cancelled or triggered by **name** (an on-demand
+job is "triggered" simply by enqueueing it; an all-nodes job is a pure local
+ticker on every process, so it is neither):
+
+```go
+// stop the run in flight right now; the schedule keeps firing as usual.
+err := rjobs.Default().CancelPeriodic(ctx, "mycomponent.cleanup")
+
+// run an extra execution immediately, on top of the regular cadence.
+err = rjobs.Default().TriggerNow(ctx, "mycomponent.cleanup")
+```
+
+`TriggerNow` respects the job's single-flight guard, so it is rejected if a run
+is already in flight, and it leaves the schedule's next-fire untouched: it is an
+extra run, not a reschedule. Like `Enqueue`, all of these are in-process today.
 
 ## Configuration
 

--- a/pkg/rjobs/runner.go
+++ b/pkg/rjobs/runner.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"math/rand"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/cs3org/reva/v3/pkg/appctx"
@@ -68,6 +69,34 @@ type Runner struct {
 	// Skip.
 	runningMu sync.Mutex
 	running   map[string]bool
+
+	// cancels holds the cancellation handle of every run currently executing on
+	// this process, so a cancel request can interrupt the right run. A run is
+	// added when execRun starts it and removed when it returns.
+	cancelsMu sync.Mutex
+	cancels   map[RunID]*runHandle
+}
+
+// runHandle is the per-run cancellation handle held while a run executes on
+// this process. cancel stops the run's context; cancelled records that the stop
+// was an explicit cancellation and not a shutdown, so execRun finalises the run
+// as cancelled instead of retrying it. once keeps tripping it idempotent across
+// the several places that may request it (a direct local cancel, the cancel
+// broadcast, the backstop poll).
+type runHandle struct {
+	job       string
+	cancel    context.CancelFunc
+	cancelled atomic.Bool
+	once      sync.Once
+}
+
+// trip marks the run cancelled and cancels its context. Only the first call has
+// an effect.
+func (h *runHandle) trip() {
+	h.once.Do(func() {
+		h.cancelled.Store(true)
+		h.cancel()
+	})
 }
 
 // NewRunner builds a Runner from the registered jobs and the given options.
@@ -83,6 +112,7 @@ func NewRunner(ctx context.Context, opts Options) (*Runner, error) {
 		log:      *appctx.GetLogger(ctx),
 		periodic: registeredPeriodic(),
 		running:  make(map[string]bool),
+		cancels:  make(map[RunID]*runHandle),
 	}
 
 	// leader-scoped and on-demand work both need a store.
@@ -291,6 +321,56 @@ func (r *Runner) ListByOwner(ctx context.Context, owner string, f ListFilter) ([
 	return r.status.List(ctx, f)
 }
 
+// Cancel requests cancellation of a previously enqueued run and returns its
+// updated status. Cancellation is cooperative and asynchronous: it records a
+// durable cancel intent and stops the run on this process if it is running
+// here. The run reaches StateCancelled once it actually stops, so callers
+// observe Status to confirm. A run that ignores its context runs to completion.
+// Cancelling a finished run is a no-op; it returns an errtypes.NotFound error
+// if the run is unknown.
+func (r *Runner) Cancel(ctx context.Context, id RunID) (Status, error) {
+	if r.status == nil {
+		return Status{}, errors.New("rjobs: no status store configured")
+	}
+	// Durable intent first: it is the source of truth and the backstop should
+	// the fast local path not reach the worker running the job.
+	st, err := r.status.RequestCancel(ctx, id)
+	if err != nil {
+		return Status{}, err
+	}
+	// Fast path: if the run is executing on this process, stop it now.
+	r.cancelLocal(id)
+	return st, nil
+}
+
+// registerRun records a run's cancellation handle for the duration of its
+// execution on this process.
+func (r *Runner) registerRun(id RunID, h *runHandle) {
+	r.cancelsMu.Lock()
+	r.cancels[id] = h
+	r.cancelsMu.Unlock()
+}
+
+// deregisterRun drops a run's cancellation handle once it has finished.
+func (r *Runner) deregisterRun(id RunID) {
+	r.cancelsMu.Lock()
+	delete(r.cancels, id)
+	r.cancelsMu.Unlock()
+}
+
+// cancelLocal stops a run if it is executing on this process, reporting whether
+// it was found here. It is the node-local half of a cancel and a no-op when the
+// run is queued or running elsewhere.
+func (r *Runner) cancelLocal(id RunID) bool {
+	r.cancelsMu.Lock()
+	defer r.cancelsMu.Unlock()
+	h, ok := r.cancels[id]
+	if ok {
+		h.trip()
+	}
+	return ok
+}
+
 // runLocalTicker drives an all-nodes periodic job on this replica. It never
 // touches the store.
 func (r *Runner) runLocalTicker(ctx context.Context, p Periodic) {
@@ -393,12 +473,41 @@ func (r *Runner) execRun(ctx context.Context, run Run) {
 		}()
 	}
 
-	stopBeat := r.startHeartbeat(ctx, run.ID, log)
+	// Per-run cancellable context, registered so a cancel request can interrupt
+	// this specific run. It derives from ctx, so a shutdown still cancels it too;
+	// the runHandle.cancelled flag is what tells the two apart below.
+	runCtx, cancel := context.WithCancel(ctx)
+	h := &runHandle{job: run.Job, cancel: cancel}
+	r.registerRun(run.ID, h)
+	defer r.deregisterRun(run.ID)
+	defer cancel()
+
+	// A cancellation may have arrived while the run was queued or waiting to be
+	// retried. Honour it before doing any work: drop the run as cancelled
+	// instead of executing it.
+	if r.cancelRequested(ctx, run) {
+		log.Info().Msg("rjobs: run cancelled before it started")
+		r.finishCancelled(ctx, run, log)
+		return
+	}
+
+	stopBeat := r.startHeartbeat(ctx, run, h, log)
 	defer stopBeat()
 
 	r.recordStatus(ctx, run, StateRunning, nil, nil, log)
 
-	result, err := r.invoke(ctx, run, log)
+	result, err := r.invoke(runCtx, run, log)
+
+	// An explicit cancellation wins over the job's return value: the run is
+	// terminal and must not be retried, whether the job returned an error or
+	// not. A shutdown does not set this flag, so in-flight work is still retried
+	// after a restart.
+	if h.cancelled.Load() {
+		log.Info().Msg("rjobs: run cancelled")
+		r.finishCancelled(ctx, run, log)
+		return
+	}
+
 	if err != nil {
 		log.Error().Err(err).Msg("rjobs: run failed")
 		r.recordStatus(ctx, run, StateFailed, nil, err, log)
@@ -420,10 +529,36 @@ func (r *Runner) execRun(ctx context.Context, run Run) {
 	}
 }
 
+// cancelRequested reports whether a cancellation has been requested for run. It
+// reads the durable cancel intent kept in the status store. Periodic runs are
+// not status-tracked, so this is always false for them; their cancellation is
+// driven separately through the schedule store.
+func (r *Runner) cancelRequested(ctx context.Context, run Run) bool {
+	if _, ok := r.lookupPeriodic(run.Job); ok {
+		return false
+	}
+	st, err := r.status.Get(ctx, run.ID)
+	if err != nil {
+		// A missing or unreadable status must not block execution; the run just
+		// misses its cancel check this round.
+		return false
+	}
+	return st.CancelRequested
+}
+
+// finishCancelled records a run as cancelled and acks it so it is not
+// redelivered. Cancellation is terminal, unlike a failure.
+func (r *Runner) finishCancelled(ctx context.Context, run Run, log zerolog.Logger) {
+	r.recordStatus(ctx, run, StateCancelled, nil, nil, log)
+	if err := r.store.Complete(ctx, run.ID); err != nil {
+		log.Error().Err(err).Msg("rjobs: completing cancelled run errored")
+	}
+}
+
 // startHeartbeat keeps a claimed run's lease alive by calling the store's
 // Heartbeat on a ticker until the returned stop function is called. It lets a
 // job run for arbitrarily long (minutes or days) without being redelivered.
-func (r *Runner) startHeartbeat(ctx context.Context, id RunID, log zerolog.Logger) (stop func()) {
+func (r *Runner) startHeartbeat(ctx context.Context, run Run, h *runHandle, log zerolog.Logger) (stop func()) {
 	interval := r.store.HeartbeatInterval()
 	if interval <= 0 {
 		return func() {}
@@ -440,8 +575,16 @@ func (r *Runner) startHeartbeat(ctx context.Context, id RunID, log zerolog.Logge
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				if err := r.store.Heartbeat(ctx, id); err != nil {
+				if err := r.store.Heartbeat(ctx, run.ID); err != nil {
 					log.Warn().Err(err).Msg("rjobs: heartbeat failed")
+				}
+				// Backstop for a cancel that did not reach this worker by the
+				// fast path: notice the durable cancel intent and stop the run.
+				// It keeps beating afterwards so the lease stays alive while the
+				// job winds down.
+				if !h.cancelled.Load() && r.cancelRequested(ctx, run) {
+					log.Info().Msg("rjobs: cancellation observed, stopping run")
+					h.trip()
 				}
 			}
 		}
@@ -475,7 +618,7 @@ func (r *Runner) recordStatus(ctx context.Context, run Run, state State, result 
 	switch state {
 	case StateRunning:
 		st.StartedAt = &now
-	case StateSucceeded, StateFailed:
+	case StateSucceeded, StateFailed, StateCancelled:
 		st.FinishedAt = &now
 	}
 	if runErr != nil {

--- a/pkg/rjobs/runner.go
+++ b/pkg/rjobs/runner.go
@@ -386,6 +386,35 @@ func (r *Runner) Cancel(ctx context.Context, id RunID) (Status, error) {
 	return st, nil
 }
 
+// CancelPeriodic requests cancellation of the in-flight run of a leader-scoped
+// periodic job, addressed by job name (a leader job has at most one run in
+// flight). Like Cancel it is cooperative and asynchronous. The schedule itself
+// is untouched, so the job keeps firing on its normal cadence; this stops only
+// the current run. It returns an error if the job is not a registered leader
+// job or if no run of it is currently in flight.
+func (r *Runner) CancelPeriodic(ctx context.Context, job string) error {
+	if r.store == nil {
+		return errors.New("rjobs: cannot cancel, no store configured")
+	}
+	if !r.isLeaderJob(job) {
+		return errors.Errorf("rjobs: %q is not a registered leader periodic job", job)
+	}
+
+	running, err := r.store.RequestCancelScheduled(ctx, job)
+	if err != nil {
+		return err
+	}
+	if !running {
+		return errors.Errorf("rjobs: no run of %q is currently in flight", job)
+	}
+
+	// Fast path: stop it here if it runs on this process, and broadcast to the
+	// process running it otherwise.
+	r.tripLocal(CancelSignal{Job: job})
+	r.broadcastCancel(ctx, CancelSignal{Job: job})
+	return nil
+}
+
 // registerRun records a run's cancellation handle for the duration of its
 // execution on this process.
 func (r *Runner) registerRun(id RunID, h *runHandle) {
@@ -602,7 +631,13 @@ func (r *Runner) execRun(ctx context.Context, run Run) {
 // driven separately through the schedule store.
 func (r *Runner) cancelRequested(ctx context.Context, run Run) bool {
 	if _, ok := r.lookupPeriodic(run.Job); ok {
-		return false
+		// Periodic runs are not status-tracked; their cancel intent lives in the
+		// schedule store, keyed by job name.
+		req, err := r.store.ScheduledCancelRequested(ctx, run.Job)
+		if err != nil {
+			return false
+		}
+		return req
 	}
 	st, err := r.status.Get(ctx, run.ID)
 	if err != nil {

--- a/pkg/rjobs/runner.go
+++ b/pkg/rjobs/runner.go
@@ -151,6 +151,15 @@ func (r *Runner) Start() {
 		return
 	}
 
+	// subscribe to cluster-wide cancel broadcasts so a cancel issued on another
+	// process can stop a run executing here. It is optional: without it cancels
+	// still land via the backstop poll, just not instantly.
+	if bus, ok := r.store.(ControlBus); ok {
+		if err := bus.SubscribeCancel(ctx, r.tripLocal); err != nil {
+			r.log.Error().Err(err).Msg("rjobs: subscribing to cancel broadcasts failed, cancels fall back to the backstop poll")
+		}
+	}
+
 	// register leader-scoped schedules so the scheduler can track them.
 	for _, p := range r.periodic {
 		if p.Scope != ScopeLeader {
@@ -338,8 +347,10 @@ func (r *Runner) Cancel(ctx context.Context, id RunID) (Status, error) {
 	if err != nil {
 		return Status{}, err
 	}
-	// Fast path: if the run is executing on this process, stop it now.
-	r.cancelLocal(id)
+	// Fast path: stop it now if it runs here, and broadcast so a worker running
+	// it on another process stops without waiting for the backstop poll.
+	r.tripLocal(CancelSignal{RunID: id})
+	r.broadcastCancel(ctx, CancelSignal{RunID: id})
 	return st, nil
 }
 
@@ -358,17 +369,41 @@ func (r *Runner) deregisterRun(id RunID) {
 	r.cancelsMu.Unlock()
 }
 
-// cancelLocal stops a run if it is executing on this process, reporting whether
-// it was found here. It is the node-local half of a cancel and a no-op when the
-// run is queued or running elsewhere.
-func (r *Runner) cancelLocal(id RunID) bool {
+// tripLocal stops any run matching sig that is executing on this process: a run
+// by id (on-demand) or every in-flight run of a job (periodic). It is the
+// node-local half of a cancel, invoked directly and from the cancel broadcast,
+// and a no-op when no matching run is running here.
+func (r *Runner) tripLocal(sig CancelSignal) {
 	r.cancelsMu.Lock()
 	defer r.cancelsMu.Unlock()
-	h, ok := r.cancels[id]
-	if ok {
-		h.trip()
+	if sig.RunID != "" {
+		if h, ok := r.cancels[sig.RunID]; ok {
+			h.trip()
+		}
+		return
 	}
-	return ok
+	if sig.Job == "" {
+		return
+	}
+	for _, h := range r.cancels {
+		if h.job == sig.Job {
+			h.trip()
+		}
+	}
+}
+
+// broadcastCancel best-effort publishes a cancel signal to the other processes
+// when the store supports it, so a run executing elsewhere stops without waiting
+// for its backstop poll. A failure only falls back to that poll, so it is
+// logged, not returned.
+func (r *Runner) broadcastCancel(ctx context.Context, sig CancelSignal) {
+	bus, ok := r.store.(ControlBus)
+	if !ok {
+		return
+	}
+	if err := bus.PublishCancel(ctx, sig); err != nil {
+		r.log.Warn().Err(err).Msg("rjobs: broadcasting cancel failed; relying on the backstop poll")
+	}
 }
 
 // runLocalTicker drives an all-nodes periodic job on this replica. It never

--- a/pkg/rjobs/runner.go
+++ b/pkg/rjobs/runner.go
@@ -307,6 +307,38 @@ func (r *Runner) enqueueUnique(ctx context.Context, run Run) (RunID, error) {
 	return run.ID, nil
 }
 
+// TriggerNow enqueues an immediate, out-of-band run of a leader-scoped periodic
+// job, on top of its schedule: the regular cadence is left untouched, so this is
+// an extra run, not a reschedule. It respects the job's single-flight guard, so
+// it is rejected with an error if a run of the job is already in flight. Like
+// Enqueue it is in-process; on-demand and all-nodes jobs cannot be triggered.
+func (r *Runner) TriggerNow(ctx context.Context, job string) error {
+	if r.store == nil {
+		return errors.New("rjobs: cannot trigger, no store configured")
+	}
+	if !r.isLeaderJob(job) {
+		return errors.Errorf("rjobs: %q is not a registered leader periodic job", job)
+	}
+
+	acquired, err := r.store.TryMarkScheduledRunning(ctx, job)
+	if err != nil {
+		return err
+	}
+	if !acquired {
+		return errors.Errorf("rjobs: a run of %q is already in flight", job)
+	}
+
+	if _, err := r.store.Enqueue(ctx, Run{Job: job}); err != nil {
+		// release the gate we just took so the job is not stuck marked-running.
+		if cerr := r.store.ClearScheduledRunning(ctx, job); cerr != nil {
+			r.log.Error().Err(cerr).Str("job", job).Msg("rjobs: releasing schedule mark after a failed trigger errored")
+		}
+		return errors.Wrap(err, "rjobs: enqueuing triggered run failed")
+	}
+	r.log.Info().Str("job", job).Msg("rjobs: triggered an immediate run")
+	return nil
+}
+
 // Status returns the current status of a previously enqueued run. It returns
 // an errtypes.NotFound error if the run is unknown.
 func (r *Runner) Status(ctx context.Context, id RunID) (Status, error) {

--- a/pkg/rjobs/runner_test.go
+++ b/pkg/rjobs/runner_test.go
@@ -20,9 +20,12 @@ package rjobs
 
 import (
 	"context"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/cs3org/reva/v3/pkg/errtypes"
 )
 
 func TestAllNodesRunOnStart(t *testing.T) {
@@ -160,4 +163,162 @@ func resetRegistry() {
 	defer reg.mu.Unlock()
 	reg.periodic = make(map[string]Periodic)
 	reg.onDemand = make(map[string]NewJob)
+}
+
+// jobFunc adapts a function to the Job interface for tests.
+type jobFunc func(context.Context, Params) (Params, error)
+
+func (f jobFunc) Run(ctx context.Context, p Params) (Params, error) { return f(ctx, p) }
+
+// fakeStatus is an in-memory StatusStore. Like the real store, a Put never
+// clears the cancel intent: only RequestCancel owns it.
+type fakeStatus struct {
+	mu  sync.Mutex
+	rec map[RunID]Status
+}
+
+func newFakeStatus() *fakeStatus { return &fakeStatus{rec: make(map[RunID]Status)} }
+
+func (f *fakeStatus) Put(_ context.Context, s Status) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if cur, ok := f.rec[s.RunID]; ok {
+		s.CancelRequested = cur.CancelRequested
+	}
+	f.rec[s.RunID] = s
+	return nil
+}
+
+func (f *fakeStatus) Get(_ context.Context, id RunID) (Status, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	s, ok := f.rec[id]
+	if !ok {
+		return Status{}, errtypes.NotFound(string(id))
+	}
+	return s, nil
+}
+
+func (f *fakeStatus) RequestCancel(_ context.Context, id RunID) (Status, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	s, ok := f.rec[id]
+	if !ok {
+		return Status{}, errtypes.NotFound(string(id))
+	}
+	if s.State == StateSucceeded || s.State == StateCancelled {
+		return s, nil
+	}
+	s.CancelRequested = true
+	s.State = StateCancelling
+	f.rec[id] = s
+	return s, nil
+}
+
+// List, Reserve and Release are part of the StatusStore interface but are not
+// exercised by the cancellation tests; minimal implementations keep the fake
+// satisfying the interface.
+func (f *fakeStatus) List(context.Context, ListFilter) ([]Status, error) { return nil, nil }
+
+func (f *fakeStatus) Reserve(_ context.Context, s Status, _ string) (Status, bool, error) {
+	if err := f.Put(context.Background(), s); err != nil {
+		return Status{}, false, err
+	}
+	return s, true, nil
+}
+
+func (f *fakeStatus) Release(context.Context, RunID) error { return nil }
+
+func (f *fakeStatus) Close(context.Context) error { return nil }
+
+// oneRunStore hands out exactly one run, then blocks Claim until shutdown. It
+// records whether the run was Completed (acked) or Failed (retried).
+type oneRunStore struct {
+	run       Run
+	claimed   atomic.Bool
+	completed atomic.Bool
+	failed    atomic.Bool
+}
+
+func (s *oneRunStore) Enqueue(_ context.Context, r Run) (RunID, error) { return r.ID, nil }
+
+func (s *oneRunStore) Claim(ctx context.Context) (Run, error) {
+	if s.claimed.CompareAndSwap(false, true) {
+		return s.run, nil
+	}
+	<-ctx.Done()
+	return Run{}, ctx.Err()
+}
+
+func (s *oneRunStore) Complete(context.Context, RunID) error { s.completed.Store(true); return nil }
+func (s *oneRunStore) Fail(context.Context, RunID, time.Duration) error {
+	s.failed.Store(true)
+	return nil
+}
+func (s *oneRunStore) Heartbeat(context.Context, RunID) error { return nil }
+func (s *oneRunStore) HeartbeatInterval() time.Duration       { return 20 * time.Millisecond }
+func (s *oneRunStore) DueScheduled(context.Context, time.Time) ([]ScheduledRun, error) {
+	return nil, nil
+}
+func (s *oneRunStore) RegisterScheduled(context.Context, string, Schedule, time.Time) error {
+	return nil
+}
+func (s *oneRunStore) MarkScheduledRunning(context.Context, string) error  { return nil }
+func (s *oneRunStore) ClearScheduledRunning(context.Context, string) error { return nil }
+func (s *oneRunStore) Close(context.Context) error                         { return nil }
+
+func TestCancelStopsRunningJob(t *testing.T) {
+	resetRegistry()
+
+	started := make(chan struct{})
+	if err := RegisterOnDemand("test.cancelme", func(context.Context, map[string]any) (Job, error) {
+		return jobFunc(func(ctx context.Context, _ Params) (Params, error) {
+			close(started)
+			<-ctx.Done() // cooperative: stop as soon as the run is cancelled
+			return nil, ctx.Err()
+		}), nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	status := newFakeStatus()
+	store := &oneRunStore{run: Run{ID: "run-1", Job: "test.cancelme", Attempt: 1}}
+	_ = status.Put(context.Background(), Status{RunID: "run-1", Job: "test.cancelme", State: StateQueued})
+
+	r, err := NewRunner(context.Background(), Options{Workers: 1, Store: store, Status: status})
+	if err != nil {
+		t.Fatal(err)
+	}
+	r.Start()
+	defer r.Stop(context.Background())
+
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("job did not start")
+	}
+
+	if _, err := r.Cancel(context.Background(), "run-1"); err != nil {
+		t.Fatal(err)
+	}
+
+	deadline := time.After(2 * time.Second)
+	for {
+		got, _ := status.Get(context.Background(), "run-1")
+		if got.State == StateCancelled {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("run did not reach cancelled, last state %q", got.State)
+		case <-time.After(5 * time.Millisecond):
+		}
+	}
+
+	if !store.completed.Load() {
+		t.Error("a cancelled run must be acked via Complete")
+	}
+	if store.failed.Load() {
+		t.Error("a cancelled run must not be failed/retried")
+	}
 }

--- a/pkg/rjobs/runner_test.go
+++ b/pkg/rjobs/runner_test.go
@@ -105,7 +105,10 @@ func (stubStore) RegisterScheduled(context.Context, string, Schedule, time.Time)
 }
 func (stubStore) MarkScheduledRunning(context.Context, string) error  { return nil }
 func (stubStore) ClearScheduledRunning(context.Context, string) error { return nil }
-func (stubStore) Close(context.Context) error                         { return nil }
+func (stubStore) TryMarkScheduledRunning(context.Context, string) (bool, error) {
+	return false, nil
+}
+func (stubStore) Close(context.Context) error { return nil }
 
 func TestGuardSkipsOverlap(t *testing.T) {
 	r := &Runner{running: make(map[string]bool)}
@@ -265,7 +268,10 @@ func (s *oneRunStore) RegisterScheduled(context.Context, string, Schedule, time.
 }
 func (s *oneRunStore) MarkScheduledRunning(context.Context, string) error  { return nil }
 func (s *oneRunStore) ClearScheduledRunning(context.Context, string) error { return nil }
-func (s *oneRunStore) Close(context.Context) error                         { return nil }
+func (s *oneRunStore) TryMarkScheduledRunning(context.Context, string) (bool, error) {
+	return false, nil
+}
+func (s *oneRunStore) Close(context.Context) error { return nil }
 
 func TestCancelStopsRunningJob(t *testing.T) {
 	resetRegistry()
@@ -400,5 +406,63 @@ func TestCancelBroadcastStopsRemoteRun(t *testing.T) {
 	}
 	if !store.completed.Load() {
 		t.Error("a broadcast-cancelled run must be acked via Complete")
+	}
+}
+
+// triggerStore records what TriggerNow does: whether it took the single-flight
+// gate and what it enqueued.
+type triggerStore struct {
+	stubStore
+	mu       sync.Mutex
+	acquire  bool
+	enqueued []string
+}
+
+func (s *triggerStore) TryMarkScheduledRunning(context.Context, string) (bool, error) {
+	return s.acquire, nil
+}
+
+func (s *triggerStore) Enqueue(_ context.Context, run Run) (RunID, error) {
+	s.mu.Lock()
+	s.enqueued = append(s.enqueued, run.Job)
+	s.mu.Unlock()
+	return "rid", nil
+}
+
+func TestTriggerNow(t *testing.T) {
+	resetRegistry()
+	if err := RegisterPeriodic(Periodic{
+		Name: "test.cleanup", Schedule: "@every 1h", Scope: ScopeLeader,
+		Run: func(context.Context) error { return nil },
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	store := &triggerStore{acquire: true}
+	r, err := NewRunner(context.Background(), Options{Workers: 1, Store: store, Status: newFakeStatus()})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := r.TriggerNow(context.Background(), "test.cleanup"); err != nil {
+		t.Fatal(err)
+	}
+	if len(store.enqueued) != 1 || store.enqueued[0] != "test.cleanup" {
+		t.Fatalf("expected one enqueue of test.cleanup, got %v", store.enqueued)
+	}
+
+	// With a run already in flight the gate is not acquired: trigger is rejected
+	// and enqueues nothing.
+	store.acquire = false
+	if err := r.TriggerNow(context.Background(), "test.cleanup"); err == nil {
+		t.Error("expected an error triggering a job already in flight")
+	}
+	if len(store.enqueued) != 1 {
+		t.Errorf("a rejected trigger must not enqueue, got %v", store.enqueued)
+	}
+
+	// On-demand and unregistered jobs cannot be triggered.
+	if err := r.TriggerNow(context.Background(), "nope"); err == nil {
+		t.Error("expected an error triggering an unregistered job")
 	}
 }

--- a/pkg/rjobs/runner_test.go
+++ b/pkg/rjobs/runner_test.go
@@ -322,3 +322,83 @@ func TestCancelStopsRunningJob(t *testing.T) {
 		t.Error("a cancelled run must not be failed/retried")
 	}
 }
+
+// busStore is a oneRunStore that also implements ControlBus, delivering a
+// published cancel straight to the subscribed handler (loopback), so a test can
+// simulate a cancel issued on another process.
+type busStore struct {
+	oneRunStore
+	mu      sync.Mutex
+	handler func(CancelSignal)
+}
+
+func (s *busStore) PublishCancel(_ context.Context, sig CancelSignal) error {
+	s.mu.Lock()
+	h := s.handler
+	s.mu.Unlock()
+	if h != nil {
+		h(sig)
+	}
+	return nil
+}
+
+func (s *busStore) SubscribeCancel(_ context.Context, handler func(CancelSignal)) error {
+	s.mu.Lock()
+	s.handler = handler
+	s.mu.Unlock()
+	return nil
+}
+
+func TestCancelBroadcastStopsRemoteRun(t *testing.T) {
+	resetRegistry()
+
+	started := make(chan struct{})
+	if err := RegisterOnDemand("test.remote", func(context.Context, map[string]any) (Job, error) {
+		return jobFunc(func(ctx context.Context, _ Params) (Params, error) {
+			close(started)
+			<-ctx.Done()
+			return nil, ctx.Err()
+		}), nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	status := newFakeStatus()
+	store := &busStore{oneRunStore: oneRunStore{run: Run{ID: "run-1", Job: "test.remote", Attempt: 1}}}
+	_ = status.Put(context.Background(), Status{RunID: "run-1", Job: "test.remote", State: StateQueued})
+
+	r, err := NewRunner(context.Background(), Options{Workers: 1, Store: store, Status: status})
+	if err != nil {
+		t.Fatal(err)
+	}
+	r.Start()
+	defer r.Stop(context.Background())
+
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("job did not start")
+	}
+
+	// Simulate a cancel issued on another process: it reaches us only via the
+	// bus, not through this runner's Cancel.
+	if err := store.PublishCancel(context.Background(), CancelSignal{RunID: "run-1"}); err != nil {
+		t.Fatal(err)
+	}
+
+	deadline := time.After(2 * time.Second)
+	for {
+		got, _ := status.Get(context.Background(), "run-1")
+		if got.State == StateCancelled {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("run did not reach cancelled, last state %q", got.State)
+		case <-time.After(5 * time.Millisecond):
+		}
+	}
+	if !store.completed.Load() {
+		t.Error("a broadcast-cancelled run must be acked via Complete")
+	}
+}

--- a/pkg/rjobs/runner_test.go
+++ b/pkg/rjobs/runner_test.go
@@ -108,6 +108,12 @@ func (stubStore) ClearScheduledRunning(context.Context, string) error { return n
 func (stubStore) TryMarkScheduledRunning(context.Context, string) (bool, error) {
 	return false, nil
 }
+func (stubStore) RequestCancelScheduled(context.Context, string) (bool, error) {
+	return false, nil
+}
+func (stubStore) ScheduledCancelRequested(context.Context, string) (bool, error) {
+	return false, nil
+}
 func (stubStore) Close(context.Context) error { return nil }
 
 func TestGuardSkipsOverlap(t *testing.T) {
@@ -269,6 +275,12 @@ func (s *oneRunStore) RegisterScheduled(context.Context, string, Schedule, time.
 func (s *oneRunStore) MarkScheduledRunning(context.Context, string) error  { return nil }
 func (s *oneRunStore) ClearScheduledRunning(context.Context, string) error { return nil }
 func (s *oneRunStore) TryMarkScheduledRunning(context.Context, string) (bool, error) {
+	return false, nil
+}
+func (s *oneRunStore) RequestCancelScheduled(context.Context, string) (bool, error) {
+	return false, nil
+}
+func (s *oneRunStore) ScheduledCancelRequested(context.Context, string) (bool, error) {
 	return false, nil
 }
 func (s *oneRunStore) Close(context.Context) error { return nil }
@@ -464,5 +476,128 @@ func TestTriggerNow(t *testing.T) {
 	// On-demand and unregistered jobs cannot be triggered.
 	if err := r.TriggerNow(context.Background(), "nope"); err == nil {
 		t.Error("expected an error triggering an unregistered job")
+	}
+}
+
+// periodicStore delivers one leader-periodic run and tracks the schedule's
+// in-flight and cancel state by job name, like the real KV-backed store.
+type periodicStore struct {
+	run       Run
+	claimed   atomic.Bool
+	completed atomic.Bool
+	mu        sync.Mutex
+	running   bool
+	cancelReq bool
+}
+
+func (s *periodicStore) Enqueue(_ context.Context, r Run) (RunID, error) { return r.ID, nil }
+
+func (s *periodicStore) Claim(ctx context.Context) (Run, error) {
+	if s.claimed.CompareAndSwap(false, true) {
+		s.mu.Lock()
+		s.running = true
+		s.mu.Unlock()
+		return s.run, nil
+	}
+	<-ctx.Done()
+	return Run{}, ctx.Err()
+}
+
+func (s *periodicStore) Complete(context.Context, RunID) error            { s.completed.Store(true); return nil }
+func (s *periodicStore) Fail(context.Context, RunID, time.Duration) error { return nil }
+func (s *periodicStore) Heartbeat(context.Context, RunID) error           { return nil }
+func (s *periodicStore) HeartbeatInterval() time.Duration                 { return 20 * time.Millisecond }
+func (s *periodicStore) DueScheduled(context.Context, time.Time) ([]ScheduledRun, error) {
+	return nil, nil
+}
+func (s *periodicStore) RegisterScheduled(context.Context, string, Schedule, time.Time) error {
+	return nil
+}
+func (s *periodicStore) MarkScheduledRunning(context.Context, string) error { return nil }
+func (s *periodicStore) TryMarkScheduledRunning(context.Context, string) (bool, error) {
+	return false, nil
+}
+func (s *periodicStore) ClearScheduledRunning(context.Context, string) error {
+	s.mu.Lock()
+	s.running = false
+	s.cancelReq = false
+	s.mu.Unlock()
+	return nil
+}
+
+func (s *periodicStore) RequestCancelScheduled(context.Context, string) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if !s.running {
+		return false, nil
+	}
+	s.cancelReq = true
+	return true, nil
+}
+
+func (s *periodicStore) ScheduledCancelRequested(context.Context, string) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.cancelReq, nil
+}
+
+func (s *periodicStore) inFlight() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.running
+}
+
+func (s *periodicStore) Close(context.Context) error { return nil }
+
+func TestCancelPeriodicStopsInFlightRun(t *testing.T) {
+	resetRegistry()
+
+	started := make(chan struct{})
+	if err := RegisterPeriodic(Periodic{
+		Name: "test.periodic", Schedule: "@every 1h", Scope: ScopeLeader,
+		Run: func(ctx context.Context) error {
+			close(started)
+			<-ctx.Done() // cooperative: stop when the run is cancelled
+			return ctx.Err()
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	store := &periodicStore{run: Run{ID: "run-1", Job: "test.periodic", Attempt: 1}}
+	r, err := NewRunner(context.Background(), Options{Workers: 1, Store: store, Status: newFakeStatus()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	r.Start()
+	defer r.Stop(context.Background())
+
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("periodic job did not start")
+	}
+
+	if err := r.CancelPeriodic(context.Background(), "test.periodic"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait until the run has fully wound down: the in-flight mark is cleared by
+	// the last deferred step of execRun, so this also implies the run was acked.
+	deadline := time.After(2 * time.Second)
+	for store.inFlight() {
+		select {
+		case <-deadline:
+			t.Fatal("cancelled periodic run did not wind down")
+		case <-time.After(5 * time.Millisecond):
+		}
+	}
+	if !store.completed.Load() {
+		t.Fatal("cancelled periodic run was not acked via Complete")
+	}
+
+	// With nothing in flight, a second cancel is an error, not a silent no-op.
+	if err := r.CancelPeriodic(context.Background(), "test.periodic"); err == nil {
+		t.Error("expected an error cancelling a job with no run in flight")
 	}
 }

--- a/pkg/rjobs/status.go
+++ b/pkg/rjobs/status.go
@@ -40,6 +40,15 @@ const (
 	// back to queued and be retried. A client should read StateFailed as
 	// "last attempt failed, another is coming", not "given up".
 	StateFailed State = "failed"
+	// StateCancelling means a cancellation was requested and the framework is
+	// winding the run down. It is transient: the run becomes StateCancelled once
+	// it actually stops, or, if it was still queued, as soon as a worker claims
+	// it and drops it.
+	StateCancelling State = "cancelling"
+	// StateCancelled is the terminal state of a run stopped by an explicit
+	// cancellation. Unlike StateFailed it is NOT retried: the run is acked and
+	// never redelivered.
+	StateCancelled State = "cancelled"
 )
 
 // Status is the observable state of a single run, addressable by its RunID.
@@ -60,6 +69,10 @@ type Status struct {
 	Result Params
 	// Owner is the username the run was created for, or empty for an internal run.
 	Owner string
+	// CancelRequested is set once a cancellation has been requested for the run.
+	// The worker executing the run observes it and stops; a still-queued run is
+	// dropped when claimed. It stays false for runs that were never cancelled.
+	CancelRequested bool
 }
 
 // Internal reports whether the run was created by reva itself rather than on
@@ -107,6 +120,13 @@ type StatusStore interface {
 	// (it succeeded, or it never reached the queue), freeing the key for a new
 	// run. It is a no-op for a run that holds no reservation.
 	Release(ctx context.Context, id RunID) error
+	// RequestCancel records that a run should be cancelled and returns its
+	// updated status. It is a targeted write of the cancel intent, not a full
+	// status upsert, so it does not race with the worker's lifecycle writes. It
+	// is a no-op on a run that has already reached a terminal state (succeeded
+	// or cancelled), returning that status unchanged, which makes cancel
+	// idempotent. It returns an errtypes.NotFound error if the run is unknown.
+	RequestCancel(ctx context.Context, id RunID) (Status, error)
 	// Close releases the status store's resources.
 	Close(ctx context.Context) error
 }

--- a/pkg/rjobs/store.go
+++ b/pkg/rjobs/store.go
@@ -114,8 +114,19 @@ type Store interface {
 	// error if the job has no registered schedule.
 	TryMarkScheduledRunning(ctx context.Context, job string) (bool, error)
 	// ClearScheduledRunning clears the in-flight mark for a leader-scoped
-	// periodic job once its run finishes, letting its schedule resume.
+	// periodic job once its run finishes, letting its schedule resume. It also
+	// clears any cancel intent recorded by RequestCancelScheduled, so a cancel
+	// can never carry over to the job's next run.
 	ClearScheduledRunning(ctx context.Context, job string) error
+	// RequestCancelScheduled records a cancel intent for a leader-scoped periodic
+	// job's in-flight run, reporting whether a run was in flight to cancel. It
+	// only marks while a run is actually running, and ClearScheduledRunning
+	// clears it, so the intent never leaks to a later run.
+	RequestCancelScheduled(ctx context.Context, job string) (bool, error)
+	// ScheduledCancelRequested reports whether a cancel has been requested for a
+	// leader-scoped periodic job's in-flight run. The worker running the job
+	// polls it as the backstop to the cancel broadcast.
+	ScheduledCancelRequested(ctx context.Context, job string) (bool, error)
 	// Close releases the store's resources.
 	Close(ctx context.Context) error
 }

--- a/pkg/rjobs/store.go
+++ b/pkg/rjobs/store.go
@@ -112,3 +112,27 @@ type Store interface {
 	// Close releases the store's resources.
 	Close(ctx context.Context) error
 }
+
+// CancelSignal is a best-effort, cluster-wide notification that a run should be
+// cancelled. Exactly one field is set: RunID targets a single on-demand run;
+// Job targets the in-flight run of a periodic job, which each process matches
+// against the runs it is currently executing.
+type CancelSignal struct {
+	RunID RunID
+	Job   string
+}
+
+// ControlBus is an optional capability of a Store: a best-effort, cluster-wide
+// pub/sub that delivers cancel signals to whichever process is running a given
+// run, without waiting for the durable backstop poll. It is strictly an
+// optimisation over the durable cancel intent: a dropped signal only delays a
+// cancel to the next poll, it never loses it. A Store that does not implement
+// ControlBus still cancels correctly, just not instantly across processes.
+type ControlBus interface {
+	// PublishCancel broadcasts a cancel signal to every subscribed process.
+	PublishCancel(ctx context.Context, sig CancelSignal) error
+	// SubscribeCancel registers handler for every cancel signal published in the
+	// cluster, including by other processes. It returns once the subscription is
+	// active.
+	SubscribeCancel(ctx context.Context, handler func(CancelSignal)) error
+}

--- a/pkg/rjobs/store.go
+++ b/pkg/rjobs/store.go
@@ -106,6 +106,13 @@ type Store interface {
 	// MarkScheduledRunning records that a leader-scoped periodic job has a run
 	// in flight, so DueScheduled skips it until the run is cleared.
 	MarkScheduledRunning(ctx context.Context, job string) error
+	// TryMarkScheduledRunning marks a leader-scoped periodic job as having a run
+	// in flight, but only if one is not already marked, reporting whether it
+	// acquired the mark. It is the single-flight gate for an out-of-band trigger:
+	// the caller that acquires it may enqueue an immediate run, and
+	// ClearScheduledRunning releases it when the run finishes. It returns an
+	// error if the job has no registered schedule.
+	TryMarkScheduledRunning(ctx context.Context, job string) (bool, error)
 	// ClearScheduledRunning clears the in-flight mark for a leader-scoped
 	// periodic job once its run finishes, letting its schedule resume.
 	ClearScheduledRunning(ctx context.Context, job string) error

--- a/pkg/rjobs/store/nats/nats.go
+++ b/pkg/rjobs/store/nats/nats.go
@@ -463,6 +463,36 @@ func (s *store) MarkScheduledRunning(ctx context.Context, job string) error {
 	return s.setRunningSince(job, true)
 }
 
+func (s *store) TryMarkScheduledRunning(ctx context.Context, job string) (bool, error) {
+	entry, err := s.kv.Get(job)
+	if err != nil {
+		if errors.Is(err, nats.ErrKeyNotFound) {
+			return false, errors.Errorf("rjobs: no schedule registered for job %q", job)
+		}
+		return false, errors.Wrap(err, "rjobs: reading schedule state failed")
+	}
+	var st scheduleState
+	if err := json.Unmarshal(entry.Value(), &st); err != nil {
+		return false, errors.Wrap(err, "rjobs: reading schedule state failed")
+	}
+	// Already running, and the mark is still fresh: do not start a second run.
+	if st.RunningSince != nil && time.Since(*st.RunningSince) < runningHold {
+		return false, nil
+	}
+	now := time.Now()
+	st.RunningSince = &now
+	data, err := json.Marshal(st)
+	if err != nil {
+		return false, errors.Wrap(err, "rjobs: marshalling schedule state failed")
+	}
+	// Conditioned on the revision we read, so a concurrent trigger or scheduler
+	// cannot also acquire the gate: the loser's update fails and it backs off.
+	if _, err := s.kv.Update(job, data, entry.Revision()); err != nil {
+		return false, nil
+	}
+	return true, nil
+}
+
 func (s *store) ClearScheduledRunning(ctx context.Context, job string) error {
 	return s.setRunningSince(job, false)
 }

--- a/pkg/rjobs/store/nats/nats.go
+++ b/pkg/rjobs/store/nats/nats.go
@@ -69,6 +69,9 @@ type store struct {
 	ackWait time.Duration
 	log     zerolog.Logger
 
+	// ctrlSub is the core-NATS subscription for cancel broadcasts, if subscribed.
+	ctrlSub *nats.Subscription
+
 	// inflight tracks the NATS message backing each claimed run, so that
 	// Complete and Fail can ack or nak the right message.
 	mu       sync.Mutex
@@ -135,6 +138,11 @@ func New(ctx context.Context, opts Options) (rjobs.Store, error) {
 func (s *store) streamName() string      { return s.prefix + "-runs" }
 func (s *store) subjectWildcard() string { return s.prefix + ".runs.*" }
 func (s *store) bucketName() string      { return s.prefix + "-schedule" }
+
+// controlSubject carries best-effort cancel broadcasts. It is plain core-NATS
+// pub/sub, not JetStream: a signal reaches the processes connected right now,
+// which is all the fast path needs; the durable cancel intent is the backstop.
+func (s *store) controlSubject() string { return s.prefix + ".control.cancel" }
 
 // subjectFor is the per-job work-queue subject. Runs for a job are published
 // here and only consumers subscribed to this subject can claim them.
@@ -491,7 +499,39 @@ func (s *store) setRunningSince(job string, running bool) error {
 	return nil
 }
 
+// PublishCancel broadcasts a cancel signal to every subscribed process.
+func (s *store) PublishCancel(ctx context.Context, sig rjobs.CancelSignal) error {
+	data, err := json.Marshal(sig)
+	if err != nil {
+		return errors.Wrap(err, "rjobs: marshalling cancel signal failed")
+	}
+	if err := s.nc.Publish(s.controlSubject(), data); err != nil {
+		return errors.Wrap(err, "rjobs: publishing cancel signal failed")
+	}
+	return nil
+}
+
+// SubscribeCancel delivers every cancel broadcast in the cluster to handler.
+func (s *store) SubscribeCancel(ctx context.Context, handler func(rjobs.CancelSignal)) error {
+	sub, err := s.nc.Subscribe(s.controlSubject(), func(msg *nats.Msg) {
+		var sig rjobs.CancelSignal
+		if err := json.Unmarshal(msg.Data, &sig); err != nil {
+			s.log.Error().Err(err).Msg("rjobs: dropping undecodable cancel signal")
+			return
+		}
+		handler(sig)
+	})
+	if err != nil {
+		return errors.Wrap(err, "rjobs: subscribing to cancel signals failed")
+	}
+	s.ctrlSub = sub
+	return nil
+}
+
 func (s *store) Close(ctx context.Context) error {
+	if s.ctrlSub != nil {
+		_ = s.ctrlSub.Drain()
+	}
 	for _, sub := range s.subs {
 		_ = sub.Drain()
 	}

--- a/pkg/rjobs/store/nats/nats.go
+++ b/pkg/rjobs/store/nats/nats.go
@@ -88,6 +88,10 @@ type scheduleState struct {
 	// when the run finishes, and ignored once older than runningHold so a
 	// crashed worker cannot block the schedule forever.
 	RunningSince *time.Time `json:"running_since,omitempty"`
+	// CancelRequested, when set, asks the worker running this job to stop the
+	// current run. It is set only while a run is in flight and cleared when the
+	// run ends, so it never carries over to a later run.
+	CancelRequested *time.Time `json:"cancel_requested,omitempty"`
 }
 
 // runningHold bounds how long a RunningSince mark is trusted. A legitimate long
@@ -497,6 +501,55 @@ func (s *store) ClearScheduledRunning(ctx context.Context, job string) error {
 	return s.setRunningSince(job, false)
 }
 
+// RequestCancelScheduled records a cancel intent for a job's in-flight run. It
+// only marks when a run is actually running, so the intent can never carry over
+// to a future scheduled run; ClearScheduledRunning clears it when the run ends.
+func (s *store) RequestCancelScheduled(ctx context.Context, job string) (bool, error) {
+	entry, err := s.kv.Get(job)
+	if err != nil {
+		if errors.Is(err, nats.ErrKeyNotFound) {
+			return false, nil
+		}
+		return false, errors.Wrap(err, "rjobs: reading schedule state failed")
+	}
+	var st scheduleState
+	if err := json.Unmarshal(entry.Value(), &st); err != nil {
+		return false, errors.Wrap(err, "rjobs: reading schedule state failed")
+	}
+	if st.RunningSince == nil {
+		return false, nil // nothing in flight to cancel.
+	}
+	now := time.Now()
+	st.CancelRequested = &now
+	data, err := json.Marshal(st)
+	if err != nil {
+		return false, errors.Wrap(err, "rjobs: marshalling schedule state failed")
+	}
+	if _, err := s.kv.Update(job, data, entry.Revision()); err != nil {
+		// lost the race to another writer; report not-cancelled so the caller can
+		// retry rather than assume it took effect.
+		return false, nil
+	}
+	return true, nil
+}
+
+// ScheduledCancelRequested reports whether a cancel is pending for a job's
+// in-flight run.
+func (s *store) ScheduledCancelRequested(ctx context.Context, job string) (bool, error) {
+	entry, err := s.kv.Get(job)
+	if err != nil {
+		if errors.Is(err, nats.ErrKeyNotFound) {
+			return false, nil
+		}
+		return false, errors.Wrap(err, "rjobs: reading schedule state failed")
+	}
+	var st scheduleState
+	if err := json.Unmarshal(entry.Value(), &st); err != nil {
+		return false, errors.Wrap(err, "rjobs: reading schedule state failed")
+	}
+	return st.CancelRequested != nil, nil
+}
+
 // setRunningSince sets or clears the RunningSince mark on a job's schedule
 // entry, conditioned on the revision so it composes with the scheduler.
 func (s *store) setRunningSince(job string, running bool) error {
@@ -516,6 +569,9 @@ func (s *store) setRunningSince(job string, running bool) error {
 		st.RunningSince = &now
 	} else {
 		st.RunningSince = nil
+		// a finished run clears any cancel intent, so it cannot leak into the
+		// job's next scheduled run.
+		st.CancelRequested = nil
 	}
 	data, err := json.Marshal(st)
 	if err != nil {

--- a/pkg/rjobs/store/sql/model/model.go
+++ b/pkg/rjobs/store/sql/model/model.go
@@ -48,6 +48,9 @@ type Run struct {
 	// (owner, key), while ordinary runs — whose key is NULL — stay entirely
 	// unconstrained.
 	ActiveDedupKey *string `gorm:"size:255;uniqueIndex:idx_active_dedup,priority:2"`
+
+	// CancelRequested is set once a cancellation has been requested for the run.
+	CancelRequested bool
 }
 
 // TableName sets the table name explicitly so it does not collide with other

--- a/pkg/rjobs/store/sql/sql.go
+++ b/pkg/rjobs/store/sql/sql.go
@@ -70,14 +70,36 @@ func (s *store) Put(ctx context.Context, st rjobs.Status) error {
 	if err != nil {
 		return err
 	}
-	// upsert on the run id: the row is created on enqueue and updated on every
-	// later transition. The reservation column is owned by Reserve/Release, so
-	// omit it here or a status update would wipe a live reservation.
-	res := s.db.WithContext(ctx).Omit("ActiveDedupKey").Save(row)
+	// later transition. The reservation column is owned by Reserve/Release and
+	// the cancel intent by RequestCancel, so both are omitted here: a lifecycle
+	// write must never wipe a live reservation or clobber a concurrent cancel.
+	res := s.db.WithContext(ctx).Omit("ActiveDedupKey", "CancelRequested").Save(row)
 	if res.Error != nil {
 		return errors.Wrap(res.Error, "rjobs sql: storing status failed")
 	}
 	return nil
+}
+
+func (s *store) RequestCancel(ctx context.Context, id rjobs.RunID) (rjobs.Status, error) {
+	// Flip the cancel intent with a targeted update that leaves the columns the
+	// worker owns (lifecycle state, timestamps, result) untouched. The state is
+	// advanced to cancelling only from a non-terminal state, so a cancel can
+	// neither resurrect a finished run nor undo a terminal state.
+	res := s.db.WithContext(ctx).Model(&model.Run{}).
+		Where("run_id = ? AND state IN ?", string(id), []string{
+			string(rjobs.StateQueued), string(rjobs.StateRunning), string(rjobs.StateFailed),
+		}).
+		Updates(map[string]any{
+			"cancel_requested": true,
+			"state":            string(rjobs.StateCancelling),
+		})
+	if res.Error != nil {
+		return rjobs.Status{}, errors.Wrap(res.Error, "rjobs sql: requesting cancel failed")
+	}
+	// Return the current status whether or not a row was updated: a terminal run
+	// is returned unchanged (idempotent cancel) and an unknown run yields
+	// NotFound from Get.
+	return s.Get(ctx, id)
 }
 
 func (s *store) Get(ctx context.Context, id rjobs.RunID) (rjobs.Status, error) {
@@ -211,15 +233,16 @@ func toModel(st rjobs.Status) (*model.Run, error) {
 		result = b
 	}
 	m := &model.Run{
-		RunID:      string(st.RunID),
-		Job:        st.Job,
-		State:      string(st.State),
-		Attempt:    st.Attempt,
-		EnqueuedAt: st.EnqueuedAt,
-		StartedAt:  st.StartedAt,
-		FinishedAt: st.FinishedAt,
-		LastError:  st.LastError,
-		Result:     result,
+		RunID:           string(st.RunID),
+		Job:             st.Job,
+		State:           string(st.State),
+		Attempt:         st.Attempt,
+		EnqueuedAt:      st.EnqueuedAt,
+		StartedAt:       st.StartedAt,
+		FinishedAt:      st.FinishedAt,
+		LastError:       st.LastError,
+		Result:          result,
+		CancelRequested: st.CancelRequested,
 	}
 	m.Owner = st.Owner
 	return m, nil
@@ -227,14 +250,15 @@ func toModel(st rjobs.Status) (*model.Run, error) {
 
 func fromModel(row model.Run) (rjobs.Status, error) {
 	st := rjobs.Status{
-		RunID:      rjobs.RunID(row.RunID),
-		Job:        row.Job,
-		State:      rjobs.State(row.State),
-		Attempt:    row.Attempt,
-		EnqueuedAt: row.EnqueuedAt,
-		StartedAt:  row.StartedAt,
-		FinishedAt: row.FinishedAt,
-		LastError:  row.LastError,
+		RunID:           rjobs.RunID(row.RunID),
+		Job:             row.Job,
+		State:           rjobs.State(row.State),
+		Attempt:         row.Attempt,
+		EnqueuedAt:      row.EnqueuedAt,
+		StartedAt:       row.StartedAt,
+		FinishedAt:      row.FinishedAt,
+		LastError:       row.LastError,
+		CancelRequested: row.CancelRequested,
 	}
 	st.Owner = row.Owner
 	if len(row.Result) > 0 {

--- a/pkg/rjobs/store/sql/sql_test.go
+++ b/pkg/rjobs/store/sql/sql_test.go
@@ -205,3 +205,64 @@ func TestReserve(t *testing.T) {
 		t.Fatalf("a released key should be reservable again: reserved=%v err=%v", reserved, err)
 	}
 }
+
+func TestRequestCancel(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Second)
+
+	if err := s.Put(ctx, rjobs.Status{
+		RunID: "run-1", Job: "j", State: rjobs.StateRunning, Attempt: 1, EnqueuedAt: now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	st, err := s.RequestCancel(ctx, "run-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !st.CancelRequested {
+		t.Error("CancelRequested should be set after RequestCancel")
+	}
+	if st.State != rjobs.StateCancelling {
+		t.Errorf("state = %q, want cancelling", st.State)
+	}
+
+	// a lifecycle write must not clobber the cancel intent.
+	if err := s.Put(ctx, rjobs.Status{
+		RunID: "run-1", Job: "j", State: rjobs.StateRunning, Attempt: 1, EnqueuedAt: now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	got, err := s.Get(ctx, "run-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got.CancelRequested {
+		t.Error("a Put must not clear CancelRequested")
+	}
+}
+
+func TestRequestCancelTerminalIsNoop(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Second)
+
+	if err := s.Put(ctx, rjobs.Status{
+		RunID: "done", Job: "j", State: rjobs.StateSucceeded, Attempt: 1, EnqueuedAt: now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	st, err := s.RequestCancel(ctx, "done")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.State != rjobs.StateSucceeded || st.CancelRequested {
+		t.Errorf("cancel of a terminal run must be a no-op, got state=%q cancel=%v", st.State, st.CancelRequested)
+	}
+
+	if _, err := s.RequestCancel(ctx, "missing"); err == nil {
+		t.Error("expected NotFound cancelling an unknown run")
+	}
+}


### PR DESCRIPTION
## Cancel background jobs, and trigger scheduled ones on demand

Builds on the background-jobs framework (#5651). Until now a background job, once started, ran to completion with no way to stop it. This PR adds the ability to **stop a job** and to **run a scheduled job immediately**.

### What you can do now
- **Cancel an on-demand job** by its run id — whether it's still queued or already running.
- **Cancel the current run of a scheduled (periodic) job** by name.
- **Trigger a scheduled job to run now**, instead of waiting for its next scheduled time.

### How it works
- Cancellation is **cooperative**: the framework signals the running job through its context and the job stops at the next safe point — the same mechanism jobs already use to shut down cleanly. A job that ignores its context just finishes normally.
- It works **across replicas**: the request is recorded durably and broadcast, so it reaches whichever process is actually running the job, usually within milliseconds.
- A cancelled run is **final** — unlike a failed run, it is not retried. Two new states, `cancelling` and `cancelled`, make the outcome visible in a run's status.
- **Triggering** a scheduled job just adds one extra run; the regular schedule is left untouched, and a job that's already running won't be started twice.