### PR TITLE
Configure on demand background jobs

### DIFF
--- a/changelog/unreleased/configure-on-demand-jobs.md
+++ b/changelog/unreleased/configure-on-demand-jobs.md
@@ -1,0 +1,9 @@
+Enhancement: configure on-demand jobs from the config file
+
+On-demand background jobs are now given their own configuration section from
+the config file, handed to the job constructor the same way the other services
+receive their configuration. Each job reads its settings from
+[serverless.services.jobs.on_demand."<name>"], so it can load what it needs at
+startup instead of seeing only the per-run parameters.
+
+https://github.com/cs3org/reva/pull/5682

--- a/internal/serverless/services/jobs/README.md
+++ b/internal/serverless/services/jobs/README.md
@@ -99,13 +99,33 @@ Register a constructor by name; the framework builds the job and calls `Run`
 with the per-run parameters. The returned `Params` are stored as the run's
 result.
 
+The constructor receives the job's own configuration section from the config
+file (see [Configuration](#configuration)), so a job can load what it needs at
+startup just like any other service, and decode it the same way. Distinguish
+the two inputs: `m` is static configuration, `p` is the per-run payload from
+`Enqueue`.
+
 ```go
 func init() {
     _ = rjobs.RegisterOnDemand("mycomponent.export", New)
 }
 
+type config struct {
+    TmpDir string `mapstructure:"tmp_dir"`
+}
+
+func (c *config) ApplyDefaults() {
+    if c.TmpDir == "" {
+        c.TmpDir = "/tmp"
+    }
+}
+
 func New(ctx context.Context, m map[string]any) (rjobs.Job, error) {
-    return &exportJob{ /* ... */ }, nil
+    var c config
+    if err := cfg.Decode(m, &c); err != nil {
+        return nil, err
+    }
+    return &exportJob{tmpDir: c.TmpDir}, nil
 }
 
 func (j *exportJob) Run(ctx context.Context, p rjobs.Params) (rjobs.Params, error) {
@@ -252,3 +272,20 @@ db_name     = "reva_jobs"
 Without `nats_address` the runner still starts, but only `ScopeAllNodes`
 periodic jobs run; on-demand and `ScopeLeader` jobs need the queue and the
 status DB.
+
+### On-demand job configuration
+
+Each on-demand job gets its own section under `on_demand`, keyed by the name it
+was registered under. The section is handed to the job's constructor (the `m`
+argument), so a job loads its static configuration there. Because job names
+contain dots and dots separate TOML tables, the name must be **quoted** in the
+table header:
+
+```toml
+[serverless.services.jobs.on_demand."mycomponent.export"]
+tmp_dir   = "/var/lib/reva/export"
+max_items = 1000
+```
+
+A job with no section is built with an empty configuration, so jobs that only
+read per-run parameters need no entry at all.

--- a/internal/serverless/services/jobs/jobs.go
+++ b/internal/serverless/services/jobs/jobs.go
@@ -50,6 +50,12 @@ type config struct {
 	// maximum job duration.
 	AckWaitSeconds int               `mapstructure:"ack_wait_seconds"`
 	StatusDB       revadcfg.Database `mapstructure:"status_db"`
+	// OnDemand holds the configuration of the on-demand jobs, keyed by job
+	// name. Each entry is the job's own config section and is handed to the
+	// job's constructor when a run is dispatched. Job names contain dots, so
+	// the name must be quoted in the table header, e.g.
+	// [serverless.services.jobs.on_demand."example.pingpong"].
+	OnDemand map[string]map[string]any `mapstructure:"on_demand"`
 }
 
 func (c *config) ApplyDefaults() {
@@ -90,7 +96,8 @@ func New(ctx context.Context, m map[string]any) (rserverless.Service, error) {
 // for single-node setups that only warm local caches.
 func (s *svc) Start() {
 	opts := rjobs.Options{
-		Workers: s.conf.WorkerPoolSize,
+		Workers:        s.conf.WorkerPoolSize,
+		OnDemandConfig: s.conf.OnDemand,
 	}
 
 	// the durable queue and the status store go together: on-demand and

--- a/pkg/rjobs/job.go
+++ b/pkg/rjobs/job.go
@@ -85,7 +85,10 @@ type Job interface {
 }
 
 // NewJob constructs an on-demand job from its configuration. It is the
-// function registered with RegisterOnDemand.
+// function registered with RegisterOnDemand. The map is the job's own section
+// of the service configuration
+// ([serverless.services.jobs.on_demand."<name>"]), or nil when the job has no
+// such section, in which case it should fall back to its defaults.
 type NewJob func(ctx context.Context, m map[string]any) (Job, error)
 
 // Periodic describes a job that runs on a schedule. The Run closure is

--- a/pkg/rjobs/runner.go
+++ b/pkg/rjobs/runner.go
@@ -50,17 +50,23 @@ type Options struct {
 	// Status records and serves per-run status. It is required whenever Store
 	// is set, since every durable run gets a status record.
 	Status StatusStore
+	// OnDemandConfig holds the configuration of the on-demand jobs, keyed by
+	// job name. When a run is dispatched the entry for its job is handed to the
+	// job's constructor; a job with no entry is built with a nil map and falls
+	// back to its own defaults.
+	OnDemandConfig map[string]map[string]any
 }
 
 // Runner owns the scheduling, dispatching and execution of jobs. A process
 // has a single Runner, created by the jobs service and reachable through
 // Default for in-process Enqueue.
 type Runner struct {
-	workers  int
-	store    Store
-	status   StatusStore
-	log      zerolog.Logger
-	periodic []Periodic
+	workers        int
+	store          Store
+	status         StatusStore
+	log            zerolog.Logger
+	periodic       []Periodic
+	onDemandConfig map[string]map[string]any
 
 	cancel context.CancelFunc
 	wg     sync.WaitGroup
@@ -106,13 +112,14 @@ func NewRunner(ctx context.Context, opts Options) (*Runner, error) {
 	}
 
 	r := &Runner{
-		workers:  opts.Workers,
-		store:    opts.Store,
-		status:   opts.Status,
-		log:      *appctx.GetLogger(ctx),
-		periodic: registeredPeriodic(),
-		running:  make(map[string]bool),
-		cancels:  make(map[RunID]*runHandle),
+		workers:        opts.Workers,
+		store:          opts.Store,
+		status:         opts.Status,
+		log:            *appctx.GetLogger(ctx),
+		periodic:       registeredPeriodic(),
+		onDemandConfig: opts.OnDemandConfig,
+		running:        make(map[string]bool),
+		cancels:        make(map[RunID]*runHandle),
 	}
 
 	// leader-scoped and on-demand work both need a store.
@@ -747,7 +754,7 @@ func (r *Runner) invoke(ctx context.Context, run Run, log zerolog.Logger) (Param
 	if !ok {
 		return nil, errors.Errorf("rjobs: run references unknown job %q", run.Job)
 	}
-	job, err := newFunc(jobCtx, nil)
+	job, err := newFunc(jobCtx, r.onDemandConfig[run.Job])
 	if err != nil {
 		return nil, errors.Wrap(err, "rjobs: building on-demand job failed")
 	}

--- a/pkg/rjobs/runner_test.go
+++ b/pkg/rjobs/runner_test.go
@@ -167,6 +167,53 @@ func TestIsLeaderJob(t *testing.T) {
 	}
 }
 
+// funcJob adapts a plain function to the Job interface for tests.
+type funcJob func(ctx context.Context, p Params) (Params, error)
+
+func (f funcJob) Run(ctx context.Context, p Params) (Params, error) { return f(ctx, p) }
+
+func TestInvokePassesOnDemandConfig(t *testing.T) {
+	resetRegistry()
+
+	got := make(map[string]map[string]any)
+	register := func(name string) {
+		err := RegisterOnDemand(name, func(ctx context.Context, m map[string]any) (Job, error) {
+			got[name] = m
+			return funcJob(func(ctx context.Context, p Params) (Params, error) { return nil, nil }), nil
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	register("test.configured")
+	register("test.bare")
+
+	r, err := NewRunner(context.Background(), Options{
+		OnDemandConfig: map[string]map[string]any{
+			"test.configured": {"greeting": "hello"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := r.invoke(context.Background(), Run{Job: "test.configured"}, r.log); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := r.invoke(context.Background(), Run{Job: "test.bare"}, r.log); err != nil {
+		t.Fatal(err)
+	}
+
+	if g := got["test.configured"]["greeting"]; g != "hello" {
+		t.Errorf("configured job did not receive its config section: got %v", got["test.configured"])
+	}
+	// a job with no config section is built with a nil map, not an empty one,
+	// so it can tell "unset" apart and rely on its own defaults.
+	if got["test.bare"] != nil {
+		t.Errorf("a job without a config section should receive nil, got %v", got["test.bare"])
+	}
+}
+
 func resetRegistry() {
 	reg.mu.Lock()
 	defer reg.mu.Unlock()


### PR DESCRIPTION
On-demand background jobs (`rjobs`) are registered with the same constructor shape as every other service factory in reva, `func(ctx, m map[string]any)`, but the runner always called it with `nil`. So a job could only see the per-run `Params` from `Enqueue`; it had no way to load static config from the file the way every other service does.

This PR lets each on-demand job take its own section of the config, keyed by the name it was registered under:

```toml
[serverless.services.jobs.on_demand."mycomponent.export"]
tmp_dir = "/var/lib/reva/export"
```