### PR TITLE
Add sciencemesh paths for external accounts

### DIFF
--- a/changelog/unreleased/enable-sciencemesh-for-externals.md
+++ b/changelog/unreleased/enable-sciencemesh-for-externals.md
@@ -1,0 +1,3 @@
+Bugfix: Add sciencemesh paths for external accounts
+
+https://github.com/cs3org/reva/pull/5685

--- a/pkg/auth/scope/lightweight.go
+++ b/pkg/auth/scope/lightweight.go
@@ -25,7 +25,8 @@ import (
 	authpb "github.com/cs3org/go-cs3apis/cs3/auth/provider/v1beta1"
 	grouppb "github.com/cs3org/go-cs3apis/cs3/identity/group/v1beta1"
 	collaboration "github.com/cs3org/go-cs3apis/cs3/sharing/collaboration/v1beta1"
-	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+	ocm "github.com/cs3org/go-cs3apis/cs3/sharing/ocm/v1beta1"
+	sp "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	types "github.com/cs3org/go-cs3apis/cs3/types/v1beta1"
 	"github.com/cs3org/reva/v3/pkg/utils"
 	"github.com/rs/zerolog"
@@ -35,11 +36,12 @@ func lightweightAccountScope(_ context.Context, scope *authpb.Scope, resource an
 	// Lightweight accounts have access to resources shared with them.
 	// These cannot be resolved from here, but need to be added to the scope from
 	// where the call to mint tokens is made.
-	// From here, we only allow ListReceivedShares calls
 	switch v := resource.(type) {
 	case *collaboration.ListReceivedSharesRequest:
 		return true, nil
-	case *provider.ListStorageSpacesRequest:
+	case *ocm.ListReceivedOCMSharesRequest:
+		return true, nil
+	case *sp.ListStorageSpacesRequest:
 		return true, nil
 	case *grouppb.GetGroupRequest:
 		return true, nil
@@ -50,7 +52,15 @@ func lightweightAccountScope(_ context.Context, scope *authpb.Scope, resource an
 }
 
 func checkLightweightPath(path string) bool {
+	// TODO(lopresti) we need a proper registration mechanism for this
 	paths := []string{
+		"/app/new",
+		"/app/open",
+		"/archiver",
+		"/dataprovider",
+		"/data",
+		"/projects",
+		"/graph",
 		"/ocs/v2.php/apps/files_sharing/api/v1/shares",
 		"/ocs/v1.php/apps/files_sharing/api/v1/shares",
 		"/ocs/v2.php/apps/files_sharing//api/v1/shares",
@@ -59,18 +69,21 @@ func checkLightweightPath(path string) bool {
 		"/ocs/v1.php/cloud/capabilities",
 		"/ocs/v2.php/cloud/user",
 		"/ocs/v1.php/cloud/user",
+		"/sciencemesh/generate-invite",
+		"/sciencemesh/list-invite",
+		"/sciencemesh/accept-invite",
+		"/sciencemesh/find-accepted-users",
+		"/sciencemesh/delete-accepted-user",
+		"/sciencemesh/list-providers",
+		"/sciencemesh/open-in-app",
+		"/sciencemesh/federations",
+		"/sciencemesh/discover",
+		"/sciencemesh/embedded-shares",
+		"/sciencemesh/process-embedded-share",
 		"/remote.php/webdav",
 		"/remote.php/dav/files",
 		"/remote.php/dav/spaces",
 		"/thumbnails",
-		"/app/open",
-		"/app/new",
-		"/archiver",
-		"/dataprovider",
-		"/data",
-		"/app/open",
-		"/projects",
-		"/graph",
 	}
 	for _, p := range paths {
 		if strings.HasPrefix(path, p) {
@@ -82,7 +95,7 @@ func checkLightweightPath(path string) bool {
 
 // AddLightweightAccountScope adds the scope to allow access to lightweight user.
 func AddLightweightAccountScope(role authpb.Role, scopes map[string]*authpb.Scope) (map[string]*authpb.Scope, error) {
-	ref := &provider.Reference{Path: "/"}
+	ref := &sp.Reference{Path: "/"}
 	val, err := utils.MarshalProtoV1ToJSON(ref)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This still relies on an old mechanism that should be refactored.