### PR TITLE
Add remote users automatically for OCM shares

### DIFF
--- a/changelog/unreleased/store-users-ocm-share.md
+++ b/changelog/unreleased/store-users-ocm-share.md
@@ -1,0 +1,9 @@
+Enhancement: Store remote users on ocm share
+
+This commit adds the following functionality:
+
+- Functionality to add remote users even without the invitation flow when an OCM share is received.
+- This configuration option is a whitelist of hosts of which this functionality is enabled for.
+- A machine secret is added so that we can impersonate the user receiving the share since the ocm endpoint is unauthenticated. 
+
+https://github.com/cs3org/reva/pull/5690

--- a/internal/http/services/opencloudmesh/ocmd/ocm.go
+++ b/internal/http/services/opencloudmesh/ocmd/ocm.go
@@ -39,6 +39,13 @@ type config struct {
 	ExposeRecipientDisplayName bool                      `mapstructure:"expose_recipient_display_name"`
 	TokenManager               string                    `mapstructure:"token_manager"`
 	TokenManagers              map[string]map[string]any `mapstructure:"token_managers"`
+	// MachineSecret is the shared secret used to impersonate the recipient of an
+	// incoming OCM share when auto-registering its remote sender/owner as accepted users.
+	MachineSecret string `mapstructure:"machine_secret"`
+	// AutoAcceptProviders is a list of regular expressions matched against the sender's
+	// provider domain. A match activates auto-registration of the share's remote users
+	// for all OCM share types (embedded shares are always auto-registered).
+	AutoAcceptProviders []string `mapstructure:"auto_accept_providers"`
 }
 
 func (c *config) ApplyDefaults() {

--- a/internal/http/services/opencloudmesh/ocmd/shares.go
+++ b/internal/http/services/opencloudmesh/ocmd/shares.go
@@ -182,12 +182,12 @@ func (h *sharesHandler) CreateShare(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// By default all incoming shares are accepted. Configuring a non-empty
-	// auto-accept whitelist restricts this: a share is then stored only if the
-	// sender's provider is on the whitelist, or if the sender is already an
+	// By default all incoming shares are accepted only if the sender is already an
 	// accepted user of the recipient (i.e. they went through a prior invitation
-	// flow). Shares matching neither are rejected outright.
-	if len(h.autoAcceptProviders) > 0 && !h.matchesAutoAccept(sender.Idp) && !h.isAcceptedUser(ctx, userRes.User, sender) {
+	// flow).  Configuring a non-empty auto-accept whitelist (that may include `.*`)
+	// allows any sender whose provider is on the whitelist to be accepted.
+	// Shares matching neither are rejected outright.
+	if !h.matchesAutoAccept(sender.Idp) && !h.isAcceptedUser(ctx, userRes.User, sender) {
 		reqres.WriteError(w, r, reqres.APIErrorUnauthenticated, "sender provider not in the auto-accept whitelist", nil)
 		return
 	}

--- a/internal/http/services/opencloudmesh/ocmd/shares.go
+++ b/internal/http/services/opencloudmesh/ocmd/shares.go
@@ -187,7 +187,8 @@ func (h *sharesHandler) CreateShare(w http.ResponseWriter, r *http.Request) {
 	// flow).  Configuring a non-empty auto-accept whitelist (that may include `.*`)
 	// allows any sender whose provider is on the whitelist to be accepted.
 	// Shares matching neither are rejected outright.
-	if !h.matchesAutoAccept(sender.Idp) && !h.isAcceptedUser(ctx, userRes.User, sender) {
+	wasAccepted := h.isAcceptedUser(ctx, userRes.User, sender)
+	if !h.matchesAutoAccept(sender.Idp) && !wasAccepted {
 		reqres.WriteError(w, r, reqres.APIErrorUnauthenticated, "sender provider not in the auto-accept whitelist", nil)
 		return
 	}
@@ -247,7 +248,7 @@ func (h *sharesHandler) CreateShare(w http.ResponseWriter, r *http.Request) {
 	// resolution of them would fail. Register them locally now, while the payload still
 	// carries their display names. This is auxiliary: any failure is logged but does
 	// not fail the share creation.
-	if h.matchesAutoAccept(sender.Idp) {
+	if !wasAccepted {
 		// We leave the email blank since it's not available in the ocm share payload.
 		h.registerAcceptedUser(ctx, userRes.User, &userpb.User{
 			Id:          sender,
@@ -270,12 +271,6 @@ func (h *sharesHandler) CreateShare(w http.ResponseWriter, r *http.Request) {
 // and simply expires. All failures are logged and swallowed.
 func (h *sharesHandler) registerAcceptedUser(ctx context.Context, recipient *userpb.User, remoteUser *userpb.User) {
 	log := appctx.GetLogger(ctx)
-
-	// skip if the remote user is already an accepted user of the recipient
-	if h.isAcceptedUser(ctx, recipient, remoteUser.Id) {
-		log.Debug().Str("remote_user", remoteUser.Id.OpaqueId).Msg("auto-register: remote user already accepted, skipping")
-		return
-	}
 
 	// impersonate the recipient so the minted invite token is owned by them
 	recipientCtx, err := h.impersonate(ctx, recipient)

--- a/internal/http/services/opencloudmesh/ocmd/shares.go
+++ b/internal/http/services/opencloudmesh/ocmd/shares.go
@@ -27,6 +27,7 @@ import (
 	"net/http"
 	"net/url"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
@@ -36,6 +37,7 @@ import (
 
 	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	ocmincoming "github.com/cs3org/go-cs3apis/cs3/ocm/incoming/v1beta1"
+	invitepb "github.com/cs3org/go-cs3apis/cs3/ocm/invite/v1beta1"
 	ocmprovider "github.com/cs3org/go-cs3apis/cs3/ocm/provider/v1beta1"
 	ocm "github.com/cs3org/go-cs3apis/cs3/sharing/ocm/v1beta1"
 
@@ -47,6 +49,7 @@ import (
 	"github.com/cs3org/reva/v3/pkg/utils"
 	"github.com/go-playground/validator/v10"
 	"github.com/studio-b12/gowebdav"
+	"google.golang.org/grpc/metadata"
 )
 
 var validate = validator.New()
@@ -54,6 +57,8 @@ var validate = validator.New()
 type sharesHandler struct {
 	gatewayClient              gateway.GatewayAPIClient
 	exposeRecipientDisplayName bool
+	machineSecret              string
+	autoAcceptProviders        []*regexp.Regexp
 }
 
 func (h *sharesHandler) init(c *config) error {
@@ -63,7 +68,46 @@ func (h *sharesHandler) init(c *config) error {
 		return err
 	}
 	h.exposeRecipientDisplayName = c.ExposeRecipientDisplayName
+	h.machineSecret = c.MachineSecret
+	for _, p := range c.AutoAcceptProviders {
+		re, err := regexp.Compile(p)
+		if err != nil {
+			return errors.Wrapf(err, "invalid auto_accept_providers regex %q", p)
+		}
+		h.autoAcceptProviders = append(h.autoAcceptProviders, re)
+	}
 	return nil
+}
+
+// matchesAutoAccept reports whether the given sender provider domain matches any
+// of the configured auto-accept provider regexes.
+func (h *sharesHandler) matchesAutoAccept(domain string) bool {
+	for _, re := range h.autoAcceptProviders {
+		if re.MatchString(domain) {
+			return true
+		}
+	}
+	return false
+}
+
+// isAcceptedUser reports whether remoteUser is already an accepted user of the
+// recipient, i.e. they know each other through a prior invitation flow.
+func (h *sharesHandler) isAcceptedUser(ctx context.Context, recipient *userpb.User, remoteUser *userpb.UserId) bool {
+	log := appctx.GetLogger(ctx)
+	filter, err := utils.MarshalProtoV1ToJSON(recipient.Id)
+	if err != nil {
+		log.Error().Err(err).Msg("auto-accept: error marshalling recipient id")
+		return false
+	}
+	res, err := h.gatewayClient.GetAcceptedUser(ctx, &invitepb.GetAcceptedUserRequest{
+		RemoteUserId: remoteUser,
+		Opaque: &types.Opaque{
+			Map: map[string]*types.OpaqueEntry{
+				"user-filter": {Decoder: "json", Value: filter},
+			},
+		},
+	})
+	return err == nil && res.Status.Code == rpc.Code_CODE_OK
 }
 
 // CreateShare implements the OCM /shares call and stores an incoming share
@@ -138,6 +182,16 @@ func (h *sharesHandler) CreateShare(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// By default all incoming shares are accepted. Configuring a non-empty
+	// auto-accept whitelist restricts this: a share is then stored only if the
+	// sender's provider is on the whitelist, or if the sender is already an
+	// accepted user of the recipient (i.e. they went through a prior invitation
+	// flow). Shares matching neither are rejected outright.
+	if len(h.autoAcceptProviders) > 0 && !h.matchesAutoAccept(sender.Idp) && !h.isAcceptedUser(ctx, userRes.User, sender) {
+		reqres.WriteError(w, r, reqres.APIErrorUnauthenticated, "sender provider not in the auto-accept whitelist", nil)
+		return
+	}
+
 	protocols, legacy, err := getAndResolveProtocols(ctx, req.Protocols, req.ResourceType, sender.Idp)
 	if err != nil || len(protocols) == 0 {
 		reqres.WriteError(w, r, reqres.APIErrorInvalidParameter, "error with protocols payload", err)
@@ -188,12 +242,90 @@ func (h *sharesHandler) CreateShare(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Shares from a whitelisted provider may arrive without a prior invitation flow, so
+	// their remote sender/owner are not yet known as accepted users and a later
+	// resolution of them would fail. Register them locally now, while the payload still
+	// carries their display names. This is auxiliary: any failure is logged but does
+	// not fail the share creation.
+	if h.matchesAutoAccept(sender.Idp) {
+		// We leave the email blank since it's not available in the ocm share payload.
+		h.registerAcceptedUser(ctx, userRes.User, &userpb.User{
+			Id:          sender,
+			DisplayName: req.SenderDisplayName,
+		})
+	}
+
 	response := map[string]any{}
 	if h.exposeRecipientDisplayName {
 		response["recipientDisplayName"] = userRes.User.DisplayName
 	}
 	w.WriteHeader(http.StatusCreated)
 	_ = json.NewEncoder(w).Encode(response)
+}
+
+// registerAcceptedUser adds remoteUser to the recipient's accepted users, unless it is
+// already known. It reuses the existing invite API: a local invite token is minted on
+// behalf of the recipient (via machine-auth impersonation) and immediately accepted,
+// which inserts the (recipient, remoteUser) relation. The token is never sent remotely
+// and simply expires. All failures are logged and swallowed.
+func (h *sharesHandler) registerAcceptedUser(ctx context.Context, recipient *userpb.User, remoteUser *userpb.User) {
+	log := appctx.GetLogger(ctx)
+
+	// skip if the remote user is already an accepted user of the recipient
+	if h.isAcceptedUser(ctx, recipient, remoteUser.Id) {
+		log.Debug().Str("remote_user", remoteUser.Id.OpaqueId).Msg("auto-register: remote user already accepted, skipping")
+		return
+	}
+
+	// impersonate the recipient so the minted invite token is owned by them
+	recipientCtx, err := h.impersonate(ctx, recipient)
+	if err != nil {
+		log.Error().Err(err).Str("recipient", recipient.Id.OpaqueId).Msg("auto-register: error impersonating recipient")
+		return
+	}
+
+	tokenRes, err := h.gatewayClient.GenerateInviteToken(recipientCtx, &invitepb.GenerateInviteTokenRequest{
+		Description: "auto-accept for received OCM share",
+	})
+	if err != nil || tokenRes.Status.Code != rpc.Code_CODE_OK {
+		log.Error().Err(err).Interface("status", tokenRes.GetStatus()).Msg("auto-register: error generating invite token")
+		return
+	}
+
+	acceptRes, err := h.gatewayClient.AcceptInvite(ctx, &invitepb.AcceptInviteRequest{
+		InviteToken: tokenRes.InviteToken,
+		RemoteUser:  remoteUser,
+	})
+	if err != nil {
+		log.Error().Err(err).Msg("auto-register: error accepting invite")
+		return
+	}
+	if acceptRes.Status.Code != rpc.Code_CODE_OK && acceptRes.Status.Code != rpc.Code_CODE_ALREADY_EXISTS {
+		log.Error().Interface("status", acceptRes.Status).Msg("auto-register: error accepting invite")
+		return
+	}
+	log.Info().Str("recipient", recipient.Id.OpaqueId).Str("remote_user", remoteUser.Id.OpaqueId).Msg("auto-registered remote user as accepted user")
+}
+
+// impersonate returns a context authenticated as the given user via machine auth,
+// for invoking protected calls (e.g. GenerateInviteToken) on their behalf.
+func (h *sharesHandler) impersonate(ctx context.Context, user *userpb.User) (context.Context, error) {
+	authRes, err := h.gatewayClient.Authenticate(ctx, &gateway.AuthenticateRequest{
+		Type:         "machine",
+		ClientId:     user.Username,
+		ClientSecret: h.machineSecret,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if authRes.Status.Code != rpc.Code_CODE_OK {
+		return nil, errors.New("error impersonating user: " + authRes.Status.Message)
+	}
+
+	userCtx := appctx.ContextSetToken(ctx, authRes.Token)
+	userCtx = appctx.ContextSetUser(userCtx, authRes.User)
+	userCtx = metadata.AppendToOutgoingContext(userCtx, appctx.TokenHeader, authRes.Token)
+	return userCtx, nil
 }
 
 func getCreateShareRequest(r *http.Request) (*NewShareRequest, error) {

--- a/internal/http/services/opencloudmesh/ocmd/shares_test.go
+++ b/internal/http/services/opencloudmesh/ocmd/shares_test.go
@@ -31,6 +31,7 @@ import (
 	gateway "github.com/cs3org/go-cs3apis/cs3/gateway/v1beta1"
 	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	ocmincoming "github.com/cs3org/go-cs3apis/cs3/ocm/incoming/v1beta1"
+	invitepb "github.com/cs3org/go-cs3apis/cs3/ocm/invite/v1beta1"
 	ocmprovider "github.com/cs3org/go-cs3apis/cs3/ocm/provider/v1beta1"
 	rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
 	"github.com/cs3org/reva/v3/internal/http/services/wellknown"
@@ -90,6 +91,12 @@ func (m *sharesMockGW) GetUser(context.Context, *userpb.GetUserRequest, ...grpc.
 
 func (m *sharesMockGW) CreateOCMIncomingShare(context.Context, *ocmincoming.CreateOCMIncomingShareRequest, ...grpc.CallOption) (*ocmincoming.CreateOCMIncomingShareResponse, error) {
 	return m.createResp, nil
+}
+
+func (m *sharesMockGW) GetAcceptedUser(context.Context, *invitepb.GetAcceptedUserRequest, ...grpc.CallOption) (*invitepb.GetAcceptedUserResponse, error) {
+	return &invitepb.GetAcceptedUserResponse{
+		Status: &rpc.Status{Code: rpc.Code_CODE_OK},
+	}, nil
 }
 
 // --- tests ---

--- a/internal/http/services/opencloudmesh/ocmd/shares_test.go
+++ b/internal/http/services/opencloudmesh/ocmd/shares_test.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"regexp"
 	"testing"
 
 	gateway "github.com/cs3org/go-cs3apis/cs3/gateway/v1beta1"
@@ -139,5 +140,34 @@ func TestCreateShareReturnsServerErrorForNonOKCreateStatus(t *testing.T) {
 
 	if rr.Code != http.StatusInternalServerError {
 		t.Fatalf("CreateShare() status = %d, want %d", rr.Code, http.StatusInternalServerError)
+	}
+}
+
+func TestMatchesAutoAccept(t *testing.T) {
+	h := &sharesHandler{
+		autoAcceptProviders: []*regexp.Regexp{
+			regexp.MustCompile(`^trusted\.example\.org$`),
+			regexp.MustCompile(`\.cern\.ch$`),
+		},
+	}
+
+	cases := map[string]bool{
+		"trusted.example.org":      true,
+		"data.cern.ch":             true,
+		"sub.data.cern.ch":         true,
+		"untrusted.example.org":    false,
+		"trusted.example.org.evil": false,
+		"cern.ch.evil":             false,
+	}
+	for domain, want := range cases {
+		if got := h.matchesAutoAccept(domain); got != want {
+			t.Errorf("matchesAutoAccept(%q) = %v, want %v", domain, got, want)
+		}
+	}
+
+	// no configured providers -> never matches
+	empty := &sharesHandler{}
+	if empty.matchesAutoAccept("trusted.example.org") {
+		t.Errorf("matchesAutoAccept with no providers should return false")
 	}
 }


### PR DESCRIPTION
This PR Introduces:

- Functionality to add remote users even without the invitation flow when an OCM share is received.
- This configuration option is a whitelist of hosts of which this functionality is enabled for.

In order to do this a `machine secret` also has to be introduced since we have to impersonate the user receiving the share (since the ocm share endpoint is unauthenticated). 