### PR TITLE
Whitelisted more request types for the lightweight scope

### DIFF
--- a/changelog/unreleased/more-lw-ocm-fixes.md
+++ b/changelog/unreleased/more-lw-ocm-fixes.md
@@ -1,0 +1,5 @@
+Bugfix: whitelisted more request types for the lightweight scope
+
+This is required to enable OCM for external accounts
+
+https://github.com/cs3org/reva/pull/5694

--- a/pkg/auth/scope/lightweight.go
+++ b/pkg/auth/scope/lightweight.go
@@ -21,32 +21,70 @@ package scope
 import (
 	"context"
 	"strings"
+	"fmt"
 
+	appregistry "github.com/cs3org/go-cs3apis/cs3/app/registry/v1beta1"
 	authpb "github.com/cs3org/go-cs3apis/cs3/auth/provider/v1beta1"
 	grouppb "github.com/cs3org/go-cs3apis/cs3/identity/group/v1beta1"
 	collaboration "github.com/cs3org/go-cs3apis/cs3/sharing/collaboration/v1beta1"
 	ocm "github.com/cs3org/go-cs3apis/cs3/sharing/ocm/v1beta1"
+	link "github.com/cs3org/go-cs3apis/cs3/sharing/link/v1beta1"
+	invitepb "github.com/cs3org/go-cs3apis/cs3/ocm/invite/v1beta1"
+	prefpb "github.com/cs3org/go-cs3apis/cs3/preferences/v1beta1"
+	stregistry "github.com/cs3org/go-cs3apis/cs3/storage/registry/v1beta1"
 	sp "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	types "github.com/cs3org/go-cs3apis/cs3/types/v1beta1"
 	"github.com/cs3org/reva/v3/pkg/utils"
 	"github.com/rs/zerolog"
 )
 
-func lightweightAccountScope(_ context.Context, scope *authpb.Scope, resource any, _ *zerolog.Logger) (bool, error) {
+func lightweightAccountScope(_ context.Context, scope *authpb.Scope, resource any, log *zerolog.Logger) (bool, error) {
 	// Lightweight accounts have access to resources shared with them.
 	// These cannot be resolved from here, but need to be added to the scope from
 	// where the call to mint tokens is made.
 	switch v := resource.(type) {
+	case *collaboration.ListSharesRequest:
+		return true, nil
 	case *collaboration.ListReceivedSharesRequest:
 		return true, nil
+	case *ocm.ListOCMSharesRequest:
+		return true, nil
 	case *ocm.ListReceivedOCMSharesRequest:
+		return true, nil
+	case *ocm.GetReceivedOCMShareRequest:
 		return true, nil
 	case *sp.ListStorageSpacesRequest:
 		return true, nil
 	case *grouppb.GetGroupRequest:
 		return true, nil
+	case *invitepb.AcceptInviteRequest:
+		return true, nil
+	case *invitepb.DeleteAcceptedUserRequest:
+		return true, nil
+	case *invitepb.FindAcceptedUsersRequest:
+		return true, nil
+	case *invitepb.ForwardInviteRequest:
+		return true, nil
+	case *invitepb.GenerateInviteTokenRequest:
+		return true, nil
+	case *invitepb.GetAcceptedUserRequest:
+		return true, nil
+	case *invitepb.InviteToken:
+		return true, nil
+	case *invitepb.ListInviteTokensRequest:
+		return true, nil
+	case *prefpb.GetKeyRequest:
+		return true, nil
+	case *link.ListPublicSharesRequest:
+		return true, nil
+	case *stregistry.GetStorageProvidersRequest:
+		return true, nil
+	case *appregistry.GetAppProvidersRequest:
+		return true, nil
 	case string:
 		return checkLightweightPath(v), nil
+	default:
+		log.Debug().Str("request_type", fmt.Sprintf("%T", v)).Msg("lightweightAccountScope: request type not supported")
 	}
 	return false, nil
 }
@@ -69,6 +107,7 @@ func checkLightweightPath(path string) bool {
 		"/ocs/v1.php/cloud/capabilities",
 		"/ocs/v2.php/cloud/user",
 		"/ocs/v1.php/cloud/user",
+		"/ocm-share",
 		"/sciencemesh/generate-invite",
 		"/sciencemesh/list-invite",
 		"/sciencemesh/accept-invite",


### PR DESCRIPTION
This is required to enable OCM for external accounts.
