### PR TITLE
Bugfix: normalize remote user ids in OCM

### DIFF
--- a/changelog/unreleased/fix-ocm-remote-user-id-normalization.md
+++ b/changelog/unreleased/fix-ocm-remote-user-id-normalization.md
@@ -1,0 +1,23 @@
+Bugfix: Normalize remote user ids in OCM to avoid malformed shareWith
+
+This fixes cross-vendor OCM shares failing when Reva is the sender and the
+peer is a non-conformant OCM server. The OCM spec requires the invite
+`userID` to be the bare identifier of the user at their OCM Server, with the
+host carried separately in `recipientProvider`. Some peers instead send a
+fully-qualified `userID` such as `id@host` (oCIS) or `id@https://host`
+(OpenCloud).
+
+Reva stored that qualified string verbatim as the federated user's opaque id
+and later re-appended the provider domain when building `shareWith`, producing
+malformed recipients like `id@host@host` or `id@https://host@host`. Receivers
+could not resolve those to a local user, so the share silently never
+materialized even though the HTTP request returned 200 OK.
+
+Reva now normalizes remote user ids on ingress (invite acceptance and invite
+forwarding) by stripping a redundant, self-referential provider suffix that
+matches the known provider domain, and defensively formats outbound OCM
+Addresses so it never emits the `id@host@host` form. Identifiers that
+legitimately contain `@` for a different host are left untouched, and
+spec-conformant peers are unaffected.
+
+https://github.com/cs3org/reva/pull/5695

--- a/internal/grpc/services/ocminvitemanager/ocminvitemanager.go
+++ b/internal/grpc/services/ocminvitemanager/ocminvitemanager.go
@@ -262,7 +262,10 @@ func (s *service) AcceptInvite(ctx context.Context, req *invitepb.AcceptInviteRe
 		}, nil
 	}
 
-	if err := s.repo.AddRemoteUser(ctx, token.GetUserId(), req.GetRemoteUser()); err != nil {
+	remoteUser := req.GetRemoteUser()
+	ocmd.CanonicalizeRemoteUserID(remoteUser.GetId())
+
+	if err := s.repo.AddRemoteUser(ctx, token.GetUserId(), remoteUser); err != nil {
 		if errors.Is(err, invite.ErrUserAlreadyAccepted) {
 			return &invitepb.AcceptInviteResponse{
 				Status: status.NewAlreadyExists(ctx, err, err.Error()),

--- a/internal/grpc/services/ocminvitemanager/ocminvitemanager.go
+++ b/internal/grpc/services/ocminvitemanager/ocminvitemanager.go
@@ -196,10 +196,14 @@ func (s *service) ForwardInvite(ctx context.Context, req *invitepb.ForwardInvite
 	// and the remote one (the initiator), so at the end of the invitation workflow they
 	// know each other
 
+	// Normalize the remote user id against the origin provider domain: some
+	// peers return a fully-qualified userID ("id@host" or "id@https://host")
+	// which would otherwise be re-qualified into "id@host@host" downstream.
+	providerDomain := req.GetOriginSystemProvider().Domain
 	remoteUserID := &userpb.UserId{
 		Type:     userpb.UserType_USER_TYPE_FEDERATED,
-		Idp:      req.GetOriginSystemProvider().Domain,
-		OpaqueId: remoteUser.UserID,
+		Idp:      ocmd.TrimOCMScheme(providerDomain),
+		OpaqueId: ocmd.NormalizeRemoteUserID(remoteUser.UserID, providerDomain),
 	}
 
 	if err := s.repo.AddRemoteUser(ctx, user.Id, &userpb.User{

--- a/internal/grpc/services/ocmshareprovider/ocmshareprovider.go
+++ b/internal/grpc/services/ocmshareprovider/ocmshareprovider.go
@@ -23,7 +23,6 @@ package ocmshareprovider
 
 import (
 	"context"
-	"fmt"
 	"net/url"
 	"path/filepath"
 	"slices"
@@ -169,7 +168,11 @@ func (s *service) UnprotectedEndpoints() []string {
 }
 
 func formatOCMUser(u *userpb.UserId) string {
-	return fmt.Sprintf("%s@%s", u.OpaqueId, u.Idp)
+	// Delegate to the shared OCM Address formatter so recipient, owner and
+	// sender ids are always spec-conformant "<opaque-id>@<host>" strings and
+	// never the malformed "id@host@host" form produced when a non-conformant
+	// peer's qualified userID was stored verbatim.
+	return ocmd.FormatOCMUser(u)
 }
 
 func getResourceType(info *providerpb.ResourceInfo) string {

--- a/internal/http/services/opencloudmesh/ocmd/identity_test.go
+++ b/internal/http/services/opencloudmesh/ocmd/identity_test.go
@@ -1,0 +1,134 @@
+// Copyright 2018-2024 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package ocmd
+
+import (
+	"testing"
+
+	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
+)
+
+func TestTrimOCMScheme(t *testing.T) {
+	cases := map[string]string{
+		"host.docker":         "host.docker",
+		"https://host.docker": "host.docker",
+		"http://host.docker":  "host.docker",
+		"":                    "",
+	}
+	for in, want := range cases {
+		if got := TrimOCMScheme(in); got != want {
+			t.Errorf("TrimOCMScheme(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestNormalizeRemoteUserID(t *testing.T) {
+	tests := []struct {
+		name     string
+		userID   string
+		provider string
+		want     string
+	}{
+		{
+			name:     "bare id is left untouched (spec-conformant)",
+			userID:   "f7fbf8c8-1234",
+			provider: "ocis2.docker",
+			want:     "f7fbf8c8-1234",
+		},
+		{
+			name:     "id qualified with matching host is stripped (oCIS)",
+			userID:   "f7fbf8c8-1234@ocis2.docker",
+			provider: "ocis2.docker",
+			want:     "f7fbf8c8-1234",
+		},
+		{
+			name:     "id qualified with scheme+host is stripped (OpenCloud)",
+			userID:   "60708dda-5678@https://opencloud2.docker",
+			provider: "opencloud2.docker",
+			want:     "60708dda-5678",
+		},
+		{
+			name:     "scheme in provider domain is tolerated",
+			userID:   "60708dda-5678@opencloud2.docker",
+			provider: "https://opencloud2.docker",
+			want:     "60708dda-5678",
+		},
+		{
+			name:     "double-qualified id collapses fully",
+			userID:   "f7fbf8c8-1234@ocis2.docker@ocis2.docker",
+			provider: "ocis2.docker",
+			want:     "f7fbf8c8-1234",
+		},
+		{
+			name:     "trailing suffix from a different host is preserved",
+			userID:   "user@other.docker",
+			provider: "ocis2.docker",
+			want:     "user@other.docker",
+		},
+		{
+			name:     "empty provider returns userID unchanged",
+			userID:   "user@ocis2.docker",
+			provider: "",
+			want:     "user@ocis2.docker",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NormalizeRemoteUserID(tt.userID, tt.provider); got != tt.want {
+				t.Errorf("NormalizeRemoteUserID(%q, %q) = %q, want %q", tt.userID, tt.provider, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatOCMUser(t *testing.T) {
+	tests := []struct {
+		name string
+		user *userpb.UserId
+		want string
+	}{
+		{
+			name: "bare opaque id and clean host",
+			user: &userpb.UserId{OpaqueId: "f7fbf8c8-1234", Idp: "cernbox2.docker"},
+			want: "f7fbf8c8-1234@cernbox2.docker",
+		},
+		{
+			name: "opaque id already qualified with matching host does not double up",
+			user: &userpb.UserId{OpaqueId: "f7fbf8c8-1234@ocis2.docker", Idp: "ocis2.docker"},
+			want: "f7fbf8c8-1234@ocis2.docker",
+		},
+		{
+			name: "scheme in host is stripped",
+			user: &userpb.UserId{OpaqueId: "60708dda-5678", Idp: "https://opencloud2.docker"},
+			want: "60708dda-5678@opencloud2.docker",
+		},
+		{
+			name: "scheme-qualified opaque id collapses to single host",
+			user: &userpb.UserId{OpaqueId: "60708dda-5678@https://opencloud2.docker", Idp: "opencloud2.docker"},
+			want: "60708dda-5678@opencloud2.docker",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := FormatOCMUser(tt.user); got != tt.want {
+				t.Errorf("FormatOCMUser(%+v) = %q, want %q", tt.user, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/http/services/opencloudmesh/ocmd/identity_test.go
+++ b/internal/http/services/opencloudmesh/ocmd/identity_test.go
@@ -97,6 +97,39 @@ func TestNormalizeRemoteUserID(t *testing.T) {
 	}
 }
 
+func TestGetUserIdFromOCMAddress(t *testing.T) {
+	uid, err := GetUserIdFromOCMAddress("id@http://host.docker")
+	if err != nil {
+		t.Fatalf("GetUserIdFromOCMAddress returned error: %v", err)
+	}
+	if uid.Idp != "host.docker" {
+		t.Errorf("Idp = %q, want %q", uid.Idp, "host.docker")
+	}
+	if uid.OpaqueId != "id" {
+		t.Errorf("OpaqueId = %q, want %q", uid.OpaqueId, "id")
+	}
+}
+
+func TestCanonicalizeRemoteUserID(t *testing.T) {
+	t.Run("nil input does not panic", func(t *testing.T) {
+		CanonicalizeRemoteUserID(nil)
+	})
+
+	t.Run("strips scheme from Idp and matching qualified opaque id", func(t *testing.T) {
+		id := &userpb.UserId{
+			OpaqueId: "id@host.docker",
+			Idp:      "https://host.docker",
+		}
+		CanonicalizeRemoteUserID(id)
+		if id.Idp != "host.docker" {
+			t.Errorf("Idp = %q, want %q", id.Idp, "host.docker")
+		}
+		if id.OpaqueId != "id" {
+			t.Errorf("OpaqueId = %q, want %q", id.OpaqueId, "id")
+		}
+	})
+}
+
 func TestFormatOCMUser(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/http/services/opencloudmesh/ocmd/invites.go
+++ b/internal/http/services/opencloudmesh/ocmd/invites.go
@@ -98,10 +98,14 @@ func (h *invitesHandler) AcceptInvite(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Some peers (oCIS, OpenCloud) send a fully-qualified userID such as
+	// "id@host" or "id@https://host" instead of the bare identifier the OCM
+	// spec mandates. Normalize it against the known provider domain so we do
+	// not later double-qualify it into "id@host@host" when building shareWith.
 	userObj := &userpb.User{
 		Id: &userpb.UserId{
-			OpaqueId: req.UserID,
-			Idp:      req.RecipientProvider,
+			OpaqueId: NormalizeRemoteUserID(req.UserID, req.RecipientProvider),
+			Idp:      TrimOCMScheme(req.RecipientProvider),
 			Type:     userpb.UserType_USER_TYPE_FEDERATED,
 		},
 		Mail:        req.Email,

--- a/internal/http/services/opencloudmesh/ocmd/specs.go
+++ b/internal/http/services/opencloudmesh/ocmd/specs.go
@@ -424,3 +424,50 @@ func GetUserIdFromOCMAddress(user string) (*userpb.UserId, error) {
 		Type: userpb.UserType_USER_TYPE_FEDERATED,
 	}, nil
 }
+
+// TrimOCMScheme removes a leading http(s):// scheme from an OCM host string.
+// OCM Addresses are not URIs and MUST NOT carry a scheme, but some servers
+// (Nextcloud, oCIS, OpenCloud) include one; we strip it defensively.
+func TrimOCMScheme(host string) string {
+	host = strings.TrimPrefix(host, "https://")
+	host = strings.TrimPrefix(host, "http://")
+	return host
+}
+
+// NormalizeRemoteUserID returns the bare OCM identifier for a remote user.
+//
+// Per the OCM spec the invite `userID` MUST be the bare identifier of the user
+// at their OCM Server, and the host travels separately in `recipientProvider`.
+// Some non-conformant servers append the host to `userID` anyway (oCIS sends
+// "id@host", OpenCloud sends "id@https://host"). If stored verbatim, CERNBox
+// keeps that qualified string as the OpaqueId and later re-appends the provider
+// domain when building `shareWith`, producing "id@host@host" (or with a scheme),
+// which the receiver cannot resolve to a local user.
+//
+// We strip a trailing "@<provider>" suffix ONLY when it matches the already-known
+// provider domain, repeating to collapse accidental double-qualification. A
+// spec-conformant identifier that legitimately contains '@' (e.g. an email local
+// part such as "a@b.org" belonging to a different provider) is left untouched.
+func NormalizeRemoteUserID(userID, providerDomain string) string {
+	host := TrimOCMScheme(providerDomain)
+	if host == "" {
+		return userID
+	}
+	for {
+		uid, err := GetUserIdFromOCMAddress(userID)
+		if err != nil || !strings.EqualFold(TrimOCMScheme(uid.Idp), host) {
+			return userID
+		}
+		userID = uid.OpaqueId
+	}
+}
+
+// FormatOCMUser renders a CS3 user id as an OCM Address "<opaque-id>@<host>".
+// It strips any scheme from the host and collapses a redundant, self-referential
+// provider suffix already present in the opaque id, so it never emits the
+// malformed "id@host@host" form even if a non-conformant peer polluted storage.
+func FormatOCMUser(u *userpb.UserId) string {
+	host := TrimOCMScheme(u.Idp)
+	opaque := NormalizeRemoteUserID(u.OpaqueId, host)
+	return fmt.Sprintf("%s@%s", opaque, host)
+}

--- a/internal/http/services/opencloudmesh/ocmd/specs.go
+++ b/internal/http/services/opencloudmesh/ocmd/specs.go
@@ -415,7 +415,7 @@ func GetUserIdFromOCMAddress(user string) (*userpb.UserId, error) {
 	if idp == "" {
 		return nil, errors.New("provider cannot be empty")
 	}
-	idp = strings.TrimPrefix(idp, "https://") // strip off leading scheme if present (despite being not OCM compliant). This is the case in Nextcloud and oCIS
+	idp = TrimOCMScheme(idp)
 
 	return &userpb.UserId{
 		OpaqueId: id,
@@ -460,6 +460,15 @@ func NormalizeRemoteUserID(userID, providerDomain string) string {
 		}
 		userID = uid.OpaqueId
 	}
+}
+
+// CanonicalizeRemoteUserID normalizes a federated remote user id in place.
+func CanonicalizeRemoteUserID(id *userpb.UserId) {
+	if id == nil {
+		return
+	}
+	id.Idp = TrimOCMScheme(id.Idp)
+	id.OpaqueId = NormalizeRemoteUserID(id.OpaqueId, id.Idp)
 }
 
 // FormatOCMUser renders a CS3 user id as an OCM Address "<opaque-id>@<host>".


### PR DESCRIPTION
## Summary

Cross-vendor OCM shares fail when Reva is the **sender** and the peer is a
non-conformant OCM server. The OCM spec requires the invite `userID` to be the
**bare** identifier of the user at their OCM Server, with the host carried
separately in `recipientProvider`. Some peers instead send a fully-qualified
`userID`:

- oCIS sends `id@host`
- OpenCloud sends `id@https://host`

Reva stored that qualified string verbatim as the federated user's opaque id,
then re-appended the provider domain when building `shareWith`, producing
malformed recipients:

- `id@host@host`
- `id@https://host@host`

Receivers cannot resolve those to a local user, so the share silently never
materializes even though the `/shares` POST returns `200 OK`.

Observed on the OCM Test Suite:

- CERNBox -> oCIS (FAIL): `shareWith: "f7fbf8c8-...@ocis2.docker@ocis2.docker"`
- CERNBox -> OpenCloud (FAIL): `shareWith: "60708dda-...@https://opencloud2.docker@opencloud2.docker"`
- CERNBox -> CERNBox (PASS): `shareWith: "f7fbf8c8-...@cernbox2.docker"`