### PR TITLE
Bugfix: Resolve single-file OCM shares over WebDAV

### DIFF
--- a/changelog/unreleased/fix-ocm-single-file-webdav-path.md
+++ b/changelog/unreleased/fix-ocm-single-file-webdav-path.md
@@ -1,0 +1,25 @@
+Bugfix: Resolve single-file OCM shares correctly over WebDAV
+
+This fixes cross-vendor OCM shares failing to appear on the receiver when Reva
+is the sender and the shared resource is a single file. Remote receivers
+(oCIS, OpenCloud) mount an OCM share as a directory and address the shared file
+as `<share>/<name>`, so the incoming WebDAV request carries the file's own name
+as a relative path.
+
+The `ocmoutcoming` storage driver resolved the share token to the shared
+resource (the file itself) and then unconditionally joined the relative path
+onto it, producing a doubled path such as
+`/home/einstein/report.txt/report.txt`. That path does not exist, so the stat
+failed and the WebDAV `PROPFIND` returned HTTP 500. Receivers treat a failed
+stat as a missing share and silently drop it from their "shared with me"
+listing, so the file never became visible even though the share was created and
+accepted.
+
+The driver now resolves paths based on the shared resource type. Folder shares
+still nest the child beneath the container. For a single-file share, which has
+exactly one resource, both the share root and a single-segment child resolve to
+the file itself, so `<file>/<file>` is never built and receivers whose appended
+name differs from the storage path base are tolerated. Nested paths under a
+file share are rejected as malformed.
+
+https://github.com/cs3org/reva/pull/5696

--- a/pkg/ocm/storage/outcoming/ocm.go
+++ b/pkg/ocm/storage/outcoming/ocm.go
@@ -255,14 +255,34 @@ func (d *driver) shareAndRelativePathFromRef(ctx context.Context, ref *provider.
 	return share, relPath, nil
 }
 
+// resolveOCMSharePath maps a relative path sent by a remote OCM receiver onto the
+// shared resource. A folder share nests the child beneath the shared container. A
+// single-file share has exactly one resource, so the receiver-supplied name carries no
+// routing information: both the share root and any single-segment child resolve to the
+// file itself. This avoids building "<file>/<file>" (which fails to stat and surfaces as
+// HTTP 500 to the receiver) and tolerates receivers whose appended name differs from the
+// storage path base. Nested paths under a file share are rejected as malformed.
+func resolveOCMSharePath(resourcePath string, isContainer bool, rel string) (string, bool) {
+	if isContainer {
+		return filepath.Join(resourcePath, rel), true
+	}
+	child := strings.TrimPrefix(filepath.Clean("/"+rel), "/")
+	if child == "" || !strings.Contains(child, "/") {
+		return resourcePath, true
+	}
+	return "", false
+}
+
 func (d *driver) translateOCMShareResourceToCS3Ref(ctx context.Context, resID *provider.ResourceId, rel string) (*provider.Reference, error) {
 	info, err := d.stat(ctx, &provider.Reference{ResourceId: resID})
 	if err != nil {
 		return nil, err
 	}
-	return &provider.Reference{
-		Path: filepath.Join(info.Path, rel),
-	}, nil
+	p, ok := resolveOCMSharePath(info.Path, info.Type == provider.ResourceType_RESOURCE_TYPE_CONTAINER, rel)
+	if !ok {
+		return nil, errtypes.NotFound(rel)
+	}
+	return &provider.Reference{Path: p}, nil
 }
 
 func (d *driver) CreateDir(ctx context.Context, ref *provider.Reference) error {

--- a/pkg/ocm/storage/outcoming/ocm_test.go
+++ b/pkg/ocm/storage/outcoming/ocm_test.go
@@ -472,3 +472,48 @@ func TestShareAndRelativePathFromRefRootMountedCodeFlow(t *testing.T) {
 		t.Fatalf("shareAndRelativePathFromRef returned rel %q, want \"./\"", rel)
 	}
 }
+
+func TestResolveOCMSharePath(t *testing.T) {
+	const file = "/home/einstein/report.txt"
+	const dir = "/home/einstein/project"
+
+	tests := []struct {
+		name        string
+		resource    string
+		isContainer bool
+		rel         string
+		wantPath    string
+		wantOK      bool
+	}{
+		// Single-file share: the share root resolves to the file. This is the
+		// receiver's expected path and must not regress.
+		{"file root empty", file, false, "", file, true},
+		{"file root dot", file, false, ".", file, true},
+		{"file root slash", file, false, "/", file, true},
+		{"file root dot slash", file, false, "./", file, true},
+		// Single-file share: receivers append the file name; it must
+		// resolve to the file, not to "<file>/<file>".
+		{"file by name", file, false, "./report.txt", file, true},
+		{"file by name abs", file, false, "/report.txt", file, true},
+		// Single-file share: any single segment resolves to the one file, so a
+		// receiver name that differs from the storage path base is tolerated.
+		{"file by other single segment", file, false, "./whatever", file, true},
+		// Single-file share: a nested path is malformed for a file.
+		{"file nested rejected", file, false, "./a/b.txt", "", false},
+		// Folder share: children nest under the container.
+		{"dir root", dir, true, "", dir, true},
+		{"dir child", dir, true, "./notes.txt", dir + "/notes.txt", true},
+		{"dir nested child", dir, true, "./sub/notes.txt", dir + "/sub/notes.txt", true},
+	}
+
+	for _, tc := range tests {
+		got, ok := resolveOCMSharePath(tc.resource, tc.isContainer, tc.rel)
+		if ok != tc.wantOK {
+			t.Errorf("%s: ok = %v, want %v (path=%q)", tc.name, ok, tc.wantOK, got)
+			continue
+		}
+		if ok && got != tc.wantPath {
+			t.Errorf("%s: path = %q, want %q", tc.name, got, tc.wantPath)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
This is a cascade PR, it relies on the previous #5695, I hope this ends up being more review friendly than a giant PR.

Cross-vendor OCM shares of a **single file** never became visible on the
receiver when Reva was the sender. The share was created and accepted, but the
receiver's "shared with me" listing silently dropped it. The root cause is a
path-doubling bug in the `ocmoutcoming` storage driver that made the receiver's
WebDAV `PROPFIND` return HTTP 500.

## Root cause

When a single file is shared over OCM, the shared resource is the file itself.
Remote receivers (oCIS, OpenCloud) mount the share as a directory and address
the file as `<share>/<name>`, so the incoming WebDAV request carries the file's
own name as a relative path.

`translateOCMShareResourceToCS3Ref` resolved the share token to the shared
resource (the file) and then unconditionally joined the relative path onto it:

    filepath.Join("/home/einstein/report.txt", "report.txt")
      => "/home/einstein/report.txt/report.txt"

That path does not exist, so the stat failed (CS3 code 15) and the `PROPFIND`
returned HTTP 500. Receivers treat a failed stat as a missing share and drop it
from the listing, so the file never appeared even though the share existed and
had been accepted.

Observed on the receiver:

    graph: "could not stat received ocm share, skipping"
           error="stat:PROPFIND /...report.txt: 500"

and on the sender:

    ERR error statting: path:"/home/einstein/report.txt/report.txt"
    PROPFIND /remote.php/dav/ocm/<share>/report.txt -> 500