### PR TITLE
Bugfix: Normalize user ids on incoming OCM shares

### DIFF
--- a/changelog/unreleased/fix-ocm-incoming-share-user-id-normalization.md
+++ b/changelog/unreleased/fix-ocm-incoming-share-user-id-normalization.md
@@ -1,0 +1,27 @@
+Bugfix: Normalize user ids on incoming OCM shares
+
+This fixes cross-vendor OCM shares failing on the receiving side when Reva is
+the receiver and the peer is a non-conformant OCM server. It is the
+receiver-side counterpart to the sender-side normalization in #5695.
+
+The OCM spec expects an address as `<bare-id>@<provider>`, with the host kept
+separate from the user id. Some peers glue the host onto the id: oCIS sends
+`id@host` and OpenCloud sends `id@https://host`, and by the time it reaches the
+`POST /ocm/shares` handler the id is doubled up as `id@host@host` (with or
+without a scheme).
+
+`GetUserIdFromOCMAddress` only strips the final `@host`, so the parsed opaque id
+kept a leftover host suffix that broke user resolution, and the two vendors
+failed at two different points. For `shareWith` (the local recipient) the
+leftover host made the local user lookup miss and the request returned 404 user
+not found. For `sender` and `owner` (the remote sharer) it made the accepted-user
+lookup miss, because the accepted remote user is stored with a bare id during the
+invitation flow, and the request returned 401 unauthenticated.
+
+The incoming-share handler now parses these three addresses through a helper that
+also strips a redundant, self-referential provider suffix that matches the parsed
+provider domain. Identifiers that legitimately contain `@` for a different host
+are left untouched, and spec-conformant peers such as CERNBox-to-CERNBox and
+Nextcloud are unaffected.
+
+https://github.com/cs3org/reva/pull/5698

--- a/internal/http/services/opencloudmesh/ocmd/shares.go
+++ b/internal/http/services/opencloudmesh/ocmd/shares.go
@@ -126,12 +126,12 @@ func (h *sharesHandler) CreateShare(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	sender, err := GetUserIdFromOCMAddress(req.Sender)
+	sender, err := parseOCMUser(req.Sender)
 	if err != nil {
 		reqres.WriteError(w, r, reqres.APIErrorInvalidParameter, "error with remote sender", err)
 		return
 	}
-	owner, err := GetUserIdFromOCMAddress(req.Owner)
+	owner, err := parseOCMUser(req.Owner)
 	if err != nil {
 		reqres.WriteError(w, r, reqres.APIErrorInvalidParameter, "error with remote owner", err)
 		return
@@ -164,7 +164,7 @@ func (h *sharesHandler) CreateShare(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	shareWith, err := GetUserIdFromOCMAddress(req.ShareWith)
+	shareWith, err := parseOCMUser(req.ShareWith)
 	if err != nil {
 		reqres.WriteError(w, r, reqres.APIErrorInvalidParameter, "error with shareWith user", err)
 		return
@@ -321,6 +321,32 @@ func (h *sharesHandler) impersonate(ctx context.Context, user *userpb.User) (con
 	userCtx = appctx.ContextSetUser(userCtx, authRes.User)
 	userCtx = metadata.AppendToOutgoingContext(userCtx, appctx.TokenHeader, authRes.Token)
 	return userCtx, nil
+}
+
+// parseOCMUser parses an OCM address "<id>@<provider>" from an incoming share
+// request and cleans up the opaque id before we try to resolve it.
+//
+// We are the receiving side here. The remote server sends us three addresses:
+// shareWith is the recipient on our side, while sender and owner are the person
+// on the remote side who is sharing. The spec says the id part should be the bare
+// user id, with the host kept separate. Some peers do not follow that: oCIS tacks
+// the host onto the id ("id@host") and OpenCloud tacks on the host with a scheme
+// ("id@https://host"), and by the time it reaches us it is doubled up as
+// "id@host@host".
+//
+// GetUserIdFromOCMAddress only peels off the final "@host", so the id we get back
+// still has a leftover host glued to it. That leftover then makes the lookup miss:
+// for shareWith we cannot find the local recipient, and for sender/owner we cannot
+// match the remote user we already stored when the invitation was accepted (we
+// store that one bare). NormalizeRemoteUserID trims the leftover host, but only
+// when it matches the provider we just parsed, so a well-formed id is left alone.
+func parseOCMUser(addr string) (*userpb.UserId, error) {
+	u, err := GetUserIdFromOCMAddress(addr)
+	if err != nil {
+		return nil, err
+	}
+	u.OpaqueId = NormalizeRemoteUserID(u.OpaqueId, u.Idp)
+	return u, nil
 }
 
 func getCreateShareRequest(r *http.Request) (*NewShareRequest, error) {

--- a/internal/http/services/opencloudmesh/ocmd/shares_test.go
+++ b/internal/http/services/opencloudmesh/ocmd/shares_test.go
@@ -178,3 +178,69 @@ func TestMatchesAutoAccept(t *testing.T) {
 		t.Errorf("matchesAutoAccept with no providers should return false")
 	}
 }
+
+func TestParseOCMUser(t *testing.T) {
+	tests := []struct {
+		name       string
+		addr       string
+		wantOpaque string
+		wantIdp    string
+		wantErr    bool
+	}{
+		{
+			name:       "spec-conformant bare id",
+			addr:       "marie@cernbox2.docker",
+			wantOpaque: "marie",
+			wantIdp:    "cernbox2.docker",
+		},
+		{
+			name:       "oCIS doubled recipient host collapses (shareWith)",
+			addr:       "cbcbcbcb-2222@cernbox2.docker@cernbox2.docker",
+			wantOpaque: "cbcbcbcb-2222",
+			wantIdp:    "cernbox2.docker",
+		},
+		{
+			name:       "oCIS doubled remote host collapses (sender/owner)",
+			addr:       "4c510ada-1234@ocis1.docker@ocis1.docker",
+			wantOpaque: "4c510ada-1234",
+			wantIdp:    "ocis1.docker",
+		},
+		{
+			name:       "OpenCloud doubled remote host with scheme collapses (sender/owner)",
+			addr:       "b1f74ec4-5678@https://opencloud1.docker@opencloud1.docker",
+			wantOpaque: "b1f74ec4-5678",
+			wantIdp:    "opencloud1.docker",
+		},
+		{
+			name:       "single scheme-qualified host is stripped to bare id",
+			addr:       "b1f74ec4-5678@https://opencloud1.docker",
+			wantOpaque: "b1f74ec4-5678",
+			wantIdp:    "opencloud1.docker",
+		},
+		{
+			name:    "address without provider is rejected",
+			addr:    "no-at-sign",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseOCMUser(tt.addr)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("parseOCMUser(%q) expected error, got nil", tt.addr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseOCMUser(%q) unexpected error: %v", tt.addr, err)
+			}
+			if got.OpaqueId != tt.wantOpaque {
+				t.Errorf("parseOCMUser(%q) OpaqueId = %q, want %q", tt.addr, got.OpaqueId, tt.wantOpaque)
+			}
+			if got.Idp != tt.wantIdp {
+				t.Errorf("parseOCMUser(%q) Idp = %q, want %q", tt.addr, got.Idp, tt.wantIdp)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

On the receiving side of an OCM share (`POST /ocm/shares`), CERNBox failed to
create incoming shares from oCIS and OpenCloud senders. Both peers send OCM
address fields where the host is glued onto the user id instead of kept separate,
and the incoming-share handler could not resolve those ids to users.

This is the receiver-side counterpart to #5695, which fixed the same class of
malformed address on the sending side (`FormatOCMUser`).

## Root cause

The OCM spec expects an address as `<bare-id>@<provider>`. Two peers deviate, and
by the time the payload reaches us the id is doubled:

- oCIS sends `id@host@host` (no scheme)
- OpenCloud sends `id@https://host@host` (with scheme)

`GetUserIdFromOCMAddress` only strips the final `@host`, so the parsed opaque id
keeps a leftover host suffix. That leftover breaks two different lookups, so the
two vendors fail at two different points:

- `shareWith` (the local recipient): the residual host means the local user
  lookup misses and the request returns `404 user not found`. This is what oCIS
  hit first, because its `shareWith` is doubled.
- `sender` / `owner` (the remote sharer): the residual host means the accepted-user
  lookup misses (we store the accepted remote user with a bare id during the
  invitation flow), and the request returns `401 unauthenticated`. This is what
  OpenCloud hit, because its `shareWith` happened to be clean but its
  `sender`/`owner` were doubled.

Because oCIS also sends doubled `sender`/`owner`, fixing only `shareWith` would
have moved oCIS from the 404 straight to the same 401. All three fields need the
same treatment.