### PR TITLE
OCM: Store share after remote operations succeed

### DIFF
--- a/changelog/unreleased/store-after-remote-ocm-shares.md
+++ b/changelog/unreleased/store-after-remote-ocm-shares.md
@@ -1,0 +1,7 @@
+Enhancement: Store OCM shares after the remote accepts them
+
+This commit introduces a behaviour where the OCM shares are only stored locally
+if the remote system accepts them first, meaning we don't have any orphaned OCM
+shares locally
+
+https://github.com/cs3org/reva/pull/5699

--- a/internal/grpc/services/ocmshareprovider/ocmshareprovider.go
+++ b/internal/grpc/services/ocmshareprovider/ocmshareprovider.go
@@ -313,20 +313,38 @@ func (s *service) CreateOCMShare(ctx context.Context, req *ocm.CreateOCMShareReq
 		AccessMethods: req.AccessMethods,
 	}
 
-	// TODO(lopresti) this is to be persisted after sending to remote,
-	// which requires the repo to expose a GenerateID() method to create
-	// the share here as it's sent in the payload
-	ocmshare, err = s.repo.StoreShare(ctx, ocmshare)
-	if err != nil {
-		if errors.Is(err, share.ErrShareAlreadyExisting) {
-			return &ocm.CreateOCMShareResponse{
-				Status: status.NewAlreadyExists(ctx, err, "share already exists"),
-			}, nil
-		}
+	// Since the share is persisted only after the remote server has accepted it,
+	// check upfront whether it already exists: this avoids sending it to the
+	// remote (and leaving a dangling share there) only to fail on the local
+	// duplicate afterwards.
+	switch _, err := s.repo.GetShare(ctx, user, &ocm.ShareReference{
+		Spec: &ocm.ShareReference_Key{
+			Key: &ocm.ShareKey{
+				Owner:      info.Owner,
+				ResourceId: req.ResourceId,
+				Grantee:    req.Grantee,
+			},
+		},
+	}); {
+	case err == nil:
+		return &ocm.CreateOCMShareResponse{
+			Status: status.NewAlreadyExists(ctx, share.ErrShareAlreadyExisting, "share already exists"),
+		}, nil
+	case !errors.Is(err, share.ErrShareNotFound):
 		return &ocm.CreateOCMShareResponse{
 			Status: status.NewInternal(ctx, err, err.Error()),
 		}, nil
 	}
+
+	// The share is persisted only once the remote server has accepted it, but
+	// its ID is part of the payload sent there, so the ID is generated upfront.
+	shareID, err := s.repo.GenerateID(ctx)
+	if err != nil {
+		return &ocm.CreateOCMShareResponse{
+			Status: status.NewInternal(ctx, err, err.Error()),
+		}, nil
+	}
+	ocmshare.Id = shareID
 
 	// look for the remote OCM endpoint
 	ocmEndpoint, err := ocmim.GetOCMEndpoint(req.RecipientMeshProvider)
@@ -403,15 +421,6 @@ func (s *service) CreateOCMShare(ctx context.Context, req *ocm.CreateOCMShareReq
 
 	newShareRes, err := s.client.NewShare(ctx, ocmEndpoint, newShareReq)
 	if err != nil {
-		// if the request doesn't succeed we need to roll back the share creation
-		delErr := s.repo.DeleteShare(ctx, user, &ocm.ShareReference{
-			Spec: &ocm.ShareReference_Id{
-				Id: ocmshare.Id,
-			},
-		})
-		if delErr != nil {
-			log.Error().Err(delErr).Msg("error rolling back share after failed remote share creation")
-		}
 		switch {
 		case errors.Is(err, ocmd.ErrInvalidParameters):
 			return &ocm.CreateOCMShareResponse{
@@ -428,9 +437,19 @@ func (s *service) CreateOCMShare(ctx context.Context, req *ocm.CreateOCMShareReq
 		}
 	}
 
+	stored, err := s.repo.StoreShare(ctx, ocmshare)
+	if err != nil {
+		// the remote server has already accepted the share, so a failure here
+		// leaves a dangling share on the remote end
+		log.Error().Err(err).Str("shareid", ocmshare.Id.OpaqueId).Msg("remote share created but persisting it locally failed")
+		return &ocm.CreateOCMShareResponse{
+			Status: status.NewInternal(ctx, err, err.Error()),
+		}, nil
+	}
+
 	res := &ocm.CreateOCMShareResponse{
 		Status:               status.NewOK(ctx),
-		Share:                ocmshare,
+		Share:                stored,
 		RecipientDisplayName: newShareRes.RecipientDisplayName,
 	}
 	return res, nil

--- a/pkg/ocm/share/repository/json/json.go
+++ b/pkg/ocm/share/repository/json/json.go
@@ -219,6 +219,12 @@ func genID() string {
 	return uuid.New().String()
 }
 
+// GenerateID generates a unique ID for a share that is yet to be stored,
+// so that the share can be referenced before being persisted with StoreShare.
+func (m *mgr) GenerateID(ctx context.Context) (*ocm.ShareId, error) {
+	return &ocm.ShareId{OpaqueId: genID()}, nil
+}
+
 func (m *mgr) StoreShare(ctx context.Context, ocmshare *ocm.Share) (*ocm.Share, error) {
 	m.Lock()
 	defer m.Unlock()
@@ -235,7 +241,6 @@ func (m *mgr) StoreShare(ctx context.Context, ocmshare *ocm.Share) (*ocm.Share, 
 		return nil, share.ErrShareAlreadyExisting
 	}
 
-	ocmshare.Id = &ocm.ShareId{OpaqueId: genID()}
 	m.model.Shares[ocmshare.Id.OpaqueId] = cloneShare(ocmshare)
 
 	if err := m.save(); err != nil {

--- a/pkg/ocm/share/repository/json/json_test.go
+++ b/pkg/ocm/share/repository/json/json_test.go
@@ -91,6 +91,7 @@ func testShare(token string, methods []*ocm.AccessMethod) *ocm.Share {
 	u := testUser()
 	now := uint64(time.Now().Unix())
 	return &ocm.Share{
+		Id:            &ocm.ShareId{OpaqueId: genID()},
 		ResourceId:    testResourceID(),
 		Name:          "test",
 		Token:         token,

--- a/pkg/ocm/share/share.go
+++ b/pkg/ocm/share/share.go
@@ -30,7 +30,13 @@ import (
 
 // Repository is the interface that manipulates the OCM shares repository.
 type Repository interface {
-	// StoreShare stores a share.
+	// GenerateID generates a unique ID for a new share, so that the share can
+	// be referenced (e.g. in the payload sent to the remote OCM server) before
+	// it is persisted with StoreShare.
+	GenerateID(ctx context.Context) (*ocm.ShareId, error)
+
+	// StoreShare stores a share. The share must carry an ID pre-generated with
+	// GenerateID, under which it is stored.
 	StoreShare(ctx context.Context, share *ocm.Share) (*ocm.Share, error)
 
 	// GetShare gets the information for a share by the given ref.

--- a/pkg/share/manager/sql/ocm_shares.go
+++ b/pkg/share/manager/sql/ocm_shares.go
@@ -81,12 +81,22 @@ func formatUserID(u *userpb.UserId) string {
 	return fmt.Sprintf("%s@%s", u.OpaqueId, u.Idp)
 }
 
-func (m *mgr) StoreShare(ctx context.Context, s *ocm.Share) (*ocm.Share, error) {
-
+// GenerateID reserves a unique ID for a share that is yet to be stored,
+// so that the share can be referenced before being persisted with StoreShare.
+func (m *mgr) GenerateID(ctx context.Context) (*ocm.ShareId, error) {
 	id, err := createID(m.db)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create id for OCM share")
 	}
+	return &ocm.ShareId{OpaqueId: strconv.FormatUint(uint64(id), 10)}, nil
+}
+
+func (m *mgr) StoreShare(ctx context.Context, s *ocm.Share) (*ocm.Share, error) {
+	parsed, err := strconv.ParseUint(s.Id.OpaqueId, 10, 64)
+	if err != nil {
+		return nil, errtypes.BadRequest("invalid share ID")
+	}
+	id := uint(parsed)
 	err = m.db.Transaction(func(tx *gorm.DB) error {
 
 		share := &model.OcmShare{
@@ -129,7 +139,6 @@ func (m *mgr) StoreShare(ctx context.Context, s *ocm.Share) (*ocm.Share, error) 
 	if err != nil {
 		return nil, err
 	}
-	s.Id = &ocm.ShareId{OpaqueId: strconv.FormatInt(int64(id), 10)}
 	return s, nil
 }
 

--- a/pkg/share/manager/sql/ocm_shares_test.go
+++ b/pkg/share/manager/sql/ocm_shares_test.go
@@ -68,6 +68,17 @@ func getOcmShare(accessMethods []*ocm.AccessMethod, grantee *provider.Grantee, c
 	}
 }
 
+// storeOcmShareWithID reserves an ID and stores the share, mirroring how the
+// service always sets a pre-generated ID before calling StoreShare.
+func storeOcmShareWithID(mgr share.Repository, ctx context.Context, s *ocm.Share) (*ocm.Share, error) {
+	id, err := mgr.GenerateID(ctx)
+	if err != nil {
+		return nil, err
+	}
+	s.Id = id
+	return mgr.StoreShare(ctx, s)
+}
+
 func getWebDavProtocol(uri string, sharedsecret string, perms *ocm.SharePermissions, role string) *ocm.Protocol {
 	switch role {
 	case "viewer":
@@ -249,7 +260,7 @@ func TestGetOCMShareById(t *testing.T) {
 	grantee := getUserOcmShareGrantee("sharee1")
 	accessMethods := getOcmAccessMethods("viewer")
 
-	share, err := mgr.StoreShare(userctx, getOcmShare(accessMethods, grantee, user.Id, getResourceId(), "sometoken"))
+	share, err := storeOcmShareWithID(mgr, userctx, getOcmShare(accessMethods, grantee, user.Id, getResourceId(), "sometoken"))
 	if err != nil {
 		t.Error(err)
 		t.FailNow()
@@ -272,6 +283,47 @@ func TestGetOCMShareById(t *testing.T) {
 	}
 }
 
+func TestStoreOCMShareWithPregeneratedID(t *testing.T) {
+	mgr, err, teardown := setupSuiteOcmShares(t)
+	defer teardown(t)
+
+	userctx := getUserContext("123456")
+	user, _ := appctx.ContextGetUser(userctx)
+	grantee := getUserOcmShareGrantee("sharee1")
+	accessMethods := getOcmAccessMethods("viewer")
+
+	id, err := mgr.GenerateID(userctx)
+	if err != nil {
+		t.Error(err)
+		t.FailNow()
+	}
+
+	ocmshare := getOcmShare(accessMethods, grantee, user.Id, getResourceId(), "sometoken")
+	ocmshare.Id = id
+
+	stored, err := mgr.StoreShare(userctx, ocmshare)
+	if err != nil {
+		t.Error(err)
+		t.FailNow()
+	}
+	if stored.Id.OpaqueId != id.OpaqueId {
+		t.Errorf("Expected share to be stored under pre-generated ID %s, got %s", id.OpaqueId, stored.Id.OpaqueId)
+	}
+
+	retrievedShare, err := mgr.GetShare(userctx, user, &ocm.ShareReference{
+		Spec: &ocm.ShareReference_Id{
+			Id: id,
+		},
+	})
+	if err != nil {
+		t.Error(err)
+		t.FailNow()
+	}
+	if retrievedShare.Id.OpaqueId != id.OpaqueId {
+		t.Errorf("Expected share ID %s, got %s", id.OpaqueId, retrievedShare.Id.OpaqueId)
+	}
+}
+
 func TestGetOCMShareByIdAllowsFederatedGrantee(t *testing.T) {
 	mgr, err, teardown := setupSuiteOcmShares(t)
 	defer teardown(t)
@@ -284,7 +336,7 @@ func TestGetOCMShareByIdAllowsFederatedGrantee(t *testing.T) {
 	grantee.GetUserId().Idp = "nextcloud1.docker"
 	accessMethods := getOcmAccessMethods("viewer")
 
-	share, err := mgr.StoreShare(ownerCtx, getOcmShare(accessMethods, grantee, owner.Id, getResourceId(), "federatedtoken"))
+	share, err := storeOcmShareWithID(mgr, ownerCtx, getOcmShare(accessMethods, grantee, owner.Id, getResourceId(), "federatedtoken"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -328,7 +380,7 @@ func TestGetOcmShareByKey(t *testing.T) {
 		},
 	}
 
-	share, err := mgr.StoreShare(userctx, getOcmShare(accessMethods, grantee, user.Id, getResourceId(), "sometoken"))
+	share, err := storeOcmShareWithID(mgr, userctx, getOcmShare(accessMethods, grantee, user.Id, getResourceId(), "sometoken"))
 	if err != nil {
 		t.Error(err)
 		t.FailNow()
@@ -360,7 +412,7 @@ func TestGetOCMShareByToken(t *testing.T) {
 		},
 	}
 
-	share, err := mgr.StoreShare(userctx, getOcmShare(accessMethods, grantee, user.Id, getResourceId(), "sometoken"))
+	share, err := storeOcmShareWithID(mgr, userctx, getOcmShare(accessMethods, grantee, user.Id, getResourceId(), "sometoken"))
 	if err != nil {
 		t.Error(err)
 		t.FailNow()
@@ -386,13 +438,13 @@ func TestDoNotCreateTheSameShareTwice(t *testing.T) {
 	grantee := getUserOcmShareGrantee("sharee1")
 	accessMethods := getOcmAccessMethods("viewer")
 
-	_, err = mgr.StoreShare(userctx, getOcmShare(accessMethods, grantee, user.Id, getResourceId(), "sometoken"))
+	_, err = storeOcmShareWithID(mgr, userctx, getOcmShare(accessMethods, grantee, user.Id, getResourceId(), "sometoken"))
 	if err != nil {
 		t.Error(err)
 		t.FailNow()
 	}
 
-	_, err = mgr.StoreShare(userctx, getOcmShare(accessMethods, grantee, user.Id, getResourceId(), "sometoken"))
+	_, err = storeOcmShareWithID(mgr, userctx, getOcmShare(accessMethods, grantee, user.Id, getResourceId(), "sometoken"))
 	if err == nil {
 		t.Error("Expected error when creating the same share twice, but got none")
 		t.FailNow()
@@ -409,13 +461,13 @@ func TestListOCMShares(t *testing.T) {
 	grantee2 := getUserOcmShareGrantee("sharee2")
 	accessMethods := getOcmAccessMethods("viewer")
 
-	_, err = mgr.StoreShare(userctx, getOcmShare(accessMethods, grantee1, user.Id, getResourceId(), "sometoken"))
+	_, err = storeOcmShareWithID(mgr, userctx, getOcmShare(accessMethods, grantee1, user.Id, getResourceId(), "sometoken"))
 	if err != nil {
 		t.Error(err)
 		t.FailNow()
 	}
 
-	_, err = mgr.StoreShare(userctx, getOcmShare(accessMethods, grantee2, user.Id, getResourceId(), "someothertoken"))
+	_, err = storeOcmShareWithID(mgr, userctx, getOcmShare(accessMethods, grantee2, user.Id, getResourceId(), "someothertoken"))
 	if err != nil {
 		t.Error(err)
 		t.FailNow()
@@ -506,7 +558,7 @@ func TestDeleteOCMShare(t *testing.T) {
 	grantee := getUserOcmShareGrantee("sharee1")
 	accessMethods := getOcmAccessMethods("viewer")
 
-	share, err := mgr.StoreShare(userctx, getOcmShare(accessMethods, grantee, user.Id, getResourceId(), "sometoken"))
+	share, err := storeOcmShareWithID(mgr, userctx, getOcmShare(accessMethods, grantee, user.Id, getResourceId(), "sometoken"))
 	if err != nil {
 		t.Error(err)
 		t.FailNow()
@@ -540,7 +592,7 @@ func TestUpdateOCMShare(t *testing.T) {
 	grantee := getUserOcmShareGrantee("sharee1")
 	accessMethods := getOcmAccessMethods("viewer")
 
-	share, err := mgr.StoreShare(userctx, getOcmShare(accessMethods, grantee, user.Id, getResourceId(), "sometoken"))
+	share, err := storeOcmShareWithID(mgr, userctx, getOcmShare(accessMethods, grantee, user.Id, getResourceId(), "sometoken"))
 	if err != nil {
 		t.Error(err)
 		t.FailNow()
@@ -580,7 +632,7 @@ func TestListOCMSharesWithOwnerFilter(t *testing.T) {
 	grantee2 := getUserOcmShareGrantee("sharee2")
 	accessMethods := getOcmAccessMethods("viewer")
 
-	_, err = mgr.StoreShare(userctx, getOcmShare(accessMethods, grantee1, user.Id, getResourceId(), "sometoken"))
+	_, err = storeOcmShareWithID(mgr, userctx, getOcmShare(accessMethods, grantee1, user.Id, getResourceId(), "sometoken"))
 	if err != nil {
 		t.Error(err)
 		t.FailNow()
@@ -591,7 +643,7 @@ func TestListOCMSharesWithOwnerFilter(t *testing.T) {
 		Type:     userpb.UserType_USER_TYPE_APPLICATION,
 	}
 
-	_, err = mgr.StoreShare(userctx, getOcmShare(accessMethods, grantee2, u, getResourceId(), "someothertoken"))
+	_, err = storeOcmShareWithID(mgr, userctx, getOcmShare(accessMethods, grantee2, u, getResourceId(), "someothertoken"))
 	if err != nil {
 		t.Error(err)
 		t.FailNow()
@@ -624,7 +676,7 @@ func TestOutgoingShareRoundTripsRequirementsAndAccessTypes(t *testing.T) {
 	grantee := getUserOcmShareGrantee("sharee1")
 	accessMethods := getOcmAccessMethodsWithCodeFlow("viewer")
 
-	stored, err := mgr.StoreShare(userctx, getOcmShare(accessMethods, grantee, user.Id, getResourceId(), "codeflowtoken"))
+	stored, err := storeOcmShareWithID(mgr, userctx, getOcmShare(accessMethods, grantee, user.Id, getResourceId(), "codeflowtoken"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -688,7 +740,7 @@ func TestUpdatePreservesRequirementsWhenFieldsOmitted(t *testing.T) {
 	grantee := getUserOcmShareGrantee("sharee1")
 	accessMethods := getOcmAccessMethodsWithCodeFlow("viewer")
 
-	stored, err := mgr.StoreShare(userctx, getOcmShare(accessMethods, grantee, user.Id, getResourceId(), "cftoken-ocs"))
+	stored, err := storeOcmShareWithID(mgr, userctx, getOcmShare(accessMethods, grantee, user.Id, getResourceId(), "cftoken-ocs"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -737,7 +789,7 @@ func TestUpdatePreservesRequirementsWithExplicitEmptySlice(t *testing.T) {
 	grantee := getUserOcmShareGrantee("sharee1")
 	accessMethods := getOcmAccessMethodsWithCodeFlow("viewer")
 
-	stored, err := mgr.StoreShare(userctx, getOcmShare(accessMethods, grantee, user.Id, getResourceId(), "cftoken-graph"))
+	stored, err := storeOcmShareWithID(mgr, userctx, getOcmShare(accessMethods, grantee, user.Id, getResourceId(), "cftoken-graph"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -787,7 +839,7 @@ func TestUpdateRejectsDifferentRequirements(t *testing.T) {
 	grantee := getUserOcmShareGrantee("sharee1")
 	accessMethods := getOcmAccessMethodsWithCodeFlow("viewer")
 
-	stored, err := mgr.StoreShare(userctx, getOcmShare(accessMethods, grantee, user.Id, getResourceId(), "cftoken-reject"))
+	stored, err := storeOcmShareWithID(mgr, userctx, getOcmShare(accessMethods, grantee, user.Id, getResourceId(), "cftoken-reject"))
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This commit introduces a behaviour where the OCM shares are only stored locally if the remote system accepts them first, meaning we don't have any orphaned OCM shares locally.

This is done by exposing the GenerateID function via the repository, so that the `ocmshareprovider` can generate an ID before storing the share, which was previously done in the ocm sql driver when the storing of the share happened.
