### PR TITLE
Takeout service

### DIFF
--- a/internal/http/services/loader/loader.go
+++ b/internal/http/services/loader/loader.go
@@ -38,6 +38,7 @@ import (
 	_ "github.com/cs3org/reva/v3/internal/http/services/preferences"
 	_ "github.com/cs3org/reva/v3/internal/http/services/prometheus"
 	_ "github.com/cs3org/reva/v3/internal/http/services/sciencemesh"
+	_ "github.com/cs3org/reva/v3/internal/http/services/takeout"
 	_ "github.com/cs3org/reva/v3/internal/http/services/wellknown"
 	// Add your own service here.
 )

--- a/internal/http/services/takeout/takeout.go
+++ b/internal/http/services/takeout/takeout.go
@@ -25,15 +25,15 @@ func init() {
 
 /* Service's configuration setup */
 
-// The takeout service config
-type config struct {
+// The takeout service Config
+type Config struct {
 	Prefix string `mapstructure:"prefix"`
 }
 
 // New sets the potential custom service config
 func New(ctx context.Context, m map[string]any) (global.Service, error) {
 	// Decode config
-	var c config
+	var c Config
 	if err := cfg.Decode(m, &c); err != nil {
 		return nil, err
 	}
@@ -45,7 +45,7 @@ func New(ctx context.Context, m map[string]any) (global.Service, error) {
 }
 
 // ApplyDefaults sets the default service config
-func (c *config) ApplyDefaults() {
+func (c *Config) ApplyDefaults() {
 	if c.Prefix == "" {
 		c.Prefix = "takeout"
 	}
@@ -67,7 +67,7 @@ type statusReply struct {
 
 // The takeout service structure
 type svc struct {
-	conf *config
+	conf *Config
 	log  *zerolog.Logger
 }
 
@@ -89,16 +89,24 @@ func (s *svc) Unprotected() []string {
 // Handler propagates the request dependanding on the suffix
 func (s *svc) Handler() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		action := strings.TrimPrefix(r.URL.Path, s.conf.Prefix)
-		s.log.Info().Msgf("action: %s", action)
-		switch action {
-		case "/post":
+		// The only accepted suffix should be the conf one
+		url := strings.TrimSuffix(r.URL.Path, "/")
+		if url != "" {
+			s.log.Warn().Msgf("takeout: %s is not a supported suffix", url)
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+
+		// Dispatch depending on request method
+		s.log.Info().Msgf("takeout: handling method %s", r.Method)
+		switch r.Method {
+		case http.MethodPost:
 			s.handlePost(w, r)
-		case "/get":
+		case http.MethodGet:
 			s.handleGet(w, r)
 
 		default:
-			s.log.Debug().Msgf("takeout: %s is not a supported endpoint", action)
+			s.log.Warn().Msgf("takeout: %s is not a supported method", r.Method)
 			w.WriteHeader(http.StatusBadRequest)
 		}
 	})

--- a/internal/http/services/takeout/takeout.go
+++ b/internal/http/services/takeout/takeout.go
@@ -1,0 +1,214 @@
+package takeout
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/cs3org/reva/v3/pkg/appctx"
+	"github.com/cs3org/reva/v3/pkg/rhttp/global"
+	"github.com/cs3org/reva/v3/pkg/rjobs"
+	"github.com/cs3org/reva/v3/pkg/takeout"
+	"github.com/cs3org/reva/v3/pkg/utils/cfg"
+	"github.com/rs/zerolog"
+)
+
+/* Service registration */
+
+// Init registers the takeout http service
+func init() {
+	global.Register("takeout", New)
+}
+
+/* Service's configuration setup */
+
+// The takeout service config
+type config struct {
+	Prefix string `mapstructure:"prefix"`
+}
+
+// New sets the potential custom service config
+func New(ctx context.Context, m map[string]any) (global.Service, error) {
+	// Decode config
+	var c config
+	if err := cfg.Decode(m, &c); err != nil {
+		return nil, err
+	}
+
+	// Declare logger
+	l := appctx.GetLogger(ctx)
+
+	return &svc{conf: &c, log: l}, nil
+}
+
+// ApplyDefaults sets the default service config
+func (c *config) ApplyDefaults() {
+	if c.Prefix == "" {
+		c.Prefix = "takeout"
+	}
+}
+
+// The GET JSON reply structure
+type statusReply struct {
+	RunID        string     `json:"run_id"`
+	State        string     `json:"state"`
+	EnqueuedAt   time.Time  `json:"enqueued_at"`
+	StartedAt    *time.Time `json:"started_at,omitempty"`
+	FinishedAt   *time.Time `json:"finished_at,omitempty"`
+	Error        string     `json:"error,omitempty"`
+	ArchivesURL  string     `json:"archives_url,omitempty"`
+	ArchivesPath string     `json:"archives_path,omitempty"`
+}
+
+/* Service setup */
+
+// The takeout service structure
+type svc struct {
+	conf *config
+	log  *zerolog.Logger
+}
+
+// Close performs a clean up
+func (s *svc) Close() error {
+	return nil
+}
+
+// Prefix sets the prefix
+func (s *svc) Prefix() string {
+	return s.conf.Prefix
+}
+
+// Unprotected sets the unprotected paths
+func (s *svc) Unprotected() []string {
+	return nil
+}
+
+// Handler propagates the request dependanding on the suffix
+func (s *svc) Handler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		action := strings.TrimPrefix(r.URL.Path, s.conf.Prefix)
+		s.log.Info().Msgf("action: %s", action)
+		switch action {
+		case "/post":
+			s.handlePost(w, r)
+		case "/get":
+			s.handleGet(w, r)
+
+		default:
+			s.log.Debug().Msgf("takeout: %s is not a supported endpoint", action)
+			w.WriteHeader(http.StatusBadRequest)
+		}
+	})
+}
+
+func (s *svc) handlePost(w http.ResponseWriter, r *http.Request) {
+	// Parse parameters from the request body
+	req := struct {
+		ArchiveFormat  string `json:"archiveFormat"`
+		MaxArchiveSize int64  `json:"maxArchiveSize"`
+	}{
+		// Default values in case they're not provided
+		ArchiveFormat:  "zip",
+		MaxArchiveSize: 2 << 30, // 2 GiB
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil && err != io.EOF {
+		s.log.Err(err).Msg("takeout: could not decode job parameters")
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	// Get job runner
+	runner := rjobs.Default()
+	if runner == nil {
+		s.log.Error().Msg("takeout: could not find runner")
+		w.WriteHeader(http.StatusFailedDependency)
+		return
+	}
+
+	// Get current authenticated user
+	user := appctx.ContextMustGetUser(r.Context())
+
+	// Enqueue job
+	runId, err := runner.Enqueue(r.Context(), takeout.JobName, rjobs.Params{
+		"archiveFormat":  req.ArchiveFormat,
+		"maxArchiveSize": req.MaxArchiveSize,
+		"username":       user.Username,
+	}, rjobs.WithOwner(user.Username), rjobs.Unique("takeout:"+user.Username))
+	if err != nil {
+		s.log.Err(err).Msg("takeout: could not enqueue job")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	// Reply with job ID
+	s.log.Info().Msgf("takeout: takeout job %s enqueued", runId)
+	w.WriteHeader(http.StatusOK)
+}
+
+func (s *svc) handleGet(w http.ResponseWriter, r *http.Request) {
+	// Get job runner
+	runner := rjobs.Default()
+	if runner == nil {
+		s.log.Error().Msg("takeout: could not find runner")
+		w.WriteHeader(http.StatusFailedDependency)
+		return
+	}
+
+	// Get takeout job from username, if any
+	user := appctx.ContextMustGetUser(r.Context())
+	jobs, err := runner.ListByOwner(r.Context(), user.Username, rjobs.ListFilter{Job: "takeout"})
+	if err != nil {
+		s.log.Err(err).Msg("takeout: could not list user's jobs")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	if len(jobs) == 0 {
+		s.log.Debug().Msgf("takeout: user %s has no takeout job listed", user.Username)
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	// Handle latest job
+	st := jobs[0]
+	rep := statusReply{
+		RunID:      string(st.RunID),
+		State:      string(st.State),
+		EnqueuedAt: st.EnqueuedAt,
+		StartedAt:  st.StartedAt,
+		FinishedAt: st.FinishedAt,
+	}
+	switch st.State {
+	case rjobs.StateFailed:
+		rep.Error = st.LastError
+	case rjobs.StateSucceeded:
+		// Reply with the public link to the archives
+		url, okT := st.Result["archives_url"].(string)
+		path, okP := st.Result["archives_path"].(string)
+		if !okT || !okP {
+			// Unreachable
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		rep.ArchivesURL = url
+		rep.ArchivesPath = path
+	case rjobs.StateQueued, rjobs.StateRunning:
+		// Nothing to add
+	default:
+		// Unreachable
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	// Encode and send the JSON reply
+	body, err := json.Marshal(rep)
+	if err != nil {
+		// Unreachable
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(body)
+}

--- a/pkg/takeout/takeout.go
+++ b/pkg/takeout/takeout.go
@@ -82,9 +82,7 @@ type params struct {
 	Username       string `mapstructure:"username" validate:"required"`
 }
 
-// Run walks the user's home space, downloads its content as the user,
-// archives it, uploads the archives to the takeout space as the takeout
-// admin, and returns a public link to the folder containing the archives
+// Run walks the user's archives the userspace
 func (j *job) Run(ctx context.Context, p rjobs.Params) (rjobs.Params, error) {
 	// Decode run parameters
 	pp := params{
@@ -121,8 +119,7 @@ func (j *job) Run(ctx context.Context, p rjobs.Params) (rjobs.Params, error) {
 	hc := httpclient.New(httpclient.RoundTripper(tr), httpclient.Timeout(time.Duration(10*time.Minute)))
 	dl := downloader.NewDownloader(gtw, hc)
 
-	// Setup upload client: no timeout, as an archive upload stays open for
-	// the whole duration of its part's creation
+	// Setup upload client
 	upHC := httpclient.New(httpclient.RoundTripper(tr), httpclient.Timeout(0))
 
 	// Setup walker
@@ -336,14 +333,25 @@ func (j *job) createTgzArchives(userCtx, adminCtx context.Context, rootPath, arc
 }
 
 func (j *job) createZipArchives(userCtx, adminCtx context.Context, root_path, arch_path string, wk walker.Walker, dl downloader.Downloader, gtw gateway.GatewayAPIClient, hc *httpclient.Client, maxArchiveSize int64) error {
-	// Ensure the destination directory exists before any upload starts
+	// Deletes the destination directory if it already exists, any public shares will be automatically removed
+	delRes, err := gtw.Delete(adminCtx, &provider.DeleteRequest{
+		Ref: &provider.Reference{Path: arch_path},
+	})
+	switch {
+	case err != nil:
+		return err
+	case delRes.Status.Code != rpc.Code_CODE_OK && delRes.Status.Code != rpc.Code_CODE_NOT_FOUND:
+		return errtypes.InternalError(delRes.Status.Message)
+	}
+
+	// Creates the empty destination directory
 	mkRes, err := gtw.CreateContainer(adminCtx, &provider.CreateContainerRequest{
 		Ref: &provider.Reference{Path: arch_path},
 	})
 	switch {
 	case err != nil:
 		return err
-	case mkRes.Status.Code != rpc.Code_CODE_OK && mkRes.Status.Code != rpc.Code_CODE_ALREADY_EXISTS:
+	case mkRes.Status.Code != rpc.Code_CODE_OK:
 		return errtypes.InternalError(mkRes.Status.Message)
 	}
 

--- a/pkg/takeout/takeout.go
+++ b/pkg/takeout/takeout.go
@@ -1,7 +1,9 @@
 package takeout
 
 import (
+	"archive/tar"
 	"archive/zip"
+	"compress/gzip"
 	"context"
 	"crypto/tls"
 	"fmt"
@@ -76,7 +78,7 @@ type job struct {
 // The per-run takeout parameters
 type params struct {
 	MaxArchiveSize int64  `mapstructure:"maxArchiveSize"` // < 10GB
-	ArchiveFormat  string `mapstructure:"archiveFormat"`  // One of ["zip", "tar"]
+	ArchiveFormat  string `mapstructure:"archiveFormat"`  // One of ["zip", "tgz"]
 	Username       string `mapstructure:"username" validate:"required"`
 }
 
@@ -137,10 +139,10 @@ func (j *job) Run(ctx context.Context, p rjobs.Params) (rjobs.Params, error) {
 		if err != nil {
 			return nil, errors.Wrap(err, "takeout: zip archive could not be created")
 		}
-	case "tar":
-		err = j.createTarArchives(userCtx, adminCtx, root, archPath, wk, dl, pp.MaxArchiveSize)
+	case "tgz":
+		err = j.createTgzArchives(userCtx, adminCtx, root, archPath, wk, dl, gtw, upHC, pp.MaxArchiveSize)
 		if err != nil {
-			return nil, errors.Wrap(err, "takeout: tar archive could not be created")
+			return nil, errors.Wrap(err, "takeout: tgz archive could not be created")
 		}
 	default:
 		return nil, errors.Errorf("takeout: %s is not a supported archive format", pp.ArchiveFormat)
@@ -178,8 +180,159 @@ func (j *job) authenticate(ctx context.Context, gtw gateway.GatewayAPIClient, cl
 	return ctx, nil
 }
 
-func (j *job) createTarArchives(userCtx, adminCtx context.Context, root_path, arch_path string, wk walker.Walker, dl downloader.Downloader, maxArchiveSize int64) error {
-	panic("unimplemented")
+func (j *job) createTgzArchives(userCtx, adminCtx context.Context, rootPath, archPath string, wk walker.Walker, dl downloader.Downloader, gtw gateway.GatewayAPIClient, hc *httpclient.Client, maxArchiveSize int64) error {
+	// Ensure the destination directory exists before any upload starts
+	mkRes, err := gtw.CreateContainer(adminCtx, &provider.CreateContainerRequest{
+		Ref: &provider.Reference{Path: archPath},
+	})
+	switch {
+	case err != nil:
+		return err
+	case mkRes.Status.Code != rpc.Code_CODE_OK && mkRes.Status.Code != rpc.Code_CODE_ALREADY_EXISTS:
+		return errtypes.InternalError(mkRes.Status.Message)
+	}
+
+	// Setup tgz archive streaming state
+	var (
+		pw        *io.PipeWriter
+		done      chan error
+		cw        *countingWriter
+		gw        *gzip.Writer
+		tw        *tar.Writer
+		archIndex = 0
+	)
+
+	// Start a fresh archive by initiating its upload and streaming the tgz into it
+	startPart := func() {
+		pr, npw := io.Pipe()
+		pw = npw
+		done = make(chan error, 1)
+
+		go func(idx int) {
+			err := j.uploadArchive(adminCtx, gtw, hc, archPath, idx, "tgz", pr)
+			// Unblock the producer if the upload fails mid-stream
+			pr.CloseWithError(err)
+			done <- err
+		}(archIndex)
+
+		cw = &countingWriter{w: pw}
+		gw = gzip.NewWriter(cw)
+		tw = tar.NewWriter(gw)
+	}
+
+	// Finalize the current archive and wait for its upload to complete
+	flush := func() error {
+		tarErr := tw.Close()
+
+		var gzipOrPipeErr error
+		if tarErr != nil {
+			_ = pw.CloseWithError(tarErr)
+		} else {
+			gzipOrPipeErr = gw.Close()
+			if gzipOrPipeErr != nil {
+				_ = pw.CloseWithError(gzipOrPipeErr)
+			} else {
+				gzipOrPipeErr = pw.Close()
+			}
+		}
+
+		upErr := <-done
+		pw = nil
+
+		if tarErr != nil {
+			return tarErr
+		}
+		if gzipOrPipeErr != nil {
+			return gzipOrPipeErr
+		}
+		return upErr
+	}
+
+	// Start the first archive
+	startPart()
+
+	// Create the archives by walking the specified directory
+	err = wk.Walk(userCtx, rootPath, func(currentPath string, info *provider.ResourceInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		isDir := info.Type == provider.ResourceType_RESOURCE_TYPE_CONTAINER
+
+		// Get relative path of the current file
+		fileName, err := filepath.Rel(filepath.Dir(rootPath), currentPath)
+		if err != nil {
+			return err
+		}
+		fileName = filepath.ToSlash(fileName)
+
+		// Cut the archive if adding the current file could exceed maxArchiveSize
+		if !isDir && cw.n > 0 && cw.n+int64(info.Size) > maxArchiveSize {
+			if err := flush(); err != nil {
+				return err
+			}
+			archIndex++
+			startPart()
+		}
+
+		// Create tar header of the current file
+		header := tar.Header{
+			Name:    fileName,
+			ModTime: time.Unix(int64(info.Mtime.Seconds), 0),
+		}
+
+		if isDir {
+			header.Mode = 0755
+			header.Typeflag = tar.TypeDir
+		} else {
+			header.Mode = 0644
+			header.Typeflag = tar.TypeReg
+			header.Size = int64(info.Size)
+		}
+
+		if err := tw.WriteHeader(&header); err != nil {
+			return err
+		}
+
+		if isDir {
+			return gw.Flush()
+		}
+
+		// Download file content
+		dlFile, err := dl.Download(userCtx, currentPath, "")
+		if err != nil {
+			return err
+		}
+
+		// Copy downloaded file to tgz archive
+		_, copyErr := io.Copy(tw, dlFile)
+		closeErr := dlFile.Close()
+
+		if copyErr != nil {
+			return copyErr
+		}
+		if closeErr != nil {
+			return closeErr
+		}
+
+		return gw.Flush()
+	})
+	if err != nil {
+		// Abort the in-flight upload, if any
+		if pw != nil {
+			_ = pw.CloseWithError(err)
+			<-done
+		}
+		return err
+	}
+
+	// Finalize last archive
+	if err := flush(); err != nil {
+		j.log.Err(err).Msg("takeout: archive upload failed")
+		return err
+	}
+
+	return nil
 }
 
 func (j *job) createZipArchives(userCtx, adminCtx context.Context, root_path, arch_path string, wk walker.Walker, dl downloader.Downloader, gtw gateway.GatewayAPIClient, hc *httpclient.Client, maxArchiveSize int64) error {
@@ -209,7 +362,7 @@ func (j *job) createZipArchives(userCtx, adminCtx context.Context, root_path, ar
 		pw = npw
 		done = make(chan error, 1)
 		go func(idx int) {
-			err := j.uploadArchive(adminCtx, gtw, hc, arch_path, idx, pr)
+			err := j.uploadArchive(adminCtx, gtw, hc, arch_path, idx, "zip", pr)
 			// Unblock the producer if the upload fails mid-stream
 			pr.CloseWithError(err)
 			done <- err
@@ -310,10 +463,10 @@ func (j *job) createZipArchives(userCtx, adminCtx context.Context, root_path, ar
 	return nil
 }
 
-func (j *job) uploadArchive(ctx context.Context, gtw gateway.GatewayAPIClient, hc *httpclient.Client, archPath string, archIndex int, arch io.Reader) error {
+func (j *job) uploadArchive(ctx context.Context, gtw gateway.GatewayAPIClient, hc *httpclient.Client, archPath string, archIndex int, ext string, arch io.Reader) error {
 	// Setup archive name
 	var (
-		archName = fmt.Sprintf("takeout-%03d.zip", archIndex)
+		archName = fmt.Sprintf("takeout-%03d.%s", archIndex, ext)
 		archFile = archPath + archName
 	)
 

--- a/pkg/takeout/takeout.go
+++ b/pkg/takeout/takeout.go
@@ -80,7 +80,9 @@ type params struct {
 	Username       string `mapstructure:"username" validate:"required"`
 }
 
-// Run downloads all files in the userspace and uploads them to a public share for takeout
+// Run walks the user's home space, downloads its content as the user,
+// archives it, uploads the archives to the takeout space as the takeout
+// admin, and returns a public link to the folder containing the archives
 func (j *job) Run(ctx context.Context, p rjobs.Params) (rjobs.Params, error) {
 	// Decode run parameters
 	pp := params{
@@ -196,8 +198,8 @@ func (j *job) createZipArchives(userCtx, adminCtx context.Context, root_path, ar
 	var (
 		pw        *io.PipeWriter
 		done      chan error
+		cw        *countingWriter
 		w         *zip.Writer
-		archSize  int64
 		archIndex = 0
 	)
 
@@ -212,7 +214,8 @@ func (j *job) createZipArchives(userCtx, adminCtx context.Context, root_path, ar
 			pr.CloseWithError(err)
 			done <- err
 		}(archIndex)
-		w = zip.NewWriter(pw)
+		cw = &countingWriter{w: pw}
+		w = zip.NewWriter(cw)
 	}
 
 	// Finalize the current archive and wait for its upload to complete
@@ -240,22 +243,21 @@ func (j *job) createZipArchives(userCtx, adminCtx context.Context, root_path, ar
 			return err
 		}
 
-		// Check current archive size
-		if archSize > maxArchiveSize {
-			if err := flush(); err != nil {
-				return err
-			}
-			archSize = 0
-			archIndex++
-			startPart()
-		}
-
 		isDir := info.Type == provider.ResourceType_RESOURCE_TYPE_CONTAINER
 
 		// Get relative path of the current file
 		fileName, err := filepath.Rel(filepath.Dir(root_path), current_path)
 		if err != nil {
 			return err
+		}
+
+		// Cut the archive if adding the current file could exceed maxArchiveSize
+		if !isDir && cw.n > 0 && cw.n+int64(info.Size) > maxArchiveSize {
+			if err := flush(); err != nil {
+				return err
+			}
+			archIndex++
+			startPart()
 		}
 
 		// Create zip header of the current file
@@ -288,8 +290,6 @@ func (j *job) createZipArchives(userCtx, adminCtx context.Context, root_path, ar
 			return err
 		}
 
-		// Update archive size metadata
-		archSize += int64(info.Size)
 		return nil
 	})
 	if err != nil {
@@ -415,4 +415,16 @@ func getUploadProtocol(protocols []*gateway.FileUploadProtocol, prot string) (*g
 		}
 	}
 	return nil, errtypes.InternalError(fmt.Sprintf("protocol %s not supported for uploading", prot))
+}
+
+// countingWriter counts the bytes written through it to measure the actual archive size
+type countingWriter struct {
+	w io.Writer
+	n int64
+}
+
+func (cw *countingWriter) Write(p []byte) (int, error) {
+	n, err := cw.w.Write(p)
+	cw.n += int64(n)
+	return n, err
 }

--- a/pkg/takeout/takeout.go
+++ b/pkg/takeout/takeout.go
@@ -1,0 +1,418 @@
+package takeout
+
+import (
+	"archive/zip"
+	"context"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"net/http"
+	"path/filepath"
+	"time"
+
+	gateway "github.com/cs3org/go-cs3apis/cs3/gateway/v1beta1"
+	rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
+	link "github.com/cs3org/go-cs3apis/cs3/sharing/link/v1beta1"
+	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+	types "github.com/cs3org/go-cs3apis/cs3/types/v1beta1"
+	"github.com/cs3org/reva/v3/internal/http/services/datagateway"
+	"github.com/cs3org/reva/v3/pkg/appctx"
+	"github.com/cs3org/reva/v3/pkg/errtypes"
+	"github.com/cs3org/reva/v3/pkg/httpclient"
+	"github.com/cs3org/reva/v3/pkg/rgrpc/todo/pool"
+	"github.com/cs3org/reva/v3/pkg/rjobs"
+	"github.com/cs3org/reva/v3/pkg/storage/utils/downloader"
+	"github.com/cs3org/reva/v3/pkg/storage/utils/walker"
+	"github.com/cs3org/reva/v3/pkg/utils/cfg"
+	"github.com/mitchellh/mapstructure"
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog"
+	"google.golang.org/grpc/metadata"
+)
+
+/* Job registration */
+
+// Takeout job name
+const JobName = "takeout"
+
+// Init registers the on-demand takeout job
+func init() {
+	if err := rjobs.RegisterOnDemand(JobName, New); err != nil {
+		panic(err)
+	}
+}
+
+/* Job's configuration setup */
+
+// The takeout job config
+type config struct {
+	MachineSecret        string `mapstructure:"machine_secret" validate:"required"`
+	TakeoutAdminUsername string `mapstructure:"takeout_admin_username" validate:"required"`
+	PublicURL            string `mapstructure:"public_url" validate:"required"`
+}
+
+// New sets the potential custom job config
+func New(ctx context.Context, m map[string]any) (rjobs.Job, error) {
+	// Decode config
+	var c config
+	if err := cfg.Decode(m, &c); err != nil {
+		return nil, err
+	}
+
+	// Declare logger
+	l := appctx.GetLogger(ctx)
+
+	return &job{conf: &c, log: l}, nil
+}
+
+/* Job setup */
+
+// The takeout job structure
+type job struct {
+	conf *config
+	log  *zerolog.Logger
+}
+
+// The per-run takeout parameters
+type params struct {
+	MaxArchiveSize int64  `mapstructure:"maxArchiveSize"` // < 10GB
+	ArchiveFormat  string `mapstructure:"archiveFormat"`  // One of ["zip", "tar"]
+	Username       string `mapstructure:"username" validate:"required"`
+}
+
+// Run downloads all files in the userspace and uploads them to a public share for takeout
+func (j *job) Run(ctx context.Context, p rjobs.Params) (rjobs.Params, error) {
+	// Decode run parameters
+	pp := params{
+		// Default values in case they're not provided
+		MaxArchiveSize: 2 << 30, // 2 GiB
+		ArchiveFormat:  "zip",
+	}
+	if err := mapstructure.Decode(map[string]any(p), &pp); err != nil {
+		return nil, errors.Wrap(err, "takeout: decoding params failed")
+	}
+	if pp.MaxArchiveSize > 10<<30 {
+		return nil, errors.Errorf("takeout: MaxArchiveSize cannot be larger than 10GB")
+	}
+	j.log.Info().Msgf("takeout: using parameters %+v", pp)
+
+	// Setup gateway
+	gtw, err := pool.GetGatewayServiceClient(pool.Endpoint("localhost:9142"))
+	if err != nil {
+		return nil, err
+	}
+
+	// Setup authentification: user context to walk and download, admin context to upload
+	userCtx, err := j.authenticate(ctx, gtw, pp.Username)
+	if err != nil {
+		return nil, errors.Wrap(err, "takeout: user authentication failed")
+	}
+	adminCtx, err := j.authenticate(ctx, gtw, j.conf.TakeoutAdminUsername)
+	if err != nil {
+		return nil, errors.Wrap(err, "takeout: admin authentication failed")
+	}
+
+	// Setup downloader
+	tr := &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}
+	hc := httpclient.New(httpclient.RoundTripper(tr), httpclient.Timeout(time.Duration(10*time.Minute)))
+	dl := downloader.NewDownloader(gtw, hc)
+
+	// Setup upload client: no timeout, as an archive upload stays open for
+	// the whole duration of its part's creation
+	upHC := httpclient.New(httpclient.RoundTripper(tr), httpclient.Timeout(0))
+
+	// Setup walker
+	wk := walker.NewWalker(gtw)
+
+	// Set the source & destination directories
+	root := "/eos/user/" + pp.Username[0:1] + "/" + pp.Username
+	archPath := fmt.Sprintf("/eos/project/t/takeout/%s_%s/", pp.Username, time.Now().Format("2006-01-02"))
+
+	// Create archives depending on requested archive format
+	switch pp.ArchiveFormat {
+	case "zip":
+		err = j.createZipArchives(userCtx, adminCtx, root, archPath, wk, dl, gtw, upHC, pp.MaxArchiveSize)
+		if err != nil {
+			return nil, errors.Wrap(err, "takeout: zip archive could not be created")
+		}
+	case "tar":
+		err = j.createTarArchives(userCtx, adminCtx, root, archPath, wk, dl, pp.MaxArchiveSize)
+		if err != nil {
+			return nil, errors.Wrap(err, "takeout: tar archive could not be created")
+		}
+	default:
+		return nil, errors.Errorf("takeout: %s is not a supported archive format", pp.ArchiveFormat)
+	}
+
+	// Share the folder containing the archives through a public link
+	token, err := j.createPublicShare(adminCtx, gtw, archPath)
+	if err != nil {
+		return nil, errors.Wrap(err, "takeout: public share could not be created")
+	}
+
+	// Return the public link to the archives and their location
+	url := fmt.Sprintf("%s/s/%s", j.conf.PublicURL, token)
+	return rjobs.Params{"archives_url": url, "archives_path": archPath}, nil
+}
+
+// authenticate performs a machine authentication as the given user and returns an appropriate context
+func (j *job) authenticate(ctx context.Context, gtw gateway.GatewayAPIClient, clientID string) (context.Context, error) {
+	authRes, err := gtw.Authenticate(ctx, &gateway.AuthenticateRequest{
+		Type:         "machine",
+		ClientId:     clientID,
+		ClientSecret: j.conf.MachineSecret,
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "takeout: authentication failed")
+	}
+	if authRes.Status.Code != rpc.Code_CODE_OK {
+		return nil, errors.Wrap(errors.New(authRes.Status.String()), "takeout: auth res status code not OK")
+	}
+
+	// Update authenticated context
+	ctx = appctx.ContextSetToken(ctx, authRes.Token)
+	ctx = appctx.ContextSetUser(ctx, authRes.User)
+	ctx = metadata.AppendToOutgoingContext(ctx, appctx.TokenHeader, authRes.Token)
+	return ctx, nil
+}
+
+func (j *job) createTarArchives(userCtx, adminCtx context.Context, root_path, arch_path string, wk walker.Walker, dl downloader.Downloader, maxArchiveSize int64) error {
+	panic("unimplemented")
+}
+
+func (j *job) createZipArchives(userCtx, adminCtx context.Context, root_path, arch_path string, wk walker.Walker, dl downloader.Downloader, gtw gateway.GatewayAPIClient, hc *httpclient.Client, maxArchiveSize int64) error {
+	// Ensure the destination directory exists before any upload starts
+	mkRes, err := gtw.CreateContainer(adminCtx, &provider.CreateContainerRequest{
+		Ref: &provider.Reference{Path: arch_path},
+	})
+	switch {
+	case err != nil:
+		return err
+	case mkRes.Status.Code != rpc.Code_CODE_OK && mkRes.Status.Code != rpc.Code_CODE_ALREADY_EXISTS:
+		return errtypes.InternalError(mkRes.Status.Message)
+	}
+
+	// Setup zip archive streaming state
+	var (
+		pw        *io.PipeWriter
+		done      chan error
+		w         *zip.Writer
+		archSize  int64
+		archIndex = 0
+	)
+
+	// Start a fresh archive by initiating its upload and streaming the zip into it
+	startPart := func() {
+		pr, npw := io.Pipe()
+		pw = npw
+		done = make(chan error, 1)
+		go func(idx int) {
+			err := j.uploadArchive(adminCtx, gtw, hc, arch_path, idx, pr)
+			// Unblock the producer if the upload fails mid-stream
+			pr.CloseWithError(err)
+			done <- err
+		}(archIndex)
+		w = zip.NewWriter(pw)
+	}
+
+	// Finalize the current archive and wait for its upload to complete
+	flush := func() error {
+		zipErr := w.Close()
+		if zipErr != nil {
+			pw.CloseWithError(zipErr)
+		} else {
+			zipErr = pw.Close()
+		}
+		upErr := <-done
+		pw = nil
+		if zipErr != nil {
+			return zipErr
+		}
+		return upErr
+	}
+
+	// Start the first archive
+	startPart()
+
+	// Create the archives by walking the specified directory
+	err = wk.Walk(userCtx, root_path, func(current_path string, info *provider.ResourceInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		// Check current archive size
+		if archSize > maxArchiveSize {
+			if err := flush(); err != nil {
+				return err
+			}
+			archSize = 0
+			archIndex++
+			startPart()
+		}
+
+		isDir := info.Type == provider.ResourceType_RESOURCE_TYPE_CONTAINER
+
+		// Get relative path of the current file
+		fileName, err := filepath.Rel(filepath.Dir(root_path), current_path)
+		if err != nil {
+			return err
+		}
+
+		// Create zip header of the current file
+		header := zip.FileHeader{
+			Name:     fileName,
+			Modified: time.Unix(int64(info.Mtime.Seconds), 0),
+			Method:   zip.Deflate,
+		}
+		if isDir {
+			header.Name += "/"
+		}
+		zip_file, err := w.CreateHeader(&header)
+		if err != nil {
+			return err
+		}
+
+		if isDir {
+			return nil
+		}
+
+		// Download file content
+		dl_file, err := dl.Download(userCtx, current_path, "")
+		if err != nil {
+			return err
+		}
+		defer dl_file.Close()
+
+		// Copies downloaded file to zip archive
+		if _, err := io.Copy(zip_file, dl_file); err != nil {
+			return err
+		}
+
+		// Update archive size metadata
+		archSize += int64(info.Size)
+		return nil
+	})
+	if err != nil {
+		// Abort the in-flight upload, if any
+		if pw != nil {
+			pw.CloseWithError(err)
+			<-done
+		}
+		return err
+	}
+
+	// Finalize last archive
+	if err := flush(); err != nil {
+		j.log.Err(err).Msg("takeout: archive upload failed")
+		return err
+	}
+
+	return nil
+}
+
+func (j *job) uploadArchive(ctx context.Context, gtw gateway.GatewayAPIClient, hc *httpclient.Client, archPath string, archIndex int, arch io.Reader) error {
+	// Setup archive name
+	var (
+		archName = fmt.Sprintf("takeout-%03d.zip", archIndex)
+		archFile = archPath + archName
+	)
+
+	// Initiate the file upload request
+	req := &provider.InitiateFileUploadRequest{
+		Ref: &provider.Reference{Path: archFile},
+		Opaque: &types.Opaque{
+			Map: map[string]*types.OpaqueEntry{
+				"Upload-Length": {
+					Decoder: "plain",
+					Value:   []byte("-1"),
+				},
+			},
+		},
+	}
+	upRes, err := gtw.InitiateFileUpload(ctx, req)
+	switch {
+	case err != nil:
+		return err
+	case upRes.Status.Code != rpc.Code_CODE_OK:
+		return errtypes.InternalError(upRes.Status.Message)
+	}
+
+	// Get upload protocol
+	p, err := getUploadProtocol(upRes.Protocols, "simple")
+	if err != nil {
+		return err
+	}
+
+	// Create the upload request
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPut, p.UploadEndpoint, arch)
+	if err != nil {
+		return err
+	}
+	httpReq.Header.Set(datagateway.TokenTransportHeader, p.Token)
+	httpReq.Header.Set("Upload-Length", "-1")
+
+	httpRes, err := hc.Do(httpReq)
+	if err != nil {
+		return err
+	}
+	defer httpRes.Body.Close()
+
+	if httpRes.StatusCode != http.StatusOK {
+		switch httpRes.StatusCode {
+		case http.StatusNotFound:
+			return errtypes.NotFound(archFile)
+		default:
+			return errtypes.InternalError(httpRes.Status)
+		}
+	}
+
+	j.log.Debug().Msgf("takeout: uploaded archive %s to %s", archName, archPath)
+	return nil
+}
+
+// createPublicShare creates a read-only public link to the given path
+func (j *job) createPublicShare(ctx context.Context, gtw gateway.GatewayAPIClient, path string) (string, error) {
+	// Get the resource info of the folder to share
+	statRes, err := gtw.Stat(ctx, &provider.StatRequest{
+		Ref: &provider.Reference{Path: path},
+	})
+	switch {
+	case err != nil:
+		return "", err
+	case statRes.Status.Code != rpc.Code_CODE_OK:
+		return "", errtypes.InternalError(statRes.Status.Message)
+	}
+
+	// Create the read-only public link
+	shareRes, err := gtw.CreatePublicShare(ctx, &link.CreatePublicShareRequest{
+		ResourceInfo: statRes.Info,
+		Grant: &link.Grant{
+			Permissions: &link.PublicSharePermissions{
+				Permissions: &provider.ResourcePermissions{
+					GetPath:              true,
+					InitiateFileDownload: true,
+					ListContainer:        true,
+					Stat:                 true,
+				},
+			},
+		},
+	})
+	switch {
+	case err != nil:
+		return "", err
+	case shareRes.Status.Code != rpc.Code_CODE_OK:
+		return "", errtypes.InternalError(shareRes.Status.Message)
+	}
+
+	j.log.Debug().Msgf("takeout: created public share %s to %s", shareRes.Share.Token, path)
+	return shareRes.Share.Token, nil
+}
+
+func getUploadProtocol(protocols []*gateway.FileUploadProtocol, prot string) (*gateway.FileUploadProtocol, error) {
+	for _, p := range protocols {
+		if p.Protocol == prot {
+			return p, nil
+		}
+	}
+	return nil, errtypes.InternalError(fmt.Sprintf("protocol %s not supported for uploading", prot))
+}


### PR DESCRIPTION
# CERNBox Takeout

Users currently have no convenient, self-service way to obtain a full, offline copy of everything they store in their CERNBox personal space. This is needed for personal backups, offboarding (e.g. leaving CERN), and data-access requests. "Takeout" lets a user trigger an export from the web interface; the system packages their space into one or more archives asynchronously, stores them in a pre-configured EOS location, and notifies the user by email with download links when the export is ready. Exports expire automatically after a configurable retention period.

## Features

This PR mplements the core takeout logic as a Reva background job. Given a user, a max archive size, and a format, the job collects the contents of the user's personal space, packages them into one or more archives of the requested format, splitting output so that no single archive exceeds the configured max size, and uploads the artifact(s) to a pre-configured EOS folder.

It exposes two HTTP endpoints: one to create a new takeout job (taking max size and format), and one to get the status of the current/last takeout for the authenticated user. The create endpoint enforces one active job per user, if a takeout is already running, it returns the existing job rather than starting a new one. The status endpoint returns the job state and, when completed, the download link(s) and expiry. In particular:

- POST endpoint creates a takeout for the authenticated user with body {max_archive_size, format}; unsupported size/format is rejected with a clear error.
- If the user already has an active takeout, the create endpoint returns the existing job's id/status instead of starting a second one.
- GET status endpoint returns the current state (none / queued / running / completed / failed) and progress if available.
- When completed, the status response includes the download link(s) and expiry time.
- When failed, the status response includes an error/cause indication.

