### PR TITLE
apps: added temporary patch for Office apps

### DIFF
--- a/changelog/unreleased/appopen-patch-edit.md
+++ b/changelog/unreleased/appopen-patch-edit.md
@@ -1,3 +1,7 @@
 Enhancement: apps: added temporary patch for Office apps
 
+This PR adds the handling of language and theme input
+parameters, and returns an app_for_editing additional
+parameter in response if appropriate.
+
 https://github.com/cs3org/reva/pull/5703

--- a/changelog/unreleased/appopen-patch-edit.md
+++ b/changelog/unreleased/appopen-patch-edit.md
@@ -1,0 +1,3 @@
+Enhancement: apps: added temporary patch for Office apps
+
+https://github.com/cs3org/reva/pull/5703

--- a/internal/http/services/appprovider/appprovider.go
+++ b/internal/http/services/appprovider/appprovider.go
@@ -480,6 +480,28 @@ func (s *svc) handleOpen(w http.ResponseWriter, r *http.Request) {
 		appForEditing = m[1]
 	}
 
+	// UI-related parameters
+	// TODO(lopresti) this overrides pkg/app/provider/wopi/wopi.go,
+	// we need to drop that one and the corresponding config entry
+	lang := r.Form.Get("lang")
+	if lang != "" {
+		appFullURL, err := url.Parse(openRes.AppUrl.AppUrl)
+		if err != nil {
+			writeError(w, r, appErrorServerError, "error parsing the app URL", err)
+			return
+		}
+		q := appFullURL.Query()
+		q.Set("ui", lang)   // EuroOffice + Office365
+		q.Set("lang", lang) // Collabora
+		q.Set("rs", lang)   // Office365, https://learn.microsoft.com/en-us/microsoft-365/cloud-storage-partner-program/online/discovery#dc_llcc
+		appFullURL.RawQuery = q.Encode()
+		openRes.AppUrl.AppUrl = appFullURL.String()
+	}
+	theme := r.Form.Get("ui_theme")
+	if theme == "light" || theme == "dark" {
+		openRes.AppUrl.FormParameters["UITheme"] = theme
+	}
+
 	// recreate the structure to be able to marshal the AppUrl.Target as a string and to add the optional forced viewmode reason
 	resPayload := map[string]any{
 		"app_url":                openRes.AppUrl.AppUrl,

--- a/internal/http/services/appprovider/appprovider.go
+++ b/internal/http/services/appprovider/appprovider.go
@@ -27,6 +27,7 @@ import (
 	"net/url"
 	"path"
 	"path/filepath"
+	"regexp"
 	"strconv"
 
 	apppb "github.com/cs3org/go-cs3apis/cs3/app/provider/v1beta1"
@@ -472,6 +473,13 @@ func (s *svc) handleOpen(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	var appForEditing string
+	// TODO(lopresti) this is a shortcut for now to avoid changing the protocol. In the future we want to only pass a coded "reason",
+	// the actual message is to be rendered by the web frontend (potentially localized).
+	if m := regexp.MustCompile(`\b([A-Za-z0-9._+-]+)\s+to edit instead$`).FindStringSubmatch(openRes.ForcedViewModeReason); m != nil {
+		appForEditing = m[1]
+	}
+
 	// recreate the structure to be able to marshal the AppUrl.Target as a string and to add the optional forced viewmode reason
 	resPayload := map[string]any{
 		"app_url":                openRes.AppUrl.AppUrl,
@@ -480,6 +488,7 @@ func (s *svc) handleOpen(w http.ResponseWriter, r *http.Request) {
 		"headers":                openRes.AppUrl.Headers,
 		"target":                 appTargetToString(openRes.AppUrl.Target),
 		"forced_viewmode_reason": openRes.ForcedViewModeReason,
+		"app_for_editing":        appForEditing,
 	}
 
 	js, err := json.Marshal(resPayload)


### PR DESCRIPTION
This must be replaced as we should localize the message in `reason` in the first place. For now this is to serve the Office pilot phase.