### PR TITLE
Implement endpoint for office notifications

### DIFF
--- a/changelog/unreleased/lowercase-signatures.md
+++ b/changelog/unreleased/lowercase-signatures.md
@@ -1,4 +1,3 @@
-
 Enhancement: use uppercase URL encoding to calculate signatures for signed urls
 
 https://github.com/cs3org/reva/pull/5726

--- a/changelog/unreleased/office-mentions.md
+++ b/changelog/unreleased/office-mentions.md
@@ -1,0 +1,5 @@
+Enhancement: add endpoint for office mentions
+
+This change adds a POST /app/mentions endpoint for Office integrations to trigger mention notifications.
+
+https://github.com/cs3org/reva/pull/5705

--- a/internal/http/services/appprovider/appprovider.go
+++ b/internal/http/services/appprovider/appprovider.go
@@ -39,6 +39,7 @@ import (
 	"github.com/cs3org/reva/v3/internal/http/services/owncloud/ocdav"
 	"github.com/cs3org/reva/v3/pkg/appctx"
 	"github.com/cs3org/reva/v3/pkg/httpclient"
+	"github.com/cs3org/reva/v3/pkg/notification/notificationhelper"
 	"github.com/cs3org/reva/v3/pkg/rgrpc/status"
 	"github.com/cs3org/reva/v3/pkg/rgrpc/todo/pool"
 	"github.com/cs3org/reva/v3/pkg/rhttp/global"
@@ -58,9 +59,10 @@ func init() {
 
 // Config holds the config options for the HTTP appprovider service.
 type Config struct {
-	Prefix     string `mapstructure:"prefix"`
-	GatewaySvc string `mapstructure:"gatewaysvc"                                              validate:"required"`
-	Insecure   bool   `docs:"false;Whether to skip certificate checks when sending requests." mapstructure:"insecure"`
+	Prefix        string         `mapstructure:"prefix"`
+	GatewaySvc    string         `mapstructure:"gatewaysvc"                                              validate:"required"`
+	Insecure      bool           `docs:"false;Whether to skip certificate checks when sending requests." mapstructure:"insecure"`
+	Notifications map[string]any `docs:"nil; settings for the notification helper"                      mapstructure:"notifications"`
 }
 
 func (c *Config) ApplyDefaults() {
@@ -71,8 +73,9 @@ func (c *Config) ApplyDefaults() {
 }
 
 type svc struct {
-	conf   *Config
-	router *chi.Mux
+	conf               *Config
+	router             *chi.Mux
+	notificationHelper notificationTriggerer
 }
 
 // New returns a new ocmd object.
@@ -88,6 +91,14 @@ func New(ctx context.Context, m map[string]any) (global.Service, error) {
 		router: r,
 	}
 
+	if c.Notifications != nil {
+		nh, err := notificationhelper.New("appprovider", c.Notifications, appctx.GetLogger(ctx))
+		if err != nil {
+			return nil, err
+		}
+		s.notificationHelper = nh
+	}
+
 	if err := s.routerInit(); err != nil {
 		return nil, err
 	}
@@ -100,11 +111,15 @@ func (s *svc) routerInit() error {
 	s.router.Post("/new", s.handleNew)
 	s.router.Post("/open", s.handleOpen)
 	s.router.Post("/notify", s.handleNotify)
+	s.router.Post("/mentions", s.handleMentions)
 	return nil
 }
 
 // Close performs cleanup.
 func (s *svc) Close() error {
+	if s.notificationHelper != nil {
+		s.notificationHelper.Stop()
+	}
 	return nil
 }
 

--- a/internal/http/services/appprovider/errors.go
+++ b/internal/http/services/appprovider/errors.go
@@ -34,6 +34,7 @@ const (
 	appErrorUnauthenticated  appErrorCode = "UNAUTHENTICATED"
 	appErrorUnimplemented    appErrorCode = "NOT_IMPLEMENTED"
 	appErrorInvalidParameter appErrorCode = "INVALID_PARAMETER"
+	appErrorUnavailable      appErrorCode = "SERVICE_UNAVAILABLE"
 	appErrorServerError      appErrorCode = "SERVER_ERROR"
 )
 
@@ -44,6 +45,7 @@ var appErrorCodeMapping = map[appErrorCode]int{
 	appErrorUnauthenticated:  http.StatusUnauthorized,
 	appErrorUnimplemented:    http.StatusNotImplemented,
 	appErrorInvalidParameter: http.StatusBadRequest,
+	appErrorUnavailable:      http.StatusServiceUnavailable,
 	appErrorServerError:      http.StatusInternalServerError,
 }
 

--- a/internal/http/services/appprovider/mentions.go
+++ b/internal/http/services/appprovider/mentions.go
@@ -1,0 +1,416 @@
+// Copyright 2018-2024 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package appprovider
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"path/filepath"
+	"strings"
+
+	gateway "github.com/cs3org/go-cs3apis/cs3/gateway/v1beta1"
+	grouppb "github.com/cs3org/go-cs3apis/cs3/identity/group/v1beta1"
+	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
+	rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
+	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+	"github.com/cs3org/reva/v3/pkg/appctx"
+	"github.com/cs3org/reva/v3/pkg/notification"
+	"github.com/cs3org/reva/v3/pkg/notification/trigger"
+	"github.com/cs3org/reva/v3/pkg/rgrpc/todo/pool"
+	"github.com/cs3org/reva/v3/pkg/spaces"
+	"github.com/cs3org/reva/v3/pkg/utils/resourceid"
+)
+
+const (
+	mentionTemplateName = "office-mention-mail"
+	maxMentionBodyBytes = 1 << 20
+	maxMentionTargets   = 100
+	maxMentionTextLen   = 2000
+)
+
+type notificationTriggerer interface {
+	TriggerNotification(*trigger.Trigger)
+	Stop()
+}
+
+type mentionRequest struct {
+	FileID      string          `json:"file_id"`
+	Path        string          `json:"path"`
+	Mentions    []mentionTarget `json:"mentions"`
+	EventID     string          `json:"event_id"`
+	CommentText string          `json:"comment_text"`
+	AnchorText  string          `json:"anchor_text"`
+	DocumentURL string          `json:"document_url"`
+	AppName     string          `json:"app_name"`
+}
+
+type mentionTarget struct {
+	Type      string `json:"type"`
+	Username  string `json:"username"`
+	GroupName string `json:"groupname"`
+	OpaqueID  string `json:"opaque_id"`
+}
+
+type mentionResponse struct {
+	Accepted []mentionResult `json:"accepted"`
+	Rejected []mentionResult `json:"rejected"`
+}
+
+type mentionResult struct {
+	Type      string `json:"type,omitempty"`
+	Username  string `json:"username,omitempty"`
+	GroupName string `json:"groupname,omitempty"`
+	Reason    string `json:"reason,omitempty"`
+}
+
+func (s *svc) handleMentions(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	log := appctx.GetLogger(ctx)
+
+	req, err := decodeMentionRequest(w, r)
+	if err != nil {
+		writeError(w, r, appErrorInvalidParameter, err.Error(), nil)
+		return
+	}
+
+	if s.notificationHelper == nil {
+		writeError(w, r, appErrorUnavailable, "notifications are not configured", nil)
+		return
+	}
+
+	author, ok := appctx.ContextGetUser(ctx)
+	if !ok || author == nil {
+		writeError(w, r, appErrorUnauthenticated, "missing authenticated user", nil)
+		return
+	}
+
+	documentURL, err := validateDocumentURL(req.DocumentURL)
+	if err != nil {
+		writeError(w, r, appErrorInvalidParameter, err.Error(), nil)
+		return
+	}
+
+	client, err := pool.GetGatewayServiceClient(pool.Endpoint(s.conf.GatewaySvc))
+	if err != nil {
+		writeError(w, r, appErrorServerError, "error getting grpc gateway client", err)
+		return
+	}
+
+	fileRef, err := resourceReferenceFromRequestValue(req.FileID, req.Path)
+	if err != nil {
+		writeError(w, r, appErrorInvalidParameter, err.Error(), nil)
+		return
+	}
+
+	statRes, err := client.Stat(ctx, &provider.StatRequest{Ref: &fileRef})
+	if err != nil {
+		writeError(w, r, appErrorServerError, "failed to stat the file", err)
+		return
+	}
+	if statRes.Status == nil || statRes.Status.Code == rpc.Code_CODE_NOT_FOUND {
+		writeError(w, r, appErrorNotFound, "file does not exist", nil)
+		return
+	}
+	if statRes.Status.Code != rpc.Code_CODE_OK {
+		writeError(w, r, appErrorServerError, "failed to stat the file", nil)
+		return
+	}
+	if statRes.Info == nil || statRes.Info.Type != provider.ResourceType_RESOURCE_TYPE_FILE {
+		writeError(w, r, appErrorInvalidParameter, "the given document reference does not point to a file", nil)
+		return
+	}
+
+	resolved := resolveMentionRecipients(ctx, client, req.Mentions, author)
+	if len(resolved.users) == 0 {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(mentionResponse{Rejected: resolved.rejected})
+		return
+	}
+
+	documentID := documentIDForNotification(statRes.Info, &fileRef)
+	for _, recipient := range resolved.users {
+		ref := mentionNotificationRef(documentID, recipient.Username)
+		s.notificationHelper.TriggerNotification(&trigger.Trigger{
+			Notification: &notification.Notification{
+				TemplateName: mentionTemplateName,
+				Ref:          ref,
+				Recipients:   []string{recipient.Mail},
+			},
+			Ref:    ref,
+			Sender: author.Mail,
+			TemplateData: map[string]any{
+				"recipientDisplayName": recipient.DisplayName,
+				"recipientUserName":    recipient.Username,
+				"mentionerDisplayName": author.DisplayName,
+				"mentionerUserName":    author.Username,
+				"fileName":             filepath.Base(statRes.Info.Path),
+				"path":                 statRes.Info.Path,
+				"fileID":               documentID,
+				"appName":              req.AppName,
+				"commentText":          req.CommentText,
+				"anchorText":           req.AnchorText,
+				"documentURL":          documentURL,
+				"eventID":              req.EventID,
+			},
+		})
+		resolved.accepted = append(resolved.accepted, mentionResult{Type: "user", Username: recipient.Username})
+	}
+
+	log.Info().
+		Str("file_id", documentID).
+		Str("event_id", req.EventID).
+		Int("accepted", len(resolved.accepted)).
+		Int("rejected", len(resolved.rejected)).
+		Msg("office mention notifications accepted")
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusAccepted)
+	_ = json.NewEncoder(w).Encode(mentionResponse{
+		Accepted: resolved.accepted,
+		Rejected: resolved.rejected,
+	})
+}
+
+func decodeMentionRequest(w http.ResponseWriter, r *http.Request) (*mentionRequest, error) {
+	r.Body = http.MaxBytesReader(w, r.Body, maxMentionBodyBytes)
+
+	dec := json.NewDecoder(r.Body)
+	dec.DisallowUnknownFields()
+
+	var req mentionRequest
+	if err := dec.Decode(&req); err != nil {
+		return nil, fmt.Errorf("invalid JSON request body")
+	}
+
+	req.FileID = strings.TrimSpace(req.FileID)
+	req.Path = strings.TrimSpace(req.Path)
+	req.EventID = strings.TrimSpace(req.EventID)
+	req.CommentText = strings.TrimSpace(req.CommentText)
+	req.AnchorText = strings.TrimSpace(req.AnchorText)
+	req.DocumentURL = strings.TrimSpace(req.DocumentURL)
+	req.AppName = strings.TrimSpace(req.AppName)
+
+	if req.FileID == "" && req.Path == "" {
+		return nil, fmt.Errorf("missing file_id or path")
+	}
+	if len(req.Mentions) == 0 {
+		return nil, fmt.Errorf("missing mentions")
+	}
+	if len(req.Mentions) > maxMentionTargets {
+		return nil, fmt.Errorf("too many mentions")
+	}
+	if len(req.CommentText) > maxMentionTextLen {
+		return nil, fmt.Errorf("comment_text is too long")
+	}
+	if len(req.AnchorText) > maxMentionTextLen {
+		return nil, fmt.Errorf("anchor_text is too long")
+	}
+
+	for i := range req.Mentions {
+		req.Mentions[i].Type = strings.ToLower(strings.TrimSpace(req.Mentions[i].Type))
+		req.Mentions[i].Username = strings.TrimSpace(req.Mentions[i].Username)
+		req.Mentions[i].GroupName = strings.TrimSpace(req.Mentions[i].GroupName)
+		req.Mentions[i].OpaqueID = strings.TrimSpace(req.Mentions[i].OpaqueID)
+
+		if req.Mentions[i].Type == "" {
+			switch {
+			case req.Mentions[i].Username != "":
+				req.Mentions[i].Type = "user"
+			case req.Mentions[i].GroupName != "":
+				req.Mentions[i].Type = "group"
+			}
+		}
+		switch req.Mentions[i].Type {
+		case "user":
+			if req.Mentions[i].Username == "" {
+				return nil, fmt.Errorf("user mention is missing username")
+			}
+		case "group":
+			if req.Mentions[i].GroupName == "" {
+				return nil, fmt.Errorf("group mention is missing groupname")
+			}
+		default:
+			return nil, fmt.Errorf("mention type must be user or group")
+		}
+	}
+
+	return &req, nil
+}
+
+func resourceReferenceFromRequestValue(fileID, path string) (provider.Reference, error) {
+	if fileID == "" {
+		if path == "" {
+			return provider.Reference{}, fmt.Errorf("missing file_id or path")
+		}
+		return provider.Reference{Path: path}, nil
+	}
+
+	if resourceID, ok := spaces.ParseResourceID(fileID); ok {
+		return provider.Reference{ResourceId: resourceID}, nil
+	}
+
+	if resourceID := resourceid.OwnCloudResourceIDUnwrap(fileID); resourceID != nil {
+		return provider.Reference{ResourceId: resourceID}, nil
+	}
+
+	if resourceID, err := spaces.ResourceIdFromString(fileID); err == nil {
+		return provider.Reference{ResourceId: resourceID}, nil
+	}
+
+	return provider.Reference{}, fmt.Errorf("invalid file_id")
+}
+
+func validateDocumentURL(rawURL string) (string, error) {
+	if rawURL == "" {
+		return "", nil
+	}
+
+	u, err := url.Parse(rawURL)
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		return "", fmt.Errorf("invalid document_url")
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return "", fmt.Errorf("invalid document_url")
+	}
+	return rawURL, nil
+}
+
+type resolvedMentionRecipients struct {
+	users    []*userpb.User
+	accepted []mentionResult
+	rejected []mentionResult
+	seen     map[string]struct{}
+}
+
+func resolveMentionRecipients(ctx context.Context, client gateway.GatewayAPIClient, mentions []mentionTarget, author *userpb.User) resolvedMentionRecipients {
+	resolved := resolvedMentionRecipients{
+		seen: make(map[string]struct{}),
+	}
+	authorKey := userKey(author)
+
+	for _, mention := range mentions {
+		switch mention.Type {
+		case "user":
+			u, reason := getUserByUsername(ctx, client, mention.Username)
+			if reason != "" {
+				resolved.rejected = append(resolved.rejected, mentionResult{Type: "user", Username: mention.Username, Reason: reason})
+				continue
+			}
+			resolved.addUser(u, authorKey, mentionResult{Type: "user", Username: mention.Username})
+		case "group":
+			groupRes, err := client.GetGroupByClaim(ctx, &grouppb.GetGroupByClaimRequest{
+				Claim:               "group_name",
+				Value:               mention.GroupName,
+				SkipFetchingMembers: false,
+			})
+			if err != nil || groupRes.Status == nil || groupRes.Status.Code != rpc.Code_CODE_OK || groupRes.Group == nil {
+				resolved.rejected = append(resolved.rejected, mentionResult{Type: "group", GroupName: mention.GroupName, Reason: "group_not_found"})
+				continue
+			}
+			if len(groupRes.Group.Members) == 0 {
+				resolved.rejected = append(resolved.rejected, mentionResult{Type: "group", GroupName: mention.GroupName, Reason: "group_has_no_members"})
+				continue
+			}
+
+			for _, memberID := range groupRes.Group.Members {
+				userRes, err := client.GetUser(ctx, &userpb.GetUserRequest{
+					UserId:                 memberID,
+					SkipFetchingUserGroups: true,
+				})
+				if err != nil || userRes.Status == nil || userRes.Status.Code != rpc.Code_CODE_OK || userRes.User == nil {
+					resolved.rejected = append(resolved.rejected, mentionResult{Type: "group", GroupName: mention.GroupName, Reason: "group_member_not_found"})
+					continue
+				}
+				resolved.addUser(userRes.User, authorKey, mentionResult{Type: "group", GroupName: mention.GroupName})
+			}
+		}
+	}
+
+	return resolved
+}
+
+func (r *resolvedMentionRecipients) addUser(u *userpb.User, authorKey string, source mentionResult) {
+	if u.Mail == "" {
+		source.Reason = "user_has_no_email"
+		if source.Username == "" {
+			source.Username = u.Username
+		}
+		r.rejected = append(r.rejected, source)
+		return
+	}
+
+	key := userKey(u)
+	if key == "" {
+		key = u.Mail
+	}
+	if key == authorKey {
+		return
+	}
+	if _, ok := r.seen[key]; ok {
+		return
+	}
+	r.seen[key] = struct{}{}
+	r.users = append(r.users, u)
+}
+
+func getUserByUsername(ctx context.Context, client gateway.GatewayAPIClient, username string) (*userpb.User, string) {
+	userRes, err := client.GetUserByClaim(ctx, &userpb.GetUserByClaimRequest{
+		Claim:                  "username",
+		Value:                  username,
+		SkipFetchingUserGroups: true,
+	})
+	if err != nil || userRes.Status == nil || userRes.Status.Code != rpc.Code_CODE_OK || userRes.User == nil {
+		return nil, "user_not_found"
+	}
+	return userRes.User, ""
+}
+
+func userKey(u *userpb.User) string {
+	if u == nil {
+		return ""
+	}
+	if u.Id != nil {
+		return u.Id.Idp + ":" + u.Id.OpaqueId
+	}
+	if u.Username != "" {
+		return "username:" + u.Username
+	}
+	return "mail:" + u.Mail
+}
+
+func documentIDForNotification(info *provider.ResourceInfo, ref *provider.Reference) string {
+	if info != nil && info.Id != nil {
+		return spaces.EncodeToStringifiedResourceID(info.Id)
+	}
+	if ref != nil && ref.ResourceId != nil {
+		return spaces.EncodeToStringifiedResourceID(ref.ResourceId)
+	}
+	if ref != nil {
+		return ref.Path
+	}
+	return ""
+}
+
+func mentionNotificationRef(documentID, username string) string {
+	return fmt.Sprintf("office-mention:%s:%s", documentID, username)
+}

--- a/internal/http/services/appprovider/mentions_test.go
+++ b/internal/http/services/appprovider/mentions_test.go
@@ -1,0 +1,364 @@
+// Copyright 2018-2024 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package appprovider
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	gateway "github.com/cs3org/go-cs3apis/cs3/gateway/v1beta1"
+	grouppb "github.com/cs3org/go-cs3apis/cs3/identity/group/v1beta1"
+	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
+	rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
+	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+	"github.com/cs3org/reva/v3/pkg/appctx"
+	"github.com/cs3org/reva/v3/pkg/notification/trigger"
+	"github.com/cs3org/reva/v3/pkg/rgrpc/todo/pool"
+	"github.com/cs3org/reva/v3/pkg/spaces"
+	"google.golang.org/grpc"
+)
+
+type fakeNotificationTriggerer struct {
+	triggers []*trigger.Trigger
+	stopped  bool
+}
+
+func (f *fakeNotificationTriggerer) TriggerNotification(t *trigger.Trigger) {
+	f.triggers = append(f.triggers, t)
+}
+
+func (f *fakeNotificationTriggerer) Stop() {
+	f.stopped = true
+}
+
+type mentionGateway struct {
+	gateway.GatewayAPIClient
+	statResp    *provider.StatResponse
+	statErr     error
+	usersByName map[string]*userpb.User
+	usersByID   map[string]*userpb.User
+	groups      map[string]*grouppb.Group
+}
+
+func (m *mentionGateway) Stat(_ context.Context, _ *provider.StatRequest, _ ...grpc.CallOption) (*provider.StatResponse, error) {
+	return m.statResp, m.statErr
+}
+
+func (m *mentionGateway) GetUserByClaim(_ context.Context, req *userpb.GetUserByClaimRequest, _ ...grpc.CallOption) (*userpb.GetUserByClaimResponse, error) {
+	if req.Claim != "username" {
+		return &userpb.GetUserByClaimResponse{Status: &rpc.Status{Code: rpc.Code_CODE_NOT_FOUND}}, nil
+	}
+	if u, ok := m.usersByName[req.Value]; ok {
+		return &userpb.GetUserByClaimResponse{Status: &rpc.Status{Code: rpc.Code_CODE_OK}, User: u}, nil
+	}
+	return &userpb.GetUserByClaimResponse{Status: &rpc.Status{Code: rpc.Code_CODE_NOT_FOUND}}, nil
+}
+
+func (m *mentionGateway) GetGroupByClaim(_ context.Context, req *grouppb.GetGroupByClaimRequest, _ ...grpc.CallOption) (*grouppb.GetGroupByClaimResponse, error) {
+	if req.Claim != "group_name" {
+		return &grouppb.GetGroupByClaimResponse{Status: &rpc.Status{Code: rpc.Code_CODE_NOT_FOUND}}, nil
+	}
+	if g, ok := m.groups[req.Value]; ok {
+		return &grouppb.GetGroupByClaimResponse{Status: &rpc.Status{Code: rpc.Code_CODE_OK}, Group: g}, nil
+	}
+	return &grouppb.GetGroupByClaimResponse{Status: &rpc.Status{Code: rpc.Code_CODE_NOT_FOUND}}, nil
+}
+
+func (m *mentionGateway) GetUser(_ context.Context, req *userpb.GetUserRequest, _ ...grpc.CallOption) (*userpb.GetUserResponse, error) {
+	if req.UserId == nil {
+		return &userpb.GetUserResponse{Status: &rpc.Status{Code: rpc.Code_CODE_NOT_FOUND}}, nil
+	}
+	if u, ok := m.usersByID[userIDKey(req.UserId)]; ok {
+		return &userpb.GetUserResponse{Status: &rpc.Status{Code: rpc.Code_CODE_OK}, User: u}, nil
+	}
+	return &userpb.GetUserResponse{Status: &rpc.Status{Code: rpc.Code_CODE_NOT_FOUND}}, nil
+}
+
+func TestDecodeMentionRequestValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		body    string
+		wantErr string
+	}{
+		{
+			name: "valid with inferred user type",
+			body: `{"path":"/doc.docx","mentions":[{"username":"alice"}]}`,
+		},
+		{
+			name:    "requires document reference",
+			body:    `{"mentions":[{"username":"alice"}]}`,
+			wantErr: "missing file_id or path",
+		},
+		{
+			name:    "requires mentions",
+			body:    `{"path":"/doc.docx","mentions":[]}`,
+			wantErr: "missing mentions",
+		},
+		{
+			name:    "rejects unknown mention type",
+			body:    `{"path":"/doc.docx","mentions":[{"type":"channel","username":"alice"}]}`,
+			wantErr: "mention type must be user or group",
+		},
+		{
+			name:    "rejects group without groupname",
+			body:    `{"path":"/doc.docx","mentions":[{"type":"group"}]}`,
+			wantErr: "group mention is missing groupname",
+		},
+		{
+			name:    "rejects invalid json fields",
+			body:    `{"path":"/doc.docx","mentions":[{"username":"alice"}],"extra":true}`,
+			wantErr: "invalid JSON request body",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "/app/mentions", strings.NewReader(tt.body))
+			rec := httptest.NewRecorder()
+
+			got, err := decodeMentionRequest(rec, req)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("decodeMentionRequest() returned error: %v", err)
+				}
+				if got.Mentions[0].Type == "" {
+					t.Fatalf("decodeMentionRequest() did not infer mention type")
+				}
+				return
+			}
+			if err == nil || err.Error() != tt.wantErr {
+				t.Fatalf("decodeMentionRequest() error = %v, want %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestResourceReferenceFromRequestValue(t *testing.T) {
+	resourceID := &provider.ResourceId{StorageId: "storage", SpaceId: "space", OpaqueId: "opaque"}
+	encoded := spaces.EncodeToStringifiedResourceID(resourceID)
+
+	t.Run("path fallback", func(t *testing.T) {
+		ref, err := resourceReferenceFromRequestValue("", "/a/b.docx")
+		if err != nil {
+			t.Fatalf("resourceReferenceFromRequestValue() returned error: %v", err)
+		}
+		if ref.Path != "/a/b.docx" {
+			t.Fatalf("ref.Path = %q, want /a/b.docx", ref.Path)
+		}
+	})
+
+	t.Run("spaces id", func(t *testing.T) {
+		ref, err := resourceReferenceFromRequestValue(encoded, "")
+		if err != nil {
+			t.Fatalf("resourceReferenceFromRequestValue() returned error: %v", err)
+		}
+		if ref.ResourceId == nil || ref.ResourceId.OpaqueId != "opaque" {
+			t.Fatalf("ref.ResourceId = %+v, want opaque id", ref.ResourceId)
+		}
+	})
+
+	t.Run("invalid id", func(t *testing.T) {
+		if _, err := resourceReferenceFromRequestValue("not a resource id", ""); err == nil {
+			t.Fatalf("resourceReferenceFromRequestValue() returned nil error for invalid id")
+		}
+	})
+}
+
+func TestResolveMentionRecipientsExpandsGroupsDeduplicatesAndSkipsSelf(t *testing.T) {
+	author := mentionUser("author", "author@cern.ch")
+	alice := mentionUser("alice", "alice@cern.ch")
+	bob := mentionUser("bob", "bob@cern.ch")
+	noMail := mentionUser("nomail", "")
+
+	gw := &mentionGateway{
+		usersByName: map[string]*userpb.User{
+			"alice":  alice,
+			"nomail": noMail,
+		},
+		usersByID: map[string]*userpb.User{
+			userIDKey(alice.Id):  alice,
+			userIDKey(bob.Id):    bob,
+			userIDKey(author.Id): author,
+		},
+		groups: map[string]*grouppb.Group{
+			"team": {
+				GroupName: "team",
+				Members:   []*userpb.UserId{alice.Id, bob.Id, author.Id},
+			},
+		},
+	}
+
+	resolved := resolveMentionRecipients(context.Background(), gw, []mentionTarget{
+		{Type: "user", Username: "alice"},
+		{Type: "user", Username: "nomail"},
+		{Type: "group", GroupName: "team"},
+		{Type: "group", GroupName: "missing"},
+	}, author)
+
+	if len(resolved.users) != 2 {
+		t.Fatalf("resolved users = %d, want 2", len(resolved.users))
+	}
+	if resolved.users[0].Username != "alice" || resolved.users[1].Username != "bob" {
+		t.Fatalf("resolved users = %v, want alice and bob", []string{resolved.users[0].Username, resolved.users[1].Username})
+	}
+	if len(resolved.rejected) != 2 {
+		t.Fatalf("rejected = %d, want 2", len(resolved.rejected))
+	}
+	if resolved.rejected[0].Reason != "user_has_no_email" || resolved.rejected[1].Reason != "group_not_found" {
+		t.Fatalf("rejected reasons = %q, %q", resolved.rejected[0].Reason, resolved.rejected[1].Reason)
+	}
+}
+
+func TestHandleMentionsPublishesTriggers(t *testing.T) {
+	endpoint := "mentions-" + t.Name()
+	author := mentionUser("author", "author@cern.ch")
+	alice := mentionUser("alice", "alice@cern.ch")
+	bob := mentionUser("bob", "bob@cern.ch")
+	resourceID := &provider.ResourceId{StorageId: "storage", SpaceId: "space", OpaqueId: "file"}
+
+	pool.RegisterGatewayServiceClient(&mentionGateway{
+		statResp: &provider.StatResponse{
+			Status: &rpc.Status{Code: rpc.Code_CODE_OK},
+			Info: &provider.ResourceInfo{
+				Id:   resourceID,
+				Path: "/spaces/project/report.docx",
+				Type: provider.ResourceType_RESOURCE_TYPE_FILE,
+			},
+		},
+		usersByName: map[string]*userpb.User{
+			"alice": alice,
+		},
+		usersByID: map[string]*userpb.User{
+			userIDKey(alice.Id):  alice,
+			userIDKey(bob.Id):    bob,
+			userIDKey(author.Id): author,
+		},
+		groups: map[string]*grouppb.Group{
+			"team": {
+				GroupName: "team",
+				Members:   []*userpb.UserId{alice.Id, bob.Id, author.Id},
+			},
+		},
+	}, endpoint)
+
+	notifier := &fakeNotificationTriggerer{}
+	s := &svc{
+		conf:               &Config{GatewaySvc: endpoint},
+		notificationHelper: notifier,
+	}
+
+	body := `{
+		"file_id":"` + spaces.EncodeToStringifiedResourceID(resourceID) + `",
+		"mentions":[
+			{"type":"user","username":"alice"},
+			{"type":"group","groupname":"team"}
+		],
+		"event_id":"event-1",
+		"comment_text":"Can you check this?",
+		"anchor_text":"Total cost",
+		"document_url":"https://cernbox.example/report.docx",
+		"app_name":"office"
+	}`
+	req := httptest.NewRequest(http.MethodPost, "/app/mentions", strings.NewReader(body))
+	req = req.WithContext(appctx.ContextSetUser(req.Context(), author))
+	rec := httptest.NewRecorder()
+
+	s.handleMentions(rec, req)
+
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want %d; body: %s", rec.Code, http.StatusAccepted, rec.Body.String())
+	}
+	if len(notifier.triggers) != 2 {
+		t.Fatalf("triggers = %d, want 2", len(notifier.triggers))
+	}
+
+	first := notifier.triggers[0]
+	if first.Notification.TemplateName != mentionTemplateName {
+		t.Fatalf("template = %q, want %q", first.Notification.TemplateName, mentionTemplateName)
+	}
+	if first.Notification.Recipients[0] != "alice@cern.ch" {
+		t.Fatalf("first recipient = %q, want alice@cern.ch", first.Notification.Recipients[0])
+	}
+	if first.Sender != "author@cern.ch" {
+		t.Fatalf("sender = %q, want author@cern.ch", first.Sender)
+	}
+	if first.TemplateData["commentText"] != "Can you check this?" {
+		t.Fatalf("commentText = %v", first.TemplateData["commentText"])
+	}
+	if first.TemplateData["anchorText"] != "Total cost" {
+		t.Fatalf("anchorText = %v", first.TemplateData["anchorText"])
+	}
+
+	second := notifier.triggers[1]
+	if second.Notification.Recipients[0] != "bob@cern.ch" {
+		t.Fatalf("second recipient = %q, want bob@cern.ch", second.Notification.Recipients[0])
+	}
+
+	var response mentionResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("response json: %v", err)
+	}
+	if len(response.Accepted) != 2 {
+		t.Fatalf("accepted = %d, want 2", len(response.Accepted))
+	}
+	if len(response.Rejected) != 0 {
+		t.Fatalf("rejected = %d, want 0", len(response.Rejected))
+	}
+}
+
+func TestHandleMentionsRequiresNotificationHelper(t *testing.T) {
+	s := &svc{conf: &Config{}}
+	req := httptest.NewRequest(http.MethodPost, "/app/mentions", strings.NewReader(`{"path":"/doc.docx","mentions":[{"username":"alice"}]}`))
+	rec := httptest.NewRecorder()
+
+	s.handleMentions(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusServiceUnavailable)
+	}
+}
+
+func TestMentionsEndpointIsProtected(t *testing.T) {
+	s := &svc{}
+	for _, path := range s.Unprotected() {
+		if path == "/mentions" {
+			t.Fatalf("/mentions must not be listed as unprotected")
+		}
+	}
+}
+
+func mentionUser(username, mail string) *userpb.User {
+	return &userpb.User{
+		Id:          &userpb.UserId{Idp: "idp", OpaqueId: username},
+		Username:    username,
+		Mail:        mail,
+		DisplayName: username + " display",
+	}
+}
+
+func userIDKey(id *userpb.UserId) string {
+	if id == nil {
+		return ""
+	}
+	return id.Idp + ":" + id.OpaqueId
+}


### PR DESCRIPTION
This PR adds a `POST /app/mentions` endpoint for Office integrations to trigger mention notifications.

Clients send a document reference via `file_id` or `path`, plus a list of mentioned users and/or groups. The endpoint validates the file, resolves recipients through the gateway, skips duplicates and the mention author, and triggers
`office-mention-mail` notifications for users with email addresses.

Example request:

POST `/app/mentions`

  ```json
  {
    "file_id": "<resource-id>",
    "mentions": [
      { "type": "user", "username": "alice" },
      { "type": "group", "groupname": "team" }
    ],
    "event_id": "event-1",
    "comment_text": "Can you check this?",
    "anchor_text": "Total cost",
    "document_url": "https://example.test/report.docx",
    "app_name": "office"
  }
```
A successful request returns 202 Accepted with accepted and rejected mention results.