### PR TITLE
Allow registering periodic jobs at any time

### DIFF
--- a/changelog/unreleased/rjobs-register-anytime.md
+++ b/changelog/unreleased/rjobs-register-anytime.md
@@ -4,11 +4,14 @@ Periodic jobs were picked up only once, when the jobs service built the
 runner at startup: a job registered later (for example by a component
 constructed after the services had started) was silently ignored.
 
-The runner now rescans the job registry on every scheduler pass and runs
-due all-nodes jobs through a pool of local workers, so periodic jobs can
-be registered at any point in the process lifetime and are picked up
-within one tick. The registration API is unchanged and keeps accepting
-closures over live dependencies. The size of the local pool can be tuned
-with the new local_pool_size option of the jobs service.
+The runner now rescans the job registry on every scheduler pass, so
+periodic jobs can be registered at any point in the process lifetime and
+are picked up within one tick. Leader-scoped jobs get their queue
+subscription and schedule set up on the fly, so a late-registered job is
+scheduled, claimed and executed exactly like one registered at init.
+All-nodes jobs run through a pool of local workers whose size can be
+tuned with the new local_pool_size option of the jobs service. The
+registration API is unchanged and keeps accepting closures over live
+dependencies.
 
 https://github.com/cs3org/reva/pull/5706

--- a/changelog/unreleased/rjobs-register-anytime.md
+++ b/changelog/unreleased/rjobs-register-anytime.md
@@ -1,0 +1,14 @@
+Enhancement: allow registering periodic jobs at any time
+
+Periodic jobs were picked up only once, when the jobs service built the
+runner at startup: a job registered later (for example by a component
+constructed after the services had started) was silently ignored.
+
+The runner now rescans the job registry on every scheduler pass and runs
+due all-nodes jobs through a pool of local workers, so periodic jobs can
+be registered at any point in the process lifetime and are picked up
+within one tick. The registration API is unchanged and keeps accepting
+closures over live dependencies. The size of the local pool can be tuned
+with the new local_pool_size option of the jobs service.
+
+https://github.com/cs3org/reva/pull/5706

--- a/internal/serverless/services/jobs/jobs.go
+++ b/internal/serverless/services/jobs/jobs.go
@@ -40,10 +40,13 @@ func init() {
 }
 
 type config struct {
-	WorkerPoolSize int    `mapstructure:"worker_pool_size"`
-	NatsAddress    string `mapstructure:"nats_address"`
-	NatsToken      string `mapstructure:"nats_token"`
-	NatsPrefix     string `mapstructure:"nats_prefix"`
+	WorkerPoolSize int `mapstructure:"worker_pool_size"`
+	// LocalPoolSize is the number of workers executing all-nodes periodic
+	// jobs on this replica.
+	LocalPoolSize int    `mapstructure:"local_pool_size"`
+	NatsAddress   string `mapstructure:"nats_address"`
+	NatsToken     string `mapstructure:"nats_token"`
+	NatsPrefix    string `mapstructure:"nats_prefix"`
 	// AckWaitSeconds is the visibility timeout: how long a claimed run may go
 	// without a heartbeat before it is redelivered. The runner heartbeats well
 	// within this window, so it bounds detection of a dead worker, not the
@@ -61,6 +64,9 @@ type config struct {
 func (c *config) ApplyDefaults() {
 	if c.WorkerPoolSize == 0 {
 		c.WorkerPoolSize = 4
+	}
+	if c.LocalPoolSize == 0 {
+		c.LocalPoolSize = 4
 	}
 	if c.NatsPrefix == "" {
 		c.NatsPrefix = "reva-jobs"
@@ -97,6 +103,7 @@ func New(ctx context.Context, m map[string]any) (rserverless.Service, error) {
 func (s *svc) Start() {
 	opts := rjobs.Options{
 		Workers:        s.conf.WorkerPoolSize,
+		LocalWorkers:   s.conf.LocalPoolSize,
 		OnDemandConfig: s.conf.OnDemand,
 	}
 

--- a/pkg/rjobs/registry.go
+++ b/pkg/rjobs/registry.go
@@ -40,10 +40,12 @@ var reg = &registry{
 	onDemand: make(map[string]NewJob),
 }
 
-// RegisterPeriodic registers a periodic job. It can be called at init time for
-// self-contained jobs, or at the owning component's construction time with a
-// closure capturing live dependencies. It validates the job and returns an
-// error if the name is already taken or the spec is invalid.
+// RegisterPeriodic registers a periodic job. It can be called at any time:
+// at init for self-contained jobs, at the owning component's construction
+// time with a closure capturing live dependencies, or even after the runner
+// has started, in which case the job is picked up on the scheduler's next
+// pass. It validates the job and returns an error if the name is already
+// taken or the spec is invalid.
 func RegisterPeriodic(p Periodic) error {
 	if err := validatePeriodic(p); err != nil {
 		return err

--- a/pkg/rjobs/registry.go
+++ b/pkg/rjobs/registry.go
@@ -101,8 +101,9 @@ func validatePeriodic(p Periodic) error {
 	return nil
 }
 
-// registeredPeriodic returns a copy of the registered periodic jobs. Used by
-// the runner at startup.
+// registeredPeriodic returns a copy of the currently registered periodic
+// jobs. The runner reads it whenever it needs the current job set, so it
+// always observes the latest registrations.
 func registeredPeriodic() []Periodic {
 	reg.mu.Lock()
 	defer reg.mu.Unlock()
@@ -111,6 +112,14 @@ func registeredPeriodic() []Periodic {
 		out = append(out, p)
 	}
 	return out
+}
+
+// lookupPeriodic returns the periodic job registered under name, if any.
+func lookupPeriodic(name string) (Periodic, bool) {
+	reg.mu.Lock()
+	defer reg.mu.Unlock()
+	p, ok := reg.periodic[name]
+	return p, ok
 }
 
 // lookupOnDemand returns the constructor registered for name, if any.

--- a/pkg/rjobs/runner.go
+++ b/pkg/rjobs/runner.go
@@ -65,7 +65,6 @@ type Runner struct {
 	store          Store
 	status         StatusStore
 	log            zerolog.Logger
-	periodic       []Periodic
 	onDemandConfig map[string]map[string]any
 
 	cancel context.CancelFunc
@@ -116,7 +115,6 @@ func NewRunner(ctx context.Context, opts Options) (*Runner, error) {
 		store:          opts.Store,
 		status:         opts.Status,
 		log:            *appctx.GetLogger(ctx),
-		periodic:       registeredPeriodic(),
 		onDemandConfig: opts.OnDemandConfig,
 		running:        make(map[string]bool),
 		cancels:        make(map[RunID]*runHandle),
@@ -124,7 +122,7 @@ func NewRunner(ctx context.Context, opts Options) (*Runner, error) {
 
 	// leader-scoped and on-demand work both need a store.
 	if r.store == nil {
-		for _, p := range r.periodic {
+		for _, p := range registeredPeriodic() {
 			if p.Scope == ScopeLeader {
 				return nil, errors.Errorf("rjobs: periodic job %q is leader-scoped but no store is configured", p.Name)
 			}
@@ -146,15 +144,17 @@ func (r *Runner) Start() {
 	ctx, cancel := context.WithCancel(appctx.WithLogger(context.Background(), &r.log))
 	r.cancel = cancel
 
+	periodic := registeredPeriodic()
+
 	// all-nodes periodic jobs run as local tickers, regardless of the store.
-	for _, p := range r.periodic {
+	for _, p := range periodic {
 		if p.Scope == ScopeAllNodes {
 			r.wg.Go(func() { r.runLocalTicker(ctx, p) })
 		}
 	}
 
 	if r.store == nil {
-		r.log.Info().Int("local_jobs", len(r.periodic)).Msg("rjobs: started without a store, only all-nodes jobs run")
+		r.log.Info().Int("local_jobs", len(periodic)).Msg("rjobs: started without a store, only all-nodes jobs run")
 		return
 	}
 
@@ -168,7 +168,7 @@ func (r *Runner) Start() {
 	}
 
 	// register leader-scoped schedules so the scheduler can track them.
-	for _, p := range r.periodic {
+	for _, p := range periodic {
 		if p.Scope != ScopeLeader {
 			continue
 		}
@@ -637,7 +637,7 @@ func (r *Runner) execRun(ctx context.Context, run Run) {
 // not status-tracked, so this is always false for them; their cancellation is
 // driven separately through the schedule store.
 func (r *Runner) cancelRequested(ctx context.Context, run Run) bool {
-	if _, ok := r.lookupPeriodic(run.Job); ok {
+	if _, ok := lookupPeriodic(run.Job); ok {
 		// Periodic runs are not status-tracked; their cancel intent lives in the
 		// schedule store, keyed by job name.
 		req, err := r.store.ScheduledCancelRequested(ctx, run.Job)
@@ -710,7 +710,7 @@ func (r *Runner) recordStatus(ctx context.Context, run Run, state State, result 
 	if r.status == nil {
 		return
 	}
-	if _, ok := r.lookupPeriodic(run.Job); ok {
+	if _, ok := lookupPeriodic(run.Job); ok {
 		return
 	}
 
@@ -746,7 +746,7 @@ func (r *Runner) recordStatus(ctx context.Context, run Run, state State, result 
 func (r *Runner) invoke(ctx context.Context, run Run, log zerolog.Logger) (Params, error) {
 	jobCtx := appctx.WithLogger(ctx, &log)
 
-	if p, ok := r.lookupPeriodic(run.Job); ok {
+	if p, ok := lookupPeriodic(run.Job); ok {
 		return nil, r.guard(p, func() error { return p.Run(jobCtx) })
 	}
 
@@ -800,20 +800,11 @@ func (r *Runner) guard(p Periodic, fn func() error) error {
 	return fn()
 }
 
-func (r *Runner) lookupPeriodic(name string) (Periodic, bool) {
-	for _, p := range r.periodic {
-		if p.Name == name {
-			return p, true
-		}
-	}
-	return Periodic{}, false
-}
-
 // isLeaderJob reports whether name is currently registered as a leader-scoped
 // periodic job. The scheduler uses it to ignore stale schedule entries left by
 // a job that changed scope or was removed.
 func (r *Runner) isLeaderJob(name string) bool {
-	p, ok := r.lookupPeriodic(name)
+	p, ok := lookupPeriodic(name)
 	return ok && p.Scope == ScopeLeader
 }
 

--- a/pkg/rjobs/runner.go
+++ b/pkg/rjobs/runner.go
@@ -40,10 +40,17 @@ const defaultRetryAfter = 30 * time.Second
 // schedulerTick is how often the scheduler loop checks for due periodic jobs.
 const schedulerTick = 10 * time.Second
 
+// localSchedulerTick is how often the local scheduler rescans the registry
+// for due all-nodes jobs. A variable so tests can shorten it.
+var localSchedulerTick = schedulerTick
+
 // Options configures a Runner.
 type Options struct {
 	// Workers is the number of concurrent workers draining the durable queue.
 	Workers int
+	// LocalWorkers is the size of the pool executing all-nodes periodic jobs
+	// on this replica.
+	LocalWorkers int
 	// Store is the durable backend. It may be nil, in which case only
 	// all-nodes periodic jobs run (no leader-scoped or on-demand work).
 	Store Store
@@ -62,10 +69,17 @@ type Options struct {
 // Default for in-process Enqueue.
 type Runner struct {
 	workers        int
+	localWorkers   int
 	store          Store
 	status         StatusStore
 	log            zerolog.Logger
 	onDemandConfig map[string]map[string]any
+
+	// dueCh hands due all-nodes jobs from the local scheduler to the local
+	// worker pool. It is unbuffered on purpose: a hand-off succeeds only when
+	// a worker is free, so the scheduler can tell a saturated pool apart and
+	// keep the job due instead of queueing runs behind it.
+	dueCh chan Periodic
 
 	cancel context.CancelFunc
 	wg     sync.WaitGroup
@@ -109,13 +123,18 @@ func NewRunner(ctx context.Context, opts Options) (*Runner, error) {
 	if opts.Workers <= 0 {
 		opts.Workers = 4
 	}
+	if opts.LocalWorkers <= 0 {
+		opts.LocalWorkers = 4
+	}
 
 	r := &Runner{
 		workers:        opts.Workers,
+		localWorkers:   opts.LocalWorkers,
 		store:          opts.Store,
 		status:         opts.Status,
 		log:            *appctx.GetLogger(ctx),
 		onDemandConfig: opts.OnDemandConfig,
+		dueCh:          make(chan Periodic),
 		running:        make(map[string]bool),
 		cancels:        make(map[RunID]*runHandle),
 	}
@@ -144,17 +163,16 @@ func (r *Runner) Start() {
 	ctx, cancel := context.WithCancel(appctx.WithLogger(context.Background(), &r.log))
 	r.cancel = cancel
 
-	periodic := registeredPeriodic()
-
-	// all-nodes periodic jobs run as local tickers, regardless of the store.
-	for _, p := range periodic {
-		if p.Scope == ScopeAllNodes {
-			r.wg.Go(func() { r.runLocalTicker(ctx, p) })
-		}
+	// the local scheduler decides when periodic jobs are due; the local pool
+	// executes the all-nodes ones. Both read the registry live, so a job
+	// registered after Start is picked up on the next pass.
+	r.wg.Go(func() { r.runLocalScheduler(ctx) })
+	for i := 0; i < r.localWorkers; i++ {
+		r.wg.Go(func() { r.runLocalWorker(ctx) })
 	}
 
 	if r.store == nil {
-		r.log.Info().Int("local_jobs", len(periodic)).Msg("rjobs: started without a store, only all-nodes jobs run")
+		r.log.Info().Msg("rjobs: started without a store, only all-nodes jobs run")
 		return
 	}
 
@@ -164,21 +182,6 @@ func (r *Runner) Start() {
 	if bus, ok := r.store.(ControlBus); ok {
 		if err := bus.SubscribeCancel(ctx, r.tripLocal); err != nil {
 			r.log.Error().Err(err).Msg("rjobs: subscribing to cancel broadcasts failed, cancels fall back to the backstop poll")
-		}
-	}
-
-	// register leader-scoped schedules so the scheduler can track them.
-	for _, p := range periodic {
-		if p.Scope != ScopeLeader {
-			continue
-		}
-		sched, _ := ParseSchedule(p.Schedule) // validated at registration
-		next := time.Now().Add(sched.Interval())
-		if p.RunOnStart {
-			next = time.Now()
-		}
-		if err := r.store.RegisterScheduled(ctx, p.Name, sched, next); err != nil {
-			r.log.Error().Err(err).Str("job", p.Name).Msg("rjobs: registering schedule failed")
 		}
 	}
 
@@ -474,22 +477,101 @@ func (r *Runner) broadcastCancel(ctx context.Context, sig CancelSignal) {
 	}
 }
 
-// runLocalTicker drives an all-nodes periodic job on this replica. It never
-// touches the store.
-func (r *Runner) runLocalTicker(ctx context.Context, p Periodic) {
-	sched, _ := ParseSchedule(p.Schedule)
-	log := r.log.With().Str("job", p.Name).Str("scope", p.Scope.String()).Logger()
+// runLocalScheduler decides when periodic jobs are due. It rescans the
+// registry on every pass, so jobs can be registered at any time, not only
+// before Start. Due all-nodes jobs are handed to the local worker pool; for
+// leader-scoped jobs only the schedule is pushed to the store, the durable
+// scheduler takes it from there. It owns all the timing state, so no locking
+// is needed.
+func (r *Runner) runLocalScheduler(ctx context.Context) {
+	next := make(map[string]time.Time)
+	leaderDone := make(map[string]bool)
 
-	if p.RunOnStart {
-		r.execPeriodic(ctx, p, log)
-	}
+	ticker := time.NewTicker(localSchedulerTick)
+	defer ticker.Stop()
 
 	for {
-		wait := sched.Interval() + jitter(p.Jitter)
+		r.localPass(ctx, next, leaderDone)
 		select {
 		case <-ctx.Done():
 			return
-		case <-time.After(wait):
+		case <-ticker.C:
+		}
+	}
+}
+
+// localPass walks the registered periodic jobs once, handing due all-nodes
+// jobs to the pool and registering the schedules of leader jobs it has not
+// dealt with yet.
+func (r *Runner) localPass(ctx context.Context, next map[string]time.Time, leaderDone map[string]bool) {
+	now := time.Now()
+	for _, p := range registeredPeriodic() {
+		if p.Scope == ScopeLeader {
+			r.registerLeaderSchedule(ctx, p, leaderDone)
+			continue
+		}
+
+		sched, _ := ParseSchedule(p.Schedule) // validated at registration
+		due, seen := next[p.Name]
+		if !seen {
+			// first sighting. For a job registered after Start, RunOnStart
+			// means run on registration.
+			due = now.Add(sched.Interval() + jitter(p.Jitter))
+			if p.RunOnStart {
+				due = now
+			}
+			next[p.Name] = due
+		}
+		if now.Before(due) {
+			continue
+		}
+
+		select {
+		case r.dueCh <- p:
+			next[p.Name] = now.Add(sched.Interval() + jitter(p.Jitter))
+		default:
+			// every local worker is busy. Leave the job due and retry on the
+			// next pass: the run is delayed, never queued up behind the pool.
+		}
+	}
+}
+
+// registerLeaderSchedule pushes a leader job's schedule to the store, once. A
+// failed attempt is retried on the next pass.
+func (r *Runner) registerLeaderSchedule(ctx context.Context, p Periodic, done map[string]bool) {
+	if done[p.Name] {
+		return
+	}
+	if r.store == nil {
+		// NewRunner rejects this for jobs registered before it ran, so this
+		// can only be a late registration. Warn once; it will not fix itself.
+		r.log.Error().Str("job", p.Name).Msg("rjobs: job is leader-scoped but no store is configured, it will not run")
+		done[p.Name] = true
+		return
+	}
+
+	sched, _ := ParseSchedule(p.Schedule) // validated at registration
+	nextFire := time.Now().Add(sched.Interval())
+	if p.RunOnStart {
+		nextFire = time.Now()
+	}
+	if err := r.store.RegisterScheduled(ctx, p.Name, sched, nextFire); err != nil {
+		r.log.Error().Err(err).Str("job", p.Name).Msg("rjobs: registering schedule failed")
+		return
+	}
+	done[p.Name] = true
+}
+
+// runLocalWorker executes due all-nodes jobs handed over by the local
+// scheduler. The pool bounds how many periodic jobs run concurrently on this
+// replica.
+func (r *Runner) runLocalWorker(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case p := <-r.dueCh:
+			log := r.log.With().Str("job", p.Name).Str("scope", p.Scope.String()).Logger()
 			r.execPeriodic(ctx, p, log)
 		}
 	}

--- a/pkg/rjobs/runner.go
+++ b/pkg/rjobs/runner.go
@@ -44,6 +44,11 @@ const schedulerTick = 10 * time.Second
 // for due all-nodes jobs. A variable so tests can shorten it.
 var localSchedulerTick = schedulerTick
 
+// localRetryWait is how soon the local scheduler retries after a due job
+// could not be handed to the pool, so a delayed run does not also wait out a
+// full tick.
+const localRetryWait = 100 * time.Millisecond
+
 // Options configures a Runner.
 type Options struct {
 	// Workers is the number of concurrent workers draining the durable queue.
@@ -487,23 +492,28 @@ func (r *Runner) runLocalScheduler(ctx context.Context) {
 	next := make(map[string]time.Time)
 	leaderDone := make(map[string]bool)
 
-	ticker := time.NewTicker(localSchedulerTick)
-	defer ticker.Stop()
-
 	for {
-		r.localPass(ctx, next, leaderDone)
+		wait := localSchedulerTick
+		if r.localPass(ctx, next, leaderDone) {
+			// a due job could not be handed off (the pool is busy, or the
+			// workers are not receiving yet right after Start): retry soon
+			// instead of a full tick later.
+			wait = localRetryWait
+		}
 		select {
 		case <-ctx.Done():
 			return
-		case <-ticker.C:
+		case <-time.After(wait):
 		}
 	}
 }
 
 // localPass walks the registered periodic jobs once, handing due all-nodes
 // jobs to the pool and registering the schedules of leader jobs it has not
-// dealt with yet.
-func (r *Runner) localPass(ctx context.Context, next map[string]time.Time, leaderDone map[string]bool) {
+// dealt with yet. It reports whether a due job is still waiting for a free
+// worker.
+func (r *Runner) localPass(ctx context.Context, next map[string]time.Time, leaderDone map[string]bool) bool {
+	blocked := false
 	now := time.Now()
 	for _, p := range registeredPeriodic() {
 		if p.Scope == ScopeLeader {
@@ -532,8 +542,10 @@ func (r *Runner) localPass(ctx context.Context, next map[string]time.Time, leade
 		default:
 			// every local worker is busy. Leave the job due and retry on the
 			// next pass: the run is delayed, never queued up behind the pool.
+			blocked = true
 		}
 	}
+	return blocked
 }
 
 // registerLeaderSchedule pushes a leader job's schedule to the store, once. A

--- a/pkg/rjobs/runner_test.go
+++ b/pkg/rjobs/runner_test.go
@@ -103,6 +103,81 @@ func TestRegisterAfterStartRuns(t *testing.T) {
 	}
 }
 
+// lateLeaderStore exercises a leader job registered after the runner started.
+// Claim only ever delivers a run the store produced itself, and a run is
+// produced when the job's schedule is registered — mimicking the real store,
+// where registering a schedule is also what makes the job's runs claimable by
+// this process.
+type lateLeaderStore struct {
+	stubStore
+	mu        sync.Mutex
+	scheduled map[string]bool
+	runs      chan Run
+}
+
+func (s *lateLeaderStore) RegisterScheduled(_ context.Context, job string, _ Schedule, _ time.Time) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if !s.scheduled[job] {
+		s.scheduled[job] = true
+		// fire the first tick right away so the test does not wait a schedule
+		// interval.
+		s.runs <- Run{ID: "run-late", Job: job, Attempt: 1}
+	}
+	return nil
+}
+
+func (s *lateLeaderStore) Claim(ctx context.Context) (Run, error) {
+	select {
+	case run := <-s.runs:
+		return run, nil
+	case <-ctx.Done():
+		return Run{}, ctx.Err()
+	}
+}
+
+func TestLateLeaderJobRuns(t *testing.T) {
+	resetRegistry()
+	old := localSchedulerTick
+	localSchedulerTick = 20 * time.Millisecond
+	defer func() { localSchedulerTick = old }()
+
+	store := &lateLeaderStore{
+		scheduled: make(map[string]bool),
+		runs:      make(chan Run, 1),
+	}
+	r, err := NewRunner(context.Background(), Options{Workers: 1, Store: store, Status: newFakeStatus()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	r.Start()
+	defer r.Stop(context.Background())
+
+	// register the leader job only after the runner is up: it must get
+	// scheduled and its run claimed and executed.
+	var runs int32
+	done := make(chan struct{}, 1)
+	if err := RegisterPeriodic(Periodic{
+		Name:     "test.latecleanup",
+		Schedule: "@every 1h",
+		Scope:    ScopeLeader,
+		Run: func(ctx context.Context) error {
+			if atomic.AddInt32(&runs, 1) == 1 {
+				done <- struct{}{}
+			}
+			return nil
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("leader job registered after Start did not run")
+	}
+}
+
 func TestLeaderJobNeedsStore(t *testing.T) {
 	resetRegistry()
 

--- a/pkg/rjobs/runner_test.go
+++ b/pkg/rjobs/runner_test.go
@@ -63,6 +63,46 @@ func TestAllNodesRunOnStart(t *testing.T) {
 	}
 }
 
+func TestRegisterAfterStartRuns(t *testing.T) {
+	resetRegistry()
+	old := localSchedulerTick
+	localSchedulerTick = 20 * time.Millisecond
+	defer func() { localSchedulerTick = old }()
+
+	r, err := NewRunner(context.Background(), Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	r.Start()
+	defer r.Stop(context.Background())
+
+	// the runner is already up: the registration must still be picked up on
+	// one of the next scheduler passes.
+	var runs int32
+	done := make(chan struct{}, 1)
+	err = RegisterPeriodic(Periodic{
+		Name:       "test.late",
+		Schedule:   "@every 1h",
+		Scope:      ScopeAllNodes,
+		RunOnStart: true,
+		Run: func(ctx context.Context) error {
+			if atomic.AddInt32(&runs, 1) == 1 {
+				done <- struct{}{}
+			}
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("job registered after Start did not run")
+	}
+}
+
 func TestLeaderJobNeedsStore(t *testing.T) {
 	resetRegistry()
 

--- a/pkg/rjobs/runner_test.go
+++ b/pkg/rjobs/runner_test.go
@@ -146,12 +146,17 @@ func TestGuardSkipsOverlap(t *testing.T) {
 }
 
 func TestIsLeaderJob(t *testing.T) {
-	r := &Runner{
-		periodic: []Periodic{
-			{Name: "cleanup", Scope: ScopeLeader},
-			{Name: "warm", Scope: ScopeAllNodes},
-		},
+	resetRegistry()
+
+	for name, scope := range map[string]Scope{"cleanup": ScopeLeader, "warm": ScopeAllNodes} {
+		if err := RegisterPeriodic(Periodic{
+			Name: name, Schedule: "@every 1h", Scope: scope,
+			Run: func(context.Context) error { return nil },
+		}); err != nil {
+			t.Fatal(err)
+		}
 	}
+	r := &Runner{}
 
 	if !r.isLeaderJob("cleanup") {
 		t.Error("a registered leader job should be reported as such")

--- a/pkg/rjobs/store.go
+++ b/pkg/rjobs/store.go
@@ -92,10 +92,12 @@ type Store interface {
 	// in-flight run, chosen so the lease never lapses between beats.
 	HeartbeatInterval() time.Duration
 	// RegisterScheduled records a leader-scoped periodic job's schedule so
-	// DueScheduled can track its next-fire across restarts. An existing
-	// next-fire is preserved across restarts, except when the configured
-	// interval changed, in which case the new interval and the given next-fire
-	// are adopted.
+	// DueScheduled can track its next-fire across restarts. It also makes
+	// this process eligible to claim the job's runs, so registering the
+	// schedule is all it takes to participate in a job, including one
+	// registered after the store was built. An existing next-fire is
+	// preserved across restarts, except when the configured interval changed,
+	// in which case the new interval and the given next-fire are adopted.
 	RegisterScheduled(ctx context.Context, job string, schedule Schedule, next time.Time) error
 	// DueScheduled returns the periodic jobs whose next-fire is at or before
 	// now, atomically advancing each one's stored next-fire by its interval. A

--- a/pkg/rjobs/store/nats/nats.go
+++ b/pkg/rjobs/store/nats/nats.go
@@ -63,7 +63,6 @@ type Options struct {
 type store struct {
 	nc      *nats.Conn
 	js      nats.JetStreamContext
-	subs    []*nats.Subscription
 	kv      nats.KeyValue
 	prefix  string
 	ackWait time.Duration
@@ -72,10 +71,17 @@ type store struct {
 	// ctrlSub is the core-NATS subscription for cancel broadcasts, if subscribed.
 	ctrlSub *nats.Subscription
 
+	// mu guards inflight and the subscription set: RegisterScheduled can grow
+	// subs at any time while the claim loops iterate it.
+	mu sync.Mutex
 	// inflight tracks the NATS message backing each claimed run, so that
 	// Complete and Fail can ack or nak the right message.
-	mu       sync.Mutex
 	inflight map[rjobs.RunID]*nats.Msg
+	// subs are the per-job pull subscriptions this process claims runs from,
+	// and subJobs the job names behind them, so a repeated subscribe is a
+	// no-op.
+	subs    []*nats.Subscription
+	subJobs map[string]bool
 }
 
 // scheduleState is what we keep per leader-scoped periodic job in the KV
@@ -129,9 +135,10 @@ func New(ctx context.Context, opts Options) (rjobs.Store, error) {
 		ackWait:  opts.AckWait,
 		log:      log,
 		inflight: make(map[rjobs.RunID]*nats.Msg),
+		subJobs:  make(map[string]bool),
 	}
 
-	if err := s.setup(opts.AckWait, opts.Jobs); err != nil {
+	if err := s.setup(opts.Jobs); err != nil {
 		nc.Close()
 		return nil, err
 	}
@@ -161,7 +168,7 @@ func (s *store) consumerFor(job string) string {
 	return s.prefix + "-worker-" + subjectToken(job)
 }
 
-func (s *store) setup(ackWait time.Duration, jobs []string) error {
+func (s *store) setup(jobs []string) error {
 	// One work-queue stream captures every per-job subject. WorkQueuePolicy
 	// deletes a message once it is acked, so each run is delivered once.
 	if _, err := s.js.AddStream(&nats.StreamConfig{
@@ -175,21 +182,12 @@ func (s *store) setup(ackWait time.Duration, jobs []string) error {
 	// Subscribe only to the jobs this process has registered: one durable,
 	// subject-filtered consumer per job. A run for a job not in this set is
 	// never delivered here; it waits in the stream for a process that has it.
+	// Leader jobs registered later are added when their schedule is
+	// registered.
 	for _, job := range jobs {
-		if _, err := s.js.AddConsumer(s.streamName(), &nats.ConsumerConfig{
-			Durable:       s.consumerFor(job),
-			FilterSubject: s.subjectFor(job),
-			AckPolicy:     nats.AckExplicitPolicy,
-			AckWait:       ackWait,
-			MaxAckPending: -1,
-		}); err != nil {
-			return errors.Wrapf(err, "rjobs: consumer creation failed for job %q", job)
+		if err := s.subscribeJob(job); err != nil {
+			return err
 		}
-		sub, err := s.js.PullSubscribe(s.subjectFor(job), s.consumerFor(job), nats.Bind(s.streamName(), s.consumerFor(job)))
-		if err != nil {
-			return errors.Wrapf(err, "rjobs: pull subscription failed for job %q", job)
-		}
-		s.subs = append(s.subs, sub)
 	}
 
 	kv, err := s.js.CreateKeyValue(&nats.KeyValueConfig{Bucket: s.bucketName()})
@@ -199,6 +197,43 @@ func (s *store) setup(ackWait time.Duration, jobs []string) error {
 	s.kv = kv
 
 	return nil
+}
+
+// subscribeJob adds the durable consumer and pull subscription for a job, so
+// this process can claim its runs. Subscribing to an already subscribed job
+// is a no-op.
+func (s *store) subscribeJob(job string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.subJobs[job] {
+		return nil
+	}
+
+	if _, err := s.js.AddConsumer(s.streamName(), &nats.ConsumerConfig{
+		Durable:       s.consumerFor(job),
+		FilterSubject: s.subjectFor(job),
+		AckPolicy:     nats.AckExplicitPolicy,
+		AckWait:       s.ackWait,
+		MaxAckPending: -1,
+	}); err != nil {
+		return errors.Wrapf(err, "rjobs: consumer creation failed for job %q", job)
+	}
+	sub, err := s.js.PullSubscribe(s.subjectFor(job), s.consumerFor(job), nats.Bind(s.streamName(), s.consumerFor(job)))
+	if err != nil {
+		return errors.Wrapf(err, "rjobs: pull subscription failed for job %q", job)
+	}
+	s.subs = append(s.subs, sub)
+	s.subJobs[job] = true
+	return nil
+}
+
+// snapshotSubs returns the current subscription set. Claim iterates a
+// snapshot so subscribeJob can grow the set concurrently.
+func (s *store) snapshotSubs() []*nats.Subscription {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]*nats.Subscription(nil), s.subs...)
 }
 
 // subjectToken encodes a job name into a single NATS subject token. Job names
@@ -257,23 +292,30 @@ func (s *store) Enqueue(ctx context.Context, run rjobs.Run) (rjobs.RunID, error)
 }
 
 func (s *store) Claim(ctx context.Context) (rjobs.Run, error) {
-	if len(s.subs) == 0 {
-		// no registered jobs: nothing to claim, block until shutdown.
-		<-ctx.Done()
-		return rjobs.Run{}, ctx.Err()
-	}
-
-	// Poll each per-job subscription in turn. The per-subscription fetch wait
-	// is spread so a full no-work cycle takes about fetchWait regardless of how
-	// many jobs are registered.
-	perSubWait := max(fetchWait/time.Duration(len(s.subs)), 100*time.Millisecond)
-
 	for {
 		if err := ctx.Err(); err != nil {
 			return rjobs.Run{}, err
 		}
 
-		for _, sub := range s.subs {
+		// Take a fresh snapshot each cycle: registering a schedule may
+		// subscribe a job at any time, and a process that started with no
+		// queue jobs must begin claiming once its first one is subscribed.
+		subs := s.snapshotSubs()
+		if len(subs) == 0 {
+			select {
+			case <-ctx.Done():
+				return rjobs.Run{}, ctx.Err()
+			case <-time.After(fetchWait):
+			}
+			continue
+		}
+
+		// Poll each per-job subscription in turn. The per-subscription fetch
+		// wait is spread so a full no-work cycle takes about fetchWait
+		// regardless of how many jobs are registered.
+		perSubWait := max(fetchWait/time.Duration(len(subs)), 100*time.Millisecond)
+
+		for _, sub := range subs {
 			if err := ctx.Err(); err != nil {
 				return rjobs.Run{}, err
 			}
@@ -355,6 +397,15 @@ func (s *store) HeartbeatInterval() time.Duration {
 }
 
 func (s *store) RegisterScheduled(ctx context.Context, job string, schedule rjobs.Schedule, next time.Time) error {
+	// registering a schedule is what marks this process as a participant in
+	// the job, so it is also the point where it becomes eligible to claim the
+	// job's runs. For jobs registered after the store was built (the initial
+	// subscriptions cover only the names known then) this is what creates the
+	// queue consumer.
+	if err := s.subscribeJob(job); err != nil {
+		return err
+	}
+
 	entry, err := s.kv.Get(job)
 	switch {
 	case err == nil:
@@ -615,7 +666,7 @@ func (s *store) Close(ctx context.Context) error {
 	if s.ctrlSub != nil {
 		_ = s.ctrlSub.Drain()
 	}
-	for _, sub := range s.subs {
+	for _, sub := range s.snapshotSubs() {
 		_ = sub.Drain()
 	}
 	return s.nc.Drain()


### PR DESCRIPTION
Periodic jobs (`rjobs.RegisterPeriodic`) used to be picked up only once, when the `jobs` serverless service built the runner at startup. Anything registered later, for example by a component constructed after the services had started, was silently ignored: the job ended up in the registry, but nobody ever read it again.

This PR makes registration work at any point in the process lifetime, for both scopes, while keeping the closure-based registration API unchanged.