### PR TITLE
Feat/feedback endpoint

### DIFF
--- a/changelog/unreleased/feedback-endpoint.md
+++ b/changelog/unreleased/feedback-endpoint.md
@@ -1,0 +1,6 @@
+Enhancement: implement feedback endpoint
+
+Implement an endpoint so users can send feedback,
+to be used for the CERNBox Office Pilot.
+
+https://github.com/cs3org/reva/pull/5732

--- a/internal/http/services/appprovider/appprovider.go
+++ b/internal/http/services/appprovider/appprovider.go
@@ -62,6 +62,9 @@ type Config struct {
 	Prefix     string `mapstructure:"prefix"`
 	GatewaySvc string `mapstructure:"gatewaysvc"                                              validate:"required"`
 	Insecure   bool   `docs:"false;Whether to skip certificate checks when sending requests." mapstructure:"insecure"`
+	// FeedbackRecipient is the email address user feedback submitted through the
+	// /feedback endpoint is sent to. Empty disables the endpoint.
+	FeedbackRecipient string `mapstructure:"feedback_recipient"`
 }
 
 func (c *Config) ApplyDefaults() {
@@ -102,6 +105,7 @@ func (s *svc) routerInit() error {
 	s.router.Post("/open", s.handleOpen)
 	s.router.Post("/notify", s.handleNotify)
 	s.router.Post("/mentions", s.handleMentions)
+	s.router.Post("/feedback", s.handleFeedback)
 	return nil
 }
 

--- a/internal/http/services/appprovider/feedback.go
+++ b/internal/http/services/appprovider/feedback.go
@@ -1,0 +1,115 @@
+// Copyright 2018-2026 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package appprovider
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	gateway "github.com/cs3org/go-cs3apis/cs3/gateway/v1beta1"
+	rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
+	"github.com/cs3org/reva/v3/pkg/appctx"
+	"github.com/cs3org/reva/v3/pkg/auth/scope"
+	"github.com/cs3org/reva/v3/pkg/notifications"
+	"github.com/cs3org/reva/v3/pkg/notifications/model"
+	"github.com/cs3org/reva/v3/pkg/rgrpc/todo/pool"
+)
+
+const (
+	maxFeedbackBodyBytes = 1 << 20
+	maxFeedbackTextLen   = 10000
+)
+
+// handleFeedback accepts a plain-text feedback message from the authenticated
+// user and publishes a feedback notification event, which the notifications
+// service delivers by email to the configured recipient. The email carries the
+// submitter's name and the submitted text.
+func (s *svc) handleFeedback(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	log := appctx.GetLogger(ctx)
+
+	if s.conf.FeedbackRecipient == "" {
+		writeError(w, r, appErrorServerError, "feedback endpoint is not configured", nil)
+		return
+	}
+
+	submitter, ok := appctx.ContextGetUser(ctx)
+	if !ok || submitter == nil {
+		writeError(w, r, appErrorUnauthenticated, "missing authenticated user", nil)
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, maxFeedbackBodyBytes)
+	raw, err := io.ReadAll(r.Body)
+	if err != nil {
+		writeError(w, r, appErrorInvalidParameter, "could not read request body", nil)
+		return
+	}
+
+	text := strings.TrimSpace(string(raw))
+	if text == "" {
+		writeError(w, r, appErrorInvalidParameter, "missing feedback text", nil)
+		return
+	}
+	if len(text) > maxFeedbackTextLen {
+		writeError(w, r, appErrorInvalidParameter, "feedback text is too long", nil)
+		return
+	}
+
+	client, err := pool.GetGatewayServiceClient(pool.Endpoint(s.conf.GatewaySvc))
+	if err != nil {
+		writeError(w, r, appErrorServerError, "error getting grpc gateway client", err)
+		return
+	}
+
+	submitterName := submitter.GetDisplayName()
+	if submitterName == "" {
+		submitterName = submitter.GetUsername()
+	}
+	templateData := map[string]any{
+		"submitter_display_name": submitterName,
+		"submitter_username":     submitter.GetUsername(),
+		"submitter_mail":         submitter.GetMail(),
+		"text":                   text,
+	}
+
+	// PublishEvent is restricted to reva daemons. Re-sign this request's token with
+	// the machine scope, keeping the acting user (the submitter) unchanged.
+	publishCtx, err := scope.ContextWithMachineScope(ctx)
+	if err != nil {
+		writeError(w, r, appErrorServerError, "failed to elevate context for feedback notification", err)
+		return
+	}
+
+	event := notifications.EncodeEvent(model.EventFeedback, []string{s.conf.FeedbackRecipient}, templateData)
+	res, err := client.PublishEvent(publishCtx, &gateway.PublishEventRequest{Event: event})
+	if err != nil {
+		writeError(w, r, appErrorServerError, "failed to send feedback notification", err)
+		return
+	}
+	if code := res.GetStatus().GetCode(); code != rpc.Code_CODE_OK {
+		writeError(w, r, appErrorServerError, fmt.Sprintf("gateway rejected feedback notification: %s (%s)", code, res.GetStatus().GetMessage()), nil)
+		return
+	}
+
+	log.Info().Str("submitter", submitter.GetUsername()).Msg("feedback submitted")
+	w.WriteHeader(http.StatusAccepted)
+}

--- a/internal/http/services/appprovider/feedback_test.go
+++ b/internal/http/services/appprovider/feedback_test.go
@@ -1,0 +1,147 @@
+// Copyright 2018-2026 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package appprovider
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	gateway "github.com/cs3org/go-cs3apis/cs3/gateway/v1beta1"
+	rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
+	revaconfig "github.com/cs3org/reva/v3/cmd/revad/pkg/config"
+	"github.com/cs3org/reva/v3/pkg/appctx"
+	"github.com/cs3org/reva/v3/pkg/notifications"
+	"github.com/cs3org/reva/v3/pkg/notifications/model"
+	"github.com/cs3org/reva/v3/pkg/rgrpc/todo/pool"
+	"github.com/cs3org/reva/v3/pkg/sharedconf"
+	"google.golang.org/grpc"
+)
+
+type feedbackGateway struct {
+	gateway.GatewayAPIClient
+	published *gateway.PublishEventRequest
+	status    rpc.Code
+	err       error
+}
+
+func (g *feedbackGateway) PublishEvent(_ context.Context, req *gateway.PublishEventRequest, _ ...grpc.CallOption) (*gateway.PublishEventResponse, error) {
+	g.published = req
+	if g.err != nil {
+		return nil, g.err
+	}
+	code := g.status
+	if code == rpc.Code_CODE_INVALID {
+		code = rpc.Code_CODE_OK
+	}
+	return &gateway.PublishEventResponse{Status: &rpc.Status{Code: code}, EventId: "evt-1"}, nil
+}
+
+// TestHandleFeedbackPublishesEvent drives a plain-text feedback submission
+// through the handler and asserts the published event carries the submitter's
+// name and the text, addressed to the configured recipient.
+func TestHandleFeedbackPublishesEvent(t *testing.T) {
+	sharedconf.Init(&revaconfig.Shared{JWTSecret: "feedback-test-secret"})
+
+	endpoint := "feedback-" + t.Name()
+	gw := &feedbackGateway{}
+	pool.RegisterGatewayServiceClient(gw, endpoint)
+
+	s := &svc{conf: &Config{GatewaySvc: endpoint, FeedbackRecipient: "cernbox-admins@cern.ch"}}
+	submitter := mentionUser("einstein", "einstein@cern.ch")
+
+	req := httptest.NewRequest(http.MethodPost, "/app/feedback", strings.NewReader("The upload dialog is confusing.\nPlease fix."))
+	req = req.WithContext(appctx.ContextSetUser(req.Context(), submitter))
+	rec := httptest.NewRecorder()
+
+	s.handleFeedback(rec, req)
+
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want %d; body: %s", rec.Code, http.StatusAccepted, rec.Body.String())
+	}
+	if gw.published == nil {
+		t.Fatal("no event was published")
+	}
+	if got := gw.published.GetEvent().GetType(); got != model.EventFeedback {
+		t.Fatalf("event type = %q, want %q", got, model.EventFeedback)
+	}
+
+	recipients, templateData, err := notifications.DecodeEvent(gw.published.GetEvent())
+	if err != nil {
+		t.Fatalf("decode event: %v", err)
+	}
+	if len(recipients) != 1 || recipients[0] != "cernbox-admins@cern.ch" {
+		t.Fatalf("recipients = %+v, want [cernbox-admins@cern.ch]", recipients)
+	}
+	if templateData["submitter_display_name"] != "einstein display" {
+		t.Errorf("submitter_display_name = %v, want %q", templateData["submitter_display_name"], "einstein display")
+	}
+	if templateData["text"] != "The upload dialog is confusing.\nPlease fix." {
+		t.Errorf("text = %v, want the submitted feedback", templateData["text"])
+	}
+}
+
+func TestHandleFeedbackValidation(t *testing.T) {
+	sharedconf.Init(&revaconfig.Shared{JWTSecret: "feedback-test-secret"})
+	submitter := mentionUser("einstein", "einstein@cern.ch")
+
+	tests := []struct {
+		name      string
+		recipient string
+		user      bool
+		body      string
+		wantCode  int
+	}{
+		{"unconfigured recipient", "", true, "hi", http.StatusInternalServerError},
+		{"missing user", "to@cern.ch", false, "hi", http.StatusUnauthorized},
+		{"empty text", "to@cern.ch", true, "   ", http.StatusBadRequest},
+		{"too long", "to@cern.ch", true, strings.Repeat("x", maxFeedbackTextLen+1), http.StatusBadRequest},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			endpoint := "feedback-" + t.Name()
+			pool.RegisterGatewayServiceClient(&feedbackGateway{}, endpoint)
+			s := &svc{conf: &Config{GatewaySvc: endpoint, FeedbackRecipient: tt.recipient}}
+
+			req := httptest.NewRequest(http.MethodPost, "/app/feedback", strings.NewReader(tt.body))
+			if tt.user {
+				req = req.WithContext(appctx.ContextSetUser(req.Context(), submitter))
+			}
+			rec := httptest.NewRecorder()
+
+			s.handleFeedback(rec, req)
+
+			if rec.Code != tt.wantCode {
+				t.Fatalf("status = %d, want %d; body: %s", rec.Code, tt.wantCode, rec.Body.String())
+			}
+		})
+	}
+}
+
+func TestFeedbackEndpointIsProtected(t *testing.T) {
+	s := &svc{}
+	for _, path := range s.Unprotected() {
+		if path == "/feedback" {
+			t.Fatalf("/feedback must not be listed as unprotected")
+		}
+	}
+}


### PR DESCRIPTION
Implement an endpoint so users can send feedback, to be used for the CERNBox Office Pilot.