### PR TITLE
eos: add support for modbits in permission set

### DIFF
--- a/changelog/unreleased/eos-modbits.md
+++ b/changelog/unreleased/eos-modbits.md
@@ -1,0 +1,5 @@
+Enhancement: EOS driver now takes modbits into account
+
+To make /app/open also take into account modbits (so you can open files in apps in the public folder) 
+
+https://github.com/cs3org/reva/pull/5737

--- a/pkg/storage/fs/eos/client/binary/eosbinary.go
+++ b/pkg/storage/fs/eos/client/binary/eosbinary.go
@@ -1194,6 +1194,12 @@ func (c *Client) mapToFileInfo(ctx context.Context, kv, attrs map[string]string)
 		return nil, err
 	}
 
+	// eos reports the mode bits in octal, e.g. mode:42555
+	var mode uint64
+	if val, ok := kv["mode"]; ok && val != "" {
+		mode, _ = strconv.ParseUint(val, 8, 64)
+	}
+
 	var treeSize uint64
 	// treeSize is only for containers, so we check
 	if val, ok := kv["treesize"]; ok {
@@ -1286,6 +1292,7 @@ func (c *Client) mapToFileInfo(ctx context.Context, kv, attrs map[string]string)
 		FID:        fid,
 		UID:        uid,
 		GID:        gid,
+		Mode:       mode,
 		ETag:       kv["etag"],
 		Size:       size,
 		TreeSize:   treeSize,

--- a/pkg/storage/fs/eos/client/eosclient.go
+++ b/pkg/storage/fs/eos/client/eosclient.go
@@ -82,6 +82,7 @@ type FileInfo struct {
 	FID        uint64            `json:"fid"`
 	UID        uint64            `json:"uid"`
 	GID        uint64            `json:"gid"`
+	Mode       uint64            `json:"mode"`
 	TreeSize   uint64            `json:"tree_size"`
 	MTimeSec   uint64            `json:"mtime_sec"`
 	MTimeNanos uint32            `json:"mtime_nanos"`

--- a/pkg/storage/fs/eos/client/grpc/file_info.go
+++ b/pkg/storage/fs/eos/client/grpc/file_info.go
@@ -171,6 +171,7 @@ func (c *Client) grpcMDResponseToFileInfo(ctx context.Context, st *erpc.MDRespon
 		fi.FID = st.Cmd.ParentId
 		fi.UID = st.Cmd.Uid
 		fi.GID = st.Cmd.Gid
+		fi.Mode = uint64(st.Cmd.Mode)
 		fi.MTimeSec = st.Cmd.Mtime.Sec
 		// For directories, we prefer stime over mtime
 		if st.Cmd.Stime != nil {
@@ -198,6 +199,8 @@ func (c *Client) grpcMDResponseToFileInfo(ctx context.Context, st *erpc.MDRespon
 		fi.FID = st.Fmd.ContId
 		fi.UID = st.Fmd.Uid
 		fi.GID = st.Fmd.Gid
+		// EOS stores the file mode bits in the FileMd flags field.
+		fi.Mode = uint64(st.Fmd.Flags)
 		fi.MTimeSec = st.Fmd.Mtime.Sec
 		fi.ETag = st.Fmd.Etag
 		fi.File = path.Clean(string(st.Fmd.Path))

--- a/pkg/storage/fs/eos/eosfs.go
+++ b/pkg/storage/fs/eos/eosfs.go
@@ -420,60 +420,63 @@ func (fs *Eosfs) permissionSet(ctx context.Context, eosFileInfo *eosclient.FileI
 		return permissions.NewManagerRole().CS3ResourcePermissions()
 	}
 
-	if eosFileInfo.SysACL == nil {
-		return &provider.ResourcePermissions{
-			// no permissions
-		}
-	}
 	var perm provider.ResourcePermissions
 
-	// as the lightweight acl are stored as normal attrs,
-	// we need to add them in the sysacl entries
-
-	for k, v := range eosFileInfo.Attrs {
-		if e, ok := attrForLightweightACL(k, v); ok {
-			eosFileInfo.SysACL.Entries = append(eosFileInfo.SysACL.Entries, e)
-		}
+	// A world-readable resource can be read by any authenticated user,
+	// independently of the sys.acl. We deliberately only look at the world
+	// read bit: owner access is handled above, group access is expressed
+	// through the sys.acl rather than the unix group bits, and write access
+	// is never granted through the mode bits.
+	if eosFileInfo.Mode&worldRead != 0 {
+		mergePermissions(&perm, permissions.NewViewerRole().CS3ResourcePermissions())
 	}
 
-	userGroupsSet := makeSet(u.Groups)
+	if eosFileInfo.SysACL != nil {
+		// as the lightweight acl are stored as normal attrs,
+		// we need to add them in the sysacl entries
 
-	if utils.IsExternalUser(u) {
-		for _, e := range eosFileInfo.SysACL.Entries {
-			userInGroup := e.Type == acl.TypeGroup && userGroupsSet.in(strings.ToLower(e.Qualifier))
-			if (e.Type == acl.TypeLightweight && e.Qualifier == u.Id.OpaqueId) || userInGroup {
-				mergePermissions(&perm, grants.GetGrantPermissionSet(e.Permissions))
+		for k, v := range eosFileInfo.Attrs {
+			if e, ok := attrForLightweightACL(k, v); ok {
+				eosFileInfo.SysACL.Entries = append(eosFileInfo.SysACL.Entries, e)
 			}
 		}
 
-		// for normal files, we need to inherit also the lw acls
-		// from the parent folder, as these, when creating a new
-		// file are not inherited
-		if !eosFileInfo.IsDir {
-			if parentPath, err := fs.unwrap(ctx, filepath.Dir(eosFileInfo.File)); err == nil {
-				if parent, err := fs.GetMD(ctx, &provider.Reference{Path: parentPath}, nil); err == nil {
-					mergePermissions(&perm, parent.PermissionSet)
+		userGroupsSet := makeSet(u.Groups)
+
+		if utils.IsExternalUser(u) {
+			for _, e := range eosFileInfo.SysACL.Entries {
+				userInGroup := e.Type == acl.TypeGroup && userGroupsSet.in(strings.ToLower(e.Qualifier))
+				if (e.Type == acl.TypeLightweight && e.Qualifier == u.Id.OpaqueId) || userInGroup {
+					mergePermissions(&perm, grants.GetGrantPermissionSet(e.Permissions))
 				}
 			}
-		}
-	} else {
-		auth, err := extractUIDAndGID(u)
-		if err != nil {
-			return &provider.ResourcePermissions{
-				// no permissions
-			}
-		}
-		for _, e := range eosFileInfo.SysACL.Entries {
-			userInGroup := e.Type == acl.TypeGroup && userGroupsSet.in(strings.ToLower(e.Qualifier))
 
-			if (e.Type == acl.TypeUser && e.Qualifier == auth.Role.UID) || userInGroup {
-				mergePermissions(&perm, grants.GetGrantPermissionSet(e.Permissions))
+			// for normal files, we need to inherit also the lw acls
+			// from the parent folder, as these, when creating a new
+			// file are not inherited
+			if !eosFileInfo.IsDir {
+				if parentPath, err := fs.unwrap(ctx, filepath.Dir(eosFileInfo.File)); err == nil {
+					if parent, err := fs.GetMD(ctx, &provider.Reference{Path: parentPath}, nil); err == nil {
+						mergePermissions(&perm, parent.PermissionSet)
+					}
+				}
+			}
+		} else if auth, err := extractUIDAndGID(u); err == nil {
+			for _, e := range eosFileInfo.SysACL.Entries {
+				userInGroup := e.Type == acl.TypeGroup && userGroupsSet.in(strings.ToLower(e.Qualifier))
+
+				if (e.Type == acl.TypeUser && e.Qualifier == auth.Role.UID) || userInGroup {
+					mergePermissions(&perm, grants.GetGrantPermissionSet(e.Permissions))
+				}
 			}
 		}
 	}
 
 	return &perm
 }
+
+// worldRead is the world (other) read bit of a unix mode.
+const worldRead = 0o004
 
 func attrForLightweightACL(k, v string) (*acl.Entry, bool) {
 	ok := strings.HasPrefix(k, "sys."+lwShareAttrKey)


### PR DESCRIPTION
To make /app/open also take into account modbits (so you can open files in apps in the public folder) 