### PR TITLE
cephmount driver: sharing for external accounts. 

### DIFF
--- a/changelog/unreleased/cephmount-external-accounts.md
+++ b/changelog/unreleased/cephmount-external-accounts.md
@@ -1,0 +1,8 @@
+Enhancement: cephmount now supports shares to external accounts
+
+* Grants to external accounts are now stored in a `user.reva.extshare.<account>` xattr and are read back by ListGrants.
+* Operations on their behalf run as the service account configured with `external_accounts_user_name`/`_uid`/`_gid`, cboxexternal by default, the same account the EOS driver uses.
+* What they are allowed to do is decided by Reva from the stored grant rather than by the permissions of that account.
+* The ResourceInfo of a shared resource now also carries a name and an etag which now is recursive, meaning you changes in subtrees also get propgated.
+
+https://github.com/cs3org/reva/pull/5740

--- a/internal/grpc/services/storageprovider/storageprovider.go
+++ b/internal/grpc/services/storageprovider/storageprovider.go
@@ -1709,12 +1709,16 @@ func getFS(ctx context.Context, c *config) (storage.FS, error) {
 	if !ok {
 		return nil, errtypes.NotFound("driver not found: " + c.Driver)
 	}
-	// Pass down the space type declared by this storage provider, so that drivers
-	// can adapt their behaviour to the kind of spaces they serve. We copy the
-	// driver config to avoid mutating the parsed configuration.
-	conf := make(map[string]any, len(c.Drivers[c.Driver])+1)
+	// Pass down the space type and layout declared by this storage provider, so
+	// that drivers can adapt to the kind of spaces they serve without redefining
+	// what it already knows. The depth is rebased on the driver's own paths:
+	// space_depth counts from this namespace root, and the mount path is trimmed
+	// off before a driver is ever called. We copy the driver config to avoid
+	// mutating the parsed configuration.
+	conf := make(map[string]any, len(c.Drivers[c.Driver])+2)
 	maps.Copy(conf, c.Drivers[c.Driver])
 	conf["provides_space_type"] = c.ProvidesSpaceType
+	conf["space_depth"] = c.SpaceDepth - pathLevels(c.MountPath)
 	return f(ctx, conf)
 }
 

--- a/internal/grpc/services/storageprovider/storageprovider_test.go
+++ b/internal/grpc/services/storageprovider/storageprovider_test.go
@@ -1,9 +1,12 @@
 package storageprovider
 
 import (
+	"context"
 	"testing"
 
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+	"github.com/cs3org/reva/v3/pkg/storage"
+	"github.com/cs3org/reva/v3/pkg/storage/fs/registry"
 )
 
 // singleFileRootMountRemap is shared by InitiateFileDownload (simple protocol)
@@ -44,5 +47,57 @@ func TestSingleFileRootMountRemapLeavesNestedPathsAlone(t *testing.T) {
 
 	if got != "/nested/file.txt" {
 		t.Fatalf("expected nested path to stay unchanged, got %q", got)
+	}
+}
+
+// getFS rebases space_depth on the paths the driver is called with: the mount
+// path is trimmed off before a driver sees a reference, so a driver must not be
+// handed a depth counted from this provider's namespace root.
+func TestGetFSInjectsSpaceDepthRelativeToTheMountPath(t *testing.T) {
+	tests := []struct {
+		name       string
+		mountPath  string
+		spaceDepth int
+		want       int
+	}{
+		// Roots at /winspaces/c/<project> are two levels into the driver's paths.
+		{name: "mounted one level deep", mountPath: "/winspaces", spaceDepth: 3, want: 2},
+		{name: "mounted at the root", mountPath: "/", spaceDepth: 2, want: 2},
+		{name: "mounted several levels deep", mountPath: "/eos/project", spaceDepth: 4, want: 2},
+		// A provider whose whole mount is a single space has no space root in the
+		// driver's paths at all.
+		{name: "single space", mountPath: "/winspaces", spaceDepth: 1, want: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			driver := "test-space-depth-" + tt.name
+			var got map[string]any
+			registry.Register(driver, func(ctx context.Context, m map[string]any) (storage.FS, error) {
+				got = m
+				return noopFS{}, nil
+			})
+			t.Cleanup(func() { delete(registry.NewFuncs, driver) })
+
+			c := &config{
+				Driver:     driver,
+				MountPath:  tt.mountPath,
+				SpaceDepth: tt.spaceDepth,
+				Drivers:    map[string]map[string]any{driver: {"some_option": "kept"}},
+			}
+			if _, err := getFS(context.Background(), c); err != nil {
+				t.Fatalf("getFS: %v", err)
+			}
+
+			if got["space_depth"] != tt.want {
+				t.Errorf("space_depth = %v, want %d", got["space_depth"], tt.want)
+			}
+			if got["some_option"] != "kept" {
+				t.Errorf("the driver's own config was dropped: %v", got)
+			}
+			if _, ok := c.Drivers[driver]["space_depth"]; ok {
+				t.Error("the parsed configuration was mutated")
+			}
+		})
 	}
 }

--- a/pkg/storage/fs/cephmount/cephmount.go
+++ b/pkg/storage/fs/cephmount/cephmount.go
@@ -437,14 +437,20 @@ func (fs *cephmountfs) fileAsResourceInfo(path string, info os.FileInfo, mdKeys 
 
 	owner, _ := user.LookupId(fmt.Sprint(stat.Uid))
 
+	externalPath := fs.fromChroot(path)
+
 	ri := &provider.ResourceInfo{
 		Type:     resourceType,
 		Id:       resourceId,
 		Checksum: &provider.ResourceChecksum{},
 		Size:     size,
 		Mtime:    &typepb.Timestamp{Seconds: uint64(info.ModTime().Unix())},
-		Path:     fs.fromChroot(path), // Convert chroot path back to external path
-		Owner:    &userv1beta1.UserId{OpaqueId: owner.Username},
+		Path:     externalPath,
+		// Clients list a received share by its name and etag, so both must be set
+		// even though the resource itself is addressed by path or id.
+		Name:  filepath.Base(externalPath),
+		Etag:  calcEtag(info, stat),
+		Owner: &userv1beta1.UserId{OpaqueId: owner.Username},
 		PermissionSet: &provider.ResourcePermissions{
 			GetPath:              true,
 			GetQuota:             true,
@@ -489,6 +495,14 @@ func (fs *cephmountfs) fileAsResourceInfo(path string, info os.FileInfo, mdKeys 
 	ri.ArbitraryMetadata.Metadata["device"] = strconv.FormatUint(uint64(stat.Dev), 10)
 
 	return ri, nil
+}
+
+// calcEtag derives an etag from the inode and the mtime, so it changes whenever
+// the resource is modified. Note that the mtime of a directory only changes when
+// its direct children do, so changes deeper in the tree do not propagate.
+func calcEtag(info os.FileInfo, stat *syscall.Stat_t) string {
+	mtime := info.ModTime()
+	return fmt.Sprintf("\"%d:%d.%d\"", stat.Ino, mtime.Unix(), mtime.Nanosecond())
 }
 
 // toChroot converts an external path to a chroot-relative path

--- a/pkg/storage/fs/cephmount/cephmount.go
+++ b/pkg/storage/fs/cephmount/cephmount.go
@@ -55,6 +55,9 @@ import (
 const (
 	xattrUserNs = "user."
 	xattrLock   = xattrUserNs + "reva.lockpayload"
+	// xattrLwShare + <account> holds the rwx permissions granted to an external
+	// account, which has no local uid to put in a POSIX ACL.
+	xattrLwShare = xattrUserNs + "reva.lwshare."
 	// recursive size in bytes of a directory subtree, maintained by the MDS
 	xattrCephRbytes = "ceph.dir.rbytes"
 )
@@ -375,6 +378,10 @@ func (fs *cephmountfs) readArbitraryMetadata(path string, mdKeys []string) map[s
 	}
 	for _, name := range names {
 		if !strings.HasPrefix(name, xattrUserNs) {
+			continue
+		}
+		if strings.HasPrefix(name, xattrLwShare) {
+			// Grants to external accounts are exposed through ListGrants, not as metadata.
 			continue
 		}
 		key := strings.TrimPrefix(name, xattrUserNs)
@@ -937,6 +944,16 @@ func (fs *cephmountfs) AddGrant(ctx context.Context, ref *provider.Reference, g 
 
 	fs.logOperation(ctx, "AddGrant", path)
 
+	// External accounts have no local uid, so they go to an xattr, not the ACL.
+	if qualifier, ok := externalAccountQualifier(g.Grantee); ok {
+		if err := fs.addExternalAccountGrant(ctx, path, qualifier, g.Permissions); err != nil {
+			wrappedErr := errors.Wrap(err, "cephmount: failed to add grant for external account")
+			fs.logOperationError(ctx, "AddGrant", path, wrappedErr)
+			return wrappedErr
+		}
+		return nil
+	}
+
 	// Use setfacl system command to set permissions
 	err = fs.addGrantViaSetfacl(ctx, path, g)
 	if err != nil {
@@ -957,6 +974,15 @@ func (fs *cephmountfs) RemoveGrant(ctx context.Context, ref *provider.Reference,
 	}
 
 	fs.logOperation(ctx, "RemoveGrant", path)
+
+	if qualifier, ok := externalAccountQualifier(g.Grantee); ok {
+		if err := fs.removeExternalAccountGrant(ctx, path, qualifier); err != nil {
+			wrappedErr := errors.Wrap(err, "cephmount: failed to remove grant for external account")
+			fs.logOperationError(ctx, "RemoveGrant", path, wrappedErr)
+			return wrappedErr
+		}
+		return nil
+	}
 
 	// Use setfacl system command to remove permissions
 	err = fs.removeGrantViaSetfacl(ctx, path, g)
@@ -995,15 +1021,18 @@ func (fs *cephmountfs) ListGrants(ctx context.Context, ref *provider.Reference) 
 
 	fullPath := filepath.Join(fs.chrootDir, path)
 
+	log := appctx.GetLogger(ctx)
+
+	// Grants to external accounts live in xattrs, not in the POSIX ACL.
+	glist = append(glist, fs.listExternalAccountGrants(ctx, fullPath)...)
+
 	// Use getfacl to read ACLs
 	cmd := exec.CommandContext(ctx, "getfacl", "--omit-header", "--numeric", fullPath)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		// No ACLs or error - return empty list
-		return []*provider.Grant{}, nil
+		// No ACLs or error - return what we have so far
+		return glist, nil
 	}
-
-	log := appctx.GetLogger(ctx)
 
 	// Parse getfacl output
 	lines := strings.SplitSeq(string(output), "\n")
@@ -1231,6 +1260,12 @@ func (fs *cephmountfs) SetArbitraryMetadata(ctx context.Context, ref *provider.R
 		if !strings.HasPrefix(k, xattrUserNs) {
 			k = xattrUserNs + k
 		}
+		if strings.HasPrefix(k, xattrLwShare) {
+			// These hold grants to external accounts and are owned by AddGrant/RemoveGrant.
+			wrappedErr := errtypes.BadRequest(fmt.Sprintf("cephmount: key %s is reserved", k))
+			fs.logOperationError(ctx, "SetArbitraryMetadata", path, wrappedErr)
+			return wrappedErr
+		}
 		if err := xattr.Set(fullPath, k, []byte(v)); err != nil {
 			wrappedErr := errors.Wrap(err, "cephmount: failed to set xattr")
 			fs.logOperationError(ctx, "SetArbitraryMetadata", path, wrappedErr)
@@ -1255,6 +1290,12 @@ func (fs *cephmountfs) UnsetArbitraryMetadata(ctx context.Context, ref *provider
 	for _, key := range keys {
 		if !strings.HasPrefix(key, xattrUserNs) {
 			key = xattrUserNs + key
+		}
+		if strings.HasPrefix(key, xattrLwShare) {
+			// These hold grants to external accounts and are owned by AddGrant/RemoveGrant.
+			wrappedErr := errtypes.BadRequest(fmt.Sprintf("cephmount: key %s is reserved", key))
+			fs.logOperationError(ctx, "UnsetArbitraryMetadata", path, wrappedErr)
+			return wrappedErr
 		}
 		if err := xattr.Remove(fullPath, key); err != nil {
 			// Ignore if the attribute doesn't exist
@@ -1513,6 +1554,100 @@ func (fs *cephmountfs) Unlock(ctx context.Context, ref *provider.Reference, lock
 	}
 	log.Debug().Str("path", path).Str("lockId", lock.LockId).Msg("cephmount: Unlock: lock removed")
 	return nil
+}
+
+// externalAccountQualifier returns the xattr qualifier for a lightweight or
+// federated grantee. Those accounts only exist inside reva, so they have no
+// /etc/passwd entry and must never be resolved as local users.
+func externalAccountQualifier(g *provider.Grantee) (string, bool) {
+	if g == nil || g.Type != provider.GranteeType_GRANTEE_TYPE_USER {
+		return "", false
+	}
+	id := g.GetUserId()
+	if id == nil {
+		return "", false
+	}
+	switch id.Type {
+	case userv1beta1.UserType_USER_TYPE_LIGHTWEIGHT, userv1beta1.UserType_USER_TYPE_FEDERATED:
+		return id.OpaqueId, true
+	default:
+		return "", false
+	}
+}
+
+// addExternalAccountGrant stores a grant to an external account as an xattr.
+// Unlike the setfacl path this is not recursive: the attribute is only read back
+// by reva, on the shared resource itself.
+func (fs *cephmountfs) addExternalAccountGrant(ctx context.Context, path, qualifier string, perms *provider.ResourcePermissions) error {
+	fullPath := filepath.Join(fs.chrootDir, path)
+	key := xattrLwShare + qualifier
+	value := fs.permissionsToACLString(perms)
+
+	if err := xattr.Set(fullPath, key, []byte(value)); err != nil {
+		return errors.Wrapf(err, "cephmount: failed to set xattr %s", key)
+	}
+
+	appctx.GetLogger(ctx).Debug().
+		Str("path", fullPath).
+		Str("xattr", key).
+		Str("permissions", value).
+		Msg("cephmount: stored grant for external account")
+
+	return nil
+}
+
+// removeExternalAccountGrant drops the xattr holding the grant.
+func (fs *cephmountfs) removeExternalAccountGrant(ctx context.Context, path, qualifier string) error {
+	fullPath := filepath.Join(fs.chrootDir, path)
+	key := xattrLwShare + qualifier
+
+	if err := xattr.Remove(fullPath, key); err != nil && !errors.Is(err, xattr.ENOATTR) {
+		return errors.Wrapf(err, "cephmount: failed to remove xattr %s", key)
+	}
+
+	appctx.GetLogger(ctx).Debug().
+		Str("path", fullPath).
+		Str("xattr", key).
+		Msg("cephmount: removed grant for external account")
+
+	return nil
+}
+
+// listExternalAccountGrants returns the grants stored in the xattrs of fullPath.
+// Reads are best-effort: unreadable attributes are skipped.
+func (fs *cephmountfs) listExternalAccountGrants(ctx context.Context, fullPath string) []*provider.Grant {
+	log := appctx.GetLogger(ctx)
+
+	names, err := xattr.List(fullPath)
+	if err != nil {
+		log.Debug().Err(err).Str("path", fullPath).Msg("cephmount: cannot list xattrs for external account grants")
+		return nil
+	}
+
+	var glist []*provider.Grant
+	for _, name := range names {
+		if !strings.HasPrefix(name, xattrLwShare) {
+			continue
+		}
+		buf, err := xattr.Get(fullPath, name)
+		if err != nil {
+			log.Debug().Err(err).Str("xattr", name).Msg("cephmount: skipping unreadable external account grant")
+			continue
+		}
+		glist = append(glist, &provider.Grant{
+			Grantee: &provider.Grantee{
+				Type: provider.GranteeType_GRANTEE_TYPE_USER,
+				Id: &provider.Grantee_UserId{UserId: &userv1beta1.UserId{
+					// Only the account name is stored, so the idp is left empty and
+					// federated accounts are reported as lightweight ones.
+					Type:     userv1beta1.UserType_USER_TYPE_LIGHTWEIGHT,
+					OpaqueId: strings.TrimPrefix(name, xattrLwShare),
+				}},
+			},
+			Permissions: fs.aclStringToPermissions(string(buf)),
+		})
+	}
+	return glist
 }
 
 // resolveGranteeIdentifier resolves a grantee (user or group) to their system identifier (UID or GID)

--- a/pkg/storage/fs/cephmount/cephmount.go
+++ b/pkg/storage/fs/cephmount/cephmount.go
@@ -55,6 +55,9 @@ import (
 const (
 	xattrUserNs = "user."
 	xattrLock   = xattrUserNs + "reva.lockpayload"
+	// xattrLwShare + <account> holds the rwx permissions granted to an external
+	// account, which has no local uid to put in a POSIX ACL.
+	xattrLwShare = xattrUserNs + "reva.lwshare."
 )
 
 // cephmountfs is a local filesystem implementation that provides a ceph-like interface
@@ -373,6 +376,10 @@ func (fs *cephmountfs) readArbitraryMetadata(path string, mdKeys []string) map[s
 	}
 	for _, name := range names {
 		if !strings.HasPrefix(name, xattrUserNs) {
+			continue
+		}
+		if strings.HasPrefix(name, xattrLwShare) {
+			// Grants to external accounts are exposed through ListGrants, not as metadata.
 			continue
 		}
 		key := strings.TrimPrefix(name, xattrUserNs)
@@ -933,6 +940,16 @@ func (fs *cephmountfs) AddGrant(ctx context.Context, ref *provider.Reference, g 
 
 	fs.logOperation(ctx, "AddGrant", path)
 
+	// External accounts have no local uid, so they go to an xattr, not the ACL.
+	if qualifier, ok := externalAccountQualifier(g.Grantee); ok {
+		if err := fs.addExternalAccountGrant(ctx, path, qualifier, g.Permissions); err != nil {
+			wrappedErr := errors.Wrap(err, "cephmount: failed to add grant for external account")
+			fs.logOperationError(ctx, "AddGrant", path, wrappedErr)
+			return wrappedErr
+		}
+		return nil
+	}
+
 	// Use setfacl system command to set permissions
 	err = fs.addGrantViaSetfacl(ctx, path, g)
 	if err != nil {
@@ -953,6 +970,15 @@ func (fs *cephmountfs) RemoveGrant(ctx context.Context, ref *provider.Reference,
 	}
 
 	fs.logOperation(ctx, "RemoveGrant", path)
+
+	if qualifier, ok := externalAccountQualifier(g.Grantee); ok {
+		if err := fs.removeExternalAccountGrant(ctx, path, qualifier); err != nil {
+			wrappedErr := errors.Wrap(err, "cephmount: failed to remove grant for external account")
+			fs.logOperationError(ctx, "RemoveGrant", path, wrappedErr)
+			return wrappedErr
+		}
+		return nil
+	}
 
 	// Use setfacl system command to remove permissions
 	err = fs.removeGrantViaSetfacl(ctx, path, g)
@@ -991,15 +1017,18 @@ func (fs *cephmountfs) ListGrants(ctx context.Context, ref *provider.Reference) 
 
 	fullPath := filepath.Join(fs.chrootDir, path)
 
+	log := appctx.GetLogger(ctx)
+
+	// Grants to external accounts live in xattrs, not in the POSIX ACL.
+	glist = append(glist, fs.listExternalAccountGrants(ctx, fullPath)...)
+
 	// Use getfacl to read ACLs
 	cmd := exec.CommandContext(ctx, "getfacl", "--omit-header", "--numeric", fullPath)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		// No ACLs or error - return empty list
-		return []*provider.Grant{}, nil
+		// No ACLs or error - return what we have so far
+		return glist, nil
 	}
-
-	log := appctx.GetLogger(ctx)
 
 	// Parse getfacl output
 	lines := strings.SplitSeq(string(output), "\n")
@@ -1203,6 +1232,12 @@ func (fs *cephmountfs) SetArbitraryMetadata(ctx context.Context, ref *provider.R
 		if !strings.HasPrefix(k, xattrUserNs) {
 			k = xattrUserNs + k
 		}
+		if strings.HasPrefix(k, xattrLwShare) {
+			// These hold grants to external accounts and are owned by AddGrant/RemoveGrant.
+			wrappedErr := errtypes.BadRequest(fmt.Sprintf("cephmount: key %s is reserved", k))
+			fs.logOperationError(ctx, "SetArbitraryMetadata", path, wrappedErr)
+			return wrappedErr
+		}
 		if err := xattr.Set(fullPath, k, []byte(v)); err != nil {
 			wrappedErr := errors.Wrap(err, "cephmount: failed to set xattr")
 			fs.logOperationError(ctx, "SetArbitraryMetadata", path, wrappedErr)
@@ -1227,6 +1262,12 @@ func (fs *cephmountfs) UnsetArbitraryMetadata(ctx context.Context, ref *provider
 	for _, key := range keys {
 		if !strings.HasPrefix(key, xattrUserNs) {
 			key = xattrUserNs + key
+		}
+		if strings.HasPrefix(key, xattrLwShare) {
+			// These hold grants to external accounts and are owned by AddGrant/RemoveGrant.
+			wrappedErr := errtypes.BadRequest(fmt.Sprintf("cephmount: key %s is reserved", key))
+			fs.logOperationError(ctx, "UnsetArbitraryMetadata", path, wrappedErr)
+			return wrappedErr
 		}
 		if err := xattr.Remove(fullPath, key); err != nil {
 			// Ignore if the attribute doesn't exist
@@ -1485,6 +1526,100 @@ func (fs *cephmountfs) Unlock(ctx context.Context, ref *provider.Reference, lock
 	}
 	log.Debug().Str("path", path).Str("lockId", lock.LockId).Msg("cephmount: Unlock: lock removed")
 	return nil
+}
+
+// externalAccountQualifier returns the xattr qualifier for a lightweight or
+// federated grantee. Those accounts only exist inside reva, so they have no
+// /etc/passwd entry and must never be resolved as local users.
+func externalAccountQualifier(g *provider.Grantee) (string, bool) {
+	if g == nil || g.Type != provider.GranteeType_GRANTEE_TYPE_USER {
+		return "", false
+	}
+	id := g.GetUserId()
+	if id == nil {
+		return "", false
+	}
+	switch id.Type {
+	case userv1beta1.UserType_USER_TYPE_LIGHTWEIGHT, userv1beta1.UserType_USER_TYPE_FEDERATED:
+		return id.OpaqueId, true
+	default:
+		return "", false
+	}
+}
+
+// addExternalAccountGrant stores a grant to an external account as an xattr.
+// Unlike the setfacl path this is not recursive: the attribute is only read back
+// by reva, on the shared resource itself.
+func (fs *cephmountfs) addExternalAccountGrant(ctx context.Context, path, qualifier string, perms *provider.ResourcePermissions) error {
+	fullPath := filepath.Join(fs.chrootDir, path)
+	key := xattrLwShare + qualifier
+	value := fs.permissionsToACLString(perms)
+
+	if err := xattr.Set(fullPath, key, []byte(value)); err != nil {
+		return errors.Wrapf(err, "cephmount: failed to set xattr %s", key)
+	}
+
+	appctx.GetLogger(ctx).Debug().
+		Str("path", fullPath).
+		Str("xattr", key).
+		Str("permissions", value).
+		Msg("cephmount: stored grant for external account")
+
+	return nil
+}
+
+// removeExternalAccountGrant drops the xattr holding the grant.
+func (fs *cephmountfs) removeExternalAccountGrant(ctx context.Context, path, qualifier string) error {
+	fullPath := filepath.Join(fs.chrootDir, path)
+	key := xattrLwShare + qualifier
+
+	if err := xattr.Remove(fullPath, key); err != nil && !errors.Is(err, xattr.ENOATTR) {
+		return errors.Wrapf(err, "cephmount: failed to remove xattr %s", key)
+	}
+
+	appctx.GetLogger(ctx).Debug().
+		Str("path", fullPath).
+		Str("xattr", key).
+		Msg("cephmount: removed grant for external account")
+
+	return nil
+}
+
+// listExternalAccountGrants returns the grants stored in the xattrs of fullPath.
+// Reads are best-effort: unreadable attributes are skipped.
+func (fs *cephmountfs) listExternalAccountGrants(ctx context.Context, fullPath string) []*provider.Grant {
+	log := appctx.GetLogger(ctx)
+
+	names, err := xattr.List(fullPath)
+	if err != nil {
+		log.Debug().Err(err).Str("path", fullPath).Msg("cephmount: cannot list xattrs for external account grants")
+		return nil
+	}
+
+	var glist []*provider.Grant
+	for _, name := range names {
+		if !strings.HasPrefix(name, xattrLwShare) {
+			continue
+		}
+		buf, err := xattr.Get(fullPath, name)
+		if err != nil {
+			log.Debug().Err(err).Str("xattr", name).Msg("cephmount: skipping unreadable external account grant")
+			continue
+		}
+		glist = append(glist, &provider.Grant{
+			Grantee: &provider.Grantee{
+				Type: provider.GranteeType_GRANTEE_TYPE_USER,
+				Id: &provider.Grantee_UserId{UserId: &userv1beta1.UserId{
+					// Only the account name is stored, so the idp is left empty and
+					// federated accounts are reported as lightweight ones.
+					Type:     userv1beta1.UserType_USER_TYPE_LIGHTWEIGHT,
+					OpaqueId: strings.TrimPrefix(name, xattrLwShare),
+				}},
+			},
+			Permissions: fs.aclStringToPermissions(string(buf)),
+		})
+	}
+	return glist
 }
 
 // resolveGranteeIdentifier resolves a grantee (user or group) to their system identifier (UID or GID)

--- a/pkg/storage/fs/cephmount/cephmount.go
+++ b/pkg/storage/fs/cephmount/cephmount.go
@@ -433,14 +433,20 @@ func (fs *cephmountfs) fileAsResourceInfo(path string, info os.FileInfo, mdKeys 
 
 	owner, _ := user.LookupId(fmt.Sprint(stat.Uid))
 
+	externalPath := fs.fromChroot(path)
+
 	ri := &provider.ResourceInfo{
 		Type:     resourceType,
 		Id:       resourceId,
 		Checksum: &provider.ResourceChecksum{},
 		Size:     size,
 		Mtime:    &typepb.Timestamp{Seconds: uint64(info.ModTime().Unix())},
-		Path:     fs.fromChroot(path), // Convert chroot path back to external path
-		Owner:    &userv1beta1.UserId{OpaqueId: owner.Username},
+		Path:     externalPath,
+		// Clients list a received share by its name and etag, so both must be set
+		// even though the resource itself is addressed by path or id.
+		Name:  filepath.Base(externalPath),
+		Etag:  calcEtag(info, stat),
+		Owner: &userv1beta1.UserId{OpaqueId: owner.Username},
 		PermissionSet: &provider.ResourcePermissions{
 			GetPath:              true,
 			GetQuota:             true,
@@ -485,6 +491,14 @@ func (fs *cephmountfs) fileAsResourceInfo(path string, info os.FileInfo, mdKeys 
 	ri.ArbitraryMetadata.Metadata["device"] = strconv.FormatUint(uint64(stat.Dev), 10)
 
 	return ri, nil
+}
+
+// calcEtag derives an etag from the inode and the mtime, so it changes whenever
+// the resource is modified. Note that the mtime of a directory only changes when
+// its direct children do, so changes deeper in the tree do not propagate.
+func calcEtag(info os.FileInfo, stat *syscall.Stat_t) string {
+	mtime := info.ModTime()
+	return fmt.Sprintf("\"%d:%d.%d\"", stat.Ino, mtime.Unix(), mtime.Nanosecond())
 }
 
 // toChroot converts an external path to a chroot-relative path

--- a/pkg/storage/fs/cephmount/cephmount.go
+++ b/pkg/storage/fs/cephmount/cephmount.go
@@ -55,9 +55,12 @@ import (
 const (
 	xattrUserNs = "user."
 	xattrLock   = xattrUserNs + "reva.lockpayload"
-	// xattrLwShare + <account> holds the rwx permissions granted to an external
+	// xattrExtShare + <account> holds the rwx permissions granted to an external
 	// account, which has no local uid to put in a POSIX ACL.
-	xattrLwShare = xattrUserNs + "reva.lwshare."
+	xattrExtShare = xattrUserNs + "reva.extshare."
+	// xattrCephRctime is the recursive ctime ceph maintains on a directory: the
+	// most recent change anywhere in its subtree, propagated up by the MDS.
+	xattrCephRctime = "ceph.dir.rctime"
 	// recursive size in bytes of a directory subtree, maintained by the MDS
 	xattrCephRbytes = "ceph.dir.rbytes"
 )
@@ -100,7 +103,15 @@ func New(ctx context.Context, m map[string]any) (storage.FS, error) {
 		return nil, errors.New("cephmount: fstabentry must be provided")
 	}
 
+	// Zero means the whole mount is a single space. Negative means the provider
+	// counts its space roots above its own mount path, which is not a layout this
+	// driver can grant on.
+	if o.SpaceDepth < 0 {
+		return nil, errors.Errorf("cephmount: space_depth must not be negative, got %d", o.SpaceDepth)
+	}
+
 	log := appctx.GetLogger(ctx)
+
 	var discoveredCephVolumePath string
 	var discoveredLocalMountPoint string
 
@@ -200,6 +211,8 @@ func New(ctx context.Context, m map[string]any) (storage.FS, error) {
 		CleanupPeriod: 1 * time.Minute, // Check for expired threads every minute
 		NobodyUID:     o.NobodyUID,     // Use configured nobody UID
 		NobodyGID:     o.NobodyGID,     // Use configured nobody GID
+		ExternalUID:   o.ExternalAccountsUserUID,
+		ExternalGID:   o.ExternalAccountsUserGID,
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "cephmount: failed to initialize user thread pool")
@@ -380,7 +393,7 @@ func (fs *cephmountfs) readArbitraryMetadata(path string, mdKeys []string) map[s
 		if !strings.HasPrefix(name, xattrUserNs) {
 			continue
 		}
-		if strings.HasPrefix(name, xattrLwShare) {
+		if strings.HasPrefix(name, xattrExtShare) {
 			// Grants to external accounts are exposed through ListGrants, not as metadata.
 			continue
 		}
@@ -397,13 +410,20 @@ func (fs *cephmountfs) readArbitraryMetadata(path string, mdKeys []string) map[s
 	return md
 }
 
-// fileAsResourceInfo converts file info to ResourceInfo without user context
-func (fs *cephmountfs) fileAsResourceInfo(path string, info os.FileInfo, mdKeys []string) (*provider.ResourceInfo, error) {
+// fileAsResourceInfo converts file info to ResourceInfo
+func (fs *cephmountfs) fileAsResourceInfo(ctx context.Context, path string, info os.FileInfo, mdKeys []string) (*provider.ResourceInfo, error) {
 	var (
 		resourceType provider.ResourceType
 		target       string
 		size         uint64
 	)
+
+	// The absolute filesystem path, needed to read the link of a symlink and the
+	// extended attributes of a directory.
+	fullPath := fs.chrootDir
+	if path != "." {
+		fullPath = filepath.Join(fs.chrootDir, path)
+	}
 
 	// Determine resource type
 	if info.IsDir() {
@@ -412,14 +432,7 @@ func (fs *cephmountfs) fileAsResourceInfo(path string, info os.FileInfo, mdKeys 
 		size = fs.directorySize(path)
 	} else if info.Mode()&os.ModeSymlink != 0 {
 		resourceType = provider.ResourceType_RESOURCE_TYPE_SYMLINK
-		// For symlinks, we need to get the absolute filesystem path to read the link
-		var absPath string
-		if path == "." {
-			absPath = fs.chrootDir
-		} else {
-			absPath = filepath.Join(fs.chrootDir, path)
-		}
-		if linkTarget, err := os.Readlink(absPath); err == nil {
+		if linkTarget, err := os.Readlink(fullPath); err == nil {
 			target = linkTarget
 		}
 	} else {
@@ -439,17 +452,29 @@ func (fs *cephmountfs) fileAsResourceInfo(path string, info os.FileInfo, mdKeys 
 
 	externalPath := fs.fromChroot(path)
 
+	// The mtime of a directory only moves when its direct entries change, so the
+	// subtree is what a client should see as the time of last change. The later
+	// of the two wins: rctime propagates lazily and can lag a direct change.
+	mtime := uint64(info.ModTime().Unix())
+	var rctime string
+	if info.IsDir() {
+		rctime = fs.recursiveCtime(ctx, fullPath)
+		if sec, ok := rctimeSeconds(rctime); ok && sec > mtime {
+			mtime = sec
+		}
+	}
+
 	ri := &provider.ResourceInfo{
 		Type:     resourceType,
 		Id:       resourceId,
 		Checksum: &provider.ResourceChecksum{},
 		Size:     size,
-		Mtime:    &typepb.Timestamp{Seconds: uint64(info.ModTime().Unix())},
+		Mtime:    &typepb.Timestamp{Seconds: mtime},
 		Path:     externalPath,
 		// Clients list a received share by its name and etag, so both must be set
 		// even though the resource itself is addressed by path or id.
 		Name:  filepath.Base(externalPath),
-		Etag:  calcEtag(info, stat),
+		Etag:  calcEtag(info, stat, rctime),
 		Owner: &userv1beta1.UserId{OpaqueId: owner.Username},
 		PermissionSet: &provider.ResourcePermissions{
 			GetPath:              true,
@@ -476,6 +501,16 @@ func (fs *cephmountfs) fileAsResourceInfo(path string, info os.FileInfo, mdKeys 
 		ArbitraryMetadata: &provider.ArbitraryMetadata{Metadata: map[string]string{}},
 	}
 
+	// An external account only ever sees what it was granted, since the uid the
+	// operation runs under is a service account and says nothing about them.
+	if u, ok := externalUser(ctx); ok {
+		perms, found := fs.externalAccountGrant(u.Id.OpaqueId, path)
+		if !found {
+			perms = &provider.ResourcePermissions{}
+		}
+		ri.PermissionSet = perms
+	}
+
 	// Set target for symlinks
 	if target != "" {
 		ri.Target = target
@@ -498,11 +533,44 @@ func (fs *cephmountfs) fileAsResourceInfo(path string, info os.FileInfo, mdKeys 
 }
 
 // calcEtag derives an etag from the inode and the mtime, so it changes whenever
-// the resource is modified. Note that the mtime of a directory only changes when
-// its direct children do, so changes deeper in the tree do not propagate.
-func calcEtag(info os.FileInfo, stat *syscall.Stat_t) string {
+// the resource is modified. A directory also folds in the rctime of its subtree,
+// as an opaque token, so that deeper changes reach it too; without one the etag
+// reflects direct entries only.
+func calcEtag(info os.FileInfo, stat *syscall.Stat_t, rctime string) string {
 	mtime := info.ModTime()
-	return fmt.Sprintf("\"%d:%d.%d\"", stat.Ino, mtime.Unix(), mtime.Nanosecond())
+	etag := fmt.Sprintf("%d:%d.%d", stat.Ino, mtime.Unix(), mtime.Nanosecond())
+	if rctime != "" {
+		etag += ":" + rctime
+	}
+	return `"` + etag + `"`
+}
+
+// recursiveCtime returns the rctime of a directory, or an empty string when
+// there is none: a non-ceph mount, or local mode in tests. Read once per entry
+// of a listing, so a miss is logged at debug level to keep large listings quiet.
+func (fs *cephmountfs) recursiveCtime(ctx context.Context, fullPath string) string {
+	rctime, err := xattr.Get(fullPath, xattrCephRctime)
+	if err != nil {
+		appctx.GetLogger(ctx).Debug().Str("path", fullPath).Err(err).
+			Msg("cephmount: no recursive ctime, this directory will not reflect changes below its direct entries")
+		return ""
+	}
+	return string(rctime)
+}
+
+// rctimeSeconds pulls the whole seconds out of an rctime, which ceph reports as
+// <seconds>.<fraction>. The fraction is dropped: clients have formatted it
+// differently, and a CS3 timestamp only carries seconds here anyway.
+func rctimeSeconds(rctime string) (uint64, bool) {
+	if rctime == "" {
+		return 0, false
+	}
+	seconds, _, _ := strings.Cut(rctime, ".")
+	parsed, err := strconv.ParseUint(seconds, 10, 64)
+	if err != nil {
+		return 0, false
+	}
+	return parsed, true
 }
 
 // toChroot converts an external path to a chroot-relative path
@@ -554,6 +622,11 @@ func (fs *cephmountfs) CreateDir(ctx context.Context, ref *provider.Reference) e
 
 	fs.logOperationWithPaths(ctx, "CreateDir", receivedPath, path)
 
+	if err := fs.authorizeExternal(ctx, path, "CreateDir", canCreate); err != nil {
+		fs.logOperationError(ctx, "CreateDir", path, err)
+		return err
+	}
+
 	// Execute directory creation on user's thread with correct UID
 	err = fs.createDirectoryAsUser(ctx, path, os.FileMode(fs.conf.DirPerms))
 	if err != nil {
@@ -580,6 +653,11 @@ func (fs *cephmountfs) Delete(ctx context.Context, ref *provider.Reference) (err
 	}
 
 	fs.logOperationWithPaths(ctx, "Delete", receivedPath, path)
+
+	if err := fs.authorizeExternal(ctx, path, "Delete", canDelete); err != nil {
+		fs.logOperationError(ctx, "Delete", path, err)
+		return err
+	}
 
 	// Execute stat and delete operations on user's thread with correct UID
 	info, err := fs.statAsUser(ctx, path)
@@ -636,6 +714,15 @@ func (fs *cephmountfs) Move(ctx context.Context, oldRef, newRef *provider.Refere
 
 	fs.logOperationWithPaths(ctx, "Move", fmt.Sprintf("%s -> %s", oldReceivedPath, newReceivedPath), fmt.Sprintf("%s -> %s", oldPath, newPath))
 
+	// Both ends have to be covered by a grant: a share can be moved within itself,
+	// not out of one share and into another the account may not write to.
+	for _, p := range []string{oldPath, newPath} {
+		if err := fs.authorizeExternal(ctx, p, "Move", canMove); err != nil {
+			fs.logOperationError(ctx, "Move", p, err)
+			return err
+		}
+	}
+
 	// oldPath and newPath are already chroot-relative from resolveRef
 	// Create parent directory if needed and execute move on user's thread with correct UID
 	parentPath := path.Dir(newPath)
@@ -683,6 +770,11 @@ func (fs *cephmountfs) GetMD(ctx context.Context, ref *provider.Reference, mdKey
 
 	fs.logOperationWithPaths(ctx, "GetMD", receivedPath, path)
 
+	if err := fs.authorizeExternal(ctx, path, "GetMD", canStat); err != nil {
+		fs.logOperationError(ctx, "GetMD", path, err)
+		return nil, err
+	}
+
 	// path is already chroot-relative from resolveRef
 	// Execute stat operation on user's thread with correct UID
 	info, err := fs.statAsUser(ctx, path)
@@ -697,7 +789,7 @@ func (fs *cephmountfs) GetMD(ctx context.Context, ref *provider.Reference, mdKey
 		return nil, wrappedErr
 	}
 
-	ri, err = fs.fileAsResourceInfo(path, info, mdKeys)
+	ri, err = fs.fileAsResourceInfo(ctx, path, info, mdKeys)
 	if err != nil {
 		log.Debug().Any("resourceInfo", ri).Err(err).Msg("fileAsResourceInfo returned error")
 		wrappedErr := errors.Wrap(err, "cephmount: failed to convert file to resource info")
@@ -733,6 +825,11 @@ func (fs *cephmountfs) ListFolder(ctx context.Context, ref *provider.Reference, 
 	}
 
 	fs.logOperationWithPaths(ctx, "ListFolder", receivedPath, path)
+
+	if err := fs.authorizeExternal(ctx, path, "ListFolder", canList); err != nil {
+		fs.logOperationError(ctx, "ListFolder", path, err)
+		return nil, err
+	}
 
 	// INFO: About to call readDirectoryAsUser
 	log.Debug().
@@ -793,7 +890,7 @@ func (fs *cephmountfs) ListFolder(ctx context.Context, ref *provider.Reference, 
 			continue
 		}
 
-		ri, err := fs.fileAsResourceInfo(filepath.Join(path, entry.Name()), entry, mdKeys)
+		ri, err := fs.fileAsResourceInfo(ctx, filepath.Join(path, entry.Name()), entry, mdKeys)
 		if ri == nil || err != nil {
 			if err != nil {
 				log.Debug().
@@ -863,6 +960,11 @@ func (fs *cephmountfs) Download(ctx context.Context, ref *provider.Reference, ra
 
 	fs.logOperationWithPaths(ctx, "Download", receivedPath, path)
 
+	if err := fs.authorizeExternal(ctx, path, "Download", canDownload); err != nil {
+		fs.logOperationError(ctx, "Download", path, err)
+		return nil, err
+	}
+
 	// Execute file open on user's thread with correct UID
 	file, err := fs.openFileAsUser(ctx, path)
 	if err != nil {
@@ -892,6 +994,11 @@ func (fs *cephmountfs) Upload(ctx context.Context, ref *provider.Reference, r io
 	}
 
 	fs.logOperationWithPaths(ctx, "Upload", receivedPath, path)
+
+	if err := fs.authorizeExternal(ctx, path, "Upload", canUpload); err != nil {
+		fs.logOperationError(ctx, "Upload", path, err)
+		return err
+	}
 
 	// Create parent directory if needed and execute upload on user's thread with correct UID
 	parentDir := filepath.Dir(path)
@@ -923,6 +1030,11 @@ func (fs *cephmountfs) InitiateUpload(ctx context.Context, ref *provider.Referen
 	}
 
 	fs.logOperation(ctx, "InitiateUpload", fmt.Sprintf("%s (length: %d)", path, uploadLength))
+
+	if err := fs.authorizeExternal(ctx, path, "InitiateUpload", canUpload); err != nil {
+		fs.logOperationError(ctx, "InitiateUpload", path, err)
+		return nil, err
+	}
 
 	return map[string]string{
 		"simple": path,
@@ -958,6 +1070,11 @@ func (fs *cephmountfs) AddGrant(ctx context.Context, ref *provider.Reference, g 
 
 	fs.logOperation(ctx, "AddGrant", path)
 
+	if err := fs.authorizeExternal(ctx, path, "AddGrant", canAddGrant); err != nil {
+		fs.logOperationError(ctx, "AddGrant", path, err)
+		return err
+	}
+
 	// External accounts have no local uid, so they go to an xattr, not the ACL.
 	if qualifier, ok := externalAccountQualifier(g.Grantee); ok {
 		if err := fs.addExternalAccountGrant(ctx, path, qualifier, g.Permissions); err != nil {
@@ -988,6 +1105,11 @@ func (fs *cephmountfs) RemoveGrant(ctx context.Context, ref *provider.Reference,
 	}
 
 	fs.logOperation(ctx, "RemoveGrant", path)
+
+	if err := fs.authorizeExternal(ctx, path, "RemoveGrant", canRemoveGrant); err != nil {
+		fs.logOperationError(ctx, "RemoveGrant", path, err)
+		return err
+	}
 
 	if qualifier, ok := externalAccountQualifier(g.Grantee); ok {
 		if err := fs.removeExternalAccountGrant(ctx, path, qualifier); err != nil {
@@ -1033,19 +1155,32 @@ func (fs *cephmountfs) ListGrants(ctx context.Context, ref *provider.Reference) 
 
 	fs.logOperation(ctx, "ListGrants", path)
 
+	if err := fs.authorizeExternal(ctx, path, "ListGrants", canListGrants); err != nil {
+		fs.logOperationError(ctx, "ListGrants", path, err)
+		return nil, err
+	}
+
 	fullPath := filepath.Join(fs.chrootDir, path)
 
 	log := appctx.GetLogger(ctx)
 
 	// Grants to external accounts live in xattrs, not in the POSIX ACL.
-	glist = append(glist, fs.listExternalAccountGrants(ctx, fullPath)...)
+	external, err := fs.listExternalAccountGrants(ctx, fullPath)
+	if err != nil {
+		return nil, fs.grantsReadError(ctx, path, fullPath, err)
+	}
+	glist = append(glist, external...)
 
-	// Use getfacl to read ACLs
+	// Use getfacl to read ACLs. A resource without any extended ACL is not an
+	// error: getfacl succeeds and prints the base entries, which the loop below
+	// skips. Anything failing here is a genuine read failure, and reporting it as
+	// an empty grant list would be indistinguishable from an unshared resource.
 	cmd := exec.CommandContext(ctx, "getfacl", "--omit-header", "--numeric", fullPath)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		// No ACLs or error - return what we have so far
-		return glist, nil
+		// CombinedOutput folds in the stderr of getfacl, which says why.
+		return nil, fs.grantsReadError(ctx, path, fullPath,
+			errors.Wrapf(err, "cephmount: getfacl failed: %s", strings.TrimSpace(string(output))))
 	}
 
 	// Parse getfacl output
@@ -1154,6 +1289,11 @@ func (fs *cephmountfs) GetQuota(ctx context.Context, ref *provider.Reference) (t
 	}
 
 	fs.logOperationWithPaths(ctx, "GetQuota", receivedPath, path)
+
+	if err := fs.authorizeExternal(ctx, path, "GetQuota", canGetQuota); err != nil {
+		fs.logOperationError(ctx, "GetQuota", path, err)
+		return 0, 0, err
+	}
 
 	// build absolute path for xattr operations
 	fullPath := filepath.Join(fs.chrootDir, path)
@@ -1269,12 +1409,17 @@ func (fs *cephmountfs) SetArbitraryMetadata(ctx context.Context, ref *provider.R
 
 	fs.logOperation(ctx, "SetArbitraryMetadata", path)
 
+	if err := fs.authorizeExternal(ctx, path, "SetArbitraryMetadata", canUpload); err != nil {
+		fs.logOperationError(ctx, "SetArbitraryMetadata", path, err)
+		return err
+	}
+
 	fullPath := filepath.Join(fs.chrootDir, path)
 	for k, v := range md.Metadata {
 		if !strings.HasPrefix(k, xattrUserNs) {
 			k = xattrUserNs + k
 		}
-		if strings.HasPrefix(k, xattrLwShare) {
+		if strings.HasPrefix(k, xattrExtShare) {
 			// These hold grants to external accounts and are owned by AddGrant/RemoveGrant.
 			wrappedErr := errtypes.BadRequest(fmt.Sprintf("cephmount: key %s is reserved", k))
 			fs.logOperationError(ctx, "SetArbitraryMetadata", path, wrappedErr)
@@ -1300,12 +1445,17 @@ func (fs *cephmountfs) UnsetArbitraryMetadata(ctx context.Context, ref *provider
 
 	fs.logOperation(ctx, "UnsetArbitraryMetadata", path)
 
+	if err := fs.authorizeExternal(ctx, path, "UnsetArbitraryMetadata", canUpload); err != nil {
+		fs.logOperationError(ctx, "UnsetArbitraryMetadata", path, err)
+		return err
+	}
+
 	fullPath := filepath.Join(fs.chrootDir, path)
 	for _, key := range keys {
 		if !strings.HasPrefix(key, xattrUserNs) {
 			key = xattrUserNs + key
 		}
-		if strings.HasPrefix(key, xattrLwShare) {
+		if strings.HasPrefix(key, xattrExtShare) {
 			// These hold grants to external accounts and are owned by AddGrant/RemoveGrant.
 			wrappedErr := errtypes.BadRequest(fmt.Sprintf("cephmount: key %s is reserved", key))
 			fs.logOperationError(ctx, "UnsetArbitraryMetadata", path, wrappedErr)
@@ -1331,6 +1481,11 @@ func (fs *cephmountfs) TouchFile(ctx context.Context, ref *provider.Reference) e
 	}
 
 	fs.logOperation(ctx, "TouchFile", path)
+
+	if err := fs.authorizeExternal(ctx, path, "TouchFile", canUpload); err != nil {
+		fs.logOperationError(ctx, "TouchFile", path, err)
+		return err
+	}
 
 	// Create parent directory if needed using chrooted operations
 	parentDir := filepath.Dir(path)
@@ -1406,6 +1561,12 @@ func (fs *cephmountfs) SetLock(ctx context.Context, ref *provider.Reference, loc
 	}
 
 	fs.logOperation(ctx, "SetLock", path)
+
+	if err := fs.authorizeExternal(ctx, path, "SetLock", canUpload); err != nil {
+		fs.logOperationError(ctx, "SetLock", path, err)
+		return err
+	}
+
 	log := appctx.GetLogger(ctx)
 	log.Debug().Str("path", path).Str("lockId", lock.LockId).Str("appName", lock.AppName).
 		Int32("type", int32(lock.Type)).Msg("cephmount: SetLock: requested")
@@ -1451,6 +1612,12 @@ func (fs *cephmountfs) GetLock(ctx context.Context, ref *provider.Reference) (*p
 	}
 
 	fs.logOperation(ctx, "GetLock", path)
+
+	if err := fs.authorizeExternal(ctx, path, "GetLock", canStat); err != nil {
+		fs.logOperationError(ctx, "GetLock", path, err)
+		return nil, err
+	}
+
 	log := appctx.GetLogger(ctx)
 
 	// Try to read lock metadata
@@ -1473,15 +1640,12 @@ func (fs *cephmountfs) GetLock(ctx context.Context, ref *provider.Reference) (*p
 		return nil, errors.Wrap(err, "cephmount: malformed lock payload")
 	}
 
-	// Check if lock has expired
+	// Check if lock has expired. The stale xattr is left where it is: reading a
+	// lock must not write, and SetLock overwrites it without looking anyway.
 	ttl := time.Until(time.Unix(int64(lock.Expiration.Seconds), 0))
 	if ttl < 0 {
-		// the lock expired
 		log.Debug().Str("path", path).Str("lockId", lock.LockId).Str("appName", lock.AppName).
-			Dur("expired_ago", -ttl).Msg("cephmount: GetLock: lock expired, dropping and returning NotFound")
-		if err := fs.UnsetArbitraryMetadata(ctx, ref, []string{xattrLock}); err != nil {
-			return nil, err
-		}
+			Dur("expired_ago", -ttl).Msg("cephmount: GetLock: lock expired, returning NotFound")
 		return nil, errtypes.NotFound("lock not found for ref")
 	}
 
@@ -1520,6 +1684,12 @@ func (fs *cephmountfs) Unlock(ctx context.Context, ref *provider.Reference, lock
 	}
 
 	fs.logOperation(ctx, "Unlock", path)
+
+	if err := fs.authorizeExternal(ctx, path, "Unlock", canUpload); err != nil {
+		fs.logOperationError(ctx, "Unlock", path, err)
+		return err
+	}
+
 	log := appctx.GetLogger(ctx)
 	log.Debug().Str("path", path).Str("lockId", lock.LockId).Str("appName", lock.AppName).Msg("cephmount: Unlock: requested")
 
@@ -1570,98 +1740,15 @@ func (fs *cephmountfs) Unlock(ctx context.Context, ref *provider.Reference, lock
 	return nil
 }
 
-// externalAccountQualifier returns the xattr qualifier for a lightweight or
-// federated grantee. Those accounts only exist inside reva, so they have no
-// /etc/passwd entry and must never be resolved as local users.
-func externalAccountQualifier(g *provider.Grantee) (string, bool) {
-	if g == nil || g.Type != provider.GranteeType_GRANTEE_TYPE_USER {
-		return "", false
+// grantsReadError reports a failure to read the grants of a resource. A resource
+// that is gone is a NotFound rather than an internal error, which is what the
+// caller of ListGrants needs to tell the two apart.
+func (fs *cephmountfs) grantsReadError(ctx context.Context, path, fullPath string, err error) error {
+	if _, statErr := os.Stat(fullPath); os.IsNotExist(statErr) {
+		err = errtypes.NotFound(path)
 	}
-	id := g.GetUserId()
-	if id == nil {
-		return "", false
-	}
-	switch id.Type {
-	case userv1beta1.UserType_USER_TYPE_LIGHTWEIGHT, userv1beta1.UserType_USER_TYPE_FEDERATED:
-		return id.OpaqueId, true
-	default:
-		return "", false
-	}
-}
-
-// addExternalAccountGrant stores a grant to an external account as an xattr.
-// Unlike the setfacl path this is not recursive: the attribute is only read back
-// by reva, on the shared resource itself.
-func (fs *cephmountfs) addExternalAccountGrant(ctx context.Context, path, qualifier string, perms *provider.ResourcePermissions) error {
-	fullPath := filepath.Join(fs.chrootDir, path)
-	key := xattrLwShare + qualifier
-	value := fs.permissionsToACLString(perms)
-
-	if err := xattr.Set(fullPath, key, []byte(value)); err != nil {
-		return errors.Wrapf(err, "cephmount: failed to set xattr %s", key)
-	}
-
-	appctx.GetLogger(ctx).Debug().
-		Str("path", fullPath).
-		Str("xattr", key).
-		Str("permissions", value).
-		Msg("cephmount: stored grant for external account")
-
-	return nil
-}
-
-// removeExternalAccountGrant drops the xattr holding the grant.
-func (fs *cephmountfs) removeExternalAccountGrant(ctx context.Context, path, qualifier string) error {
-	fullPath := filepath.Join(fs.chrootDir, path)
-	key := xattrLwShare + qualifier
-
-	if err := xattr.Remove(fullPath, key); err != nil && !errors.Is(err, xattr.ENOATTR) {
-		return errors.Wrapf(err, "cephmount: failed to remove xattr %s", key)
-	}
-
-	appctx.GetLogger(ctx).Debug().
-		Str("path", fullPath).
-		Str("xattr", key).
-		Msg("cephmount: removed grant for external account")
-
-	return nil
-}
-
-// listExternalAccountGrants returns the grants stored in the xattrs of fullPath.
-// Reads are best-effort: unreadable attributes are skipped.
-func (fs *cephmountfs) listExternalAccountGrants(ctx context.Context, fullPath string) []*provider.Grant {
-	log := appctx.GetLogger(ctx)
-
-	names, err := xattr.List(fullPath)
-	if err != nil {
-		log.Debug().Err(err).Str("path", fullPath).Msg("cephmount: cannot list xattrs for external account grants")
-		return nil
-	}
-
-	var glist []*provider.Grant
-	for _, name := range names {
-		if !strings.HasPrefix(name, xattrLwShare) {
-			continue
-		}
-		buf, err := xattr.Get(fullPath, name)
-		if err != nil {
-			log.Debug().Err(err).Str("xattr", name).Msg("cephmount: skipping unreadable external account grant")
-			continue
-		}
-		glist = append(glist, &provider.Grant{
-			Grantee: &provider.Grantee{
-				Type: provider.GranteeType_GRANTEE_TYPE_USER,
-				Id: &provider.Grantee_UserId{UserId: &userv1beta1.UserId{
-					// Only the account name is stored, so the idp is left empty and
-					// federated accounts are reported as lightweight ones.
-					Type:     userv1beta1.UserType_USER_TYPE_LIGHTWEIGHT,
-					OpaqueId: strings.TrimPrefix(name, xattrLwShare),
-				}},
-			},
-			Permissions: fs.aclStringToPermissions(string(buf)),
-		})
-	}
-	return glist
+	fs.logOperationError(ctx, "ListGrants", path, err)
+	return err
 }
 
 // resolveGranteeIdentifier resolves a grantee (user or group) to their system identifier (UID or GID)

--- a/pkg/storage/fs/cephmount/external_account_grant_test.go
+++ b/pkg/storage/fs/cephmount/external_account_grant_test.go
@@ -25,6 +25,7 @@ import (
 
 	userv1beta1 "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+	"github.com/cs3org/reva/v3/pkg/errtypes"
 	"github.com/pkg/xattr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -129,7 +130,7 @@ func TestExternalAccountGrantRoundTrip(t *testing.T) {
 			// account has no entry in /etc/passwd to resolve.
 			require.NoError(t, fs.AddGrant(ctx, ref, grant))
 
-			value, err := xattr.Get(fullPath, xattrLwShare+"guest@example.org")
+			value, err := xattr.Get(fullPath, xattrExtShare+"guest@example.org")
 			require.NoError(t, err, "grant should be stored as an xattr")
 			assert.Equal(t, "r-x", string(value))
 
@@ -148,12 +149,12 @@ func TestExternalAccountGrantRoundTrip(t *testing.T) {
 			// UpdateGrant overwrites the stored permissions.
 			grant.Permissions.InitiateFileUpload = true
 			require.NoError(t, fs.UpdateGrant(ctx, ref, grant))
-			value, err = xattr.Get(fullPath, xattrLwShare+"guest@example.org")
+			value, err = xattr.Get(fullPath, xattrExtShare+"guest@example.org")
 			require.NoError(t, err)
 			assert.Equal(t, "rwx", string(value))
 
 			require.NoError(t, fs.RemoveGrant(ctx, ref, grant))
-			_, err = xattr.Get(fullPath, xattrLwShare+"guest@example.org")
+			_, err = xattr.Get(fullPath, xattrExtShare+"guest@example.org")
 			assert.ErrorIs(t, err, xattr.ENOATTR, "grant xattr should be gone")
 
 			glist, err = fs.ListGrants(ctx, ref)
@@ -176,6 +177,27 @@ func TestRemoveExternalAccountGrantIsIdempotent(t *testing.T) {
 	require.NoError(t, fs.RemoveGrant(ctx, &provider.Reference{Path: "/shared.txt"}, grant))
 }
 
+// A failure to read the grants must not be reported as a resource without any:
+// the caller cannot tell the two apart, and an empty list reads as "not shared".
+func TestListGrantsFailsInsteadOfReportingNoGrants(t *testing.T) {
+	fs := newGrantTestFS(t)
+	ctx := ContextWithTestLogger(t)
+	ref := &provider.Reference{Path: "/shared.txt"}
+
+	require.NoError(t, fs.AddGrant(ctx, ref, &provider.Grant{
+		Grantee:     externalGrantee("guest@example.org", userv1beta1.UserType_USER_TYPE_LIGHTWEIGHT),
+		Permissions: &provider.ResourcePermissions{Stat: true},
+	}))
+
+	// The resource disappears under the listing.
+	require.NoError(t, os.Remove(filepath.Join(fs.chrootDir, fs.toChroot("/shared.txt"))))
+
+	glist, err := fs.ListGrants(ctx, ref)
+	require.Error(t, err, "reading the grants of a resource that is gone must fail")
+	assert.Empty(t, glist)
+	assert.Implements(t, (*errtypes.IsNotFound)(nil), err, "a resource that is gone is a NotFound, not an internal error")
+}
+
 func TestExternalAccountGrantsAreNotArbitraryMetadata(t *testing.T) {
 	fs := newGrantTestFS(t)
 	ctx := ContextWithTestLogger(t)
@@ -192,19 +214,19 @@ func TestExternalAccountGrantsAreNotArbitraryMetadata(t *testing.T) {
 
 	md := fs.readArbitraryMetadata(chrootPath, nil)
 	assert.Equal(t, "blue", md["colour"])
-	assert.NotContains(t, md, "reva.lwshare.guest@example.org", "grants must not leak into arbitrary metadata")
+	assert.NotContains(t, md, "reva.extshare.guest@example.org", "grants must not leak into arbitrary metadata")
 
 	// The reserved keys cannot be written or cleared through the metadata API,
 	// which would otherwise silently revoke or forge a share.
 	err := fs.SetArbitraryMetadata(ctx, ref, &provider.ArbitraryMetadata{
-		Metadata: map[string]string{"reva.lwshare.guest@example.org": "rwx"},
+		Metadata: map[string]string{"reva.extshare.guest@example.org": "rwx"},
 	})
 	assert.Error(t, err)
 
-	err = fs.UnsetArbitraryMetadata(ctx, ref, []string{"reva.lwshare.guest@example.org"})
+	err = fs.UnsetArbitraryMetadata(ctx, ref, []string{"reva.extshare.guest@example.org"})
 	assert.Error(t, err)
 
-	value, err := xattr.Get(filepath.Join(fs.chrootDir, chrootPath), xattrLwShare+"guest@example.org")
+	value, err := xattr.Get(filepath.Join(fs.chrootDir, chrootPath), xattrExtShare+"guest@example.org")
 	require.NoError(t, err)
 	assert.Equal(t, "r--", string(value), "the stored grant must be untouched")
 }

--- a/pkg/storage/fs/cephmount/external_account_grant_test.go
+++ b/pkg/storage/fs/cephmount/external_account_grant_test.go
@@ -1,0 +1,210 @@
+// Copyright 2018-2026 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package cephmount
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	userv1beta1 "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
+	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+	"github.com/pkg/xattr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func externalGrantee(opaqueID string, t userv1beta1.UserType) *provider.Grantee {
+	return &provider.Grantee{
+		Type: provider.GranteeType_GRANTEE_TYPE_USER,
+		Id: &provider.Grantee_UserId{UserId: &userv1beta1.UserId{
+			Idp:      "external.example.org",
+			OpaqueId: opaqueID,
+			Type:     t,
+		}},
+	}
+}
+
+func TestExternalAccountQualifier(t *testing.T) {
+	tests := []struct {
+		name     string
+		grantee  *provider.Grantee
+		expected string
+		isExtern bool
+	}{
+		{
+			name:     "lightweight account",
+			grantee:  externalGrantee("guest@example.org", userv1beta1.UserType_USER_TYPE_LIGHTWEIGHT),
+			expected: "guest@example.org",
+			isExtern: true,
+		},
+		{
+			name:     "federated account",
+			grantee:  externalGrantee("remote@other.org", userv1beta1.UserType_USER_TYPE_FEDERATED),
+			expected: "remote@other.org",
+			isExtern: true,
+		},
+		{
+			name:    "primary account is resolved locally",
+			grantee: externalGrantee("alice", userv1beta1.UserType_USER_TYPE_PRIMARY),
+		},
+		{
+			name:    "unspecified type is resolved locally",
+			grantee: externalGrantee("alice", userv1beta1.UserType_USER_TYPE_INVALID),
+		},
+		{
+			name: "group grantee",
+			grantee: &provider.Grantee{
+				Type: provider.GranteeType_GRANTEE_TYPE_GROUP,
+			},
+		},
+		{
+			name:    "user grantee without id",
+			grantee: &provider.Grantee{Type: provider.GranteeType_GRANTEE_TYPE_USER},
+		},
+		{
+			name: "nil grantee",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			qualifier, ok := externalAccountQualifier(tt.grantee)
+			assert.Equal(t, tt.isExtern, ok)
+			assert.Equal(t, tt.expected, qualifier)
+		})
+	}
+}
+
+// newGrantTestFS returns a filesystem rooted at a temporary directory holding a
+// single file and directory, both reachable through their external paths.
+func newGrantTestFS(t *testing.T) *cephmountfs {
+	t.Helper()
+
+	tempDir, cleanup := GetTestDir(t, "external-account-grants")
+	t.Cleanup(cleanup)
+
+	require.NoError(t, os.WriteFile(filepath.Join(tempDir, "shared.txt"), []byte("content"), 0644))
+	require.NoError(t, os.Mkdir(filepath.Join(tempDir, "shared-dir"), 0755))
+
+	config := map[string]any{"testing_allow_local_mode": true}
+	return CreateCephMountFSForTesting(t, ContextWithTestLogger(t), config, "/volumes/_nogroup/test", tempDir)
+}
+
+func TestExternalAccountGrantRoundTrip(t *testing.T) {
+	for _, target := range []string{"/shared.txt", "/shared-dir"} {
+		t.Run(target, func(t *testing.T) {
+			fs := newGrantTestFS(t)
+			ctx := ContextWithTestLogger(t)
+			ref := &provider.Reference{Path: target}
+			fullPath := filepath.Join(fs.chrootDir, fs.toChroot(target))
+
+			grant := &provider.Grant{
+				Grantee: externalGrantee("guest@example.org", userv1beta1.UserType_USER_TYPE_LIGHTWEIGHT),
+				Permissions: &provider.ResourcePermissions{
+					Stat:                 true,
+					GetPath:              true,
+					InitiateFileDownload: true,
+					ListContainer:        true,
+				},
+			}
+
+			// The grant lands in an xattr, never in a POSIX ACL: a lightweight
+			// account has no entry in /etc/passwd to resolve.
+			require.NoError(t, fs.AddGrant(ctx, ref, grant))
+
+			value, err := xattr.Get(fullPath, xattrLwShare+"guest@example.org")
+			require.NoError(t, err, "grant should be stored as an xattr")
+			assert.Equal(t, "r-x", string(value))
+
+			glist, err := fs.ListGrants(ctx, ref)
+			require.NoError(t, err)
+			require.Len(t, glist, 1)
+			got := glist[0]
+			assert.Equal(t, provider.GranteeType_GRANTEE_TYPE_USER, got.Grantee.Type)
+			assert.Equal(t, "guest@example.org", got.Grantee.GetUserId().OpaqueId)
+			assert.Equal(t, userv1beta1.UserType_USER_TYPE_LIGHTWEIGHT, got.Grantee.GetUserId().Type)
+			assert.True(t, got.Permissions.Stat)
+			assert.True(t, got.Permissions.InitiateFileDownload)
+			assert.True(t, got.Permissions.ListContainer)
+			assert.False(t, got.Permissions.InitiateFileUpload)
+
+			// UpdateGrant overwrites the stored permissions.
+			grant.Permissions.InitiateFileUpload = true
+			require.NoError(t, fs.UpdateGrant(ctx, ref, grant))
+			value, err = xattr.Get(fullPath, xattrLwShare+"guest@example.org")
+			require.NoError(t, err)
+			assert.Equal(t, "rwx", string(value))
+
+			require.NoError(t, fs.RemoveGrant(ctx, ref, grant))
+			_, err = xattr.Get(fullPath, xattrLwShare+"guest@example.org")
+			assert.ErrorIs(t, err, xattr.ENOATTR, "grant xattr should be gone")
+
+			glist, err = fs.ListGrants(ctx, ref)
+			require.NoError(t, err)
+			assert.Empty(t, glist)
+		})
+	}
+}
+
+func TestRemoveExternalAccountGrantIsIdempotent(t *testing.T) {
+	fs := newGrantTestFS(t)
+	ctx := ContextWithTestLogger(t)
+
+	grant := &provider.Grant{
+		Grantee:     externalGrantee("guest@example.org", userv1beta1.UserType_USER_TYPE_FEDERATED),
+		Permissions: &provider.ResourcePermissions{},
+	}
+
+	// Removing a grant that was never added must not fail.
+	require.NoError(t, fs.RemoveGrant(ctx, &provider.Reference{Path: "/shared.txt"}, grant))
+}
+
+func TestExternalAccountGrantsAreNotArbitraryMetadata(t *testing.T) {
+	fs := newGrantTestFS(t)
+	ctx := ContextWithTestLogger(t)
+	ref := &provider.Reference{Path: "/shared.txt"}
+	chrootPath := fs.toChroot("/shared.txt")
+
+	require.NoError(t, fs.AddGrant(ctx, ref, &provider.Grant{
+		Grantee:     externalGrantee("guest@example.org", userv1beta1.UserType_USER_TYPE_LIGHTWEIGHT),
+		Permissions: &provider.ResourcePermissions{Stat: true},
+	}))
+	require.NoError(t, fs.SetArbitraryMetadata(ctx, ref, &provider.ArbitraryMetadata{
+		Metadata: map[string]string{"colour": "blue"},
+	}))
+
+	md := fs.readArbitraryMetadata(chrootPath, nil)
+	assert.Equal(t, "blue", md["colour"])
+	assert.NotContains(t, md, "reva.lwshare.guest@example.org", "grants must not leak into arbitrary metadata")
+
+	// The reserved keys cannot be written or cleared through the metadata API,
+	// which would otherwise silently revoke or forge a share.
+	err := fs.SetArbitraryMetadata(ctx, ref, &provider.ArbitraryMetadata{
+		Metadata: map[string]string{"reva.lwshare.guest@example.org": "rwx"},
+	})
+	assert.Error(t, err)
+
+	err = fs.UnsetArbitraryMetadata(ctx, ref, []string{"reva.lwshare.guest@example.org"})
+	assert.Error(t, err)
+
+	value, err := xattr.Get(filepath.Join(fs.chrootDir, chrootPath), xattrLwShare+"guest@example.org")
+	require.NoError(t, err)
+	assert.Equal(t, "r--", string(value), "the stored grant must be untouched")
+}

--- a/pkg/storage/fs/cephmount/external_accounts.go
+++ b/pkg/storage/fs/cephmount/external_accounts.go
@@ -1,0 +1,361 @@
+// Copyright 2018-2026 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package cephmount
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	userv1beta1 "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
+	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+	"github.com/cs3org/reva/v3/pkg/appctx"
+	"github.com/cs3org/reva/v3/pkg/errtypes"
+	"github.com/cs3org/reva/v3/pkg/utils"
+	"github.com/pkg/errors"
+	"github.com/pkg/xattr"
+)
+
+// External accounts are unknown to the system: they have no uid, so the kernel
+// cannot decide what they may do. Operations on their behalf run as the service
+// account configured in external_accounts_user_*. This file holds the grants
+// those accounts are given, stored in xattrs because there is no uid to put in
+// a POSIX ACL, and decides from them what the service account may do.
+
+// externalAccountQualifier returns the xattr qualifier for a lightweight or
+// federated grantee. Those accounts only exist inside reva and must never be
+// resolved as local users.
+func externalAccountQualifier(g *provider.Grantee) (string, bool) {
+	if g == nil || g.Type != provider.GranteeType_GRANTEE_TYPE_USER {
+		return "", false
+	}
+	id := g.GetUserId()
+	if id == nil {
+		return "", false
+	}
+	switch id.Type {
+	case userv1beta1.UserType_USER_TYPE_LIGHTWEIGHT, userv1beta1.UserType_USER_TYPE_FEDERATED:
+		return id.OpaqueId, true
+	default:
+		return "", false
+	}
+}
+
+// addExternalAccountGrant stores a grant to an external account as an xattr.
+// Unlike the setfacl path this is not recursive: the attribute is only read back
+// by reva, on the shared resource itself.
+func (fs *cephmountfs) addExternalAccountGrant(ctx context.Context, path, qualifier string, perms *provider.ResourcePermissions) error {
+	fullPath := filepath.Join(fs.chrootDir, path)
+	key := xattrExtShare + qualifier
+	value := fs.permissionsToACLString(perms)
+
+	if err := xattr.Set(fullPath, key, []byte(value)); err != nil {
+		return errors.Wrapf(err, "cephmount: failed to set xattr %s", key)
+	}
+
+	// The grant is only meaningful to reva. The service account acting for the
+	// sharee still needs the kernel to let it through.
+	if err := fs.ensureServiceAccountAccess(ctx, path, perms); err != nil {
+		return err
+	}
+
+	appctx.GetLogger(ctx).Debug().
+		Str("path", fullPath).
+		Str("xattr", key).
+		Str("permissions", value).
+		Msg("cephmount: stored grant for external account")
+
+	return nil
+}
+
+// removeExternalAccountGrant drops the xattr holding the grant.
+func (fs *cephmountfs) removeExternalAccountGrant(ctx context.Context, path, qualifier string) error {
+	fullPath := filepath.Join(fs.chrootDir, path)
+	key := xattrExtShare + qualifier
+
+	if err := xattr.Remove(fullPath, key); err != nil && !errors.Is(err, xattr.ENOATTR) {
+		return errors.Wrapf(err, "cephmount: failed to remove xattr %s", key)
+	}
+
+	// Once the last external account loses its grant, the service account has no
+	// reason to keep reaching the resource. Revoking it is recursive, so it may
+	// only happen when the remaining grants are known: a failed read here would
+	// otherwise cut off every other account sharing this tree.
+	remaining, err := fs.hasExternalAccountGrants(fullPath)
+	if err != nil {
+		return errors.Wrap(err, "cephmount: failed to check the remaining grants for external accounts")
+	}
+	if !remaining {
+		if err := fs.removeServiceAccountAccess(ctx, path); err != nil {
+			return err
+		}
+	}
+
+	appctx.GetLogger(ctx).Debug().
+		Str("path", fullPath).
+		Str("xattr", key).
+		Msg("cephmount: removed grant for external account")
+
+	return nil
+}
+
+// listExternalAccountGrants returns the grants stored in the xattrs of fullPath.
+// A resource without any is not an error, but a failure to read them is: an
+// empty list must never stand for grants that could not be read.
+func (fs *cephmountfs) listExternalAccountGrants(ctx context.Context, fullPath string) ([]*provider.Grant, error) {
+	log := appctx.GetLogger(ctx)
+
+	names, err := xattr.List(fullPath)
+	if err != nil {
+		return nil, errors.Wrapf(err, "cephmount: failed to list the xattrs of %s", fullPath)
+	}
+
+	var glist []*provider.Grant
+	for _, name := range names {
+		if !strings.HasPrefix(name, xattrExtShare) {
+			continue
+		}
+		buf, err := xattr.Get(fullPath, name)
+		if err != nil {
+			if errors.Is(err, xattr.ENOATTR) {
+				// The grant was removed between the listing and the read.
+				log.Debug().Str("xattr", name).Msg("cephmount: external account grant vanished while listing")
+				continue
+			}
+			return nil, errors.Wrapf(err, "cephmount: failed to read the xattr %s", name)
+		}
+		glist = append(glist, &provider.Grant{
+			Grantee: &provider.Grantee{
+				Type: provider.GranteeType_GRANTEE_TYPE_USER,
+				Id: &provider.Grantee_UserId{UserId: &userv1beta1.UserId{
+					// Only the account name is stored, so the idp is left empty and
+					// federated accounts are reported as lightweight ones.
+					Type:     userv1beta1.UserType_USER_TYPE_LIGHTWEIGHT,
+					OpaqueId: strings.TrimPrefix(name, xattrExtShare),
+				}},
+			},
+			Permissions: fs.aclStringToPermissions(string(buf)),
+		})
+	}
+	return glist, nil
+}
+
+// externalUser returns the user from ctx when it is an external account.
+func externalUser(ctx context.Context) (*userv1beta1.User, bool) {
+	u, ok := appctx.ContextGetUser(ctx)
+	if !ok || u.Id == nil {
+		return nil, false
+	}
+	if !utils.IsExternalUser(u) {
+		return nil, false
+	}
+	return u, true
+}
+
+// externalAccountGrant returns the permissions granted to account on a
+// chroot-relative path. The resource is checked first, then each ancestor up to
+// the chroot root, so a grant on a directory covers everything below it. The
+// xattrs are read with the driver's own privileges: the service account cannot
+// be trusted to read them, and may not even be able to.
+func (fs *cephmountfs) externalAccountGrant(account, chrootPath string) (*provider.ResourcePermissions, bool) {
+	key := xattrExtShare + account
+	for p := filepath.Clean(chrootPath); ; p = filepath.Dir(p) {
+		value, err := xattr.Get(filepath.Join(fs.chrootDir, p), key)
+		if err == nil {
+			return fs.aclStringToPermissions(string(value)), true
+		}
+		if p == "." || p == string(filepath.Separator) {
+			return nil, false
+		}
+	}
+}
+
+// authorizeExternal denies an operation when the user is an external account
+// that has no grant covering chrootPath, or a grant that does not allow it. For
+// every other user it does nothing: the operation runs under their own uid and
+// the kernel enforces access, as it always has.
+func (fs *cephmountfs) authorizeExternal(ctx context.Context, chrootPath, operation string, allowed func(*provider.ResourcePermissions) bool) error {
+	u, ok := externalUser(ctx)
+	if !ok {
+		return nil
+	}
+
+	log := appctx.GetLogger(ctx)
+	account := u.Id.OpaqueId
+
+	perms, found := fs.externalAccountGrant(account, chrootPath)
+	if !found {
+		log.Debug().Str("account", account).Str("path", chrootPath).Str("operation", operation).
+			Msg("cephmount: denying external account without a grant")
+		return errtypes.PermissionDenied(fmt.Sprintf("cephmount: %s is not shared with %s", chrootPath, account))
+	}
+	if !allowed(perms) {
+		log.Debug().Str("account", account).Str("path", chrootPath).Str("operation", operation).
+			Msg("cephmount: denying external account, grant does not allow the operation")
+		return errtypes.PermissionDenied(fmt.Sprintf("cephmount: %s not allowed on %s for %s", operation, chrootPath, account))
+	}
+	return nil
+}
+
+// The permissions an operation requires from the grant.
+func canStat(p *provider.ResourcePermissions) bool     { return p.Stat }
+func canGetPath(p *provider.ResourcePermissions) bool  { return p.GetPath }
+func canGetQuota(p *provider.ResourcePermissions) bool { return p.GetQuota }
+func canList(p *provider.ResourcePermissions) bool     { return p.ListContainer }
+func canDownload(p *provider.ResourcePermissions) bool { return p.InitiateFileDownload }
+func canUpload(p *provider.ResourcePermissions) bool   { return p.InitiateFileUpload }
+func canCreate(p *provider.ResourcePermissions) bool   { return p.CreateContainer }
+func canDelete(p *provider.ResourcePermissions) bool   { return p.Delete }
+func canMove(p *provider.ResourcePermissions) bool     { return p.Move }
+func canListGrants(p *provider.ResourcePermissions) bool {
+	return p.ListGrants
+}
+func canAddGrant(p *provider.ResourcePermissions) bool { return p.AddGrant }
+func canRemoveGrant(p *provider.ResourcePermissions) bool {
+	return p.RemoveGrant
+}
+func canListRevisions(p *provider.ResourcePermissions) bool {
+	return p.ListFileVersions
+}
+func canRestoreRevision(p *provider.ResourcePermissions) bool {
+	return p.RestoreFileVersion
+}
+
+// ensureServiceAccountAccess gives the external accounts service account the
+// POSIX access it needs to reach chrootPath for a sharee whose own uid does not
+// exist, and without which the kernel refuses before reva's check is reached:
+// the granted permissions on the shared resource, and rwx on the project root
+// above it. The rest is assumed provisioned — world-readable directories down
+// to the project roots, which are closed (other::--x) with named entries for
+// the accounts let in. This adds the service account's on the first external
+// share, as provisioning does for the others.
+func (fs *cephmountfs) ensureServiceAccountAccess(ctx context.Context, chrootPath string, perms *provider.ResourcePermissions) error {
+	fullPath := filepath.Join(fs.chrootDir, chrootPath)
+	info, err := os.Stat(fullPath)
+	if err != nil {
+		return errors.Wrap(err, "cephmount: failed to stat path")
+	}
+
+	// The service account needs at least read and search on the shared resource
+	// itself, whatever the sharee is allowed to do with it.
+	acl := fs.permissionsToACLString(perms)
+	if !strings.Contains(acl, "r") {
+		acl = "r" + acl[1:]
+	}
+	if info.IsDir() && !strings.Contains(acl, "x") {
+		acl = acl[:2] + "x"
+	}
+	if err := fs.setServiceACL(ctx, fullPath, acl, info.IsDir()); err != nil {
+		return err
+	}
+
+	if root, ok := fs.spaceRootFor(chrootPath); ok {
+		if err := fs.setServiceACL(ctx, filepath.Join(fs.chrootDir, root), "rwx", false); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// spaceRootFor returns the space (project) root a chroot-relative path lives
+// under: its first SpaceDepth components (c/<project> in the canonical layout).
+// The second return is false when the path is at or above space-root depth,
+// where there is no space root to grant on, and when the storage provider did
+// not tell us where spaces start: the chroot root is never a space root, and
+// granting the service account rwx on it would open the whole mount.
+func (fs *cephmountfs) spaceRootFor(chrootPath string) (string, bool) {
+	if fs.conf.SpaceDepth <= 0 {
+		return "", false
+	}
+	parts := strings.Split(filepath.Clean(chrootPath), string(filepath.Separator))
+	if len(parts) <= fs.conf.SpaceDepth {
+		return "", false
+	}
+	return filepath.Join(parts[:fs.conf.SpaceDepth]...), true
+}
+
+// removeServiceAccountAccess drops the service account's ACL from a resource
+// that is no longer shared with any external account. The search rights on the
+// ancestors are left in place: other shares below them may still need those, and
+// they grant nothing beyond traversal.
+func (fs *cephmountfs) removeServiceAccountAccess(ctx context.Context, chrootPath string) error {
+	fullPath := filepath.Join(fs.chrootDir, chrootPath)
+	info, err := os.Stat(fullPath)
+	if err != nil {
+		return errors.Wrap(err, "cephmount: failed to stat path")
+	}
+
+	entry := fmt.Sprintf("u:%d", fs.conf.ExternalAccountsUserUID)
+	args := []string{"-x", entry}
+	if info.IsDir() {
+		args = append(args, "-x", "d:"+entry, "-R")
+	}
+	args = append(args, fullPath)
+
+	return fs.runSetfacl(ctx, args, fullPath)
+}
+
+// hasExternalAccountGrants reports whether any external account still holds a
+// grant on the resource. The error must not be mistaken for a false: the caller
+// revokes access on it.
+func (fs *cephmountfs) hasExternalAccountGrants(fullPath string) (bool, error) {
+	names, err := xattr.List(fullPath)
+	if err != nil {
+		return false, errors.Wrap(err, "cephmount: failed to list xattrs")
+	}
+	for _, name := range names {
+		if strings.HasPrefix(name, xattrExtShare) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// setServiceACL grants the service account acl on fullPath. Directories also get
+// a default entry so that new children inherit it, and are applied recursively,
+// matching what the setfacl path does for regular grants.
+func (fs *cephmountfs) setServiceACL(ctx context.Context, fullPath, acl string, recursive bool) error {
+	entry := fmt.Sprintf("u:%d:%s", fs.conf.ExternalAccountsUserUID, acl)
+	args := []string{"-m", entry}
+	if recursive {
+		args = append(args, "-m", "d:"+entry, "-R")
+	}
+	args = append(args, fullPath)
+
+	return fs.runSetfacl(ctx, args, fullPath)
+}
+
+func (fs *cephmountfs) runSetfacl(ctx context.Context, args []string, fullPath string) error {
+	log := appctx.GetLogger(ctx)
+
+	cmd := exec.CommandContext(ctx, "setfacl", args...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		log.Error().Err(err).Str("path", fullPath).Strs("args", args).Str("output", string(output)).
+			Msg("cephmount: setfacl for the external accounts service user failed")
+		return errors.Wrapf(err, "cephmount: setfacl failed: %s", string(output))
+	}
+
+	log.Debug().Str("path", fullPath).Strs("args", args).
+		Msg("cephmount: updated the external accounts service user ACL")
+	return nil
+}

--- a/pkg/storage/fs/cephmount/external_accounts_test.go
+++ b/pkg/storage/fs/cephmount/external_accounts_test.go
@@ -1,0 +1,323 @@
+// Copyright 2018-2026 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package cephmount
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	userv1beta1 "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
+	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+	"github.com/cs3org/reva/v3/pkg/appctx"
+	"github.com/cs3org/reva/v3/pkg/errtypes"
+	"github.com/pkg/xattr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testExternalAccount = "guest@example.org"
+
+// newAuthTestFS builds a tree with a shared folder, a file inside it, and an
+// unshared file next to it.
+func newAuthTestFS(t *testing.T) (*cephmountfs, context.Context) {
+	t.Helper()
+
+	tempDir, cleanup := GetTestDir(t, "external-auth")
+	t.Cleanup(cleanup)
+
+	require.NoError(t, os.MkdirAll(filepath.Join(tempDir, "shared", "sub"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(tempDir, "shared", "sub", "deep.txt"), []byte("deep"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(tempDir, "private.txt"), []byte("private"), 0644))
+
+	ctx := ContextWithTestLogger(t)
+	fs := CreateCephMountFSForTesting(t, ctx, map[string]any{"testing_allow_local_mode": true}, "/volumes/_nogroup/test", tempDir)
+	return fs, ctx
+}
+
+// grantTo writes the grant xattr directly, bypassing AddGrant so the test does
+// not depend on setfacl being able to name the service account uid.
+func grantTo(t *testing.T, fs *cephmountfs, chrootPath, perms string) {
+	t.Helper()
+	require.NoError(t, xattr.Set(filepath.Join(fs.chrootDir, chrootPath), xattrExtShare+testExternalAccount, []byte(perms)))
+}
+
+func externalCtx(ctx context.Context) context.Context {
+	return appctx.ContextSetUser(ctx, &userv1beta1.User{
+		Id: &userv1beta1.UserId{
+			Idp:      "external.example.org",
+			OpaqueId: testExternalAccount,
+			Type:     userv1beta1.UserType_USER_TYPE_LIGHTWEIGHT,
+		},
+		Username: testExternalAccount,
+	})
+}
+
+func TestExternalAccountGrantAppliesToDescendants(t *testing.T) {
+	fs, _ := newAuthTestFS(t)
+	grantTo(t, fs, "shared", "r-x")
+
+	tests := []struct {
+		path    string
+		granted bool
+	}{
+		{path: "shared", granted: true},
+		{path: "shared/sub", granted: true},
+		{path: "shared/sub/deep.txt", granted: true},
+		{path: "private.txt", granted: false},
+		{path: ".", granted: false},
+		// A path that does not exist resolves against its nearest existing
+		// ancestor, which is what uploads of new files rely on.
+		{path: "shared/sub/new.txt", granted: true},
+		{path: "new-at-root.txt", granted: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			perms, found := fs.externalAccountGrant(testExternalAccount, tt.path)
+			assert.Equal(t, tt.granted, found)
+			if tt.granted {
+				assert.True(t, perms.Stat)
+				assert.True(t, perms.ListContainer)
+				assert.False(t, perms.InitiateFileUpload)
+			}
+		})
+	}
+}
+
+func TestAuthorizeExternalOnlyAppliesToExternalAccounts(t *testing.T) {
+	fs, ctx := newAuthTestFS(t)
+
+	// A regular user is never blocked here: their own uid is real and the kernel
+	// decides, exactly as before external accounts existed.
+	require.NoError(t, fs.authorizeExternal(ctx, "private.txt", "GetMD", canStat))
+	require.NoError(t, fs.authorizeExternal(appctx.ContextSetUser(ctx, GetCurrentTestUser(t)), "private.txt", "GetMD", canStat))
+
+	// An external account without any grant is refused.
+	err := fs.authorizeExternal(externalCtx(ctx), "private.txt", "GetMD", canStat)
+	require.Error(t, err)
+	assert.IsType(t, errtypes.PermissionDenied(""), err)
+}
+
+func TestAuthorizeExternalHonoursGrantedPermissions(t *testing.T) {
+	fs, ctx := newAuthTestFS(t)
+	ctx = externalCtx(ctx)
+	grantTo(t, fs, "shared", "r-x")
+
+	// Read-only grant: reads pass, writes do not.
+	require.NoError(t, fs.authorizeExternal(ctx, "shared/sub/deep.txt", "Download", canDownload))
+	require.NoError(t, fs.authorizeExternal(ctx, "shared", "ListFolder", canList))
+
+	for _, op := range []struct {
+		name    string
+		allowed func(*provider.ResourcePermissions) bool
+	}{
+		{"Upload", canUpload},
+		{"Delete", canDelete},
+		{"CreateDir", canCreate},
+		{"AddGrant", canAddGrant},
+	} {
+		t.Run(op.name, func(t *testing.T) {
+			err := fs.authorizeExternal(ctx, "shared/sub/deep.txt", op.name, op.allowed)
+			require.Error(t, err)
+			assert.IsType(t, errtypes.PermissionDenied(""), err)
+		})
+	}
+
+	// Widening the grant lets the writes through.
+	grantTo(t, fs, "shared", "rwx")
+	require.NoError(t, fs.authorizeExternal(ctx, "shared/sub/deep.txt", "Upload", canUpload))
+	require.NoError(t, fs.authorizeExternal(ctx, "shared/sub", "Delete", canDelete))
+}
+
+func TestExternalAccountOperationsAreDenied(t *testing.T) {
+	fs, ctx := newAuthTestFS(t)
+	ctx = externalCtx(ctx)
+	grantTo(t, fs, "shared", "r-x")
+
+	t.Run("unshared resource is invisible", func(t *testing.T) {
+		_, err := fs.GetMD(ctx, &provider.Reference{Path: "/private.txt"}, nil)
+		require.Error(t, err)
+		assert.IsType(t, errtypes.PermissionDenied(""), err)
+
+		_, err = fs.ListFolder(ctx, &provider.Reference{Path: "/"}, nil)
+		require.Error(t, err)
+		assert.IsType(t, errtypes.PermissionDenied(""), err)
+	})
+
+	t.Run("read-only grant refuses writes", func(t *testing.T) {
+		err := fs.Delete(ctx, &provider.Reference{Path: "/shared/sub/deep.txt"})
+		require.Error(t, err)
+		assert.IsType(t, errtypes.PermissionDenied(""), err)
+
+		err = fs.CreateDir(ctx, &provider.Reference{Path: "/shared/newdir"})
+		require.Error(t, err)
+		assert.IsType(t, errtypes.PermissionDenied(""), err)
+
+		err = fs.SetArbitraryMetadata(ctx, &provider.Reference{Path: "/shared"}, &provider.ArbitraryMetadata{
+			Metadata: map[string]string{"colour": "blue"},
+		})
+		require.Error(t, err)
+		assert.IsType(t, errtypes.PermissionDenied(""), err)
+	})
+
+	t.Run("shared resource reports the granted permissions", func(t *testing.T) {
+		ri, err := fs.GetMD(ctx, &provider.Reference{Path: "/shared/sub/deep.txt"}, nil)
+		require.NoError(t, err)
+		assert.Equal(t, "deep.txt", ri.Name)
+		assert.True(t, ri.PermissionSet.Stat)
+		assert.True(t, ri.PermissionSet.InitiateFileDownload)
+		assert.False(t, ri.PermissionSet.InitiateFileUpload, "a read-only sharee must not be offered write actions")
+		assert.False(t, ri.PermissionSet.Delete)
+	})
+}
+
+// aclEntries returns the access ACL of path as getfacl reports it, numeric ids.
+func aclEntries(t *testing.T, path string) string {
+	t.Helper()
+	out, err := exec.Command("getfacl", "--omit-header", "--numeric", path).CombinedOutput()
+	require.NoError(t, err, "getfacl failed: %s", out)
+	return string(out)
+}
+
+// TestServiceAccountGetsRwxOnSpaceRoot covers the canonical project layout:
+// world-readable directories down to the space root, the space root itself
+// closed (other::--x). Sharing a file inside must give the service account rwx
+// on the space root — that is the only directory reva touches.
+func TestServiceAccountGetsRwxOnSpaceRoot(t *testing.T) {
+	if _, err := exec.LookPath("setfacl"); err != nil {
+		t.Skip("setfacl not available")
+	}
+
+	tempDir, cleanup := GetTestDir(t, "space-root-acl")
+	t.Cleanup(cleanup)
+
+	// <chroot>/c/myproj/file.txt with myproj closed like a project root.
+	spaceRoot := filepath.Join(tempDir, "c", "myproj")
+	require.NoError(t, os.MkdirAll(spaceRoot, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(spaceRoot, "file.txt"), []byte("x"), 0644))
+	require.NoError(t, os.Chmod(spaceRoot, 0711))
+	t.Cleanup(func() { _ = os.Chmod(spaceRoot, 0755) })
+
+	ctx := ContextWithTestLogger(t)
+	// What the storage provider injects for this layout: roots at
+	// /winspaces/c/<project> are two levels below the chroot once /winspaces is
+	// trimmed off, so its space_depth of 3 arrives here as 2.
+	fs := CreateCephMountFSForTesting(t, ctx, map[string]any{
+		"testing_allow_local_mode": true,
+		"space_depth":              2,
+	}, "/volumes/_nogroup/test", tempDir)
+	uidEntry := fmt.Sprintf("user:%d:rwx", fs.conf.ExternalAccountsUserUID)
+
+	grant := &provider.Grant{
+		Grantee:     externalGrantee("guest@example.org", userv1beta1.UserType_USER_TYPE_LIGHTWEIGHT),
+		Permissions: &provider.ResourcePermissions{Stat: true, InitiateFileDownload: true},
+	}
+	require.NoError(t, fs.AddGrant(ctx, &provider.Reference{Path: "/c/myproj/file.txt"}, grant))
+
+	assert.Contains(t, aclEntries(t, spaceRoot), uidEntry,
+		"the space root must carry the service account entry")
+	assert.NotContains(t, aclEntries(t, filepath.Join(tempDir, "c")), "user:"+fmt.Sprint(fs.conf.ExternalAccountsUserUID),
+		"world-readable directories must not be touched")
+
+	// Removing the last grant clears the file's entry but leaves the space root:
+	// other shares in the same project may still rely on it.
+	require.NoError(t, fs.RemoveGrant(ctx, &provider.Reference{Path: "/c/myproj/file.txt"}, grant))
+	assert.NotContains(t, aclEntries(t, filepath.Join(spaceRoot, "file.txt")), fmt.Sprint(fs.conf.ExternalAccountsUserUID))
+	assert.Contains(t, aclEntries(t, spaceRoot), uidEntry)
+}
+
+func TestSpaceRootFor(t *testing.T) {
+	tempDir, cleanup := GetTestDir(t, "space-root-for")
+	t.Cleanup(cleanup)
+	ctx := ContextWithTestLogger(t)
+
+	// The canonical layout: roots at /winspaces/c/<project>, which a provider
+	// mounted at /winspaces declares as space_depth 3 and injects here as 2.
+	fs := CreateCephMountFSForTesting(t, ctx, map[string]any{
+		"testing_allow_local_mode": true,
+		"space_depth":              2,
+	}, "/volumes/_nogroup/test", tempDir)
+
+	tests := []struct {
+		path string
+		root string
+		ok   bool
+	}{
+		{path: "c/myproj/file.txt", root: "c/myproj", ok: true},
+		{path: "c/myproj/sub/deep.txt", root: "c/myproj", ok: true},
+		{path: "c/myproj", ok: false}, // the space root itself gets its ACL as the shared resource
+		{path: "c", ok: false},
+		{path: ".", ok: false},
+	}
+	for _, tt := range tests {
+		root, ok := fs.spaceRootFor(tt.path)
+		assert.Equal(t, tt.ok, ok, tt.path)
+		assert.Equal(t, tt.root, root, tt.path)
+	}
+}
+
+// Without a space depth the chroot root must not be mistaken for a space root:
+// the service account would be granted rwx on the whole mount.
+func TestSpaceRootForWithoutSpaceDepth(t *testing.T) {
+	tempDir, cleanup := GetTestDir(t, "space-root-no-depth")
+	t.Cleanup(cleanup)
+	ctx := ContextWithTestLogger(t)
+	fs := CreateCephMountFSForTesting(t, ctx, map[string]any{"testing_allow_local_mode": true}, "/volumes/_nogroup/test", tempDir)
+
+	require.Zero(t, fs.conf.SpaceDepth, "space_depth must not be defaulted by the driver")
+	for _, p := range []string{"c/myproj/file.txt", "c/myproj", "c", "."} {
+		root, ok := fs.spaceRootFor(p)
+		assert.False(t, ok, p)
+		assert.Empty(t, root, p)
+	}
+}
+
+// A space root above the driver's own chroot is not a layout it can grant on.
+func TestNegativeSpaceDepthIsRejected(t *testing.T) {
+	tempDir, cleanup := GetTestDir(t, "space-depth-negative")
+	t.Cleanup(cleanup)
+	ctx := ContextWithTestLogger(t)
+
+	t.Setenv("CEPHMOUNT_TEST_CHROOT_DIR", tempDir)
+	_, err := New(ctx, map[string]any{
+		"testing_allow_local_mode": true,
+		"space_depth":              -1,
+	})
+	require.Error(t, err, "a negative space_depth must not be accepted")
+}
+
+func TestExternalAccountMapsToServiceUID(t *testing.T) {
+	fs, _ := newAuthTestFS(t)
+
+	uid, gid := fs.threadPool.mapUserToUIDGID(&userv1beta1.User{
+		Id: &userv1beta1.UserId{
+			OpaqueId: testExternalAccount,
+			Type:     userv1beta1.UserType_USER_TYPE_LIGHTWEIGHT,
+		},
+		Username: testExternalAccount,
+	})
+
+	assert.Equal(t, fs.conf.ExternalAccountsUserUID, uid, "external accounts must act as the service account")
+	assert.Equal(t, fs.conf.ExternalAccountsUserGID, gid)
+	assert.NotEqual(t, 1000, uid, "external accounts must not fall through to the default uid")
+}

--- a/pkg/storage/fs/cephmount/options.go
+++ b/pkg/storage/fs/cephmount/options.go
@@ -29,6 +29,25 @@ type Options struct {
 	NobodyUID int `mapstructure:"nobody_uid"`
 	NobodyGID int `mapstructure:"nobody_gid"`
 
+	// External (lightweight, federated, guest) accounts have no uid of their own,
+	// so operations on their behalf run as this local service account instead.
+	// What they are allowed to do is decided by reva from the stored grants, not
+	// by the permissions of this account.
+	ExternalAccountsUserName string `mapstructure:"external_accounts_user_name"`
+	ExternalAccountsUserUID  int    `mapstructure:"external_accounts_user_uid"`
+	ExternalAccountsUserGID  int    `mapstructure:"external_accounts_user_gid"`
+
+	// SpaceDepth defines how many levels below the chroot the space (project)
+	// roots sit: with roots at /winspaces/c/<project>, served by a provider
+	// mounted at /winspaces, it is 2. The service account is granted rwx on the
+	// space root when something inside it is shared with an external account.
+	//
+	// It is injected by the storage provider, which rebases its own space_depth
+	// on the paths it hands to the driver: its mount path is trimmed off first,
+	// so the number here is smaller than the one in its configuration. It should
+	// not be set in the driver configuration.
+	SpaceDepth int `mapstructure:"space_depth"`
+
 	// Simplified Ceph configuration - just paste the fstab entry
 	FstabEntry string `mapstructure:"fstabentry"` // Complete fstab line for Ceph mount
 	RootDir    string `mapstructure:"root_dir"`   // Root directory for the Ceph mount
@@ -53,6 +72,17 @@ func (c *Options) ApplyDefaults() {
 	if c.NobodyGID == 0 {
 		c.NobodyGID = 65534
 	}
+
+	// Same service account the eos driver uses for external accounts.
+	if c.ExternalAccountsUserName == "" || c.ExternalAccountsUserUID == 0 || c.ExternalAccountsUserGID == 0 {
+		c.ExternalAccountsUserName = "cboxexternal"
+		c.ExternalAccountsUserUID = 193339
+		c.ExternalAccountsUserGID = 2766
+	}
+
+	// SpaceDepth is deliberately left alone: it comes from the storage provider,
+	// and guessing a layout here would place the service account ACL on the wrong
+	// directory. New rejects a negative depth.
 
 	// No Ceph defaults needed - everything is extracted from the fstab entry
 	// Chroot directory defaults will be set from fstab parsing (local mount point)

--- a/pkg/storage/fs/cephmount/pathbyid_ceph.go
+++ b/pkg/storage/fs/cephmount/pathbyid_ceph.go
@@ -226,6 +226,13 @@ func (fs *cephmountfs) GetPathByID(ctx context.Context, id *provider.ResourceId)
 		return "", err
 	}
 
+	// An external account may only learn the path of something shared with it,
+	// otherwise any inode could be turned into a path by guessing.
+	if err := fs.authorizeExternal(ctx, fs.toChroot(userRelativePath), "GetPathByID", canGetPath); err != nil {
+		fs.logOperationError(ctx, "GetPathByID", userRelativePath, err)
+		return "", err
+	}
+
 	log.Info().
 		Str("ceph_volume_path", cephVolumePath).
 		Str("user_relative_path", userRelativePath).

--- a/pkg/storage/fs/cephmount/resourceinfo_test.go
+++ b/pkg/storage/fs/cephmount/resourceinfo_test.go
@@ -21,6 +21,7 @@ package cephmount
 import (
 	"os"
 	"path/filepath"
+	"syscall"
 	"testing"
 	"time"
 
@@ -86,4 +87,73 @@ func TestEtagChangesWhenFileIsModified(t *testing.T) {
 	after, err := fs.GetMD(ctx, ref, nil)
 	require.NoError(t, err)
 	assert.NotEqual(t, before.Etag, after.Etag, "etag must change when the file is modified")
+}
+
+// Without a ceph mount there is no rctime, and the etag still has to be valid,
+// stable, and move when a direct entry changes.
+func TestDirectoryEtagWithoutRecursiveCtime(t *testing.T) {
+	tempDir, cleanup := GetTestDir(t, "etag-directory")
+	t.Cleanup(cleanup)
+
+	dir := filepath.Join(tempDir, "folder")
+	require.NoError(t, os.MkdirAll(dir, 0755))
+
+	ctx := ContextWithTestLogger(t)
+	fs := CreateCephMountFSForTesting(t, ctx, map[string]any{"testing_allow_local_mode": true}, "/volumes/_nogroup/test", tempDir)
+	ref := &provider.Reference{Path: "/folder"}
+
+	before, err := fs.GetMD(ctx, ref, nil)
+	require.NoError(t, err)
+	assert.Equal(t, `"`, string(before.Etag[0]), "etag should be quoted")
+
+	again, err := fs.GetMD(ctx, ref, nil)
+	require.NoError(t, err)
+	assert.Equal(t, before.Etag, again.Etag, "etag must be stable while the directory is untouched")
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "child.txt"), []byte("x"), 0644))
+	require.NoError(t, os.Chtimes(dir, time.Now().Add(time.Second), time.Now().Add(time.Second)))
+
+	after, err := fs.GetMD(ctx, ref, nil)
+	require.NoError(t, err)
+	assert.NotEqual(t, before.Etag, after.Etag, "etag must change when a direct child changes")
+}
+
+// A change below a directory reaches its etag, which is what makes a sync
+// client descend into it.
+func TestCalcEtagIncludesRecursiveCtime(t *testing.T) {
+	tempDir, cleanup := GetTestDir(t, "etag-rctime")
+	t.Cleanup(cleanup)
+
+	info, err := os.Stat(tempDir)
+	require.NoError(t, err)
+	stat := info.Sys().(*syscall.Stat_t)
+
+	without := calcEtag(info, stat, "")
+	with := calcEtag(info, stat, "1690000000.000000000")
+	later := calcEtag(info, stat, "1690000001.000000000")
+
+	assert.Equal(t, `"`, string(with[0]), "etag should be quoted")
+	assert.NotEqual(t, without, with, "a subtree change must change the etag")
+	assert.NotEqual(t, with, later, "a later subtree change must change the etag again")
+	assert.Equal(t, without, calcEtag(info, stat, ""), "the fallback must be stable")
+}
+
+func TestRctimeSeconds(t *testing.T) {
+	tests := []struct {
+		rctime  string
+		seconds uint64
+		ok      bool
+	}{
+		{rctime: "1690000000.000000000", seconds: 1690000000, ok: true},
+		{rctime: "1690000000.09123456789", seconds: 1690000000, ok: true},
+		{rctime: "1690000000", seconds: 1690000000, ok: true},
+		{rctime: "", ok: false},
+		{rctime: "not-a-time", ok: false},
+	}
+
+	for _, tt := range tests {
+		seconds, ok := rctimeSeconds(tt.rctime)
+		assert.Equal(t, tt.ok, ok, tt.rctime)
+		assert.Equal(t, tt.seconds, seconds, tt.rctime)
+	}
 }

--- a/pkg/storage/fs/cephmount/resourceinfo_test.go
+++ b/pkg/storage/fs/cephmount/resourceinfo_test.go
@@ -1,0 +1,89 @@
+// Copyright 2018-2026 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package cephmount
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestResourceInfoNameAndEtag covers the fields clients need to render a shared
+// resource: without them a received share shows up unnamed in the web UI.
+func TestResourceInfoNameAndEtag(t *testing.T) {
+	tempDir, cleanup := GetTestDir(t, "resourceinfo")
+	t.Cleanup(cleanup)
+
+	require.NoError(t, os.MkdirAll(filepath.Join(tempDir, "folder"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(tempDir, "folder", "report.pdf"), []byte("data"), 0644))
+
+	ctx := ContextWithTestLogger(t)
+	fs := CreateCephMountFSForTesting(t, ctx, map[string]any{"testing_allow_local_mode": true}, "/volumes/_nogroup/test", tempDir)
+
+	tests := []struct {
+		path         string
+		expectedName string
+	}{
+		{path: "/folder/report.pdf", expectedName: "report.pdf"},
+		{path: "/folder", expectedName: "folder"},
+		{path: "/", expectedName: "/"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			ri, err := fs.GetMD(ctx, &provider.Reference{Path: tt.path}, nil)
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.expectedName, ri.Name)
+			assert.NotEmpty(t, ri.Etag)
+			assert.Equal(t, `"`, string(ri.Etag[0]), "etag should be quoted")
+		})
+	}
+}
+
+func TestEtagChangesWhenFileIsModified(t *testing.T) {
+	tempDir, cleanup := GetTestDir(t, "etag-changes")
+	t.Cleanup(cleanup)
+
+	filePath := filepath.Join(tempDir, "file.txt")
+	require.NoError(t, os.WriteFile(filePath, []byte("before"), 0644))
+
+	ctx := ContextWithTestLogger(t)
+	fs := CreateCephMountFSForTesting(t, ctx, map[string]any{"testing_allow_local_mode": true}, "/volumes/_nogroup/test", tempDir)
+	ref := &provider.Reference{Path: "/file.txt"}
+
+	before, err := fs.GetMD(ctx, ref, nil)
+	require.NoError(t, err)
+
+	// Two stats of an unmodified file must agree, otherwise clients re-download.
+	again, err := fs.GetMD(ctx, ref, nil)
+	require.NoError(t, err)
+	assert.Equal(t, before.Etag, again.Etag, "etag must be stable while the file is untouched")
+
+	require.NoError(t, os.Chtimes(filePath, time.Now().Add(time.Second), time.Now().Add(time.Second)))
+
+	after, err := fs.GetMD(ctx, ref, nil)
+	require.NoError(t, err)
+	assert.NotEqual(t, before.Etag, after.Etag, "etag must change when the file is modified")
+}

--- a/pkg/storage/fs/cephmount/user_thread_pool.go
+++ b/pkg/storage/fs/cephmount/user_thread_pool.go
@@ -34,6 +34,7 @@ import (
 
 	userv1beta1 "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	"github.com/cs3org/reva/v3/pkg/appctx"
+	"github.com/cs3org/reva/v3/pkg/utils"
 )
 
 // PrivilegeVerificationResult contains the results of privilege verification
@@ -215,6 +216,8 @@ type UserThreadPool struct {
 	cleanupTimer *time.Timer
 	nobodyUID    int // UID for nobody user (fallback)
 	nobodyGID    int // GID for nobody group (fallback)
+	externalUID  int // UID of the service account used for external accounts
+	externalGID  int // GID of the service account used for external accounts
 }
 
 // UserThread represents a dedicated thread for a user with persistent UID
@@ -251,6 +254,8 @@ type UserThreadPoolConfig struct {
 	CleanupPeriod time.Duration // How often to check for expired threads
 	NobodyUID     int           // UID for nobody user (fallback)
 	NobodyGID     int           // GID for nobody group (fallback)
+	ExternalUID   int           // UID of the service account used for external accounts
+	ExternalGID   int           // GID of the service account used for external accounts
 }
 
 // NewUserThreadPool creates a new thread pool for managing per-user threads
@@ -272,10 +277,12 @@ func NewUserThreadPool(config UserThreadPoolConfig) (*UserThreadPool, *Privilege
 	privResult := VerifyPrivileges(config.NobodyUID, config.NobodyGID)
 
 	pool := &UserThreadPool{
-		threads:   make(map[int]*UserThread),
-		threadTTL: config.ThreadTTL,
-		nobodyUID: config.NobodyUID,
-		nobodyGID: config.NobodyGID,
+		threads:     make(map[int]*UserThread),
+		threadTTL:   config.ThreadTTL,
+		nobodyUID:   config.NobodyUID,
+		nobodyGID:   config.NobodyGID,
+		externalUID: config.ExternalUID,
+		externalGID: config.ExternalGID,
 	}
 
 	// Start cleanup routine
@@ -336,6 +343,13 @@ func (p *UserThreadPool) mapUserToUIDGID(user *userv1beta1.User) (int, int) {
 	// Handle nobody user specially
 	if user.Id != nil && user.Id.OpaqueId == "nobody" {
 		return p.nobodyUID, p.nobodyGID
+	}
+
+	// External accounts are unknown to the system and have no uid of their own,
+	// so they act through the dedicated service account. Their access is decided
+	// by the caller from the stored grants, not by this uid.
+	if user.Id != nil && utils.IsExternalUser(user) {
+		return p.externalUID, p.externalGID
 	}
 
 	// Handle root user specially - check by username for explicit root


### PR DESCRIPTION
Adds missing functionality for shares to external accounts on ceph

* Grants to external accounts are now stored in a `user.reva.lwshare.<account>` xattr and are read back by ListGrants. 
* Operations on their behalf run as the service account configured with `external_accounts_user_name`/`_uid`/`_gid`, `cboxexternal` by default, the same account the EOS driver uses.
* What they are allowed to do is decided by Reva from the stored grant rather than by the permissions of that account.

* The ResourceInfo of a shared resource now also carries a name and an recursive etag instead of mtime, meaning that it will show changes in the subtree at the top level as well.