### PR TITLE
Return fileid and etag in MKCOL response

### DIFF
--- a/changelog/unreleased/mkcol-fileid-etag.md
+++ b/changelog/unreleased/mkcol-fileid-etag.md
@@ -3,4 +3,10 @@ Enhancement: return fileid and etag in MKCOL response
 A successful MKCOL now returns the OC-FileId and OC-ETag headers of the
 newly created collection, so clients do not need a follow-up PROPFIND.
 
+The storage.FS CreateDir method was changed to return the created
+directory's ResourceInfo, which the storage provider passes along in the
+CreateContainerResponse opaque. This way no extra stat call through the
+gateway is needed to obtain the fileid and etag.
+
+https://github.com/cs3org/reva/pull/5748
 https://github.com/cs3org/reva/issues/4769

--- a/changelog/unreleased/mkcol-fileid-etag.md
+++ b/changelog/unreleased/mkcol-fileid-etag.md
@@ -1,0 +1,6 @@
+Enhancement: return fileid and etag in MKCOL response
+
+A successful MKCOL now returns the OC-FileId and OC-ETag headers of the
+newly created collection, so clients do not need a follow-up PROPFIND.
+
+https://github.com/cs3org/reva/issues/4769

--- a/internal/grpc/services/publicstorageprovider/publicstorageprovider.go
+++ b/internal/grpc/services/publicstorageprovider/publicstorageprovider.go
@@ -388,20 +388,30 @@ func (s *service) CreateContainer(ctx context.Context, req *provider.CreateConta
 		return res, nil
 	}
 
-	// the fileid in the opaque points at the real resource,
-	// translate it to the public namespace like Stat does
-	if res.Opaque != nil {
-		if e, ok := res.Opaque.Map["fileid"]; ok {
-			if id, ok := spaces.ParseResourceID(string(e.Value)); ok {
-				s.setPublicStorageID(&provider.ResourceInfo{Id: id}, tkn)
-				e.Value = []byte(spaces.EncodeToStringifiedResourceID(id))
-			} else {
-				delete(res.Opaque.Map, "fileid")
-			}
-		}
-	}
+	s.translateOpaqueFileID(res.Opaque, tkn)
 
 	return res, nil
+}
+
+// the fileid a storage reports points at the real resource, so rewrite it into
+// the public namespace the same way Stat does
+func (s *service) translateOpaqueFileID(o *typesv1beta1.Opaque, shareToken string) {
+	if o == nil {
+		return
+	}
+	e, ok := o.Map["fileid"]
+	if !ok {
+		return
+	}
+	id, ok := spaces.ParseResourceID(string(e.Value))
+	if !ok {
+		// an id we cannot read is worse than no id, the etag next to it is still good
+		delete(o.Map, "fileid")
+		return
+	}
+	// setPublicStorageID writes through the id we pass in
+	s.setPublicStorageID(&provider.ResourceInfo{Id: id}, shareToken)
+	e.Value = []byte(spaces.EncodeToStringifiedResourceID(id))
 }
 
 func (s *service) TouchFile(ctx context.Context, req *provider.TouchFileRequest) (*provider.TouchFileResponse, error) {

--- a/internal/grpc/services/publicstorageprovider/publicstorageprovider.go
+++ b/internal/grpc/services/publicstorageprovider/publicstorageprovider.go
@@ -34,6 +34,7 @@ import (
 	"github.com/cs3org/reva/v3/pkg/rgrpc/status"
 	revaservice "github.com/cs3org/reva/v3/pkg/service"
 	"github.com/cs3org/reva/v3/pkg/sharedconf"
+	"github.com/cs3org/reva/v3/pkg/spaces"
 	"github.com/cs3org/reva/v3/pkg/utils"
 	"github.com/cs3org/reva/v3/pkg/utils/cfg"
 	"github.com/pkg/errors"
@@ -352,7 +353,7 @@ func (s *service) DeleteStorageSpace(ctx context.Context, req *provider.DeleteSt
 }
 
 func (s *service) CreateContainer(ctx context.Context, req *provider.CreateContainerRequest) (*provider.CreateContainerResponse, error) {
-	cs3Ref, _, ls, st, err := s.translatePublicRefToCS3Ref(ctx, req.Ref)
+	cs3Ref, tkn, ls, st, err := s.translatePublicRefToCS3Ref(ctx, req.Ref)
 	switch {
 	case err != nil:
 		return nil, err
@@ -385,6 +386,19 @@ func (s *service) CreateContainer(ctx context.Context, req *provider.CreateConta
 	}
 	if res.Status.Code == rpc.Code_CODE_INTERNAL {
 		return res, nil
+	}
+
+	// the fileid in the opaque points at the real resource,
+	// translate it to the public namespace like Stat does
+	if res.Opaque != nil {
+		if e, ok := res.Opaque.Map["fileid"]; ok {
+			if id, ok := spaces.ParseResourceID(string(e.Value)); ok {
+				s.setPublicStorageID(&provider.ResourceInfo{Id: id}, tkn)
+				e.Value = []byte(spaces.EncodeToStringifiedResourceID(id))
+			} else {
+				delete(res.Opaque.Map, "fileid")
+			}
+		}
 	}
 
 	return res, nil

--- a/internal/grpc/services/publicstorageprovider/publicstorageprovider_test.go
+++ b/internal/grpc/services/publicstorageprovider/publicstorageprovider_test.go
@@ -1,0 +1,108 @@
+// Copyright 2018-2024 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package publicstorageprovider
+
+import (
+	"testing"
+
+	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+	typesv1beta1 "github.com/cs3org/go-cs3apis/cs3/types/v1beta1"
+	"github.com/cs3org/reva/v3/pkg/spaces"
+)
+
+// a public link must never hand out the id of the resource behind it
+func TestTranslateOpaqueFileID(t *testing.T) {
+	realID := spaces.EncodeToStringifiedResourceID(&provider.ResourceId{
+		StorageId: "storage-id",
+		SpaceId:   "space-id",
+		OpaqueId:  "inode",
+	})
+	publicID := spaces.EncodeToStringifiedResourceID(&provider.ResourceId{
+		StorageId: "public-mount",
+		SpaceId:   "space-id",
+		OpaqueId:  "sometoken/inode",
+	})
+
+	// an empty wantID means the fileid should no longer be there
+	tests := []struct {
+		name    string
+		mountID string
+		opaque  *typesv1beta1.Opaque
+		wantID  string
+	}{
+		{
+			name:    "the fileid is rewritten into the public namespace",
+			mountID: "public-mount",
+			opaque:  opaqueWith(map[string]string{"fileid": realID, "etag": `"abc"`}),
+			wantID:  publicID,
+		},
+		{
+			name:    "an unparsable fileid is dropped",
+			mountID: "public-mount",
+			opaque:  opaqueWith(map[string]string{"fileid": "not-an-id", "etag": `"abc"`}),
+		},
+		{
+			name:   "without a mount id the fileid is left alone",
+			opaque: opaqueWith(map[string]string{"fileid": realID, "etag": `"abc"`}),
+			wantID: realID,
+		},
+		{
+			name:    "an opaque without a fileid is untouched",
+			mountID: "public-mount",
+			opaque:  opaqueWith(map[string]string{"etag": `"abc"`}),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &service{mountID: tt.mountID}
+			s.translateOpaqueFileID(tt.opaque, "sometoken")
+
+			entry, ok := tt.opaque.Map["fileid"]
+			switch {
+			case tt.wantID == "":
+				if ok {
+					t.Fatalf("expected no fileid, got %q", entry.Value)
+				}
+			case !ok:
+				t.Fatalf("expected fileid %q, got none", tt.wantID)
+			case string(entry.Value) != tt.wantID:
+				t.Fatalf("got fileid %q, want %q", entry.Value, tt.wantID)
+			}
+
+			// the etag rides next to the fileid and is never rewritten
+			if e, ok := tt.opaque.Map["etag"]; !ok || string(e.Value) != `"abc"` {
+				t.Fatalf("etag changed: %v", tt.opaque.Map["etag"])
+			}
+		})
+	}
+}
+
+func TestTranslateOpaqueFileIDOnNilOpaque(t *testing.T) {
+	s := &service{mountID: "public-mount"}
+	s.translateOpaqueFileID(nil, "sometoken")
+}
+
+func opaqueWith(entries map[string]string) *typesv1beta1.Opaque {
+	o := &typesv1beta1.Opaque{Map: map[string]*typesv1beta1.OpaqueEntry{}}
+	for k, v := range entries {
+		o.Map[k] = &typesv1beta1.OpaqueEntry{Decoder: "plain", Value: []byte(v)}
+	}
+	return o
+}

--- a/internal/grpc/services/storageprovider/createcontainer_test.go
+++ b/internal/grpc/services/storageprovider/createcontainer_test.go
@@ -1,0 +1,111 @@
+package storageprovider
+
+import (
+	"context"
+	"testing"
+
+	rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
+	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+
+	"github.com/cs3org/reva/v3/pkg/errtypes"
+	"github.com/cs3org/reva/v3/pkg/spaces"
+)
+
+// fakeCreateDirFS returns canned results for CreateDir.
+type fakeCreateDirFS struct {
+	noopFS
+	md  *provider.ResourceInfo
+	err error
+}
+
+func (f *fakeCreateDirFS) CreateDir(ctx context.Context, ref *provider.Reference) (*provider.ResourceInfo, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.md, nil
+}
+
+func TestCreateContainer(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		md         *provider.ResourceInfo
+		err        error
+		wantCode   rpc.Code
+		wantFileID string
+		wantEtag   string
+	}{
+		{
+			name: "driver returns the new dir info",
+			md: &provider.ResourceInfo{
+				Id:   &provider.ResourceId{OpaqueId: "inode-42"},
+				Etag: `"abc"`,
+				Path: "/newdir",
+			},
+			wantCode: rpc.Code_CODE_OK,
+			wantFileID: spaces.EncodeToStringifiedResourceID(&provider.ResourceId{
+				StorageId: "test-mount-id",
+				SpaceId:   spaces.EncodeSpaceID("/home"),
+				OpaqueId:  "inode-42",
+			}),
+			wantEtag: `"abc"`,
+		},
+		{
+			name:     "driver returns no info",
+			wantCode: rpc.Code_CODE_OK,
+		},
+		{
+			name:     "dir already exists",
+			err:      errtypes.AlreadyExists("newdir"),
+			wantCode: rpc.Code_CODE_ALREADY_EXISTS,
+		},
+		{
+			name:     "parent does not exist",
+			err:      errtypes.NotFound("newdir"),
+			wantCode: rpc.Code_CODE_NOT_FOUND,
+		},
+		{
+			name:     "permission denied",
+			err:      errtypes.PermissionDenied("newdir"),
+			wantCode: rpc.Code_CODE_PERMISSION_DENIED,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := &service{
+				conf:      &config{},
+				storage:   &fakeCreateDirFS{md: tt.md, err: tt.err},
+				mountPath: "/home",
+				mountID:   "test-mount-id",
+			}
+
+			res, err := svc.CreateContainer(context.Background(), &provider.CreateContainerRequest{
+				Ref: &provider.Reference{Path: "/home/newdir"},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if res.Status.Code != tt.wantCode {
+				t.Fatalf("expected status %v, got %v (%s)", tt.wantCode, res.Status.Code, res.Status.Message)
+			}
+
+			var gotFileID, gotEtag string
+			if res.Opaque != nil {
+				if e, ok := res.Opaque.Map["fileid"]; ok {
+					gotFileID = string(e.Value)
+				}
+				if e, ok := res.Opaque.Map["etag"]; ok {
+					gotEtag = string(e.Value)
+				}
+			}
+			if gotFileID != tt.wantFileID {
+				t.Errorf("expected fileid %q, got %q", tt.wantFileID, gotFileID)
+			}
+			if gotEtag != tt.wantEtag {
+				t.Errorf("expected etag %q, got %q", tt.wantEtag, gotEtag)
+			}
+		})
+	}
+}

--- a/internal/grpc/services/storageprovider/initiateupload_test.go
+++ b/internal/grpc/services/storageprovider/initiateupload_test.go
@@ -25,8 +25,8 @@ func (noopFS) GetHome(ctx context.Context) (string, error) {
 	return "", errtypes.NotSupported("noop")
 }
 func (noopFS) CreateHome(ctx context.Context) error { return errtypes.NotSupported("noop") }
-func (noopFS) CreateDir(ctx context.Context, ref *provider.Reference) error {
-	return errtypes.NotSupported("noop")
+func (noopFS) CreateDir(ctx context.Context, ref *provider.Reference) (*provider.ResourceInfo, error) {
+	return nil, errtypes.NotSupported("noop")
 }
 func (noopFS) TouchFile(ctx context.Context, ref *provider.Reference) error {
 	return errtypes.NotSupported("noop")

--- a/internal/grpc/services/storageprovider/storageprovider.go
+++ b/internal/grpc/services/storageprovider/storageprovider.go
@@ -722,7 +722,7 @@ func (s *service) CreateContainer(ctx context.Context, req *provider.CreateConta
 			Status: status.NewInternal(ctx, err, "error unwrapping path"),
 		}, nil
 	}
-	if err := s.storage.CreateDir(ctx, newRef); err != nil {
+	if _, err := s.storage.CreateDir(ctx, newRef); err != nil {
 		var st *rpc.Status
 		switch err.(type) {
 		case errtypes.IsNotFound:

--- a/internal/grpc/services/storageprovider/storageprovider.go
+++ b/internal/grpc/services/storageprovider/storageprovider.go
@@ -35,6 +35,7 @@ import (
 	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+	typespb "github.com/cs3org/go-cs3apis/cs3/types/v1beta1"
 
 	cachereg "github.com/cs3org/reva/v3/pkg/share/cache/registry"
 
@@ -722,7 +723,8 @@ func (s *service) CreateContainer(ctx context.Context, req *provider.CreateConta
 			Status: status.NewInternal(ctx, err, "error unwrapping path"),
 		}, nil
 	}
-	if _, err := s.storage.CreateDir(ctx, newRef); err != nil {
+	md, err := s.storage.CreateDir(ctx, newRef)
+	if err != nil {
 		var st *rpc.Status
 		switch err.(type) {
 		case errtypes.IsNotFound:
@@ -741,6 +743,19 @@ func (s *service) CreateContainer(ctx context.Context, req *provider.CreateConta
 
 	res := &provider.CreateContainerResponse{
 		Status: status.NewOK(ctx),
+	}
+	// if the driver told us about the new dir, hand its fileid and etag
+	// to the client to spare it a stat
+	if md != nil && md.Id != nil {
+		if err := s.wrap(ctx, md, true); err == nil {
+			s.addSpaceInfo(ctx, md)
+			res.Opaque = &typespb.Opaque{
+				Map: map[string]*typespb.OpaqueEntry{
+					"fileid": {Decoder: "plain", Value: []byte(spaces.EncodeToStringifiedResourceID(md.Id))},
+					"etag":   {Decoder: "plain", Value: []byte(md.Etag)},
+				},
+			}
+		}
 	}
 	return res, nil
 }

--- a/internal/http/services/owncloud/ocdav/mkcol.go
+++ b/internal/http/services/owncloud/ocdav/mkcol.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/cs3org/reva/v3/pkg/appctx"
 	"github.com/cs3org/reva/v3/pkg/service"
+	"github.com/cs3org/reva/v3/pkg/spaces"
 )
 
 func (s *svc) handlePathMkcol(w http.ResponseWriter, r *http.Request, ns string) {
@@ -155,6 +156,15 @@ func (s *svc) handleMkcol(ctx context.Context, w http.ResponseWriter, r *http.Re
 	}
 	switch res.Status.Code {
 	case rpc.Code_CODE_OK:
+		// CreateContainer does not return the resource info, stat the new collection to expose its fileid and etag
+		createdStatRes, err := client.Stat(ctx, &provider.StatRequest{Ref: childRef})
+		if err == nil && createdStatRes.Status.Code == rpc.Code_CODE_OK {
+			w.Header().Set(HeaderOCFileID, spaces.EncodeToStringifiedResourceID(createdStatRes.Info.Id))
+			w.Header().Set(HeaderOCETag, createdStatRes.Info.Etag)
+		} else {
+			// the collection was created, return 201 with the headers missing
+			log.Warn().Err(err).Str("path", childRef.Path).Interface("status", createdStatRes.GetStatus()).Msg("error statting created collection")
+		}
 		w.WriteHeader(http.StatusCreated)
 	case rpc.Code_CODE_NOT_FOUND:
 		log.Debug().Str("path", childRef.Path).Interface("status", statRes.Status).Msg("conflict")

--- a/internal/http/services/owncloud/ocdav/mkcol.go
+++ b/internal/http/services/owncloud/ocdav/mkcol.go
@@ -31,7 +31,6 @@ import (
 
 	"github.com/cs3org/reva/v3/pkg/appctx"
 	"github.com/cs3org/reva/v3/pkg/service"
-	"github.com/cs3org/reva/v3/pkg/spaces"
 )
 
 func (s *svc) handlePathMkcol(w http.ResponseWriter, r *http.Request, ns string) {
@@ -156,14 +155,15 @@ func (s *svc) handleMkcol(ctx context.Context, w http.ResponseWriter, r *http.Re
 	}
 	switch res.Status.Code {
 	case rpc.Code_CODE_OK:
-		// CreateContainer does not return the resource info, stat the new collection to expose its fileid and etag
-		createdStatRes, err := client.Stat(ctx, &provider.StatRequest{Ref: childRef})
-		if err == nil && createdStatRes.Status.Code == rpc.Code_CODE_OK {
-			w.Header().Set(HeaderOCFileID, spaces.EncodeToStringifiedResourceID(createdStatRes.Info.Id))
-			w.Header().Set(HeaderOCETag, createdStatRes.Info.Etag)
-		} else {
-			// the collection was created, return 201 with the headers missing
-			log.Warn().Err(err).Str("path", childRef.Path).Interface("status", createdStatRes.GetStatus()).Msg("error statting created collection")
+		// the fileid and etag of the new collection come in the response
+		// opaque, if the storage was able to report them
+		if res.Opaque != nil {
+			if e, ok := res.Opaque.Map["fileid"]; ok && len(e.Value) > 0 {
+				w.Header().Set(HeaderOCFileID, string(e.Value))
+			}
+			if e, ok := res.Opaque.Map["etag"]; ok && len(e.Value) > 0 {
+				w.Header().Set(HeaderOCETag, string(e.Value))
+			}
 		}
 		w.WriteHeader(http.StatusCreated)
 	case rpc.Code_CODE_NOT_FOUND:

--- a/internal/http/services/owncloud/ocdav/mkcol_test.go
+++ b/internal/http/services/owncloud/ocdav/mkcol_test.go
@@ -1,0 +1,108 @@
+// Copyright 2018-2026 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package ocdav
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
+	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+	mockgateway "github.com/cs3org/go-cs3apis/mocks/github.com/cs3org/go-cs3apis/cs3/gateway/v1beta1"
+	"github.com/cs3org/reva/v3/pkg/rgrpc/todo/pool"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestMkcol(t *testing.T) {
+	tests := []struct {
+		name       string
+		statRes    *provider.StatResponse
+		statErr    error
+		wantFileID string
+		wantEtag   string
+	}{
+		{
+			name: "returns fileid and etag of the created collection",
+			statRes: &provider.StatResponse{
+				Status: &rpc.Status{Code: rpc.Code_CODE_OK},
+				Info: &provider.ResourceInfo{
+					Type: provider.ResourceType_RESOURCE_TYPE_CONTAINER,
+					Id:   &provider.ResourceId{StorageId: "storage-id", SpaceId: "space-id", OpaqueId: "opaque-id"},
+					Etag: `"deadbeef"`,
+				},
+			},
+			wantFileID: "storage-id$space-id!opaque-id",
+			wantEtag:   `"deadbeef"`,
+		},
+		{
+			name:    "returns 201 without headers when the stat status is not ok",
+			statRes: &provider.StatResponse{Status: &rpc.Status{Code: rpc.Code_CODE_INTERNAL}},
+		},
+		{
+			name:    "returns 201 without headers when the stat call fails",
+			statErr: errors.New("transport error"),
+		},
+	}
+
+	parentRef := &provider.Reference{Path: "/home"}
+	childRef := &provider.Reference{Path: "/home/newdir"}
+	statOf := func(ref *provider.Reference) interface{} {
+		return mock.MatchedBy(func(req *provider.StatRequest) bool { return req.Ref.Path == ref.Path })
+	}
+
+	for i, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gw := mockgateway.NewMockGatewayAPIClient(t)
+			gw.On("Stat", mock.Anything, statOf(parentRef)).Return(&provider.StatResponse{
+				Status: &rpc.Status{Code: rpc.Code_CODE_OK},
+				Info:   &provider.ResourceInfo{Type: provider.ResourceType_RESOURCE_TYPE_CONTAINER},
+			}, nil).Once()
+			gw.On("Stat", mock.Anything, statOf(childRef)).Return(&provider.StatResponse{
+				Status: &rpc.Status{Code: rpc.Code_CODE_NOT_FOUND},
+			}, nil).Once()
+			gw.On("CreateContainer", mock.Anything, mock.Anything).Return(&provider.CreateContainerResponse{
+				Status: &rpc.Status{Code: rpc.Code_CODE_OK},
+			}, nil).Once()
+			gw.On("Stat", mock.Anything, statOf(childRef)).Return(tt.statRes, tt.statErr).Once()
+
+			endpoint := fmt.Sprintf("mkcol-gw-%d", i)
+			pool.RegisterGatewayServiceClient(gw, endpoint)
+			s := svc{c: &Config{GatewaySvc: endpoint}}
+
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest("MKCOL", "http://localhost/home/newdir", nil)
+			s.handleMkcol(context.Background(), w, r, parentRef, childRef, zerolog.Logger{})
+
+			if w.Code != http.StatusCreated {
+				t.Fatalf("expected status %d, got %d", http.StatusCreated, w.Code)
+			}
+			if got := w.Header().Get(HeaderOCFileID); got != tt.wantFileID {
+				t.Errorf("expected %s header %q, got %q", HeaderOCFileID, tt.wantFileID, got)
+			}
+			if got := w.Header().Get(HeaderOCETag); got != tt.wantEtag {
+				t.Errorf("expected %s header %q, got %q", HeaderOCETag, tt.wantEtag, got)
+			}
+		})
+	}
+}

--- a/internal/http/services/owncloud/ocdav/mkcol_test.go
+++ b/internal/http/services/owncloud/ocdav/mkcol_test.go
@@ -20,16 +20,14 @@ package ocdav
 
 import (
 	"context"
-	"errors"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+	typespb "github.com/cs3org/go-cs3apis/cs3/types/v1beta1"
 	mockgateway "github.com/cs3org/go-cs3apis/mocks/github.com/cs3org/go-cs3apis/cs3/gateway/v1beta1"
-	"github.com/cs3org/reva/v3/pkg/rgrpc/todo/pool"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/mock"
 )
@@ -37,31 +35,41 @@ import (
 func TestMkcol(t *testing.T) {
 	tests := []struct {
 		name       string
-		statRes    *provider.StatResponse
-		statErr    error
+		createRes  *provider.CreateContainerResponse
 		wantFileID string
 		wantEtag   string
 	}{
 		{
 			name: "returns fileid and etag of the created collection",
-			statRes: &provider.StatResponse{
+			createRes: &provider.CreateContainerResponse{
 				Status: &rpc.Status{Code: rpc.Code_CODE_OK},
-				Info: &provider.ResourceInfo{
-					Type: provider.ResourceType_RESOURCE_TYPE_CONTAINER,
-					Id:   &provider.ResourceId{StorageId: "storage-id", SpaceId: "space-id", OpaqueId: "opaque-id"},
-					Etag: `"deadbeef"`,
+				Opaque: &typespb.Opaque{
+					Map: map[string]*typespb.OpaqueEntry{
+						"fileid": {Decoder: "plain", Value: []byte("storage-id$space-id!opaque-id")},
+						"etag":   {Decoder: "plain", Value: []byte(`"deadbeef"`)},
+					},
 				},
 			},
 			wantFileID: "storage-id$space-id!opaque-id",
 			wantEtag:   `"deadbeef"`,
 		},
 		{
-			name:    "returns 201 without headers when the stat status is not ok",
-			statRes: &provider.StatResponse{Status: &rpc.Status{Code: rpc.Code_CODE_INTERNAL}},
+			name: "returns 201 without headers when the provider returns no opaque",
+			createRes: &provider.CreateContainerResponse{
+				Status: &rpc.Status{Code: rpc.Code_CODE_OK},
+			},
 		},
 		{
-			name:    "returns 201 without headers when the stat call fails",
-			statErr: errors.New("transport error"),
+			name: "returns 201 without headers when the opaque entries are empty",
+			createRes: &provider.CreateContainerResponse{
+				Status: &rpc.Status{Code: rpc.Code_CODE_OK},
+				Opaque: &typespb.Opaque{
+					Map: map[string]*typespb.OpaqueEntry{
+						"fileid": {Decoder: "plain", Value: []byte("")},
+						"etag":   {Decoder: "plain", Value: []byte("")},
+					},
+				},
+			},
 		},
 	}
 
@@ -71,7 +79,7 @@ func TestMkcol(t *testing.T) {
 		return mock.MatchedBy(func(req *provider.StatRequest) bool { return req.Ref.Path == ref.Path })
 	}
 
-	for i, tt := range tests {
+	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			gw := mockgateway.NewMockGatewayAPIClient(t)
 			gw.On("Stat", mock.Anything, statOf(parentRef)).Return(&provider.StatResponse{
@@ -81,14 +89,10 @@ func TestMkcol(t *testing.T) {
 			gw.On("Stat", mock.Anything, statOf(childRef)).Return(&provider.StatResponse{
 				Status: &rpc.Status{Code: rpc.Code_CODE_NOT_FOUND},
 			}, nil).Once()
-			gw.On("CreateContainer", mock.Anything, mock.Anything).Return(&provider.CreateContainerResponse{
-				Status: &rpc.Status{Code: rpc.Code_CODE_OK},
-			}, nil).Once()
-			gw.On("Stat", mock.Anything, statOf(childRef)).Return(tt.statRes, tt.statErr).Once()
+			gw.On("CreateContainer", mock.Anything, mock.Anything).Return(tt.createRes, nil).Once()
 
-			endpoint := fmt.Sprintf("mkcol-gw-%d", i)
-			pool.RegisterGatewayServiceClient(gw, endpoint)
-			s := svc{c: &Config{GatewaySvc: endpoint}}
+			stampGateway(gw)
+			s := svc{c: &Config{}}
 
 			w := httptest.NewRecorder()
 			r := httptest.NewRequest("MKCOL", "http://localhost/home/newdir", nil)

--- a/internal/http/services/owncloud/ocdav/ocdav_test.go
+++ b/internal/http/services/owncloud/ocdav/ocdav_test.go
@@ -166,7 +166,7 @@ func newLocalFSOCDavService(t *testing.T, endpoint string) *svc {
 	if err := fs.CreateHome(ctx); err != nil {
 		t.Fatalf("failed to create localfs home: %v", err)
 	}
-	if err := fs.CreateDir(ctx, &providerv1beta1.Reference{Path: "/Documents"}); err != nil {
+	if _, err := fs.CreateDir(ctx, &providerv1beta1.Reference{Path: "/Documents"}); err != nil {
 		t.Fatalf("failed to create fixture folder: %v", err)
 	}
 	if err := fs.TouchFile(ctx, &providerv1beta1.Reference{Path: "/Documents/report.txt"}); err != nil {

--- a/pkg/ocm/storage/outcoming/ocm.go
+++ b/pkg/ocm/storage/outcoming/ocm.go
@@ -292,13 +292,13 @@ func (d *driver) translateOCMShareResourceToCS3Ref(ctx context.Context, resID *p
 	return &provider.Reference{Path: p}, nil
 }
 
-func (d *driver) CreateDir(ctx context.Context, ref *provider.Reference) error {
+func (d *driver) CreateDir(ctx context.Context, ref *provider.Reference) (*provider.ResourceInfo, error) {
 	share, rel, err := d.shareAndRelativePathFromRef(ctx, ref)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	return d.unwrappedOpFromShareCreator(ctx, share, rel, func(ctx context.Context, ref *provider.Reference) error {
+	return nil, d.unwrappedOpFromShareCreator(ctx, share, rel, func(ctx context.Context, ref *provider.Reference) error {
 		gw, err := service.Gateway(ctx)
 		if err != nil {
 			return err

--- a/pkg/ocm/storage/received/ocm.go
+++ b/pkg/ocm/storage/received/ocm.go
@@ -347,8 +347,8 @@ func (d *driver) withExchangeRetry(ctx context.Context, ref *provider.Reference,
 	return nil
 }
 
-func (d *driver) CreateDir(ctx context.Context, ref *provider.Reference) error {
-	return d.withExchangeRetry(ctx, ref, func(c *gowebdav.Client, rel string) error {
+func (d *driver) CreateDir(ctx context.Context, ref *provider.Reference) (*provider.ResourceInfo, error) {
+	return nil, d.withExchangeRetry(ctx, ref, func(c *gowebdav.Client, rel string) error {
 		return c.MkdirAll(rel, 0)
 	})
 }

--- a/pkg/storage/fs/cephfs/cephfs.go
+++ b/pkg/storage/fs/cephfs/cephfs.go
@@ -150,9 +150,10 @@ func (fs *cephfs) CreateDir(ctx context.Context, ref *provider.Reference) (*prov
 		return nil, getRevaError(ctx, err)
 	}
 
-	// stat the new dir to return its info, best effort
+	// the dir is there, we only miss its metadata
 	md, err := fs.GetMD(ctx, ref, nil)
 	if err != nil {
+		log.Warn().Str("path", path).Err(err).Msg("cephfs: error statting created directory")
 		return nil, nil
 	}
 	return md, nil

--- a/pkg/storage/fs/cephfs/cephfs.go
+++ b/pkg/storage/fs/cephfs/cephfs.go
@@ -132,11 +132,11 @@ func (fs *cephfs) CreateHome(ctx context.Context) (err error) {
 	return nil
 }
 
-func (fs *cephfs) CreateDir(ctx context.Context, ref *provider.Reference) error {
+func (fs *cephfs) CreateDir(ctx context.Context, ref *provider.Reference) (*provider.ResourceInfo, error) {
 	user := fs.makeUser(ctx)
 	path, err := user.resolveRef(ref)
 	if err != nil {
-		return getRevaError(ctx, err)
+		return nil, getRevaError(ctx, err)
 	}
 
 	log := appctx.GetLogger(ctx)
@@ -146,8 +146,16 @@ func (fs *cephfs) CreateDir(ctx context.Context, ref *provider.Reference) error 
 			return
 		}
 	})
+	if err != nil {
+		return nil, getRevaError(ctx, err)
+	}
 
-	return getRevaError(ctx, err)
+	// stat the new dir to return its info, best effort
+	md, err := fs.GetMD(ctx, ref, nil)
+	if err != nil {
+		return nil, nil
+	}
+	return md, nil
 }
 
 func (fs *cephfs) Delete(ctx context.Context, ref *provider.Reference) (err error) {

--- a/pkg/storage/fs/cephmount/benchmark_ceph_test.go
+++ b/pkg/storage/fs/cephmount/benchmark_ceph_test.go
@@ -643,7 +643,7 @@ func benchmarkUploadDirectoriesCeph(b *testing.B, depth int) {
 		dirPath += fmt.Sprintf("/level_%d", i)
 		// Create directory through filesystem
 		dirRef := &provider.Reference{Path: dirPath}
-		err := fs.CreateDir(ctx, dirRef)
+		_, err := fs.CreateDir(ctx, dirRef)
 		if err != nil {
 			// Directory might already exist, which is fine
 		}
@@ -866,7 +866,7 @@ func benchmarkMultiUserConcurrentReadsCeph(b *testing.B, userCount, readsPerUser
 		// First ensure the directory exists using cephmount
 		dirPath := fmt.Sprintf("/benchmark-tests/%s", testDirName)
 		dirRef := &provider.Reference{Path: dirPath}
-		_ = fs.CreateDir(userContexts[userID], dirRef) // Ignore error if it already exists
+		_, _ = fs.CreateDir(userContexts[userID], dirRef) // Ignore error if it already exists
 
 		reader := bytes.NewReader(testData)
 		err := fs.Upload(userContexts[userID], fileRefs[userID], io.NopCloser(reader), nil)
@@ -1049,7 +1049,7 @@ func setupCephBenchmark(b *testing.B, prefix string) (*cephmountfs, string, func
 	}
 
 	// Verify the directory is accessible via cephmount (optional - don't fail if this doesn't work)
-	if err := fs.CreateDir(ctx, testDirRef); err != nil {
+	if _, err := fs.CreateDir(ctx, testDirRef); err != nil {
 		if !strings.Contains(err.Error(), "file exists") && !strings.Contains(err.Error(), "already exists") {
 			b.Logf("Note: Directory creation via cephmount interface failed (using direct filesystem access): %v", err)
 		}

--- a/pkg/storage/fs/cephmount/benchmark_test.go
+++ b/pkg/storage/fs/cephmount/benchmark_test.go
@@ -762,7 +762,7 @@ func benchmarkUploadDirectories(b *testing.B, depth int) {
 		dirPath.WriteString(fmt.Sprintf("/level_%d", i))
 		// Create directory through filesystem
 		dirRef := &provider.Reference{Path: dirPath.String()}
-		err := fs.CreateDir(ctx, dirRef)
+		_, err := fs.CreateDir(ctx, dirRef)
 		if err != nil {
 			// Directory might already exist, which is fine
 		}

--- a/pkg/storage/fs/cephmount/cephmount.go
+++ b/pkg/storage/fs/cephmount/cephmount.go
@@ -635,9 +635,10 @@ func (fs *cephmountfs) CreateDir(ctx context.Context, ref *provider.Reference) (
 		return nil, wrappedErr
 	}
 
-	// creation succeeded, so a failing stat only costs us the response info
+	// the dir is there, we only miss its metadata
 	md, err := fs.GetMD(ctx, ref, nil)
 	if err != nil {
+		appctx.GetLogger(ctx).Warn().Str("path", path).Err(err).Msg("cephmount: error statting created directory")
 		return nil, nil
 	}
 	return md, nil

--- a/pkg/storage/fs/cephmount/cephmount.go
+++ b/pkg/storage/fs/cephmount/cephmount.go
@@ -624,7 +624,7 @@ func (fs *cephmountfs) CreateDir(ctx context.Context, ref *provider.Reference) (
 
 	if err := fs.authorizeExternal(ctx, path, "CreateDir", canCreate); err != nil {
 		fs.logOperationError(ctx, "CreateDir", path, err)
-		return err
+		return nil, err
 	}
 
 	// Execute directory creation on user's thread with correct UID

--- a/pkg/storage/fs/cephmount/cephmount.go
+++ b/pkg/storage/fs/cephmount/cephmount.go
@@ -606,7 +606,7 @@ func (fs *cephmountfs) CreateHome(ctx context.Context) error {
 	return errtypes.NotSupported("cephmount: CreateHome not implemented")
 }
 
-func (fs *cephmountfs) CreateDir(ctx context.Context, ref *provider.Reference) error {
+func (fs *cephmountfs) CreateDir(ctx context.Context, ref *provider.Reference) (*provider.ResourceInfo, error) {
 	// Capture the original received path for logging
 	var receivedPath string
 	if ref != nil && ref.Path != "" {
@@ -617,7 +617,7 @@ func (fs *cephmountfs) CreateDir(ctx context.Context, ref *provider.Reference) e
 
 	path, err := fs.resolveRef(ctx, ref)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	fs.logOperationWithPaths(ctx, "CreateDir", receivedPath, path)
@@ -632,10 +632,15 @@ func (fs *cephmountfs) CreateDir(ctx context.Context, ref *provider.Reference) e
 	if err != nil {
 		wrappedErr := errors.Wrap(err, "cephmount: failed to create directory")
 		fs.logOperationError(ctx, "CreateDir", path, wrappedErr)
-		return wrappedErr
+		return nil, wrappedErr
 	}
 
-	return nil
+	// creation succeeded, so a failing stat only costs us the response info
+	md, err := fs.GetMD(ctx, ref, nil)
+	if err != nil {
+		return nil, nil
+	}
+	return md, nil
 }
 
 func (fs *cephmountfs) Delete(ctx context.Context, ref *provider.Reference) (err error) {

--- a/pkg/storage/fs/cephmount/cephmount_test.go
+++ b/pkg/storage/fs/cephmount/cephmount_test.go
@@ -77,7 +77,7 @@ func TestCephMount_BasicOperations(t *testing.T) {
 
 	// Test CreateDir
 	ref := &provider.Reference{Path: "/testdir"}
-	err = fs.CreateDir(ctx, ref)
+	_, err = fs.CreateDir(ctx, ref)
 	assert.NoError(t, err)
 
 	// Verify directory was created within the chroot

--- a/pkg/storage/fs/cephmount/external_accounts_test.go
+++ b/pkg/storage/fs/cephmount/external_accounts_test.go
@@ -169,7 +169,7 @@ func TestExternalAccountOperationsAreDenied(t *testing.T) {
 		require.Error(t, err)
 		assert.IsType(t, errtypes.PermissionDenied(""), err)
 
-		err = fs.CreateDir(ctx, &provider.Reference{Path: "/shared/newdir"})
+		_, err = fs.CreateDir(ctx, &provider.Reference{Path: "/shared/newdir"})
 		require.Error(t, err)
 		assert.IsType(t, errtypes.PermissionDenied(""), err)
 

--- a/pkg/storage/fs/cephmount/nobody_fallback_test.go
+++ b/pkg/storage/fs/cephmount/nobody_fallback_test.go
@@ -232,7 +232,7 @@ func TestNobodyUserOperations(t *testing.T) {
 
 	// Test directory creation (should use nobody thread)
 	ref := &provider.Reference{Path: "test-nobody-dir"}
-	err = fs.CreateDir(ctx, ref)
+	_, err = fs.CreateDir(ctx, ref)
 	if err != nil {
 		t.Fatalf("Failed to create directory with nobody user: %v", err)
 	}
@@ -270,7 +270,7 @@ func TestNobodyUserOperations(t *testing.T) {
 
 	// This should use the regular user thread (UID 1000)
 	ref = &provider.Reference{Path: "test-user-dir"}
-	err = fs.CreateDir(ctxWithUser, ref)
+	_, err = fs.CreateDir(ctxWithUser, ref)
 	if err != nil {
 		t.Fatalf("Failed to create directory with regular user: %v", err)
 	}

--- a/pkg/storage/fs/cephmount/path_translation_test.go
+++ b/pkg/storage/fs/cephmount/path_translation_test.go
@@ -90,7 +90,7 @@ func TestPathTranslation(t *testing.T) {
 			if !tt.shouldExist {
 				// Create directory or file
 				if tt.externalPath == "/subdir" {
-					err = fs.CreateDir(ctx, ref)
+					_, err = fs.CreateDir(ctx, ref)
 					assert.NoError(t, err)
 				} else if tt.externalPath == "/subdir/file.txt" {
 					err = fs.TouchFile(ctx, ref)

--- a/pkg/storage/fs/cephmount/pathbyid_ceph_test.go
+++ b/pkg/storage/fs/cephmount/pathbyid_ceph_test.go
@@ -149,7 +149,7 @@ func TestGetPathByIDWithCreatedFiles(t *testing.T) {
 		t.Logf("Creating %s at path %s", tc.name, tc.path)
 
 		if tc.isDir {
-			err := fs.CreateDir(ctx, &provider.Reference{Path: tc.path})
+			_, err := fs.CreateDir(ctx, &provider.Reference{Path: tc.path})
 			require.NoError(t, err, "Failed to create directory %s", tc.path)
 		} else {
 			err := fs.TouchFile(ctx, &provider.Reference{Path: tc.path})

--- a/pkg/storage/fs/eos/file_ops.go
+++ b/pkg/storage/fs/eos/file_ops.go
@@ -42,13 +42,13 @@ import (
 	"github.com/pkg/errors"
 )
 
-func (fs *Eosfs) CreateDir(ctx context.Context, ref *provider.Reference) error {
+func (fs *Eosfs) CreateDir(ctx context.Context, ref *provider.Reference) (*provider.ResourceInfo, error) {
 	log := appctx.GetLogger(ctx)
 
 	fn, err := fs.resolve(ctx, ref)
 	log.Debug().Any("ref", ref).Str("fn", fn).Err(err).Msgf("CreateDir")
 	if err != nil {
-		return errors.Wrap(err, "eosfs: error resolving reference")
+		return nil, errors.Wrap(err, "eosfs: error resolving reference")
 	}
 
 	// We are creating a directory, so we should have write access in the parent directory
@@ -56,11 +56,21 @@ func (fs *Eosfs) CreateDir(ctx context.Context, ref *provider.Reference) error {
 	if err != nil {
 		log.Error().Any("ref", ref).Any("auth", auth).Str("fn", fn).Err(err).Msgf("CreateDir auth error")
 
-		return err
+		return nil, err
 	}
 
 	log.Info().Msgf("eosfs: createdir: path=%s", fn)
-	return fs.c.CreateDir(ctx, auth, fn)
+	if err := fs.c.CreateDir(ctx, auth, fn); err != nil {
+		return nil, err
+	}
+
+	md, err := fs.GetMD(ctx, ref, nil)
+	if err != nil {
+		// the dir is there, we only miss its metadata
+		log.Warn().Str("fn", fn).Err(err).Msg("eosfs: error statting created directory")
+		return nil, nil
+	}
+	return md, nil
 }
 
 func (fs *Eosfs) CreateReference(ctx context.Context, fn string, targetURI *url.URL) error {

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -34,8 +34,10 @@ import (
 type FS interface {
 	GetHome(ctx context.Context) (string, error)
 	CreateHome(ctx context.Context) error
-	// CreateDir creates a directory. It returns the ResourceInfo of the new
-	// directory when the driver can provide it without extra cost, nil otherwise.
+	// CreateDir creates a directory and describes it, so that callers do not
+	// have to stat it themselves. Drivers usually pay a stat for this. It is
+	// best effort: the directory is created even when the info comes back nil,
+	// so callers have to handle that.
 	CreateDir(ctx context.Context, ref *provider.Reference) (*provider.ResourceInfo, error)
 	TouchFile(ctx context.Context, ref *provider.Reference) error
 	Delete(ctx context.Context, ref *provider.Reference) error

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -34,7 +34,9 @@ import (
 type FS interface {
 	GetHome(ctx context.Context) (string, error)
 	CreateHome(ctx context.Context) error
-	CreateDir(ctx context.Context, ref *provider.Reference) error
+	// CreateDir creates a directory. It returns the ResourceInfo of the new
+	// directory when the driver can provide it without extra cost, nil otherwise.
+	CreateDir(ctx context.Context, ref *provider.Reference) (*provider.ResourceInfo, error)
 	TouchFile(ctx context.Context, ref *provider.Reference) error
 	Delete(ctx context.Context, ref *provider.Reference) error
 	Move(ctx context.Context, oldRef, newRef *provider.Reference) error

--- a/pkg/storage/utils/localfs/localfs.go
+++ b/pkg/storage/utils/localfs/localfs.go
@@ -909,9 +909,10 @@ func (fs *localfs) CreateDir(ctx context.Context, ref *provider.Reference) (*pro
 		return nil, err
 	}
 
-	// don't fail the creation if we cannot stat the new dir
+	// the dir is there, we only miss its metadata
 	md, err := fs.GetMD(ctx, ref, nil)
 	if err != nil {
+		appctx.GetLogger(ctx).Warn().Str("fn", fn).Err(err).Msg("localfs: error statting created directory")
 		return nil, nil
 	}
 	return md, nil

--- a/pkg/storage/utils/localfs/localfs.go
+++ b/pkg/storage/utils/localfs/localfs.go
@@ -883,29 +883,38 @@ func (fs *localfs) createHomeInternal(ctx context.Context, fn string) error {
 	return nil
 }
 
-func (fs *localfs) CreateDir(ctx context.Context, ref *provider.Reference) error {
+func (fs *localfs) CreateDir(ctx context.Context, ref *provider.Reference) (*provider.ResourceInfo, error) {
 	fn, err := fs.resolve(ctx, ref)
 	if err != nil {
-		return nil
+		return nil, nil
 	}
 
 	if fs.isShareFolder(ctx, fn) {
-		return errtypes.PermissionDenied("localfs: cannot create folder under the share folder")
+		return nil, errtypes.PermissionDenied("localfs: cannot create folder under the share folder")
 	}
 
 	fn = fs.wrap(ctx, fn)
 	if _, err := os.Stat(fn); err == nil {
-		return errtypes.AlreadyExists(fn)
+		return nil, errtypes.AlreadyExists(fn)
 	}
 	err = os.Mkdir(fn, 0700)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return errtypes.NotFound(fn)
+			return nil, errtypes.NotFound(fn)
 		}
-		return errors.Wrap(err, "localfs: error creating dir "+fn)
+		return nil, errors.Wrap(err, "localfs: error creating dir "+fn)
 	}
 
-	return fs.propagate(ctx, path.Dir(fn))
+	if err := fs.propagate(ctx, path.Dir(fn)); err != nil {
+		return nil, err
+	}
+
+	// don't fail the creation if we cannot stat the new dir
+	md, err := fs.GetMD(ctx, ref, nil)
+	if err != nil {
+		return nil, nil
+	}
+	return md, nil
 }
 
 // TouchFile as defined in the storage.FS interface.


### PR DESCRIPTION
Fixes #4769

MKCOL now returns the `OC-FileId` and `OC-ETag` headers of the collection it just created, the same way PUT already does. Clients can skip the PROPFIND they currently have to send right after creating a folder.

to get there.. `storage.FS.CreateDir` now returns the new directory's `ResourceInfo` alongside the error. The storage provider puts the fileid and etag in the `CreateContainerResponse` opaque and ocdav turns them into headers. Drivers get the info from a local stat, which is cheaper than the gateway round trip a caller would otherwise make, and it keeps the fileid encoding identical to what PROPFIND reports so clients can match them up.

This changes the storage.FS interface, so every driver in the tree is updated and any out-of-tree driver will need the new signature. It is a one line change per driver: return nil, err instead of err, and return the info if a stat after creation succeeds.

It is best effort throughout. If the stat fails the directory still exists, MKCOL still returns 201, and the headers are simply absent. Public links get the fileid rewritten into the public namespace so they never leak the id of the resource behind the link.