### PR TITLE
Restrict public link management to the link owner

### DIFF
--- a/changelog/unreleased/publicshare-ownership.md
+++ b/changelog/unreleased/publicshare-ownership.md
@@ -1,0 +1,9 @@
+Security: restrict public link management to the link owner
+
+Reading, updating or revoking a public link by its id only required knowing that
+id: no layer between the OCS API and the share managers compared the caller to
+the link's creator or to the owner of the shared resource. The publicshareprovider
+service now performs that check. Resolving a link by its token is unchanged, since
+that is how link visitors reach the shared resource.
+
+https://github.com/cs3org/reva/pull/5750

--- a/internal/grpc/services/publicshareprovider/publicshareprovider.go
+++ b/internal/grpc/services/publicshareprovider/publicshareprovider.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"regexp"
 
+	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
 	link "github.com/cs3org/go-cs3apis/cs3/sharing/link/v1beta1"
 	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
 	"github.com/cs3org/reva/v3/pkg/appctx"
@@ -163,12 +164,44 @@ func (s *service) CreatePublicShare(ctx context.Context, req *link.CreatePublicS
 	}
 }
 
+// isManager reports whether the user created the link or owns the resource
+// behind it. The sql driver stores creator and owner without an idp, so an
+// empty idp on either side is not counted as a mismatch.
+func isManager(u *userpb.User, share *link.PublicShare) bool {
+	if u.GetId().GetOpaqueId() == "" || share == nil {
+		return false
+	}
+	sameUser := func(other *userpb.UserId) bool {
+		if other.GetOpaqueId() == "" || other.GetOpaqueId() != u.GetId().GetOpaqueId() {
+			return false
+		}
+		return other.GetIdp() == "" || u.GetId().GetIdp() == "" || other.GetIdp() == u.GetId().GetIdp()
+	}
+	return sameUser(share.GetCreator()) || sameUser(share.GetOwner())
+}
+
 func (s *service) RemovePublicShare(ctx context.Context, req *link.RemovePublicShareRequest) (*link.RemovePublicShareResponse, error) {
 	log := appctx.GetLogger(ctx)
 	log.Info().Str("publicshareprovider", "remove").Msg("remove public share")
 
-	user := appctx.ContextMustGetUser(ctx)
-	err := s.sm.RevokePublicShare(ctx, user, req.Ref)
+	user, ok := appctx.ContextGetUser(ctx)
+	if !ok {
+		return &link.RemovePublicShareResponse{
+			Status: status.NewNotFound(ctx, "share not found"),
+		}, nil
+	}
+
+	// a ref proves nothing on its own, fetch the link to see whose it is
+	share, err := s.sm.GetPublicShare(ctx, user, req.Ref, false)
+	if err != nil || !isManager(user, share) {
+		log.Warn().Err(err).Interface("ref", req.Ref).Str("user", user.GetId().GetOpaqueId()).
+			Msg("denied removal of a public share the user does not manage")
+		return &link.RemovePublicShareResponse{
+			Status: status.NewNotFound(ctx, "share not found"),
+		}, nil
+	}
+
+	err = s.sm.RevokePublicShare(ctx, user, req.Ref)
 
 	switch err.(type) {
 	case nil:
@@ -219,12 +252,23 @@ func (s *service) GetPublicShare(ctx context.Context, req *link.GetPublicShareRe
 
 	u, ok := appctx.ContextGetUser(ctx)
 	if !ok {
-		log.Error().Msg("error getting user from context")
+		return &link.GetPublicShareResponse{
+			Status: status.NewNotFound(ctx, "share not found"),
+		}, nil
 	}
 
 	found, err := s.sm.GetPublicShare(ctx, u, req.Ref, req.GetSign())
 	switch err.(type) {
 	case nil:
+		// by id this is a management call, by token it is a visitor resolving the
+		// link they were handed and the token itself is the credential
+		if req.GetRef().GetId() != nil && !isManager(u, found) {
+			log.Warn().Interface("ref", req.Ref).Str("user", u.GetId().GetOpaqueId()).
+				Msg("denied read of a public share the user does not manage")
+			return &link.GetPublicShareResponse{
+				Status: status.NewNotFound(ctx, "share not found"),
+			}, nil
+		}
 		return &link.GetPublicShareResponse{
 			Status: status.NewOK(ctx),
 			Share:  found,
@@ -272,11 +316,16 @@ func (s *service) UpdatePublicShare(ctx context.Context, req *link.UpdatePublicS
 
 	u, ok := appctx.ContextGetUser(ctx)
 	if !ok {
-		log.Error().Msg("error getting user from context")
+		return &link.UpdatePublicShareResponse{
+			Status: status.NewNotFound(ctx, "share not found"),
+		}, nil
 	}
 
-	_, err := s.sm.GetPublicShare(ctx, u, req.Ref, false)
-	if err != nil {
+	// knowing the id or the token is not permission to change password or perms
+	share, err := s.sm.GetPublicShare(ctx, u, req.Ref, false)
+	if err != nil || !isManager(u, share) {
+		log.Warn().Err(err).Interface("ref", req.Ref).Str("user", u.GetId().GetOpaqueId()).
+			Msg("denied update of a public share the user does not manage")
 		return &link.UpdatePublicShareResponse{
 			Status: status.NewNotFound(ctx, "share not found"),
 		}, nil

--- a/internal/grpc/services/publicshareprovider/publicshareprovider_test.go
+++ b/internal/grpc/services/publicshareprovider/publicshareprovider_test.go
@@ -1,0 +1,277 @@
+// Copyright 2018-2026 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package publicshareprovider
+
+import (
+	"context"
+	"testing"
+
+	userpb "github.com/cs3org/go-cs3apis/cs3/identity/user/v1beta1"
+	rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
+	link "github.com/cs3org/go-cs3apis/cs3/sharing/link/v1beta1"
+	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+
+	"github.com/cs3org/reva/v3/pkg/appctx"
+	"github.com/cs3org/reva/v3/pkg/publicshare"
+)
+
+var (
+	owner    = &userpb.User{Id: &userpb.UserId{Idp: "cern.ch", OpaqueId: "einstein"}}
+	attacker = &userpb.User{Id: &userpb.UserId{Idp: "cern.ch", OpaqueId: "marie"}}
+)
+
+func TestIsManager(t *testing.T) {
+	t.Parallel()
+
+	id := func(idp, opaque string) *userpb.UserId {
+		return &userpb.UserId{Idp: idp, OpaqueId: opaque}
+	}
+
+	tests := []struct {
+		name  string
+		user  *userpb.User
+		share *link.PublicShare
+		want  bool
+	}{
+		{
+			name:  "creator may manage",
+			user:  owner,
+			share: &link.PublicShare{Creator: id("cern.ch", "einstein")},
+			want:  true,
+		},
+		{
+			name:  "resource owner may manage",
+			user:  owner,
+			share: &link.PublicShare{Creator: id("cern.ch", "curie"), Owner: id("cern.ch", "einstein")},
+			want:  true,
+		},
+		{
+			name: "sql driver drops the idp, opaque id still matches",
+			user: owner,
+			// what MakeUserID produces when reading a link back from the database
+			share: &link.PublicShare{Creator: &userpb.UserId{OpaqueId: "einstein"}},
+			want:  true,
+		},
+		{
+			name:  "another user may not manage",
+			user:  attacker,
+			share: &link.PublicShare{Creator: id("cern.ch", "einstein"), Owner: id("cern.ch", "einstein")},
+			want:  false,
+		},
+		{
+			name:  "same name at another provider is a different person",
+			user:  owner,
+			share: &link.PublicShare{Creator: id("example.org", "einstein")},
+			want:  false,
+		},
+		{
+			name:  "link visitors carry no matching id",
+			user:  &userpb.User{Id: &userpb.UserId{OpaqueId: "publiclink:42", Type: userpb.UserType_USER_TYPE_GUEST}},
+			share: &link.PublicShare{Creator: id("cern.ch", "einstein")},
+			want:  false,
+		},
+		{
+			name:  "empty ids never match",
+			user:  &userpb.User{Id: &userpb.UserId{}},
+			share: &link.PublicShare{Creator: &userpb.UserId{}},
+			want:  false,
+		},
+		{
+			name:  "share without creator or owner",
+			user:  owner,
+			share: &link.PublicShare{},
+			want:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isManager(tt.user, tt.share); got != tt.want {
+				t.Errorf("isManager() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// stubManager serves a single share and records whether the write paths ran.
+type stubManager struct {
+	publicshare.Manager
+	share   *link.PublicShare
+	revoked bool
+	updated bool
+}
+
+func (m *stubManager) GetPublicShare(ctx context.Context, u *userpb.User, ref *link.PublicShareReference, sign bool) (*link.PublicShare, error) {
+	return m.share, nil
+}
+
+func (m *stubManager) RevokePublicShare(ctx context.Context, u *userpb.User, ref *link.PublicShareReference) error {
+	m.revoked = true
+	return nil
+}
+
+func (m *stubManager) UpdatePublicShare(ctx context.Context, u *userpb.User, req *link.UpdatePublicShareRequest, g *link.Grant) (*link.PublicShare, error) {
+	m.updated = true
+	return m.share, nil
+}
+
+func (m *stubManager) CreatePublicShare(ctx context.Context, u *userpb.User, md *provider.ResourceInfo, g *link.Grant, description string, internal bool, notifyUploads bool, notifyUploadsExtraRecipients string) (*link.PublicShare, error) {
+	return m.share, nil
+}
+
+func byID(id string) *link.PublicShareReference {
+	return &link.PublicShareReference{
+		Spec: &link.PublicShareReference_Id{Id: &link.PublicShareId{OpaqueId: id}},
+	}
+}
+
+func byToken(tkn string) *link.PublicShareReference {
+	return &link.PublicShareReference{
+		Spec: &link.PublicShareReference_Token{Token: tkn},
+	}
+}
+
+// einstein's link, as the managers would return it
+func einsteinsShare() *link.PublicShare {
+	return &link.PublicShare{
+		Id:      &link.PublicShareId{OpaqueId: "7"},
+		Token:   "sometoken",
+		Creator: &userpb.UserId{Idp: "cern.ch", OpaqueId: "einstein"},
+		Owner:   &userpb.UserId{Idp: "cern.ch", OpaqueId: "einstein"},
+	}
+}
+
+func TestPublicShareAccessControl(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		user *userpb.User
+		ref  *link.PublicShareReference
+		// whether the caller is expected to get through
+		allowed bool
+	}{
+		{
+			name:    "owner reads own link by id",
+			user:    owner,
+			ref:     byID("7"),
+			allowed: true,
+		},
+		{
+			name:    "stranger reads someone else's link by id",
+			user:    attacker,
+			ref:     byID("7"),
+			allowed: false,
+		},
+		{
+			name: "link visitor resolves the link by token",
+			user: &userpb.User{Id: &userpb.UserId{OpaqueId: "publiclink:7", Type: userpb.UserType_USER_TYPE_GUEST}},
+			ref:  byToken("sometoken"),
+			// resolving by token has to keep working, that is how public links are served
+			allowed: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := &service{sm: &stubManager{share: einsteinsShare()}}
+			ctx := appctx.ContextSetUser(context.Background(), tt.user)
+
+			res, err := svc.GetPublicShare(ctx, &link.GetPublicShareRequest{Ref: tt.ref})
+			if err != nil {
+				t.Fatal(err)
+			}
+			gotAllowed := res.Status.Code == rpc.Code_CODE_OK
+			if gotAllowed != tt.allowed {
+				t.Fatalf("GetPublicShare: allowed = %v (status %v), want %v", gotAllowed, res.Status.Code, tt.allowed)
+			}
+			if !tt.allowed && res.Share != nil {
+				t.Error("a denied read must not return the share")
+			}
+		})
+	}
+}
+
+func TestUpdateAndRemoveRequireOwnership(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		user    *userpb.User
+		ref     *link.PublicShareReference
+		allowed bool
+	}{
+		{name: "owner updates and removes by id", user: owner, ref: byID("7"), allowed: true},
+		{name: "stranger with the id", user: attacker, ref: byID("7"), allowed: false},
+		{name: "stranger with the token", user: attacker, ref: byToken("sometoken"), allowed: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := appctx.ContextSetUser(context.Background(), tt.user)
+
+			sm := &stubManager{share: einsteinsShare()}
+			svc := &service{sm: sm}
+			updRes, err := svc.UpdatePublicShare(ctx, &link.UpdatePublicShareRequest{Ref: tt.ref})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := updRes.Status.Code == rpc.Code_CODE_OK; got != tt.allowed {
+				t.Errorf("UpdatePublicShare: allowed = %v (status %v), want %v", got, updRes.Status.Code, tt.allowed)
+			}
+			if sm.updated != tt.allowed {
+				t.Errorf("UpdatePublicShare reached the manager = %v, want %v", sm.updated, tt.allowed)
+			}
+
+			sm = &stubManager{share: einsteinsShare()}
+			svc = &service{sm: sm}
+			remRes, err := svc.RemovePublicShare(ctx, &link.RemovePublicShareRequest{Ref: tt.ref})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := remRes.Status.Code == rpc.Code_CODE_OK; got != tt.allowed {
+				t.Errorf("RemovePublicShare: allowed = %v (status %v), want %v", got, remRes.Status.Code, tt.allowed)
+			}
+			if sm.revoked != tt.allowed {
+				t.Errorf("RemovePublicShare reached the manager = %v, want %v", sm.revoked, tt.allowed)
+			}
+		})
+	}
+}
+
+func TestAnonymousCallersAreRejected(t *testing.T) {
+	t.Parallel()
+
+	sm := &stubManager{share: einsteinsShare()}
+	svc := &service{sm: sm}
+	ctx := context.Background() // no user
+
+	if res, _ := svc.GetPublicShare(ctx, &link.GetPublicShareRequest{Ref: byID("7")}); res.Status.Code == rpc.Code_CODE_OK {
+		t.Error("GetPublicShare must not serve a request without a user")
+	}
+	if res, _ := svc.UpdatePublicShare(ctx, &link.UpdatePublicShareRequest{Ref: byID("7")}); res.Status.Code == rpc.Code_CODE_OK {
+		t.Error("UpdatePublicShare must not serve a request without a user")
+	}
+	if res, _ := svc.RemovePublicShare(ctx, &link.RemovePublicShareRequest{Ref: byID("7")}); res.Status.Code == rpc.Code_CODE_OK {
+		t.Error("RemovePublicShare must not serve a request without a user")
+	}
+	if sm.updated || sm.revoked {
+		t.Error("an anonymous request reached the share manager")
+	}
+}


### PR DESCRIPTION

reading, updating or revoking a public link by its id only needed the id.
Nothing between the OCS API and the share managers checked the caller owned the
link, and with the sql driver the ids are an auto-increment sequence you can
walk. So any logged-in user could strip the password off someone else's link,
bump it to write, change its expiry, or delete links in bulk.

The `publicshareprovider` service now checks the caller against the link's
creator/owner on the by-id get, update and revoke paths. One check, since every
frontend and driver goes through it. Lookups by token are left alone, that's how
a visitor resolves their own link. Denials return NOT_FOUND so the ids can't be
probed, and the check tolerates the sql driver dropping the idp so real owners
aren't locked out.

### Testing

Table-driven tests for `isManager` and the get/update/revoke paths (owner ok,
stranger by id or token denied, anonymous denied, visitor by-token still works),
mutation-checked. Also confirmed against a running revad: the reported attack
(marie editing and deleting einstein's link) now fails while einstein's own
operations and public-link visitors keep working.

i have mailed regarding this please check.. fixes are done .. let me know if something we can improve