### PR TITLE
Harden OCM federation against SSRF, spoofed IPs and TLS downgrade

### DIFF
--- a/changelog/unreleased/ocm-federation-hardening.md
+++ b/changelog/unreleased/ocm-federation-hardening.md
@@ -1,0 +1,8 @@
+Security: harden OCM federation against SSRF, spoofed IPs and TLS downgrade
+
+The unauthenticated ScienceMesh `/discover` endpoint no longer connects to
+loopback, private, link-local or cloud-metadata addresses. The OCM provider
+allow list no longer trusts a caller-supplied `X-Forwarded-For` header, and
+remote provider discovery now verifies TLS certificates by default.
+
+https://github.com/cs3org/reva/pull/5752

--- a/internal/http/services/opencloudmesh/ocmd/client.go
+++ b/internal/http/services/opencloudmesh/ocmd/client.go
@@ -90,6 +90,8 @@ func NewClient(timeout time.Duration, insecure bool) *OCMClient {
 // it also covers redirects and DNS rebinding.
 func NewPublicOnlyClient(timeout time.Duration, insecure bool) *OCMClient {
 	tr := newOCMTransport(insecure)
+	// with a proxy the dial goes to the proxy, so Control never sees the target
+	tr.Proxy = nil
 	tr.DialContext = (&net.Dialer{
 		Timeout:   timeout,
 		KeepAlive: 30 * time.Second,
@@ -116,7 +118,7 @@ func refuseNonPublicAddr(_, address string, _ syscall.RawConn) error {
 }
 
 // 64:ff9b::/96 embeds an IPv4 address in its low 32 bits (RFC 6052), so on a
-// NAT64 network it can still reach internal hosts. Check the embedded address.
+// NAT64 network it can still reach internal hosts.
 var nat64WellKnownPrefix = net.IPNet{IP: net.ParseIP("64:ff9b::"), Mask: net.CIDRMask(96, 128)}
 
 func isPublicIP(ip net.IP) bool {

--- a/internal/http/services/opencloudmesh/ocmd/client.go
+++ b/internal/http/services/opencloudmesh/ocmd/client.go
@@ -25,9 +25,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/cs3org/reva/v3/internal/http/services/wellknown"
@@ -81,6 +83,57 @@ func NewClient(timeout time.Duration, insecure bool) *OCMClient {
 			Timeout:   timeout,
 		},
 	}
+}
+
+// NewPublicOnlyClient returns an OCMClient that only dials public addresses, for
+// discovery of hosts named by an untrusted caller. The check is in the dialer so
+// it also covers redirects and DNS rebinding.
+func NewPublicOnlyClient(timeout time.Duration, insecure bool) *OCMClient {
+	tr := newOCMTransport(insecure)
+	tr.DialContext = (&net.Dialer{
+		Timeout:   timeout,
+		KeepAlive: 30 * time.Second,
+		Control:   refuseNonPublicAddr,
+	}).DialContext
+	return &OCMClient{
+		client: &http.Client{
+			Transport: tr,
+			Timeout:   timeout,
+		},
+	}
+}
+
+func refuseNonPublicAddr(_, address string, _ syscall.RawConn) error {
+	host, _, err := net.SplitHostPort(address)
+	if err != nil {
+		return err
+	}
+	ip := net.ParseIP(host)
+	if ip == nil || !isPublicIP(ip) {
+		return errtypes.BadRequest("refusing to connect to non-public address " + address)
+	}
+	return nil
+}
+
+// 64:ff9b::/96 embeds an IPv4 address in its low 32 bits (RFC 6052), so on a
+// NAT64 network it can still reach internal hosts. Check the embedded address.
+var nat64WellKnownPrefix = net.IPNet{IP: net.ParseIP("64:ff9b::"), Mask: net.CIDRMask(96, 128)}
+
+func isPublicIP(ip net.IP) bool {
+	if nat64WellKnownPrefix.Contains(ip) {
+		v6 := ip.To16()
+		return isPublicIP(net.IPv4(v6[12], v6[13], v6[14], v6[15]))
+	}
+	if ip.IsLoopback() || ip.IsPrivate() || ip.IsUnspecified() ||
+		ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() ||
+		ip.IsMulticast() || ip.IsInterfaceLocalMulticast() {
+		return false
+	}
+	// 100.64.0.0/10 is carrier-grade NAT, which net.IP.IsPrivate does not cover
+	if ip4 := ip.To4(); ip4 != nil && ip4[0] == 100 && ip4[1]&0xc0 == 64 {
+		return false
+	}
+	return true
 }
 
 // Discover returns a number of properties used to discover the capabilities offered by a remote cloud storage.

--- a/internal/http/services/opencloudmesh/ocmd/client_test.go
+++ b/internal/http/services/opencloudmesh/ocmd/client_test.go
@@ -21,6 +21,7 @@ package ocmd
 import (
 	"context"
 	"encoding/json"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -256,5 +257,102 @@ func TestNewClientUsesOCMTransport(t *testing.T) {
 	}
 	if tr.Proxy == nil {
 		t.Fatal("client transport Proxy must not be nil")
+	}
+}
+
+func TestIsPublicIP(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		ip   string
+		want bool
+	}{
+		{name: "public v4", ip: "93.184.216.34", want: true},
+		{name: "public v6", ip: "2606:2800:220:1:248:1893:25c8:1946", want: true},
+		{name: "loopback", ip: "127.0.0.1", want: false},
+		{name: "loopback v6", ip: "::1", want: false},
+		{name: "private 10/8", ip: "10.1.2.3", want: false},
+		{name: "private 172.16/12", ip: "172.16.5.4", want: false},
+		{name: "private 192.168/16", ip: "192.168.1.1", want: false},
+		{name: "cloud metadata service", ip: "169.254.169.254", want: false},
+		{name: "unspecified", ip: "0.0.0.0", want: false},
+		{name: "multicast", ip: "224.0.0.1", want: false},
+		{name: "unique local v6", ip: "fd00::1", want: false},
+		{name: "link local v6", ip: "fe80::1", want: false},
+		{name: "carrier-grade nat", ip: "100.64.0.1", want: false},
+		{name: "just outside carrier-grade nat", ip: "100.128.0.1", want: true},
+		{name: "ipv4-mapped metadata service", ip: "::ffff:169.254.169.254", want: false},
+		{name: "ipv4-mapped loopback", ip: "::ffff:127.0.0.1", want: false},
+		{name: "nat64 metadata service", ip: "64:ff9b::a9fe:a9fe", want: false},
+		{name: "nat64 loopback", ip: "64:ff9b::7f00:1", want: false},
+		{name: "nat64 public address", ip: "64:ff9b::5db8:d822", want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ip := net.ParseIP(tt.ip)
+			if ip == nil {
+				t.Fatalf("could not parse %q", tt.ip)
+			}
+			if got := isPublicIP(ip); got != tt.want {
+				t.Errorf("isPublicIP(%s) = %v, want %v", tt.ip, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRefuseNonPublicAddr(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		address string
+		wantErr bool
+	}{
+		{name: "public host", address: "93.184.216.34:443"},
+		{name: "loopback", address: "127.0.0.1:8080", wantErr: true},
+		{name: "metadata service", address: "169.254.169.254:80", wantErr: true},
+		{name: "private range", address: "10.0.0.5:9000", wantErr: true},
+		{name: "ipv6 loopback", address: "[::1]:8080", wantErr: true},
+		{name: "no port", address: "93.184.216.34", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := refuseNonPublicAddr("tcp", tt.address, nil)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("refuseNonPublicAddr(%q) error = %v, wantErr %v", tt.address, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// only the public-only client refuses internal targets; the plain one still reaches them.
+func TestPublicOnlyClientRefusesInternalHosts(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"enabled":true,"apiVersion":"1.1"}`))
+	}))
+	defer srv.Close()
+
+	tests := []struct {
+		name    string
+		client  *OCMClient
+		wantErr bool
+	}{
+		{name: "public-only client refuses the loopback target", client: NewPublicOnlyClient(5*time.Second, true), wantErr: true},
+		{name: "plain client still reaches it", client: NewClient(5*time.Second, true), wantErr: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := tt.client.Discover(context.Background(), srv.URL)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Discover() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
 	}
 }

--- a/internal/http/services/opencloudmesh/ocmd/client_test.go
+++ b/internal/http/services/opencloudmesh/ocmd/client_test.go
@@ -196,8 +196,8 @@ type roundTripperFunc func(*http.Request) (*http.Response, error)
 
 func (f roundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
 
-// TestNewOCMTransportUsesProxyFromEnvironment is the core regression guard: the
-// outbound transport must be wired to http.ProxyFromEnvironment, not left nil.
+// The trusted transport must keep http.ProxyFromEnvironment: some deployments
+// only reach their peers through a corporate proxy.
 func TestNewOCMTransportUsesProxyFromEnvironment(t *testing.T) {
 	tr := newOCMTransport(false)
 	if tr.Proxy == nil {
@@ -207,6 +207,19 @@ func TestNewOCMTransportUsesProxyFromEnvironment(t *testing.T) {
 	want := reflect.ValueOf(http.ProxyFromEnvironment).Pointer()
 	if got != want {
 		t.Error("transport Proxy must be http.ProxyFromEnvironment")
+	}
+}
+
+// The public-only transport must not proxy, or the dial Control would see the
+// proxy address instead of the target.
+func TestNewPublicOnlyClientTransportProxyNil(t *testing.T) {
+	c := NewPublicOnlyClient(5*time.Second, true)
+	tr, ok := c.client.Transport.(*http.Transport)
+	if !ok {
+		t.Fatal("public-only client must use an *http.Transport")
+	}
+	if tr.Proxy != nil {
+		t.Error("public-only client must not use a proxy")
 	}
 }
 

--- a/internal/http/services/opencloudmesh/ocmd/invites.go
+++ b/internal/http/services/opencloudmesh/ocmd/invites.go
@@ -37,7 +37,8 @@ import (
 )
 
 type invitesHandler struct {
-	gatewayClient gateway.GatewayAPIClient
+	gatewayClient     gateway.GatewayAPIClient
+	trustForwardedFor bool
 }
 
 func (h *invitesHandler) init(c *config) error {
@@ -46,6 +47,7 @@ func (h *invitesHandler) init(c *config) error {
 	if err != nil {
 		return err
 	}
+	h.trustForwardedFor = c.TrustForwardedFor
 	return nil
 }
 
@@ -72,7 +74,7 @@ func (h *invitesHandler) AcceptInvite(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	clientIP, err := utils.GetClientIP(r)
+	clientIP, err := utils.GetClientIP(r, h.trustForwardedFor)
 	if err != nil {
 		reqres.WriteError(w, r, reqres.APIErrorServerError, fmt.Sprintf("error retrieving client IP from request: %s", r.RemoteAddr), err)
 		return

--- a/internal/http/services/opencloudmesh/ocmd/ocm.go
+++ b/internal/http/services/opencloudmesh/ocmd/ocm.go
@@ -49,6 +49,9 @@ type config struct {
 	// TrustForwardedFor reads the sender IP from X-Forwarded-For. Enable it only
 	// behind a reverse proxy that sets the header, else peers can spoof it.
 	TrustForwardedFor bool `mapstructure:"trust_forwarded_for"`
+	// OCMClientInsecure skips TLS verification when probing a remote provider's
+	// discovery endpoint. Off by default; turning it on exposes discovery to MITM.
+	OCMClientInsecure bool `mapstructure:"ocm_client_insecure"`
 }
 
 func (c *config) ApplyDefaults() {

--- a/internal/http/services/opencloudmesh/ocmd/ocm.go
+++ b/internal/http/services/opencloudmesh/ocmd/ocm.go
@@ -46,6 +46,9 @@ type config struct {
 	// provider domain. A match activates auto-registration of the share's remote users
 	// for all OCM share types (embedded shares are always auto-registered).
 	AutoAcceptProviders []string `mapstructure:"auto_accept_providers"`
+	// TrustForwardedFor reads the sender IP from X-Forwarded-For. Enable it only
+	// behind a reverse proxy that sets the header, else peers can spoof it.
+	TrustForwardedFor bool `mapstructure:"trust_forwarded_for"`
 }
 
 func (c *config) ApplyDefaults() {

--- a/internal/http/services/opencloudmesh/ocmd/shares.go
+++ b/internal/http/services/opencloudmesh/ocmd/shares.go
@@ -59,6 +59,7 @@ type sharesHandler struct {
 	exposeRecipientDisplayName bool
 	machineSecret              string
 	autoAcceptProviders        []*regexp.Regexp
+	trustForwardedFor          bool
 }
 
 func (h *sharesHandler) init(c *config) error {
@@ -69,6 +70,7 @@ func (h *sharesHandler) init(c *config) error {
 	}
 	h.exposeRecipientDisplayName = c.ExposeRecipientDisplayName
 	h.machineSecret = c.MachineSecret
+	h.trustForwardedFor = c.TrustForwardedFor
 	for _, p := range c.AutoAcceptProviders {
 		re, err := regexp.Compile(p)
 		if err != nil {
@@ -139,7 +141,7 @@ func (h *sharesHandler) CreateShare(w http.ResponseWriter, r *http.Request) {
 
 	// extract the client IP (or the proxied one) from the request and validate it against the allowed providers
 	// TODO(lopresti) this should rather be replaced with signed requests as per more recent OCM specifications
-	senderIP, err := utils.GetClientIP(r)
+	senderIP, err := utils.GetClientIP(r, h.trustForwardedFor)
 	if err != nil {
 		reqres.WriteError(w, r, reqres.APIErrorServerError, fmt.Sprintf("error retrieving client IP from request: %s", r.RemoteAddr), err)
 		return

--- a/internal/http/services/opencloudmesh/ocmd/shares.go
+++ b/internal/http/services/opencloudmesh/ocmd/shares.go
@@ -60,6 +60,7 @@ type sharesHandler struct {
 	machineSecret              string
 	autoAcceptProviders        []*regexp.Regexp
 	trustForwardedFor          bool
+	ocmClientInsecure          bool
 }
 
 func (h *sharesHandler) init(c *config) error {
@@ -71,6 +72,7 @@ func (h *sharesHandler) init(c *config) error {
 	h.exposeRecipientDisplayName = c.ExposeRecipientDisplayName
 	h.machineSecret = c.MachineSecret
 	h.trustForwardedFor = c.TrustForwardedFor
+	h.ocmClientInsecure = c.OCMClientInsecure
 	for _, p := range c.AutoAcceptProviders {
 		re, err := regexp.Compile(p)
 		if err != nil {
@@ -195,7 +197,7 @@ func (h *sharesHandler) CreateShare(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	protocols, legacy, err := getAndResolveProtocols(ctx, req.Protocols, req.ResourceType, sender.Idp)
+	protocols, legacy, err := h.getAndResolveProtocols(ctx, req.Protocols, req.ResourceType, sender.Idp)
 	if err != nil || len(protocols) == 0 {
 		reqres.WriteError(w, r, reqres.APIErrorInvalidParameter, "error with protocols payload", err)
 		return
@@ -402,12 +404,12 @@ func getOCMShareType(st string) ocm.RecipientType {
 	}
 }
 
-func getAndResolveProtocols(ctx context.Context, p Protocols, resType string, ownerServer string) (protos []*ocm.Protocol, legacy bool, err error) {
+func (h *sharesHandler) getAndResolveProtocols(ctx context.Context, p Protocols, resType string, ownerServer string) (protos []*ocm.Protocol, legacy bool, err error) {
 	protos = make([]*ocm.Protocol, 0, len(p))
 	legacy = false
 
 	// discover remote resource types
-	ocmRTs, ocmEndpoint, err := discoverOcmResourceTypes(ctx, ownerServer)
+	ocmRTs, ocmEndpoint, err := h.discoverOcmResourceTypes(ctx, ownerServer)
 	if err != nil {
 		return nil, false, errors.Wrap(err, "error discovering remote OCM resource types")
 	}
@@ -489,8 +491,8 @@ func getAndResolveProtocols(ctx context.Context, p Protocols, resType string, ow
 	return protos, legacy, nil
 }
 
-func discoverOcmResourceTypes(ctx context.Context, ownerServer string) ([]wellknown.ResourceTypes, string, error) {
-	ocmClient := NewClient(time.Duration(10)*time.Second, true)
+func (h *sharesHandler) discoverOcmResourceTypes(ctx context.Context, ownerServer string) ([]wellknown.ResourceTypes, string, error) {
+	ocmClient := NewClient(time.Duration(10)*time.Second, h.ocmClientInsecure)
 	ocmCaps, err := ocmClient.Discover(ctx, ownerServer)
 	if err != nil {
 		return nil, "", err

--- a/internal/http/services/opencloudmesh/ocmd/shares_test.go
+++ b/internal/http/services/opencloudmesh/ocmd/shares_test.go
@@ -244,3 +244,44 @@ func TestParseOCMUser(t *testing.T) {
 		})
 	}
 }
+
+// tlsOcmDiscoveryServer serves discovery over TLS with a self-signed cert.
+func tlsOcmDiscoveryServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/ocm", func(w http.ResponseWriter, r *http.Request) {
+		disco := wellknown.OcmDiscoveryData{
+			Endpoint: "https://" + r.Host,
+			ResourceTypes: []wellknown.ResourceTypes{
+				{Name: "file", Protocols: map[string]any{"webdav": "/remote.php/dav/ocm"}},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(disco)
+	})
+	return httptest.NewTLSServer(mux)
+}
+
+// discovery must verify certs by default, and skip only when asked.
+func TestDiscoverVerifiesTLSUnlessInsecure(t *testing.T) {
+	srv := tlsOcmDiscoveryServer(t) // self-signed, https://127.0.0.1:port
+	defer srv.Close()
+
+	tests := []struct {
+		name    string
+		handler *sharesHandler
+		wantErr bool
+	}{
+		{name: "verifies by default", handler: &sharesHandler{}, wantErr: true},
+		{name: "skips when opted out", handler: &sharesHandler{ocmClientInsecure: true}, wantErr: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, err := tt.handler.discoverOcmResourceTypes(context.Background(), srv.URL)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("discoverOcmResourceTypes() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/http/services/sciencemesh/wayf.go
+++ b/internal/http/services/sciencemesh/wayf.go
@@ -35,6 +35,9 @@ import (
 type wayfHandler struct {
 	directoryServices []ocmd.DirectoryService
 	ocmClient         *ocmd.OCMClient
+	// for /discover, where the host to contact comes from the request body rather
+	// than from our own config
+	untrustedClient *ocmd.OCMClient
 }
 
 type DiscoverRequest struct {
@@ -66,6 +69,7 @@ func (h *wayfHandler) init(c *config) error {
 
 	// Create OCM client for discovery from config
 	h.ocmClient = ocmd.NewClient(time.Duration(c.OCMClientTimeout)*time.Second, c.OCMClientInsecure)
+	h.untrustedClient = ocmd.NewPublicOnlyClient(time.Duration(c.OCMClientTimeout)*time.Second, c.OCMClientInsecure)
 	log.Debug().
 		Int("timeout_seconds", c.OCMClientTimeout).
 		Bool("insecure", c.OCMClientInsecure).
@@ -216,7 +220,8 @@ func (h *wayfHandler) DiscoverProvider(w http.ResponseWriter, r *http.Request) {
 	}
 
 	log.Debug().Str("domain", domain).Msg("Attempting OCM discovery")
-	disco, err := h.ocmClient.Discover(ctx, domain)
+	// this endpoint needs no authentication, so keep the fetch on the public internet
+	disco, err := h.untrustedClient.Discover(ctx, domain)
 	if err != nil {
 		log.Info().Err(err).Str("domain", domain).Msg("Discovery failed")
 		reqres.WriteError(w, r, reqres.APIErrorNotFound,

--- a/internal/http/services/sciencemesh/wayf.go
+++ b/internal/http/services/sciencemesh/wayf.go
@@ -35,8 +35,7 @@ import (
 type wayfHandler struct {
 	directoryServices []ocmd.DirectoryService
 	ocmClient         *ocmd.OCMClient
-	// for /discover, where the host to contact comes from the request body rather
-	// than from our own config
+	// for /discover, where the host comes from the request body, not from config
 	untrustedClient *ocmd.OCMClient
 }
 
@@ -220,7 +219,6 @@ func (h *wayfHandler) DiscoverProvider(w http.ResponseWriter, r *http.Request) {
 	}
 
 	log.Debug().Str("domain", domain).Msg("Attempting OCM discovery")
-	// this endpoint needs no authentication, so keep the fetch on the public internet
 	disco, err := h.untrustedClient.Discover(ctx, domain)
 	if err != nil {
 		log.Info().Err(err).Str("domain", domain).Msg("Discovery failed")

--- a/pkg/ocm/provider/authorizer/open/open.go
+++ b/pkg/ocm/provider/authorizer/open/open.go
@@ -44,13 +44,16 @@ func New(ctx context.Context, m map[string]any) (provider.Authorizer, error) {
 		return nil, err
 	}
 
-	a := &authorizer{}
+	a := &authorizer{insecure: c.Insecure}
 	return a, nil
 }
 
 type config struct {
 	// Users holds a path to a file containing json conforming the Users struct
 	Providers string `mapstructure:"providers"`
+	// Insecure skips TLS verification when discovering an unknown provider. Off by
+	// default; turning it on exposes discovery to MITM.
+	Insecure bool `mapstructure:"insecure"`
 }
 
 func (c *config) ApplyDefaults() {
@@ -58,6 +61,7 @@ func (c *config) ApplyDefaults() {
 
 type authorizer struct {
 	providers []*ocmprovider.ProviderInfo
+	insecure  bool
 }
 
 func (a *authorizer) GetInfoByDomain(ctx context.Context, domain string) (*ocmprovider.ProviderInfo, error) {
@@ -75,7 +79,7 @@ func (a *authorizer) GetInfoByDomain(ctx context.Context, domain string) (*ocmpr
 	}
 
 	// not yet known: try to discover the remote OCM endpoint
-	ocmClient := client.NewClient(time.Duration(10)*time.Second, true)
+	ocmClient := client.NewClient(time.Duration(10)*time.Second, a.insecure)
 	ocmCaps, err := ocmClient.Discover(ctx, endpoint)
 	if err != nil {
 		return nil, errors.Wrap(err, "error probing OCM services at remote server")

--- a/pkg/utils/clientip_test.go
+++ b/pkg/utils/clientip_test.go
@@ -1,0 +1,124 @@
+// Copyright 2018-2026 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package utils
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestGetClientIP(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		remoteAddr string
+		forwarded  string
+		trust      bool
+		want       string
+		wantErr    bool
+	}{
+		{
+			name:       "peer address when there is no header",
+			remoteAddr: "192.0.2.10:54321",
+			want:       "192.0.2.10",
+		},
+		{
+			name:       "a spoofed header is ignored while we do not trust it",
+			remoteAddr: "192.0.2.10:54321",
+			forwarded:  "198.51.100.7",
+			want:       "192.0.2.10",
+		},
+		{
+			name:       "the header is read once a proxy is declared",
+			remoteAddr: "10.0.0.1:443",
+			forwarded:  "198.51.100.7",
+			trust:      true,
+			want:       "198.51.100.7",
+		},
+		{
+			name:       "chain: the last hop is the one our proxy saw",
+			remoteAddr: "10.0.0.1:443",
+			forwarded:  "1.2.3.4, 198.51.100.7",
+			trust:      true,
+			want:       "198.51.100.7",
+		},
+		{
+			name:       "chain with spaces",
+			remoteAddr: "10.0.0.1:443",
+			forwarded:  "  1.2.3.4 ,  198.51.100.7  ",
+			trust:      true,
+			want:       "198.51.100.7",
+		},
+		{
+			name:       "empty header falls back to the peer",
+			remoteAddr: "192.0.2.10:54321",
+			forwarded:  "",
+			trust:      true,
+			want:       "192.0.2.10",
+		},
+		{
+			name:       "header holding only a comma falls back to the peer",
+			remoteAddr: "192.0.2.10:54321",
+			forwarded:  ",",
+			trust:      true,
+			want:       "192.0.2.10",
+		},
+		{
+			name:       "ipv6 peer",
+			remoteAddr: "[2001:db8::1]:443",
+			want:       "2001:db8::1",
+		},
+		{
+			name:       "peer without a port",
+			remoteAddr: "192.0.2.10",
+			want:       "192.0.2.10",
+		},
+		{
+			name:       "unparseable peer",
+			remoteAddr: "not-an-address",
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := httptest.NewRequest(http.MethodPost, "/ocm/shares", nil)
+			r.RemoteAddr = tt.remoteAddr
+			if tt.forwarded != "" {
+				r.Header.Set("X-Forwarded-For", tt.forwarded)
+			}
+
+			got, err := GetClientIP(r, tt.trust)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected an error, got %q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tt.want {
+				t.Errorf("GetClientIP() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -82,8 +82,8 @@ func Skip(source string, prefixes []string) bool {
 }
 
 // GetClientIP retrieves the client IP from incoming requests. X-Forwarded-For is
-// only read when trustForwardedFor is set, since the caller can forge it; the last
-// hop is the one a trusted proxy appended, the rest can be made up.
+// read only when trustForwardedFor is set: a peer can forge it, and only the last
+// hop was appended by our own proxy.
 func GetClientIP(r *http.Request, trustForwardedFor bool) (string, error) {
 	if trustForwardedFor {
 		if forwarded := r.Header.Get("X-Forwarded-For"); forwarded != "" {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -81,25 +81,26 @@ func Skip(source string, prefixes []string) bool {
 	return false
 }
 
-// GetClientIP retrieves the client IP from incoming requests.
-func GetClientIP(r *http.Request) (string, error) {
-	var clientIP string
-	forwarded := r.Header.Get("X-FORWARDED-FOR")
-
-	if forwarded != "" {
-		clientIP = forwarded
-	} else {
-		if ip, _, err := net.SplitHostPort(r.RemoteAddr); err != nil {
-			ipObj := net.ParseIP(r.RemoteAddr)
-			if ipObj == nil {
-				return "", err
+// GetClientIP retrieves the client IP from incoming requests. X-Forwarded-For is
+// only read when trustForwardedFor is set, since the caller can forge it; the last
+// hop is the one a trusted proxy appended, the rest can be made up.
+func GetClientIP(r *http.Request, trustForwardedFor bool) (string, error) {
+	if trustForwardedFor {
+		if forwarded := r.Header.Get("X-Forwarded-For"); forwarded != "" {
+			hops := strings.Split(forwarded, ",")
+			if peer := strings.TrimSpace(hops[len(hops)-1]); peer != "" {
+				return peer, nil
 			}
-			clientIP = ipObj.String()
-		} else {
-			clientIP = ip
 		}
 	}
-	return clientIP, nil
+
+	if ip, _, err := net.SplitHostPort(r.RemoteAddr); err == nil {
+		return ip, nil
+	}
+	if ipObj := net.ParseIP(r.RemoteAddr); ipObj != nil {
+		return ipObj.String(), nil
+	}
+	return "", errors.New("could not determine the client IP of " + r.RemoteAddr)
 }
 
 // ToSnakeCase converts a CamelCase string to a snake_case string.


### PR DESCRIPTION
Three small unrelated things I hit while reading the OCM / ScienceMesh code, one
commit each.

**SSRF via `/sciencemesh/discover`** endpoint is unauthenticated
and fetches whatever host the body names, so it could be pointed at
`169.254.169.254` or anything internal. Discovery of caller-supplied domains now
goes through a client that refuses loopback, private, link-local, CGNAT and
metadata addresses.. check is in the dialer, so redirects, DNS rebinding and
the NAT64 prefix are covered too. Operator-configured targets keep the plain
client.

**Allow list trusts `X-Forwarded-For`**  sender IP was read from
the header whenever present, so a peer could pick which address it was checked as.
Now it's only read behind the new `trust_forwarded_for` option, taking the last
hop. Defense in depth, not a bypass: the invite token and accepted-user checks
still gate the real actions.

**Discovery skips TLS verification**  Two call sites hardcoded it off
while every other one reads it from config. A MITM on discovery could redirect
where content is fetched from. Both now verify certificates by default

## Testing

Table-driven tests for the IP checks, the header parsing and TLS-by-default
Confirmed the SSRF fix against a running revad: the old build connects to an
attacker-named internal port, the fixed one doesn't