### PR TITLE
Ceph: fix dir size

### DIFF
--- a/changelog/unreleased/cephmount-directory-size.md
+++ b/changelog/unreleased/cephmount-directory-size.md
@@ -1,0 +1,7 @@
+Bugfix: report the recursive size of directories in cephmount
+
+Directories were reported with a size of 0, so a folder's size did not match
+the contents seen inside it. The size of the subtree is now taken from the
+CephFS `ceph.dir.rbytes` extended attribute.
+
+https://github.com/cs3org/reva/pull/5761

--- a/pkg/storage/fs/cephmount/cephmount.go
+++ b/pkg/storage/fs/cephmount/cephmount.go
@@ -55,6 +55,8 @@ import (
 const (
 	xattrUserNs = "user."
 	xattrLock   = xattrUserNs + "reva.lockpayload"
+	// recursive size in bytes of a directory subtree, maintained by the MDS
+	xattrCephRbytes = "ceph.dir.rbytes"
 )
 
 // cephmountfs is a local filesystem implementation that provides a ceph-like interface
@@ -399,6 +401,8 @@ func (fs *cephmountfs) fileAsResourceInfo(path string, info os.FileInfo, mdKeys 
 	// Determine resource type
 	if info.IsDir() {
 		resourceType = provider.ResourceType_RESOURCE_TYPE_CONTAINER
+		// info.Size() is the size of the directory entry itself, not of its contents
+		size = fs.directorySize(path)
 	} else if info.Mode()&os.ModeSymlink != 0 {
 		resourceType = provider.ResourceType_RESOURCE_TYPE_SYMLINK
 		// For symlinks, we need to get the absolute filesystem path to read the link
@@ -1142,7 +1146,7 @@ func (fs *cephmountfs) GetQuota(ctx context.Context, ref *provider.Reference) (t
 
 	// rbytes exists at every level and is not inherited like max_bytes
 	// so we only check the path where the quota was found.
-	usedQuotaData, err := xattr.Get(currentPath, "ceph.dir.rbytes")
+	usedQuotaData, err := xattr.Get(currentPath, xattrCephRbytes)
 	if err == nil {
 		// Found the attribute
 		used, _ = strconv.ParseUint(string(usedQuotaData), 10, 64)
@@ -1151,6 +1155,30 @@ func (fs *cephmountfs) GetQuota(ctx context.Context, ref *provider.Reference) (t
 	}
 
 	return total, used, nil
+}
+
+// directorySize returns the recursive size in bytes of the subtree rooted at the
+// given chroot-relative directory, or 0 if it cannot be measured.
+func (fs *cephmountfs) directorySize(path string) uint64 {
+	fullPath := filepath.Join(fs.chrootDir, path)
+
+	if rbytes, err := xattr.Get(fullPath, xattrCephRbytes); err == nil {
+		size, err := strconv.ParseUint(string(rbytes), 10, 64)
+		if err == nil {
+			return size
+		}
+	}
+
+	// Only walk without Ceph: a listing would otherwise walk once per subdirectory.
+	if !fs.conf.TestingAllowLocalMode {
+		return 0
+	}
+
+	size, err := fs.calculateDirectorySize(fullPath)
+	if err != nil {
+		return 0
+	}
+	return size
 }
 
 func (fs *cephmountfs) calculateDirectorySize(root string) (uint64, error) {

--- a/pkg/storage/fs/cephmount/directory_size_test.go
+++ b/pkg/storage/fs/cephmount/directory_size_test.go
@@ -1,0 +1,74 @@
+// Copyright 2018-2024 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package cephmount
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+	"github.com/cs3org/reva/v3/pkg/appctx"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDirectorySize checks that a directory reports the size of everything below
+// it, both when stat'ed directly and when seen as an entry of its parent listing.
+func TestDirectorySize(t *testing.T) {
+	tempDir, cleanup := GetTestDir(t, "directory-size-test")
+	defer cleanup()
+
+	// /folder holds an 11 byte file plus a subdirectory with a 9 byte one
+	folder := filepath.Join(tempDir, "folder")
+	require.NoError(t, os.MkdirAll(filepath.Join(folder, "sub"), 0777))
+	require.NoError(t, os.WriteFile(filepath.Join(folder, "a.txt"), []byte("hello world"), 0666))
+	require.NoError(t, os.WriteFile(filepath.Join(folder, "sub", "b.txt"), []byte("nine byte"), 0666))
+	require.NoError(t, os.Chmod(tempDir, 0777))
+
+	const wantSize = uint64(20)
+
+	config := map[string]any{
+		"testing_allow_local_mode": true,
+	}
+	fs := CreateCephMountFSForTesting(t, ContextWithTestLogger(t), config, "/volumes/_nogroup/rasmus", tempDir)
+
+	ctx := appctx.ContextSetUser(ContextWithTestLogger(t), GetCurrentTestUser(t))
+
+	t.Run("GetMD_reports_recursive_size", func(t *testing.T) {
+		ri, err := fs.GetMD(ctx, &provider.Reference{Path: "/folder"}, nil)
+		require.NoError(t, err)
+		assert.Equal(t, provider.ResourceType_RESOURCE_TYPE_CONTAINER, ri.Type)
+		assert.Equal(t, wantSize, ri.Size, "folder should report the size of its whole subtree")
+	})
+
+	t.Run("ListFolder_reports_recursive_size_of_child", func(t *testing.T) {
+		entries, err := fs.ListFolder(ctx, &provider.Reference{Path: "/"}, nil)
+		require.NoError(t, err)
+
+		var folderEntry *provider.ResourceInfo
+		for _, entry := range entries {
+			if entry.Path == "/folder" {
+				folderEntry = entry
+			}
+		}
+		require.NotNil(t, folderEntry, "listing of / should contain /folder")
+		assert.Equal(t, wantSize, folderEntry.Size, "folder seen from its parent should report the same size")
+	})
+}


### PR DESCRIPTION
Directories were reported with a size of 0, so a folder's size did not match the contents seen inside it. The size of the subtree is now taken from the CephFS `ceph.dir.rbytes` extended attribute.