### PR TITLE
Guard the provider cache against concurrent access

### DIFF
--- a/changelog/unreleased/oidc-provider-cache-race.md
+++ b/changelog/unreleased/oidc-provider-cache-race.md
@@ -1,0 +1,6 @@
+Bugfix: fix data race in the OIDC provider cache
+
+Concurrent logins for an issuer that was not cached yet could take revad down
+with Go's unrecoverable "concurrent map writes".
+
+https://github.com/cs3org/reva/pull/5765

--- a/pkg/auth/manager/oidc/oidc.go
+++ b/pkg/auth/manager/oidc/oidc.go
@@ -28,6 +28,7 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/coreos/go-oidc/v3/oidc"
@@ -48,6 +49,7 @@ import (
 	"github.com/juliangruber/go-intersect"
 	"github.com/pkg/errors"
 	"golang.org/x/oauth2"
+	"golang.org/x/sync/singleflight"
 )
 
 func init() {
@@ -55,7 +57,9 @@ func init() {
 }
 
 type mgr struct {
-	providers map[string]*oidc.Provider
+	providersMu sync.RWMutex
+	providers   map[string]*oidc.Provider
+	discovery   singleflight.Group
 
 	c                *config
 	oidcUsersMapping map[string]*oidcUserMapping
@@ -160,17 +164,32 @@ func extractIssuer(m jwt.MapClaims) (string, bool) {
 }
 
 func (am *mgr) getOIDCProviderForIssuer(ctx context.Context, issuer string) (*oidc.Provider, error) {
-	// FIXME: op not atomic TODO: fix message and make it more clear
-	if am.providers[issuer] == nil {
-		// TODO (gdelmont): the provider should be periodically recreated
-		// as the public key can change over time
-		provider, err := oidc.NewProvider(ctx, issuer)
-		if err != nil {
-			return nil, errors.Wrapf(err, "oidc: error creating a new oidc provider")
-		}
-		am.providers[issuer] = provider
+	am.providersMu.RLock()
+	provider := am.providers[issuer]
+	am.providersMu.RUnlock()
+	if provider != nil {
+		return provider, nil
 	}
-	return am.providers[issuer], nil
+
+	// TODO (gdelmont): the provider should be periodically recreated
+	// as the public key can change over time
+	// shared and outside the lock: a slow issuer must not block the other
+	// issuers, and one caller disconnecting must not fail the others
+	v, err, _ := am.discovery.Do(issuer, func() (any, error) {
+		return oidc.NewProvider(context.WithoutCancel(ctx), issuer)
+	})
+	if err != nil {
+		return nil, errors.Wrapf(err, "oidc: error creating a new oidc provider")
+	}
+
+	am.providersMu.Lock()
+	defer am.providersMu.Unlock()
+	if cached := am.providers[issuer]; cached != nil {
+		return cached, nil
+	}
+	provider = v.(*oidc.Provider)
+	am.providers[issuer] = provider
+	return provider, nil
 }
 
 func (am *mgr) isIssuerAllowed(issuer string) bool {

--- a/pkg/auth/manager/oidc/oidc_test.go
+++ b/pkg/auth/manager/oidc/oidc_test.go
@@ -1,0 +1,148 @@
+// Copyright 2018-2026 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package oidc
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/coreos/go-oidc/v3/oidc"
+)
+
+// The issuer must equal the server URL or NewProvider rejects the response.
+func discoveryServer(t *testing.T) (*httptest.Server, *atomic.Int64) {
+	t.Helper()
+	var hits atomic.Int64
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/.well-known/openid-configuration" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		hits.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"issuer":                                srv.URL,
+			"authorization_endpoint":                srv.URL + "/auth",
+			"token_endpoint":                        srv.URL + "/token",
+			"jwks_uri":                              srv.URL + "/keys",
+			"id_token_signing_alg_values_supported": []string{"RS256"},
+		})
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &hits
+}
+
+func resolveConcurrently(t *testing.T, am *mgr, n int, issuerFor func(i int) string) {
+	t.Helper()
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	errs := make(chan error, n)
+
+	for i := range n {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			if _, err := am.getOIDCProviderForIssuer(context.Background(), issuerFor(i)); err != nil {
+				errs <- err
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		t.Fatalf("getOIDCProviderForIssuer: %v", err)
+	}
+}
+
+// Unsynchronized this is "fatal error: concurrent map writes". Run with -race.
+func TestGetOIDCProviderForIssuerConcurrent(t *testing.T) {
+	tests := []struct {
+		name    string
+		issuers int
+		primed  bool
+	}{
+		{
+			name:    "one uncached issuer",
+			issuers: 1,
+		},
+		{
+			// a read racing a write is equally fatal, so the read path needs
+			// the lock too
+			name:    "uncached issuer racing a cached one",
+			issuers: 2,
+			primed:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srvs := make([]*httptest.Server, tt.issuers)
+			hits := make([]*atomic.Int64, tt.issuers)
+			for i := range srvs {
+				srvs[i], hits[i] = discoveryServer(t)
+			}
+
+			am := &mgr{providers: make(map[string]*oidc.Provider)}
+			if tt.primed {
+				if _, err := am.getOIDCProviderForIssuer(context.Background(), srvs[0].URL); err != nil {
+					t.Fatalf("priming the cache: %v", err)
+				}
+			}
+
+			resolveConcurrently(t, am, 32, func(i int) string {
+				return srvs[i%tt.issuers].URL
+			})
+
+			for i, h := range hits {
+				if got := h.Load(); got != 1 {
+					t.Errorf("issuer %d: discovery requests = %d, want 1", i, got)
+				}
+			}
+		})
+	}
+}
+
+func TestGetOIDCProviderForIssuerCaches(t *testing.T) {
+	srv, hits := discoveryServer(t)
+	am := &mgr{providers: make(map[string]*oidc.Provider)}
+
+	first, err := am.getOIDCProviderForIssuer(context.Background(), srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := am.getOIDCProviderForIssuer(context.Background(), srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first != second {
+		t.Error("expected the cached provider to be reused")
+	}
+	if got := hits.Load(); got != 1 {
+		t.Errorf("discovery requests = %d, want 1", got)
+	}
+}


### PR DESCRIPTION
`getOIDCProviderForIssuer` reads and writes `am.providers` with no lock, which the code already flags with `// FIXME: op not atomic`.

two logins landing together for an issuer that isn't cached yet race on that map. Go doesn't make this a panic, it's `fatal error: concurrent map writes`, so neither recover() nor the grpc recovery interceptor catches it and revad exits.

map is empty after every restart, so the window is the first logins after one, which is also when a lot of people tend to log in at once. With more than one issuer configured a read racing a write is equally fatal, so it isn't only a startup thing.

guarded with a RWMutex and a re-check under the write lock. Discovery stays outside the lock, otherwise one unreachable issuer would block logins for every other issuer, and goes through a singleflight group so a burst costs the IdP one request instead of one per caller.

#### Testing
ran with `-race` against master the same tests report the data race and die with the fatal error, with the fix they pass. also assert that concurrent logins cause a single discovery request, dropping the singleflight makes that fail
