### PR TITLE
Report failures on COPY and third-party copy instead of success

### DIFF
--- a/changelog/unreleased/copy-upload-failure.md
+++ b/changelog/unreleased/copy-upload-failure.md
@@ -1,0 +1,6 @@
+Bugfix: report an error when a COPY or third-party copy upload fails
+
+Both reported success when the upload failed, leaving the destination unwritten,
+and a third-party copy push of a missing source panicked instead of returning 404.
+
+https://github.com/cs3org/reva/pull/5774

--- a/internal/http/services/owncloud/ocdav/copy.go
+++ b/internal/http/services/owncloud/ocdav/copy.go
@@ -272,7 +272,7 @@ func (s *svc) executePathCopy(ctx context.Context, client gateway.GatewayAPIClie
 		defer httpUploadRes.Body.Close()
 		if httpUploadRes.StatusCode != http.StatusOK {
 			log.Error().Any("status", httpUploadRes.StatusCode).Msg("executePathCopy: failed to do upload to data server")
-			return err
+			return fmt.Errorf("status code %d", httpUploadRes.StatusCode)
 		}
 	}
 	return nil

--- a/internal/http/services/owncloud/ocdav/copy_test.go
+++ b/internal/http/services/owncloud/ocdav/copy_test.go
@@ -1,0 +1,94 @@
+// Copyright 2018-2026 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package ocdav
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	gateway "github.com/cs3org/go-cs3apis/cs3/gateway/v1beta1"
+	rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
+	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+	mockgateway "github.com/cs3org/go-cs3apis/mocks/github.com/cs3org/go-cs3apis/cs3/gateway/v1beta1"
+	"github.com/cs3org/reva/v3/pkg/httpclient"
+	"github.com/cs3org/reva/v3/pkg/rgrpc/todo/pool"
+	"github.com/stretchr/testify/mock"
+)
+
+// A file copy must fail when the upload to the data server fails, otherwise the
+// COPY reports success while the destination was never written (silent data loss).
+func TestExecutePathCopyFilePropagatesUploadFailure(t *testing.T) {
+	tests := []struct {
+		name             string
+		uploadStatusCode int
+		wantErr          bool
+	}{
+		{name: "upload succeeds", uploadStatusCode: http.StatusOK, wantErr: false},
+		{name: "upload fails", uploadStatusCode: http.StatusInternalServerError, wantErr: true},
+	}
+
+	for i, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			download := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set(HeaderContentLength, "5")
+				_, _ = w.Write([]byte("hello"))
+			}))
+			defer download.Close()
+
+			upload := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tt.uploadStatusCode)
+			}))
+			defer upload.Close()
+
+			gw := mockgateway.NewMockGatewayAPIClient(t)
+			gw.On("InitiateFileDownload", mock.Anything, mock.Anything).Return(&gateway.InitiateFileDownloadResponse{
+				Status: &rpc.Status{Code: rpc.Code_CODE_OK},
+				Protocols: []*gateway.FileDownloadProtocol{
+					{Protocol: "simple", DownloadEndpoint: download.URL, Token: "download-token"},
+				},
+			}, nil)
+			gw.On("InitiateFileUpload", mock.Anything, mock.Anything).Return(&gateway.InitiateFileUploadResponse{
+				Status: &rpc.Status{Code: rpc.Code_CODE_OK},
+				Protocols: []*gateway.FileUploadProtocol{
+					{Protocol: "simple", UploadEndpoint: upload.URL, Token: "upload-token"},
+				},
+			}, nil)
+
+			endpoint := "copy-gw-" + string(rune('a'+i))
+			pool.RegisterGatewayServiceClient(gw, endpoint)
+			s := svc{c: &Config{GatewaySvc: endpoint}, client: httpclient.New()}
+
+			cp := &copy{
+				sourceInfo:  &provider.ResourceInfo{Type: provider.ResourceType_RESOURCE_TYPE_FILE, Path: "/src.txt"},
+				destination: &provider.Reference{Path: "/dst.txt"},
+				depth:       "0",
+				successCode: http.StatusCreated,
+			}
+
+			r := httptest.NewRequest("COPY", "http://localhost/dst.txt", nil)
+			err := s.executePathCopy(context.Background(), gw, httptest.NewRecorder(), r, cp)
+
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("executePathCopy() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/http/services/owncloud/ocdav/tpc.go
+++ b/internal/http/services/owncloud/ocdav/tpc.go
@@ -254,7 +254,7 @@ func (s *svc) performHTTPPull(ctx context.Context, client gateway.GatewayAPIClie
 	defer httpUploadRes.Body.Close()
 	if httpUploadRes.StatusCode != http.StatusOK {
 		w.WriteHeader(httpUploadRes.StatusCode)
-		return err
+		return fmt.Errorf("upload to the data server returned status code %d", httpUploadRes.StatusCode)
 	}
 	return nil
 }
@@ -376,7 +376,7 @@ func (s *svc) performHTTPPush(ctx context.Context, client gateway.GatewayAPIClie
 	defer httpDownloadRes.Body.Close()
 	if httpDownloadRes.StatusCode != http.StatusOK {
 		w.WriteHeader(httpDownloadRes.StatusCode)
-		return fmt.Errorf("remote PUT returned status code %d", httpDownloadRes.StatusCode)
+		return fmt.Errorf("download from the data server returned status code %d", httpDownloadRes.StatusCode)
 	}
 
 	// send performance markers periodically every PerfMarkerResponseTime (5 seconds unless configured)
@@ -426,7 +426,7 @@ func (s *svc) performHTTPPush(ctx context.Context, client gateway.GatewayAPIClie
 
 	if httpUploadRes.StatusCode != http.StatusOK {
 		w.WriteHeader(httpUploadRes.StatusCode)
-		return err
+		return fmt.Errorf("remote PUT returned status code %d", httpUploadRes.StatusCode)
 	}
 
 	return nil

--- a/internal/http/services/owncloud/ocdav/tpc.go
+++ b/internal/http/services/owncloud/ocdav/tpc.go
@@ -312,7 +312,7 @@ func (s *svc) handleTPCPush(ctx context.Context, w http.ResponseWriter, r *http.
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
-	if srcStatRes.Status.Code != rpc.Code_CODE_OK && srcStatRes.Status.Code != rpc.Code_CODE_NOT_FOUND {
+	if srcStatRes.Status.Code != rpc.Code_CODE_OK {
 		HandleErrorStatus(&sublog, w, srcStatRes.Status)
 		return
 	}

--- a/internal/http/services/owncloud/ocdav/tpc_test.go
+++ b/internal/http/services/owncloud/ocdav/tpc_test.go
@@ -133,3 +133,38 @@ func TestPerformHTTPPushPropagatesUploadFailure(t *testing.T) {
 		})
 	}
 }
+
+// A push must reject a source it cannot stat rather than panic on a nil Info.
+func TestHandleTPCPushRejectsUnreadableSource(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode rpc.Code
+		wantStatus int
+	}{
+		{name: "source not found", statusCode: rpc.Code_CODE_NOT_FOUND, wantStatus: http.StatusNotFound},
+		{name: "permission denied", statusCode: rpc.Code_CODE_PERMISSION_DENIED, wantStatus: http.StatusForbidden},
+	}
+
+	for i, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gw := mockgateway.NewMockGatewayAPIClient(t)
+			gw.On("Stat", mock.Anything, mock.Anything).Return(&provider.StatResponse{
+				Status: &rpc.Status{Code: tt.statusCode},
+			}, nil)
+
+			endpoint := "tpc-push-badsrc-" + string(rune('a'+i))
+			pool.RegisterGatewayServiceClient(gw, endpoint)
+			s := svc{c: &Config{GatewaySvc: endpoint, EnableHTTPTpc: true}, client: httpclient.New()}
+
+			r := httptest.NewRequest("COPY", "http://localhost/src.txt", nil)
+			r.Header.Set("Destination", "http://remote/dst.txt")
+			w := httptest.NewRecorder()
+
+			s.handleTPCPush(context.Background(), w, r, "/ns")
+
+			if w.Code != tt.wantStatus {
+				t.Fatalf("handleTPCPush() status = %d, want %d", w.Code, tt.wantStatus)
+			}
+		})
+	}
+}

--- a/internal/http/services/owncloud/ocdav/tpc_test.go
+++ b/internal/http/services/owncloud/ocdav/tpc_test.go
@@ -1,0 +1,135 @@
+// Copyright 2018-2026 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package ocdav
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	gateway "github.com/cs3org/go-cs3apis/cs3/gateway/v1beta1"
+	rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
+	provider "github.com/cs3org/go-cs3apis/cs3/storage/provider/v1beta1"
+	mockgateway "github.com/cs3org/go-cs3apis/mocks/github.com/cs3org/go-cs3apis/cs3/gateway/v1beta1"
+	"github.com/cs3org/reva/v3/pkg/httpclient"
+	"github.com/cs3org/reva/v3/pkg/rgrpc/todo/pool"
+	"github.com/stretchr/testify/mock"
+)
+
+// The caller writes "success: Created" whenever this returns nil, and the 202 has
+// already gone out, so that trailer is all the client sees.
+func TestPerformHTTPPullPropagatesUploadFailure(t *testing.T) {
+	tests := []struct {
+		name             string
+		uploadStatusCode int
+		wantErr          bool
+	}{
+		{name: "upload succeeds", uploadStatusCode: http.StatusOK, wantErr: false},
+		{name: "upload fails", uploadStatusCode: http.StatusInternalServerError, wantErr: true},
+	}
+
+	for i, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			source := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_, _ = w.Write([]byte("hello"))
+			}))
+			defer source.Close()
+
+			upload := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tt.uploadStatusCode)
+			}))
+			defer upload.Close()
+
+			gw := mockgateway.NewMockGatewayAPIClient(t)
+			gw.On("InitiateFileUpload", mock.Anything, mock.Anything).Return(&gateway.InitiateFileUploadResponse{
+				Status: &rpc.Status{Code: rpc.Code_CODE_OK},
+				Protocols: []*gateway.FileUploadProtocol{
+					{Protocol: "simple", UploadEndpoint: upload.URL, Token: "upload-token"},
+				},
+			}, nil)
+
+			endpoint := "tpc-pull-gw-" + string(rune('a'+i))
+			pool.RegisterGatewayServiceClient(gw, endpoint)
+			s := svc{c: &Config{GatewaySvc: endpoint}, client: httpclient.New()}
+
+			r := httptest.NewRequest("COPY", "http://localhost/dst.txt", nil)
+			r.Header.Set("Source", source.URL)
+
+			err := s.performHTTPPull(context.Background(), gw, r, httptest.NewRecorder(), "/ns")
+
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("performHTTPPull() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// Same for the push direction, where the PUT goes to the remote destination.
+func TestPerformHTTPPushPropagatesUploadFailure(t *testing.T) {
+	tests := []struct {
+		name             string
+		uploadStatusCode int
+		wantErr          bool
+	}{
+		{name: "upload succeeds", uploadStatusCode: http.StatusOK, wantErr: false},
+		{name: "upload fails", uploadStatusCode: http.StatusInternalServerError, wantErr: true},
+	}
+
+	for i, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			download := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_, _ = w.Write([]byte("hello"))
+			}))
+			defer download.Close()
+
+			destination := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tt.uploadStatusCode)
+			}))
+			defer destination.Close()
+
+			gw := mockgateway.NewMockGatewayAPIClient(t)
+			gw.On("InitiateFileDownload", mock.Anything, mock.Anything).Return(&gateway.InitiateFileDownloadResponse{
+				Status: &rpc.Status{Code: rpc.Code_CODE_OK},
+				Protocols: []*gateway.FileDownloadProtocol{
+					{Protocol: "simple", DownloadEndpoint: download.URL, Token: "download-token"},
+				},
+			}, nil)
+
+			endpoint := "tpc-push-gw-" + string(rune('a'+i))
+			pool.RegisterGatewayServiceClient(gw, endpoint)
+			s := svc{c: &Config{GatewaySvc: endpoint}, client: httpclient.New()}
+
+			r := httptest.NewRequest("COPY", "http://localhost/src.txt", nil)
+			r.Header.Set("Destination", destination.URL)
+
+			srcInfo := &provider.ResourceInfo{
+				Type: provider.ResourceType_RESOURCE_TYPE_FILE,
+				Path: "/src.txt",
+				Size: 5,
+			}
+
+			err := s.performHTTPPush(context.Background(), gw, r, httptest.NewRecorder(), srcInfo, "/ns")
+
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("performHTTPPush() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
COPY handler and the third-party copy push/pull handlers reported success even when the upload to the data server (or the remote PUT) returned a non-2xx status. For overwrite COPY the destination is deleted before the upload, so a false success silently lost the file, for a third-party copy a transfer manager could delete the source after a copy that never actually happened.

While in there, a third-party copy push of a source that doesn't exist dereferenced a nil stat result and panicked.. it now returns 404
**Now its:**
- report an error when a COPY upload fails
- report an error when a third-party copy upload fails
- return 404 for a third-party copy push of a missing source

