### PR TITLE
Return proper error codes instead of NewInternal

### DIFF
--- a/changelog/unreleased/review-internal-errors.md
+++ b/changelog/unreleased/review-internal-errors.md
@@ -1,0 +1,10 @@
+Change: return tailored grpc error codes instead of always INTERNAL
+
+Many grpc handlers wrapped every error in status.NewInternal, hiding the real
+code from callers. They now map known errtypes (not found, permission denied,
+already exists, invalid argument, ...) to the matching grpc status code through
+a fixed status.NewStatusFromErrType, and the gateway share handlers propagate
+the downstream status instead of flattening it.
+
+https://github.com/cs3org/reva/pull/5781
+https://github.com/cs3org/reva/issues/4915

--- a/internal/grpc/services/applicationauth/applicationauth.go
+++ b/internal/grpc/services/applicationauth/applicationauth.go
@@ -100,7 +100,7 @@ func (s *service) GenerateAppPassword(ctx context.Context, req *appauthpb.Genera
 	pwd, err := s.am.GenerateAppPassword(ctx, req.TokenScope, req.Label, req.Expiration)
 	if err != nil {
 		return &appauthpb.GenerateAppPasswordResponse{
-			Status: status.NewInternal(ctx, err, "error generating app password"),
+			Status: status.NewStatusFromErrType(ctx, "error generating app password", err),
 		}, nil
 	}
 
@@ -114,7 +114,7 @@ func (s *service) ListAppPasswords(ctx context.Context, req *appauthpb.ListAppPa
 	pwds, err := s.am.ListAppPasswords(ctx)
 	if err != nil {
 		return &appauthpb.ListAppPasswordsResponse{
-			Status: status.NewInternal(ctx, err, "error listing app passwords"),
+			Status: status.NewStatusFromErrType(ctx, "error listing app passwords", err),
 		}, nil
 	}
 
@@ -128,7 +128,7 @@ func (s *service) InvalidateAppPassword(ctx context.Context, req *appauthpb.Inva
 	err := s.am.InvalidateAppPassword(ctx, req.Password)
 	if err != nil {
 		return &appauthpb.InvalidateAppPasswordResponse{
-			Status: status.NewInternal(ctx, err, "error invalidating app password"),
+			Status: status.NewStatusFromErrType(ctx, "error invalidating app password", err),
 		}, nil
 	}
 
@@ -141,7 +141,7 @@ func (s *service) GetAppPassword(ctx context.Context, req *appauthpb.GetAppPassw
 	pwd, err := s.am.GetAppPassword(ctx, req.User, req.Password)
 	if err != nil {
 		return &appauthpb.GetAppPasswordResponse{
-			Status: status.NewInternal(ctx, err, "error getting app password via username/password"),
+			Status: status.NewStatusFromErrType(ctx, "error getting app password via username/password", err),
 		}, nil
 	}
 

--- a/internal/grpc/services/appregistry/appregistry.go
+++ b/internal/grpc/services/appregistry/appregistry.go
@@ -99,7 +99,7 @@ func (s *svc) GetAppProviders(ctx context.Context, req *registrypb.GetAppProvide
 	p, err := s.reg.FindProviders(ctx, req.ResourceInfo.MimeType)
 	if err != nil {
 		return &registrypb.GetAppProvidersResponse{
-			Status: status.NewInternal(ctx, err, "error looking for the app provider"),
+			Status: status.NewStatusFromErrType(ctx, "error looking for the app provider", err),
 		}, nil
 	}
 
@@ -114,7 +114,7 @@ func (s *svc) AddAppProvider(ctx context.Context, req *registrypb.AddAppProvider
 	err := s.reg.AddProvider(ctx, req.Provider)
 	if err != nil {
 		return &registrypb.AddAppProviderResponse{
-			Status: status.NewInternal(ctx, err, "error adding the app provider"),
+			Status: status.NewStatusFromErrType(ctx, "error adding the app provider", err),
 		}, nil
 	}
 
@@ -128,7 +128,7 @@ func (s *svc) ListAppProviders(ctx context.Context, req *registrypb.ListAppProvi
 	providers, err := s.reg.ListProviders(ctx)
 	if err != nil {
 		return &registrypb.ListAppProvidersResponse{
-			Status: status.NewInternal(ctx, err, "error listing the app providers"),
+			Status: status.NewStatusFromErrType(ctx, "error listing the app providers", err),
 		}, nil
 	}
 
@@ -143,7 +143,7 @@ func (s *svc) ListSupportedMimeTypes(ctx context.Context, req *registrypb.ListSu
 	mimeTypes, err := s.reg.ListSupportedMimeTypes(ctx)
 	if err != nil {
 		return &registrypb.ListSupportedMimeTypesResponse{
-			Status: status.NewInternal(ctx, err, "error listing the supported mime types"),
+			Status: status.NewStatusFromErrType(ctx, "error listing the supported mime types", err),
 		}, nil
 	}
 
@@ -165,7 +165,7 @@ func (s *svc) GetDefaultAppProviderForMimeType(ctx context.Context, req *registr
 	provider, err := s.reg.GetDefaultProviderForMimeType(ctx, req.MimeType)
 	if err != nil {
 		return &registrypb.GetDefaultAppProviderForMimeTypeResponse{
-			Status: status.NewInternal(ctx, err, "error getting the default app provider for the mimetype"),
+			Status: status.NewStatusFromErrType(ctx, "error getting the default app provider for the mimetype", err),
 		}, nil
 	}
 
@@ -180,7 +180,7 @@ func (s *svc) SetDefaultAppProviderForMimeType(ctx context.Context, req *registr
 	err := s.reg.SetDefaultProviderForMimeType(ctx, req.MimeType, req.Provider)
 	if err != nil {
 		return &registrypb.SetDefaultAppProviderForMimeTypeResponse{
-			Status: status.NewInternal(ctx, err, "error setting the default app provider for the mimetype"),
+			Status: status.NewStatusFromErrType(ctx, "error setting the default app provider for the mimetype", err),
 		}, nil
 	}
 

--- a/internal/grpc/services/appregistry/appregistry_test.go
+++ b/internal/grpc/services/appregistry/appregistry_test.go
@@ -251,9 +251,9 @@ func Test_GetAppProviders(t *testing.T) {
 			search: &providerv1beta1.ResourceInfo{MimeType: "doesnot/exist"},
 			want: &registrypb.GetAppProvidersResponse{
 				Status: &rpcv1beta1.Status{
-					Code:    15,
+					Code:    6,
 					Trace:   "",
-					Message: "error looking for the app provider",
+					Message: "error looking for the app provider: error: not found: application provider not found for mime type doesnot/exist",
 				},
 				Providers: nil,
 			},
@@ -263,9 +263,9 @@ func Test_GetAppProviders(t *testing.T) {
 			search: &providerv1beta1.ResourceInfo{MimeType: ""},
 			want: &registrypb.GetAppProvidersResponse{
 				Status: &rpcv1beta1.Status{
-					Code:    15,
+					Code:    6,
 					Trace:   "",
-					Message: "error looking for the app provider",
+					Message: "error looking for the app provider: error: not found: application provider not found for mime type ",
 				},
 				Providers: nil,
 			},
@@ -275,9 +275,9 @@ func Test_GetAppProviders(t *testing.T) {
 			search: &providerv1beta1.ResourceInfo{},
 			want: &registrypb.GetAppProvidersResponse{
 				Status: &rpcv1beta1.Status{
-					Code:    15,
+					Code:    6,
 					Trace:   "",
-					Message: "error looking for the app provider",
+					Message: "error looking for the app provider: error: not found: application provider not found for mime type ",
 				},
 				Providers: nil,
 			},
@@ -287,9 +287,9 @@ func Test_GetAppProviders(t *testing.T) {
 			search: &providerv1beta1.ResourceInfo{MimeType: "this/type\\IS.not?VALID@all"},
 			want: &registrypb.GetAppProvidersResponse{
 				Status: &rpcv1beta1.Status{
-					Code:    15,
+					Code:    6,
 					Trace:   "",
-					Message: "error looking for the app provider",
+					Message: "error looking for the app provider: error: not found: application provider not found for mime type this/type\\IS.not?VALID@all",
 				},
 				Providers: nil,
 			},

--- a/internal/grpc/services/authregistry/authregistry.go
+++ b/internal/grpc/services/authregistry/authregistry.go
@@ -102,7 +102,7 @@ func (s *service) ListAuthProviders(ctx context.Context, req *registrypb.ListAut
 	pinfos, err := s.reg.ListProviders(ctx)
 	if err != nil {
 		return &registrypb.ListAuthProvidersResponse{
-			Status: status.NewInternal(ctx, err, "error getting list of auth providers"),
+			Status: status.NewStatusFromErrType(ctx, "error getting list of auth providers", err),
 		}, nil
 	}
 
@@ -117,7 +117,7 @@ func (s *service) GetAuthProviders(ctx context.Context, req *registrypb.GetAuthP
 	pinfo, err := s.reg.GetProvider(ctx, req.Type)
 	if err != nil {
 		return &registrypb.GetAuthProvidersResponse{
-			Status: status.NewInternal(ctx, err, "error getting auth provider for type: "+req.Type),
+			Status: status.NewStatusFromErrType(ctx, "error getting auth provider for type: "+req.Type, err),
 		}, nil
 	}
 

--- a/internal/grpc/services/datatx/datatx.go
+++ b/internal/grpc/services/datatx/datatx.go
@@ -167,11 +167,10 @@ func (s *service) GetTransferStatus(ctx context.Context, req *datatx.GetTransfer
 
 	txInfo, err := s.txManager.GetTransferStatus(ctx, req.GetTxId().OpaqueId)
 	if err != nil {
-		err = errors.Wrap(err, "datatx service: error retrieving transfer status")
 		return &datatx.GetTransferStatusResponse{
-			Status: status.NewInternal(ctx, err, "datatx service: error getting transfer status"),
+			Status: status.NewStatusFromErrType(ctx, "datatx service: error getting transfer status", err),
 			TxInfo: txInfo,
-		}, err
+		}, nil
 	}
 
 	txInfo.ShareId = &ocm.ShareId{OpaqueId: transfer.ShareID}
@@ -189,7 +188,6 @@ func (s *service) CancelTransfer(ctx context.Context, req *datatx.CancelTransfer
 		return nil, errtypes.InternalError("datatx service: transfer not found")
 	}
 
-	transferRemovedMessage := ""
 	if s.conf.RemoveOnCancel {
 		if err := s.storageDriver.DeleteTransfer(transfer); err != nil {
 			err = errors.Wrap(err, "datatx service: error deleting transfer: "+datatx.Status_STATUS_INVALID.String())
@@ -197,17 +195,15 @@ func (s *service) CancelTransfer(ctx context.Context, req *datatx.CancelTransfer
 				Status: status.NewInvalid(ctx, "error cancelling transfer"),
 			}, err
 		}
-		transferRemovedMessage = "transfer successfully removed"
 	}
 
 	txInfo, err := s.txManager.CancelTransfer(ctx, req.GetTxId().OpaqueId)
 	if err != nil {
 		txInfo.ShareId = &ocm.ShareId{OpaqueId: transfer.ShareID}
-		err = errors.Wrapf(err, "(%v) datatx service: error cancelling transfer", transferRemovedMessage)
 		return &datatx.CancelTransferResponse{
-			Status: status.NewInternal(ctx, err, "error cancelling transfer"),
+			Status: status.NewStatusFromErrType(ctx, "error cancelling transfer", err),
 			TxInfo: txInfo,
-		}, err
+		}, nil
 	}
 
 	txInfo.ShareId = &ocm.ShareId{OpaqueId: transfer.ShareID}
@@ -222,12 +218,11 @@ func (s *service) ListTransfers(ctx context.Context, req *datatx.ListTransfersRe
 	userID := appctx.ContextMustGetUser(ctx).GetId()
 	transfers, err := s.storageDriver.ListTransfers(req.Filters, userID)
 	if err != nil {
-		err = errors.Wrap(err, "datatx service: error listing transfers")
 		var txInfos []*datatx.TxInfo
 		return &datatx.ListTransfersResponse{
-			Status:    status.NewInternal(ctx, err, "error listing transfers"),
+			Status:    status.NewStatusFromErrType(ctx, "error listing transfers", err),
 			Transfers: txInfos,
-		}, err
+		}, nil
 	}
 
 	txInfos := []*datatx.TxInfo{}
@@ -252,11 +247,10 @@ func (s *service) RetryTransfer(ctx context.Context, req *datatx.RetryTransferRe
 
 	txInfo, err := s.txManager.RetryTransfer(ctx, req.GetTxId().OpaqueId)
 	if err != nil {
-		err = errors.Wrap(err, "datatx service: error retrying transfer")
 		return &datatx.RetryTransferResponse{
-			Status: status.NewInternal(ctx, err, "error retrying transfer"),
+			Status: status.NewStatusFromErrType(ctx, "error retrying transfer", err),
 			TxInfo: txInfo,
-		}, err
+		}, nil
 	}
 
 	txInfo.ShareId = &ocm.ShareId{OpaqueId: transfer.ShareID}

--- a/internal/grpc/services/gateway/appprovider.go
+++ b/internal/grpc/services/gateway/appprovider.go
@@ -76,9 +76,8 @@ func (s *svc) OpenInApp(ctx context.Context, req *gateway.OpenInAppRequest) (*pr
 		}, nil
 	}
 	if statRes.Status.Code != rpc.Code_CODE_OK {
-		err := status.NewErrorFromCode(statRes.Status.GetCode(), "gateway")
 		return &providerpb.OpenInAppResponse{
-			Status: status.NewInternal(ctx, err, "Stat failed on the resource path for the app provider: "+req.Ref.GetPath()),
+			Status: statRes.Status,
 		}, nil
 	}
 
@@ -106,9 +105,8 @@ func (s *svc) OpenInApp(ctx context.Context, req *gateway.OpenInAppRequest) (*pr
 			}, nil
 		}
 		if res.Status.Code != rpc.Code_CODE_OK {
-			err := status.NewErrorFromCode(res.Status.GetCode(), "gateway")
 			return &providerpb.OpenInAppResponse{
-				Status: status.NewInternal(ctx, err, "Stat failed on the resource path for the app provider: "+req.Ref.GetPath()),
+				Status: res.Status,
 			}, nil
 		}
 		fileInfo = res.Info

--- a/internal/grpc/services/gateway/authprovider.go
+++ b/internal/grpc/services/gateway/authprovider.go
@@ -44,9 +44,8 @@ func (s *svc) Authenticate(ctx context.Context, req *gateway.AuthenticateRequest
 	// find auth provider
 	c, err := s.findAuthProvider(ctx, req.Type)
 	if err != nil {
-		err = errtypes.NotFound("gateway: error finding auth provider for type: " + req.Type)
 		return &gateway.AuthenticateResponse{
-			Status: status.NewInternal(ctx, err, "error getting auth provider client"),
+			Status: status.NewStatusFromErrType(ctx, "error finding auth provider for type: "+req.Type, err),
 		}, nil
 	}
 

--- a/internal/grpc/services/gateway/authprovider.go
+++ b/internal/grpc/services/gateway/authprovider.go
@@ -72,9 +72,8 @@ func (s *svc) Authenticate(ctx context.Context, req *gateway.AuthenticateRequest
 			Status: res.Status,
 		}, nil
 	case res.Status.Code != rpc.Code_CODE_OK:
-		err := status.NewErrorFromCode(res.Status.Code, "gateway")
 		return &gateway.AuthenticateResponse{
-			Status: status.NewInternal(ctx, err, fmt.Sprintf("error authenticating credentials to auth provider for type: %s", req.Type)),
+			Status: res.Status,
 		}, nil
 	}
 
@@ -174,10 +173,9 @@ func (s *svc) Authenticate(ctx context.Context, req *gateway.AuthenticateRequest
 			}
 
 			if createHomeRes.Status.Code != rpc.Code_CODE_OK {
-				err := status.NewErrorFromCode(createHomeRes.Status.Code, "gateway")
-				log.Err(err).Any("response", createHomeRes).Msg("return from CreateHome")
+				log.Err(status.NewErrorFromCode(createHomeRes.Status.Code, "gateway")).Any("response", createHomeRes).Msg("return from CreateHome")
 				return &gateway.AuthenticateResponse{
-					Status: status.NewInternal(ctx, err, "error creating user home"),
+					Status: createHomeRes.Status,
 				}, nil
 			}
 			if s.c.CreateHomeCacheTTL > 0 {

--- a/internal/grpc/services/gateway/authregistry.go
+++ b/internal/grpc/services/gateway/authregistry.go
@@ -47,9 +47,8 @@ func (s *svc) ListAuthProviders(ctx context.Context, req *registry.ListAuthProvi
 	}
 
 	if res.Status.Code != rpc.Code_CODE_OK {
-		err := status.NewErrorFromCode(res.Status.Code, "gateway")
 		return &gateway.ListAuthProvidersResponse{
-			Status: status.NewInternal(ctx, err, "gateway"),
+			Status: res.Status,
 		}, nil
 	}
 

--- a/internal/grpc/services/gateway/ocmshareprovider.go
+++ b/internal/grpc/services/gateway/ocmshareprovider.go
@@ -23,8 +23,8 @@ import (
 	"fmt"
 	"net/url"
 	"path"
-	"strings"
 	"slices"
+	"strings"
 
 	"github.com/alitto/pond/v2"
 	gateway "github.com/cs3org/go-cs3apis/cs3/gateway/v1beta1"

--- a/internal/grpc/services/gateway/ocmshareprovider.go
+++ b/internal/grpc/services/gateway/ocmshareprovider.go
@@ -158,7 +158,7 @@ func (s *svc) ListExistingOCMShares(ctx context.Context, req *ocm.ListOCMSharesR
 					return err
 				}
 				if stat.Status.Code != rpc.Code_CODE_OK {
-					return errors.New("An error occurred: " + stat.Status.Message)
+					return status.NewErrtypeFromStatus(stat.Status)
 				}
 				resourceInfo = stat.Info
 				if s.resourceInfoCacheTTL > 0 {

--- a/internal/grpc/services/gateway/publicshareprovider.go
+++ b/internal/grpc/services/gateway/publicshareprovider.go
@@ -185,7 +185,7 @@ func (s *svc) ListExistingPublicShares(ctx context.Context, req *link.ListPublic
 					return err
 				}
 				if stat.Status.Code != rpc.Code_CODE_OK {
-					return errors.New("An error occurred: " + stat.Status.Message)
+					return status.NewErrtypeFromStatus(stat.Status)
 				}
 				resourceInfo = stat.Info
 				if s.resourceInfoCacheTTL > 0 {

--- a/internal/grpc/services/gateway/storageprovider.go
+++ b/internal/grpc/services/gateway/storageprovider.go
@@ -920,7 +920,7 @@ func (s *svc) findProviders(ctx context.Context, ref *provider.Reference) ([]*re
 		case rpc.Code_CODE_UNIMPLEMENTED:
 			return nil, errtypes.NotSupported("gateway: " + res.Status.Message + " for " + ref.String() + " with code " + res.Status.Code.String())
 		default:
-			return nil, status.NewErrorFromCode(res.Status.Code, "gateway")
+			return nil, status.NewErrtypeFromStatus(res.Status)
 		}
 	}
 

--- a/internal/grpc/services/gateway/userprovider.go
+++ b/internal/grpc/services/gateway/userprovider.go
@@ -98,7 +98,7 @@ func (s *svc) FindUsers(ctx context.Context, req *user.FindUsersRequest) (*user.
 
 		if res.Status.Code != rpc.Code_CODE_OK {
 			return &user.FindUsersResponse{
-				Status: status.NewInternal(ctx, errors.New(res.Status.Message), res.Status.Message),
+				Status: res.Status,
 			}, nil
 		}
 		res.Users = append(res.Users, ocm_res.AcceptedUsers...)

--- a/internal/grpc/services/gateway/usershareprovider.go
+++ b/internal/grpc/services/gateway/usershareprovider.go
@@ -108,7 +108,7 @@ func (s *svc) CreateShare(ctx context.Context, req *collaboration.CreateShareReq
 	existingShares, err := s.listSharesForGranteeInSpace(ctx, shareClient, spaceId, req.Grant.Grantee)
 	if err != nil {
 		return &collaboration.CreateShareResponse{
-			Status: status.NewInternal(ctx, err, "error listing shares for hierarchy check"),
+			Status: status.NewStatusFromErrType(ctx, "error listing shares for hierarchy check", err),
 		}, nil
 	}
 
@@ -211,7 +211,7 @@ func (s *svc) RemoveShare(ctx context.Context, req *collaboration.RemoveShareReq
 	existingShares, listErr := s.listSharesForGranteeInSpace(ctx, c, share.ResourceId.SpaceId, share.Grantee)
 	if listErr != nil {
 		return &collaboration.RemoveShareResponse{
-			Status: status.NewInternal(ctx, listErr, "error listing shares for hierarchy reapply"),
+			Status: status.NewStatusFromErrType(ctx, "error listing shares for hierarchy reapply", listErr),
 		}, nil
 	}
 	reapply := checker.GrantsToReapplyAfterRemove(ctx, share.Id.OpaqueId, share.ResourceId, existingShares)
@@ -412,7 +412,7 @@ func (s *svc) UpdateShare(ctx context.Context, req *collaboration.UpdateShareReq
 		existingShares, listErr := s.listSharesForGranteeInSpace(ctx, c, currentShare.ResourceId.SpaceId, currentShare.Grantee)
 		if listErr != nil {
 			return &collaboration.UpdateShareResponse{
-				Status: status.NewInternal(ctx, listErr, "error listing shares for hierarchy check"),
+				Status: status.NewStatusFromErrType(ctx, "error listing shares for hierarchy check", listErr),
 			}, nil
 		}
 		existingShares = filterOutShare(existingShares, currentShare.Id.OpaqueId)
@@ -420,7 +420,7 @@ func (s *svc) UpdateShare(ctx context.Context, req *collaboration.UpdateShareReq
 		currentPath, pathErr := s.getPathForResourceId(ctx, currentShare.ResourceId)
 		if pathErr != nil {
 			return &collaboration.UpdateShareResponse{
-				Status: status.NewInternal(ctx, pathErr, "error resolving share path for hierarchy check"),
+				Status: status.NewStatusFromErrType(ctx, "error resolving share path for hierarchy check", pathErr),
 			}, nil
 		}
 
@@ -741,10 +741,7 @@ func (s *svc) removeReference(ctx context.Context, resourceID *provider.Resource
 	idReference := &provider.Reference{ResourceId: resourceID}
 	storageProvider, err := s.find(ctx, idReference)
 	if err != nil {
-		if _, ok := err.(errtypes.IsNotFound); ok {
-			return status.NewNotFound(ctx, "storage provider not found")
-		}
-		return status.NewInternal(ctx, err, "error finding storage provider")
+		return status.NewStatusFromErrType(ctx, "error finding storage provider", err)
 	}
 
 	statRes, err := storageProvider.Stat(ctx, &provider.StatRequest{Ref: idReference})
@@ -768,10 +765,7 @@ func (s *svc) removeReference(ctx context.Context, resourceID *provider.Resource
 
 	homeProvider, err := s.find(ctx, &provider.Reference{Path: sharePath})
 	if err != nil {
-		if _, ok := err.(errtypes.IsNotFound); ok {
-			return status.NewNotFound(ctx, "storage provider not found")
-		}
-		return status.NewInternal(ctx, err, "error finding storage provider")
+		return status.NewStatusFromErrType(ctx, "error finding storage provider", err)
 	}
 
 	deleteReq := &provider.DeleteRequest{
@@ -813,10 +807,7 @@ func (s *svc) createReference(ctx context.Context, resourceID *provider.Resource
 	// get the metadata about the share
 	c, err := s.find(ctx, ref)
 	if err != nil {
-		if _, ok := err.(errtypes.IsNotFound); ok {
-			return status.NewNotFound(ctx, "storage provider not found")
-		}
-		return status.NewInternal(ctx, err, "error finding storage provider")
+		return status.NewStatusFromErrType(ctx, "error finding storage provider", err)
 	}
 
 	statReq := &provider.StatRequest{
@@ -860,10 +851,7 @@ func (s *svc) createReference(ctx context.Context, resourceID *provider.Resource
 
 	c, err = s.findByPath(ctx, refPath)
 	if err != nil {
-		if _, ok := err.(errtypes.IsNotFound); ok {
-			return status.NewNotFound(ctx, "storage provider not found")
-		}
-		return status.NewInternal(ctx, err, "error finding storage provider")
+		return status.NewStatusFromErrType(ctx, "error finding storage provider", err)
 	}
 
 	createRefRes, err := c.CreateReference(ctx, createRefReq)
@@ -893,10 +881,7 @@ func (s *svc) denyGrant(ctx context.Context, id *provider.ResourceId, g *provide
 
 	c, err := s.find(ctx, ref)
 	if err != nil {
-		if _, ok := err.(errtypes.IsNotFound); ok {
-			return status.NewNotFound(ctx, "storage provider not found"), nil
-		}
-		return status.NewInternal(ctx, err, "error finding storage provider"), nil
+		return status.NewStatusFromErrType(ctx, "error finding storage provider", err), nil
 	}
 
 	grantRes, err := c.DenyGrant(ctx, grantReq)
@@ -925,10 +910,7 @@ func (s *svc) addGrant(ctx context.Context, id *provider.ResourceId, g *provider
 
 	c, err := s.find(ctx, ref)
 	if err != nil {
-		if _, ok := err.(errtypes.IsNotFound); ok {
-			return status.NewNotFound(ctx, "storage provider not found"), nil
-		}
-		return status.NewInternal(ctx, err, "error finding storage provider"), nil
+		return status.NewStatusFromErrType(ctx, "error finding storage provider", err), nil
 	}
 
 	grantRes, err := c.AddGrant(ctx, grantReq)
@@ -957,10 +939,7 @@ func (s *svc) updateGrant(ctx context.Context, id *provider.ResourceId, g *provi
 
 	c, err := s.find(ctx, ref)
 	if err != nil {
-		if _, ok := err.(errtypes.IsNotFound); ok {
-			return status.NewNotFound(ctx, "storage provider not found"), nil
-		}
-		return status.NewInternal(ctx, err, "error finding storage provider"), nil
+		return status.NewStatusFromErrType(ctx, "error finding storage provider", err), nil
 	}
 
 	grantRes, err := c.UpdateGrant(ctx, grantReq)
@@ -989,10 +968,7 @@ func (s *svc) removeGrant(ctx context.Context, id *provider.ResourceId, g *provi
 
 	c, err := s.find(ctx, ref)
 	if err != nil {
-		if _, ok := err.(errtypes.IsNotFound); ok {
-			return status.NewNotFound(ctx, "storage provider not found"), nil
-		}
-		return status.NewInternal(ctx, err, "error finding storage provider"), nil
+		return status.NewStatusFromErrType(ctx, "error finding storage provider", err), nil
 	}
 
 	grantRes, err := c.RemoveGrant(ctx, grantReq)

--- a/internal/grpc/services/gateway/usershareprovider.go
+++ b/internal/grpc/services/gateway/usershareprovider.go
@@ -155,7 +155,7 @@ func (s *svc) CreateShare(ctx context.Context, req *collaboration.CreateShareReq
 		return nil, errors.Wrap(err, "gateway: error calling CreateShare")
 	}
 	if res.Status.Code != rpc.Code_CODE_OK {
-		return nil, errors.New("ShareClient returned error: " + res.Status.Code.String() + ": " + res.Status.Message)
+		return nil, status.NewErrtypeFromStatus(res.Status)
 	}
 
 	// And we remove from the db the deleted shares made redundant by the new share.
@@ -181,8 +181,7 @@ func (s *svc) RemoveShare(ctx context.Context, req *collaboration.RemoveShareReq
 	}
 	if getShareRes.Status.Code != rpc.Code_CODE_OK {
 		return &collaboration.RemoveShareResponse{
-			Status: status.NewInternal(ctx, status.NewErrorFromCode(getShareRes.Status.Code, "gateway"),
-				"error getting share to be removed"),
+			Status: getShareRes.Status,
 		}, nil
 	}
 	share := getShareRes.Share
@@ -317,7 +316,7 @@ func (s *svc) ListExistingShares(ctx context.Context, req *collaboration.ListSha
 					return err
 				}
 				if stat.Status.Code != rpc.Code_CODE_OK {
-					return errors.New("An error occurred: " + stat.Status.Message)
+					return status.NewErrtypeFromStatus(stat.Status)
 				}
 				resourceInfo = stat.Info
 				if s.resourceInfoCacheTTL > 0 {
@@ -376,7 +375,7 @@ func (s *svc) UpdateShare(ctx context.Context, req *collaboration.UpdateShareReq
 	}
 	if getRes.Status.Code != rpc.Code_CODE_OK {
 		return &collaboration.UpdateShareResponse{
-			Status: status.NewInternal(ctx, status.NewErrorFromCode(getRes.Status.Code, "gateway"), "error getting share for update"),
+			Status: getRes.Status,
 		}, nil
 	}
 	currentShare := getRes.Share
@@ -529,7 +528,7 @@ func (s *svc) ListExistingReceivedShares(ctx context.Context, req *collaboration
 					return err
 				}
 				if stat.Status.Code != rpc.Code_CODE_OK {
-					return errors.New("An error occurred: " + stat.Status.Message)
+					return status.NewErrtypeFromStatus(stat.Status)
 				}
 				resourceInfo = stat.Info
 				if s.resourceInfoCacheTTL > 0 {
@@ -655,7 +654,7 @@ func (s *svc) getPathForResourceId(ctx context.Context, id *provider.ResourceId)
 		return "", errors.Wrap(err, "gateway: error calling GetPath")
 	}
 	if res.Status.Code != rpc.Code_CODE_OK {
-		return "", errors.New("gateway: GetPath failed: " + res.Status.Message)
+		return "", status.NewErrtypeFromStatus(res.Status)
 	}
 	return res.Path, nil
 }
@@ -677,7 +676,7 @@ func (s *svc) listSharesForGranteeInSpace(ctx context.Context, c collaboration.C
 		return nil, errors.Wrap(err, "gateway: error listing shares for grantee in space")
 	}
 	if res.Status.Code != rpc.Code_CODE_OK {
-		return nil, errors.New("gateway: ListShares for space returned: " + res.Status.Message)
+		return nil, status.NewErrtypeFromStatus(res.Status)
 	}
 	return res.Shares, nil
 }
@@ -755,8 +754,7 @@ func (s *svc) removeReference(ctx context.Context, resourceID *provider.Resource
 
 	// FIXME how can we delete a reference if the original resource was deleted?
 	if statRes.Status.Code != rpc.Code_CODE_OK {
-		err := status.NewErrorFromCode(statRes.Status.GetCode(), "gateway")
-		return status.NewInternal(ctx, err, "could not delete share reference")
+		return statRes.Status
 	}
 
 	homeRes, err := s.GetHome(ctx, &provider.GetHomeRequest{})
@@ -798,8 +796,7 @@ func (s *svc) removeReference(ctx context.Context, resourceID *provider.Resource
 		// This is fine, we wanted to delete it anyway
 		return status.NewOK(ctx)
 	default:
-		err := status.NewErrorFromCode(deleteResp.Status.GetCode(), "gateway")
-		return status.NewInternal(ctx, err, "could not delete share reference")
+		return deleteResp.Status
 	}
 
 	log.Debug().Str("share_path", sharePath).Msg("share reference successfully removed")
@@ -832,9 +829,8 @@ func (s *svc) createReference(ctx context.Context, resourceID *provider.Resource
 	}
 
 	if statRes.Status.Code != rpc.Code_CODE_OK {
-		err := status.NewErrorFromCode(statRes.Status.GetCode(), "gateway")
-		log.Err(err).Msg("gateway: Stat failed on the share resource id: " + resourceID.String())
-		return status.NewInternal(ctx, err, "error updating received share")
+		log.Err(status.NewErrorFromCode(statRes.Status.GetCode(), "gateway")).Msg("gateway: Stat failed on the share resource id: " + resourceID.String())
+		return statRes.Status
 	}
 
 	homeRes, err := s.GetHome(ctx, &provider.GetHomeRequest{})
@@ -879,8 +875,7 @@ func (s *svc) createReference(ctx context.Context, resourceID *provider.Resource
 	}
 
 	if createRefRes.Status.Code != rpc.Code_CODE_OK {
-		err := status.NewErrorFromCode(createRefRes.Status.GetCode(), "gateway")
-		return status.NewInternal(ctx, err, "error updating received share")
+		return createRefRes.Status
 	}
 
 	return status.NewOK(ctx)
@@ -909,8 +904,7 @@ func (s *svc) denyGrant(ctx context.Context, id *provider.ResourceId, g *provide
 		return nil, errors.Wrap(err, "gateway: error calling DenyGrant")
 	}
 	if grantRes.Status.Code != rpc.Code_CODE_OK {
-		return status.NewInternal(ctx, status.NewErrorFromCode(grantRes.Status.Code, "gateway"),
-			"error committing share to storage grant"), nil
+		return grantRes.Status, nil
 	}
 
 	return status.NewOK(ctx), nil
@@ -943,8 +937,7 @@ func (s *svc) addGrant(ctx context.Context, id *provider.ResourceId, g *provider
 		return status.NewInternal(ctx, err, "error committing share to storage grant"), err
 	}
 	if grantRes.Status.Code != rpc.Code_CODE_OK {
-		return status.NewInternal(ctx, status.NewErrorFromCode(grantRes.Status.Code, "gateway"),
-			"error committing share to storage grant"), nil
+		return grantRes.Status, nil
 	}
 
 	return status.NewOK(ctx), nil
@@ -975,8 +968,7 @@ func (s *svc) updateGrant(ctx context.Context, id *provider.ResourceId, g *provi
 		return nil, errors.Wrap(err, "gateway: error calling UpdateGrant")
 	}
 	if grantRes.Status.Code != rpc.Code_CODE_OK {
-		return status.NewInternal(ctx, status.NewErrorFromCode(grantRes.Status.Code, "gateway"),
-			"error committing share to storage grant"), nil
+		return grantRes.Status, nil
 	}
 
 	return status.NewOK(ctx), nil
@@ -1008,8 +1000,7 @@ func (s *svc) removeGrant(ctx context.Context, id *provider.ResourceId, g *provi
 		return nil, errors.Wrap(err, "gateway: error calling RemoveGrant")
 	}
 	if grantRes.Status.Code != rpc.Code_CODE_OK {
-		return status.NewInternal(ctx, status.NewErrorFromCode(grantRes.Status.Code, "gateway"),
-			"error removing storage grant"), nil
+		return grantRes.Status, nil
 	}
 
 	return status.NewOK(ctx), nil

--- a/internal/grpc/services/groupprovider/groupprovider.go
+++ b/internal/grpc/services/groupprovider/groupprovider.go
@@ -33,7 +33,6 @@ import (
 	"github.com/cs3org/reva/v3/pkg/rgrpc/status"
 	"github.com/cs3org/reva/v3/pkg/utils"
 	"github.com/cs3org/reva/v3/pkg/utils/cfg"
-	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 )
 
@@ -105,8 +104,7 @@ func (s *service) GetGroup(ctx context.Context, req *grouppb.GetGroupRequest) (*
 		if _, ok := err.(errtypes.NotFound); ok {
 			res.Status = status.NewNotFound(ctx, "group not found")
 		} else {
-			err = errors.Wrap(err, "groupprovidersvc: error getting group")
-			res.Status = status.NewInternal(ctx, err, "error getting group")
+			res.Status = status.NewStatusFromErrType(ctx, "error getting group", err)
 		}
 		return res, nil
 	}
@@ -124,8 +122,7 @@ func (s *service) GetGroupByClaim(ctx context.Context, req *grouppb.GetGroupByCl
 		if _, ok := err.(errtypes.NotFound); ok {
 			res.Status = status.NewNotFound(ctx, fmt.Sprintf("group not found %s %s", req.Claim, req.Value))
 		} else {
-			err = errors.Wrap(err, "groupprovidersvc: error getting group by claim")
-			res.Status = status.NewInternal(ctx, err, "error getting group by claim")
+			res.Status = status.NewStatusFromErrType(ctx, "error getting group by claim", err)
 		}
 		return res, nil
 	}
@@ -143,9 +140,8 @@ func (s *service) FindGroups(ctx context.Context, req *grouppb.FindGroupsRequest
 	}
 	groups, err := s.groupmgr.FindGroups(ctx, req.Filters[idx].GetQuery(), req.SkipFetchingMembers)
 	if err != nil {
-		err = errors.Wrap(err, "groupprovidersvc: error finding groups")
 		return &grouppb.FindGroupsResponse{
-			Status: status.NewInternal(ctx, err, "error finding groups"),
+			Status: status.NewStatusFromErrType(ctx, "error finding groups", err),
 		}, nil
 	}
 
@@ -163,9 +159,8 @@ func (s *service) FindGroups(ctx context.Context, req *grouppb.FindGroupsRequest
 func (s *service) GetMembers(ctx context.Context, req *grouppb.GetMembersRequest) (*grouppb.GetMembersResponse, error) {
 	members, err := s.groupmgr.GetMembers(ctx, req.GroupId)
 	if err != nil {
-		err = errors.Wrap(err, "groupprovidersvc: error getting group members")
 		return &grouppb.GetMembersResponse{
-			Status: status.NewInternal(ctx, err, "error getting group members"),
+			Status: status.NewStatusFromErrType(ctx, "error getting group members", err),
 		}, nil
 	}
 
@@ -178,9 +173,8 @@ func (s *service) GetMembers(ctx context.Context, req *grouppb.GetMembersRequest
 func (s *service) HasMember(ctx context.Context, req *grouppb.HasMemberRequest) (*grouppb.HasMemberResponse, error) {
 	ok, err := s.groupmgr.HasMember(ctx, req.GroupId, req.UserId)
 	if err != nil {
-		err = errors.Wrap(err, "groupprovidersvc: error checking for group member")
 		return &grouppb.HasMemberResponse{
-			Status: status.NewInternal(ctx, err, "error checking for group member"),
+			Status: status.NewStatusFromErrType(ctx, "error checking for group member", err),
 		}, nil
 	}
 

--- a/internal/grpc/services/labelsprovider/labelsprovider.go
+++ b/internal/grpc/services/labelsprovider/labelsprovider.go
@@ -107,7 +107,7 @@ func (s *service) AddLabel(ctx context.Context, req *labelsv1beta1.AddLabelReque
 	err := s.mgr.SetLabel(ctx, req.GetLabel(), ref.GetResourceId())
 	if err != nil {
 		return &labelsv1beta1.AddLabelResponse{
-			Status: status.NewInternal(ctx, err, "error setting label"),
+			Status: status.NewStatusFromErrType(ctx, "error setting label", err),
 		}, nil
 	}
 
@@ -127,7 +127,7 @@ func (s *service) RemoveLabel(ctx context.Context, req *labelsv1beta1.RemoveLabe
 	err := s.mgr.UnsetLabel(ctx, req.GetLabel(), ref.GetResourceId())
 	if err != nil {
 		return &labelsv1beta1.RemoveLabelResponse{
-			Status: status.NewInternal(ctx, err, "error removing label"),
+			Status: status.NewStatusFromErrType(ctx, "error removing label", err),
 		}, nil
 	}
 
@@ -140,7 +140,7 @@ func (s *service) ListLabels(ctx context.Context, req *labelsv1beta1.ListLabelsR
 	lbls, err := s.mgr.ListLabels(ctx)
 	if err != nil {
 		return &labelsv1beta1.ListLabelsResponse{
-			Status: status.NewInternal(ctx, err, "error listing labels"),
+			Status: status.NewStatusFromErrType(ctx, "error listing labels", err),
 		}, nil
 	}
 
@@ -154,7 +154,7 @@ func (s *service) ListResourcesForLabel(ctx context.Context, req *labelsv1beta1.
 	resourceIds, err := s.mgr.ListResourcesForLabel(ctx, req.GetLabels())
 	if err != nil {
 		return &labelsv1beta1.ListResourcesForLabelResponse{
-			Status: status.NewInternal(ctx, err, "error listing resources for label"),
+			Status: status.NewStatusFromErrType(ctx, "error listing resources for label", err),
 		}, nil
 	}
 

--- a/internal/grpc/services/ocminvitemanager/ocminvitemanager.go
+++ b/internal/grpc/services/ocminvitemanager/ocminvitemanager.go
@@ -132,7 +132,7 @@ func (s *service) GenerateInviteToken(ctx context.Context, req *invitepb.Generat
 
 	if err := s.repo.AddToken(ctx, token); err != nil {
 		return &invitepb.GenerateInviteTokenResponse{
-			Status: status.NewInternal(ctx, err, "error generating invite token"),
+			Status: status.NewStatusFromErrType(ctx, "error generating invite token", err),
 		}, nil
 	}
 
@@ -147,7 +147,7 @@ func (s *service) ListInviteTokens(ctx context.Context, req *invitepb.ListInvite
 	tokens, err := s.repo.ListTokens(ctx, user.Id)
 	if err != nil {
 		return &invitepb.ListInviteTokensResponse{
-			Status: status.NewInternal(ctx, err, "error listing tokens"),
+			Status: status.NewStatusFromErrType(ctx, "error listing tokens", err),
 		}, nil
 	}
 	return &invitepb.ListInviteTokensResponse{
@@ -187,7 +187,7 @@ func (s *service) ForwardInvite(ctx context.Context, req *invitepb.ForwardInvite
 			}, nil
 		default:
 			return &invitepb.ForwardInviteResponse{
-				Status: status.NewInternal(ctx, err, err.Error()),
+				Status: status.NewStatusFromErrType(ctx, "error forwarding invite", err),
 			}, nil
 		}
 	}
@@ -214,7 +214,7 @@ func (s *service) ForwardInvite(ctx context.Context, req *invitepb.ForwardInvite
 		if !errors.Is(err, invite.ErrUserAlreadyAccepted) {
 			// skip error if user was already accepted
 			return &invitepb.ForwardInviteResponse{
-				Status: status.NewInternal(ctx, err, err.Error()),
+				Status: status.NewStatusFromErrType(ctx, "error adding remote user", err),
 			}, nil
 		}
 	}
@@ -245,7 +245,7 @@ func (s *service) AcceptInvite(ctx context.Context, req *invitepb.AcceptInviteRe
 			}, nil
 		}
 		return &invitepb.AcceptInviteResponse{
-			Status: status.NewInternal(ctx, err, err.Error()),
+			Status: status.NewStatusFromErrType(ctx, "error accepting invite", err),
 		}, nil
 	}
 
@@ -258,7 +258,7 @@ func (s *service) AcceptInvite(ctx context.Context, req *invitepb.AcceptInviteRe
 	initiator, err := s.getUserInfo(ctx, token.UserId)
 	if err != nil {
 		return &invitepb.AcceptInviteResponse{
-			Status: status.NewInternal(ctx, err, err.Error()),
+			Status: status.NewStatusFromErrType(ctx, "error getting invite initiator", err),
 		}, nil
 	}
 
@@ -272,7 +272,7 @@ func (s *service) AcceptInvite(ctx context.Context, req *invitepb.AcceptInviteRe
 			}, nil
 		}
 		return &invitepb.AcceptInviteResponse{
-			Status: status.NewInternal(ctx, err, err.Error()),
+			Status: status.NewStatusFromErrType(ctx, "error adding remote user", err),
 		}, nil
 	}
 
@@ -296,7 +296,7 @@ func (s *service) getUserInfo(ctx context.Context, id *userpb.UserId) (*userpb.U
 		return nil, err
 	}
 	if res.Status.Code != rpcv1beta1.Code_CODE_OK {
-		return nil, errors.New(res.Status.Message)
+		return nil, status.NewErrtypeFromStatus(res.Status)
 	}
 
 	return res.User, nil
@@ -358,7 +358,7 @@ func (s *service) FindAcceptedUsers(ctx context.Context, req *invitepb.FindAccep
 	acceptedUsers, err := s.repo.FindRemoteUsers(ctx, user.GetId(), req.GetFilter())
 	if err != nil {
 		return &invitepb.FindAcceptedUsersResponse{
-			Status: status.NewInternal(ctx, err, "error finding remote users: "+err.Error()),
+			Status: status.NewStatusFromErrType(ctx, "error finding remote users", err),
 		}, nil
 	}
 
@@ -372,7 +372,7 @@ func (s *service) DeleteAcceptedUser(ctx context.Context, req *invitepb.DeleteAc
 	user := appctx.ContextMustGetUser(ctx)
 	if err := s.repo.DeleteRemoteUser(ctx, user.Id, req.RemoteUserId); err != nil {
 		return &invitepb.DeleteAcceptedUserResponse{
-			Status: status.NewInternal(ctx, err, "error deleting remote users: "+err.Error()),
+			Status: status.NewStatusFromErrType(ctx, "error deleting remote users", err),
 		}, nil
 	}
 

--- a/internal/grpc/services/ocmproviderauthorizer/ocmproviderauthorizer.go
+++ b/internal/grpc/services/ocmproviderauthorizer/ocmproviderauthorizer.go
@@ -104,7 +104,7 @@ func (s *service) GetInfoByDomain(ctx context.Context, req *ocmprovider.GetInfoB
 	domainInfo, err := s.pa.GetInfoByDomain(ctx, req.Domain)
 	if err != nil {
 		return &ocmprovider.GetInfoByDomainResponse{
-			Status: status.NewInternal(ctx, err, "error getting provider info"),
+			Status: status.NewStatusFromErrType(ctx, "error getting provider info", err),
 		}, nil
 	}
 
@@ -120,7 +120,7 @@ func (s *service) IsProviderAllowed(ctx context.Context, req *ocmprovider.IsProv
 	err := s.pa.IsProviderAllowed(ctx, req.Provider)
 	if err != nil {
 		return &ocmprovider.IsProviderAllowedResponse{
-			Status: status.NewInternal(ctx, err, "error verifying mesh provider"),
+			Status: status.NewStatusFromErrType(ctx, "error verifying mesh provider", err),
 		}, nil
 	}
 
@@ -133,7 +133,7 @@ func (s *service) ListAllProviders(ctx context.Context, req *ocmprovider.ListAll
 	providers, err := s.pa.ListAllProviders(ctx)
 	if err != nil {
 		return &ocmprovider.ListAllProvidersResponse{
-			Status: status.NewInternal(ctx, err, "error retrieving mesh providers"),
+			Status: status.NewStatusFromErrType(ctx, "error retrieving mesh providers", err),
 		}, nil
 	}
 

--- a/internal/grpc/services/ocmshareprovider/ocmshareprovider.go
+++ b/internal/grpc/services/ocmshareprovider/ocmshareprovider.go
@@ -289,7 +289,7 @@ func (s *service) CreateOCMShare(ctx context.Context, req *ocm.CreateOCMShareReq
 			}, nil
 		}
 		return &ocm.CreateOCMShareResponse{
-			Status: status.NewInternal(ctx, errors.New(statRes.Status.Message), statRes.Status.Message),
+			Status: statRes.Status,
 		}, nil
 	}
 
@@ -469,7 +469,7 @@ func (s *service) RemoveOCMShare(ctx context.Context, req *ocm.RemoveOCMShareReq
 			}, nil
 		}
 		return &ocm.RemoveOCMShareResponse{
-			Status: status.NewInternal(ctx, err, "error removing share"),
+			Status: status.NewStatusFromErrType(ctx, "error removing share", err),
 		}, nil
 	}
 
@@ -492,7 +492,7 @@ func (s *service) GetOCMShare(ctx context.Context, req *ocm.GetOCMShareRequest) 
 			}, nil
 		}
 		return &ocm.GetOCMShareResponse{
-			Status: status.NewInternal(ctx, err, "error getting share"),
+			Status: status.NewStatusFromErrType(ctx, "error getting share", err),
 		}, nil
 	}
 
@@ -515,7 +515,7 @@ func (s *service) GetOCMShareByToken(ctx context.Context, req *ocm.GetOCMShareBy
 			}, nil
 		}
 		return &ocm.GetOCMShareByTokenResponse{
-			Status: status.NewInternal(ctx, err, "error getting share"),
+			Status: status.NewStatusFromErrType(ctx, "error getting share", err),
 		}, nil
 	}
 
@@ -530,7 +530,7 @@ func (s *service) ListOCMShares(ctx context.Context, req *ocm.ListOCMSharesReque
 	shares, err := s.repo.ListShares(ctx, user, req.Filters)
 	if err != nil {
 		return &ocm.ListOCMSharesResponse{
-			Status: status.NewInternal(ctx, err, "error listing shares"),
+			Status: status.NewStatusFromErrType(ctx, "error listing shares", err),
 		}, nil
 	}
 
@@ -556,7 +556,7 @@ func (s *service) UpdateOCMShare(ctx context.Context, req *ocm.UpdateOCMShareReq
 			}, nil
 		}
 		return &ocm.UpdateOCMShareResponse{
-			Status: status.NewInternal(ctx, err, "error updating share"),
+			Status: status.NewStatusFromErrType(ctx, "error updating share", err),
 		}, nil
 	}
 
@@ -571,7 +571,7 @@ func (s *service) ListReceivedOCMShares(ctx context.Context, req *ocm.ListReceiv
 	shares, err := s.repo.ListReceivedShares(ctx, user, req.Filters)
 	if err != nil {
 		return &ocm.ListReceivedOCMSharesResponse{
-			Status: status.NewInternal(ctx, err, "error listing received shares"),
+			Status: status.NewStatusFromErrType(ctx, "error listing received shares", err),
 		}, nil
 	}
 
@@ -598,7 +598,7 @@ func (s *service) UpdateReceivedOCMShare(ctx context.Context, req *ocm.UpdateRec
 				}, nil
 			}
 			return &ocm.UpdateReceivedOCMShareResponse{
-				Status: status.NewInternal(ctx, err, "error retrieving embedded share payload"),
+				Status: status.NewStatusFromErrType(ctx, "error retrieving embedded share payload", err),
 			}, nil
 		}
 		if payload != "" {
@@ -613,7 +613,7 @@ func (s *service) UpdateReceivedOCMShare(ctx context.Context, req *ocm.UpdateRec
 			}, nil
 		}
 		return &ocm.UpdateReceivedOCMShareResponse{
-			Status: status.NewInternal(ctx, err, "error updating received share"),
+			Status: status.NewStatusFromErrType(ctx, "error updating received share", err),
 		}, nil
 	}
 
@@ -642,7 +642,7 @@ func (s *service) processEmbeddedShare(ctx context.Context, user *userpb.User, r
 			}, nil
 		}
 		return &ocm.UpdateReceivedOCMShareResponse{
-			Status: status.NewInternal(ctx, err, "error getting received share"),
+			Status: status.NewStatusFromErrType(ctx, "error getting received share", err),
 		}, nil
 	}
 	if current.State == ocm.ShareState_SHARE_STATE_TRANSFERRING {
@@ -661,7 +661,7 @@ func (s *service) processEmbeddedShare(ctx context.Context, user *userpb.User, r
 			}, nil
 		}
 		return &ocm.UpdateReceivedOCMShareResponse{
-			Status: status.NewInternal(ctx, err, "error updating received share"),
+			Status: status.NewStatusFromErrType(ctx, "error updating received share", err),
 		}, nil
 	}
 
@@ -682,7 +682,7 @@ func (s *service) processEmbeddedShare(ctx context.Context, user *userpb.User, r
 
 	if err := s.transferrer.Process(ctx, payload, recvShare.Destination, onComplete); err != nil {
 		return &ocm.UpdateReceivedOCMShareResponse{
-			Status: status.NewInternal(ctx, err, "error processing embedded share"),
+			Status: status.NewStatusFromErrType(ctx, "error processing embedded share", err),
 		}, nil
 	}
 
@@ -701,7 +701,7 @@ func (s *service) GetReceivedOCMShare(ctx context.Context, req *ocm.GetReceivedO
 			}, nil
 		}
 		return &ocm.GetReceivedOCMShareResponse{
-			Status: status.NewInternal(ctx, err, "error getting received share"),
+			Status: status.NewStatusFromErrType(ctx, "error getting received share", err),
 		}, nil
 	}
 

--- a/internal/grpc/services/preferences/preferences.go
+++ b/internal/grpc/services/preferences/preferences.go
@@ -99,7 +99,7 @@ func (s *service) SetKey(ctx context.Context, req *preferencespb.SetKeyRequest) 
 	err := s.pm.SetKey(ctx, req.Key.Key, req.Key.Namespace, req.Val)
 	if err != nil {
 		return &preferencespb.SetKeyResponse{
-			Status: status.NewInternal(ctx, err, "error setting key"),
+			Status: status.NewStatusFromErrType(ctx, "error setting key", err),
 		}, nil
 	}
 
@@ -111,7 +111,7 @@ func (s *service) SetKey(ctx context.Context, req *preferencespb.SetKeyRequest) 
 func (s *service) GetKey(ctx context.Context, req *preferencespb.GetKeyRequest) (*preferencespb.GetKeyResponse, error) {
 	val, err := s.pm.GetKey(ctx, req.Key.Key, req.Key.Namespace)
 	if err != nil {
-		st := status.NewInternal(ctx, err, "error retrieving key")
+		st := status.NewStatusFromErrType(ctx, "error retrieving key", err)
 		if _, ok := err.(errtypes.IsNotFound); ok {
 			st = status.NewNotFound(ctx, "key not found")
 		}

--- a/internal/grpc/services/publicshareprovider/publicshareprovider.go
+++ b/internal/grpc/services/publicshareprovider/publicshareprovider.go
@@ -158,7 +158,7 @@ func (s *service) CreatePublicShare(ctx context.Context, req *link.CreatePublicS
 		}, nil
 	default:
 		return &link.CreatePublicShareResponse{
-			Status: status.NewInternal(ctx, err, "unknown error"),
+			Status: status.NewStatusFromErrType(ctx, "error creating public share", err),
 		}, nil
 	}
 }
@@ -181,7 +181,7 @@ func (s *service) RemovePublicShare(ctx context.Context, req *link.RemovePublicS
 		}, nil
 	default:
 		return &link.RemovePublicShareResponse{
-			Status: status.NewInternal(ctx, err, "error deleting public share"),
+			Status: status.NewStatusFromErrType(ctx, "error deleting public share", err),
 		}, nil
 	}
 }
@@ -235,7 +235,7 @@ func (s *service) GetPublicShare(ctx context.Context, req *link.GetPublicShareRe
 		}, nil
 	default:
 		return &link.GetPublicShareResponse{
-			Status: status.NewInternal(ctx, err, "unknown error"),
+			Status: status.NewStatusFromErrType(ctx, "error getting public share", err),
 		}, nil
 	}
 }
@@ -255,7 +255,7 @@ func (s *service) ListPublicShares(ctx context.Context, req *link.ListPublicShar
 	if err != nil {
 		log.Err(err).Msg("error listing shares")
 		return &link.ListPublicSharesResponse{
-			Status: status.NewInternal(ctx, err, "error listing public shares"),
+			Status: status.NewStatusFromErrType(ctx, "error listing public shares", err),
 		}, nil
 	}
 
@@ -295,7 +295,7 @@ func (s *service) UpdatePublicShare(ctx context.Context, req *link.UpdatePublicS
 		}, nil
 	default:
 		return &link.UpdatePublicShareResponse{
-			Status: status.NewInternal(ctx, err, "unknown error"),
+			Status: status.NewStatusFromErrType(ctx, "error updating public share", err),
 		}, nil
 	}
 }

--- a/internal/grpc/services/publicstorageprovider/publicstorageprovider.go
+++ b/internal/grpc/services/publicstorageprovider/publicstorageprovider.go
@@ -156,9 +156,8 @@ func (s *service) InitiateFileDownload(ctx context.Context, req *provider.Initia
 				Status: status.NewNotFound(ctx, "gateway: file not found"),
 			}, nil
 		}
-		err := status.NewErrorFromCode(statRes.Status.Code, "gateway")
 		return &provider.InitiateFileDownloadResponse{
-			Status: status.NewInternal(ctx, err, "gateway: error stating ref"),
+			Status: statRes.Status,
 		}, nil
 	}
 

--- a/internal/grpc/services/spacesregistry/spacesregistry.go
+++ b/internal/grpc/services/spacesregistry/spacesregistry.go
@@ -169,7 +169,7 @@ func (s *service) ListStorageSpaces(ctx context.Context, req *provider.ListStora
 		log.Debug().Bool("filterByID", byId).Str("id", id).Msg("ListStorageSpaces: going over all possible space types")
 		homes, err := s.listSpacesByType(ctx, req, user, spaces.SpaceTypeHome)
 		if err != nil {
-			return &provider.ListStorageSpacesResponse{Status: status.NewInternal(ctx, err, err.Error())}, nil
+			return &provider.ListStorageSpacesResponse{Status: status.NewStatusFromErrType(ctx, "error listing storage spaces", err)}, nil
 		}
 		sp = append(sp, homes...)
 		if byId && len(homes) == 1 {
@@ -181,7 +181,7 @@ func (s *service) ListStorageSpaces(ctx context.Context, req *provider.ListStora
 			sp = append(sp, projects...)
 		}
 		if err != nil {
-			return &provider.ListStorageSpacesResponse{Status: status.NewInternal(ctx, err, err.Error()), StorageSpaces: sp}, nil
+			return &provider.ListStorageSpacesResponse{Status: status.NewStatusFromErrType(ctx, "error listing storage spaces", err), StorageSpaces: sp}, nil
 		}
 		if byId && len(projects) == 1 {
 			return &provider.ListStorageSpacesResponse{Status: status.NewOK(ctx), StorageSpaces: sp}, nil
@@ -189,7 +189,7 @@ func (s *service) ListStorageSpaces(ctx context.Context, req *provider.ListStora
 
 		publicSpaces, err := s.listSpacesByType(ctx, req, user, spaces.SpaceTypePublic)
 		if err != nil {
-			return &provider.ListStorageSpacesResponse{Status: status.NewInternal(ctx, err, err.Error())}, nil
+			return &provider.ListStorageSpacesResponse{Status: status.NewStatusFromErrType(ctx, "error listing storage spaces", err)}, nil
 		}
 		sp = append(sp, publicSpaces...)
 	} else {
@@ -202,7 +202,7 @@ func (s *service) ListStorageSpaces(ctx context.Context, req *provider.ListStora
 				log.Debug().Bool("filterByID", byId).Str("id", id).Msgf("ListStorageSpaces: listing type %s", filter.Term.(*provider.ListStorageSpacesRequest_Filter_SpaceType).SpaceType)
 				spaces, err := s.listSpacesByType(ctx, req, user, spaces.SpaceType(filter.Term.(*provider.ListStorageSpacesRequest_Filter_SpaceType).SpaceType))
 				if err != nil {
-					return &provider.ListStorageSpacesResponse{Status: status.NewInternal(ctx, err, err.Error())}, nil
+					return &provider.ListStorageSpacesResponse{Status: status.NewStatusFromErrType(ctx, "error listing storage spaces", err)}, nil
 				}
 				sp = append(sp, spaces...)
 			}
@@ -339,7 +339,7 @@ func (s *service) decorateProject(ctx context.Context, proj *provider.StorageSpa
 			return err
 		}
 		if authRes.Status.Code != rpcv1beta1.Code_CODE_OK {
-			return errors.New(authRes.Status.Message)
+			return status.NewErrtypeFromStatus(authRes.Status)
 		}
 
 		token := authRes.Token

--- a/internal/grpc/services/storageprovider/storageprovider.go
+++ b/internal/grpc/services/storageprovider/storageprovider.go
@@ -236,9 +236,8 @@ func New(ctx context.Context, m map[string]any) (rgrpc.Service, error) {
 func (s *service) SetArbitraryMetadata(ctx context.Context, req *provider.SetArbitraryMetadataRequest) (*provider.SetArbitraryMetadataResponse, error) {
 	newRef, err := s.unwrap(ctx, req.Ref)
 	if err != nil {
-		err := errors.Wrap(err, "storageprovidersvc: error unwrapping path")
 		return &provider.SetArbitraryMetadataResponse{
-			Status: status.NewInternal(ctx, err, "error setting arbitrary metadata"),
+			Status: status.NewStatusFromErrType(ctx, "error setting arbitrary metadata", err),
 		}, nil
 	}
 
@@ -250,7 +249,7 @@ func (s *service) SetArbitraryMetadata(ctx context.Context, req *provider.SetArb
 		case errtypes.PermissionDenied:
 			st = status.NewPermissionDenied(ctx, err, "permission denied")
 		default:
-			st = status.NewInternal(ctx, err, "error setting arbitrary metadata: "+req.Ref.String())
+			st = status.NewStatusFromErrType(ctx, "error setting arbitrary metadata: "+req.Ref.String(), err)
 		}
 		return &provider.SetArbitraryMetadataResponse{
 			Status: st,
@@ -267,9 +266,8 @@ func (s *service) UnsetArbitraryMetadata(ctx context.Context, req *provider.Unse
 	log := appctx.GetLogger(ctx)
 	newRef, err := s.unwrap(ctx, req.Ref)
 	if err != nil {
-		err := errors.Wrap(err, "storageprovidersvc: error unwrapping path")
 		return &provider.UnsetArbitraryMetadataResponse{
-			Status: status.NewInternal(ctx, err, "error unsetting arbitrary metadata"),
+			Status: status.NewStatusFromErrType(ctx, "error unsetting arbitrary metadata", err),
 		}, nil
 	}
 
@@ -282,7 +280,7 @@ func (s *service) UnsetArbitraryMetadata(ctx context.Context, req *provider.Unse
 			st = status.NewPermissionDenied(ctx, err, "permission denied")
 		default:
 			log.Error().Err(err).Str("ref", req.Ref.String()).Any("keys", req.ArbitraryMetadataKeys).Msg("error unsetting arbitrary metadata")
-			st = status.NewInternal(ctx, err, "error unsetting arbitrary metadata: "+req.Ref.String())
+			st = status.NewStatusFromErrType(ctx, "error unsetting arbitrary metadata: "+req.Ref.String(), err)
 		}
 		return &provider.UnsetArbitraryMetadataResponse{
 			Status: st,
@@ -299,9 +297,8 @@ func (s *service) UnsetArbitraryMetadata(ctx context.Context, req *provider.Unse
 func (s *service) SetLock(ctx context.Context, req *provider.SetLockRequest) (*provider.SetLockResponse, error) {
 	newRef, err := s.unwrap(ctx, req.Ref)
 	if err != nil {
-		err := errors.Wrap(err, "storageprovidersvc: error unwrapping path")
 		return &provider.SetLockResponse{
-			Status: status.NewInternal(ctx, err, "error setting lock"),
+			Status: status.NewStatusFromErrType(ctx, "error setting lock", err),
 		}, nil
 	}
 
@@ -315,7 +312,7 @@ func (s *service) SetLock(ctx context.Context, req *provider.SetLockRequest) (*p
 		case errtypes.Conflict:
 			st = status.NewFailedPrecondition(ctx, err, "reference already locked")
 		default:
-			st = status.NewInternal(ctx, err, "error setting lock: "+req.Ref.String())
+			st = status.NewStatusFromErrType(ctx, "error setting lock: "+req.Ref.String(), err)
 		}
 		return &provider.SetLockResponse{
 			Status: st,
@@ -332,9 +329,8 @@ func (s *service) SetLock(ctx context.Context, req *provider.SetLockRequest) (*p
 func (s *service) GetLock(ctx context.Context, req *provider.GetLockRequest) (*provider.GetLockResponse, error) {
 	newRef, err := s.unwrap(ctx, req.Ref)
 	if err != nil {
-		err := errors.Wrap(err, "storageprovidersvc: error unwrapping path")
 		return &provider.GetLockResponse{
-			Status: status.NewInternal(ctx, err, "error getting lock"),
+			Status: status.NewStatusFromErrType(ctx, "error getting lock", err),
 		}, nil
 	}
 
@@ -347,7 +343,7 @@ func (s *service) GetLock(ctx context.Context, req *provider.GetLockRequest) (*p
 		case errtypes.PermissionDenied:
 			st = status.NewPermissionDenied(ctx, err, "permission denied")
 		default:
-			st = status.NewInternal(ctx, err, "error getting lock: "+req.Ref.String())
+			st = status.NewStatusFromErrType(ctx, "error getting lock: "+req.Ref.String(), err)
 		}
 		return &provider.GetLockResponse{
 			Status: st,
@@ -365,9 +361,8 @@ func (s *service) GetLock(ctx context.Context, req *provider.GetLockRequest) (*p
 func (s *service) RefreshLock(ctx context.Context, req *provider.RefreshLockRequest) (*provider.RefreshLockResponse, error) {
 	newRef, err := s.unwrap(ctx, req.Ref)
 	if err != nil {
-		err := errors.Wrap(err, "storageprovidersvc: error unwrapping path")
 		return &provider.RefreshLockResponse{
-			Status: status.NewInternal(ctx, err, "error refreshing lock"),
+			Status: status.NewStatusFromErrType(ctx, "error refreshing lock", err),
 		}, nil
 	}
 
@@ -381,7 +376,7 @@ func (s *service) RefreshLock(ctx context.Context, req *provider.RefreshLockRequ
 		case errtypes.BadRequest:
 			st = status.NewFailedPrecondition(ctx, err, "reference not locked or caller does not hold the lock")
 		default:
-			st = status.NewInternal(ctx, err, "error refreshing lock: "+req.Ref.String())
+			st = status.NewStatusFromErrType(ctx, "error refreshing lock: "+req.Ref.String(), err)
 		}
 		return &provider.RefreshLockResponse{
 			Status: st,
@@ -398,9 +393,8 @@ func (s *service) RefreshLock(ctx context.Context, req *provider.RefreshLockRequ
 func (s *service) Unlock(ctx context.Context, req *provider.UnlockRequest) (*provider.UnlockResponse, error) {
 	newRef, err := s.unwrap(ctx, req.Ref)
 	if err != nil {
-		err := errors.Wrap(err, "storageprovidersvc: error unwrapping path")
 		return &provider.UnlockResponse{
-			Status: status.NewInternal(ctx, err, "error on unlocking"),
+			Status: status.NewStatusFromErrType(ctx, "error on unlocking", err),
 		}, nil
 	}
 
@@ -414,7 +408,7 @@ func (s *service) Unlock(ctx context.Context, req *provider.UnlockRequest) (*pro
 		case errtypes.BadRequest:
 			st = status.NewFailedPrecondition(ctx, err, "reference not locked")
 		default:
-			st = status.NewInternal(ctx, err, "error unlocking: "+req.Ref.String())
+			st = status.NewStatusFromErrType(ctx, "error unlocking: "+req.Ref.String(), err)
 		}
 		return &provider.UnlockResponse{
 			Status: st,
@@ -446,7 +440,7 @@ func (s *service) InitiateFileDownload(ctx context.Context, req *provider.Initia
 		newRef, err := s.unwrap(ctx, req.Ref)
 		if err != nil {
 			return &provider.InitiateFileDownloadResponse{
-				Status: status.NewInternal(ctx, err, "error unwrapping path"),
+				Status: status.NewStatusFromErrType(ctx, "error unwrapping path", err),
 			}, nil
 		}
 		// Currently, we only support the simple protocol for GET requests
@@ -494,7 +488,7 @@ func (s *service) InitiateFileUpload(ctx context.Context, req *provider.Initiate
 	newRef, err := s.unwrap(ctx, req.Ref)
 	if err != nil {
 		return &provider.InitiateFileUploadResponse{
-			Status: status.NewInternal(ctx, err, "error unwrapping path"),
+			Status: status.NewStatusFromErrType(ctx, "error unwrapping path", err),
 		}, nil
 	}
 
@@ -516,7 +510,7 @@ func (s *service) InitiateFileUpload(ctx context.Context, req *provider.Initiate
 	}
 	if uploadRef.GetPath() == "/" {
 		return &provider.InitiateFileUploadResponse{
-			Status: status.NewInternal(ctx, errtypes.BadRequest("can't upload to mount path"), "can't upload to mount path"),
+			Status: status.NewInvalidArg(ctx, "can't upload to mount path"),
 		}, nil
 	}
 
@@ -528,7 +522,7 @@ func (s *service) InitiateFileUpload(ctx context.Context, req *provider.Initiate
 			uploadLength, err = strconv.ParseInt(string(req.Opaque.Map["Upload-Length"].Value), 10, 64)
 			if err != nil {
 				return &provider.InitiateFileUploadResponse{
-					Status: status.NewInternal(ctx, err, "error parsing upload length"),
+					Status: status.NewInvalidArg(ctx, "error parsing upload length: "+err.Error()),
 				}, nil
 			}
 		}
@@ -563,7 +557,7 @@ func (s *service) InitiateFileUpload(ctx context.Context, req *provider.Initiate
 		case errtypes.InsufficientStorage:
 			st = status.NewInsufficientStorage(ctx, err, "insufficient storage")
 		default:
-			st = status.NewInternal(ctx, err, "error getting upload id: "+req.Ref.String())
+			st = status.NewStatusFromErrType(ctx, "error getting upload id: "+req.Ref.String(), err)
 		}
 		return &provider.InitiateFileUploadResponse{
 			Status: st,
@@ -669,7 +663,7 @@ func (s *service) ListStorageSpaces(ctx context.Context, req *provider.ListStora
 		case errtypes.NotSupported:
 			st = status.NewUnimplemented(ctx, err, "not implemented")
 		default:
-			st = status.NewInternal(ctx, err, "error listing spaces")
+			st = status.NewStatusFromErrType(ctx, "error listing spaces", err)
 		}
 		return &provider.ListStorageSpacesResponse{
 			Status: st,
@@ -711,7 +705,7 @@ func (s *service) CreateContainer(ctx context.Context, req *provider.CreateConta
 	newRef, err := s.unwrap(ctx, req.Ref)
 	if err != nil {
 		return &provider.CreateContainerResponse{
-			Status: status.NewInternal(ctx, err, "error unwrapping path"),
+			Status: status.NewStatusFromErrType(ctx, "error unwrapping path", err),
 		}, nil
 	}
 	if err := s.storage.CreateDir(ctx, newRef); err != nil {
@@ -724,7 +718,7 @@ func (s *service) CreateContainer(ctx context.Context, req *provider.CreateConta
 		case errtypes.PermissionDenied:
 			st = status.NewPermissionDenied(ctx, err, "permission denied")
 		default:
-			st = status.NewInternal(ctx, err, "error creating container: "+req.Ref.String())
+			st = status.NewStatusFromErrType(ctx, "error creating container: "+req.Ref.String(), err)
 		}
 		return &provider.CreateContainerResponse{
 			Status: st,
@@ -741,7 +735,7 @@ func (s *service) TouchFile(ctx context.Context, req *provider.TouchFileRequest)
 	newRef, err := s.unwrap(ctx, req.Ref)
 	if err != nil {
 		return &provider.TouchFileResponse{
-			Status: status.NewInternal(ctx, err, "error unwrapping path"),
+			Status: status.NewStatusFromErrType(ctx, "error unwrapping path", err),
 		}, nil
 	}
 	if err := s.storage.TouchFile(ctx, newRef); err != nil {
@@ -754,7 +748,7 @@ func (s *service) TouchFile(ctx context.Context, req *provider.TouchFileRequest)
 		case errtypes.PermissionDenied:
 			st = status.NewPermissionDenied(ctx, err, "permission denied")
 		default:
-			st = status.NewInternal(ctx, err, "error touching file "+req.Ref.String()+": "+err.Error())
+			st = status.NewStatusFromErrType(ctx, "error touching file "+req.Ref.String(), err)
 		}
 		return &provider.TouchFileResponse{
 			Status: st,
@@ -771,12 +765,12 @@ func (s *service) Delete(ctx context.Context, req *provider.DeleteRequest) (*pro
 	newRef, err := s.unwrap(ctx, req.Ref)
 	if err != nil {
 		return &provider.DeleteResponse{
-			Status: status.NewInternal(ctx, err, "error unwrapping path"),
+			Status: status.NewStatusFromErrType(ctx, "error unwrapping path", err),
 		}, nil
 	}
 	if newRef.GetPath() == "/" {
 		return &provider.DeleteResponse{
-			Status: status.NewInternal(ctx, errtypes.BadRequest("can't delete mount path"), "can't delete mount path"),
+			Status: status.NewInvalidArg(ctx, "can't delete mount path"),
 		}, nil
 	}
 
@@ -788,7 +782,7 @@ func (s *service) Delete(ctx context.Context, req *provider.DeleteRequest) (*pro
 		case errtypes.PermissionDenied:
 			st = status.NewPermissionDenied(ctx, err, "permission denied")
 		default:
-			st = status.NewInternal(ctx, err, "error deleting file: "+req.Ref.String())
+			st = status.NewStatusFromErrType(ctx, "error deleting file: "+req.Ref.String(), err)
 		}
 		return &provider.DeleteResponse{
 			Status: st,
@@ -823,7 +817,7 @@ func (s *service) Move(ctx context.Context, req *provider.MoveRequest) (*provide
 		case errtypes.PermissionDenied:
 			st = status.NewPermissionDenied(ctx, err, "permission denied")
 		default:
-			st = status.NewInternal(ctx, err, "error moving: "+sourceRef.String())
+			st = status.NewStatusFromErrType(ctx, "error moving: "+sourceRef.String(), err)
 		}
 		return &provider.MoveResponse{
 			Status: st,
@@ -898,7 +892,7 @@ func (s *service) Stat(ctx context.Context, req *provider.StatRequest) (*provide
 			return s.statVirtualView(ctx, req.Ref)
 		}
 		return &provider.StatResponse{
-			Status: status.NewInternal(ctx, err, "error unwrapping path"),
+			Status: status.NewStatusFromErrType(ctx, "error unwrapping path", err),
 		}, nil
 	}
 
@@ -911,7 +905,7 @@ func (s *service) Stat(ctx context.Context, req *provider.StatRequest) (*provide
 		case errtypes.PermissionDenied:
 			st = status.NewPermissionDenied(ctx, err, "permission denied")
 		default:
-			st = status.NewInternal(ctx, err, "error statting: "+req.Ref.String())
+			st = status.NewStatusFromErrType(ctx, "error statting: "+req.Ref.String(), err)
 		}
 		return &provider.StatResponse{
 			Status: st,
@@ -987,7 +981,7 @@ func (s *service) statVirtualView(ctx context.Context, ref *provider.Reference) 
 		case errtypes.PermissionDenied:
 			st = status.NewPermissionDenied(ctx, err, "permission denied")
 		default:
-			st = status.NewInternal(ctx, err, "error statting root")
+			st = status.NewStatusFromErrType(ctx, "error statting root", err)
 		}
 		return &provider.StatResponse{
 			Status: st,
@@ -1016,7 +1010,7 @@ func (s *service) ListContainerStream(req *provider.ListContainerStreamRequest, 
 	newRef, err := s.unwrap(ctx, req.Ref)
 	if err != nil {
 		res := &provider.ListContainerStreamResponse{
-			Status: status.NewInternal(ctx, err, "error unwrapping path"),
+			Status: status.NewStatusFromErrType(ctx, "error unwrapping path", err),
 		}
 		if err := ss.Send(res); err != nil {
 			log.Error().Err(err).Msg("ListContainerStream: error sending response")
@@ -1034,7 +1028,7 @@ func (s *service) ListContainerStream(req *provider.ListContainerStreamRequest, 
 		case errtypes.PermissionDenied:
 			st = status.NewPermissionDenied(ctx, err, "permission denied")
 		default:
-			st = status.NewInternal(ctx, err, "error listing container: "+req.Ref.String())
+			st = status.NewStatusFromErrType(ctx, "error listing container: "+req.Ref.String(), err)
 		}
 		res := &provider.ListContainerStreamResponse{
 			Status: st,
@@ -1081,7 +1075,7 @@ func (s *service) ListContainer(ctx context.Context, req *provider.ListContainer
 		}
 
 		return &provider.ListContainerResponse{
-			Status: status.NewInternal(ctx, err, "error unwrapping path"),
+			Status: status.NewStatusFromErrType(ctx, "error unwrapping path", err),
 		}, nil
 	}
 
@@ -1114,7 +1108,7 @@ func (s *service) ListContainer(ctx context.Context, req *provider.ListContainer
 			st = status.NewPermissionDenied(ctx, err, "permission denied")
 		default:
 			log.Error().Any("ref", newRef).Err(err).Msg("storageprovider: error listing container")
-			st = status.NewInternal(ctx, err, "error listing container: "+req.Ref.String())
+			st = status.NewStatusFromErrType(ctx, "error listing container: "+req.Ref.String(), err)
 		}
 		return &provider.ListContainerResponse{
 			Status: st,
@@ -1153,7 +1147,7 @@ func (s *service) listVirtualView(ctx context.Context, ref *provider.Reference) 
 		case errtypes.PermissionDenied:
 			st = status.NewPermissionDenied(ctx, err, "permission denied")
 		default:
-			st = status.NewInternal(ctx, err, "error listing root")
+			st = status.NewStatusFromErrType(ctx, "error listing root", err)
 		}
 		return &provider.ListContainerResponse{
 			Status: st,
@@ -1220,7 +1214,7 @@ func (s *service) ListFileVersions(ctx context.Context, req *provider.ListFileVe
 	newRef, err := s.unwrap(ctx, req.Ref)
 	if err != nil {
 		return &provider.ListFileVersionsResponse{
-			Status: status.NewInternal(ctx, err, "error unwrapping path"),
+			Status: status.NewStatusFromErrType(ctx, "error unwrapping path", err),
 		}, nil
 	}
 
@@ -1233,7 +1227,7 @@ func (s *service) ListFileVersions(ctx context.Context, req *provider.ListFileVe
 		case errtypes.PermissionDenied:
 			st = status.NewPermissionDenied(ctx, err, "permission denied")
 		default:
-			st = status.NewInternal(ctx, err, "error listing file versions for "+req.Ref.String()+": "+err.Error())
+			st = status.NewStatusFromErrType(ctx, "error listing file versions for "+req.Ref.String()+": "+err.Error(), err)
 		}
 		return &provider.ListFileVersionsResponse{
 			Status: st,
@@ -1253,7 +1247,7 @@ func (s *service) RestoreFileVersion(ctx context.Context, req *provider.RestoreF
 	newRef, err := s.unwrap(ctx, req.Ref)
 	if err != nil {
 		return &provider.RestoreFileVersionResponse{
-			Status: status.NewInternal(ctx, err, "error unwrapping path"),
+			Status: status.NewStatusFromErrType(ctx, "error unwrapping path", err),
 		}, nil
 	}
 
@@ -1265,7 +1259,7 @@ func (s *service) RestoreFileVersion(ctx context.Context, req *provider.RestoreF
 		case errtypes.PermissionDenied:
 			st = status.NewPermissionDenied(ctx, err, "permission denied")
 		default:
-			st = status.NewInternal(ctx, err, "error restoring version: "+req.Ref.String())
+			st = status.NewStatusFromErrType(ctx, "error restoring version: "+req.Ref.String(), err)
 		}
 		return &provider.RestoreFileVersionResponse{
 			Status: st,
@@ -1299,7 +1293,7 @@ func (s *service) ListRecycleStream(req *provider.ListRecycleStreamRequest, ss p
 		case errtypes.BadRequest:
 			st = status.NewInvalidArg(ctx, "too many days or too many entries")
 		default:
-			st = status.NewInternal(ctx, err, "error listing recycle stream")
+			st = status.NewStatusFromErrType(ctx, "error listing recycle stream", err)
 		}
 		res := &provider.ListRecycleStreamResponse{
 			Status: st,
@@ -1343,7 +1337,7 @@ func (s *service) ListRecycle(ctx context.Context, req *provider.ListRecycleRequ
 		case errtypes.BadRequest:
 			st = status.NewInvalidArg(ctx, "too many days or too many entries")
 		default:
-			st = status.NewInternal(ctx, err, "error listing recycle")
+			st = status.NewStatusFromErrType(ctx, "error listing recycle", err)
 		}
 		return &provider.ListRecycleResponse{
 			Status: st,
@@ -1381,7 +1375,7 @@ func (s *service) RestoreRecycleItem(ctx context.Context, req *provider.RestoreR
 		case errtypes.PermissionDenied:
 			st = status.NewPermissionDenied(ctx, err, "permission denied")
 		default:
-			st = status.NewInternal(ctx, err, "error restoring recycle bin item")
+			st = status.NewStatusFromErrType(ctx, "error restoring recycle bin item", err)
 		}
 		return &provider.RestoreRecycleItemResponse{
 			Status: st,
@@ -1410,7 +1404,7 @@ func (s *service) PurgeRecycle(ctx context.Context, req *provider.PurgeRecycleRe
 			case errtypes.PermissionDenied:
 				st = status.NewPermissionDenied(ctx, err, "permission denied")
 			default:
-				st = status.NewInternal(ctx, err, "error purging recycle item")
+				st = status.NewStatusFromErrType(ctx, "error purging recycle item", err)
 			}
 			return &provider.PurgeRecycleResponse{
 				Status: st,
@@ -1425,7 +1419,7 @@ func (s *service) PurgeRecycle(ctx context.Context, req *provider.PurgeRecycleRe
 		case errtypes.PermissionDenied:
 			st = status.NewPermissionDenied(ctx, err, "permission denied")
 		default:
-			st = status.NewInternal(ctx, err, "error purging recycle bin")
+			st = status.NewStatusFromErrType(ctx, "error purging recycle bin", err)
 		}
 		return &provider.PurgeRecycleResponse{
 			Status: st,
@@ -1442,7 +1436,7 @@ func (s *service) ListGrants(ctx context.Context, req *provider.ListGrantsReques
 	newRef, err := s.unwrap(ctx, req.Ref)
 	if err != nil {
 		return &provider.ListGrantsResponse{
-			Status: status.NewInternal(ctx, err, "error unwrapping path"),
+			Status: status.NewStatusFromErrType(ctx, "error unwrapping path", err),
 		}, nil
 	}
 
@@ -1455,7 +1449,7 @@ func (s *service) ListGrants(ctx context.Context, req *provider.ListGrantsReques
 		case errtypes.PermissionDenied:
 			st = status.NewPermissionDenied(ctx, err, "permission denied")
 		default:
-			st = status.NewInternal(ctx, err, "error listing grants")
+			st = status.NewStatusFromErrType(ctx, "error listing grants", err)
 		}
 		return &provider.ListGrantsResponse{
 			Status: st,
@@ -1473,7 +1467,7 @@ func (s *service) DenyGrant(ctx context.Context, req *provider.DenyGrantRequest)
 	newRef, err := s.unwrap(ctx, req.Ref)
 	if err != nil {
 		return &provider.DenyGrantResponse{
-			Status: status.NewInternal(ctx, err, "error unwrapping path"),
+			Status: status.NewStatusFromErrType(ctx, "error unwrapping path", err),
 		}, nil
 	}
 
@@ -1493,7 +1487,7 @@ func (s *service) DenyGrant(ctx context.Context, req *provider.DenyGrantRequest)
 		case errtypes.PermissionDenied:
 			st = status.NewPermissionDenied(ctx, err, "permission denied")
 		default:
-			st = status.NewInternal(ctx, err, "error setting grants")
+			st = status.NewStatusFromErrType(ctx, "error setting grants", err)
 		}
 		return &provider.DenyGrantResponse{
 			Status: st,
@@ -1510,7 +1504,7 @@ func (s *service) AddGrant(ctx context.Context, req *provider.AddGrantRequest) (
 	newRef, err := s.unwrap(ctx, req.Ref)
 	if err != nil {
 		return &provider.AddGrantResponse{
-			Status: status.NewInternal(ctx, err, "error unwrapping path"),
+			Status: status.NewStatusFromErrType(ctx, "error unwrapping path", err),
 		}, nil
 	}
 
@@ -1530,7 +1524,7 @@ func (s *service) AddGrant(ctx context.Context, req *provider.AddGrantRequest) (
 		case errtypes.PermissionDenied:
 			st = status.NewPermissionDenied(ctx, err, "permission denied")
 		default:
-			st = status.NewInternal(ctx, err, "error setting grants")
+			st = status.NewStatusFromErrType(ctx, "error setting grants", err)
 		}
 		return &provider.AddGrantResponse{
 			Status: st,
@@ -1554,7 +1548,7 @@ func (s *service) UpdateGrant(ctx context.Context, req *provider.UpdateGrantRequ
 	newRef, err := s.unwrap(ctx, req.Ref)
 	if err != nil {
 		return &provider.UpdateGrantResponse{
-			Status: status.NewInternal(ctx, err, "error unwrapping path"),
+			Status: status.NewStatusFromErrType(ctx, "error unwrapping path", err),
 		}, nil
 	}
 
@@ -1566,7 +1560,7 @@ func (s *service) UpdateGrant(ctx context.Context, req *provider.UpdateGrantRequ
 		case errtypes.PermissionDenied:
 			st = status.NewPermissionDenied(ctx, err, "permission denied")
 		default:
-			st = status.NewInternal(ctx, err, "error updating grant")
+			st = status.NewStatusFromErrType(ctx, "error updating grant", err)
 		}
 		return &provider.UpdateGrantResponse{
 			Status: st,
@@ -1590,7 +1584,7 @@ func (s *service) RemoveGrant(ctx context.Context, req *provider.RemoveGrantRequ
 	newRef, err := s.unwrap(ctx, req.Ref)
 	if err != nil {
 		return &provider.RemoveGrantResponse{
-			Status: status.NewInternal(ctx, err, "error unwrapping path"),
+			Status: status.NewStatusFromErrType(ctx, "error unwrapping path", err),
 		}, nil
 	}
 
@@ -1602,7 +1596,7 @@ func (s *service) RemoveGrant(ctx context.Context, req *provider.RemoveGrantRequ
 		case errtypes.PermissionDenied:
 			st = status.NewPermissionDenied(ctx, err, "permission denied")
 		default:
-			st = status.NewInternal(ctx, err, "error removing grant")
+			st = status.NewStatusFromErrType(ctx, "error removing grant", err)
 		}
 		return &provider.RemoveGrantResponse{
 			Status: st,
@@ -1630,7 +1624,7 @@ func (s *service) CreateReference(ctx context.Context, req *provider.CreateRefer
 	newRef, err := s.unwrap(ctx, req.Ref)
 	if err != nil {
 		return &provider.CreateReferenceResponse{
-			Status: status.NewInternal(ctx, err, "error unwrapping path"),
+			Status: status.NewStatusFromErrType(ctx, "error unwrapping path", err),
 		}, nil
 	}
 
@@ -1643,7 +1637,7 @@ func (s *service) CreateReference(ctx context.Context, req *provider.CreateRefer
 		case errtypes.PermissionDenied:
 			st = status.NewPermissionDenied(ctx, err, "permission denied")
 		default:
-			st = status.NewInternal(ctx, err, "error creating reference")
+			st = status.NewStatusFromErrType(ctx, "error creating reference", err)
 		}
 		return &provider.CreateReferenceResponse{
 			Status: st,
@@ -1677,7 +1671,7 @@ func (s *service) GetQuota(ctx context.Context, req *provider.GetQuotaRequest) (
 	newRef, err := s.unwrap(ctx, req.Ref)
 	if err != nil {
 		return &provider.GetQuotaResponse{
-			Status: status.NewInternal(ctx, err, "error unwrapping path"),
+			Status: status.NewStatusFromErrType(ctx, "error unwrapping path", err),
 		}, nil
 	}
 	total, used, err := s.storage.GetQuota(ctx, newRef)
@@ -1689,7 +1683,7 @@ func (s *service) GetQuota(ctx context.Context, req *provider.GetQuotaRequest) (
 		case errtypes.PermissionDenied:
 			st = status.NewPermissionDenied(ctx, err, "permission denied")
 		default:
-			st = status.NewInternal(ctx, err, "error getting quota")
+			st = status.NewStatusFromErrType(ctx, "error getting quota", err)
 		}
 		return &provider.GetQuotaResponse{
 			Status: st,

--- a/internal/grpc/services/storageprovider/storageprovider.go
+++ b/internal/grpc/services/storageprovider/storageprovider.go
@@ -594,7 +594,7 @@ func (s *service) GetPath(ctx context.Context, req *provider.GetPathRequest) (*p
 	fn, err := s.storage.GetPathByID(ctx, req.ResourceId)
 	if err != nil {
 		return &provider.GetPathResponse{
-			Status: status.NewInternal(ctx, err, "error getting path by id"),
+			Status: status.NewStatusFromErrType(ctx, "error getting path by id", err),
 		}, nil
 	}
 
@@ -620,7 +620,7 @@ func (s *service) GetHome(ctx context.Context, req *provider.GetHomeRequest) (*p
 func (s *service) CreateHome(ctx context.Context, req *provider.CreateHomeRequest) (*provider.CreateHomeResponse, error) {
 	log := appctx.GetLogger(ctx)
 	if err := s.storage.CreateHome(ctx); err != nil {
-		st := status.NewInternal(ctx, err, "error creating home")
+		st := status.NewStatusFromErrType(ctx, "error creating home", err)
 		log.Err(err).Msg("storageprovider: error calling CreateHome of storage driver")
 		return &provider.CreateHomeResponse{
 			Status: st,
@@ -799,13 +799,13 @@ func (s *service) Move(ctx context.Context, req *provider.MoveRequest) (*provide
 	sourceRef, err := s.unwrap(ctx, req.Source)
 	if err != nil {
 		return &provider.MoveResponse{
-			Status: status.NewInternal(ctx, err, "error unwrapping source path"),
+			Status: status.NewStatusFromErrType(ctx, "error unwrapping source path", err),
 		}, nil
 	}
 	targetRef, err := s.unwrap(ctx, req.Destination)
 	if err != nil {
 		return &provider.MoveResponse{
-			Status: status.NewInternal(ctx, err, "error unwrapping destination path"),
+			Status: status.NewStatusFromErrType(ctx, "error unwrapping destination path", err),
 		}, nil
 	}
 

--- a/internal/grpc/services/storageregistry/storageregistry.go
+++ b/internal/grpc/services/storageregistry/storageregistry.go
@@ -100,7 +100,7 @@ func (s *service) ListStorageProviders(ctx context.Context, req *registrypb.List
 	pinfos, err := s.reg.ListProviders(ctx)
 	if err != nil {
 		return &registrypb.ListStorageProvidersResponse{
-			Status: status.NewInternal(ctx, err, "error getting list of storage providers"),
+			Status: status.NewStatusFromErrType(ctx, "error getting list of storage providers", err),
 		}, nil
 	}
 
@@ -121,7 +121,7 @@ func (s *service) GetStorageProviders(ctx context.Context, req *registrypb.GetSt
 			}, nil
 		default:
 			return &registrypb.GetStorageProvidersResponse{
-				Status: status.NewInternal(ctx, err, "error finding storage provider"),
+				Status: status.NewStatusFromErrType(ctx, "error finding storage provider", err),
 			}, nil
 		}
 	}
@@ -139,7 +139,7 @@ func (s *service) GetHome(ctx context.Context, req *registrypb.GetHomeRequest) (
 	if err != nil {
 		log.Error().Err(err).Msg("error getting home")
 		res := &registrypb.GetHomeResponse{
-			Status: status.NewInternal(ctx, err, "error getting home"),
+			Status: status.NewStatusFromErrType(ctx, "error getting home", err),
 		}
 		return res, nil
 	}

--- a/internal/grpc/services/userprovider/userprovider.go
+++ b/internal/grpc/services/userprovider/userprovider.go
@@ -34,7 +34,6 @@ import (
 	"github.com/cs3org/reva/v3/pkg/user/manager/registry"
 	"github.com/cs3org/reva/v3/pkg/utils"
 	"github.com/cs3org/reva/v3/pkg/utils/cfg"
-	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 )
 
@@ -106,8 +105,7 @@ func (s *service) GetUser(ctx context.Context, req *userpb.GetUserRequest) (*use
 		if _, ok := err.(errtypes.NotFound); ok {
 			res.Status = status.NewNotFound(ctx, "user not found")
 		} else {
-			err = errors.Wrap(err, "userprovidersvc: error getting user")
-			res.Status = status.NewInternal(ctx, err, "error getting user")
+			res.Status = status.NewStatusFromErrType(ctx, "error getting user", err)
 		}
 		return res, nil
 	}
@@ -129,8 +127,7 @@ func (s *service) GetUserByClaim(ctx context.Context, req *userpb.GetUserByClaim
 		case errtypes.Conflict:
 			res.Status = status.NewConflict(ctx, err, fmt.Sprintf("conflict getting user %s by claim %s", req.Value, req.Claim))
 		default:
-			err = errors.Wrap(err, "userprovidersvc: error getting user by claim")
-			res.Status = status.NewInternal(ctx, err, fmt.Sprintf("error getting user %s by claim %s", req.Value, req.Claim))
+			res.Status = status.NewStatusFromErrType(ctx, fmt.Sprintf("error getting user %s by claim %s", req.Value, req.Claim), err)
 		}
 		return res, nil
 	}
@@ -153,9 +150,8 @@ func (s *service) FindUsers(ctx context.Context, req *userpb.FindUsersRequest) (
 	users, err := s.usermgr.FindUsers(ctx, query, req.Filters, req.SkipFetchingUserGroups)
 	if err != nil {
 		log.Error().Err(err).Str("query", query).Msg("Failed to find users")
-		err = errors.Wrap(err, "userprovidersvc: error finding users")
 		res := &userpb.FindUsersResponse{
-			Status: status.NewInternal(ctx, err, "error finding users"),
+			Status: status.NewStatusFromErrType(ctx, "error finding users", err),
 		}
 		return res, nil
 	}
@@ -175,9 +171,8 @@ func (s *service) FindUsers(ctx context.Context, req *userpb.FindUsersRequest) (
 func (s *service) GetUserGroups(ctx context.Context, req *userpb.GetUserGroupsRequest) (*userpb.GetUserGroupsResponse, error) {
 	groups, err := s.usermgr.GetUserGroups(ctx, req.UserId)
 	if err != nil {
-		err = errors.Wrap(err, "userprovidersvc: error getting user groups")
 		res := &userpb.GetUserGroupsResponse{
-			Status: status.NewInternal(ctx, err, "error getting user groups"),
+			Status: status.NewStatusFromErrType(ctx, "error getting user groups", err),
 		}
 		return res, nil
 	}

--- a/internal/grpc/services/usershareprovider/usershareprovider.go
+++ b/internal/grpc/services/usershareprovider/usershareprovider.go
@@ -172,7 +172,7 @@ func (s *service) GetShare(ctx context.Context, req *collaboration.GetShareReque
 	if err != nil {
 		return &collaboration.GetShareResponse{
 			Status: status.NewStatusFromErrType(ctx, "error getting share", err),
-		}, nil
+		}, err
 	}
 
 	return &collaboration.GetShareResponse{

--- a/internal/grpc/services/usershareprovider/usershareprovider.go
+++ b/internal/grpc/services/usershareprovider/usershareprovider.go
@@ -143,7 +143,7 @@ func (s *service) CreateShare(ctx context.Context, req *collaboration.CreateShar
 	share, err := s.sm.Share(ctx, req.ResourceInfo, req.Grant)
 	if err != nil {
 		return &collaboration.CreateShareResponse{
-			Status: status.NewInternal(ctx, err, "error creating share: "+err.Error()),
+			Status: status.NewStatusFromErrType(ctx, "error creating share", err),
 		}, nil
 	}
 
@@ -158,7 +158,7 @@ func (s *service) RemoveShare(ctx context.Context, req *collaboration.RemoveShar
 	err := s.sm.Unshare(ctx, req.Ref)
 	if err != nil {
 		return &collaboration.RemoveShareResponse{
-			Status: status.NewInternal(ctx, err, "error removing share"),
+			Status: status.NewStatusFromErrType(ctx, "error removing share", err),
 		}, nil
 	}
 
@@ -171,8 +171,8 @@ func (s *service) GetShare(ctx context.Context, req *collaboration.GetShareReque
 	share, err := s.sm.GetShare(ctx, req.Ref)
 	if err != nil {
 		return &collaboration.GetShareResponse{
-			Status: status.NewInternal(ctx, err, "error getting share"),
-		}, err
+			Status: status.NewStatusFromErrType(ctx, "error getting share", err),
+		}, nil
 	}
 
 	return &collaboration.GetShareResponse{
@@ -191,7 +191,7 @@ func (s *service) ListShares(ctx context.Context, req *collaboration.ListSharesR
 	shares, err := s.sm.ListShares(ctx, req.Filters) // TODO(labkode): add filter to share manager
 	if err != nil {
 		return &collaboration.ListSharesResponse{
-			Status: status.NewInternal(ctx, err, "error listing shares"),
+			Status: status.NewStatusFromErrType(ctx, "error listing shares", err),
 		}, nil
 	}
 
@@ -206,7 +206,7 @@ func (s *service) UpdateShare(ctx context.Context, req *collaboration.UpdateShar
 	share, err := s.sm.UpdateShare(ctx, req.Ref, req)
 	if err != nil {
 		return &collaboration.UpdateShareResponse{
-			Status: status.NewInternal(ctx, err, "error updating share"),
+			Status: status.NewStatusFromErrType(ctx, "error updating share", err),
 		}, nil
 	}
 
@@ -232,7 +232,7 @@ func (s *service) ListReceivedShares(ctx context.Context, req *collaboration.Lis
 	shares, err := s.sm.ListReceivedShares(ctx, req.Filters) // TODO(labkode): check what to update
 	if err != nil {
 		return &collaboration.ListReceivedSharesResponse{
-			Status: status.NewInternal(ctx, err, "error listing received shares"),
+			Status: status.NewStatusFromErrType(ctx, "error listing received shares", err),
 		}, nil
 	}
 
@@ -250,7 +250,7 @@ func (s *service) GetReceivedShare(ctx context.Context, req *collaboration.GetRe
 	if err != nil {
 		log.Err(err).Msg("error getting received share")
 		return &collaboration.GetReceivedShareResponse{
-			Status: status.NewInternal(ctx, err, "error getting received share"),
+			Status: status.NewStatusFromErrType(ctx, "error getting received share", err),
 		}, nil
 	}
 
@@ -265,7 +265,7 @@ func (s *service) UpdateReceivedShare(ctx context.Context, req *collaboration.Up
 	share, err := s.sm.UpdateReceivedShare(ctx, req.Share, req.UpdateMask) // TODO(labkode): check what to update
 	if err != nil {
 		return &collaboration.UpdateReceivedShareResponse{
-			Status: status.NewInternal(ctx, err, "error updating received share"),
+			Status: status.NewStatusFromErrType(ctx, "error updating received share", err),
 		}, nil
 	}
 

--- a/pkg/errtypes/errtypes.go
+++ b/pkg/errtypes/errtypes.go
@@ -196,6 +196,12 @@ type IsInsufficientStorage interface {
 	IsInsufficientStorage()
 }
 
+// IsConflict is the interface to implement
+// to specify that the request conflicts with the current state of the server.
+type IsConflict interface {
+	IsConflict()
+}
+
 // ShareParentConflict is returned when creating a share is redundant or inconsistent
 // because a parent resource is already shared with the same grantee.
 type ShareParentConflict string

--- a/pkg/rgrpc/status/status.go
+++ b/pkg/rgrpc/status/status.go
@@ -165,24 +165,30 @@ func NewFailedPrecondition(ctx context.Context, err error, msg string) *rpc.Stat
 	}
 }
 
-// NewStatusFromErrType returns a status that corresponds to the given errtype.
+// NewStatusFromErrType returns the status matching the type of err.
+// A nil error maps to OK, an unknown error falls back to INTERNAL.
 func NewStatusFromErrType(ctx context.Context, msg string, err error) *rpc.Status {
-	switch e := err.(type) {
+	switch err.(type) {
 	case nil:
-		NewOK(ctx)
+		return NewOK(ctx)
 	case errtypes.IsNotFound:
-		return NewNotFound(ctx, "gateway: "+msg+": "+err.Error())
+		return NewNotFound(ctx, msg+": "+err.Error())
 	case errtypes.IsInvalidCredentials:
-		// TODO this maps badly
-		return NewUnauthenticated(ctx, err, "gateway: "+msg+": "+err.Error())
-	case errtypes.PermissionDenied:
-		return NewPermissionDenied(ctx, e, "gateway: "+msg+": "+err.Error())
+		return NewUnauthenticated(ctx, err, msg+": "+err.Error())
+	case errtypes.IsPermissionDenied:
+		return NewPermissionDenied(ctx, err, msg+": "+err.Error())
+	case errtypes.IsUserRequired:
+		return NewUnauthenticated(ctx, err, msg+": "+err.Error())
 	case errtypes.IsNotSupported:
-		return NewUnimplemented(ctx, err, "gateway: "+msg+":"+err.Error())
-	case errtypes.BadRequest:
-		return NewInvalidArg(ctx, "gateway: "+msg+":"+err.Error())
-	case errtypes.AlreadyExists:
-		return NewAlreadyExists(ctx, err, "gateway: "+msg+":"+err.Error())
+		return NewUnimplemented(ctx, err, msg+": "+err.Error())
+	case errtypes.IsBadRequest:
+		return NewInvalidArg(ctx, msg+": "+err.Error())
+	case errtypes.IsAlreadyExists:
+		return NewAlreadyExists(ctx, err, msg+": "+err.Error())
+	case errtypes.IsConflict:
+		return NewConflict(ctx, err, msg+": "+err.Error())
+	case errtypes.IsInsufficientStorage:
+		return NewInsufficientStorage(ctx, err, msg+": "+err.Error())
 	}
 
 	// map GRPC status codes coming from the auth middleware
@@ -192,11 +198,11 @@ func NewStatusFromErrType(ctx context.Context, msg string, err error) *rpc.Statu
 		if ok {
 			switch st.Code() {
 			case codes.NotFound:
-				return NewNotFound(ctx, "gateway: "+msg+": "+err.Error())
+				return NewNotFound(ctx, msg+": "+err.Error())
 			case codes.Unauthenticated:
-				return NewUnauthenticated(ctx, err, "gateway: "+msg+": "+err.Error())
+				return NewUnauthenticated(ctx, err, msg+": "+err.Error())
 			case codes.PermissionDenied:
-				return NewPermissionDenied(ctx, err, "gateway: "+msg+": "+err.Error())
+				return NewPermissionDenied(ctx, err, msg+": "+err.Error())
 			}
 		}
 		// the actual error can be wrapped multiple times
@@ -206,7 +212,29 @@ func NewStatusFromErrType(ctx context.Context, msg string, err error) *rpc.Statu
 		}
 	}
 
-	return NewInternal(ctx, err, "gateway: "+msg+":"+err.Error())
+	return NewInternal(ctx, err, msg+": "+err.Error())
+}
+
+// NewErrtypeFromStatus returns an errtype matching a non-OK status, so a helper
+// that receives a downstream status can hand its caller an error that
+// NewStatusFromErrType maps back to the right code instead of a flattened one.
+func NewErrtypeFromStatus(s *rpc.Status) error {
+	switch s.Code {
+	case rpc.Code_CODE_NOT_FOUND:
+		return errtypes.NotFound(s.Message)
+	case rpc.Code_CODE_PERMISSION_DENIED:
+		return errtypes.PermissionDenied(s.Message)
+	case rpc.Code_CODE_ALREADY_EXISTS:
+		return errtypes.AlreadyExists(s.Message)
+	case rpc.Code_CODE_INVALID_ARGUMENT:
+		return errtypes.BadRequest(s.Message)
+	case rpc.Code_CODE_UNAUTHENTICATED:
+		return errtypes.InvalidCredentials(s.Message)
+	case rpc.Code_CODE_UNIMPLEMENTED:
+		return errtypes.NotSupported(s.Message)
+	default:
+		return errtypes.InternalError(s.Message)
+	}
 }
 
 // NewErrorFromCode returns a standardized Error for a given RPC code.

--- a/pkg/rgrpc/status/status_test.go
+++ b/pkg/rgrpc/status/status_test.go
@@ -1,0 +1,57 @@
+// Copyright 2018-2024 CERN
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// In applying this license, CERN does not waive the privileges and immunities
+// granted to it by virtue of its status as an Intergovernmental Organization
+// or submit itself to any jurisdiction.
+
+package status
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	rpc "github.com/cs3org/go-cs3apis/cs3/rpc/v1beta1"
+	"github.com/cs3org/reva/v3/pkg/errtypes"
+)
+
+func TestNewStatusFromErrType(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want rpc.Code
+	}{
+		{name: "nil", err: nil, want: rpc.Code_CODE_OK},
+		{name: "not found", err: errtypes.NotFound("x"), want: rpc.Code_CODE_NOT_FOUND},
+		{name: "permission denied", err: errtypes.PermissionDenied("x"), want: rpc.Code_CODE_PERMISSION_DENIED},
+		{name: "invalid credentials", err: errtypes.InvalidCredentials("x"), want: rpc.Code_CODE_UNAUTHENTICATED},
+		{name: "user required", err: errtypes.UserRequired("x"), want: rpc.Code_CODE_UNAUTHENTICATED},
+		{name: "not supported", err: errtypes.NotSupported("x"), want: rpc.Code_CODE_UNIMPLEMENTED},
+		{name: "bad request", err: errtypes.BadRequest("x"), want: rpc.Code_CODE_INVALID_ARGUMENT},
+		{name: "already exists", err: errtypes.AlreadyExists("x"), want: rpc.Code_CODE_ALREADY_EXISTS},
+		{name: "conflict", err: errtypes.Conflict("x"), want: rpc.Code_CODE_ABORTED},
+		{name: "insufficient storage", err: errtypes.InsufficientStorage("x"), want: rpc.Code_CODE_INSUFFICIENT_STORAGE},
+		{name: "unknown", err: errors.New("boom"), want: rpc.Code_CODE_INTERNAL},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := NewStatusFromErrType(context.Background(), "op", tt.err)
+			if got.Code != tt.want {
+				t.Fatalf("code = %v, want %v", got.Code, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #4915.
`NewInternal()` was used as a catch-all across the grpc services and flattened errors that already carried a code (notfound, permission denied, ...) into INTERNAL. routes those through `NewStatusFromErrType` so the real code reaches the client, adds the inverse `NewErrtypeFromStatus` for the gateway helpers that receive a downstream status and fixes a few miscoded BadRequests

also i see there are genuinely internal sites (transport failures, marshaling, client setup) i left them as-it-is
