### PR TITLE
Make service names unique per transport

### DIFF
--- a/changelog/unreleased/svc-reg-transports.md
+++ b/changelog/unreleased/svc-reg-transports.md
@@ -1,0 +1,8 @@
+Bugfix: Make service names unique per transport 
+
+Currently, multiple services with the same name (e.g. `preferences`), but using
+different transports (`http` vs `grpc`) could conflict. This caused connections
+to be randomly to either of the services. We now bind this to specific transports,
+so a service is queried with a transport.
+
+https://github.com/cs3org/reva/pull/5813

--- a/cmd/revad/runtime/registration.go
+++ b/cmd/revad/runtime/registration.go
@@ -92,12 +92,12 @@ func (r *Reva) addServerlessNodes(msg string) {
 	for _, si := range r.serverlessInstances {
 		id := nodeID(r.controlAddr, si.name)
 		meta := map[string]string{
-			"transport":           "serverless",
-			"host":                hostname,
-			"pid":                 fmt.Sprintf("%d", pid),
-			registry.MetaState:    rotationState(id),
-			registry.MetaLastSeen: time.Now().UTC().Format(time.RFC3339),
-			registry.MetaControl:  r.controlAddr,
+			registry.MetaTransport: registry.TransportServerless,
+			"host":                 hostname,
+			"pid":                  fmt.Sprintf("%d", pid),
+			registry.MetaState:     rotationState(id),
+			registry.MetaLastSeen:  time.Now().UTC().Format(time.RFC3339),
+			registry.MetaControl:   r.controlAddr,
 		}
 		if names := invoke.InvocationNames(id); len(names) > 0 {
 			meta[invoke.MetaInvocations] = strings.Join(names, ",")
@@ -169,13 +169,13 @@ func isWildcard(host string) bool {
 // the instance's invocation names, and any service-owned keys.
 func nodeMetadata(srv *Server, id, hostname string, pid int, impl any) map[string]string {
 	meta := map[string]string{
-		"transport":           srv.transport,
-		"host":                hostname,
-		"pid":                 fmt.Sprintf("%d", pid),
-		registry.MetaState:    rotationState(id),
-		registry.MetaLastSeen: time.Now().UTC().Format(time.RFC3339),
+		registry.MetaTransport: srv.transport,
+		"host":                 hostname,
+		"pid":                  fmt.Sprintf("%d", pid),
+		registry.MetaState:     rotationState(id),
+		registry.MetaLastSeen:  time.Now().UTC().Format(time.RFC3339),
 	}
-	if srv.transport == "http" {
+	if srv.transport == registry.TransportHTTP {
 		meta[registry.MetaScheme] = srv.scheme
 		if hs, ok := impl.(global.Service); ok {
 			meta[registry.MetaPrefix] = hs.Prefix()

--- a/cmd/revad/runtime/runtime.go
+++ b/cmd/revad/runtime/runtime.go
@@ -570,7 +570,7 @@ func newServers(ctx context.Context, grpc []*config.GRPC, http []*config.HTTP, l
 		server := &Server{
 			server:    s,
 			listener:  ln,
-			transport: "grpc",
+			transport: registry.TransportGRPC,
 			services:  maps.MapValues(services, func(s rgrpc.Service) any { return s }),
 		}
 		log.Debug().
@@ -609,7 +609,7 @@ func newServers(ctx context.Context, grpc []*config.GRPC, http []*config.HTTP, l
 		server := &Server{
 			server:    s,
 			listener:  ln,
-			transport: "http",
+			transport: registry.TransportHTTP,
 			scheme:    scheme,
 			services:  maps.MapValues(services, func(s global.Service) any { return s }),
 		}
@@ -661,7 +661,7 @@ func newControlServer(cfg *config.Config, hasServerless bool, log *zerolog.Logge
 	server := &Server{
 		server:    s,
 		listener:  ln,
-		transport: "grpc",
+		transport: registry.TransportGRPC,
 		internal:  true,
 		services:  maps.MapValues(services, func(s rgrpc.Service) any { return s }),
 	}

--- a/internal/grpc/services/storageprovider/initiateupload_test.go
+++ b/internal/grpc/services/storageprovider/initiateupload_test.go
@@ -171,6 +171,7 @@ func newServiceForInitiateUploadTest(t *testing.T, fs storage.FS, expose bool) *
 	reg := memory.New(nil)
 	_ = reg.Add(registry.NewService("dataprovider", []registry.Node{
 		registry.NewNode("dp1", "localhost", map[string]string{
+			registry.MetaTransport: registry.TransportHTTP,
 			registry.MetaState:     registry.StateReady,
 			registry.MetaMountID:   mountID,
 			registry.MetaPublicURL: "http://localhost/data",

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -63,6 +63,7 @@ type Event struct {
 const (
 	MetaState     = "state"
 	MetaLastSeen  = "last_seen"
+	MetaTransport = "transport"  // "grpc" | "http" | "serverless"
 	MetaScheme    = "scheme"     // "http" | "https" for HTTP services
 	MetaPrefix    = "prefix"     // HTTP URL path prefix
 	MetaPublicURL = "public_url" // explicit external URL override
@@ -73,4 +74,11 @@ const (
 	StateDegraded = "degraded"
 	StateOffline  = "offline"
 	StateDraining = "draining"
+
+	// A service name is unique per transport, not globally: the same name can
+	// name a gRPC service and an HTTP one (e.g. "preferences"). Resolution
+	// must therefore filter on the transport it can speak.
+	TransportGRPC       = "grpc"
+	TransportHTTP       = "http"
+	TransportServerless = "serverless"
 )

--- a/pkg/service/clients.go
+++ b/pkg/service/clients.go
@@ -143,15 +143,17 @@ func (c *clients) WithSelector(s Selector) *clients {
 	return c
 }
 
-// resolve picks a node for name and returns a cached connection to it.
+// resolve picks a gRPC node for name and returns a cached connection to it. A
+// name is unique per transport, so an HTTP service can carry the same one.
 func (c *clients) resolve(name string) (*grpc.ClientConn, string, error) {
 	svc, err := c.registry.GetService(name)
 	if err != nil {
 		return nil, "", fmt.Errorf("service registry: resolving %q: %w", name, err)
 	}
-	node, ok := c.selector.Pick(svc.Nodes())
+	nodes := filterByMetadata(svc.Nodes(), map[string]string{registry.MetaTransport: registry.TransportGRPC})
+	node, ok := c.selector.Pick(nodes)
 	if !ok {
-		return nil, "", fmt.Errorf("service registry: no selectable node for %q", name)
+		return nil, "", fmt.Errorf("service registry: no selectable grpc node for %q", name)
 	}
 	addr := node.Address()
 	conn, err := c.connFor(addr)

--- a/pkg/service/clients_test.go
+++ b/pkg/service/clients_test.go
@@ -19,6 +19,7 @@
 package service
 
 import (
+	"context"
 	"testing"
 
 	"github.com/cs3org/reva/v3/pkg/registry"
@@ -26,7 +27,14 @@ import (
 )
 
 func meta(state string) map[string]string {
-	return map[string]string{registry.MetaState: state}
+	return metaTransport(state, registry.TransportGRPC)
+}
+
+func metaTransport(state, transport string) map[string]string {
+	return map[string]string{
+		registry.MetaState:     state,
+		registry.MetaTransport: transport,
+	}
 }
 
 func TestSelectorPrefersReadyAndSkipsOfflineDraining(t *testing.T) {
@@ -88,6 +96,56 @@ func TestResolveReturnsAddressAndCachesConn(t *testing.T) {
 	}
 	if conn1 != conn2 {
 		t.Fatal("expected the conn cache to return the same connection")
+	}
+}
+
+func TestResolveSkipsSameNamedHTTPNode(t *testing.T) {
+	reg := memory.New(nil)
+	_ = reg.Add(registry.NewService(NamePreferences, []registry.Node{
+		registry.NewNode("http", "127.0.0.1:19143", metaTransport(registry.StateReady, registry.TransportHTTP)),
+		registry.NewNode("grpc", "127.0.0.1:19142", metaTransport(registry.StateReady, registry.TransportGRPC)),
+	}))
+	c := NewClients(reg).(*clients)
+
+	for range 20 {
+		_, addr, err := c.resolve(NamePreferences)
+		if err != nil {
+			t.Fatalf("resolve failed: %v", err)
+		}
+		if addr != "127.0.0.1:19142" {
+			t.Fatalf("resolved the http node %q", addr)
+		}
+	}
+}
+
+func TestResolveNoGRPCNode(t *testing.T) {
+	reg := memory.New(nil)
+	_ = reg.Add(registry.NewService(NamePreferences, []registry.Node{
+		registry.NewNode("http", "127.0.0.1:19143", metaTransport(registry.StateReady, registry.TransportHTTP)),
+	}))
+	c := NewClients(reg).(*clients)
+
+	if _, _, err := c.resolve(NamePreferences); err == nil {
+		t.Fatal("expected no selectable grpc node")
+	}
+}
+
+func TestHTTPEndpointSkipsSameNamedGRPCNode(t *testing.T) {
+	reg := memory.New(nil)
+	_ = reg.Add(registry.NewService(NamePreferences, []registry.Node{
+		registry.NewNode("grpc", "127.0.0.1:19142", metaTransport(registry.StateReady, registry.TransportGRPC)),
+		registry.NewNode("http", "127.0.0.1:19143", metaTransport(registry.StateReady, registry.TransportHTTP)),
+	}))
+	c := NewClients(reg)
+
+	for range 20 {
+		ep, err := c.HTTPEndpoint(context.Background(), ByName(NamePreferences))
+		if err != nil {
+			t.Fatalf("HTTPEndpoint failed: %v", err)
+		}
+		if ep.Address() != "127.0.0.1:19143" {
+			t.Fatalf("resolved the grpc node %q", ep.Address())
+		}
 	}
 }
 

--- a/pkg/service/endpoints.go
+++ b/pkg/service/endpoints.go
@@ -21,6 +21,7 @@ package service
 import (
 	"context"
 	"fmt"
+	"maps"
 	"net"
 
 	"github.com/cs3org/reva/v3/pkg/registry"
@@ -110,6 +111,17 @@ func ByMetadata(key, value string) EndpointOption {
 	}
 }
 
+// httpFilters adds the http transport to the query filters, unless the caller
+// asked for a specific transport.
+func (q endpointQuery) httpFilters() map[string]string {
+	meta := make(map[string]string, len(q.meta)+1)
+	maps.Copy(meta, q.meta)
+	if _, ok := meta[registry.MetaTransport]; !ok {
+		meta[registry.MetaTransport] = registry.TransportHTTP
+	}
+	return meta
+}
+
 // HTTPEndpoints returns every ready node matching the filters.
 func (c *clients) HTTPEndpoints(_ context.Context, opts ...EndpointOption) ([]Endpoint, error) {
 	q := endpointQuery{}
@@ -123,7 +135,7 @@ func (c *clients) HTTPEndpoints(_ context.Context, opts ...EndpointOption) ([]En
 	if err != nil {
 		return nil, fmt.Errorf("service registry: resolving %q: %w", q.name, err)
 	}
-	nodes := filterByMetadata(svc.Nodes(), q.meta)
+	nodes := filterByMetadata(svc.Nodes(), q.httpFilters())
 	out := make([]Endpoint, 0, len(nodes))
 	for _, n := range nodes {
 		out = append(out, endpoint{name: q.name, node: n})
@@ -147,7 +159,7 @@ func (c *clients) HTTPEndpoint(ctx context.Context, opts ...EndpointOption) (End
 	if err != nil {
 		return nil, fmt.Errorf("service registry: resolving %q: %w", q.name, err)
 	}
-	node, ok := c.selector.Pick(filterByMetadata(svc.Nodes(), q.meta))
+	node, ok := c.selector.Pick(filterByMetadata(svc.Nodes(), q.httpFilters()))
 	if !ok {
 		return nil, fmt.Errorf("service registry: no selectable node for %q matching filters", q.name)
 	}


### PR DESCRIPTION
Currently, multiple services with the same name (e.g. `preferences`), but using different transports (`http` vs `grpc`) could conflict. This caused connections to be randomly to either of the services. We now bind this to specific transports, so a service is queried with a transport.