### PR TITLE
Allow mounting via /webdav/ for LW accounts

### DIFF
--- a/changelog/unreleased/lightweight-path.md
+++ b/changelog/unreleased/lightweight-path.md
@@ -1,0 +1,5 @@
+Enhancement: Allow LW accounts to use modern paths
+
+Allows LW accounts to use the more modern path version without `/remote.php/`
+
+https://github.com/cs3org/reva/pull/5814

--- a/pkg/auth/scope/lightweight.go
+++ b/pkg/auth/scope/lightweight.go
@@ -122,9 +122,14 @@ func checkLightweightPath(path string) bool {
 		"/sciencemesh/discover",
 		"/sciencemesh/embedded-shares",
 		"/sciencemesh/process-embedded-share",
+		// Legacy paths
 		"/remote.php/webdav",
 		"/remote.php/dav/files",
 		"/remote.php/dav/spaces",
+		// Modern paths
+		"/webdav",
+		"/dav/files",
+		"/dav/spaces",
 		"/thumbnails",
 	}
 	for _, p := range paths {


### PR DESCRIPTION
The scope for LW accounts was restricted to the legacy path `/remote.php/webdav`, this change also allows LW accounts to use the more modern version without `/remote.php/.`