### PR TITLE
Bugfix: labelsprovider had incorrect name

### DIFF
--- a/changelog/unreleased/labelsprovider-fix.md
+++ b/changelog/unreleased/labelsprovider-fix.md
@@ -1,0 +1,6 @@
+Bugfix: Incorrect name for labelsprovider
+
+The labels provider was incorrectly named labels and this caused an
+issue where the other services could not find it via the service registry
+
+https://github.com/cs3org/reva/pull/5816

--- a/pkg/service/clients.go
+++ b/pkg/service/clients.go
@@ -79,7 +79,7 @@ const (
 	NameAppProvider     = "appprovider"
 	NameSpaces          = "spacesregistry"
 	NameDataTx          = "datatx"
-	NameLabels          = "labels"
+	NameLabels          = "labelsprovider"
 	NameAdmin           = "admin"
 	// NameControl labels the per-process control channel on its internal
 	// server; it is discovered via node metadata, not registered as a service.


### PR DESCRIPTION
The labels provider was incorrectly named `labels` and this caused and issue where the other services could not find it via the service registry. 