### PR TITLE
registry: reconnect to nats when publishing fails

### DIFF
--- a/changelog/unreleased/registry-nats-publish-reconnect.md
+++ b/changelog/unreleased/registry-nats-publish-reconnect.md
@@ -1,0 +1,11 @@
+Bugfix: Reconnect the service registry when publishing fails
+
+A process whose NATS write failed marked its registry connection as lost and
+queued the write, but only the watch path ever reconnected. A process with a
+healthy watcher therefore never reconnected: it kept queueing its own
+heartbeats, silently, while its peers aged its nodes out and stopped being able
+to resolve it, until the process was restarted. Writes now reconnect too, so a
+NATS outage recovers on the next heartbeat, and a reconnect no longer leaves the
+previous connection open.
+
+https://github.com/cs3org/reva/pull/5817

--- a/pkg/registry/nats/nats.go
+++ b/pkg/registry/nats/nats.go
@@ -76,6 +76,10 @@ type driver struct {
 	// keyIndex maps a KV key back to its service+id for delete events.
 	keyIndex map[string][2]string
 
+	// connectFn establishes the connection. It is a field so that tests can
+	// observe that the write path tries to reconnect.
+	connectFn func() error
+
 	ctx    context.Context
 	cancel context.CancelFunc
 }
@@ -109,6 +113,7 @@ func New(m map[string]any) (registry.Driver, error) {
 		ctx:      ctx,
 		cancel:   cancel,
 	}
+	d.connectFn = d.connect
 	return d, nil
 }
 
@@ -118,13 +123,20 @@ func (d *driver) Add(service string, n registry.Node) error {
 
 	d.mu.Lock()
 	d.keyIndex[key] = [2]string{service, n.ID()}
-	connected, kv := d.connected, d.kv
-	if !connected {
-		d.pending[key] = e
-		delete(d.removed, key)
-		d.mu.Unlock()
+	d.mu.Unlock()
+
+	// Reconnect here if a previous write dropped the connection. Writes are the
+	// only thing that happens on a schedule (the runtime re-adds every node on
+	// each heartbeat), so if this path does not reconnect, nothing does: the
+	// process goes on queueing its own heartbeats forever while its peers age
+	// its nodes out of their caches and stop being able to resolve it.
+	if err := d.ensureConnected(); err != nil {
+		d.queue(key, e)
 		return nil
 	}
+
+	d.mu.Lock()
+	kv := d.kv
 	d.mu.Unlock()
 
 	b, err := json.Marshal(e)
@@ -135,25 +147,37 @@ func (d *driver) Add(service string, n registry.Node) error {
 	_, err = kv.Put(ctx, key, b)
 	cancel()
 	if err != nil {
+		// Queue the write and drop the connection, so the next heartbeat
+		// reconnects and flushes it.
+		d.queue(key, e)
 		d.mu.Lock()
-		d.pending[key] = e
 		d.connected = false
 		d.mu.Unlock()
 	}
 	return nil
 }
 
+// queue records a write to be flushed once the connection is back.
+func (d *driver) queue(key string, e entry) {
+	d.mu.Lock()
+	d.pending[key] = e
+	delete(d.removed, key)
+	d.mu.Unlock()
+}
+
 func (d *driver) Remove(service, nodeID string) error {
 	key := keyFor(service, nodeID)
 
-	d.mu.Lock()
-	connected, kv := d.connected, d.kv
-	if !connected {
+	if err := d.ensureConnected(); err != nil {
+		d.mu.Lock()
 		d.removed[key] = struct{}{}
 		delete(d.pending, key)
 		d.mu.Unlock()
 		return nil
 	}
+
+	d.mu.Lock()
+	kv := d.kv
 	d.mu.Unlock()
 
 	ctx, cancel := context.WithTimeout(d.ctx, 5*time.Second)
@@ -229,12 +253,12 @@ func (d *driver) forward(w jetstream.KeyWatcher, out chan<- registry.Event) {
 
 func (d *driver) ensureConnected() error {
 	d.mu.Lock()
-	if d.connected {
-		d.mu.Unlock()
+	connected, connect := d.connected, d.connectFn
+	d.mu.Unlock()
+	if connected {
 		return nil
 	}
-	d.mu.Unlock()
-	return d.connect()
+	return connect()
 }
 
 func (d *driver) connect() error {
@@ -265,10 +289,16 @@ func (d *driver) connect() error {
 	}
 
 	d.mu.Lock()
+	// Reconnecting replaces the previous connection, which would otherwise be
+	// left open once per reconnect.
+	old := d.nc
 	d.nc = nc
 	d.kv = kv
 	d.connected = true
 	d.mu.Unlock()
+	if old != nil {
+		old.Close()
+	}
 
 	d.flushPending()
 	return nil

--- a/pkg/registry/nats/nats_test.go
+++ b/pkg/registry/nats/nats_test.go
@@ -19,9 +19,12 @@
 package nats
 
 import (
+	"context"
+	"errors"
 	"testing"
 
 	"github.com/cs3org/reva/v3/pkg/registry"
+	"github.com/nats-io/nats.go/jetstream"
 )
 
 func TestSanitizeKey(t *testing.T) {
@@ -61,5 +64,78 @@ func TestOfflineQueuesWriteThrough(t *testing.T) {
 	d.mu.Unlock()
 	if !queued {
 		t.Fatal("expected the write to be queued while disconnected")
+	}
+}
+
+// TestWriteReconnects is the regression test for a process that silently stopped
+// publishing: writes are the only scheduled work, so if they do not reconnect,
+// nothing does, and the process keeps queueing its own heartbeats forever while
+// its peers age its nodes out and can no longer resolve it.
+func TestWriteReconnects(t *testing.T) {
+	drv, err := New(map[string]any{"address": "nats://127.0.0.1:14222"}) // nothing listening
+	if err != nil {
+		t.Fatalf("New should not fail: %v", err)
+	}
+	d := drv.(*driver)
+	defer d.Close()
+
+	var attempts int
+	d.connectFn = func() error {
+		attempts++
+		return errors.New("still down")
+	}
+
+	node := registry.NewNode("n1", "10.0.0.1:19000", map[string]string{registry.MetaState: registry.StateReady})
+	if err := d.Add("gateway", node); err != nil {
+		t.Fatalf("Add returned error while offline: %v", err)
+	}
+	if err := d.Remove("gateway", "n1"); err != nil {
+		t.Fatalf("Remove returned error while offline: %v", err)
+	}
+	if attempts != 2 {
+		t.Fatalf("every write must try to reconnect, got %d attempts for 2 writes", attempts)
+	}
+}
+
+// failingKV fails every write. Only Put is ever called, so embedding the
+// interface is enough to satisfy it.
+type failingKV struct{ jetstream.KeyValue }
+
+func (failingKV) Put(context.Context, string, []byte) (uint64, error) {
+	return 0, errors.New("connection lost")
+}
+
+// TestFailedWriteDropsTheConnection checks the other half of the loop: a write
+// that fails has to leave the driver disconnected, so that the next heartbeat
+// reconnects and flushes what was queued.
+func TestFailedWriteDropsTheConnection(t *testing.T) {
+	drv, err := New(map[string]any{"address": "nats://127.0.0.1:14222"})
+	if err != nil {
+		t.Fatalf("New should not fail: %v", err)
+	}
+	d := drv.(*driver)
+	defer d.Close()
+
+	d.mu.Lock()
+	d.connected = true
+	d.kv = failingKV{}
+	d.mu.Unlock()
+	d.connectFn = func() error { return errors.New("still down") }
+
+	node := registry.NewNode("n1", "10.0.0.1:19000", map[string]string{registry.MetaState: registry.StateReady})
+	if err := d.Add("gateway", node); err != nil {
+		t.Fatalf("Add returned error: %v", err)
+	}
+
+	d.mu.Lock()
+	connected := d.connected
+	_, queued := d.pending[keyFor("gateway", "n1")]
+	d.mu.Unlock()
+
+	if connected {
+		t.Fatal("a failed write must drop the connection so the next one reconnects")
+	}
+	if !queued {
+		t.Fatal("a failed write must be queued for the next flush")
 	}
 }


### PR DESCRIPTION
A process whose NATS write failed marked its registry connection as lost and queued the write, but only the watch path ever reconnected. A process with a healthy watcher therefore never reconnected: it kept queueing its own heartbeats, silently, while its peers aged its nodes out and stopped being able to resolve it, until the process was restarted. Writes now reconnect too, so a NATS outage recovers on the next heartbeat, and a reconnect no longer leaves the previous connection open.